### PR TITLE
jnigen: object-based JniGen builder, typed flatten specs

### DIFF
--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -121,11 +121,11 @@ identical to the identity closures registered here).
 
 ## Configuration toggles
 
-- **`disable_handle_locks`** — *kept at its default (locks ON).* This is a
+- **`set_emit_handle_locks`** — *kept at its default (locks ON).* This is a
   global, binary toggle: a single binding can only be in one lock mode.
   Keeping the default covers the richer `withSortedHandleLocks` scaffold that
   the generated wrappers emit (and that this example's handle round-trips and
-  the 4-thread smoke exercise); calling `disable_handle_locks()` would simply
+  the 4-thread smoke exercise); calling `set_emit_handle_locks(false)` would simply
   omit it.
 
 [`lang::JniGen`]: https://docs.rs/prebindgen

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -28,7 +28,7 @@
 //! | `.flatten_output()` (+`.field()`/self)| `Summary` fields + `StorageError` `message` + `field_self` (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
-//! | base-package functions               | `string_new` (declared in a `PackageDecl::new("")`) |
+//! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `.flatten_input_suppress()`          | `summary_total_raw` |
 //! | `.flatten_output_suppress()`         | `storage_summary_handle` / `archive_latest` |
 //! | `.flatten_input_with()` (+`.variant()`/self)| `storage_expect_summary` |
@@ -67,8 +67,8 @@ use prebindgen::{
     core::Registry,
     data_class, enum_class, flatten_input, flatten_output, fun, function_flatten_input,
     function_flatten_output,
-    lang::{JniGen, JniGenConfig, PackageDecl, ScalarTypeWrapperDecl},
-    ptr_class, value_class,
+    lang::{JniGen, JniGenConfig},
+    package, ptr_class, scalar_type_wrapper, value_class,
 };
 use syn::parse_quote as pq;
 
@@ -96,17 +96,17 @@ fn main() {
     // generated class) — global, not tied to any package (see the `decl`
     // module doc for why a scalar wrapper never needs package placement).
     .scalar_type_wrapper(
-        ScalarTypeWrapperDecl::new(pq!(Millis), pq!(jni::sys::jlong), "Long")
+        scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")
             .input(|v| pq!(perftest_flat::Millis(*#v as u64)))
             .output(|v| pq!(#v.0 as jni::sys::jlong)),
     )
     // ── Base-package types ──────────────────────────────────────────────
     // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
     // reassembled via a generated `fromParts`).
-    .package(PackageDecl::new("").class(data_class!(Payload)))
+    .package(package!().class(data_class!(Payload)))
     // ── Subpackage `model`: enum + value class + nested data class ──────
     .package(
-        PackageDecl::new("model")
+        package!("model")
             // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
             .class(enum_class!(Priority))
             // `Annotated` exercises a NESTED data-class field (`payload`,
@@ -124,7 +124,7 @@ fn main() {
     )
     // ── Subpackage `errors`: the Result error channel ───────────────────
     .package(
-        PackageDecl::new("errors").class(
+        package!("errors").class(
             // `StorageError` is the `E` of a fallible `Result`. Declaring it a
             // ptr_class with a flatten-output makes the generated `onError`
             // handler receive the flattened fields: the `message` string plus —
@@ -137,7 +137,7 @@ fn main() {
     )
     // ── Subpackage `analytics`: flatten input/output on `Summary` ───────
     .package(
-        PackageDecl::new("analytics")
+        package!("analytics")
             // `Summary` is an opaque handle whose default boundary shape is its
             // `(count, total)` leaves: flatten-output decomposes it, flatten-input
             // rebuilds it (via the `of` constructor) or accepts a handle.
@@ -161,7 +161,7 @@ fn main() {
     // Back in the base package so the typed handle classes live alongside
     // `Payload`.
     .package(
-        PackageDecl::new("")
+        package!()
             .class(
                 ptr_class!(Storage)
                     .accessor(fun!(storage_len).name("len"))
@@ -181,7 +181,7 @@ fn main() {
     // model: enum return/param/option + value-class return + Vec<value> +
     //        Option<scalar>.
     .package(
-        PackageDecl::new("model")
+        package!("model")
             .fun(fun!(payload_priority))
             .fun(fun!(priority_weight))
             .fun(fun!(priority_or))
@@ -195,7 +195,7 @@ fn main() {
     )
     // analytics: the flatten matrix (default / suppress / with, in + out).
     .package(
-        PackageDecl::new("analytics")
+        package!("analytics")
             .fun(fun!(storage_summary))
             .fun(fun!(storage_matches_summary))
             .fun(fun!(storage_summary_handle).flatten_output_suppress())
@@ -222,7 +222,7 @@ fn main() {
     // storage: the perf surface (handles, callbacks, Vec, Option) plus the
     // fallible constructor and the Millis wrapper.
     .package(
-        PackageDecl::new("storage")
+        package!("storage")
             .fun(fun!(storage_new))
             .fun(fun!(storage_get))
             .fun(fun!(storage_put_by_take))
@@ -255,7 +255,7 @@ fn main() {
     // base-package classes). (`string_len` stays undeclared like the
     // `storage_get_into_*` group: its `&String` param / `usize` return are
     // C-tier shapes with no JVM mapping.)
-    .package(PackageDecl::new("").fun(fun!(string_new)));
+    .package(package!().fun(fun!(string_new)));
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -135,8 +135,8 @@ fn main() {
             // owned `StorageError` the handler must `close()`).
             ptr_class!(StorageError)
                 .fun(fun!(storage_error_message).name("message"))
-                .default_return_field(fun!(storage_error_message).name("message"))
-                .default_return_field_self(),
+                .default_return_expand(fun!(storage_error_message).name("message"))
+                .default_return_expand_self(),
         ),
     )
     // ── Subpackage `analytics`: param-variant / return-field defaults on `Summary`
@@ -151,10 +151,10 @@ fn main() {
                     .fun(fun!(summary_count).name("count"))
                     .fun(fun!(summary_total).name("total"))
                     .fun(fun!(summary_scaled).name("scaled"))
-                    .default_param_variant(fun!(summary_new))
-                    .default_param_variant_self()
-                    .default_return_field(fun!(summary_count).name("count"))
-                    .default_return_field(fun!(summary_total).name("total")),
+                    .default_param_expand(fun!(summary_new))
+                    .default_param_expand_self()
+                    .default_return_expand(fun!(summary_count).name("count"))
+                    .default_return_expand(fun!(summary_total).name("total")),
             )
             // `Archive` holds the latest `Summary` and returns it BORROWED
             // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -204,25 +204,25 @@ fn main() {
         package!("analytics")
             .fun(fun!(storage_summary))
             .fun(fun!(storage_matches_summary))
-            .fun(fun!(storage_summary_handle).return_field_self())
-            .fun(fun!(summary_total_raw).param_variant_self(pq!(s)))
+            .fun(fun!(storage_summary_handle).return_expand_self())
+            .fun(fun!(summary_total_raw).param_expand_self(pq!(s)))
             .fun(
                 fun!(storage_summary_full)
-                    .return_field(fun!(summary_count).name("count"))
-                    .return_field(fun!(summary_total).name("total"))
-                    .return_field_self(),
+                    .return_expand(fun!(summary_count).name("count"))
+                    .return_expand(fun!(summary_total).name("total"))
+                    .return_expand_self(),
             )
             .fun(
                 fun!(storage_expect_summary)
-                    .param_variant(pq!(expected), fun!(summary_new))
-                    .param_variant_self(pq!(expected)),
+                    .param_expand(pq!(expected), fun!(summary_new))
+                    .param_expand_self(pq!(expected)),
             )
             // The borrowed-accessor trio. `archive_latest` suppresses the default
             // Summary return-field default so the BORROWED handle path (clone into a
             // fresh owned handle, null when absent) is what crosses.
             .fun(fun!(archive_new))
             .fun(fun!(archive_store))
-            .fun(fun!(archive_latest).return_field_self()),
+            .fun(fun!(archive_latest).return_expand_self()),
     )
     // storage: the perf surface (handles, callbacks, Vec, Option) plus the
     // fallible constructor and the Millis wrapper.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -24,15 +24,15 @@
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
-//! | `.default_param_variant()` (+`_self`)| `Summary` default input |
-//! | `.default_return_field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
+//! | `.default_param_expand()` (+`_self`)| `Summary` default input |
+//! | `.default_return_expand()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
-//! | `.param_variant_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
-//! | `.return_field_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
-//! | per-fn `.param_variant(param, …)` (+`_self`)| `storage_expect_summary` |
-//! | per-fn `.return_field(…)` (+`_self`) | `storage_summary_full` |
+//! | `.param_expand_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
+//! | `.return_expand_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
+//! | per-fn `.param_expand(param, …)` (+`_self`)| `storage_expect_summary` |
+//! | per-fn `.return_expand(…)` (+`_self`) | `storage_summary_full` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -131,7 +131,7 @@ fn main() {
             // `StorageError` is the `E` of a fallible `Result`. Declaring it a
             // ptr_class with a a default return-field list makes the generated `onError`
             // handler receive the decomposed fields: the `message` string plus —
-            // via `.default_return_field_self()` — the error handle itself (an
+            // via `.default_return_expand_self()` — the error handle itself (an
             // owned `StorageError` the handler must `close()`).
             ptr_class!(StorageError)
                 .fun(fun!(storage_error_message).name("message"))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -65,12 +65,10 @@
 
 use prebindgen::{
     core::Registry,
-    ident,
-    lang::{
-        DataClassDecl, EnumClassDecl, FlattenInput, FlattenOutput, FunctionDecl,
-        FunctionFlattenInput, FunctionFlattenOutput, JniGen, JniGenConfig, PackageDecl,
-        PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
-    },
+    data_class, enum_class, flatten_input, flatten_output, fun, function_flatten_input,
+    function_flatten_output,
+    lang::{JniGen, JniGenConfig, PackageDecl, ScalarTypeWrapperDecl},
+    ptr_class, value_class,
 };
 use syn::parse_quote as pq;
 
@@ -105,23 +103,23 @@ fn main() {
     // ── Base-package types ──────────────────────────────────────────────
     // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
     // reassembled via a generated `fromParts`).
-    .package(PackageDecl::new("").class(DataClassDecl::new(pq!(Payload))))
+    .package(PackageDecl::new("").class(data_class!(Payload)))
     // ── Subpackage `model`: enum + value class + nested data class ──────
     .package(
         PackageDecl::new("model")
             // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
-            .class(EnumClassDecl::new(pq!(Priority)))
+            .class(enum_class!(Priority))
             // `Annotated` exercises a NESTED data-class field (`payload`,
             // recursive fromParts / recursive leaf decode) plus Option<prim> and
             // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
-            .class(DataClassDecl::new(pq!(Annotated)))
+            .class(data_class!(Annotated))
             // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
             // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
             // surfaces as `List<ByteArray>`.
             .class(
-                ValueClassDecl::new(pq!(Stamp))
-                    .accessor(ident!(stamp_secs), "secs")
-                    .accessor(ident!(stamp_nanos), "nanos"),
+                value_class!(Stamp)
+                    .accessor(fun!(stamp_secs).name("secs"))
+                    .accessor(fun!(stamp_nanos).name("nanos")),
             ),
     )
     // ── Subpackage `errors`: the Result error channel ───────────────────
@@ -132,9 +130,9 @@ fn main() {
             // handler receive the flattened fields: the `message` string plus —
             // via the TYPE-LEVEL `.field_self()` — the error handle itself (an
             // owned `StorageError` the handler must `close()`).
-            PtrClassDecl::new(pq!(StorageError))
-                .accessor(ident!(storage_error_message), "message")
-                .flatten_output(FlattenOutput::new().field("message").field_self()),
+            ptr_class!(StorageError)
+                .accessor(fun!(storage_error_message).name("message"))
+                .flatten_output(flatten_output!().field("message").field_self()),
         ),
     )
     // ── Subpackage `analytics`: flatten input/output on `Summary` ───────
@@ -144,20 +142,20 @@ fn main() {
             // `(count, total)` leaves: flatten-output decomposes it, flatten-input
             // rebuilds it (via the `of` constructor) or accepts a handle.
             .class(
-                PtrClassDecl::new(pq!(Summary))
-                    .constructor(ident!(summary_new), "of")
-                    .accessor(ident!(summary_count), "count")
-                    .accessor(ident!(summary_total), "total")
-                    .method(ident!(summary_scaled), "scaled")
-                    .flatten_input(FlattenInput::new().variant("of").variant_self())
-                    .flatten_output(FlattenOutput::new().field("count").field("total")),
+                ptr_class!(Summary)
+                    .constructor(fun!(summary_new).name("of"))
+                    .accessor(fun!(summary_count).name("count"))
+                    .accessor(fun!(summary_total).name("total"))
+                    .method(fun!(summary_scaled).name("scaled"))
+                    .flatten_input(flatten_input!().variant("of").variant_self())
+                    .flatten_output(flatten_output!().field("count").field("total")),
             )
             // `Archive` holds the latest `Summary` and returns it BORROWED
             // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
             // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
             // RENAMED via the per-declaration `.name()` override (the type-level
             // dual of the per-fn `.name`; literal, bypasses the mangle closures).
-            .class(PtrClassDecl::new(pq!(Archive)).name("SummaryVault")),
+            .class(ptr_class!(Archive).name("SummaryVault")),
     )
     // ── Base-package handle type: `Storage` + scalar members ────────────
     // Back in the base package so the typed handle classes live alongside
@@ -165,99 +163,99 @@ fn main() {
     .package(
         PackageDecl::new("")
             .class(
-                PtrClassDecl::new(pq!(Storage))
-                    .accessor(ident!(storage_len), "len")
-                    .method(ident!(storage_contains), "contains")
-                    .constructor(ident!(storage_with_payload), "withPayload"),
+                ptr_class!(Storage)
+                    .accessor(fun!(storage_len).name("len"))
+                    .method(fun!(storage_contains).name("contains"))
+                    .constructor(fun!(storage_with_payload).name("withPayload")),
             )
             // The callback-handler handles (single payload / whole batch / owned
             // storage handle).
-            .class(PtrClassDecl::new(pq!(PayloadHandler)))
+            .class(ptr_class!(PayloadHandler))
             // `StorageHandler`'s callback receives an OWNED opaque handle
             // (`Fn(Storage)`): the raw pointer crosses and the generated Kotlin
             // proxy wraps it into a typed `Storage` and closes it after `run`.
-            .class(PtrClassDecl::new(pq!(StorageHandler)))
-            .class(PtrClassDecl::new(pq!(PayloadVecHandler))),
+            .class(ptr_class!(StorageHandler))
+            .class(ptr_class!(PayloadVecHandler)),
     )
     // ── Free functions, grouped by subpackage ───────────────────────────
     // model: enum return/param/option + value-class return + Vec<value> +
     //        Option<scalar>.
     .package(
         PackageDecl::new("model")
-            .fun(ident!(payload_priority))
-            .fun(ident!(priority_weight))
-            .fun(ident!(priority_or))
-            .fun(ident!(stamp_new))
-            .fun(ident!(stamp_series))
-            .fun(ident!(payload_label_len))
-            .fun(ident!(annotated_new))
-            .fun(ident!(annotated_ttl))
-            .fun(ident!(annotated_priority))
-            .fun(ident!(annotated_payload_value)),
+            .fun(fun!(payload_priority))
+            .fun(fun!(priority_weight))
+            .fun(fun!(priority_or))
+            .fun(fun!(stamp_new))
+            .fun(fun!(stamp_series))
+            .fun(fun!(payload_label_len))
+            .fun(fun!(annotated_new))
+            .fun(fun!(annotated_ttl))
+            .fun(fun!(annotated_priority))
+            .fun(fun!(annotated_payload_value)),
     )
     // analytics: the flatten matrix (default / suppress / with, in + out).
     .package(
         PackageDecl::new("analytics")
-            .fun(ident!(storage_summary))
-            .fun(ident!(storage_matches_summary))
-            .fun(FunctionDecl::new(pq!(storage_summary_handle)).flatten_output_suppress())
-            .fun(FunctionDecl::new(pq!(summary_total_raw)).flatten_input_suppress(pq!(s)))
-            .fun(FunctionDecl::new(pq!(storage_summary_full)).flatten_output_with(
-                FunctionFlattenOutput::new()
-                    .field(ident!(summary_count), "count")
-                    .field(ident!(summary_total), "total")
+            .fun(fun!(storage_summary))
+            .fun(fun!(storage_matches_summary))
+            .fun(fun!(storage_summary_handle).flatten_output_suppress())
+            .fun(fun!(summary_total_raw).flatten_input_suppress(pq!(s)))
+            .fun(fun!(storage_summary_full).flatten_output_with(
+                function_flatten_output!()
+                    .field(fun!(summary_count).name("count"))
+                    .field(fun!(summary_total).name("total"))
                     .field_self(),
             ))
-            .fun(FunctionDecl::new(pq!(storage_expect_summary)).flatten_input_with(
+            .fun(fun!(storage_expect_summary).flatten_input_with(
                 pq!(expected),
-                FunctionFlattenInput::new()
-                    .variant(ident!(summary_new))
+                function_flatten_input!()
+                    .variant(fun!(summary_new))
                     .variant_self(),
             ))
             // The borrowed-accessor trio. `archive_latest` suppresses the default
             // Summary output flatten so the BORROWED handle path (clone into a
             // fresh owned handle, null when absent) is what crosses.
-            .fun(ident!(archive_new))
-            .fun(ident!(archive_store))
-            .fun(FunctionDecl::new(pq!(archive_latest)).flatten_output_suppress()),
+            .fun(fun!(archive_new))
+            .fun(fun!(archive_store))
+            .fun(fun!(archive_latest).flatten_output_suppress()),
     )
     // storage: the perf surface (handles, callbacks, Vec, Option) plus the
     // fallible constructor and the Millis wrapper.
     .package(
         PackageDecl::new("storage")
-            .fun(ident!(storage_new))
-            .fun(ident!(storage_get))
-            .fun(ident!(storage_put_by_take))
-            .fun(ident!(storage_put_by_read))
-            .fun(ident!(storage_put_slice))
-            .fun(ident!(storage_get_vec))
-            .fun(ident!(payload_handler_new))
-            .fun(ident!(storage_callback))
-            .fun(ident!(payload_vec_handler_new))
-            .fun(ident!(storage_callback_vec))
-            .fun(ident!(storage_try_with_label))
+            .fun(fun!(storage_new))
+            .fun(fun!(storage_get))
+            .fun(fun!(storage_put_by_take))
+            .fun(fun!(storage_put_by_read))
+            .fun(fun!(storage_put_slice))
+            .fun(fun!(storage_get_vec))
+            .fun(fun!(payload_handler_new))
+            .fun(fun!(storage_callback))
+            .fun(fun!(payload_vec_handler_new))
+            .fun(fun!(storage_callback_vec))
+            .fun(fun!(storage_try_with_label))
             // Vec<opaque-handle> returns (plain + under the Option niche).
-            .fun(ident!(storage_shards))
-            .fun(ident!(storage_shards_opt))
+            .fun(fun!(storage_shards))
+            .fun(fun!(storage_shards_opt))
             // Owned-handle-in-callback pair.
-            .fun(ident!(storage_handler_new))
-            .fun(ident!(storage_emit))
+            .fun(fun!(storage_handler_new))
+            .fun(fun!(storage_emit))
             // A 3-opaque-handle call (sorted N-ary handle locking).
-            .fun(ident!(storage_total_len))
+            .fun(fun!(storage_total_len))
             // Vec<String> return (single-leaf string fold).
-            .fun(ident!(storage_labels))
+            .fun(fun!(storage_labels))
             // Option<data-class> input.
-            .fun(ident!(storage_put_opt))
+            .fun(fun!(storage_put_opt))
             // `.name(...)`: per-function Kotlin rename override. The default name
             // would be `millisAdd`; force it to `addMillis` to exercise the
             // override path (the Rust symbol/extern is unaffected).
-            .fun(FunctionDecl::new(pq!(millis_add)).name("addMillis")),
+            .fun(fun!(millis_add).name("addMillis")),
     )
     // Plain String return, declared in the BASE package (mirroring the
     // base-package classes). (`string_len` stays undeclared like the
     // `storage_get_into_*` group: its `&String` param / `usize` return are
     // C-tier shapes with no JVM mapping.)
-    .package(PackageDecl::new("").fun(ident!(string_new)));
+    .package(PackageDecl::new("").fun(fun!(string_new)));
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -65,6 +65,7 @@
 
 use prebindgen::{
     core::Registry,
+    ident,
     lang::{
         DataClassDecl, EnumClassDecl, FlattenInput, FlattenOutput, FunctionDecl,
         FunctionFlattenInput, FunctionFlattenOutput, JniGen, JniGenConfig, PackageDecl,
@@ -119,8 +120,8 @@ fn main() {
             // surfaces as `List<ByteArray>`.
             .class(
                 ValueClassDecl::new(pq!(Stamp))
-                    .accessor(pq!(stamp_secs), "secs")
-                    .accessor(pq!(stamp_nanos), "nanos"),
+                    .accessor(ident!(stamp_secs), "secs")
+                    .accessor(ident!(stamp_nanos), "nanos"),
             ),
     )
     // ── Subpackage `errors`: the Result error channel ───────────────────
@@ -132,7 +133,7 @@ fn main() {
             // via the TYPE-LEVEL `.field_self()` — the error handle itself (an
             // owned `StorageError` the handler must `close()`).
             PtrClassDecl::new(pq!(StorageError))
-                .accessor(pq!(storage_error_message), "message")
+                .accessor(ident!(storage_error_message), "message")
                 .flatten_output(FlattenOutput::new().field("message").field_self()),
         ),
     )
@@ -144,10 +145,10 @@ fn main() {
             // rebuilds it (via the `of` constructor) or accepts a handle.
             .class(
                 PtrClassDecl::new(pq!(Summary))
-                    .constructor(pq!(summary_new), "of")
-                    .accessor(pq!(summary_count), "count")
-                    .accessor(pq!(summary_total), "total")
-                    .method(pq!(summary_scaled), "scaled")
+                    .constructor(ident!(summary_new), "of")
+                    .accessor(ident!(summary_count), "count")
+                    .accessor(ident!(summary_total), "total")
+                    .method(ident!(summary_scaled), "scaled")
                     .flatten_input(FlattenInput::new().variant("of").variant_self())
                     .flatten_output(FlattenOutput::new().field("count").field("total")),
             )
@@ -165,9 +166,9 @@ fn main() {
         PackageDecl::new("")
             .class(
                 PtrClassDecl::new(pq!(Storage))
-                    .accessor(pq!(storage_len), "len")
-                    .method(pq!(storage_contains), "contains")
-                    .constructor(pq!(storage_with_payload), "withPayload"),
+                    .accessor(ident!(storage_len), "len")
+                    .method(ident!(storage_contains), "contains")
+                    .constructor(ident!(storage_with_payload), "withPayload"),
             )
             // The callback-handler handles (single payload / whole batch / owned
             // storage handle).
@@ -183,70 +184,70 @@ fn main() {
     //        Option<scalar>.
     .package(
         PackageDecl::new("model")
-            .fun(FunctionDecl::new(pq!(payload_priority)))
-            .fun(FunctionDecl::new(pq!(priority_weight)))
-            .fun(FunctionDecl::new(pq!(priority_or)))
-            .fun(FunctionDecl::new(pq!(stamp_new)))
-            .fun(FunctionDecl::new(pq!(stamp_series)))
-            .fun(FunctionDecl::new(pq!(payload_label_len)))
-            .fun(FunctionDecl::new(pq!(annotated_new)))
-            .fun(FunctionDecl::new(pq!(annotated_ttl)))
-            .fun(FunctionDecl::new(pq!(annotated_priority)))
-            .fun(FunctionDecl::new(pq!(annotated_payload_value))),
+            .fun(ident!(payload_priority))
+            .fun(ident!(priority_weight))
+            .fun(ident!(priority_or))
+            .fun(ident!(stamp_new))
+            .fun(ident!(stamp_series))
+            .fun(ident!(payload_label_len))
+            .fun(ident!(annotated_new))
+            .fun(ident!(annotated_ttl))
+            .fun(ident!(annotated_priority))
+            .fun(ident!(annotated_payload_value)),
     )
     // analytics: the flatten matrix (default / suppress / with, in + out).
     .package(
         PackageDecl::new("analytics")
-            .fun(FunctionDecl::new(pq!(storage_summary)))
-            .fun(FunctionDecl::new(pq!(storage_matches_summary)))
+            .fun(ident!(storage_summary))
+            .fun(ident!(storage_matches_summary))
             .fun(FunctionDecl::new(pq!(storage_summary_handle)).flatten_output_suppress())
             .fun(FunctionDecl::new(pq!(summary_total_raw)).flatten_input_suppress(pq!(s)))
             .fun(FunctionDecl::new(pq!(storage_summary_full)).flatten_output_with(
                 FunctionFlattenOutput::new()
-                    .field(pq!(summary_count), "count")
-                    .field(pq!(summary_total), "total")
+                    .field(ident!(summary_count), "count")
+                    .field(ident!(summary_total), "total")
                     .field_self(),
             ))
             .fun(FunctionDecl::new(pq!(storage_expect_summary)).flatten_input_with(
                 pq!(expected),
                 FunctionFlattenInput::new()
-                    .variant(pq!(summary_new))
+                    .variant(ident!(summary_new))
                     .variant_self(),
             ))
             // The borrowed-accessor trio. `archive_latest` suppresses the default
             // Summary output flatten so the BORROWED handle path (clone into a
             // fresh owned handle, null when absent) is what crosses.
-            .fun(FunctionDecl::new(pq!(archive_new)))
-            .fun(FunctionDecl::new(pq!(archive_store)))
+            .fun(ident!(archive_new))
+            .fun(ident!(archive_store))
             .fun(FunctionDecl::new(pq!(archive_latest)).flatten_output_suppress()),
     )
     // storage: the perf surface (handles, callbacks, Vec, Option) plus the
     // fallible constructor and the Millis wrapper.
     .package(
         PackageDecl::new("storage")
-            .fun(FunctionDecl::new(pq!(storage_new)))
-            .fun(FunctionDecl::new(pq!(storage_get)))
-            .fun(FunctionDecl::new(pq!(storage_put_by_take)))
-            .fun(FunctionDecl::new(pq!(storage_put_by_read)))
-            .fun(FunctionDecl::new(pq!(storage_put_slice)))
-            .fun(FunctionDecl::new(pq!(storage_get_vec)))
-            .fun(FunctionDecl::new(pq!(payload_handler_new)))
-            .fun(FunctionDecl::new(pq!(storage_callback)))
-            .fun(FunctionDecl::new(pq!(payload_vec_handler_new)))
-            .fun(FunctionDecl::new(pq!(storage_callback_vec)))
-            .fun(FunctionDecl::new(pq!(storage_try_with_label)))
+            .fun(ident!(storage_new))
+            .fun(ident!(storage_get))
+            .fun(ident!(storage_put_by_take))
+            .fun(ident!(storage_put_by_read))
+            .fun(ident!(storage_put_slice))
+            .fun(ident!(storage_get_vec))
+            .fun(ident!(payload_handler_new))
+            .fun(ident!(storage_callback))
+            .fun(ident!(payload_vec_handler_new))
+            .fun(ident!(storage_callback_vec))
+            .fun(ident!(storage_try_with_label))
             // Vec<opaque-handle> returns (plain + under the Option niche).
-            .fun(FunctionDecl::new(pq!(storage_shards)))
-            .fun(FunctionDecl::new(pq!(storage_shards_opt)))
+            .fun(ident!(storage_shards))
+            .fun(ident!(storage_shards_opt))
             // Owned-handle-in-callback pair.
-            .fun(FunctionDecl::new(pq!(storage_handler_new)))
-            .fun(FunctionDecl::new(pq!(storage_emit)))
+            .fun(ident!(storage_handler_new))
+            .fun(ident!(storage_emit))
             // A 3-opaque-handle call (sorted N-ary handle locking).
-            .fun(FunctionDecl::new(pq!(storage_total_len)))
+            .fun(ident!(storage_total_len))
             // Vec<String> return (single-leaf string fold).
-            .fun(FunctionDecl::new(pq!(storage_labels)))
+            .fun(ident!(storage_labels))
             // Option<data-class> input.
-            .fun(FunctionDecl::new(pq!(storage_put_opt)))
+            .fun(ident!(storage_put_opt))
             // `.name(...)`: per-function Kotlin rename override. The default name
             // would be `millisAdd`; force it to `addMillis` to exercise the
             // override path (the Rust symbol/extern is unaffected).
@@ -256,7 +257,7 @@ fn main() {
     // base-package classes). (`string_len` stays undeclared like the
     // `storage_get_into_*` group: its `&String` param / `usize` return are
     // C-tier shapes with no JVM mapping.)
-    .package(PackageDecl::new("").fun(FunctionDecl::new(pq!(string_new))));
+    .package(PackageDecl::new("").fun(ident!(string_new)));
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -44,6 +44,7 @@
 //! | `String` return                      | `string_new` |
 //! | binding-error channel (`je != null`) | malformed `Stamp` bytes (value-blob length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
+//! | `JniGen::ignore_fun`                 | `string_len` / `storage_get_into_*` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
 //!
 //! One feature is deliberately left at its default and documented rather than
 //! toggled, because it is mutually exclusive with a richer path this example
@@ -59,9 +60,12 @@
 //! per-kind name hooks (≡ the identity closures registered here) — which are
 //! binding-exclusive like the lock toggle above and add no code-path coverage.
 //!
-//! One perf-surface function stays undeclared like the `storage_get_into_*`
-//! group: `string_len` (`&String` param / `usize` return are C-tier shapes with
-//! no JVM mapping).
+//! Four functions are deliberately NOT wrapped — their shapes are C-tier
+//! with no JVM mapping (`string_len`'s `&String` param / `usize` return, the
+//! `storage_get_into_*` out-param group, `storage_put_by_read_and_update`'s
+//! read-write borrow) — and are acknowledged via `JniGen::ignore_fun`, which
+//! suppresses the per-item "skipping undeclared" build warning while
+//! emitting nothing.
 
 use prebindgen::{
     core::Registry,
@@ -253,10 +257,15 @@ fn main() {
             .fun(fun!(millis_add).name("addMillis")),
     )
     // Plain String return, declared in the BASE package (mirroring the
-    // base-package classes). (`string_len` stays undeclared like the
-    // `storage_get_into_*` group: its `&String` param / `usize` return are
-    // C-tier shapes with no JVM mapping.)
-    .package(package!().fun(fun!(string_new)));
+    // base-package classes).
+    .package(package!().fun(fun!(string_new)))
+    // The deliberately-unbound group (C-tier shapes with no JVM mapping):
+    // acknowledged so the build log stays free of "skipping undeclared"
+    // warnings without emitting anything.
+    .ignore_fun(fun!(string_len))
+    .ignore_fun(fun!(storage_get_into_init))
+    .ignore_fun(fun!(storage_get_into_uninit))
+    .ignore_fun(fun!(storage_put_by_read_and_update));
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -13,10 +13,10 @@
 //!
 //! | JniGen feature                       | Exercised by |
 //! |--------------------------------------|--------------|
-//! | `JniGenConfig::source_module`        | `perftest_flat` |
-//! | `JniGenConfig::package_prefix`       | `io.prebindgen.covertest` |
+//! | `JniGen::set_source_module`        | `perftest_flat` |
+//! | `JniGen::set_package_prefix`       | `io.prebindgen.covertest` |
 //! | `JniGen::package` (subpackages)      | `model` / `errors` / `analytics` / `storage` |
-//! | `JniGenConfig::jni_native_init`      | `NativeLibrary.ensureLoaded()` |
+//! | `JniGen::set_jni_native_init`      | `NativeLibrary.ensureLoaded()` |
 //! | 5 name-mangle closures               | harness (`Cov*`) + the four per-kind hooks |
 //! | `DataClassDecl`                      | `Payload`; `Annotated` (NESTED field + `Option<prim>`/`Option<enum>` fields) |
 //! | `PtrClassDecl`                       | `Storage` / `Summary` / `StorageError` / `Archive` / handlers |
@@ -49,7 +49,7 @@
 //! One feature is deliberately left at its default and documented rather than
 //! toggled, because it is mutually exclusive with a richer path this example
 //! prefers to keep covered:
-//!   * `JniGenConfig::disable_handle_locks` — kept ENABLED (default). Toggling
+//!   * `JniGen::set_emit_handle_locks` — kept ENABLED (default). Toggling
 //!     it OFF would remove the `withSortedHandleLocks` codegen this example
 //!     asserts against; a single binding can only be in one lock mode, so we
 //!     keep the locked one.
@@ -70,7 +70,7 @@
 use prebindgen::{
     core::Registry,
     data_class, enum_class, fun,
-    lang::{JniGen, JniGenConfig},
+    lang::JniGen,
     package, ptr_class, scalar_type_wrapper, value_class,
 };
 use syn::parse_quote as pq;
@@ -78,23 +78,21 @@ use syn::parse_quote as pq;
 fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(pq!(perftest_flat))
-            .package_prefix("io.prebindgen.covertest")
-            .jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
+    let jni = JniGen::new()
+            .set_source_module(pq!(perftest_flat))
+            .set_package_prefix("io.prebindgen.covertest")
+            .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
             // All five per-kind name-mangle hooks are registered. The harness hook
             // is a real transform (`Native` → `CovNative`, an internal symbol so it
             // needs no Kotlin-side coordination); the other four are the identity
             // (the domain names are already the desired Kotlin names) — registering
             // them still exercises the customization API and its `Some(closure)`
             // path.
-            .kotlin_harness_name_mangle(|n| format!("Cov{n}"))
-            .kotlin_fun_name_mangle(|n| n.to_string())
-            .kotlin_ptr_class_name_mangle(|n| n.to_string())
-            .kotlin_data_class_name_mangle(|n| n.to_string())
-            .kotlin_enum_name_mangle(|n| n.to_string()),
-    )
+            .set_kotlin_harness_name_mangle(|n| format!("Cov{n}"))
+            .set_kotlin_fun_name_mangle(|n| n.to_string())
+            .set_kotlin_ptr_class_name_mangle(|n| n.to_string())
+            .set_kotlin_data_class_name_mangle(|n| n.to_string())
+            .set_kotlin_enum_name_mangle(|n| n.to_string())
     // `Millis` newtype: a custom scalar wire mapping to a bare `Long` (no
     // generated class) — global, not tied to any package (see the `decl`
     // module doc for why a scalar wrapper never needs package placement).

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -24,15 +24,15 @@
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
-//! | `.flatten_input()` (+`_self`)        | `Summary` default input |
-//! | `.flatten_output()` (+`_self`)        | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
+//! | `.default_param_variant()` (+`_self`)| `Summary` default input |
+//! | `.default_return_field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
-//! | `.flatten_input_suppress()`          | `summary_total_raw` |
-//! | `.flatten_output_suppress()`         | `storage_summary_handle` / `archive_latest` |
-//! | per-fn `.flatten_input(param, …)` (+`_self`)| `storage_expect_summary` |
-//! | per-fn `.flatten_output(…)` (+`_self`)| `storage_summary_full` |
+//! | `.param_variant_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
+//! | `.return_field_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
+//! | per-fn `.param_variant(param, …)` (+`_self`)| `storage_expect_summary` |
+//! | per-fn `.return_field(…)` (+`_self`) | `storage_summary_full` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -129,21 +129,21 @@ fn main() {
     .package(
         package!("errors").class(
             // `StorageError` is the `E` of a fallible `Result`. Declaring it a
-            // ptr_class with a flatten-output makes the generated `onError`
-            // handler receive the flattened fields: the `message` string plus —
-            // via `.flatten_output_self()` — the error handle itself (an
+            // ptr_class with a a default return-field list makes the generated `onError`
+            // handler receive the decomposed fields: the `message` string plus —
+            // via `.default_return_field_self()` — the error handle itself (an
             // owned `StorageError` the handler must `close()`).
             ptr_class!(StorageError)
                 .fun(fun!(storage_error_message).name("message"))
-                .flatten_output(fun!(storage_error_message).name("message"))
-                .flatten_output_self(),
+                .default_return_field(fun!(storage_error_message).name("message"))
+                .default_return_field_self(),
         ),
     )
-    // ── Subpackage `analytics`: flatten input/output on `Summary` ───────
+    // ── Subpackage `analytics`: param-variant / return-field defaults on `Summary`
     .package(
         package!("analytics")
             // `Summary` is an opaque handle whose default boundary shape is its
-            // `(count, total)` leaves: flatten-output decomposes it, flatten-input
+            // `(count, total)` leaves: the return-field default decomposes it, the param-variant default
             // rebuilds it (via the `of` constructor) or accepts a handle.
             .class(
                 ptr_class!(Summary)
@@ -151,10 +151,10 @@ fn main() {
                     .fun(fun!(summary_count).name("count"))
                     .fun(fun!(summary_total).name("total"))
                     .fun(fun!(summary_scaled).name("scaled"))
-                    .flatten_input(fun!(summary_new))
-                    .flatten_input_self()
-                    .flatten_output(fun!(summary_count).name("count"))
-                    .flatten_output(fun!(summary_total).name("total")),
+                    .default_param_variant(fun!(summary_new))
+                    .default_param_variant_self()
+                    .default_return_field(fun!(summary_count).name("count"))
+                    .default_return_field(fun!(summary_total).name("total")),
             )
             // `Archive` holds the latest `Summary` and returns it BORROWED
             // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -199,30 +199,30 @@ fn main() {
             .fun(fun!(annotated_priority))
             .fun(fun!(annotated_payload_value)),
     )
-    // analytics: the flatten matrix (default / suppress / with, in + out).
+    // analytics: the param-variant / return-field matrix (class default / raw-self override / per-fn override, in + out).
     .package(
         package!("analytics")
             .fun(fun!(storage_summary))
             .fun(fun!(storage_matches_summary))
-            .fun(fun!(storage_summary_handle).flatten_output_suppress())
-            .fun(fun!(summary_total_raw).flatten_input_suppress(pq!(s)))
+            .fun(fun!(storage_summary_handle).return_field_self())
+            .fun(fun!(summary_total_raw).param_variant_self(pq!(s)))
             .fun(
                 fun!(storage_summary_full)
-                    .flatten_output(fun!(summary_count).name("count"))
-                    .flatten_output(fun!(summary_total).name("total"))
-                    .flatten_output_self(),
+                    .return_field(fun!(summary_count).name("count"))
+                    .return_field(fun!(summary_total).name("total"))
+                    .return_field_self(),
             )
             .fun(
                 fun!(storage_expect_summary)
-                    .flatten_input(pq!(expected), fun!(summary_new))
-                    .flatten_input_self(pq!(expected)),
+                    .param_variant(pq!(expected), fun!(summary_new))
+                    .param_variant_self(pq!(expected)),
             )
             // The borrowed-accessor trio. `archive_latest` suppresses the default
-            // Summary output flatten so the BORROWED handle path (clone into a
+            // Summary return-field default so the BORROWED handle path (clone into a
             // fresh owned handle, null when absent) is what crosses.
             .fun(fun!(archive_new))
             .fun(fun!(archive_store))
-            .fun(fun!(archive_latest).flatten_output_suppress()),
+            .fun(fun!(archive_latest).return_field_self()),
     )
     // storage: the perf surface (handles, callbacks, Vec, Option) plus the
     // fallible constructor and the Millis wrapper.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -23,9 +23,9 @@
 //! | `EnumClassDecl`                      | `Priority` |
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
-//! | `.accessor()` / `.method()` / `.constructor()`| `Storage` + `Summary` + `Stamp` members |
-//! | `.flatten_input()` (+`.variant()`/self)| `Summary` default input |
-//! | `.flatten_output()` (+`.field()`/self)| `Summary` fields + `StorageError` `message` + `field_self` (error handle → `onError`) |
+//! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
+//! | `.flatten_input()` (+`_self`)        | `Summary` default input |
+//! | `.flatten_output()` (+`_self`)        | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
@@ -65,8 +65,7 @@
 
 use prebindgen::{
     core::Registry,
-    data_class, enum_class, flatten_input, flatten_output, fun, function_flatten_input,
-    function_flatten_output,
+    data_class, enum_class, fun, function_flatten_input, function_flatten_output,
     lang::{JniGen, JniGenConfig},
     package, ptr_class, scalar_type_wrapper, value_class,
 };
@@ -118,8 +117,8 @@ fn main() {
             // surfaces as `List<ByteArray>`.
             .class(
                 value_class!(Stamp)
-                    .accessor(fun!(stamp_secs).name("secs"))
-                    .accessor(fun!(stamp_nanos).name("nanos")),
+                    .fun(fun!(stamp_secs).name("secs"))
+                    .fun(fun!(stamp_nanos).name("nanos")),
             ),
     )
     // ── Subpackage `errors`: the Result error channel ───────────────────
@@ -128,11 +127,12 @@ fn main() {
             // `StorageError` is the `E` of a fallible `Result`. Declaring it a
             // ptr_class with a flatten-output makes the generated `onError`
             // handler receive the flattened fields: the `message` string plus —
-            // via the TYPE-LEVEL `.field_self()` — the error handle itself (an
+            // via `.flatten_output_self()` — the error handle itself (an
             // owned `StorageError` the handler must `close()`).
             ptr_class!(StorageError)
-                .accessor(fun!(storage_error_message).name("message"))
-                .flatten_output(flatten_output!().field("message").field_self()),
+                .fun(fun!(storage_error_message).name("message"))
+                .flatten_output(fun!(storage_error_message).name("message"))
+                .flatten_output_self(),
         ),
     )
     // ── Subpackage `analytics`: flatten input/output on `Summary` ───────
@@ -144,11 +144,13 @@ fn main() {
             .class(
                 ptr_class!(Summary)
                     .constructor(fun!(summary_new).name("of"))
-                    .accessor(fun!(summary_count).name("count"))
-                    .accessor(fun!(summary_total).name("total"))
-                    .method(fun!(summary_scaled).name("scaled"))
-                    .flatten_input(flatten_input!().variant("of").variant_self())
-                    .flatten_output(flatten_output!().field("count").field("total")),
+                    .fun(fun!(summary_count).name("count"))
+                    .fun(fun!(summary_total).name("total"))
+                    .fun(fun!(summary_scaled).name("scaled"))
+                    .flatten_input(fun!(summary_new))
+                    .flatten_input_self()
+                    .flatten_output(fun!(summary_count).name("count"))
+                    .flatten_output(fun!(summary_total).name("total")),
             )
             // `Archive` holds the latest `Summary` and returns it BORROWED
             // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -164,8 +166,8 @@ fn main() {
         package!()
             .class(
                 ptr_class!(Storage)
-                    .accessor(fun!(storage_len).name("len"))
-                    .method(fun!(storage_contains).name("contains"))
+                    .fun(fun!(storage_len).name("len"))
+                    .fun(fun!(storage_contains).name("contains"))
                     .constructor(fun!(storage_with_payload).name("withPayload")),
             )
             // The callback-handler handles (single payload / whole batch / owned

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -88,18 +88,18 @@ fn main() {
             // (the domain names are already the desired Kotlin names) — registering
             // them still exercises the customization API and its `Some(closure)`
             // path.
-            .set_kotlin_harness_name_mangle(|n| format!("Cov{n}"))
-            .set_kotlin_fun_name_mangle(|n| n.to_string())
-            .set_kotlin_ptr_class_name_mangle(|n| n.to_string())
-            .set_kotlin_data_class_name_mangle(|n| n.to_string())
-            .set_kotlin_enum_name_mangle(|n| n.to_string())
+            .set_harness_name_mangle(|n| format!("Cov{n}"))
+            .set_fun_name_mangle(|n| n.to_string())
+            .set_ptr_class_name_mangle(|n| n.to_string())
+            .set_data_class_name_mangle(|n| n.to_string())
+            .set_enum_name_mangle(|n| n.to_string())
     // `Millis` newtype: a custom scalar wire mapping to a bare `Long` (no
     // generated class) — global, not tied to any package (see the `decl`
     // module doc for why a scalar wrapper never needs package placement).
     .scalar_type_wrapper(
         scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")
-            .input(|v| pq!(perftest_flat::Millis(*#v as u64)))
-            .output(|v| pq!(#v.0 as jni::sys::jlong)),
+            .on_param(|v| pq!(perftest_flat::Millis(*#v as u64)))
+            .on_return(|v| pq!(#v.0 as jni::sys::jlong)),
     )
     // ── Base-package types ──────────────────────────────────────────────
     // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -31,8 +31,8 @@
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `.flatten_input_suppress()`          | `summary_total_raw` |
 //! | `.flatten_output_suppress()`         | `storage_summary_handle` / `archive_latest` |
-//! | `.flatten_input_with()` (+`.variant()`/self)| `storage_expect_summary` |
-//! | `.flatten_output_with()` (+`.field()`/self)| `storage_summary_full` |
+//! | per-fn `.flatten_input(param, …)` (+`_self`)| `storage_expect_summary` |
+//! | per-fn `.flatten_output(…)` (+`_self`)| `storage_summary_full` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -65,7 +65,7 @@
 
 use prebindgen::{
     core::Registry,
-    data_class, enum_class, fun, function_flatten_input, function_flatten_output,
+    data_class, enum_class, fun,
     lang::{JniGen, JniGenConfig},
     package, ptr_class, scalar_type_wrapper, value_class,
 };
@@ -202,18 +202,17 @@ fn main() {
             .fun(fun!(storage_matches_summary))
             .fun(fun!(storage_summary_handle).flatten_output_suppress())
             .fun(fun!(summary_total_raw).flatten_input_suppress(pq!(s)))
-            .fun(fun!(storage_summary_full).flatten_output_with(
-                function_flatten_output!()
-                    .field(fun!(summary_count).name("count"))
-                    .field(fun!(summary_total).name("total"))
-                    .field_self(),
-            ))
-            .fun(fun!(storage_expect_summary).flatten_input_with(
-                pq!(expected),
-                function_flatten_input!()
-                    .variant(fun!(summary_new))
-                    .variant_self(),
-            ))
+            .fun(
+                fun!(storage_summary_full)
+                    .flatten_output(fun!(summary_count).name("count"))
+                    .flatten_output(fun!(summary_total).name("total"))
+                    .flatten_output_self(),
+            )
+            .fun(
+                fun!(storage_expect_summary)
+                    .flatten_input(pq!(expected), fun!(summary_new))
+                    .flatten_input_self(pq!(expected)),
+            )
             // The borrowed-accessor trio. `archive_latest` suppresses the default
             // Summary output flatten so the BORROWED handle path (clone into a
             // fresh owned handle, null when absent) is what crosses.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -5,31 +5,34 @@
 //! Unlike `examples/perftest-kotlin` (which maps only the lean perf surface in
 //! the performance-optimal shape), this binding maps the *same* flat library —
 //! including the coverage-only items in `perftest_flat::ext` — through the full
-//! adapter surface:
+//! adapter surface. `JniGen` accepts pre-built declaration objects (see
+//! `prebindgen::lang::jnigen::jni::decl`) rather than a fluent typestate
+//! chain — each row below is a `PackageDecl`/`ScalarTypeWrapperDecl`/etc. built
+//! independently and then handed to `jni.package(...)` /
+//! `jni.scalar_type_wrapper(...)`:
 //!
 //! | JniGen feature                       | Exercised by |
 //! |--------------------------------------|--------------|
-//! | `source_module`                      | `perftest_flat` |
-//! | `package_prefix`                     | `io.prebindgen.covertest` |
-//! | `package` (subpackages)              | `model` / `errors` / `analytics` / `storage` |
-//! | `jni_native_init`                    | `NativeLibrary.ensureLoaded()` |
-//! | 6 name-mangle closures               | harness (`Cov*`) + the five per-kind hooks |
-//! | `data_class`                         | `Payload`; `Annotated` (NESTED field + `Option<prim>`/`Option<enum>` fields) |
-//! | `ptr_class`                          | `Storage` / `Summary` / `StorageError` / `Archive` / handlers |
-//! | `enum_class`                         | `Priority` |
-//! | `value_class`                        | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
-//! | `kotlin_type`                        | `Millis` → `Long` |
-//! | `accessor` / `method` / `constructor`| `Storage` + `Summary` + `Stamp` members |
-//! | `flatten_input` (+`variant`/self)    | `Summary` default input |
-//! | `flatten_output` (+`field`/self)     | `Summary` fields + `StorageError` `message` + `field_self` (error handle → `onError`) |
-//! | `fun` / `name`                       | every free function; `.name` renames `millis_add` → `addMillis` |
+//! | `JniGenConfig::source_module`        | `perftest_flat` |
+//! | `JniGenConfig::package_prefix`       | `io.prebindgen.covertest` |
+//! | `JniGen::package` (subpackages)      | `model` / `errors` / `analytics` / `storage` |
+//! | `JniGenConfig::jni_native_init`      | `NativeLibrary.ensureLoaded()` |
+//! | 5 name-mangle closures               | harness (`Cov*`) + the four per-kind hooks |
+//! | `DataClassDecl`                      | `Payload`; `Annotated` (NESTED field + `Option<prim>`/`Option<enum>` fields) |
+//! | `PtrClassDecl`                       | `Storage` / `Summary` / `StorageError` / `Archive` / handlers |
+//! | `EnumClassDecl`                      | `Priority` |
+//! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
+//! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
+//! | `.accessor()` / `.method()` / `.constructor()`| `Storage` + `Summary` + `Stamp` members |
+//! | `.flatten_input()` (+`.variant()`/self)| `Summary` default input |
+//! | `.flatten_output()` (+`.field()`/self)| `Summary` fields + `StorageError` `message` + `field_self` (error handle → `onError`) |
+//! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
-//! | base-package functions               | `string_new` (declared after `.package("")`) |
-//! | `flatten_input_suppress`             | `summary_total_raw` |
-//! | `flatten_output_suppress`            | `storage_summary_handle` / `archive_latest` |
-//! | `flatten_input_with` (+`variant`/self)| `storage_expect_summary` |
-//! | `flatten_output_with` (+`field`/self)| `storage_summary_full` |
-//! | `input_wrapper` / `output_wrapper`   | `Millis` ⇄ `Long` |
+//! | base-package functions               | `string_new` (declared in a `PackageDecl::new("")`) |
+//! | `.flatten_input_suppress()`          | `summary_total_raw` |
+//! | `.flatten_output_suppress()`         | `storage_summary_handle` / `archive_latest` |
+//! | `.flatten_input_with()` (+`.variant()`/self)| `storage_expect_summary` |
+//! | `.flatten_output_with()` (+`.field()`/self)| `storage_summary_full` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -45,9 +48,10 @@
 //! One feature is deliberately left at its default and documented rather than
 //! toggled, because it is mutually exclusive with a richer path this example
 //! prefers to keep covered:
-//!   * `disable_handle_locks` — kept ENABLED (default). Toggling it OFF would
-//!     remove the `withSortedHandleLocks` codegen this example asserts against;
-//!     a single binding can only be in one lock mode, so we keep the locked one.
+//!   * `JniGenConfig::disable_handle_locks` — kept ENABLED (default). Toggling
+//!     it OFF would remove the `withSortedHandleLocks` codegen this example
+//!     asserts against; a single binding can only be in one lock mode, so we
+//!     keep the locked one.
 //!
 //! `perftest-kotlin`'s declared surface is a strict subset of this binding
 //! (verified 2026-07-03): its only unique configurations are the unset
@@ -59,195 +63,200 @@
 //! group: `string_len` (`&String` param / `usize` return are C-tier shapes with
 //! no JVM mapping).
 
-use prebindgen::{core::Registry, lang::JniGen};
+use prebindgen::{
+    core::Registry,
+    lang::{
+        DataClassDecl, EnumClassDecl, FlattenInput, FlattenOutput, FunctionDecl,
+        FunctionFlattenInput, FunctionFlattenOutput, JniGen, JniGenConfig, PackageDecl,
+        PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
+    },
+};
 use syn::parse_quote as pq;
 
 fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
-    let jni = JniGen::new()
-        // ── Global configuration ────────────────────────────────────────────
-        .source_module(pq!(perftest_flat))
-        .package_prefix("io.prebindgen.covertest")
-        .jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
-        // All six per-kind name-mangle hooks are registered. The harness hook is
-        // a real transform (`Native` → `CovNative`, an internal symbol so it
-        // needs no Kotlin-side coordination); the other five are the identity
-        // (the domain names are already the desired Kotlin names) — registering
-        // them still exercises the customization API and its `Some(closure)`
-        // path.
-        .kotlin_harness_name_mangle(|n| format!("Cov{n}"))
-        .kotlin_fun_name_mangle(|n| n.to_string())
-        .kotlin_ptr_class_name_mangle(|n| n.to_string())
-        .kotlin_data_class_name_mangle(|n| n.to_string())
-        .kotlin_enum_name_mangle(|n| n.to_string())
-        .kotlin_wrapper_name_mangle(|n| n.to_string())
-        // ── Base-package types ──────────────────────────────────────────────
-        // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
-        // reassembled via a generated `fromParts`). Declared while no subpackage
-        // is active, so it lands in the base package.
-        .data_class(pq!(Payload))
-        // `Millis` newtype: a custom input/output wrapper maps it to a bare
-        // `Long` wire (no generated class). `.kotlin_type("Long")` overrides the
-        // phantom class name the rank-0 wrapper registration would otherwise
-        // stamp, so it surfaces as Kotlin `Long`.
-        .input_wrapper(
-            pq!(Millis),
-            |_r: &Registry<_>| -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
-                Some((
-                    pq!(jni::sys::jlong),
-                    None,
-                    pq!(perftest_flat::Millis(*v as u64)),
-                ))
-            },
-        )
-        .output_wrapper(
-            pq!(Millis),
-            |_r: &Registry<_>| -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
-                Some((pq!(jni::sys::jlong), None, pq!(v.0 as jni::sys::jlong)))
-            },
-        )
-        .kotlin_type("Long")
-        // ── Subpackage `model`: enum + value class + nested data class ──────
-        .package("model")
-        // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
-        .enum_class(pq!(Priority))
-        // `Annotated` exercises a NESTED data-class field (`payload`,
-        // recursive fromParts / recursive leaf decode) plus Option<prim> and
-        // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
-        .data_class(pq!(Annotated))
-        // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
-        // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
-        // surfaces as `List<ByteArray>`.
-        .value_class(pq!(Stamp))
-        .accessor(pq!(stamp_secs), "secs")
-        .accessor(pq!(stamp_nanos), "nanos")
-        // ── Subpackage `errors`: the Result error channel ───────────────────
-        .package("errors")
-        // `StorageError` is the `E` of a fallible `Result`. Declaring it a
-        // ptr_class with a flatten-output makes the generated `onError`
-        // handler receive the flattened fields: the `message` string plus —
-        // via the TYPE-LEVEL `.field_self()` — the error handle itself (an
-        // owned `StorageError` the handler must `close()`).
-        .ptr_class(pq!(StorageError))
-        .accessor(pq!(storage_error_message), "message")
-        .flatten_output()
-        .field("message")
-        .field_self()
-        // ── Subpackage `analytics`: flatten input/output on `Summary` ───────
-        .package("analytics")
-        // `Summary` is an opaque handle whose default boundary shape is its
-        // `(count, total)` leaves: flatten-output decomposes it, flatten-input
-        // rebuilds it (via the `of` constructor) or accepts a handle.
-        .ptr_class(pq!(Summary))
-        .constructor(pq!(summary_new), "of")
-        .accessor(pq!(summary_count), "count")
-        .accessor(pq!(summary_total), "total")
-        .method(pq!(summary_scaled), "scaled")
-        .flatten_input()
-        .variant("of")
-        .variant_self()
-        .flatten_output()
-        .field("count")
-        .field("total")
-        // `Archive` holds the latest `Summary` and returns it BORROWED
-        // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
-        // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
-        // RENAMED via the per-declaration `.name()` override (the type-level
-        // dual of the per-fn `.name`; literal, bypasses the mangle closures).
-        .ptr_class(pq!(Archive))
-        .name("SummaryVault")
-        // ── Base-package handle type: `Storage` + scalar members ────────────
-        // Cleared back to the base package so the typed handle classes live
-        // alongside `Payload`.
-        .package("")
-        .ptr_class(pq!(Storage))
-        .accessor(pq!(storage_len), "len")
-        .method(pq!(storage_contains), "contains")
-        .constructor(pq!(storage_with_payload), "withPayload")
-        // The callback-handler handles (single payload / whole batch / owned
-        // storage handle).
-        .ptr_class(pq!(PayloadHandler))
-        // `StorageHandler`'s callback receives an OWNED opaque handle
-        // (`Fn(Storage)`): the raw pointer crosses and the generated Kotlin
-        // proxy wraps it into a typed `Storage` and closes it after `run`.
-        .ptr_class(pq!(StorageHandler))
-        .ptr_class(pq!(PayloadVecHandler))
-        // ── Free functions, grouped by subpackage ───────────────────────────
-        // model: enum return/param/option + value-class return + Vec<value> +
-        //        Option<scalar>.
-        .package("model")
-        .fun(pq!(payload_priority))
-        .fun(pq!(priority_weight))
-        .fun(pq!(priority_or))
-        .fun(pq!(stamp_new))
-        .fun(pq!(stamp_series))
-        .fun(pq!(payload_label_len))
-        .fun(pq!(annotated_new))
-        .fun(pq!(annotated_ttl))
-        .fun(pq!(annotated_priority))
-        .fun(pq!(annotated_payload_value))
-        // analytics: the flatten matrix (default / suppress / with, in + out).
-        .package("analytics")
-        .fun(pq!(storage_summary))
-        .fun(pq!(storage_matches_summary))
-        .fun(pq!(storage_summary_handle))
-        .flatten_output_suppress()
-        .fun(pq!(summary_total_raw))
-        .flatten_input_suppress(pq!(s))
-        .fun(pq!(storage_summary_full))
-        .flatten_output_with()
-        .field(pq!(summary_count), "count")
-        .field(pq!(summary_total), "total")
-        .field_self()
-        .fun(pq!(storage_expect_summary))
-        .flatten_input_with(pq!(expected))
-        .variant(pq!(summary_new))
-        .variant_self()
-        // The borrowed-accessor trio. `archive_latest` suppresses the default
-        // Summary output flatten so the BORROWED handle path (clone into a
-        // fresh owned handle, null when absent) is what crosses.
-        .fun(pq!(archive_new))
-        .fun(pq!(archive_store))
-        .fun(pq!(archive_latest))
-        .flatten_output_suppress()
-        // storage: the perf surface (handles, callbacks, Vec, Option) plus the
-        // fallible constructor and the Millis wrapper.
-        .package("storage")
-        .fun(pq!(storage_new))
-        .fun(pq!(storage_get))
-        .fun(pq!(storage_put_by_take))
-        .fun(pq!(storage_put_by_read))
-        .fun(pq!(storage_put_slice))
-        .fun(pq!(storage_get_vec))
-        .fun(pq!(payload_handler_new))
-        .fun(pq!(storage_callback))
-        .fun(pq!(payload_vec_handler_new))
-        .fun(pq!(storage_callback_vec))
-        .fun(pq!(storage_try_with_label))
-        // Vec<opaque-handle> returns (plain + under the Option niche).
-        .fun(pq!(storage_shards))
-        .fun(pq!(storage_shards_opt))
-        // Owned-handle-in-callback pair.
-        .fun(pq!(storage_handler_new))
-        .fun(pq!(storage_emit))
-        // A 3-opaque-handle call (sorted N-ary handle locking).
-        .fun(pq!(storage_total_len))
-        // Vec<String> return (single-leaf string fold).
-        .fun(pq!(storage_labels))
-        // Option<data-class> input.
-        .fun(pq!(storage_put_opt))
-        // `.name(...)`: per-function Kotlin rename override. The default name
-        // would be `millisAdd`; force it to `addMillis` to exercise the
-        // override path (the Rust symbol/extern is unaffected).
-        .fun(pq!(millis_add))
-        .name("addMillis")
-        // Plain String return, declared in the BASE package (`.package("")`,
-        // mirroring the base-package classes). (`string_len` stays undeclared
-        // like the `storage_get_into_*` group: its `&String` param / `usize`
-        // return are C-tier shapes with no JVM mapping.)
-        .package("")
-        .fun(pq!(string_new));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(pq!(perftest_flat))
+            .package_prefix("io.prebindgen.covertest")
+            .jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
+            // All five per-kind name-mangle hooks are registered. The harness hook
+            // is a real transform (`Native` → `CovNative`, an internal symbol so it
+            // needs no Kotlin-side coordination); the other four are the identity
+            // (the domain names are already the desired Kotlin names) — registering
+            // them still exercises the customization API and its `Some(closure)`
+            // path.
+            .kotlin_harness_name_mangle(|n| format!("Cov{n}"))
+            .kotlin_fun_name_mangle(|n| n.to_string())
+            .kotlin_ptr_class_name_mangle(|n| n.to_string())
+            .kotlin_data_class_name_mangle(|n| n.to_string())
+            .kotlin_enum_name_mangle(|n| n.to_string()),
+    )
+    // `Millis` newtype: a custom scalar wire mapping to a bare `Long` (no
+    // generated class) — global, not tied to any package (see the `decl`
+    // module doc for why a scalar wrapper never needs package placement).
+    .scalar_type_wrapper(
+        ScalarTypeWrapperDecl::new(pq!(Millis), pq!(jni::sys::jlong), "Long")
+            .input(|v| pq!(perftest_flat::Millis(*#v as u64)))
+            .output(|v| pq!(#v.0 as jni::sys::jlong)),
+    )
+    // ── Base-package types ──────────────────────────────────────────────
+    // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
+    // reassembled via a generated `fromParts`).
+    .package(PackageDecl::new("").class(DataClassDecl::new(pq!(Payload))))
+    // ── Subpackage `model`: enum + value class + nested data class ──────
+    .package(
+        PackageDecl::new("model")
+            // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
+            .class(EnumClassDecl::new(pq!(Priority)))
+            // `Annotated` exercises a NESTED data-class field (`payload`,
+            // recursive fromParts / recursive leaf decode) plus Option<prim> and
+            // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
+            .class(DataClassDecl::new(pq!(Annotated)))
+            // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
+            // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
+            // surfaces as `List<ByteArray>`.
+            .class(
+                ValueClassDecl::new(pq!(Stamp))
+                    .accessor(pq!(stamp_secs), "secs")
+                    .accessor(pq!(stamp_nanos), "nanos"),
+            ),
+    )
+    // ── Subpackage `errors`: the Result error channel ───────────────────
+    .package(
+        PackageDecl::new("errors").class(
+            // `StorageError` is the `E` of a fallible `Result`. Declaring it a
+            // ptr_class with a flatten-output makes the generated `onError`
+            // handler receive the flattened fields: the `message` string plus —
+            // via the TYPE-LEVEL `.field_self()` — the error handle itself (an
+            // owned `StorageError` the handler must `close()`).
+            PtrClassDecl::new(pq!(StorageError))
+                .accessor(pq!(storage_error_message), "message")
+                .flatten_output(FlattenOutput::new().field("message").field_self()),
+        ),
+    )
+    // ── Subpackage `analytics`: flatten input/output on `Summary` ───────
+    .package(
+        PackageDecl::new("analytics")
+            // `Summary` is an opaque handle whose default boundary shape is its
+            // `(count, total)` leaves: flatten-output decomposes it, flatten-input
+            // rebuilds it (via the `of` constructor) or accepts a handle.
+            .class(
+                PtrClassDecl::new(pq!(Summary))
+                    .constructor(pq!(summary_new), "of")
+                    .accessor(pq!(summary_count), "count")
+                    .accessor(pq!(summary_total), "total")
+                    .method(pq!(summary_scaled), "scaled")
+                    .flatten_input(FlattenInput::new().variant("of").variant_self())
+                    .flatten_output(FlattenOutput::new().field("count").field("total")),
+            )
+            // `Archive` holds the latest `Summary` and returns it BORROWED
+            // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
+            // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
+            // RENAMED via the per-declaration `.name()` override (the type-level
+            // dual of the per-fn `.name`; literal, bypasses the mangle closures).
+            .class(PtrClassDecl::new(pq!(Archive)).name("SummaryVault")),
+    )
+    // ── Base-package handle type: `Storage` + scalar members ────────────
+    // Back in the base package so the typed handle classes live alongside
+    // `Payload`.
+    .package(
+        PackageDecl::new("")
+            .class(
+                PtrClassDecl::new(pq!(Storage))
+                    .accessor(pq!(storage_len), "len")
+                    .method(pq!(storage_contains), "contains")
+                    .constructor(pq!(storage_with_payload), "withPayload"),
+            )
+            // The callback-handler handles (single payload / whole batch / owned
+            // storage handle).
+            .class(PtrClassDecl::new(pq!(PayloadHandler)))
+            // `StorageHandler`'s callback receives an OWNED opaque handle
+            // (`Fn(Storage)`): the raw pointer crosses and the generated Kotlin
+            // proxy wraps it into a typed `Storage` and closes it after `run`.
+            .class(PtrClassDecl::new(pq!(StorageHandler)))
+            .class(PtrClassDecl::new(pq!(PayloadVecHandler))),
+    )
+    // ── Free functions, grouped by subpackage ───────────────────────────
+    // model: enum return/param/option + value-class return + Vec<value> +
+    //        Option<scalar>.
+    .package(
+        PackageDecl::new("model")
+            .fun(FunctionDecl::new(pq!(payload_priority)))
+            .fun(FunctionDecl::new(pq!(priority_weight)))
+            .fun(FunctionDecl::new(pq!(priority_or)))
+            .fun(FunctionDecl::new(pq!(stamp_new)))
+            .fun(FunctionDecl::new(pq!(stamp_series)))
+            .fun(FunctionDecl::new(pq!(payload_label_len)))
+            .fun(FunctionDecl::new(pq!(annotated_new)))
+            .fun(FunctionDecl::new(pq!(annotated_ttl)))
+            .fun(FunctionDecl::new(pq!(annotated_priority)))
+            .fun(FunctionDecl::new(pq!(annotated_payload_value))),
+    )
+    // analytics: the flatten matrix (default / suppress / with, in + out).
+    .package(
+        PackageDecl::new("analytics")
+            .fun(FunctionDecl::new(pq!(storage_summary)))
+            .fun(FunctionDecl::new(pq!(storage_matches_summary)))
+            .fun(FunctionDecl::new(pq!(storage_summary_handle)).flatten_output_suppress())
+            .fun(FunctionDecl::new(pq!(summary_total_raw)).flatten_input_suppress(pq!(s)))
+            .fun(FunctionDecl::new(pq!(storage_summary_full)).flatten_output_with(
+                FunctionFlattenOutput::new()
+                    .field(pq!(summary_count), "count")
+                    .field(pq!(summary_total), "total")
+                    .field_self(),
+            ))
+            .fun(FunctionDecl::new(pq!(storage_expect_summary)).flatten_input_with(
+                pq!(expected),
+                FunctionFlattenInput::new()
+                    .variant(pq!(summary_new))
+                    .variant_self(),
+            ))
+            // The borrowed-accessor trio. `archive_latest` suppresses the default
+            // Summary output flatten so the BORROWED handle path (clone into a
+            // fresh owned handle, null when absent) is what crosses.
+            .fun(FunctionDecl::new(pq!(archive_new)))
+            .fun(FunctionDecl::new(pq!(archive_store)))
+            .fun(FunctionDecl::new(pq!(archive_latest)).flatten_output_suppress()),
+    )
+    // storage: the perf surface (handles, callbacks, Vec, Option) plus the
+    // fallible constructor and the Millis wrapper.
+    .package(
+        PackageDecl::new("storage")
+            .fun(FunctionDecl::new(pq!(storage_new)))
+            .fun(FunctionDecl::new(pq!(storage_get)))
+            .fun(FunctionDecl::new(pq!(storage_put_by_take)))
+            .fun(FunctionDecl::new(pq!(storage_put_by_read)))
+            .fun(FunctionDecl::new(pq!(storage_put_slice)))
+            .fun(FunctionDecl::new(pq!(storage_get_vec)))
+            .fun(FunctionDecl::new(pq!(payload_handler_new)))
+            .fun(FunctionDecl::new(pq!(storage_callback)))
+            .fun(FunctionDecl::new(pq!(payload_vec_handler_new)))
+            .fun(FunctionDecl::new(pq!(storage_callback_vec)))
+            .fun(FunctionDecl::new(pq!(storage_try_with_label)))
+            // Vec<opaque-handle> returns (plain + under the Option niche).
+            .fun(FunctionDecl::new(pq!(storage_shards)))
+            .fun(FunctionDecl::new(pq!(storage_shards_opt)))
+            // Owned-handle-in-callback pair.
+            .fun(FunctionDecl::new(pq!(storage_handler_new)))
+            .fun(FunctionDecl::new(pq!(storage_emit)))
+            // A 3-opaque-handle call (sorted N-ary handle locking).
+            .fun(FunctionDecl::new(pq!(storage_total_len)))
+            // Vec<String> return (single-leaf string fold).
+            .fun(FunctionDecl::new(pq!(storage_labels)))
+            // Option<data-class> input.
+            .fun(FunctionDecl::new(pq!(storage_put_opt)))
+            // `.name(...)`: per-function Kotlin rename override. The default name
+            // would be `millisAdd`; force it to `addMillis` to exercise the
+            // override path (the Rust symbol/extern is unaffected).
+            .fun(FunctionDecl::new(pq!(millis_add)).name("addMillis")),
+    )
+    // Plain String return, declared in the BASE package (mirroring the
+    // base-package classes). (`string_len` stays undeclared like the
+    // `storage_get_into_*` group: its `&String` param / `usize` return are
+    // C-tier shapes with no JVM mapping.)
+    .package(PackageDecl::new("").fun(FunctionDecl::new(pq!(string_new))));
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -16,68 +16,81 @@
 //! JniGen maps `Box<String>` → Kotlin `String` and `Option<Box<String>>` →
 //! `String?` automatically.
 
-use prebindgen::{core::Registry, lang::JniGen};
+use prebindgen::{
+    core::Registry,
+    data_class, fun,
+    lang::{JniGen, JniGenConfig},
+    package, ptr_class,
+};
 use syn::parse_quote as pq;
 
 fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
-    let jni = JniGen::new()
-        .source_module(pq!(perftest_flat))
-        .package_prefix("io.prebindgen.perftest")
-        // Trigger native-library loading from the generated `JNINative` static
-        // init (the single choke point through which every JNI call routes).
-        .jni_native_init("io.prebindgen.perftest.NativeLibrary.ensureLoaded()")
-        // `Payload` as a Kotlin `data class` with a `fromParts` companion factory:
-        // returning/accepting it crosses its fields as decoupled leaves and the
-        // object is (re)assembled on the Kotlin side — no Java object is built on
-        // the Rust side.
-        .data_class(pq!(Payload))
-        // `Storage` as an opaque Kotlin handle class (`NativeHandle`, closeable);
-        // the functions read/write the payload it owns.
-        .ptr_class(pq!(Storage))
-        // `PayloadHandler` as an opaque Kotlin handle class: a prepared callback built
-        // once via `payloadHandlerNew` and fired by `storageCallback` — the
-        // registered-subscriber pattern (the JNI trampoline is built once, not per call).
-        .ptr_class(pq!(PayloadHandler))
-        // `PayloadVecHandler`: a prepared WHOLE-BATCH callback fired by
-        // `storageCallbackVec` — its `PayloadListCallback.run(List<Payload>)` receives
-        // the entire batch in one upcall. Because `Payload` is a `data_class`, the
-        // `List` is assembled by a **fold**: the trampoline allocates the list and
-        // folds each element's raw leaves through the hoisted folder (Kotlin does
-        // `fromParts` + `add`) — no per-element Java object is built on the Rust side.
-        .ptr_class(pq!(PayloadVecHandler))
-        .package("storage")
-        // Only the value/ref-input put forms map to JNI: `storage_put_by_take`
-        // (by-value `Payload`) and `storage_put_by_read` (`&Payload`). The
-        // `&mut Payload` / `&mut MaybeUninit<Payload>` out-param forms
-        // (`storage_put_by_read_and_update`, `storage_get_into_*`) are C-only — a
-        // Kotlin `data class` is an immutable value with no out-param/uninit
-        // semantics — so they are left undeclared here.
-        //
-        // `payload_handler_new(impl Fn(&Payload)) -> PayloadHandler` prepares the callback
-        // ONCE (decodes the JVM callback into the reusable native trampoline); then
-        // `storage_callback(s, &PayloadHandler)` fires it. The callback arg still crosses
-        // as decoupled leaves reassembled into a whole `PayloadCallback.run(Payload)` — only
-        // WHERE the trampoline is built changes (once, in `payloadHandlerNew`).
-        .fun(pq!(storage_new))
-        .fun(pq!(storage_get))
-        .fun(pq!(storage_put_by_take))
-        .fun(pq!(storage_put_by_read))
-        .fun(pq!(payload_handler_new))
-        .fun(pq!(storage_callback))
-        // Array (slice / Vec) API. `storage_put_slice(&[Payload])` takes a
-        // `List<Payload>` (decoded element-by-element into an owned `Vec`, then
-        // borrowed as a slice); `storage_get_vec() -> Option<Vec<Payload>>` returns
-        // a `List<Payload>?`. The element is a `data class`, so the return is a
-        // **fixed fold**: each element's fields cross as decoupled raw leaves and a
-        // hoisted Kotlin folder reassembles them via `fromParts` and appends to the
-        // list — no `ArrayList` and no per-element Java object on the Rust side.
-        .fun(pq!(storage_put_slice))
-        .fun(pq!(storage_get_vec))
-        // Whole-batch callback: prepared once, fired with the entire `List<Payload>`.
-        .fun(pq!(payload_vec_handler_new))
-        .fun(pq!(storage_callback_vec));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(pq!(perftest_flat))
+            .package_prefix("io.prebindgen.perftest")
+            // Trigger native-library loading from the generated `JNINative` static
+            // init (the single choke point through which every JNI call routes).
+            .jni_native_init("io.prebindgen.perftest.NativeLibrary.ensureLoaded()"),
+    )
+    // Base-package types.
+    .package(
+        package!()
+            // `Payload` as a Kotlin `data class` with a `fromParts` companion factory:
+            // returning/accepting it crosses its fields as decoupled leaves and the
+            // object is (re)assembled on the Kotlin side — no Java object is built on
+            // the Rust side.
+            .class(data_class!(Payload))
+            // `Storage` as an opaque Kotlin handle class (`NativeHandle`, closeable);
+            // the functions read/write the payload it owns.
+            .class(ptr_class!(Storage))
+            // `PayloadHandler` as an opaque Kotlin handle class: a prepared callback built
+            // once via `payloadHandlerNew` and fired by `storageCallback` — the
+            // registered-subscriber pattern (the JNI trampoline is built once, not per call).
+            .class(ptr_class!(PayloadHandler))
+            // `PayloadVecHandler`: a prepared WHOLE-BATCH callback fired by
+            // `storageCallbackVec` — its `PayloadListCallback.run(List<Payload>)` receives
+            // the entire batch in one upcall. Because `Payload` is a `data_class!`, the
+            // `List` is assembled by a **fold**: the trampoline allocates the list and
+            // folds each element's raw leaves through the hoisted folder (Kotlin does
+            // `fromParts` + `add`) — no per-element Java object is built on the Rust side.
+            .class(ptr_class!(PayloadVecHandler)),
+    )
+    // Only the value/ref-input put forms map to JNI: `storage_put_by_take`
+    // (by-value `Payload`) and `storage_put_by_read` (`&Payload`). The
+    // `&mut Payload` / `&mut MaybeUninit<Payload>` out-param forms
+    // (`storage_put_by_read_and_update`, `storage_get_into_*`) are C-only — a
+    // Kotlin `data class` is an immutable value with no out-param/uninit
+    // semantics — so they are left undeclared here.
+    //
+    // `payload_handler_new(impl Fn(&Payload)) -> PayloadHandler` prepares the callback
+    // ONCE (decodes the JVM callback into the reusable native trampoline); then
+    // `storage_callback(s, &PayloadHandler)` fires it. The callback arg still crosses
+    // as decoupled leaves reassembled into a whole `PayloadCallback.run(Payload)` — only
+    // WHERE the trampoline is built changes (once, in `payloadHandlerNew`).
+    .package(
+        package!("storage")
+            .fun(fun!(storage_new))
+            .fun(fun!(storage_get))
+            .fun(fun!(storage_put_by_take))
+            .fun(fun!(storage_put_by_read))
+            .fun(fun!(payload_handler_new))
+            .fun(fun!(storage_callback))
+            // Array (slice / Vec) API. `storage_put_slice(&[Payload])` takes a
+            // `List<Payload>` (decoded element-by-element into an owned `Vec`, then
+            // borrowed as a slice); `storage_get_vec() -> Option<Vec<Payload>>` returns
+            // a `List<Payload>?`. The element is a `data class`, so the return is a
+            // **fixed fold**: each element's fields cross as decoupled raw leaves and a
+            // hoisted Kotlin folder reassembles them via `fromParts` and appends to the
+            // list — no `ArrayList` and no per-element Java object on the Rust side.
+            .fun(fun!(storage_put_slice))
+            .fun(fun!(storage_get_vec))
+            // Whole-batch callback: prepared once, fired with the entire `List<Payload>`.
+            .fun(fun!(payload_vec_handler_new))
+            .fun(fun!(storage_callback_vec)),
+    );
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -19,7 +19,7 @@
 use prebindgen::{
     core::Registry,
     data_class, fun,
-    lang::{JniGen, JniGenConfig},
+    lang::JniGen,
     package, ptr_class,
 };
 use syn::parse_quote as pq;
@@ -27,14 +27,12 @@ use syn::parse_quote as pq;
 fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(pq!(perftest_flat))
-            .package_prefix("io.prebindgen.perftest")
+    let jni = JniGen::new()
+            .set_source_module(pq!(perftest_flat))
+            .set_package_prefix("io.prebindgen.perftest")
             // Trigger native-library loading from the generated `JNINative` static
             // init (the single choke point through which every JNI call routes).
-            .jni_native_init("io.prebindgen.perftest.NativeLibrary.ensureLoaded()"),
-    )
+            .set_jni_native_init("io.prebindgen.perftest.NativeLibrary.ensureLoaded()")
     // Base-package types.
     .package(
         package!()

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -5,7 +5,7 @@
 //! A *constructor* is any `#[prebindgen]` function `f(p0, …) -> T` (or
 //! `-> Result<T, E>`) that builds a target type `T`. A type's input flatten
 //! (`.flatten_input()` + `.variant`/`.variant_self`, or the per-fn
-//! `.flatten_input_with(param)` override) replaces a parameter of that type —
+//! `.flatten_input(param, …)` override) replaces a parameter of that type —
 //! in the generated foreign signature only — with the constructor's inputs,
 //! flattened. The generated wrapper decodes those inputs, runs the
 //! constructor Rust-side (the **fold**), and passes the built value to the
@@ -72,7 +72,7 @@ struct ConstructorDecl {
 enum ExpandSel {
     /// Use the target type's default constructor (error if none/ambiguous).
     TopLevel,
-    /// Per-fn override (`.flatten_input_with`): use exactly these build-from
+    /// Per-fn override (`.flatten_input`): use exactly these build-from
     /// variants (constructor fns and/or the identity/self arm).
     Subset(Vec<Variant>),
 }
@@ -93,7 +93,7 @@ pub struct Expansions {
     expands: Vec<ExpandDecl>,
     /// Cursor for the constructor builder (`.constructor_variant*` / `.default`).
     cur_constructor: Option<usize>,
-    /// Cursor for an in-progress per-fn input subset (`.flatten_input_with(...)`
+    /// Cursor for an in-progress per-fn input subset (`.flatten_input(...)`
     /// → `.variant`/`.variant_self`): index into [`Self::expands`].
     cur_expand: Option<usize>,
     /// `.skip_default_construct(param)` opt-outs: `(fn, param)` excluded from a
@@ -146,7 +146,7 @@ impl Expansions {
         self.constructors[i].variants.push(Variant::Identity);
     }
 
-    /// Begin a per-fn input flatten (`.flatten_input_with(param)`): construct
+    /// Begin a per-fn input flatten (`.flatten_input(param, …)`): construct
     /// `param` from an explicit, incrementally-built variant list (constructor
     /// arms via [`Self::push_subset_variant`] and/or the identity/self arm via
     /// [`Self::push_subset_self`]). Recorded as an explicit decl so the
@@ -161,23 +161,23 @@ impl Expansions {
         self.cur_expand = Some(self.expands.len() - 1);
     }
 
-    /// `.variant(fn)` inside a `.flatten_input_with(...)` — append a build-from
+    /// `.variant(fn)` inside a `.flatten_input(...)` — append a build-from
     /// constructor arm to the current per-fn input subset.
     pub fn push_subset_variant(&mut self, func: syn::Ident) {
         let i = self
             .cur_expand
-            .expect(".variant called without a current .flatten_input_with");
+            .expect(".variant called without a current .flatten_input");
         if let ExpandSel::Subset(v) = &mut self.expands[i].sel {
             v.push(Variant::Ctor(func));
         }
     }
 
-    /// `.variant_self()` inside a `.flatten_input_with(...)` — append the
+    /// `.variant_self()` inside a `.flatten_input(...)` — append the
     /// identity (pass-the-handle-through) arm to the current per-fn subset.
     pub fn push_subset_self(&mut self) {
         let i = self
             .cur_expand
-            .expect(".variant_self called without a current .flatten_input_with");
+            .expect(".variant_self called without a current .flatten_input");
         if let ExpandSel::Subset(v) = &mut self.expands[i].sel {
             v.push(Variant::Identity);
         }

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -4,8 +4,8 @@
 //!
 //! A *constructor* is any `#[prebindgen]` function `f(p0, …) -> T` (or
 //! `-> Result<T, E>`) that builds a target type `T`. A type's input flatten
-//! (`.flatten_input()` + `.variant`/`.variant_self`, or the per-fn
-//! `.flatten_input(param, …)` override) replaces a parameter of that type —
+//! (`.default_param_variant*` on a class decl, or the per-fn
+//! `.param_variant(param, …)` override) replaces a parameter of that type —
 //! in the generated foreign signature only — with the constructor's inputs,
 //! flattened. The generated wrapper decodes those inputs, runs the
 //! constructor Rust-side (the **fold**), and passes the built value to the
@@ -63,7 +63,7 @@ struct ConstructorDecl {
     target: syn::Type,
     variants: Vec<Variant>,
     /// Auto-`construct` every matching param of every declared fn. Always
-    /// `true` for `.flatten_input()`-created declarations.
+    /// `true` for class-default (`.default_param_variant*`) declarations.
     default: bool,
 }
 
@@ -72,7 +72,7 @@ struct ConstructorDecl {
 enum ExpandSel {
     /// Use the target type's default constructor (error if none/ambiguous).
     TopLevel,
-    /// Per-fn override (`.flatten_input`): use exactly these build-from
+    /// Per-fn override (`.param_variant`): use exactly these build-from
     /// variants (constructor fns and/or the identity/self arm).
     Subset(Vec<Variant>),
 }
@@ -93,7 +93,7 @@ pub struct Expansions {
     expands: Vec<ExpandDecl>,
     /// Cursor for the constructor builder (`.constructor_variant*` / `.default`).
     cur_constructor: Option<usize>,
-    /// Cursor for an in-progress per-fn input subset (`.flatten_input(...)`
+    /// Cursor for an in-progress per-fn input subset (`.param_variant(...)`
     /// → `.variant`/`.variant_self`): index into [`Self::expands`].
     cur_expand: Option<usize>,
     /// `.skip_default_construct(param)` opt-outs: `(fn, param)` excluded from a
@@ -103,7 +103,7 @@ pub struct Expansions {
 
 impl Expansions {
     /// Find-or-create the default (always-`default`) constructor for `target`
-    /// and set the cursor to it. Idempotent across a `.flatten_input()` chain —
+    /// and set the cursor to it. Idempotent across a `.default_param_variant` chain —
     /// the first call creates it, subsequent ones reuse it so variants accumulate.
     pub fn ensure_default_constructor(&mut self, target: syn::Type) {
         let key = TypeKey::from_type(&target);
@@ -123,30 +123,30 @@ impl Expansions {
         }
     }
 
-    /// `.flatten_input_suppress(param)` on the current `.fun` — exclude
+    /// identity-only `.param_variant_self(param)` — exclude
     /// `(func, param)` from constructor default auto-apply.
     pub fn add_skip_default_construct(&mut self, func: syn::Ident, param: syn::Ident) {
         self.skip_construct.insert((func, param));
     }
 
-    /// `.variant(name)` inside `.flatten_input()` — add a constructor-function arm.
+    /// `.default_param_variant(fun)` — add a constructor-function arm.
     pub fn add_constructor_variant(&mut self, func: syn::Ident) {
         let i = self
             .cur_constructor
-            .expect(".variant called without a current .flatten_input");
+            .expect(".variant called without a current constructor");
         self.constructors[i].variants.push(Variant::Ctor(func));
     }
 
-    /// `.variant_self()` inside `.flatten_input()` — add the identity arm
+    /// `.default_param_variant_self()` — add the identity arm
     /// (pass the target value straight through).
     pub fn add_constructor_variant_id(&mut self) {
         let i = self
             .cur_constructor
-            .expect(".variant_self called without a current .flatten_input");
+            .expect(".variant_self called without a current constructor");
         self.constructors[i].variants.push(Variant::Identity);
     }
 
-    /// Begin a per-fn input flatten (`.flatten_input(param, …)`): construct
+    /// Begin a per-fn input override (`.param_variant(param, …)`): construct
     /// `param` from an explicit, incrementally-built variant list (constructor
     /// arms via [`Self::push_subset_variant`] and/or the identity/self arm via
     /// [`Self::push_subset_self`]). Recorded as an explicit decl so the
@@ -161,23 +161,23 @@ impl Expansions {
         self.cur_expand = Some(self.expands.len() - 1);
     }
 
-    /// `.variant(fn)` inside a `.flatten_input(...)` — append a build-from
+    /// `.param_variant(param, fn)` — append a build-from
     /// constructor arm to the current per-fn input subset.
     pub fn push_subset_variant(&mut self, func: syn::Ident) {
         let i = self
             .cur_expand
-            .expect(".variant called without a current .flatten_input");
+            .expect(".variant called without a current constructor");
         if let ExpandSel::Subset(v) = &mut self.expands[i].sel {
             v.push(Variant::Ctor(func));
         }
     }
 
-    /// `.variant_self()` inside a `.flatten_input(...)` — append the
+    /// `.param_variant_self(param)` (with other variants) — append the
     /// identity (pass-the-handle-through) arm to the current per-fn subset.
     pub fn push_subset_self(&mut self) {
         let i = self
             .cur_expand
-            .expect(".variant_self called without a current .flatten_input");
+            .expect(".variant_self called without a current constructor");
         if let ExpandSel::Subset(v) = &mut self.expands[i].sel {
             v.push(Variant::Identity);
         }

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -4,8 +4,8 @@
 //!
 //! A *constructor* is any `#[prebindgen]` function `f(p0, …) -> T` (or
 //! `-> Result<T, E>`) that builds a target type `T`. A type's input flatten
-//! (`.default_param_variant*` on a class decl, or the per-fn
-//! `.param_variant(param, …)` override) replaces a parameter of that type —
+//! (`.default_param_expand*` on a class decl, or the per-fn
+//! `.param_expand(param, …)` override) replaces a parameter of that type —
 //! in the generated foreign signature only — with the constructor's inputs,
 //! flattened. The generated wrapper decodes those inputs, runs the
 //! constructor Rust-side (the **fold**), and passes the built value to the
@@ -63,7 +63,7 @@ struct ConstructorDecl {
     target: syn::Type,
     variants: Vec<Variant>,
     /// Auto-`construct` every matching param of every declared fn. Always
-    /// `true` for class-default (`.default_param_variant*`) declarations.
+    /// `true` for class-default (`.default_param_expand*`) declarations.
     default: bool,
 }
 
@@ -72,7 +72,7 @@ struct ConstructorDecl {
 enum ExpandSel {
     /// Use the target type's default constructor (error if none/ambiguous).
     TopLevel,
-    /// Per-fn override (`.param_variant`): use exactly these build-from
+    /// Per-fn override (`.param_expand`): use exactly these build-from
     /// variants (constructor fns and/or the identity/self arm).
     Subset(Vec<Variant>),
 }
@@ -93,7 +93,7 @@ pub struct Expansions {
     expands: Vec<ExpandDecl>,
     /// Cursor for the constructor builder (`.constructor_variant*` / `.default`).
     cur_constructor: Option<usize>,
-    /// Cursor for an in-progress per-fn input subset (`.param_variant(...)`
+    /// Cursor for an in-progress per-fn input subset (`.param_expand(...)`
     /// → `.variant`/`.variant_self`): index into [`Self::expands`].
     cur_expand: Option<usize>,
     /// `.skip_default_construct(param)` opt-outs: `(fn, param)` excluded from a
@@ -103,7 +103,7 @@ pub struct Expansions {
 
 impl Expansions {
     /// Find-or-create the default (always-`default`) constructor for `target`
-    /// and set the cursor to it. Idempotent across a `.default_param_variant` chain —
+    /// and set the cursor to it. Idempotent across a `.default_param_expand` chain —
     /// the first call creates it, subsequent ones reuse it so variants accumulate.
     pub fn ensure_default_constructor(&mut self, target: syn::Type) {
         let key = TypeKey::from_type(&target);
@@ -123,13 +123,13 @@ impl Expansions {
         }
     }
 
-    /// identity-only `.param_variant_self(param)` — exclude
+    /// identity-only `.param_expand_self(param)` — exclude
     /// `(func, param)` from constructor default auto-apply.
     pub fn add_skip_default_construct(&mut self, func: syn::Ident, param: syn::Ident) {
         self.skip_construct.insert((func, param));
     }
 
-    /// `.default_param_variant(fun)` — add a constructor-function arm.
+    /// `.default_param_expand(fun)` — add a constructor-function arm.
     pub fn add_constructor_variant(&mut self, func: syn::Ident) {
         let i = self
             .cur_constructor
@@ -137,7 +137,7 @@ impl Expansions {
         self.constructors[i].variants.push(Variant::Ctor(func));
     }
 
-    /// `.default_param_variant_self()` — add the identity arm
+    /// `.default_param_expand_self()` — add the identity arm
     /// (pass the target value straight through).
     pub fn add_constructor_variant_id(&mut self) {
         let i = self
@@ -146,7 +146,7 @@ impl Expansions {
         self.constructors[i].variants.push(Variant::Identity);
     }
 
-    /// Begin a per-fn input override (`.param_variant(param, …)`): construct
+    /// Begin a per-fn input override (`.param_expand(param, …)`): construct
     /// `param` from an explicit, incrementally-built variant list (constructor
     /// arms via [`Self::push_subset_variant`] and/or the identity/self arm via
     /// [`Self::push_subset_self`]). Recorded as an explicit decl so the
@@ -161,7 +161,7 @@ impl Expansions {
         self.cur_expand = Some(self.expands.len() - 1);
     }
 
-    /// `.param_variant(param, fn)` — append a build-from
+    /// `.param_expand(param, fn)` — append a build-from
     /// constructor arm to the current per-fn input subset.
     pub fn push_subset_variant(&mut self, func: syn::Ident) {
         let i = self
@@ -172,7 +172,7 @@ impl Expansions {
         }
     }
 
-    /// `.param_variant_self(param)` (with other variants) — append the
+    /// `.param_expand_self(param)` (with other variants) — append the
     /// identity (pass-the-handle-through) arm to the current per-fn subset.
     pub fn push_subset_self(&mut self) {
         let i = self

--- a/prebindgen/src/api/core/expand/error.rs
+++ b/prebindgen/src/api/core/expand/error.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for ExpandError {
             }
             ExpandError::ConstructOnAccessor { func } => write!(
                 f,
-                "expand: input flatten on accessor fn `{}` — an accessor is never \
+                "expand: param-variant override on accessor fn `{}` — an accessor is never \
                  parameter-composed (remove the override, or declare it as `.fun`)",
                 func
             ),

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -15,7 +15,7 @@ fn single_constructor_plan_and_fold() {
     ]);
     let mut exp = Expansions::default();
     // Single build-from variant = one Ctor arm (no selector), declared
-    // per-fn (`.param_variant`).
+    // per-fn (`.param_expand`).
     exp.begin_subset(ident("z_keyexpr_intersects"), ident("a"));
     exp.push_subset_variant(ident("z_keyexpr_try_from"));
 

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -15,7 +15,7 @@ fn single_constructor_plan_and_fold() {
     ]);
     let mut exp = Expansions::default();
     // Single build-from variant = one Ctor arm (no selector), declared
-    // per-fn (`.flatten_input_with`).
+    // per-fn (`.flatten_input`).
     exp.begin_subset(ident("z_keyexpr_intersects"), ident("a"));
     exp.push_subset_variant(ident("z_keyexpr_try_from"));
 

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -15,7 +15,7 @@ fn single_constructor_plan_and_fold() {
     ]);
     let mut exp = Expansions::default();
     // Single build-from variant = one Ctor arm (no selector), declared
-    // per-fn (`.flatten_input`).
+    // per-fn (`.param_variant`).
     exp.begin_subset(ident("z_keyexpr_intersects"), ident("a"));
     exp.push_subset_variant(ident("z_keyexpr_try_from"));
 

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -2,8 +2,8 @@
 //! (`api/core/expand.rs`). A function returning a rich type is *decomposed* by a
 //! **deconstructor** into a set of leaf values.
 //!
-//! A **deconstructor** (a type's `.default_return_field*` list /
-//! or the per-fn `.return_field*` override) is a
+//! A **deconstructor** (a type's `.default_return_expand*` list /
+//! or the per-fn `.return_expand*` override) is a
 //! **deterministic product**: every record always runs and contributes its leaf
 //! — there is no selector (unlike a *constructor*, whose selector picks one
 //! variant). A record's accessor is a `#[prebindgen]` function `f(&T) -> &F` (a
@@ -66,18 +66,18 @@ struct DeconstructorDecl {
     records: Vec<DeconRecord>,
     /// Auto-apply this deconstructor to every matching declared fn (`Some`
     /// carries the inferred `(target-position, delivery)` to use). Always
-    /// `Some` for class-default (`.default_return_field*`) declarations.
+    /// `Some` for class-default (`.default_return_expand*`) declarations.
     default: Option<(DeconTarget, Delivery)>,
 }
 
 /// How an output expansion chooses the deconstructor for a function's return
-/// type: the type's default (`.default_return_field*`) or a per-fn
-/// inline record list (`.return_field*`).
+/// type: the type's default (`.default_return_expand*`) or a per-fn
+/// inline record list (`.return_expand*`).
 #[derive(Clone)]
 enum DeconSel {
     /// Use the return type's unique deconstructor (error if ambiguous).
     TopLevel,
-    /// Per-fn override (`.return_field`): use exactly these
+    /// Per-fn override (`.return_expand`): use exactly these
     /// accessor-fn records.
     Inline(Vec<DeconRecord>),
 }
@@ -119,20 +119,20 @@ struct OutputDecl {
 pub struct Deconstructors {
     deconstructors: Vec<DeconstructorDecl>,
     outputs: Vec<OutputDecl>,
-    /// Cursor for the type-level default builder (`.default_return_field` →
+    /// Cursor for the type-level default builder (`.default_return_expand` →
     /// `.field`/`.field_self`).
     cur_deconstructor: Option<usize>,
-    /// Cursor for an in-progress per-fn inline output override    /// (`.return_field`/`.return_field_self`): index into
+    /// Cursor for an in-progress per-fn inline output override    /// (`.return_expand`/`.return_expand_self`): index into
     /// [`Self::outputs`].
     cur_output: Option<usize>,
-    /// identity-only `.return_field_self()` opt-outs: fns excluded from the
+    /// identity-only `.return_expand_self()` opt-outs: fns excluded from the
     /// default auto-apply.
     skip_output: std::collections::HashSet<syn::Ident>,
 }
 
 impl Deconstructors {
     /// Find-or-create the default (always-`default`) deconstructor for `target`
-    /// and set the cursor to it. Idempotent across a `.default_return_field` chain.
+    /// and set the cursor to it. Idempotent across a `.default_return_expand` chain.
     /// Delivery is derived from leaf count at emit time (1 ⇒ return, N ⇒ callback),
     /// so the stored `Delivery` is just a marker.
     pub fn ensure_default_deconstructor(&mut self, target: syn::Type) {
@@ -160,13 +160,13 @@ impl Deconstructors {
         }
     }
 
-    /// identity-only `.return_field_self()` — exclude `func` from output-position
+    /// identity-only `.return_expand_self()` — exclude `func` from output-position
     /// default auto-apply.
     pub fn add_skip_default_output(&mut self, func: syn::Ident) {
         self.skip_output.insert(func);
     }
 
-    /// `.default_return_field(fun)` — add an accessor-function
+    /// `.default_return_expand(fun)` — add an accessor-function
     /// record with the author-supplied (literal) leaf `name`.
     pub fn add_deconstructor_record(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
@@ -178,7 +178,7 @@ impl Deconstructors {
         });
     }
 
-    /// `.default_return_field_self()` — add the identity record
+    /// `.default_return_expand_self()` — add the identity record
     /// (the value itself).
     pub fn add_deconstructor_record_id(&mut self) {
         let i = self
@@ -187,7 +187,7 @@ impl Deconstructors {
         self.deconstructors[i].records.push(DeconRecord::Identity);
     }
 
-    /// Begin a per-fn inline output override (`.return_field`):
+    /// Begin a per-fn inline output override (`.return_expand`):
     /// decompose `func`'s return via an incrementally-built record list
     /// (accessor fields via [`Self::push_inline_field`] and/or the identity/self
     /// field via [`Self::push_inline_field_self`]). Recorded as an explicit decl
@@ -203,7 +203,7 @@ impl Deconstructors {
         self.cur_output = Some(self.outputs.len() - 1);
     }
 
-    /// `.return_field(fun)` — append an
+    /// `.return_expand(fun)` — append an
     /// accessor-function field (named `name`) to the current per-fn inline output.
     pub fn push_inline_field(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
@@ -217,7 +217,7 @@ impl Deconstructors {
         }
     }
 
-    /// `.default_return_field_self()` — append the identity
+    /// `.default_return_expand_self()` — append the identity
     /// (the handle itself) field to the current per-fn inline output.
     pub fn push_inline_field_self(&mut self) {
         let i = self
@@ -278,7 +278,7 @@ pub fn apply<M>(
         done.insert((ed.func.clone(), ed.target));
     }
 
-    // Default auto-apply: a type's deconstructor (`.default_return_field*`) is
+    // Default auto-apply: a type's deconstructor (`.default_return_expand*`) is
     // applied to every declared fn that returns it (Output) or has it as a
     // `Result<_, E>` error (Error), unless the fn is `fun_accessor` or has a
     // per-fn override. `Delivery` is recomputed from leaf count inside

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -2,8 +2,8 @@
 //! (`api/core/expand.rs`). A function returning a rich type is *decomposed* by a
 //! **deconstructor** into a set of leaf values.
 //!
-//! A **deconstructor** (a type's `.flatten_output()` + `.field(name)` /
-//! `.field_self()`, or the per-fn `.flatten_output()` override) is a
+//! A **deconstructor** (a type's `.default_return_field*` list /
+//! or the per-fn `.return_field*` override) is a
 //! **deterministic product**: every record always runs and contributes its leaf
 //! — there is no selector (unlike a *constructor*, whose selector picks one
 //! variant). A record's accessor is a `#[prebindgen]` function `f(&T) -> &F` (a
@@ -66,18 +66,18 @@ struct DeconstructorDecl {
     records: Vec<DeconRecord>,
     /// Auto-apply this deconstructor to every matching declared fn (`Some`
     /// carries the inferred `(target-position, delivery)` to use). Always
-    /// `Some` for `.flatten_output()`-created declarations.
+    /// `Some` for class-default (`.default_return_field*`) declarations.
     default: Option<(DeconTarget, Delivery)>,
 }
 
 /// How an output expansion chooses the deconstructor for a function's return
-/// type: the type's default flatten (`.flatten_output()`) or a per-fn
-/// inline record list (`.flatten_output()`).
+/// type: the type's default (`.default_return_field*`) or a per-fn
+/// inline record list (`.return_field*`).
 #[derive(Clone)]
 enum DeconSel {
     /// Use the return type's unique deconstructor (error if ambiguous).
     TopLevel,
-    /// Per-fn override (`.flatten_output()`): use exactly these
+    /// Per-fn override (`.return_field`): use exactly these
     /// accessor-fn records.
     Inline(Vec<DeconRecord>),
 }
@@ -119,21 +119,20 @@ struct OutputDecl {
 pub struct Deconstructors {
     deconstructors: Vec<DeconstructorDecl>,
     outputs: Vec<OutputDecl>,
-    /// Cursor for the type-level flatten builder (`.flatten_output()` →
+    /// Cursor for the type-level default builder (`.default_return_field` →
     /// `.field`/`.field_self`).
     cur_deconstructor: Option<usize>,
-    /// Cursor for an in-progress per-fn inline output flatten
-    /// (`.flatten_output()` → `.field`/`.field_self`): index into
+    /// Cursor for an in-progress per-fn inline output override    /// (`.return_field`/`.return_field_self`): index into
     /// [`Self::outputs`].
     cur_output: Option<usize>,
-    /// `.flatten_output_suppress()` opt-outs: fns excluded from the
+    /// identity-only `.return_field_self()` opt-outs: fns excluded from the
     /// default auto-apply.
     skip_output: std::collections::HashSet<syn::Ident>,
 }
 
 impl Deconstructors {
     /// Find-or-create the default (always-`default`) deconstructor for `target`
-    /// and set the cursor to it. Idempotent across a `.flatten_output()` chain.
+    /// and set the cursor to it. Idempotent across a `.default_return_field` chain.
     /// Delivery is derived from leaf count at emit time (1 ⇒ return, N ⇒ callback),
     /// so the stored `Delivery` is just a marker.
     pub fn ensure_default_deconstructor(&mut self, target: syn::Type) {
@@ -161,34 +160,34 @@ impl Deconstructors {
         }
     }
 
-    /// `.flatten_output_suppress()` — exclude `func` from output-position
+    /// identity-only `.return_field_self()` — exclude `func` from output-position
     /// default auto-apply.
     pub fn add_skip_default_output(&mut self, func: syn::Ident) {
         self.skip_output.insert(func);
     }
 
-    /// `.field(name)` inside `.flatten_output()` — add an accessor-function
+    /// `.default_return_field(fun)` — add an accessor-function
     /// record with the author-supplied (literal) leaf `name`.
     pub fn add_deconstructor_record(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
             .cur_deconstructor
-            .expect(".field called without a current .flatten_output");
+            .expect(".field called without a current deconstructor");
         self.deconstructors[i].records.push(DeconRecord::Acc {
             func,
             name: name.into(),
         });
     }
 
-    /// `.field_self()` inside `.flatten_output()` — add the identity record
+    /// `.default_return_field_self()` — add the identity record
     /// (the value itself).
     pub fn add_deconstructor_record_id(&mut self) {
         let i = self
             .cur_deconstructor
-            .expect(".field_self called without a current .flatten_output");
+            .expect(".field_self called without a current deconstructor");
         self.deconstructors[i].records.push(DeconRecord::Identity);
     }
 
-    /// Begin a per-fn inline output flatten (`.flatten_output()`):
+    /// Begin a per-fn inline output override (`.return_field`):
     /// decompose `func`'s return via an incrementally-built record list
     /// (accessor fields via [`Self::push_inline_field`] and/or the identity/self
     /// field via [`Self::push_inline_field_self`]). Recorded as an explicit decl
@@ -204,12 +203,12 @@ impl Deconstructors {
         self.cur_output = Some(self.outputs.len() - 1);
     }
 
-    /// `.field(fn, name)` inside `.flatten_output()` — append an
+    /// `.return_field(fun)` — append an
     /// accessor-function field (named `name`) to the current per-fn inline output.
     pub fn push_inline_field(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
             .cur_output
-            .expect(".field called without a current .flatten_output");
+            .expect(".field called without a current deconstructor");
         if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
             records.push(DeconRecord::Acc {
                 func,
@@ -218,12 +217,12 @@ impl Deconstructors {
         }
     }
 
-    /// `.field_self()` inside `.flatten_output()` — append the identity
+    /// `.default_return_field_self()` — append the identity
     /// (the handle itself) field to the current per-fn inline output.
     pub fn push_inline_field_self(&mut self) {
         let i = self
             .cur_output
-            .expect(".field_self called without a current .flatten_output");
+            .expect(".field_self called without a current deconstructor");
         if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
             records.push(DeconRecord::Identity);
         }
@@ -279,7 +278,7 @@ pub fn apply<M>(
         done.insert((ed.func.clone(), ed.target));
     }
 
-    // Default auto-apply: a type's deconstructor (`.flatten_output()`) is
+    // Default auto-apply: a type's deconstructor (`.default_return_field*`) is
     // applied to every declared fn that returns it (Output) or has it as a
     // `Result<_, E>` error (Error), unless the fn is `fun_accessor` or has a
     // per-fn override. `Delivery` is recomputed from leaf count inside

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -3,7 +3,7 @@
 //! **deconstructor** into a set of leaf values.
 //!
 //! A **deconstructor** (a type's `.flatten_output()` + `.field(name)` /
-//! `.field_self()`, or the per-fn `.flatten_output_with()` override) is a
+//! `.field_self()`, or the per-fn `.flatten_output()` override) is a
 //! **deterministic product**: every record always runs and contributes its leaf
 //! — there is no selector (unlike a *constructor*, whose selector picks one
 //! variant). A record's accessor is a `#[prebindgen]` function `f(&T) -> &F` (a
@@ -72,12 +72,12 @@ struct DeconstructorDecl {
 
 /// How an output expansion chooses the deconstructor for a function's return
 /// type: the type's default flatten (`.flatten_output()`) or a per-fn
-/// inline record list (`.flatten_output_with()`).
+/// inline record list (`.flatten_output()`).
 #[derive(Clone)]
 enum DeconSel {
     /// Use the return type's unique deconstructor (error if ambiguous).
     TopLevel,
-    /// Per-fn override (`.flatten_output_with()`): use exactly these
+    /// Per-fn override (`.flatten_output()`): use exactly these
     /// accessor-fn records.
     Inline(Vec<DeconRecord>),
 }
@@ -123,7 +123,7 @@ pub struct Deconstructors {
     /// `.field`/`.field_self`).
     cur_deconstructor: Option<usize>,
     /// Cursor for an in-progress per-fn inline output flatten
-    /// (`.flatten_output_with()` → `.field`/`.field_self`): index into
+    /// (`.flatten_output()` → `.field`/`.field_self`): index into
     /// [`Self::outputs`].
     cur_output: Option<usize>,
     /// `.flatten_output_suppress()` opt-outs: fns excluded from the
@@ -188,7 +188,7 @@ impl Deconstructors {
         self.deconstructors[i].records.push(DeconRecord::Identity);
     }
 
-    /// Begin a per-fn inline output flatten (`.flatten_output_with()`):
+    /// Begin a per-fn inline output flatten (`.flatten_output()`):
     /// decompose `func`'s return via an incrementally-built record list
     /// (accessor fields via [`Self::push_inline_field`] and/or the identity/self
     /// field via [`Self::push_inline_field_self`]). Recorded as an explicit decl
@@ -204,12 +204,12 @@ impl Deconstructors {
         self.cur_output = Some(self.outputs.len() - 1);
     }
 
-    /// `.field(fn, name)` inside `.flatten_output_with()` — append an
+    /// `.field(fn, name)` inside `.flatten_output()` — append an
     /// accessor-function field (named `name`) to the current per-fn inline output.
     pub fn push_inline_field(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
             .cur_output
-            .expect(".field called without a current .flatten_output_with");
+            .expect(".field called without a current .flatten_output");
         if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
             records.push(DeconRecord::Acc {
                 func,
@@ -218,12 +218,12 @@ impl Deconstructors {
         }
     }
 
-    /// `.field_self()` inside `.flatten_output_with()` — append the identity
+    /// `.field_self()` inside `.flatten_output()` — append the identity
     /// (the handle itself) field to the current per-fn inline output.
     pub fn push_inline_field_self(&mut self) {
         let i = self
             .cur_output
-            .expect(".field_self called without a current .flatten_output_with");
+            .expect(".field_self called without a current .flatten_output");
         if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
             records.push(DeconRecord::Identity);
         }

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -126,10 +126,10 @@ impl std::fmt::Display for UnfoldError {
             ),
             UnfoldError::RootIdentityBeforeNested { target } => write!(
                 f,
-                "output flatten of `{}`: `.field_self()` (the root identity) must be declared \
-                 AFTER fields that splice a nested identity — the root identity moves the owned \
+                "return-field list of `{}`: `.default_return_field_self()` (the root identity) must be \
+                 declared AFTER fields that splice a nested identity — the root identity moves the owned \
                  value while nested identities borrow it, so this order would generate \
-                 non-compiling Rust. Declare `.field_self()` last.",
+                 non-compiling Rust. Declare the `_self` field last.",
                 target
             ),
         }

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -126,7 +126,7 @@ impl std::fmt::Display for UnfoldError {
             ),
             UnfoldError::RootIdentityBeforeNested { target } => write!(
                 f,
-                "return-field list of `{}`: `.default_return_field_self()` (the root identity) must be \
+                "return-field list of `{}`: `.default_return_expand_self()` (the root identity) must be \
                  declared AFTER fields that splice a nested identity — the root identity moves the owned \
                  value while nested identities borrow it, so this order would generate \
                  non-compiling Rust. Declare the `_self` field last.",

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -29,7 +29,7 @@ pub use crate::api::core::shape::Shape as UnfoldShape;
 pub enum DeconId {
     /// The type's default (`.flatten_output()`-declared) deconstructor.
     Default(String),
-    /// Per-fn inline records (`.flatten_output_with()`) — unique to the
+    /// Per-fn inline records (`.flatten_output()`) — unique to the
     /// function (second field = the fn ident).
     PerFn(String, String),
 }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -27,9 +27,9 @@ pub use crate::api::core::shape::Shape as UnfoldShape;
 /// string.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DeconId {
-    /// The type's default (`.default_return_field*`-declared) deconstructor.
+    /// The type's default (`.default_return_expand*`-declared) deconstructor.
     Default(String),
-    /// Per-fn inline records (`.return_field*`) — unique to the
+    /// Per-fn inline records (`.return_expand*`) — unique to the
     /// function (second field = the fn ident).
     PerFn(String, String),
 }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -27,9 +27,9 @@ pub use crate::api::core::shape::Shape as UnfoldShape;
 /// string.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DeconId {
-    /// The type's default (`.flatten_output()`-declared) deconstructor.
+    /// The type's default (`.default_return_field*`-declared) deconstructor.
     Default(String),
-    /// Per-fn inline records (`.flatten_output()`) — unique to the
+    /// Per-fn inline records (`.return_field*`) — unique to the
     /// function (second field = the fn ident).
     PerFn(String, String),
 }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -70,6 +70,7 @@ impl JniGen {
             expansions: crate::api::core::expand::Expansions::default(),
             deconstructors: crate::api::core::unfold::Deconstructors::default(),
             class_members: HashMap::new(),
+            accessor_record_fns: std::collections::HashSet::new(),
         };
         jni.recompute_derived();
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
@@ -243,6 +244,7 @@ impl JniGen {
             for f in fields {
                 match f {
                     LocalField::Named(func, name) => {
+                        self.accessor_record_fns.insert(func.clone());
                         self.deconstructors.add_deconstructor_record(func, name)
                     }
                     LocalField::SelfField => self.deconstructors.add_deconstructor_record_id(),
@@ -368,6 +370,7 @@ impl JniGen {
             for f in fields {
                 match f {
                     LocalField::Named(func, name) => {
+                        self.accessor_record_fns.insert(func.clone());
                         self.deconstructors.push_inline_field(func, name)
                     }
                     LocalField::SelfField => self.deconstructors.push_inline_field_self(),

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -10,16 +10,6 @@
 use super::*;
 
 impl JniGen {
-    /// Look up the registered Kotlin FQN for a canonical Rust type key
-    /// (the inverse of the `(key, fqn)` rows pushed into
-    /// [`Self::kotlin_type_fqns`] by the class-decl accept logic).
-    pub(crate) fn kotlin_fqn(&self, rust_canon: &str) -> Option<&str> {
-        self.kotlin_type_fqns
-            .iter()
-            .find(|(k, _)| k == rust_canon)
-            .map(|(_, v)| v.as_str())
-    }
-
     /// Whether `ty` was registered via an `EnumClassDecl` — used by the
     /// Kotlin wrapper generator to decide if a parameter needs a `.value`
     /// projection between the typed enum (Kotlin signature) and the `Int`
@@ -40,21 +30,18 @@ impl JniGen {
     /// methods, add declarations with [`package`](Self::package),
     /// [`scalar_type_wrapper`](Self::scalar_type_wrapper), etc., then run the
     /// result through `Registry::write_rust` / `write_kotlin`. Settings and
-    /// declarations may be interleaved in any order — setting-derived names
-    /// are re-derived when a setter runs.
+    /// declarations may be interleaved in any order — the builder stores
+    /// only raw inputs, and every setting-derived name is computed at the
+    /// point of use.
     pub fn new() -> Self {
         let mut jni = Self {
             source_module: syn::parse_str("crate").unwrap(),
             package: String::new(),
-            java_class_prefix: String::new(),
-            jni_class_path: String::new(),
             kotlin_fun_name_mangle: None,
             kotlin_ptr_class_name_mangle: None,
             kotlin_data_class_name_mangle: None,
             kotlin_enum_name_mangle: None,
             kotlin_harness_name_mangle: None,
-            kotlin_type_fqns: Vec::new(),
-            declared_class_names: Vec::new(),
             types: HashMap::new(),
             packages: BTreeMap::new(),
             input_wrappers: [
@@ -78,7 +65,6 @@ impl JniGen {
             ignored_class_types: std::collections::HashSet::new(),
             accessor_record_fns: std::collections::HashSet::new(),
         };
-        jni.recompute_derived();
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
         // as T and routes E to the error-sink on Err. Consumers may override
         // per-binding by registering a more specific rank-1
@@ -93,20 +79,6 @@ impl JniGen {
             }),
         );
         jni
-    }
-
-    /// Recompute the derived caches (`java_class_prefix`, `jni_class_path`)
-    /// from (`package`, `kotlin_harness_name_mangle`). The JNI extern symbol
-    /// path resolves to the centralized Native object, whose mangled name
-    /// comes from the harness mangle (default `"JNI" + n` → `JNINative`).
-    pub(crate) fn recompute_derived(&mut self) {
-        self.java_class_prefix = self.package.replace(".", "/");
-        let native_class = self.mangle_harness("Native");
-        self.jni_class_path = if self.package.is_empty() {
-            format!("Java_{}", native_class)
-        } else {
-            format!("Java_{}_{}", self.package.replace(".", "_"), native_class)
-        };
     }
 
     /// Apply the fun-name mangle closure to `name`, returning the closure
@@ -240,31 +212,43 @@ impl JniGen {
         }
     }
 
-    /// Retain one class declaration's raw naming inputs (so a later `set_*`
-    /// call can re-derive the FQN), derive the FQN from the current
-    /// settings, and register it in [`Self::types`] +
-    /// [`Self::kotlin_type_fqns`].
-    fn register_class_name(&mut self, declared: DeclaredClassName) {
-        let fqn = self.derive_class_fqn(&declared);
-        let key = declared.key.clone();
-        self.declared_class_names.push(declared);
+    /// Store one class declaration's raw [`NameSpec`] in the type table.
+    /// No FQN is derived here — names materialize at read time via
+    /// [`JniGen::fqn_of`], against whatever the settings are then.
+    fn register_class_name(&mut self, key: &TypeKey, spec: NameSpec) {
+        // Early failure for a bad per-decl `.name()`: the FQN itself is only
+        // derived at write time, but a dotted relative name is a declaration
+        // mistake and should surface in the declaring call (the same check
+        // `resolve_class_fqn` repeats at derivation time).
+        if let NameSpec::Class {
+            name_override: Some(n),
+            ..
+        } = &spec
+        {
+            assert!(
+                !n.contains('.'),
+                "Kotlin class name `{}` must be relative (no dots) — FQNs are derived from the \
+                 base package + subpackage",
+                n
+            );
+        }
         let entry = self.types.entry(key.clone()).or_default();
         entry.class_decl = true;
-        entry.kotlin_name = Some(fqn.clone());
-        self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
+        entry.name_spec = Some(spec);
     }
 
     fn accept_ptr_class(&mut self, subpackage: &str, decl: PtrClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.register_class_name(DeclaredClassName {
-            key: key.clone(),
-            subpackage: subpackage.to_string(),
-            short,
-            name_override: decl.name_override,
-            explicit_fqn: None,
-            kind: NameKind::Ptr,
-        });
+        self.register_class_name(
+            &key,
+            NameSpec::Class {
+                subpackage: subpackage.to_string(),
+                short,
+                name_override: decl.name_override,
+                kind: NameKind::Ptr,
+            },
+        );
         self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
@@ -312,44 +296,55 @@ impl JniGen {
              a type can be one or the other, not both",
             short
         );
-        self.register_class_name(DeclaredClassName {
-            key: key.clone(),
-            subpackage: subpackage.to_string(),
-            short,
-            name_override: decl.name_override,
-            explicit_fqn: None,
-            kind: NameKind::Enum,
-        });
+        self.register_class_name(
+            &key,
+            NameSpec::Class {
+                subpackage: subpackage.to_string(),
+                short,
+                name_override: decl.name_override,
+                kind: NameKind::Enum,
+            },
+        );
         self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
             .enum_cfg = Some(EnumConfig::default());
     }
 
+    /// A data/value class's explicit `kotlin_type` expression is a verbatim
+    /// Kotlin type and wins over everything; otherwise the name derives from
+    /// settings at read time like any other declared class.
+    fn data_value_name_spec(
+        subpackage: &str,
+        short: String,
+        name_override: Option<String>,
+        kotlin_type: Option<String>,
+    ) -> NameSpec {
+        match kotlin_type {
+            Some(expr) => NameSpec::Verbatim(expr),
+            None => NameSpec::Class {
+                subpackage: subpackage.to_string(),
+                short,
+                name_override,
+                kind: NameKind::DataOrValue,
+            },
+        }
+    }
+
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.register_class_name(DeclaredClassName {
-            key,
-            subpackage: subpackage.to_string(),
-            short,
-            name_override: decl.name_override,
-            explicit_fqn: decl.kotlin_type,
-            kind: NameKind::DataOrValue,
-        });
+        let spec =
+            Self::data_value_name_spec(subpackage, short, decl.name_override, decl.kotlin_type);
+        self.register_class_name(&key, spec);
     }
 
     fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.register_class_name(DeclaredClassName {
-            key: key.clone(),
-            subpackage: subpackage.to_string(),
-            short,
-            name_override: decl.name_override,
-            explicit_fqn: decl.kotlin_type,
-            kind: NameKind::DataOrValue,
-        });
+        let spec =
+            Self::data_value_name_spec(subpackage, short, decl.name_override, decl.kotlin_type);
+        self.register_class_name(&key, spec);
         self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
@@ -485,9 +480,7 @@ impl JniGen {
             );
         }
         let entry = self.types.entry(key.clone()).or_default();
-        entry.kotlin_name = Some(decl.kotlin_type.clone());
-        self.kotlin_type_fqns
-            .push((key.as_str().to_string(), decl.kotlin_type));
+        entry.name_spec = Some(NameSpec::Verbatim(decl.kotlin_type));
         self
     }
 
@@ -620,8 +613,8 @@ impl JniGen {
                     let kn = self
                         .types
                         .get(&key)
-                        .and_then(|c| c.kotlin_name.clone())
-                        .map(kt::KtType::cls)
+                        .and_then(|c| c.name_spec.as_ref())
+                        .map(|s| kt::KtType::cls(self.fqn_of(s)))
                         .or_else(|| kotlin_for_wire(&ty));
                     (Niches::empty(), kn)
                 } else {
@@ -741,8 +734,8 @@ impl JniGen {
                     let kn = self
                         .types
                         .get(&key)
-                        .and_then(|c| c.kotlin_name.clone())
-                        .map(kt::KtType::cls)
+                        .and_then(|c| c.name_spec.as_ref())
+                        .map(|s| kt::KtType::cls(self.fqn_of(s)))
                         .or_else(|| kotlin_for_wire(&ty));
                     (kn, None)
                 };

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -70,6 +70,8 @@ impl JniGen {
             expansions: crate::api::core::expand::Expansions::default(),
             deconstructors: crate::api::core::unfold::Deconstructors::default(),
             class_members: HashMap::new(),
+            ignored_fns: std::collections::HashSet::new(),
+            ignored_class_types: std::collections::HashSet::new(),
             accessor_record_fns: std::collections::HashSet::new(),
         };
         jni.recompute_derived();
@@ -203,6 +205,23 @@ impl JniGen {
         self
     }
 
+    /// Acknowledge a `#[prebindgen]` function this binding deliberately does
+    /// NOT wrap: nothing is emitted for it and the registry's per-item
+    /// "skipping undeclared" warning is suppressed. Global — an ignored fn
+    /// belongs to no package. E.g. `.ignore_fun(fun!(string_len))`.
+    pub fn ignore_fun(mut self, decl: FunctionDecl) -> Self {
+        self.ignored_fns.insert(decl.rust_ident);
+        self
+    }
+
+    /// Acknowledge a `#[prebindgen]` type this binding deliberately does NOT
+    /// declare as a class — the type-level dual of [`Self::ignore_fun`].
+    pub fn ignore_class(mut self, rust_type: syn::Type) -> Self {
+        self.ignored_class_types
+            .insert(TypeKey::from_type(&rust_type));
+        self
+    }
+
     fn accept_class(&mut self, subpackage: &str, decl: ClassDecl) {
         match decl {
             ClassDecl::Ptr(d) => self.accept_ptr_class(subpackage, d),
@@ -274,7 +293,6 @@ impl JniGen {
         entry.enum_cfg = Some(EnumConfig::default());
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
-        self.accept_members(&key, decl.members);
     }
 
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
@@ -292,7 +310,6 @@ impl JniGen {
         entry.class_decl = true;
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
-        self.accept_members(&key, decl.members);
     }
 
     fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
@@ -314,9 +331,10 @@ impl JniGen {
         self.accept_members(&key, decl.members);
     }
 
-    /// Shared tail of the four `accept_*_class` methods: a constructor
-    /// member's return is never output-flattened (it's a factory), then the
-    /// members join the class's registered set.
+    /// Shared tail of `accept_ptr_class`/`accept_value_class` (the two class
+    /// kinds whose members are emitted): a constructor member's return is
+    /// never output-flattened (it's a factory), then the members join the
+    /// class's registered set.
     fn accept_members(&mut self, key: &TypeKey, members: Vec<ClassMember>) {
         for m in &members {
             if m.kind == MemberKind::Constructor {

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -34,11 +34,12 @@ impl JniGen {
 }
 
 impl JniGen {
-    /// Build a `JniGen` from a finished [`JniGenConfig`]. Because the whole
-    /// config is supplied atomically here, there is no way to change
-    /// `package_prefix`/the mangle closures after any declaration exists —
-    /// the ordering hazard the old fluent builder guarded with a runtime
-    /// panic is structurally impossible now.
+    /// Start a binding generator from a finished [`JniGenConfig`] (the
+    /// package prefix, native-init hook and name-mangle rules). From here you
+    /// add declarations with [`package`](Self::package),
+    /// [`scalar_type_wrapper`](Self::scalar_type_wrapper), etc., then run the
+    /// result through `Registry::write_rust` / `write_kotlin`. Taking the
+    /// whole config up front means it can't change once declarations exist.
     pub fn new(config: JniGenConfig) -> Self {
         let mut jni = Self {
             source_module: config.source_module,
@@ -184,11 +185,10 @@ impl JniGen {
 // ── Accepting a `PackageDecl` ────────────────────────────────────────────
 
 impl JniGen {
-    /// Accept a batch of package-scoped declarations (classes + functions).
-    /// **Merges** into whatever `decl.name`'s subpackage bucket already
-    /// holds — the same subpackage name may be reopened across several
-    /// `PackageDecl` values / `package` calls (e.g. one for its classes,
-    /// another later for its functions).
+    /// Register a package's worth of classes and functions (a
+    /// [`PackageDecl`], built with [`package!`](crate::package)). Call it once
+    /// per package, or several times for the same package name — the
+    /// declarations merge, so you can split a large package across calls.
     pub fn package(mut self, decl: PackageDecl) -> Self {
         let PackageDecl {
             name,
@@ -249,7 +249,7 @@ impl JniGen {
         self.accept_members(&key, decl.members);
 
         if let Some(variants) = decl.input_variants {
-            // Identity-only normalization: `.default_param_variant_self()`
+            // Identity-only normalization: `.default_param_expand_self()`
             // alone declares the plain-handle form — exactly the default
             // when nothing is declared, so registering it would only add a
             // degenerate 1-variant selector to every param of this type.
@@ -379,7 +379,7 @@ impl JniGen {
     }
 
     /// Replay a [`FunctionDecl`]'s per-fn overrides (per-param
-    /// `.param_variant*` / `.return_field*`) into the
+    /// `.param_expand*` / `.return_expand*`) into the
     /// expansion/deconstruction bookkeeping. Shared by [`Self::accept_function`]
     /// (free package fns) and [`Self::accept_members`] (class members) — the
     /// overrides mean the same thing in both positions.
@@ -433,9 +433,11 @@ impl JniGen {
 // ── Accepting wrapper decls ──────────────────────────────────────────────
 
 impl JniGen {
-    /// Register a rank-0 custom scalar wire mapping (e.g. a newtype wrapping
-    /// a primitive). Global — not tied to any package (see `decl.rs`'s
-    /// module doc for why).
+    /// Teach the generator how a **custom scalar type** crosses the boundary
+    /// — e.g. a newtype like `Millis(u64)` that should travel as a plain
+    /// `Long` rather than as a class. You supply the wire type and the
+    /// convert-in / convert-out expressions (see [`ScalarTypeWrapperDecl`]).
+    /// Applies wherever that type appears; not tied to any package.
     pub fn scalar_type_wrapper(mut self, decl: ScalarTypeWrapperDecl) -> Self {
         let key = TypeKey::from_type(&decl.pattern);
         if let Some(input) = decl.input {
@@ -467,8 +469,11 @@ impl JniGen {
         self
     }
 
-    /// Register a rank 1-3 structural-dispatch override (e.g. a per-error
-    /// `Result<_, ConcreteErr>` peel). Global — not tied to any package.
+    /// Override how a **generic wrapper type** is unwrapped for a specific
+    /// inner type — e.g. peel `Result<_, MyError>` your own way rather than
+    /// through the built-in `Result` handling. You give a pattern with
+    /// wildcards and the convert bodies (see [`GenericTypeWrapperDecl`]).
+    /// Not tied to any package.
     pub fn generic_type_wrapper(mut self, decl: GenericTypeWrapperDecl) -> Self {
         let key = TypeKey::from_type(&decl.pattern);
         if let Some((rank, f)) = decl.input {

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -37,11 +37,11 @@ impl JniGen {
         let mut jni = Self {
             source_module: syn::parse_str("crate").unwrap(),
             package: String::new(),
-            kotlin_fun_name_mangle: None,
-            kotlin_ptr_class_name_mangle: None,
-            kotlin_data_class_name_mangle: None,
-            kotlin_enum_name_mangle: None,
-            kotlin_harness_name_mangle: None,
+            fun_name_mangle: None,
+            ptr_class_name_mangle: None,
+            data_class_name_mangle: None,
+            enum_name_mangle: None,
+            harness_name_mangle: None,
             types: HashMap::new(),
             packages: BTreeMap::new(),
             input_wrappers: [
@@ -87,7 +87,7 @@ impl JniGen {
     /// `#[prebindgen]` extern symbols, the synthetic `freePtr` destructor,
     /// and the Kotlin-side `external fun` that pairs with each.
     pub(crate) fn mangle_fun(&self, name: &str) -> String {
-        match &self.kotlin_fun_name_mangle {
+        match &self.fun_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
@@ -95,7 +95,7 @@ impl JniGen {
     /// Apply the ptr-class mangle closure to `name`, returning the closure
     /// result or `name` verbatim when unset.
     pub(crate) fn mangle_ptr_class(&self, name: &str) -> String {
-        match &self.kotlin_ptr_class_name_mangle {
+        match &self.ptr_class_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
@@ -103,7 +103,7 @@ impl JniGen {
     /// Apply the data-class mangle closure to `name`, returning the closure
     /// result or `name` verbatim when unset.
     pub(crate) fn mangle_data_class(&self, name: &str) -> String {
-        match &self.kotlin_data_class_name_mangle {
+        match &self.data_class_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
@@ -111,7 +111,7 @@ impl JniGen {
     /// Apply the enum mangle closure to `name`, returning the closure result
     /// or `name` verbatim when unset.
     pub(crate) fn mangle_enum(&self, name: &str) -> String {
-        match &self.kotlin_enum_name_mangle {
+        match &self.enum_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
@@ -120,7 +120,7 @@ impl JniGen {
     /// `|n| format!("JNI{n}")` when unset, so `mangle_harness("Native")`
     /// yields `"JNINative"`.
     pub(crate) fn mangle_harness(&self, name: &str) -> String {
-        match &self.kotlin_harness_name_mangle {
+        match &self.harness_name_mangle {
             Some(f) => f(name),
             None => format!("JNI{name}"),
         }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1,11 +1,11 @@
 //! Builder API for [`JniGen`].
 //!
-//! [`JniGen::new`] takes a finished [`JniGenConfig`]; from then on `JniGen`
-//! only *accepts* pre-built declaration objects (`decl.rs`) via
-//! [`JniGen::package`], [`JniGen::scalar_type_wrapper`], and
-//! [`JniGen::generic_type_wrapper`] — there is no fluent typestate cursor.
-//! Carved from the former monolithic JNI module; shares the `jni` namespace
-//! via `use super::*`.
+//! [`JniGen::new`] starts from defaults; global settings are applied with
+//! the `set_*` methods (`config.rs`) and declarations are *accepted* as
+//! pre-built objects (`decl.rs`) via [`JniGen::package`],
+//! [`JniGen::scalar_type_wrapper`], and [`JniGen::generic_type_wrapper`] —
+//! there is no fluent typestate cursor. Carved from the former monolithic
+//! JNI module; shares the `jni` namespace via `use super::*`.
 
 use super::*;
 
@@ -34,24 +34,27 @@ impl JniGen {
 }
 
 impl JniGen {
-    /// Start a binding generator from a finished [`JniGenConfig`] (the
-    /// package prefix, native-init hook and name-mangle rules). From here you
-    /// add declarations with [`package`](Self::package),
+    /// Start a binding generator with default settings: `source_module =
+    /// crate`, empty base package, no `JNINative` init block, identity
+    /// name-mangling, handle locks enabled. Adjust settings with the `set_*`
+    /// methods, add declarations with [`package`](Self::package),
     /// [`scalar_type_wrapper`](Self::scalar_type_wrapper), etc., then run the
-    /// result through `Registry::write_rust` / `write_kotlin`. Taking the
-    /// whole config up front means it can't change once declarations exist.
-    pub fn new(config: JniGenConfig) -> Self {
+    /// result through `Registry::write_rust` / `write_kotlin`. Settings and
+    /// declarations may be interleaved in any order — setting-derived names
+    /// are re-derived when a setter runs.
+    pub fn new() -> Self {
         let mut jni = Self {
-            source_module: config.source_module,
-            package: config.package_prefix,
+            source_module: syn::parse_str("crate").unwrap(),
+            package: String::new(),
             java_class_prefix: String::new(),
             jni_class_path: String::new(),
-            kotlin_fun_name_mangle: config.kotlin_fun_name_mangle,
-            kotlin_ptr_class_name_mangle: config.kotlin_ptr_class_name_mangle,
-            kotlin_data_class_name_mangle: config.kotlin_data_class_name_mangle,
-            kotlin_enum_name_mangle: config.kotlin_enum_name_mangle,
-            kotlin_harness_name_mangle: config.kotlin_harness_name_mangle,
+            kotlin_fun_name_mangle: None,
+            kotlin_ptr_class_name_mangle: None,
+            kotlin_data_class_name_mangle: None,
+            kotlin_enum_name_mangle: None,
+            kotlin_harness_name_mangle: None,
             kotlin_type_fqns: Vec::new(),
+            declared_class_names: Vec::new(),
             types: HashMap::new(),
             packages: BTreeMap::new(),
             input_wrappers: [
@@ -66,8 +69,8 @@ impl JniGen {
                 HashMap::new(),
                 HashMap::new(),
             ],
-            emit_handle_locks: config.emit_handle_locks,
-            jni_native_init: config.jni_native_init,
+            emit_handle_locks: true,
+            jni_native_init: None,
             expansions: crate::api::core::expand::Expansions::default(),
             deconstructors: crate::api::core::unfold::Deconstructors::default(),
             class_members: HashMap::new(),
@@ -96,7 +99,7 @@ impl JniGen {
     /// from (`package`, `kotlin_harness_name_mangle`). The JNI extern symbol
     /// path resolves to the centralized Native object, whose mangled name
     /// comes from the harness mangle (default `"JNI" + n` → `JNINative`).
-    fn recompute_derived(&mut self) {
+    pub(crate) fn recompute_derived(&mut self) {
         self.java_class_prefix = self.package.replace(".", "/");
         let native_class = self.mangle_harness("Native");
         self.jni_class_path = if self.package.is_empty() {
@@ -182,6 +185,12 @@ impl JniGen {
     }
 }
 
+impl Default for JniGen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ── Accepting a `PackageDecl` ────────────────────────────────────────────
 
 impl JniGen {
@@ -231,21 +240,35 @@ impl JniGen {
         }
     }
 
-    fn accept_ptr_class(&mut self, subpackage: &str, decl: PtrClassDecl) {
-        let short = rust_short_name(&decl.key);
-        let fqn = match decl.name_override {
-            Some(n) => self.resolve_class_fqn(subpackage, &n),
-            None => {
-                let mangled = self.mangle_ptr_class(&short);
-                self.resolve_class_fqn(subpackage, &mangled)
-            }
-        };
-        let key = decl.key;
+    /// Retain one class declaration's raw naming inputs (so a later `set_*`
+    /// call can re-derive the FQN), derive the FQN from the current
+    /// settings, and register it in [`Self::types`] +
+    /// [`Self::kotlin_type_fqns`].
+    fn register_class_name(&mut self, declared: DeclaredClassName) {
+        let fqn = self.derive_class_fqn(&declared);
+        let key = declared.key.clone();
+        self.declared_class_names.push(declared);
         let entry = self.types.entry(key.clone()).or_default();
         entry.class_decl = true;
-        entry.opaque = Some(OpaqueConfig::default());
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
+    }
+
+    fn accept_ptr_class(&mut self, subpackage: &str, decl: PtrClassDecl) {
+        let short = rust_short_name(&decl.key);
+        let key = decl.key;
+        self.register_class_name(DeclaredClassName {
+            key: key.clone(),
+            subpackage: subpackage.to_string(),
+            short,
+            name_override: decl.name_override,
+            explicit_fqn: None,
+            kind: NameKind::Ptr,
+        });
+        self.types
+            .get_mut(&key)
+            .expect("register_class_name created the entry")
+            .opaque = Some(OpaqueConfig::default());
         self.accept_members(&key, decl.members);
 
         if let Some(variants) = decl.input_variants {
@@ -258,9 +281,7 @@ impl JniGen {
                 for v in variants {
                     match v {
                         LocalVariant::Ctor(f) => self.expansions.add_constructor_variant(f),
-                        LocalVariant::SelfIdentity => {
-                            self.expansions.add_constructor_variant_id()
-                        }
+                        LocalVariant::SelfIdentity => self.expansions.add_constructor_variant_id(),
                     }
                 }
             }
@@ -282,60 +303,57 @@ impl JniGen {
 
     fn accept_enum_class(&mut self, subpackage: &str, decl: EnumClassDecl) {
         let short = rust_short_name(&decl.key);
-        let fqn = match decl.name_override {
-            Some(n) => self.resolve_class_fqn(subpackage, &n),
-            None => {
-                let mangled = self.mangle_enum(&short);
-                self.resolve_class_fqn(subpackage, &mangled)
-            }
-        };
         let key = decl.key;
-        let entry = self.types.entry(key.clone()).or_default();
         assert!(
-            entry.opaque.is_none(),
+            self.types
+                .get(&key)
+                .is_none_or(|entry| entry.opaque.is_none()),
             "EnumClassDecl: `{}` is already registered as an opaque handle via a PtrClassDecl — \
              a type can be one or the other, not both",
             short
         );
-        entry.class_decl = true;
-        entry.enum_cfg = Some(EnumConfig::default());
-        entry.kotlin_name = Some(fqn.clone());
-        self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
+        self.register_class_name(DeclaredClassName {
+            key: key.clone(),
+            subpackage: subpackage.to_string(),
+            short,
+            name_override: decl.name_override,
+            explicit_fqn: None,
+            kind: NameKind::Enum,
+        });
+        self.types
+            .get_mut(&key)
+            .expect("register_class_name created the entry")
+            .enum_cfg = Some(EnumConfig::default());
     }
 
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
         let short = rust_short_name(&decl.key);
-        let fqn = match (decl.kotlin_type, decl.name_override) {
-            (Some(expr), _) => expr,
-            (None, Some(n)) => self.resolve_class_fqn(subpackage, &n),
-            (None, None) => {
-                let mangled = self.mangle_data_class(&short);
-                self.resolve_class_fqn(subpackage, &mangled)
-            }
-        };
         let key = decl.key;
-        let entry = self.types.entry(key.clone()).or_default();
-        entry.class_decl = true;
-        entry.kotlin_name = Some(fqn.clone());
-        self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
+        self.register_class_name(DeclaredClassName {
+            key,
+            subpackage: subpackage.to_string(),
+            short,
+            name_override: decl.name_override,
+            explicit_fqn: decl.kotlin_type,
+            kind: NameKind::DataOrValue,
+        });
     }
 
     fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
         let short = rust_short_name(&decl.key);
-        let fqn = match (decl.kotlin_type, decl.name_override) {
-            (Some(expr), _) => expr,
-            (None, Some(n)) => self.resolve_class_fqn(subpackage, &n),
-            (None, None) => {
-                let mangled = self.mangle_data_class(&short);
-                self.resolve_class_fqn(subpackage, &mangled)
-            }
-        };
         let key = decl.key;
-        let entry = self.types.entry(key.clone()).or_default();
-        entry.class_decl = true;
-        entry.value_blob = true;
-        entry.kotlin_name = Some(fqn.clone());
-        self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
+        self.register_class_name(DeclaredClassName {
+            key: key.clone(),
+            subpackage: subpackage.to_string(),
+            short,
+            name_override: decl.name_override,
+            explicit_fqn: decl.kotlin_type,
+            kind: NameKind::DataOrValue,
+        });
+        self.types
+            .get_mut(&key)
+            .expect("register_class_name created the entry")
+            .value_blob = true;
         self.accept_members(&key, decl.members);
     }
 
@@ -444,22 +462,26 @@ impl JniGen {
             let wire_src = decl.wire.clone();
             self.input_wrappers[0].insert(
                 key.clone(),
-                Arc::new(move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                    let wire: syn::Type =
-                        syn::parse_str(&wire_src).expect("stored wire type re-parses");
-                    Some((wire, None, input(&wrapper_value_ident())))
-                }),
+                Arc::new(
+                    move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                        let wire: syn::Type =
+                            syn::parse_str(&wire_src).expect("stored wire type re-parses");
+                        Some((wire, None, input(&wrapper_value_ident())))
+                    },
+                ),
             );
         }
         if let Some(output) = decl.output {
             let wire_src = decl.wire.clone();
             self.output_wrappers[0].insert(
                 key.clone(),
-                Arc::new(move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                    let wire: syn::Type =
-                        syn::parse_str(&wire_src).expect("stored wire type re-parses");
-                    Some((wire, None, output(&wrapper_value_ident())))
-                }),
+                Arc::new(
+                    move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                        let wire: syn::Type =
+                            syn::parse_str(&wire_src).expect("stored wire type re-parses");
+                        Some((wire, None, output(&wrapper_value_ident())))
+                    },
+                ),
             );
         }
         let entry = self.types.entry(key.clone()).or_default();

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1,16 +1,18 @@
 //! Builder API for [`JniGen`].
 //!
-//! Carved from the former monolithic JNI module; shares the `jni`
-//! namespace via `use super::*`.
+//! [`JniGen::new`] takes a finished [`JniGenConfig`]; from then on `JniGen`
+//! only *accepts* pre-built declaration objects (`decl.rs`) via
+//! [`JniGen::package`], [`JniGen::scalar_type_wrapper`], and
+//! [`JniGen::generic_type_wrapper`] — there is no fluent typestate cursor.
+//! Carved from the former monolithic JNI module; shares the `jni` namespace
+//! via `use super::*`.
 
 use super::*;
 
-impl<S> JniGen<S> {
+impl JniGen {
     /// Look up the registered Kotlin FQN for a canonical Rust type key
     /// (the inverse of the `(key, fqn)` rows pushed into
-    /// [`Self::kotlin_type_fqns`] by the type-declaration builders). Single
-    /// home for what used to be ~10 open-coded `kotlin_type_fqns.iter().find`
-    /// scans across the emitters.
+    /// [`Self::kotlin_type_fqns`] by the class-decl accept logic).
     pub(crate) fn kotlin_fqn(&self, rust_canon: &str) -> Option<&str> {
         self.kotlin_type_fqns
             .iter()
@@ -18,244 +20,78 @@ impl<S> JniGen<S> {
             .map(|(_, v)| v.as_str())
     }
 
-    fn into_state<T>(self, state: T) -> JniGen<T> {
-        JniGen {
-            inner: self.inner,
-            state,
-        }
+    /// Whether `ty` was registered via an `EnumClassDecl` — used by the
+    /// Kotlin wrapper generator to decide if a parameter needs a `.value`
+    /// projection between the typed enum (Kotlin signature) and the `Int`
+    /// wire (JNI `external fun`).
+    pub(crate) fn is_kotlin_enum(&self, ty: &syn::Type) -> bool {
+        let key = TypeKey::from_type(ty);
+        self.types
+            .get(&key)
+            .and_then(|c| c.enum_cfg.as_ref())
+            .is_some()
     }
 }
 
-impl JniGen<Root> {
-    /// Convenience constructor with sensible defaults; the paths still need
-    /// to be set explicitly via the field-mutation builder methods.
-    pub fn new() -> Self {
-        let mut base = Self {
-            inner: JniGenInner {
-                source_module: syn::parse_str("crate").unwrap(),
-                package: String::new(),
-                java_class_prefix: String::new(),
-                jni_class_path: "Java_JNINative".to_string(),
-                kotlin_fun_name_mangle: None,
-                kotlin_ptr_class_name_mangle: None,
-                kotlin_data_class_name_mangle: None,
-                kotlin_enum_name_mangle: None,
-                kotlin_wrapper_name_mangle: None,
-                kotlin_harness_name_mangle: None,
-                kotlin_type_fqns: Vec::new(),
-                types: HashMap::new(),
-                packages: BTreeMap::new(),
-                input_wrappers: [
-                    HashMap::new(),
-                    HashMap::new(),
-                    HashMap::new(),
-                    HashMap::new(),
-                ],
-                output_wrappers: [
-                    HashMap::new(),
-                    HashMap::new(),
-                    HashMap::new(),
-                    HashMap::new(),
-                ],
-                active_subpackage: None,
-                emit_handle_locks: true,
-                expansions: crate::api::core::expand::Expansions::default(),
-                deconstructors: crate::api::core::unfold::Deconstructors::default(),
-                class_members: HashMap::new(),
-                jni_native_init: None,
-                declarations_started: false,
-            },
-            state: Root,
+impl JniGen {
+    /// Build a `JniGen` from a finished [`JniGenConfig`]. Because the whole
+    /// config is supplied atomically here, there is no way to change
+    /// `package_prefix`/the mangle closures after any declaration exists —
+    /// the ordering hazard the old fluent builder guarded with a runtime
+    /// panic is structurally impossible now.
+    pub fn new(config: JniGenConfig) -> Self {
+        let mut jni = Self {
+            source_module: config.source_module,
+            package: config.package_prefix,
+            java_class_prefix: String::new(),
+            jni_class_path: String::new(),
+            kotlin_fun_name_mangle: config.kotlin_fun_name_mangle,
+            kotlin_ptr_class_name_mangle: config.kotlin_ptr_class_name_mangle,
+            kotlin_data_class_name_mangle: config.kotlin_data_class_name_mangle,
+            kotlin_enum_name_mangle: config.kotlin_enum_name_mangle,
+            kotlin_harness_name_mangle: config.kotlin_harness_name_mangle,
+            kotlin_type_fqns: Vec::new(),
+            types: HashMap::new(),
+            packages: BTreeMap::new(),
+            input_wrappers: [
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ],
+            output_wrappers: [
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+            ],
+            emit_handle_locks: config.emit_handle_locks,
+            jni_native_init: config.jni_native_init,
+            expansions: crate::api::core::expand::Expansions::default(),
+            deconstructors: crate::api::core::unfold::Deconstructors::default(),
+            class_members: HashMap::new(),
         };
+        jni.recompute_derived();
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
-        // as T and routes E to the error-sink on Err. The error type `E` is
-        // carried through the middle slot so the converter signature is
-        // `Result<wire, E>` and the extern's `Err` arm can `signal_error`
-        // with `E: Display`. Consumers may override per-binding by
-        // registering a more specific rank-1 `Result<_, ConcreteErr>`
-        // (rank-1 phase fires before rank-2).
+        // as T and routes E to the error-sink on Err. Consumers may override
+        // per-binding by registering a more specific rank-1
+        // `GenericTypeWrapperDecl::new(pq!(Result<_, ConcreteErr>))` (rank-1
+        // fires before rank-2 in resolve and short-circuits this).
         let pattern: syn::Type = syn::parse_quote!(Result<_, _>);
         let key = TypeKey::from_type(&pattern);
-        base.output_wrappers[2].insert(
-            key.clone(),
+        jni.output_wrappers[2].insert(
+            key,
             Arc::new(|args: &[syn::Type], _: &Registry<KotlinMeta>| {
                 Some((args[0].clone(), Some(args[1].clone()), syn::parse_quote!(v)))
             }),
         );
-        base.note_wrapper_registration(key, 2);
-        base
-    }
-}
-
-impl<S> JniGen<S> {
-    /// Set the Rust module path that contains the original `#[prebindgen]`
-    /// items. Generated Rust wrappers call functions as
-    /// `<source_module>::<function>(...)`; defaults to `crate`.
-    pub fn source_module(mut self, p: syn::Path) -> Self {
-        self.source_module = p;
-        self
+        jni
     }
 
-    /// Set the JVM/Kotlin **base** package (dot-separated, e.g.
-    /// `"io.zenoh.jni"`). All derived forms are recomputed.
-    ///
-    /// Use [`Self::package`] for generated subpackages below this base.
-    /// Must be set BEFORE the first type / function / wrapper declaration —
-    /// FQNs are derived at declaration time (see
-    /// [`Self::assert_before_declarations`]).
-    pub fn package_prefix(mut self, p: impl Into<String>) -> Self {
-        self.assert_before_declarations("package_prefix");
-        self.package = p.into().trim_matches('.').trim_matches('/').to_string();
-        self.recompute_derived();
-        self
-    }
-
-    /// Panic when an order-sensitive global setting (`package_prefix`, the
-    /// `kotlin_*_name_mangle` closures) is configured after a declaration:
-    /// FQNs / mangled names are baked into each declaration as it is made,
-    /// so a late change would silently mis-name everything already declared.
-    fn assert_before_declarations(&self, what: &str) {
-        assert!(
-            !self.declarations_started,
-            "JniGen::{what} must be configured before the first type / function / \
-             wrapper declaration — names are derived at declaration time, so \
-             setting it later would silently mis-name earlier declarations"
-        );
-    }
-
-    /// Disable the per-call handle-lock scaffold.
-    pub fn disable_handle_locks(mut self) -> Self {
-        self.emit_handle_locks = false;
-        self
-    }
-
-    /// Emit `code` inside an `init { … }` block of the generated centralized
-    /// externs object (`JNINative`). Because every generated native call routes
-    /// through that object, its static initializer is the single point at which
-    /// the consumer can trigger native-library loading transparently — e.g.
-    /// `.jni_native_init("io.zenoh.jni.NativeLibrary.ensureLoaded()")` so any
-    /// call into the generated bindings loads the library first. The referenced
-    /// loader is the consumer's own (hand-written) code; this keeps the
-    /// generator free of any concrete loading logic. Unset = no init block.
-    pub fn jni_native_init(mut self, code: impl Into<String>) -> Self {
-        self.jni_native_init = Some(code.into());
-        self
-    }
-
-    /// Set the closure that mangles the framework "harness" class name
-    /// `"Native"` (the centralized extern holder). Default = prepend
-    /// `"JNI"` (yielding `JNINative`). Affects the generated Kotlin
-    /// class name and the derived JNI extern symbol path on the Rust side.
-    pub fn kotlin_harness_name_mangle<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        self.assert_before_declarations("kotlin_harness_name_mangle");
-        self.kotlin_harness_name_mangle = Some(Arc::new(f));
-        self.recompute_derived();
-        self
-    }
-    /// Set the closure that mangles function names. Called for every
-    /// scanned `#[prebindgen]` free function and the synthetic
-    /// `freePtr` destructor; receives the camelCased Kotlin-side name
-    /// and returns the final form (e.g. `"putPublisher"` →
-    /// `"putPublisherViaJNI"`). Default = identity.
-    pub fn kotlin_fun_name_mangle<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        self.assert_before_declarations("kotlin_fun_name_mangle");
-        self.kotlin_fun_name_mangle = Some(Arc::new(f));
-        self
-    }
-    /// Set the closure that mangles Kotlin ptr-class names declared
-    /// via [`Self::ptr_class`]. Receives the Rust short name.
-    /// Default = identity.
-    pub fn kotlin_ptr_class_name_mangle<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        self.assert_before_declarations("kotlin_ptr_class_name_mangle");
-        self.kotlin_ptr_class_name_mangle = Some(Arc::new(f));
-        self
-    }
-    /// Set the closure that mangles Kotlin data-class names declared
-    /// via [`Self::data_class`]. Receives the Rust short name.
-    /// Default = identity.
-    pub fn kotlin_data_class_name_mangle<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        self.assert_before_declarations("kotlin_data_class_name_mangle");
-        self.kotlin_data_class_name_mangle = Some(Arc::new(f));
-        self
-    }
-    /// Set the closure that mangles [`Self::enum_class`]-declared
-    /// enum class names. Receives the Rust short name. Default =
-    /// identity.
-    pub fn kotlin_enum_name_mangle<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        self.assert_before_declarations("kotlin_enum_name_mangle");
-        self.kotlin_enum_name_mangle = Some(Arc::new(f));
-        self
-    }
-    /// Set the closure that mangles rank-0
-    /// [`Self::input_wrapper`] / [`Self::output_wrapper`] pattern
-    /// names (e.g. `"Encoding"`). Rank-N patterns are NOT routed
-    /// through this closure — they inherit from the inner type's
-    /// metadata via the existing rank-N handlers, preserving the
-    /// structural invariant `Option<Encoding>` ↔ `JNIEncoding?`.
-    /// Default = identity.
-    pub fn kotlin_wrapper_name_mangle<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> String + Send + Sync + 'static,
-    {
-        self.assert_before_declarations("kotlin_wrapper_name_mangle");
-        self.kotlin_wrapper_name_mangle = Some(Arc::new(f));
-        self
-    }
-
-    /// Activate a generated subpackage context below the base package set by
-    /// [`Self::package_prefix`]. Despite the short name, this does **not** set
-    /// the base package; use [`Self::package_prefix`] for that. Subsequent
-    /// [`JniGen::fun`] calls land in this subpackage, and
-    /// any class declared
-    /// ([`Self::ptr_class`] / [`Self::data_class`] /
-    /// [`Self::enum_class`] / [`Self::value_class`]) while the
-    /// subpackage is active gets an FQN of
-    /// `<package>.<subpackage>.<ClassName>`.
-    ///
-    /// Subpackage inheritance is **not** supported — chaining
-    /// `.package("a").package("b")` does not produce
-    /// `"a.b"`; each call overwrites the previous active subpackage.
-    /// To nest, pass a dotted path: `.package("a.b")`.
-    ///
-    /// Passing an empty string clears the active subpackage: subsequent class
-    /// AND function declarations land in the base `<package>`.
-    pub fn package(mut self, subpackage: impl Into<String>) -> JniGen<Package> {
-        let sub = subpackage
-            .into()
-            .trim_matches('.')
-            .trim_matches('/')
-            .to_string();
-        if sub.is_empty() {
-            self.active_subpackage = None;
-        } else {
-            self.packages.entry(sub.clone()).or_default();
-            self.active_subpackage = Some(sub);
-        }
-        self.into_state(Package)
-    }
-
-    /// Recompute the derived caches (`java_class_prefix`,
-    /// `jni_class_path`) from (`package`,
-    /// `kotlin_harness_name_mangle`). Called by
-    /// every setter that touches one of those source fields. The JNI
-    /// extern symbol path resolves to the centralized Native object,
-    /// whose mangled name comes from the harness mangle (default
-    /// `"JNI" + n` → `JNINative`).
+    /// Recompute the derived caches (`java_class_prefix`, `jni_class_path`)
+    /// from (`package`, `kotlin_harness_name_mangle`). The JNI extern symbol
+    /// path resolves to the centralized Native object, whose mangled name
+    /// comes from the harness mangle (default `"JNI" + n` → `JNINative`).
     fn recompute_derived(&mut self) {
         self.java_class_prefix = self.package.replace(".", "/");
         let native_class = self.mangle_harness("Native");
@@ -266,87 +102,73 @@ impl<S> JniGen<S> {
         };
     }
 
-    /// Apply [`Self::kotlin_fun_name_mangle`] to `name`, returning the
-    /// closure result or `name` verbatim when unset. Called everywhere
-    /// the framework derives a function-shaped Kotlin/JNI short name —
-    /// scanned `#[prebindgen]` extern symbols, the synthetic `freePtr`
-    /// destructor, and the Kotlin-side `external fun` that pairs with
-    /// each.
+    /// Apply the fun-name mangle closure to `name`, returning the closure
+    /// result or `name` verbatim when unset. Called everywhere the framework
+    /// derives a function-shaped Kotlin/JNI short name — scanned
+    /// `#[prebindgen]` extern symbols, the synthetic `freePtr` destructor,
+    /// and the Kotlin-side `external fun` that pairs with each.
     pub(crate) fn mangle_fun(&self, name: &str) -> String {
         match &self.kotlin_fun_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
     }
-    /// Apply [`Self::kotlin_ptr_class_name_mangle`] to `name`,
-    /// returning the closure result or `name` verbatim when unset.
+    /// Apply the ptr-class mangle closure to `name`, returning the closure
+    /// result or `name` verbatim when unset.
     pub(crate) fn mangle_ptr_class(&self, name: &str) -> String {
         match &self.kotlin_ptr_class_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
     }
-    /// Apply [`Self::kotlin_data_class_name_mangle`] to `name`,
-    /// returning the closure result or `name` verbatim when unset.
+    /// Apply the data-class mangle closure to `name`, returning the closure
+    /// result or `name` verbatim when unset.
     pub(crate) fn mangle_data_class(&self, name: &str) -> String {
         match &self.kotlin_data_class_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
     }
-    /// Apply [`Self::kotlin_enum_name_mangle`] to `name`, returning the
-    /// closure result or `name` verbatim when unset.
+    /// Apply the enum mangle closure to `name`, returning the closure result
+    /// or `name` verbatim when unset.
     pub(crate) fn mangle_enum(&self, name: &str) -> String {
         match &self.kotlin_enum_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
     }
-    /// Apply [`Self::kotlin_wrapper_name_mangle`] to `name`, returning
-    /// the closure result or `name` verbatim when unset.
-    pub(crate) fn mangle_wrapper(&self, name: &str) -> String {
-        match &self.kotlin_wrapper_name_mangle {
-            Some(f) => f(name),
-            None => name.to_string(),
-        }
-    }
-    /// Apply [`Self::kotlin_harness_name_mangle`] to `name`. The
-    /// closure defaults to `|n| format!("JNI{n}")` when unset, so calling
-    /// `mangle_harness("Native")` yields `"JNINative"`.
+    /// Apply the harness mangle closure to `name`. Defaults to
+    /// `|n| format!("JNI{n}")` when unset, so `mangle_harness("Native")`
+    /// yields `"JNINative"`.
     pub(crate) fn mangle_harness(&self, name: &str) -> String {
         match &self.kotlin_harness_name_mangle {
             Some(f) => f(name),
             None => format!("JNI{name}"),
         }
     }
-    /// The mangled name of the centralized Native object that hosts
-    /// every JNI `external fun`. Drives both the Kotlin class emission
-    /// and the JNI extern symbol path on the Rust side.
+    /// The mangled name of the centralized Native object that hosts every
+    /// JNI `external fun`. Drives both the Kotlin class emission and the
+    /// JNI extern symbol path on the Rust side.
     pub(crate) fn jni_native_class_name(&self) -> String {
         self.mangle_harness("Native")
     }
 
-    /// Resolve a relative class name against [`Self::package`]. Panics
-    /// if `name` contains a `.` (a check that catches accidental FQNs in
-    /// the relative-name builders). The framework refuses dotted names
-    /// on purpose: a binding crate owns one package and must not write
-    /// classes into anyone else's namespace. Higher layers wrap or
-    /// re-export — they don't get injected into.
-    pub(crate) fn resolve_class_fqn(&self, name: &str) -> String {
+    /// Resolve a relative class name against [`Self::package`] +
+    /// `subpackage` (dot-separated; empty `subpackage` = the base package).
+    /// Panics if `name` contains a `.` (a check that catches accidental FQNs
+    /// in the relative-name builders) — a binding crate owns one package and
+    /// must not write classes into anyone else's namespace.
+    pub(crate) fn resolve_class_fqn(&self, subpackage: &str, name: &str) -> String {
         assert!(
             !name.contains('.'),
-            "Kotlin class name `{}` must be relative (no dots) — FQNs are derived from JniGen::package",
+            "Kotlin class name `{}` must be relative (no dots) — FQNs are derived from the base \
+             package + subpackage",
             name
         );
-        // If a `package(p)` context is active, classes declared
-        // while it's active land under `<package>.<p>` instead of just
-        // `<package>`. The user explicitly opts in by ordering the
-        // declaration after the `package` call.
-        let base: String = match (&self.package, &self.active_subpackage) {
-            (p, Some(sub)) if !p.is_empty() => format!("{}.{}", p, sub),
-            (p, Some(sub)) if p.is_empty() => sub.clone(),
-            (p, None) => p.clone(),
-            _ => String::new(),
+        let base: String = match (&self.package, subpackage) {
+            (p, sub) if !sub.is_empty() && !p.is_empty() => format!("{}.{}", p, sub),
+            (p, sub) if !sub.is_empty() && p.is_empty() => sub.to_string(),
+            (p, _) => p.clone(),
         };
         if base.is_empty() {
             name.to_string()
@@ -356,560 +178,257 @@ impl<S> JniGen<S> {
     }
 }
 
-impl<S: TypeDeclState> JniGen<S> {
-    // ── Structured type-conversion builders ──────────────────────────
+// ── Accepting a `PackageDecl` ────────────────────────────────────────────
 
-    /// Declare a typed Kotlin handle class backed by an opaque Rust
-    /// type. Configures: jlong wire for both input and output,
-    /// `Box::into_raw`/`Box::from_raw` lifecycle, the `instanceof`
-    /// dispatch class, and the Kotlin typed-handle class FQN. A `.kt`
-    /// shell is auto-emitted; chain `.flatten_input()` /
-    /// `.flatten_output()` to define its default flatten shape.
-    pub fn ptr_class(mut self, rust_type: syn::Type) -> JniGen<PtrClass> {
-        self.declarations_started = true;
-        let key = TypeKey::from_type(&rust_type);
-        let short = rust_short_name(&key);
-        let fqn = self.resolve_class_fqn(&self.mangle_ptr_class(&short));
+impl JniGen {
+    /// Accept a batch of package-scoped declarations (classes + functions).
+    /// **Merges** into whatever `decl.name`'s subpackage bucket already
+    /// holds — the same subpackage name may be reopened across several
+    /// `PackageDecl` values / `package` calls (e.g. one for its classes,
+    /// another later for its functions).
+    pub fn package(mut self, decl: PackageDecl) -> Self {
+        let PackageDecl {
+            name,
+            classes,
+            functions,
+        } = decl;
+        self.packages.entry(name.clone()).or_default();
+        for class in classes {
+            self.accept_class(&name, class);
+        }
+        for func in functions {
+            self.accept_function(&name, func);
+        }
+        self
+    }
+
+    fn accept_class(&mut self, subpackage: &str, decl: ClassDecl) {
+        match decl {
+            ClassDecl::Ptr(d) => self.accept_ptr_class(subpackage, d),
+            ClassDecl::Enum(d) => self.accept_enum_class(subpackage, d),
+            ClassDecl::Data(d) => self.accept_data_class(subpackage, d),
+            ClassDecl::Value(d) => self.accept_value_class(subpackage, d),
+        }
+    }
+
+    fn accept_ptr_class(&mut self, subpackage: &str, decl: PtrClassDecl) {
+        let short = rust_short_name(&decl.key);
+        let fqn = match decl.name_override {
+            Some(n) => self.resolve_class_fqn(subpackage, &n),
+            None => {
+                let mangled = self.mangle_ptr_class(&short);
+                self.resolve_class_fqn(subpackage, &mangled)
+            }
+        };
+        let key = decl.key;
         let entry = self.types.entry(key.clone()).or_default();
         entry.class_decl = true;
         entry.opaque = Some(OpaqueConfig::default());
-        // `kotlin_name` holds the typed-handle FQN for FQN-consumers
-        // (typed-handle class emission, `instanceof` dispatch, return-
-        // value constructor wrap). The value-context Kotlin name for
-        // opaque types — `"Long"` — flows separately through
-        // [`KotlinMeta::kotlin_name`] produced by the rank-0 opaque
-        // handler, so wire-level mentions don't collide with the FQN.
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
-        self.into_state(PtrClass {
-            key,
-            package: std::marker::PhantomData,
-        })
-    }
-}
+        self.accept_members(&key, decl.members);
 
-impl<S: PackageState> JniGen<S> {
-    /// Declare a `#[prebindgen]` function as a free-standing package wrapper
-    /// under the currently-active [`Self::package`] subpackage context — or in
-    /// the **base** package when no subpackage is active (after
-    /// `.package("")`, or before any `.package(...)` call), mirroring class
-    /// declarations. If a class context is live, calling `fun` clears it —
-    /// the idea being that "leak class context to package level" makes the
-    /// chain unambiguous after one fn-level declaration.
-    pub fn fun(self, ident: syn::Ident) -> JniGen<Function> {
-        self.push_fun(MethodEntry::new(ident))
-    }
-
-    /// Shared body of [`Self::fun`]. An empty subpackage key = the base
-    /// package.
-    fn push_fun(mut self, entry: MethodEntry) -> JniGen<Function> {
-        self.declarations_started = true;
-        let sub = self.active_subpackage.clone().unwrap_or_default();
-        let pkg = self.packages.entry(sub.clone()).or_default();
-        let idx = pkg.functions.len();
-        pkg.functions.push(entry);
-        self.into_state(Function {
-            package: sub,
-            index: idx,
-        })
-    }
-}
-
-impl JniGen<Function> {
-    /// Override the Kotlin-side function name for this [`JniGen::fun`]
-    /// entry. Default (without `.name(...)`) is
-    /// `snake_to_camel(rust_ident)` (e.g. `z_hello_whatami` → `zHelloWhatami`).
-    pub fn name(mut self, kotlin_name: impl Into<String>) -> Self {
-        let name = kotlin_name.into();
-        let package = self.state.package.clone();
-        let index = self.state.index;
-        let pkg = self
-            .packages
-            .get_mut(&package)
-            .expect("package entry vanished");
-        pkg.functions[index].kotlin_name_override = Some(name);
-        self
-    }
-}
-
-impl JniGen<PtrClass> {
-    // ── Default flatten shape (input / output) on the ptr_class ──
-
-    /// Rust type of this [`Self::ptr_class`] state, for the
-    /// `.flatten_input*` / `.flatten_output*` chain.
-    fn current_ptr_class(&self) -> syn::Type {
-        self.state.key.to_type()
+        if let Some(variants) = decl.input_variants {
+            self.expansions.ensure_default_constructor(key.to_type());
+            for v in variants {
+                match v {
+                    LocalVariant::Ctor(f) => self.expansions.add_constructor_variant(f),
+                    LocalVariant::SelfIdentity => self.expansions.add_constructor_variant_id(),
+                }
+            }
+        }
+        if let Some(fields) = decl.output_fields {
+            self.deconstructors
+                .ensure_default_deconstructor(key.to_type());
+            for f in fields {
+                match f {
+                    LocalField::Named(func, name) => {
+                        self.deconstructors.add_deconstructor_record(func, name)
+                    }
+                    LocalField::SelfField => self.deconstructors.add_deconstructor_record_id(),
+                }
+            }
+        }
     }
 
-    /// Resolve a member `name` of the given [`MemberKind`] on the current class
-    /// to its Rust ident, or panic with a clear build-script message.
-    fn resolve_member(&self, name: &str, kind: MemberKind, verb: &str) -> syn::Ident {
-        let key = self.state.key.clone();
-        self.class_members
-            .get(&key)
-            .and_then(|ms| ms.iter().find(|m| m.kind == kind && m.kotlin_name == name))
-            .unwrap_or_else(|| {
-                let what = match kind {
-                    MemberKind::Accessor => ".accessor",
-                    MemberKind::Constructor => ".constructor",
-                    MemberKind::Method => ".method",
-                };
-                panic!(
-                    "{verb}(\"{name}\"): no `{what}(.., \"{name}\")` declared on `{}` — declare \
-                     the member on this class before referencing it here.",
-                    key.as_str()
-                )
-            })
-            .rust_ident
-            .clone()
-    }
-
-    /// Begin the class's **default input flatten**: how a parameter of this
-    /// class type is assembled at the boundary. Chain `.variant(name)` (build
-    /// via a declared `.constructor`) and/or `.variant_self()` (accept the
-    /// handle directly); multiple variants are selector-dispatched.
-    pub fn flatten_input(mut self) -> Self {
-        let t = self.current_ptr_class();
-        self.expansions.ensure_default_constructor(t);
-        self
-    }
-
-    /// `.variant(name)` inside `.flatten_input()` — add a build-from variant via
-    /// the constructor declared as `name` (see [`Self::constructor`]).
-    pub fn variant(mut self, name: impl Into<String>) -> Self {
-        let func = self.resolve_member(&name.into(), MemberKind::Constructor, "variant");
-        self.expansions.add_constructor_variant(func);
-        self
-    }
-
-    /// `.variant_self()` inside `.flatten_input()` — accept an already-built
-    /// handle directly (the identity variant).
-    pub fn variant_self(mut self) -> Self {
-        self.expansions.add_constructor_variant_id();
-        self
-    }
-
-    /// Begin the class's **default output flatten**: how a returned/callback
-    /// value of this class is decomposed into fields. Chain `.field(name)`
-    /// (a declared `.accessor`'s value) and/or `.field_self()` (the handle
-    /// itself).
-    pub fn flatten_output(mut self) -> Self {
-        let t = self.current_ptr_class();
-        self.deconstructors.ensure_default_deconstructor(t);
-        self
-    }
-
-    /// `.field(name)` inside `.flatten_output()` — include the value of the
-    /// accessor declared as `name` (see [`Self::accessor`]), flattened per its
-    /// return type's own default output. `name` is also the literal
-    /// callback-parameter name (emitted verbatim; unique within the flatten,
-    /// no reserved `"__"` separator). A nested class field prefixes the child
-    /// field names (`name__<child>`).
-    pub fn field(mut self, name: impl Into<String>) -> Self {
-        let name = name.into();
-        let func = self.resolve_member(&name, MemberKind::Accessor, "field");
-        let t = self.current_ptr_class();
-        self.deconstructors.ensure_default_deconstructor(t);
-        self.deconstructors.add_deconstructor_record(func, name);
-        self
-    }
-
-    /// `.field_self()` inside `.flatten_output()` — include the handle itself
-    /// as a field.
-    pub fn field_self(mut self) -> Self {
-        let t = self.current_ptr_class();
-        self.deconstructors.ensure_default_deconstructor(t);
-        self.deconstructors.add_deconstructor_record_id();
-        self
-    }
-}
-
-impl JniGen<Function> {
-    // ── Per-function flatten overrides ──────────────────────────────────
-
-    /// Per-fn: `param` skips input-flattening and takes the raw handle.
-    pub fn flatten_input_suppress(mut self, param: syn::Ident) -> Self {
-        let func = self.current_fn_ident();
-        self.expansions.add_skip_default_construct(func, param);
-        self
-    }
-
-    /// Per-fn: the return value skips output-flattening and stays a raw handle.
-    pub fn flatten_output_suppress(mut self) -> Self {
-        let func = self.current_fn_ident();
-        self.deconstructors.add_skip_default_output(func);
-        self
-    }
-
-    /// Per-fn: replace the default input flatten of `param` with an explicit,
-    /// incrementally-built variant list — chain `.variant(fn)` (build-from
-    /// constructor fns) and/or `.variant_self()` (accept the handle directly).
-    pub fn flatten_input_with(mut self, param: syn::Ident) -> Self {
-        let func = self.current_fn_ident();
-        self.expansions.begin_subset(func, param);
-        self
-    }
-
-    /// `.variant(fn)` inside `.flatten_input_with(param)` — add a build-from
-    /// constructor arm (the rust constructor fn directly).
-    pub fn variant(mut self, func: syn::Ident) -> Self {
-        self.expansions.push_subset_variant(func);
-        self
-    }
-
-    /// `.variant_self()` inside `.flatten_input_with(param)` — accept an
-    /// already-built handle directly (the identity arm).
-    pub fn variant_self(mut self) -> Self {
-        self.expansions.push_subset_self();
-        self
-    }
-
-    /// Per-fn: replace the default output flatten with an explicit,
-    /// incrementally-built field list — chain `.field(fn, name)` (accessor fns
-    /// with their leaf name) and/or `.field_self()` (the handle itself).
-    pub fn flatten_output_with(mut self) -> Self {
-        let func = self.current_fn_ident();
-        self.deconstructors.begin_inline_output(func);
-        self
-    }
-
-    /// `.field(fn, name)` inside `.flatten_output_with()` — include the value of
-    /// the accessor fn `fn` (the rust accessor fn directly) as field `name`.
-    pub fn field(mut self, func: syn::Ident, name: impl Into<String>) -> Self {
-        self.deconstructors.push_inline_field(func, name);
-        self
-    }
-
-    /// `.field_self()` inside `.flatten_output_with()` — include the handle
-    /// itself as a field.
-    pub fn field_self(mut self) -> Self {
-        self.deconstructors.push_inline_field_self();
-        self
-    }
-
-    /// Rust ident of the function the current per-fn override chain targets,
-    /// resolved from the live [`Self::fun`] state.
-    fn current_fn_ident(&self) -> syn::Ident {
-        self.packages
-            .get(&self.state.package)
-            .expect("package entry vanished")
-            .functions[self.state.index]
-            .rust_ident
-            .clone()
-    }
-}
-
-impl<S> JniGen<S> {
-    /// Whether `ty` was registered via [`Self::enum_class`] — used by
-    /// the Kotlin wrapper generator to decide if a parameter needs a
-    /// `.value` projection between the typed enum (Kotlin signature) and
-    /// the `Int` wire (JNI `external fun`).
-    pub(crate) fn is_kotlin_enum(&self, ty: &syn::Type) -> bool {
-        let key = TypeKey::from_type(ty);
-        self.types
-            .get(&key)
-            .and_then(|c| c.enum_cfg.as_ref())
-            .is_some()
-    }
-}
-
-impl<S: TypeDeclState> JniGen<S> {
-    /// Declare a `#[prebindgen]`-marked `enum` as a Kotlin `enum class`.
-    /// Configures: `jni::sys::jint` wire (input + output), `TryFrom<i32>`
-    /// decode on input, `as jint` encode on output, and Kotlin enum-file
-    /// emission. The enum must be C-like (unit variants only) and either
-    /// `#[repr(i32)]` / `#[repr(u8)]` (or similar) with explicit
-    /// discriminants — the Kotlin emitter and the generated
-    /// `TryFrom<i32>` decode rely on the discriminant values matching the
-    /// jint wire.
-    ///
-    /// A `.kt` file is auto-emitted under [`Self::package`]; the class name
-    /// passes through [`Self::kotlin_enum_name_mangle`] (default = Rust
-    /// short name).
-    pub fn enum_class(mut self, rust_type: syn::Type) -> JniGen<EnumClass> {
-        self.declarations_started = true;
-        let key = TypeKey::from_type(&rust_type);
-        let short = rust_short_name(&key);
-        let fqn = self.resolve_class_fqn(&self.mangle_enum(&short));
+    fn accept_enum_class(&mut self, subpackage: &str, decl: EnumClassDecl) {
+        let short = rust_short_name(&decl.key);
+        let fqn = match decl.name_override {
+            Some(n) => self.resolve_class_fqn(subpackage, &n),
+            None => {
+                let mangled = self.mangle_enum(&short);
+                self.resolve_class_fqn(subpackage, &mangled)
+            }
+        };
+        let key = decl.key;
         let entry = self.types.entry(key.clone()).or_default();
         assert!(
             entry.opaque.is_none(),
-            "JniGen::enum_class: `{}` is already registered as an opaque \
-             handle via `ptr_class` — a type can be one or the other, \
-             not both",
+            "EnumClassDecl: `{}` is already registered as an opaque handle via a PtrClassDecl — \
+             a type can be one or the other, not both",
             short
         );
         entry.class_decl = true;
         entry.enum_cfg = Some(EnumConfig::default());
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
-        self.into_state(EnumClass {
-            key,
-            package: std::marker::PhantomData,
-        })
+        self.accept_members(&key, decl.members);
     }
 
-    /// Declare a Rust struct that should appear in Kotlin as a data
-    /// class under a derived name. The name passes through
-    /// [`Self::kotlin_data_class_name_mangle`] (default = Rust short
-    /// name, generics / lifetimes stripped). Only affects Kotlin
-    /// emission — no Rust-side converter override.
-    pub fn data_class(mut self, rust_type: syn::Type) -> JniGen<TypeMeta> {
-        self.declarations_started = true;
-        let key = TypeKey::from_type(&rust_type);
-        let short = rust_short_name(&key);
-        let fqn = self.resolve_class_fqn(&self.mangle_data_class(&short));
+    fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
+        let short = rust_short_name(&decl.key);
+        let fqn = match (decl.kotlin_type, decl.name_override) {
+            (Some(expr), _) => expr,
+            (None, Some(n)) => self.resolve_class_fqn(subpackage, &n),
+            (None, None) => {
+                let mangled = self.mangle_data_class(&short);
+                self.resolve_class_fqn(subpackage, &mangled)
+            }
+        };
+        let key = decl.key;
         let entry = self.types.entry(key.clone()).or_default();
         entry.class_decl = true;
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
-        self.into_state(TypeMeta {
-            key,
-            package: std::marker::PhantomData,
-        })
+        self.accept_members(&key, decl.members);
     }
 
-    /// Declare a **`Copy` value class** type: a Rust type passed across the
-    /// JNI boundary **by value as its raw memory bytes** in a `ByteArray`,
-    /// rather than as a closeable `jlong` heap handle. The value-level peer
-    /// of [`Self::ptr_class`] — `ByteArray` is to a blob what `Long` is to a
-    /// handle. Use it for small `Copy` types (e.g. `ZenohId`) so they need no
-    /// `close()` and so `Vec<T>` can surface as `List<ByteArray>` (a
-    /// `Vec<closeable-handle>` is rejected; see the `Vec<_>` handler).
-    ///
-    /// The type **must be `Copy`** — the generator emits a compile-time
-    /// assertion to that effect (a non-`Copy` declaration is a hard build
-    /// error). Conversions reinterpret the bytes (`read_unaligned` on input,
-    /// raw-bytes read on output), so the blob is valid only same-architecture
-    /// in-process, exactly like an opaque handle pointer. Mutually exclusive
-    /// with `ptr_class` / `enum_class`.
-    pub fn value_class(mut self, rust_type: syn::Type) -> JniGen<TypeMeta> {
-        self.declarations_started = true;
-        let key = TypeKey::from_type(&rust_type);
-        let short = rust_short_name(&key);
-        // Typed Kotlin FQN for the emitted `@JvmInline value class` — the same
-        // FQN-consumer slot a `ptr_class` / `value_class` uses (typed-class
-        // emission, projection-leaf lookup, `instanceof` imports). The
-        // *value-level* name (`"ByteArray"`) is set separately on the rank-0
-        // converter's metadata, so wire mentions stay `ByteArray` while typed
-        // positions render the value class.
-        let fqn = self.resolve_class_fqn(&self.mangle_data_class(&short));
+    fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
+        let short = rust_short_name(&decl.key);
+        let fqn = match (decl.kotlin_type, decl.name_override) {
+            (Some(expr), _) => expr,
+            (None, Some(n)) => self.resolve_class_fqn(subpackage, &n),
+            (None, None) => {
+                let mangled = self.mangle_data_class(&short);
+                self.resolve_class_fqn(subpackage, &mangled)
+            }
+        };
+        let key = decl.key;
         let entry = self.types.entry(key.clone()).or_default();
         entry.class_decl = true;
         entry.value_blob = true;
         entry.kotlin_name = Some(fqn.clone());
         self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
-        self.into_state(TypeMeta {
-            key,
-            package: std::marker::PhantomData,
-        })
+        self.accept_members(&key, decl.members);
     }
-}
 
-impl JniGen<TypeMeta> {
-    /// Stamp a verbatim Kotlin type expression (e.g. `"List<ByteArray>"`)
-    /// onto the entry registered by the most recent `data_class` /
-    /// `value_class` / rank-0 wrapper declaration. Use this when the Kotlin
-    /// type is not a class FQN (generics, primitives, container types). For
-    /// class names, the per-kind `kotlin_*_name_mangle` closures (configured
-    /// on [`JniGen`]) own derivation — `kotlin_type` is the escape hatch for
-    /// verbatim expressions that don't map onto any one element kind.
-    /// Deliberately NOT available on `ptr_class` / `enum_class` states: their
-    /// registered FQN feeds typed-handle emission and `instanceof` dispatch,
-    /// which a verbatim expression would corrupt.
-    pub fn kotlin_type(mut self, kotlin_expr: impl Into<String>) -> Self {
-        let key = self.state.type_key().clone();
-        let expr = kotlin_expr.into();
-        let entry = self.types.get_mut(&key).expect("meta entry vanished");
-        entry.kotlin_name = Some(expr.clone());
-        self.kotlin_type_fqns.push((key.as_str().to_string(), expr));
-        self
-    }
-}
-
-impl<S: TypeKeyState> JniGen<S> {
-    /// Override the Kotlin **class name** for the most recent type declaration
-    /// (`ptr_class` / `enum_class` / `data_class` / `value_class` / rank-0
-    /// wrapper) — the per-declaration dual of [`JniGen::name`] on functions.
-    /// `kotlin_name` is a **relative** class name (no dots; the FQN is derived
-    /// from the active [`JniGen::package`] context, exactly like the default
-    /// name) and is used **literally** — the per-kind `kotlin_*_name_mangle`
-    /// closures do not apply to it.
-    pub fn name(mut self, kotlin_name: impl Into<String>) -> Self {
-        let key = self.state.type_key().clone();
-        let fqn = self.resolve_class_fqn(&kotlin_name.into());
-        let entry = self.types.get_mut(&key).expect("type entry vanished");
-        entry.kotlin_name = Some(fqn.clone());
-        // Replace the pair the declaration pushed, so FQN consumers reading
-        // the flat view see exactly one (renamed) row for this type.
-        match self
-            .kotlin_type_fqns
-            .iter_mut()
-            .rev()
-            .find(|(k, _)| k == key.as_str())
-        {
-            Some(pair) => pair.1 = fqn,
-            None => self.kotlin_type_fqns.push((key.as_str().to_string(), fqn)),
+    /// Shared tail of the four `accept_*_class` methods: a constructor
+    /// member's return is never output-flattened (it's a factory), then the
+    /// members join the class's registered set.
+    fn accept_members(&mut self, key: &TypeKey, members: Vec<ClassMember>) {
+        for m in &members {
+            if m.kind == MemberKind::Constructor {
+                self.deconstructors
+                    .add_skip_default_output(m.rust_ident.clone());
+            }
         }
-        self
+        self.class_members
+            .entry(key.clone())
+            .or_default()
+            .extend(members);
     }
 
-    /// Declare a `#[prebindgen]` **read accessor** (`f(&Self) -> R`, a single
-    /// parameter) as an **instance method** `name` of the current class. The
-    /// receiver is dropped from the Kotlin signature and bound to `this`. An
-    /// accessor's params are never input-flattened and its return is never
-    /// output-flattened; it is the only member kind usable as a flatten
-    /// `.field(name)`. Declare it BEFORE any `.flatten_output().field(name)`
-    /// that references it.
-    pub fn accessor(self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        self.push_member(rust_fun, name, MemberKind::Accessor)
-    }
+    fn accept_function(&mut self, subpackage: &str, decl: FunctionDecl) {
+        let FunctionDecl {
+            rust_ident,
+            kotlin_name_override,
+            input_suppressed,
+            input_overrides,
+            output_suppressed,
+            output_override,
+        } = decl;
 
-    /// Declare a `#[prebindgen]` **method** (`f(&Self, …) -> R`) as an
-    /// **instance method** `name` of the current class. The first parameter
-    /// (the `&Self` receiver) is dropped and bound to `this`; the remaining
-    /// parameters flatten like a normal function. A method is NOT usable as a
-    /// flatten field.
-    pub fn method(self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        self.push_member(rust_fun, name, MemberKind::Method)
-    }
+        let mut entry = MethodEntry::new(rust_ident.clone());
+        entry.kotlin_name_override = kotlin_name_override;
+        self.packages
+            .entry(subpackage.to_string())
+            .or_default()
+            .functions
+            .push(entry);
 
-    /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
-    /// `Result<Self, E>`) as a **companion-object factory** member `name` of the
-    /// current class, returning the class. Its return never output-flattens (it
-    /// is a factory). Reference it from `.flatten_input().variant(name)` to make
-    /// it a build-from variant for parameters of this class type.
-    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        // A constructor returns the class itself — never decompose its return.
-        self.deconstructors
-            .add_skip_default_output(rust_fun.clone());
-        self.push_member(rust_fun, name, MemberKind::Constructor)
-    }
-
-    /// Shared body of [`Self::accessor`] / [`Self::method`] / [`Self::constructor`].
-    fn push_member(
-        mut self,
-        rust_fun: syn::Ident,
-        name: impl Into<String>,
-        kind: MemberKind,
-    ) -> Self {
-        let key = self.state.type_key().clone();
-        self.class_members.entry(key).or_default().push(
-            crate::api::lang::jnigen::jni::ClassMember {
-                rust_ident: rust_fun,
-                kotlin_name: name.into(),
-                kind,
-            },
-        );
-        self
-    }
-}
-
-impl<S> JniGen<S> {
-    /// Register a rank-N **input converter**. `pattern` contains 0–3
-    /// `_` placeholders; the closure's arity selects the rank table.
-    /// The closure returns `Some((ty, exc, body))` (see the internal wrapper
-    /// function type
-    /// for the triple's full semantics) or `None` (defer to a later
-    /// resolver phase). The body sees `env: &mut JNIEnv` and `v: &<wire>`
-    /// in scope.
-    ///
-    /// * `exc = None` ⇒ binding-fallible only: `body` evaluates to a bare
-    ///   `ty`; framework emits `-> Result<ty, __JniErr>` with an `Ok(...)`
-    ///   wrap, and `?` inside propagates the framework error.
-    /// * `exc = Some(<Rust type>)` ⇒ domain-fallible: `body` evaluates to
-    ///   `Result<ty, <Rust type>>`; framework emits it verbatim. The type
-    ///   is the `E` peeled from the source `Result<T, E>`, matched by
-    ///   **exact canonical-form equality** (no short-name fallback); a
-    ///   failure routes to the wrapper's error sink, never a JVM throw.
-    ///
-    /// `ty` is auto-classified at resolve: a wire shape ⇒ terminal
-    /// converter; a distinct rust type with its own converter ⇒ a
-    /// value-inspecting stage composed onto that converter's chain
-    /// (resolved by the adapter's wrapper lookup).
-    pub fn input_wrapper<A, B>(self, pattern: syn::Type, builder: B) -> JniGen<B::NextState>
-    where
-        B: WrapperBuilder<A>,
-    {
-        let key = TypeKey::from_type(&pattern);
-        let rank = B::rank();
-        Self::reject_builtin_wrapper_pattern(&key, rank);
-        let mut s = self;
-        s.declarations_started = true;
-        s.input_wrappers[rank].insert(key.clone(), builder.into_wrapper_fn());
-        let next = B::NextState::from_wrapper(key.clone());
-        s.note_wrapper_registration(key, rank);
-        s.into_state(next)
-    }
-
-    /// Output-direction counterpart of [`Self::input_wrapper`]. Same
-    /// closure shape, same `exc = None` / `Some(<Rust type>)` semantics,
-    /// same terminal-vs-composed classification — see that method's docs.
-    /// (`Some(parse_quote!(<full path>))` with a rust-typed `ty`, e.g.
-    /// `(T, Some(parse_quote!(zenoh_flat::errors::ZError)), v)` for
-    /// `ZResult<T>`, gives the auto-composed peel that the deleted
-    /// `output_throw_stage` used to register.)
-    pub fn output_wrapper<A, B>(self, pattern: syn::Type, builder: B) -> JniGen<B::NextState>
-    where
-        B: WrapperBuilder<A>,
-    {
-        let key = TypeKey::from_type(&pattern);
-        let rank = B::rank();
-        Self::reject_builtin_wrapper_pattern(&key, rank);
-        let mut s = self;
-        s.declarations_started = true;
-        s.output_wrappers[rank].insert(key.clone(), builder.into_wrapper_fn());
-        let next = B::NextState::from_wrapper(key.clone());
-        s.note_wrapper_registration(key, rank);
-        s.into_state(next)
-    }
-
-    /// Reject a rank-0 wrapper on a Rust **builtin** type: the generated
-    /// converter qualifies the pattern with the `source_module`
-    /// (`perftest_flat::usize`), which does not compile. Wrap the builtin in
-    /// a source-crate newtype (like `Millis(u64)`) instead. Known limitation
-    /// found via `examples/covertest-kotlin` (2026-07-03).
-    fn reject_builtin_wrapper_pattern(key: &TypeKey, rank: usize) {
-        const BUILTINS: &[&str] = &[
-            "usize", "isize", "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128",
-            "f32", "f64", "bool", "char", "str",
-        ];
-        assert!(
-            !(rank == 0 && BUILTINS.contains(&key.as_str())),
-            "JniGen wrapper on builtin `{}`: rank-0 wrappers must target a \
-             source-crate type (the generated converter qualifies the pattern \
-             with the source module, which is invalid for builtins) — wrap the \
-             builtin in a newtype instead",
-            key.as_str()
-        );
-    }
-
-    /// Shared post-registration bookkeeping for wrapper inserts. Rank-0
-    /// patterns identify a concrete type — auto-stamp `kotlin_name` via
-    /// [`Self::mangle_wrapper`] (skipping non-path patterns like `()`
-    /// where there is no sensible short name). Rank ≥1 patterns are
-    /// wildcards — per-outer-type names come from inner-metadata
-    /// propagation via [`Self::override_kotlin_name`].
-    fn note_wrapper_registration(&mut self, key: TypeKey, rank: usize) {
-        if rank == 0 {
-            let entry = self.types.entry(key.clone()).or_default();
-            // Skip any entry whose kotlin_name has already been stamped
-            // (e.g. by an earlier data_class / ptr_class call for the
-            // same type — a wrapper layered on top should not override
-            // it). Then derive the short name from the canonical
-            // TypeKey; non-path patterns ($()$, references, etc.)
-            // yield no Kotlin class name and are left as `None`.
-            if entry.kotlin_name.is_none() {
-                if let Some(short) = rust_short_name_opt(&key) {
-                    let fqn = self.resolve_class_fqn(&self.mangle_wrapper(&short));
-                    let entry = self.types.get_mut(&key).expect("just-inserted entry");
-                    entry.kotlin_name = Some(fqn.clone());
-                    self.kotlin_type_fqns.push((key.as_str().to_string(), fqn));
+        for param in input_suppressed {
+            self.expansions
+                .add_skip_default_construct(rust_ident.clone(), param);
+        }
+        for (param, variants) in input_overrides {
+            self.expansions.begin_subset(rust_ident.clone(), param);
+            for v in variants {
+                match v {
+                    LocalVariant::Ctor(f) => self.expansions.push_subset_variant(f),
+                    LocalVariant::SelfIdentity => self.expansions.push_subset_self(),
+                }
+            }
+        }
+        if output_suppressed {
+            self.deconstructors
+                .add_skip_default_output(rust_ident.clone());
+        }
+        if let Some(fields) = output_override {
+            self.deconstructors.begin_inline_output(rust_ident.clone());
+            for f in fields {
+                match f {
+                    LocalField::Named(func, name) => {
+                        self.deconstructors.push_inline_field(func, name)
+                    }
+                    LocalField::SelfField => self.deconstructors.push_inline_field_self(),
                 }
             }
         }
     }
+}
 
+// ── Accepting wrapper decls ──────────────────────────────────────────────
+
+impl JniGen {
+    /// Register a rank-0 custom scalar wire mapping (e.g. a newtype wrapping
+    /// a primitive). Global — not tied to any package (see `decl.rs`'s
+    /// module doc for why).
+    pub fn scalar_type_wrapper(mut self, decl: ScalarTypeWrapperDecl) -> Self {
+        let key = TypeKey::from_type(&decl.pattern);
+        if let Some(input) = decl.input {
+            let wire_src = decl.wire.clone();
+            self.input_wrappers[0].insert(
+                key.clone(),
+                Arc::new(move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                    let wire: syn::Type =
+                        syn::parse_str(&wire_src).expect("stored wire type re-parses");
+                    Some((wire, None, input(&wrapper_value_ident())))
+                }),
+            );
+        }
+        if let Some(output) = decl.output {
+            let wire_src = decl.wire.clone();
+            self.output_wrappers[0].insert(
+                key.clone(),
+                Arc::new(move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                    let wire: syn::Type =
+                        syn::parse_str(&wire_src).expect("stored wire type re-parses");
+                    Some((wire, None, output(&wrapper_value_ident())))
+                }),
+            );
+        }
+        let entry = self.types.entry(key.clone()).or_default();
+        entry.kotlin_name = Some(decl.kotlin_type.clone());
+        self.kotlin_type_fqns
+            .push((key.as_str().to_string(), decl.kotlin_type));
+        self
+    }
+
+    /// Register a rank 1-3 structural-dispatch override (e.g. a per-error
+    /// `Result<_, ConcreteErr>` peel). Global — not tied to any package.
+    pub fn generic_type_wrapper(mut self, decl: GenericTypeWrapperDecl) -> Self {
+        let key = TypeKey::from_type(&decl.pattern);
+        if let Some((rank, f)) = decl.input {
+            self.input_wrappers[rank].insert(key.clone(), f);
+        }
+        if let Some((rank, f)) = decl.output {
+            self.output_wrappers[rank].insert(key, f);
+        }
+        self
+    }
+}
+
+impl JniGen {
     /// Build a `KotlinMeta` carrying just the value-context Kotlin name.
     /// Used by every built-in converter (primitives, structs, `Option<_>`,
     /// `Vec<_>`, `impl Fn(...)` lambdas). Errors are routed uniformly to the
@@ -943,7 +462,6 @@ impl<S> JniGen<S> {
     /// Structurally match `ty` against every registered **input** wrapper
     /// pattern, most-specific-first (fewest wildcards win, e.g.
     /// `Result<_, ConcreteErr>` over `Result<_, _>`), and build the first hit.
-    /// Replaces the rank resolver's per-arity enumeration for the user table.
     pub(crate) fn match_user_input(
         &self,
         ty: &syn::Type,
@@ -1005,11 +523,10 @@ impl<S> JniGen<S> {
         let outer = substitute_wildcards(pat, args);
         // Terminal vs composed: `ty` is composed iff it's a *distinct*
         // rust type with its own input converter. The self-check guards
-        // the void/identity case (`output_wrapper("()")` returns `ty ==
-        // outer`), and the registered-converter probe distinguishes a
-        // rust continue-type (compose) from a wire (terminal) without
-        // forcing `()` either way. A non-wire `ty` that isn't yet
-        // resolved defers.
+        // the void/identity case, and the registered-converter probe
+        // distinguishes a rust continue-type (compose) from a wire
+        // (terminal) without forcing `()` either way. A non-wire `ty` that
+        // isn't yet resolved defers.
         let is_self = TypeKey::from_type(&ty) == TypeKey::from_type(&outer);
         let inner = if is_self {
             None
@@ -1097,8 +614,7 @@ impl<S> JniGen<S> {
     ///
     /// The closure's returned type is classified by [`is_wire_type`]:
     /// * **wire** ⇒ terminal: a single converter `outer → wire`,
-    ///   returning `Result<wire, err>` (throwing iff [`ConverterReg::exc`]
-    ///   is set).
+    ///   returning `Result<wire, err>` (throwing iff exc is set).
     /// * **rust type** ⇒ composed: this body is a value-inspecting stage
     ///   `outer → ty` prepended to `ty`'s own output converter chain
     ///   (e.g. `ZResult<T>` returns rust `T`, so the peel stage raises
@@ -1221,11 +737,11 @@ impl<S> JniGen<S> {
 /// allowlist to keep in sync.
 ///
 /// `()` is deliberately **not** treated as a wire here: it is ambiguous
-/// (the void wire of the `output_wrapper("()")` self-converter *and* the
-/// unit continue-type of `ZResult<()>`). The terminal-vs-composed
-/// decision in [`JniGen::lookup_input`] / [`JniGen::lookup_output`]
-/// resolves that ambiguity via the self-check + registered-converter
-/// probe, so `()` flows correctly without being force-classified here.
+/// (the void wire of a self-converter *and* the unit continue-type of
+/// `ZResult<()>`). The terminal-vs-composed decision in
+/// [`JniGen::lookup_input`] / [`JniGen::lookup_output`] resolves that
+/// ambiguity via the self-check + registered-converter probe, so `()`
+/// flows correctly without being force-classified here.
 pub(crate) fn is_wire_type(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Ptr(_)) || kotlin_for_wire(ty).is_some()
 }
@@ -1324,10 +840,4 @@ fn ordered_patterns(buckets: &[HashMap<TypeKey, WrapperFn>; 4]) -> Vec<syn::Type
         .collect();
     keys.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
     keys.into_iter().map(|(_, _, ty)| ty).collect()
-}
-
-impl Default for JniGen {
-    fn default() -> Self {
-        Self::new()
-    }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -249,11 +249,19 @@ impl JniGen {
         self.accept_members(&key, decl.members);
 
         if let Some(variants) = decl.input_variants {
-            self.expansions.ensure_default_constructor(key.to_type());
-            for v in variants {
-                match v {
-                    LocalVariant::Ctor(f) => self.expansions.add_constructor_variant(f),
-                    LocalVariant::SelfIdentity => self.expansions.add_constructor_variant_id(),
+            // Identity-only normalization: `.default_param_variant_self()`
+            // alone declares the plain-handle form — exactly the default
+            // when nothing is declared, so registering it would only add a
+            // degenerate 1-variant selector to every param of this type.
+            if !matches!(variants.as_slice(), [LocalVariant::SelfIdentity]) {
+                self.expansions.ensure_default_constructor(key.to_type());
+                for v in variants {
+                    match v {
+                        LocalVariant::Ctor(f) => self.expansions.add_constructor_variant(f),
+                        LocalVariant::SelfIdentity => {
+                            self.expansions.add_constructor_variant_id()
+                        }
+                    }
                 }
             }
         }
@@ -370,27 +378,30 @@ impl JniGen {
         self.apply_fn_flatten_modifiers(decl);
     }
 
-    /// Replay a [`FunctionDecl`]'s per-fn flatten modifiers
-    /// (`.flatten_input_suppress` / per-param `.flatten_input(...)` /
-    /// `.flatten_output_suppress` / per-fn `.flatten_output(...)`) into the
+    /// Replay a [`FunctionDecl`]'s per-fn overrides (per-param
+    /// `.param_variant*` / `.return_field*`) into the
     /// expansion/deconstruction bookkeeping. Shared by [`Self::accept_function`]
     /// (free package fns) and [`Self::accept_members`] (class members) — the
-    /// modifiers mean the same thing in both positions.
+    /// overrides mean the same thing in both positions.
+    ///
+    /// Identity-only normalization: an override consisting of only the
+    /// `_self` form means "the plain handle, nothing else" and lowers to the
+    /// skip-default opt-out — no selector on the input side, the raw
+    /// whole-handle return (borrowed-`&T`-capable) on the output side.
     fn apply_fn_flatten_modifiers(&mut self, decl: FunctionDecl) {
         let FunctionDecl {
             rust_ident,
             kotlin_name_override: _,
-            input_suppressed,
             input_overrides,
-            output_suppressed,
             output_override,
         } = decl;
 
-        for param in input_suppressed {
-            self.expansions
-                .add_skip_default_construct(rust_ident.clone(), param);
-        }
         for (param, variants) in input_overrides {
+            if matches!(variants.as_slice(), [LocalVariant::SelfIdentity]) {
+                self.expansions
+                    .add_skip_default_construct(rust_ident.clone(), param);
+                continue;
+            }
             self.expansions.begin_subset(rust_ident.clone(), param);
             for v in variants {
                 match v {
@@ -399,11 +410,12 @@ impl JniGen {
                 }
             }
         }
-        if output_suppressed {
-            self.deconstructors
-                .add_skip_default_output(rust_ident.clone());
-        }
         if let Some(fields) = output_override {
+            if matches!(fields.as_slice(), [LocalField::SelfField]) {
+                self.deconstructors
+                    .add_skip_default_output(rust_ident.clone());
+                return;
+            }
             self.deconstructors.begin_inline_output(rust_ident.clone());
             for f in fields {
                 match f {

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -332,39 +332,59 @@ impl JniGen {
     }
 
     /// Shared tail of `accept_ptr_class`/`accept_value_class` (the two class
-    /// kinds whose members are emitted): a constructor member's return is
-    /// never output-flattened (it's a factory), then the members join the
-    /// class's registered set.
-    fn accept_members(&mut self, key: &TypeKey, members: Vec<ClassMember>) {
-        for m in &members {
-            if m.kind == MemberKind::Constructor {
+    /// kinds whose members are emitted): each member's per-fn flatten
+    /// modifiers apply exactly as a free function's would; a constructor
+    /// member's return is additionally never output-flattened (it's a
+    /// factory); then the members join the class's registered set.
+    fn accept_members(&mut self, key: &TypeKey, members: Vec<(FunctionDecl, MemberKind)>) {
+        for (decl, kind) in members {
+            let rust_ident = decl.rust_ident.clone();
+            let kotlin_name = decl
+                .kotlin_name_override
+                .clone()
+                .unwrap_or_else(|| snake_to_camel(&rust_ident.to_string()));
+            self.apply_fn_flatten_modifiers(decl);
+            if kind == MemberKind::Constructor {
                 self.deconstructors
-                    .add_skip_default_output(m.rust_ident.clone());
+                    .add_skip_default_output(rust_ident.clone());
             }
+            self.class_members
+                .entry(key.clone())
+                .or_default()
+                .push(ClassMember {
+                    rust_ident,
+                    kotlin_name,
+                    kind,
+                });
         }
-        self.class_members
-            .entry(key.clone())
-            .or_default()
-            .extend(members);
     }
 
     fn accept_function(&mut self, subpackage: &str, decl: FunctionDecl) {
-        let FunctionDecl {
-            rust_ident,
-            kotlin_name_override,
-            input_suppressed,
-            input_overrides,
-            output_suppressed,
-            output_override,
-        } = decl;
-
-        let mut entry = MethodEntry::new(rust_ident.clone());
-        entry.kotlin_name_override = kotlin_name_override;
+        let mut entry = MethodEntry::new(decl.rust_ident.clone());
+        entry.kotlin_name_override = decl.kotlin_name_override.clone();
         self.packages
             .entry(subpackage.to_string())
             .or_default()
             .functions
             .push(entry);
+        self.apply_fn_flatten_modifiers(decl);
+    }
+
+    /// Replay a [`FunctionDecl`]'s per-fn flatten modifiers
+    /// (`.flatten_input_suppress` / per-param `.flatten_input(...)` /
+    /// `.flatten_output_suppress` / per-fn `.flatten_output(...)`) into the
+    /// expansion/deconstruction bookkeeping. Shared by [`Self::accept_function`]
+    /// (free package fns) and [`Self::accept_members`] (class members) — the
+    /// modifiers mean the same thing in both positions.
+    fn apply_fn_flatten_modifiers(&mut self, decl: FunctionDecl) {
+        let FunctionDecl {
+            rust_ident,
+            kotlin_name_override: _,
+            input_suppressed,
+            input_overrides,
+            output_suppressed,
+            output_override,
+        } = decl;
 
         for param in input_suppressed {
             self.expansions

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -39,7 +39,7 @@ impl TypeConfig {
     }
 }
 
-impl<S> JniGen<S> {
+impl JniGen {
     /// Classify `bare` against the declared-type table and the registry's
     /// captured structs. Callers strip `Option<_>` / `&_` layers first —
     /// wrapper folding is the resolver's business, not this table's.

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -1,0 +1,145 @@
+//! Global, order-insensitive [`JniGen`] configuration, supplied once at
+//! [`JniGen::new`] time.
+//!
+//! Everything here used to be a set of `JniGen` setter methods guarded by a
+//! runtime `assert_before_declarations` check ("must be called before the
+//! first type/function/wrapper declaration", because each one is baked into
+//! declarations' FQNs as they're made). Moving them onto a separate value
+//! built *before* `JniGen` exists makes that ordering hazard structurally
+//! impossible instead of a panic: there is no `JniGen` to declare anything on
+//! until the whole config is already final.
+
+use super::*;
+
+/// Global configuration for a [`JniGen`] instance: the Rust module path,
+/// JVM/Kotlin package, per-kind name-mangling hooks, the `JNINative` static
+/// initializer, and the handle-lock scaffold toggle. Build one and hand it to
+/// [`JniGen::new`].
+pub struct JniGenConfig {
+    pub(crate) source_module: syn::Path,
+    pub(crate) package_prefix: String,
+    pub(crate) jni_native_init: Option<String>,
+    pub(crate) kotlin_harness_name_mangle: Option<NameMangle>,
+    pub(crate) kotlin_fun_name_mangle: Option<NameMangle>,
+    pub(crate) kotlin_ptr_class_name_mangle: Option<NameMangle>,
+    pub(crate) kotlin_data_class_name_mangle: Option<NameMangle>,
+    pub(crate) kotlin_enum_name_mangle: Option<NameMangle>,
+    pub(crate) emit_handle_locks: bool,
+}
+
+impl JniGenConfig {
+    /// Defaults: `source_module = crate`, empty base package, no
+    /// `JNINative` init block, identity name-mangling, handle locks enabled.
+    pub fn new() -> Self {
+        Self {
+            source_module: syn::parse_str("crate").unwrap(),
+            package_prefix: String::new(),
+            jni_native_init: None,
+            kotlin_harness_name_mangle: None,
+            kotlin_fun_name_mangle: None,
+            kotlin_ptr_class_name_mangle: None,
+            kotlin_data_class_name_mangle: None,
+            kotlin_enum_name_mangle: None,
+            emit_handle_locks: true,
+        }
+    }
+
+    /// Set the Rust module path that contains the original `#[prebindgen]`
+    /// items. Generated Rust wrappers call functions as
+    /// `<source_module>::<function>(...)`; defaults to `crate`.
+    pub fn source_module(mut self, p: syn::Path) -> Self {
+        self.source_module = p;
+        self
+    }
+
+    /// Set the JVM/Kotlin **base** package (dot-separated, e.g.
+    /// `"io.zenoh.jni"`). All derived forms (slash-separated `FindClass`
+    /// paths, `_`-mangled JNI extern idents, Kotlin `package` declarations)
+    /// are computed from this. Empty = no prefix.
+    pub fn package_prefix(mut self, p: impl Into<String>) -> Self {
+        self.package_prefix = p.into().trim_matches('.').trim_matches('/').to_string();
+        self
+    }
+
+    /// Emit `code` inside an `init { … }` block of the generated centralized
+    /// externs object (`JNINative`). Because every generated native call
+    /// routes through that object, its static initializer is the single
+    /// point at which the consumer can trigger native-library loading
+    /// transparently — e.g.
+    /// `.jni_native_init("io.zenoh.jni.NativeLibrary.ensureLoaded()")` so any
+    /// call into the generated bindings loads the library first. The
+    /// referenced loader is the consumer's own (hand-written) code; this
+    /// keeps the generator free of any concrete loading logic. Unset = no
+    /// init block.
+    pub fn jni_native_init(mut self, code: impl Into<String>) -> Self {
+        self.jni_native_init = Some(code.into());
+        self
+    }
+
+    /// Set the closure that mangles the framework "harness" class name
+    /// `"Native"` (the centralized extern holder). Default = prepend
+    /// `"JNI"` (yielding `JNINative`). Affects the generated Kotlin class
+    /// name and the derived JNI extern symbol path on the Rust side.
+    pub fn kotlin_harness_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.kotlin_harness_name_mangle = Some(Arc::new(f));
+        self
+    }
+
+    /// Set the closure that mangles function names. Called for every scanned
+    /// `#[prebindgen]` free function and the synthetic `freePtr` destructor;
+    /// receives the camelCased Kotlin-side name and returns the final form
+    /// (e.g. `"putPublisher"` → `"putPublisherViaJNI"`). Default = identity.
+    pub fn kotlin_fun_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.kotlin_fun_name_mangle = Some(Arc::new(f));
+        self
+    }
+
+    /// Set the closure that mangles Kotlin ptr-class names declared via a
+    /// `PtrClassDecl`. Receives the Rust short name. Default = identity.
+    pub fn kotlin_ptr_class_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.kotlin_ptr_class_name_mangle = Some(Arc::new(f));
+        self
+    }
+
+    /// Set the closure that mangles Kotlin data-class names declared via a
+    /// `DataClassDecl`. Receives the Rust short name. Default = identity.
+    pub fn kotlin_data_class_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.kotlin_data_class_name_mangle = Some(Arc::new(f));
+        self
+    }
+
+    /// Set the closure that mangles enum-class names declared via an
+    /// `EnumClassDecl`. Receives the Rust short name. Default = identity.
+    pub fn kotlin_enum_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.kotlin_enum_name_mangle = Some(Arc::new(f));
+        self
+    }
+
+    /// Disable the per-call handle-lock scaffold (`withSortedHandleLocks`).
+    /// Enabled by default.
+    pub fn disable_handle_locks(mut self) -> Self {
+        self.emit_handle_locks = false;
+        self
+    }
+}
+
+impl Default for JniGenConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -4,11 +4,12 @@
 //! Every setter carries the `set_` prefix: unlike the declaration methods
 //! ([`JniGen::package`], [`JniGen::scalar_type_wrapper`], …) which each add
 //! one item to the binding surface, a `set_` method changes how *all* other
-//! declarations are interpreted. Setters are **order-insensitive**: a
-//! setting-derived name (class FQN, extern symbol path) is re-derived from
-//! the retained raw declaration inputs whenever a relevant setter runs, so
-//! `set_package_prefix` after `.package(...)` yields the same output as
-//! before it.
+//! declarations are interpreted. Setters are **order-independent by
+//! construction**: the builder stores only raw inputs — settings here,
+//! declaration name specs ([`NameSpec`]) in the type table — and every
+//! setting-derived value (class FQN, `FindClass` path, JNI extern symbol
+//! path) is computed at the point of use, so there is no stored derived
+//! state that could go stale.
 
 use super::*;
 
@@ -21,22 +22,24 @@ pub(crate) enum NameKind {
     DataOrValue,
 }
 
-/// Raw naming inputs of one accepted class declaration, retained so the
-/// derived Kotlin FQN can be recomputed when a naming-relevant setter
-/// (`set_package_prefix`, a class mangle) runs after the declaration.
+/// Raw naming spec of one type, stored in [`TypeConfig`] as declared and
+/// turned into a concrete Kotlin FQN only when read ([`JniGen::fqn_of`]),
+/// against whatever the settings are at that moment.
 #[derive(Clone)]
-pub(crate) struct DeclaredClassName {
-    pub(crate) key: TypeKey,
-    pub(crate) subpackage: String,
-    pub(crate) short: String,
-    /// Per-decl `.name()` — resolved against package + subpackage, bypasses
-    /// the mangle hook.
-    pub(crate) name_override: Option<String>,
-    /// Data/value `kotlin_type` expression — a verbatim Kotlin type,
-    /// bypassing package, subpackage and mangle entirely. Wins over
-    /// `name_override`.
-    pub(crate) explicit_fqn: Option<String>,
-    pub(crate) kind: NameKind,
+pub(crate) enum NameSpec {
+    /// Verbatim Kotlin type/FQN — a scalar wrapper's `kotlin_type`, or a
+    /// data/value class's `kotlin_type` expression. Settings-independent.
+    Verbatim(String),
+    /// A declared class whose FQN derives from the current settings.
+    Class {
+        subpackage: String,
+        /// `rust_short_name(&key)` — the mangle hook's input.
+        short: String,
+        /// Per-decl `.name()` — resolved against package + subpackage,
+        /// bypasses the mangle hook.
+        name_override: Option<String>,
+        kind: NameKind,
+    },
 }
 
 impl JniGen {
@@ -54,8 +57,6 @@ impl JniGen {
     /// are computed from this. Empty = no prefix.
     pub fn set_package_prefix(mut self, p: impl Into<String>) -> Self {
         self.package = p.into().trim_matches('.').trim_matches('/').to_string();
-        self.refresh_class_names();
-        self.recompute_derived();
         self
     }
 
@@ -83,7 +84,6 @@ impl JniGen {
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_harness_name_mangle = Some(Arc::new(f));
-        self.recompute_derived();
         self
     }
 
@@ -106,7 +106,6 @@ impl JniGen {
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_ptr_class_name_mangle = Some(Arc::new(f));
-        self.refresh_class_names();
         self
     }
 
@@ -118,7 +117,6 @@ impl JniGen {
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_data_class_name_mangle = Some(Arc::new(f));
-        self.refresh_class_names();
         self
     }
 
@@ -129,7 +127,6 @@ impl JniGen {
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_enum_name_mangle = Some(Arc::new(f));
-        self.refresh_class_names();
         self
     }
 
@@ -145,48 +142,57 @@ impl JniGen {
 }
 
 impl JniGen {
-    /// Derive the Kotlin FQN of one declared class from its retained raw
-    /// inputs and the *current* settings. Precedence: verbatim
-    /// `explicit_fqn` (data/value `kotlin_type`), then per-decl
-    /// `name_override` (package-resolved, mangle-bypassed), then the
-    /// mangle hook for the class kind.
-    pub(crate) fn derive_class_fqn(&self, d: &DeclaredClassName) -> String {
-        if let Some(fqn) = &d.explicit_fqn {
-            return fqn.clone();
+    /// Materialize a [`NameSpec`] into a concrete Kotlin FQN under the
+    /// current settings. Precedence for a declared class: per-decl
+    /// `name_override` (package-resolved, mangle-bypassed), then the mangle
+    /// hook for the class kind + package resolution.
+    pub(crate) fn fqn_of(&self, spec: &NameSpec) -> String {
+        match spec {
+            NameSpec::Verbatim(fqn) => fqn.clone(),
+            NameSpec::Class {
+                subpackage,
+                short,
+                name_override,
+                kind,
+            } => {
+                if let Some(n) = name_override {
+                    return self.resolve_class_fqn(subpackage, n);
+                }
+                let mangled = match kind {
+                    NameKind::Ptr => self.mangle_ptr_class(short),
+                    NameKind::Enum => self.mangle_enum(short),
+                    NameKind::DataOrValue => self.mangle_data_class(short),
+                };
+                self.resolve_class_fqn(subpackage, &mangled)
+            }
         }
-        if let Some(n) = &d.name_override {
-            return self.resolve_class_fqn(&d.subpackage, n);
-        }
-        let mangled = match d.kind {
-            NameKind::Ptr => self.mangle_ptr_class(&d.short),
-            NameKind::Enum => self.mangle_enum(&d.short),
-            NameKind::DataOrValue => self.mangle_data_class(&d.short),
-        };
-        self.resolve_class_fqn(&d.subpackage, &mangled)
     }
 
-    /// Re-derive every declared class's FQN from the current settings,
-    /// updating both the structured [`Self::types`] entry and the flat
-    /// [`Self::kotlin_type_fqns`] view. Rows registered by
-    /// [`JniGen::scalar_type_wrapper`] carry a verbatim FQN independent of
-    /// any setting and are left untouched (they have no
-    /// [`DeclaredClassName`]).
-    pub(crate) fn refresh_class_names(&mut self) {
-        let declared = std::mem::take(&mut self.declared_class_names);
-        for d in &declared {
-            let fqn = self.derive_class_fqn(d);
-            if let Some(entry) = self.types.get_mut(&d.key) {
-                entry.kotlin_name = Some(fqn.clone());
-            }
-            let key_str = d.key.as_str();
-            for row in self
-                .kotlin_type_fqns
-                .iter_mut()
-                .filter(|(k, _)| k.as_str() == key_str)
-            {
-                row.1 = fqn.clone();
-            }
+    /// The registered Kotlin FQN for a canonical Rust type key, derived on
+    /// demand from the type's stored [`NameSpec`].
+    pub(crate) fn kotlin_fqn(&self, rust_canon: &str) -> Option<String> {
+        self.types
+            .iter()
+            .find(|(k, _)| k.as_str() == rust_canon)
+            .and_then(|(_, cfg)| cfg.name_spec.as_ref())
+            .map(|spec| self.fqn_of(spec))
+    }
+
+    /// Derived on demand: `package.replace('.', "/")` — the slash-separated
+    /// prefix `FindClass` strings are built from.
+    pub(crate) fn java_class_prefix(&self) -> String {
+        self.package.replace('.', "/")
+    }
+
+    /// Derived on demand: `"Java_" + package.replace('.', "_") + "_" +
+    /// mangle_harness("Native")` — the JNI extern symbol path of the
+    /// centralized Native object every emitted wrapper hangs off.
+    pub(crate) fn jni_class_path(&self) -> String {
+        let native_class = self.mangle_harness("Native");
+        if self.package.is_empty() {
+            format!("Java_{}", native_class)
+        } else {
+            format!("Java_{}_{}", self.package.replace('.', "_"), native_class)
         }
-        self.declared_class_names = declared;
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -1,13 +1,6 @@
-//! Global, order-insensitive [`JniGen`] configuration, supplied once at
-//! [`JniGen::new`] time.
-//!
-//! Everything here used to be a set of `JniGen` setter methods guarded by a
-//! runtime `assert_before_declarations` check ("must be called before the
-//! first type/function/wrapper declaration", because each one is baked into
-//! declarations' FQNs as they're made). Moving them onto a separate value
-//! built *before* `JniGen` exists makes that ordering hazard structurally
-//! impossible instead of a panic: there is no `JniGen` to declare anything on
-//! until the whole config is already final.
+//! Global settings for a whole binding — the source module, target package,
+//! name-mangling rules and native-init hook — collected into one value and
+//! handed to [`JniGen::new`] before any declaration is made.
 
 use super::*;
 
@@ -130,8 +123,10 @@ impl JniGenConfig {
         self
     }
 
-    /// Disable the per-call handle-lock scaffold (`withSortedHandleLocks`).
-    /// Enabled by default.
+    /// Turn off the per-call locking the generator normally wraps around
+    /// every handle a wrapper touches (which guards against a handle being
+    /// `close()`d on another thread mid-call). Leave it on unless you know
+    /// your handles are never used concurrently and want the overhead gone.
     pub fn disable_handle_locks(mut self) -> Self {
         self.emit_handle_locks = false;
         self

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -79,11 +79,11 @@ impl JniGen {
     /// `"Native"` (the centralized extern holder). Default = prepend
     /// `"JNI"` (yielding `JNINative`). Affects the generated Kotlin class
     /// name and the derived JNI extern symbol path on the Rust side.
-    pub fn set_kotlin_harness_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_harness_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
-        self.kotlin_harness_name_mangle = Some(Arc::new(f));
+        self.harness_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -91,42 +91,42 @@ impl JniGen {
     /// `#[prebindgen]` free function and the synthetic `freePtr` destructor;
     /// receives the camelCased Kotlin-side name and returns the final form
     /// (e.g. `"putPublisher"` → `"putPublisherViaJNI"`). Default = identity.
-    pub fn set_kotlin_fun_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_fun_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
-        self.kotlin_fun_name_mangle = Some(Arc::new(f));
+        self.fun_name_mangle = Some(Arc::new(f));
         self
     }
 
     /// Set the closure that mangles Kotlin ptr-class names declared via a
     /// `PtrClassDecl`. Receives the Rust short name. Default = identity.
-    pub fn set_kotlin_ptr_class_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_ptr_class_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
-        self.kotlin_ptr_class_name_mangle = Some(Arc::new(f));
+        self.ptr_class_name_mangle = Some(Arc::new(f));
         self
     }
 
     /// Set the closure that mangles Kotlin data-class names declared via a
     /// `DataClassDecl` (and value classes, which reuse this hook). Receives
     /// the Rust short name. Default = identity.
-    pub fn set_kotlin_data_class_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_data_class_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
-        self.kotlin_data_class_name_mangle = Some(Arc::new(f));
+        self.data_class_name_mangle = Some(Arc::new(f));
         self
     }
 
     /// Set the closure that mangles enum-class names declared via an
     /// `EnumClassDecl`. Receives the Rust short name. Default = identity.
-    pub fn set_kotlin_enum_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_enum_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
-        self.kotlin_enum_name_mangle = Some(Arc::new(f));
+        self.enum_name_mangle = Some(Arc::new(f));
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -1,46 +1,49 @@
-//! Global settings for a whole binding — the source module, target package,
-//! name-mangling rules and native-init hook — collected into one value and
-//! handed to [`JniGen::new`] before any declaration is made.
+//! Global settings of a [`JniGen`] instance — the source module, target
+//! package, name-mangling rules, native-init hook and handle-lock toggle.
+//!
+//! Every setter carries the `set_` prefix: unlike the declaration methods
+//! ([`JniGen::package`], [`JniGen::scalar_type_wrapper`], …) which each add
+//! one item to the binding surface, a `set_` method changes how *all* other
+//! declarations are interpreted. Setters are **order-insensitive**: a
+//! setting-derived name (class FQN, extern symbol path) is re-derived from
+//! the retained raw declaration inputs whenever a relevant setter runs, so
+//! `set_package_prefix` after `.package(...)` yields the same output as
+//! before it.
 
 use super::*;
 
-/// Global configuration for a [`JniGen`] instance: the Rust module path,
-/// JVM/Kotlin package, per-kind name-mangling hooks, the `JNINative` static
-/// initializer, and the handle-lock scaffold toggle. Build one and hand it to
-/// [`JniGen::new`].
-pub struct JniGenConfig {
-    pub(crate) source_module: syn::Path,
-    pub(crate) package_prefix: String,
-    pub(crate) jni_native_init: Option<String>,
-    pub(crate) kotlin_harness_name_mangle: Option<NameMangle>,
-    pub(crate) kotlin_fun_name_mangle: Option<NameMangle>,
-    pub(crate) kotlin_ptr_class_name_mangle: Option<NameMangle>,
-    pub(crate) kotlin_data_class_name_mangle: Option<NameMangle>,
-    pub(crate) kotlin_enum_name_mangle: Option<NameMangle>,
-    pub(crate) emit_handle_locks: bool,
+/// Which per-kind mangle hook applies when deriving a declared class's
+/// Kotlin name. Value classes reuse the data-class hook.
+#[derive(Clone, Copy)]
+pub(crate) enum NameKind {
+    Ptr,
+    Enum,
+    DataOrValue,
 }
 
-impl JniGenConfig {
-    /// Defaults: `source_module = crate`, empty base package, no
-    /// `JNINative` init block, identity name-mangling, handle locks enabled.
-    pub fn new() -> Self {
-        Self {
-            source_module: syn::parse_str("crate").unwrap(),
-            package_prefix: String::new(),
-            jni_native_init: None,
-            kotlin_harness_name_mangle: None,
-            kotlin_fun_name_mangle: None,
-            kotlin_ptr_class_name_mangle: None,
-            kotlin_data_class_name_mangle: None,
-            kotlin_enum_name_mangle: None,
-            emit_handle_locks: true,
-        }
-    }
+/// Raw naming inputs of one accepted class declaration, retained so the
+/// derived Kotlin FQN can be recomputed when a naming-relevant setter
+/// (`set_package_prefix`, a class mangle) runs after the declaration.
+#[derive(Clone)]
+pub(crate) struct DeclaredClassName {
+    pub(crate) key: TypeKey,
+    pub(crate) subpackage: String,
+    pub(crate) short: String,
+    /// Per-decl `.name()` — resolved against package + subpackage, bypasses
+    /// the mangle hook.
+    pub(crate) name_override: Option<String>,
+    /// Data/value `kotlin_type` expression — a verbatim Kotlin type,
+    /// bypassing package, subpackage and mangle entirely. Wins over
+    /// `name_override`.
+    pub(crate) explicit_fqn: Option<String>,
+    pub(crate) kind: NameKind,
+}
 
+impl JniGen {
     /// Set the Rust module path that contains the original `#[prebindgen]`
     /// items. Generated Rust wrappers call functions as
     /// `<source_module>::<function>(...)`; defaults to `crate`.
-    pub fn source_module(mut self, p: syn::Path) -> Self {
+    pub fn set_source_module(mut self, p: syn::Path) -> Self {
         self.source_module = p;
         self
     }
@@ -49,8 +52,10 @@ impl JniGenConfig {
     /// `"io.zenoh.jni"`). All derived forms (slash-separated `FindClass`
     /// paths, `_`-mangled JNI extern idents, Kotlin `package` declarations)
     /// are computed from this. Empty = no prefix.
-    pub fn package_prefix(mut self, p: impl Into<String>) -> Self {
-        self.package_prefix = p.into().trim_matches('.').trim_matches('/').to_string();
+    pub fn set_package_prefix(mut self, p: impl Into<String>) -> Self {
+        self.package = p.into().trim_matches('.').trim_matches('/').to_string();
+        self.refresh_class_names();
+        self.recompute_derived();
         self
     }
 
@@ -59,12 +64,12 @@ impl JniGenConfig {
     /// routes through that object, its static initializer is the single
     /// point at which the consumer can trigger native-library loading
     /// transparently — e.g.
-    /// `.jni_native_init("io.zenoh.jni.NativeLibrary.ensureLoaded()")` so any
-    /// call into the generated bindings loads the library first. The
+    /// `.set_jni_native_init("io.zenoh.jni.NativeLibrary.ensureLoaded()")` so
+    /// any call into the generated bindings loads the library first. The
     /// referenced loader is the consumer's own (hand-written) code; this
     /// keeps the generator free of any concrete loading logic. Unset = no
     /// init block.
-    pub fn jni_native_init(mut self, code: impl Into<String>) -> Self {
+    pub fn set_jni_native_init(mut self, code: impl Into<String>) -> Self {
         self.jni_native_init = Some(code.into());
         self
     }
@@ -73,11 +78,12 @@ impl JniGenConfig {
     /// `"Native"` (the centralized extern holder). Default = prepend
     /// `"JNI"` (yielding `JNINative`). Affects the generated Kotlin class
     /// name and the derived JNI extern symbol path on the Rust side.
-    pub fn kotlin_harness_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_kotlin_harness_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_harness_name_mangle = Some(Arc::new(f));
+        self.recompute_derived();
         self
     }
 
@@ -85,7 +91,7 @@ impl JniGenConfig {
     /// `#[prebindgen]` free function and the synthetic `freePtr` destructor;
     /// receives the camelCased Kotlin-side name and returns the final form
     /// (e.g. `"putPublisher"` → `"putPublisherViaJNI"`). Default = identity.
-    pub fn kotlin_fun_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_kotlin_fun_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
@@ -95,46 +101,92 @@ impl JniGenConfig {
 
     /// Set the closure that mangles Kotlin ptr-class names declared via a
     /// `PtrClassDecl`. Receives the Rust short name. Default = identity.
-    pub fn kotlin_ptr_class_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_kotlin_ptr_class_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_ptr_class_name_mangle = Some(Arc::new(f));
+        self.refresh_class_names();
         self
     }
 
     /// Set the closure that mangles Kotlin data-class names declared via a
-    /// `DataClassDecl`. Receives the Rust short name. Default = identity.
-    pub fn kotlin_data_class_name_mangle<F>(mut self, f: F) -> Self
+    /// `DataClassDecl` (and value classes, which reuse this hook). Receives
+    /// the Rust short name. Default = identity.
+    pub fn set_kotlin_data_class_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_data_class_name_mangle = Some(Arc::new(f));
+        self.refresh_class_names();
         self
     }
 
     /// Set the closure that mangles enum-class names declared via an
     /// `EnumClassDecl`. Receives the Rust short name. Default = identity.
-    pub fn kotlin_enum_name_mangle<F>(mut self, f: F) -> Self
+    pub fn set_kotlin_enum_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.kotlin_enum_name_mangle = Some(Arc::new(f));
+        self.refresh_class_names();
         self
     }
 
-    /// Turn off the per-call locking the generator normally wraps around
-    /// every handle a wrapper touches (which guards against a handle being
-    /// `close()`d on another thread mid-call). Leave it on unless you know
-    /// your handles are never used concurrently and want the overhead gone.
-    pub fn disable_handle_locks(mut self) -> Self {
-        self.emit_handle_locks = false;
+    /// Toggle the per-call locking the generator wraps around every handle a
+    /// wrapper touches (which guards against a handle being `close()`d on
+    /// another thread mid-call). Defaults to `true`; pass `false` only if
+    /// you know your handles are never used concurrently and want the
+    /// overhead gone.
+    pub fn set_emit_handle_locks(mut self, emit: bool) -> Self {
+        self.emit_handle_locks = emit;
         self
     }
 }
 
-impl Default for JniGenConfig {
-    fn default() -> Self {
-        Self::new()
+impl JniGen {
+    /// Derive the Kotlin FQN of one declared class from its retained raw
+    /// inputs and the *current* settings. Precedence: verbatim
+    /// `explicit_fqn` (data/value `kotlin_type`), then per-decl
+    /// `name_override` (package-resolved, mangle-bypassed), then the
+    /// mangle hook for the class kind.
+    pub(crate) fn derive_class_fqn(&self, d: &DeclaredClassName) -> String {
+        if let Some(fqn) = &d.explicit_fqn {
+            return fqn.clone();
+        }
+        if let Some(n) = &d.name_override {
+            return self.resolve_class_fqn(&d.subpackage, n);
+        }
+        let mangled = match d.kind {
+            NameKind::Ptr => self.mangle_ptr_class(&d.short),
+            NameKind::Enum => self.mangle_enum(&d.short),
+            NameKind::DataOrValue => self.mangle_data_class(&d.short),
+        };
+        self.resolve_class_fqn(&d.subpackage, &mangled)
+    }
+
+    /// Re-derive every declared class's FQN from the current settings,
+    /// updating both the structured [`Self::types`] entry and the flat
+    /// [`Self::kotlin_type_fqns`] view. Rows registered by
+    /// [`JniGen::scalar_type_wrapper`] carry a verbatim FQN independent of
+    /// any setting and are left untouched (they have no
+    /// [`DeclaredClassName`]).
+    pub(crate) fn refresh_class_names(&mut self) {
+        let declared = std::mem::take(&mut self.declared_class_names);
+        for d in &declared {
+            let fqn = self.derive_class_fqn(d);
+            if let Some(entry) = self.types.get_mut(&d.key) {
+                entry.kotlin_name = Some(fqn.clone());
+            }
+            let key_str = d.key.as_str();
+            for row in self
+                .kotlin_type_fqns
+                .iter_mut()
+                .filter(|(k, _)| k.as_str() == key_str)
+            {
+                row.1 = fqn.clone();
+            }
+        }
+        self.declared_class_names = declared;
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -1,0 +1,868 @@
+//! Declaration objects: one standalone, independently-constructible value
+//! type per kind of thing `JniGen` can be told about (a `ptr_class`, an
+//! `enum_class`, a function, a scalar wire mapping, …), plus the `PackageDecl`
+//! that aggregates the package-scoped ones. Each type is both its own
+//! "builder" and the final value `JniGen`/`PackageDecl` accepts — no separate
+//! `Builder`/`Decl` split, no terminal `.build()` call.
+//!
+//! `JniGen` itself only ever *accepts* fully-built values of these types
+//! (`JniGen::package`, `JniGen::scalar_type_wrapper`,
+//! `JniGen::generic_type_wrapper`, in `builder.rs`); none of them reach back
+//! into any `JniGen` state while being built.
+
+use super::*;
+
+// ──────────────────────────────────────────────────────────────────────
+// Shared local accumulators (replayed into `Expansions`/`Deconstructors`
+// by the accept logic in `builder.rs` once a decl is handed to `JniGen`)
+// ──────────────────────────────────────────────────────────────────────
+
+/// One arm of a `.flatten_input()`/`.flatten_input_with()` build-from list.
+#[derive(Clone)]
+pub(crate) enum LocalVariant {
+    /// Build via this declared constructor member / constructor fn.
+    Ctor(syn::Ident),
+    /// Accept an already-built value directly.
+    SelfIdentity,
+}
+
+/// One arm of a `.flatten_output()`/`.flatten_output_with()` field list.
+#[derive(Clone)]
+pub(crate) enum LocalField {
+    /// Include the named accessor's value as this leaf/field name.
+    Named(syn::Ident, String),
+    /// Include the handle itself as a field.
+    SelfField,
+}
+
+/// Push `(rust_fun, name, kind)` onto `members`, shared by every class-kind
+/// decl's `.accessor()`/`.method()`/`.constructor()`.
+fn push_member(
+    members: &mut Vec<ClassMember>,
+    rust_fun: syn::Ident,
+    name: impl Into<String>,
+    kind: MemberKind,
+) {
+    members.push(ClassMember {
+        rust_ident: rust_fun,
+        kotlin_name: name.into(),
+        kind,
+    });
+}
+
+/// Resolve a member `name` of the given kind to its Rust ident, or panic with
+/// a clear build-script message. Shared by every class-kind decl's
+/// `.variant(name)`/`.field(name)` lookups.
+fn resolve_member(members: &[ClassMember], name: &str, kind: MemberKind, verb: &str) -> syn::Ident {
+    members
+        .iter()
+        .find(|m| m.kind == kind && m.kotlin_name == name)
+        .unwrap_or_else(|| {
+            let what = match kind {
+                MemberKind::Accessor => ".accessor",
+                MemberKind::Constructor => ".constructor",
+                MemberKind::Method => ".method",
+            };
+            panic!(
+                "{verb}(\"{name}\"): no `{what}(.., \"{name}\")` declared on this class before \
+                 referencing it here"
+            )
+        })
+        .rust_ident
+        .clone()
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Class-kind decls
+// ──────────────────────────────────────────────────────────────────────
+
+/// Declares a typed Kotlin handle class backed by an opaque Rust type.
+/// Configures: jlong wire for both input and output, `Box::into_raw`/
+/// `Box::from_raw` lifecycle, the `instanceof` dispatch class, and the Kotlin
+/// typed-handle class FQN. Feed it to a [`PackageDecl`] (via [`ClassDecl`])
+/// which in turn is handed to [`JniGen::package`].
+///
+/// `.flatten_output`/`.flatten_input` take a [`FlattenOutput`]/[`FlattenInput`]
+/// spec built independently:
+///
+/// ```
+/// use prebindgen::lang::{FlattenOutput, PtrClassDecl};
+/// use syn::parse_quote as pq;
+///
+/// let _ = PtrClassDecl::new(pq!(ZThing))
+///     .accessor(pq!(z_thing_name), "name")
+///     .flatten_output(FlattenOutput::new().field_self().field("name"));
+/// ```
+///
+/// `.field()`/`.field_self()` only exist on [`FlattenOutput`], not on
+/// `PtrClassDecl` itself, so there's no way to call them before a
+/// `.flatten_output(...)` exists to resolve them against:
+///
+/// ```compile_fail
+/// use prebindgen::lang::{FlattenOutput, PtrClassDecl};
+/// use syn::parse_quote as pq;
+///
+/// let _ = PtrClassDecl::new(pq!(ZThing))
+///     .accessor(pq!(z_thing_name), "name")
+///     .field("name"); // no such method on `PtrClassDecl`
+/// ```
+pub struct PtrClassDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) name_override: Option<String>,
+    pub(crate) members: Vec<ClassMember>,
+    pub(crate) input_variants: Option<Vec<LocalVariant>>,
+    pub(crate) output_fields: Option<Vec<LocalField>>,
+}
+
+impl PtrClassDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            name_override: None,
+            members: Vec::new(),
+            input_variants: None,
+            output_fields: None,
+        }
+    }
+
+    /// Override the Kotlin **class name** (relative, no dots — the FQN is
+    /// derived from the [`PackageDecl`] this class is declared in). Used
+    /// literally; the `kotlin_ptr_class_name_mangle` hook does not apply.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name_override = Some(name.into());
+        self
+    }
+
+    /// Declare a `#[prebindgen]` **read accessor** (`f(&Self) -> R`) as an
+    /// instance method `name`. Usable as a `.flatten_output()` `.field(name)`.
+    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+        self
+    }
+
+    /// Declare a `#[prebindgen]` **method** (`f(&Self, …) -> R`) as an
+    /// instance method `name`. Not usable as a flatten field.
+    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+        self
+    }
+
+    /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
+    /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
+    /// from `.flatten_input().variant(name)`.
+    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+        self
+    }
+
+    /// Set this class's default **input flatten**: how a parameter of this
+    /// class type is assembled at the boundary. `decl` is built independently
+    /// via [`FlattenInput::new`] + `.variant(name)` (build via a declared
+    /// `.constructor`) / `.variant_self()` (accept the handle directly), then
+    /// resolved against this class's declared members here.
+    pub fn flatten_input(mut self, decl: FlattenInput) -> Self {
+        self.input_variants = Some(
+            decl.variants
+                .into_iter()
+                .map(|v| match v {
+                    NamedVariant::Ctor(name) => {
+                        let func =
+                            resolve_member(&self.members, &name, MemberKind::Constructor, "variant");
+                        LocalVariant::Ctor(func)
+                    }
+                    NamedVariant::SelfIdentity => LocalVariant::SelfIdentity,
+                })
+                .collect(),
+        );
+        self
+    }
+
+    /// Set this class's default **output flatten**: how a returned/callback
+    /// value of this class is decomposed into fields. `decl` is built
+    /// independently via [`FlattenOutput::new`] + `.field(name)` (a declared
+    /// `.accessor`'s value) / `.field_self()` (the handle itself), then
+    /// resolved against this class's declared members here.
+    pub fn flatten_output(mut self, decl: FlattenOutput) -> Self {
+        self.output_fields = Some(
+            decl.fields
+                .into_iter()
+                .map(|f| match f {
+                    NamedField::Acc(name) => {
+                        let func = resolve_member(&self.members, &name, MemberKind::Accessor, "field");
+                        LocalField::Named(func, name)
+                    }
+                    NamedField::SelfField => LocalField::SelfField,
+                })
+                .collect(),
+        );
+        self
+    }
+}
+
+/// Standalone spec for [`PtrClassDecl::flatten_input`], built independently
+/// (`FlattenInput::new().variant("of").variant_self()`) and handed in as a
+/// value — `.variant()`/`.variant_self()` only exist on this type, so there
+/// is no way to call them before a `.flatten_input()` exists to resolve them
+/// against.
+pub struct FlattenInput {
+    variants: Vec<NamedVariant>,
+}
+
+pub(crate) enum NamedVariant {
+    Ctor(String),
+    SelfIdentity,
+}
+
+impl FlattenInput {
+    pub fn new() -> Self {
+        Self {
+            variants: Vec::new(),
+        }
+    }
+
+    /// Build via the constructor declared as `name` (see
+    /// [`PtrClassDecl::constructor`]).
+    pub fn variant(mut self, name: impl Into<String>) -> Self {
+        self.variants.push(NamedVariant::Ctor(name.into()));
+        self
+    }
+
+    /// Accept an already-built handle directly (the identity variant).
+    pub fn variant_self(mut self) -> Self {
+        self.variants.push(NamedVariant::SelfIdentity);
+        self
+    }
+}
+
+impl Default for FlattenInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Standalone spec for [`PtrClassDecl::flatten_output`] — the output-side
+/// dual of [`FlattenInput`].
+pub struct FlattenOutput {
+    fields: Vec<NamedField>,
+}
+
+pub(crate) enum NamedField {
+    Acc(String),
+    SelfField,
+}
+
+impl FlattenOutput {
+    pub fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+
+    /// Include the value of the accessor declared as `name` (see
+    /// [`PtrClassDecl::accessor`]).
+    pub fn field(mut self, name: impl Into<String>) -> Self {
+        self.fields.push(NamedField::Acc(name.into()));
+        self
+    }
+
+    /// Include the handle itself as a field.
+    pub fn field_self(mut self) -> Self {
+        self.fields.push(NamedField::SelfField);
+        self
+    }
+}
+
+impl Default for FlattenOutput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<syn::Type> for PtrClassDecl {
+    fn from(rust_type: syn::Type) -> Self {
+        Self::new(rust_type)
+    }
+}
+
+/// Declares a `#[prebindgen]`-marked `enum` as a Kotlin `enum class`. The
+/// enum must be C-like (unit variants only) and `#[repr(i32)]`-alike with
+/// explicit discriminants — the Kotlin emitter and the generated
+/// `TryFrom<i32>` decode rely on the discriminant values matching the jint
+/// wire.
+pub struct EnumClassDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) name_override: Option<String>,
+    pub(crate) members: Vec<ClassMember>,
+}
+
+impl EnumClassDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            name_override: None,
+            members: Vec::new(),
+        }
+    }
+
+    /// Override the Kotlin **class name** (relative, no dots).
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name_override = Some(name.into());
+        self
+    }
+
+    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+        self
+    }
+
+    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+        self
+    }
+
+    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+        self
+    }
+}
+
+impl From<syn::Type> for EnumClassDecl {
+    fn from(rust_type: syn::Type) -> Self {
+        Self::new(rust_type)
+    }
+}
+
+/// Declares a Rust struct that should appear in Kotlin as a `data class`.
+/// Only affects Kotlin emission — no Rust-side converter override.
+pub struct DataClassDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) name_override: Option<String>,
+    pub(crate) kotlin_type: Option<String>,
+    pub(crate) members: Vec<ClassMember>,
+}
+
+impl DataClassDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            name_override: None,
+            kotlin_type: None,
+            members: Vec::new(),
+        }
+    }
+
+    /// Override the Kotlin **class name** (relative, no dots).
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name_override = Some(name.into());
+        self
+    }
+
+    /// Stamp a verbatim Kotlin type expression (e.g. `"List<ByteArray>"`)
+    /// instead of a class FQN — for generics/primitives/container types.
+    pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
+        self.kotlin_type = Some(expr.into());
+        self
+    }
+
+    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+        self
+    }
+
+    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+        self
+    }
+
+    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+        self
+    }
+}
+
+impl From<syn::Type> for DataClassDecl {
+    fn from(rust_type: syn::Type) -> Self {
+        Self::new(rust_type)
+    }
+}
+
+/// Declares a **`Copy` value class** type: a Rust type passed across the JNI
+/// boundary **by value as its raw memory bytes** in a `ByteArray`, rather
+/// than as a closeable `jlong` heap handle — the value-level peer of
+/// [`PtrClassDecl`]. The type **must be `Copy`** — the generator emits a
+/// compile-time assertion to that effect.
+pub struct ValueClassDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) name_override: Option<String>,
+    pub(crate) kotlin_type: Option<String>,
+    pub(crate) members: Vec<ClassMember>,
+}
+
+impl ValueClassDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            name_override: None,
+            kotlin_type: None,
+            members: Vec::new(),
+        }
+    }
+
+    /// Override the Kotlin **class name** (relative, no dots).
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name_override = Some(name.into());
+        self
+    }
+
+    /// Stamp a verbatim Kotlin type expression instead of a class FQN.
+    pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
+        self.kotlin_type = Some(expr.into());
+        self
+    }
+
+    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+        self
+    }
+
+    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+        self
+    }
+
+    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
+        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+        self
+    }
+}
+
+impl From<syn::Type> for ValueClassDecl {
+    fn from(rust_type: syn::Type) -> Self {
+        Self::new(rust_type)
+    }
+}
+
+/// Unifies the four class-kind decls into one type so [`PackageDecl::class`]
+/// can expose a single entry point. Deliberately **no**
+/// `impl From<syn::Type> for ClassDecl` — a bare `syn::Type` alone doesn't
+/// say which of the four kinds it should become, so every declaration names
+/// its kind explicitly via the concrete constructor:
+/// `.class(PtrClassDecl::new(pq!(Storage)))`,
+/// `.class(EnumClassDecl::new(pq!(Priority)))`, etc.
+pub enum ClassDecl {
+    Ptr(PtrClassDecl),
+    Enum(EnumClassDecl),
+    Data(DataClassDecl),
+    Value(ValueClassDecl),
+}
+
+impl From<PtrClassDecl> for ClassDecl {
+    fn from(d: PtrClassDecl) -> Self {
+        Self::Ptr(d)
+    }
+}
+impl From<EnumClassDecl> for ClassDecl {
+    fn from(d: EnumClassDecl) -> Self {
+        Self::Enum(d)
+    }
+}
+impl From<DataClassDecl> for ClassDecl {
+    fn from(d: DataClassDecl) -> Self {
+        Self::Data(d)
+    }
+}
+impl From<ValueClassDecl> for ClassDecl {
+    fn from(d: ValueClassDecl) -> Self {
+        Self::Value(d)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Function decl
+// ──────────────────────────────────────────────────────────────────────
+
+/// Declares a `#[prebindgen]` function as a free-standing package wrapper.
+/// Feed it to a [`PackageDecl`] via [`PackageDecl::fun`].
+pub struct FunctionDecl {
+    pub(crate) rust_ident: syn::Ident,
+    pub(crate) kotlin_name_override: Option<String>,
+    pub(crate) input_suppressed: Vec<syn::Ident>,
+    pub(crate) input_overrides: Vec<(syn::Ident, Vec<LocalVariant>)>,
+    pub(crate) output_suppressed: bool,
+    pub(crate) output_override: Option<Vec<LocalField>>,
+}
+
+impl FunctionDecl {
+    pub fn new(rust_ident: syn::Ident) -> Self {
+        Self {
+            rust_ident,
+            kotlin_name_override: None,
+            input_suppressed: Vec::new(),
+            input_overrides: Vec::new(),
+            output_suppressed: false,
+            output_override: None,
+        }
+    }
+
+    /// Override the Kotlin-side function name. Default (without `.name(...)`)
+    /// is `snake_to_camel(rust_ident)`.
+    pub fn name(mut self, kotlin_name: impl Into<String>) -> Self {
+        self.kotlin_name_override = Some(kotlin_name.into());
+        self
+    }
+
+    /// `param` skips input-flattening and takes the raw handle.
+    pub fn flatten_input_suppress(mut self, param: syn::Ident) -> Self {
+        self.input_suppressed.push(param);
+        self
+    }
+
+    /// Replace the default input flatten of `param` with an explicit variant
+    /// list. `decl` is built independently via [`FunctionFlattenInput::new`]
+    /// + `.variant(fn)` (build-from constructor fns) / `.variant_self()`
+    /// (accept the handle directly). May be called more than once, for
+    /// different params.
+    pub fn flatten_input_with(mut self, param: syn::Ident, decl: FunctionFlattenInput) -> Self {
+        self.input_overrides.push((param, decl.variants));
+        self
+    }
+
+    /// The return value skips output-flattening and stays a raw handle.
+    pub fn flatten_output_suppress(mut self) -> Self {
+        self.output_suppressed = true;
+        self
+    }
+
+    /// Replace the default output flatten with an explicit field list.
+    /// `decl` is built independently via [`FunctionFlattenOutput::new`] +
+    /// `.field(fn, name)` (accessor fns with their leaf name) /
+    /// `.field_self()` (the handle itself).
+    pub fn flatten_output_with(mut self, decl: FunctionFlattenOutput) -> Self {
+        self.output_override = Some(decl.fields);
+        self
+    }
+}
+
+/// Standalone spec for [`FunctionDecl::flatten_input_with`], built
+/// independently and handed in as a value — the per-param dual of
+/// [`FlattenInput`], except `.variant(func)` names the `#[prebindgen]`
+/// constructor's Rust ident **directly** (a free function has no declared
+/// member list to resolve a name against, unlike a class).
+pub struct FunctionFlattenInput {
+    variants: Vec<LocalVariant>,
+}
+
+impl FunctionFlattenInput {
+    pub fn new() -> Self {
+        Self {
+            variants: Vec::new(),
+        }
+    }
+
+    /// Build via this `#[prebindgen]` constructor function directly.
+    pub fn variant(mut self, func: syn::Ident) -> Self {
+        self.variants.push(LocalVariant::Ctor(func));
+        self
+    }
+
+    /// Accept an already-built handle directly (the identity variant).
+    pub fn variant_self(mut self) -> Self {
+        self.variants.push(LocalVariant::SelfIdentity);
+        self
+    }
+}
+
+impl Default for FunctionFlattenInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Standalone spec for [`FunctionDecl::flatten_output_with`] — the
+/// per-function output-side dual of [`FunctionFlattenInput`]/[`FlattenOutput`].
+pub struct FunctionFlattenOutput {
+    fields: Vec<LocalField>,
+}
+
+impl FunctionFlattenOutput {
+    pub fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+
+    /// Include the value of the accessor fn `func` (the rust accessor fn
+    /// directly) as field `name`.
+    pub fn field(mut self, func: syn::Ident, name: impl Into<String>) -> Self {
+        self.fields.push(LocalField::Named(func, name.into()));
+        self
+    }
+
+    /// Include the handle itself as a field.
+    pub fn field_self(mut self) -> Self {
+        self.fields.push(LocalField::SelfField);
+        self
+    }
+}
+
+impl Default for FunctionFlattenOutput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<syn::Ident> for FunctionDecl {
+    fn from(rust_ident: syn::Ident) -> Self {
+        Self::new(rust_ident)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// PackageDecl — aggregates the package-scoped decls
+// ──────────────────────────────────────────────────────────────────────
+
+/// A batch of class and function declarations under one Kotlin subpackage
+/// (or the base package, for `PackageDecl::new("")`). Built independently of
+/// `JniGen`, then handed to [`JniGen::package`], which **merges** it into
+/// whatever that package already holds — so the same subpackage name may be
+/// reopened across several `PackageDecl` values / `JniGen::package` calls.
+pub struct PackageDecl {
+    pub(crate) name: String,
+    pub(crate) classes: Vec<ClassDecl>,
+    pub(crate) functions: Vec<FunctionDecl>,
+}
+
+impl PackageDecl {
+    /// `name` is dot-separated, relative to the base package set by
+    /// [`JniGenConfig::package_prefix`]; the empty string is the base
+    /// package itself.
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
+        let name = name.trim_matches('.').trim_matches('/').to_string();
+        Self {
+            name,
+            classes: Vec::new(),
+            functions: Vec::new(),
+        }
+    }
+
+    /// Add a class declaration (any of [`PtrClassDecl`]/[`EnumClassDecl`]/
+    /// [`DataClassDecl`]/[`ValueClassDecl`], via [`ClassDecl`]'s `From` impls).
+    pub fn class(mut self, decl: impl Into<ClassDecl>) -> Self {
+        self.classes.push(decl.into());
+        self
+    }
+
+    /// Add a free-function declaration. Takes a `FunctionDecl` directly
+    /// (not `impl Into<FunctionDecl>` + a bare-`syn::Ident` bridge): with a
+    /// generic bound here, `syn::parse_quote!(ident)` can't infer whether to
+    /// target `syn::Ident` or `FunctionDecl`, so every declaration spells out
+    /// `FunctionDecl::new(pq!(ident))` — trivial for the common case
+    /// (`.fun(FunctionDecl::new(pq!(z_ping)))`), same "always name the
+    /// concrete type" rule `PackageDecl::class` already applies.
+    pub fn fun(mut self, decl: FunctionDecl) -> Self {
+        self.functions.push(decl);
+        self
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Wrapper decls — split by rank (see the module doc for why)
+// ──────────────────────────────────────────────────────────────────────
+
+/// Rejects a wrapper registration on a Rust **builtin** type: the generated
+/// converter qualifies the pattern with the `source_module`
+/// (`myflat::usize`), which does not compile. Wrap the builtin in a
+/// source-crate newtype (like `Millis(u64)`) instead. Only ever relevant for
+/// rank-0 (a builtin type has no wildcards), so this is called from
+/// [`ScalarTypeWrapperDecl::new`] alone.
+fn reject_builtin_wrapper_pattern(key: &TypeKey) {
+    const BUILTINS: &[&str] = &[
+        "usize", "isize", "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128",
+        "f32", "f64", "bool", "char", "str",
+    ];
+    assert!(
+        !BUILTINS.contains(&key.as_str()),
+        "ScalarTypeWrapperDecl on builtin `{}`: the generated converter qualifies the pattern \
+         with the source module, which is invalid for builtins — wrap the builtin in a newtype \
+         instead",
+        key.as_str()
+    );
+}
+
+/// The fixed identifier every wrapper body sees in scope for "the value being
+/// converted" (`env: &mut JNIEnv` is NOT provided — confirmed zero real
+/// wrapper bodies, built-in or user, ever need it; see the module doc).
+pub(crate) fn wrapper_value_ident() -> syn::Ident {
+    syn::Ident::new("v", Span::call_site())
+}
+
+/// Declares how one concrete Rust type (`pattern`) crosses the JNI boundary
+/// **as a custom scalar wire value** — the primitive-wire peer of
+/// [`ValueClassDecl`] (which does the same job for `ByteArray`-backed
+/// types). Global — not part of any [`PackageDecl`] (see the module doc for
+/// why `kotlin_type` needs no package placement).
+pub struct ScalarTypeWrapperDecl {
+    pub(crate) pattern: syn::Type,
+    // Stored as tokenized source text, not `syn::Type`: this workspace's
+    // proc-macro2 feature resolution makes `syn::Type`/`syn::Expr` `!Send`/
+    // `!Sync` (it unconditionally wraps the compiler's non-Send
+    // `proc_macro::TokenStream` variant even outside a real proc-macro
+    // expansion), so an owned one can't be captured into the `Send + Sync`
+    // `WrapperFn` closure `JniGen::scalar_type_wrapper` builds from this —
+    // re-parsed fresh at lookup time instead.
+    pub(crate) wire: String,
+    pub(crate) kotlin_type: String,
+    pub(crate) input: Option<Arc<dyn Fn(&syn::Ident) -> syn::Expr + Send + Sync>>,
+    pub(crate) output: Option<Arc<dyn Fn(&syn::Ident) -> syn::Expr + Send + Sync>>,
+}
+
+impl ScalarTypeWrapperDecl {
+    /// `wire` is the one wire type shared by both directions; `kotlin_type`
+    /// is the Kotlin-visible type this pattern surfaces as (e.g. `"Long"`) —
+    /// required, since a scalar mapping has no sensible auto-derived name.
+    pub fn new(pattern: syn::Type, wire: syn::Type, kotlin_type: impl Into<String>) -> Self {
+        reject_builtin_wrapper_pattern(&TypeKey::from_type(&pattern));
+        Self {
+            pattern,
+            wire: quote!(#wire).to_string(),
+            kotlin_type: kotlin_type.into(),
+            input: None,
+            output: None,
+        }
+    }
+
+    /// Build the wire → rust conversion body. `body` receives the ident of
+    /// the wire-typed value in scope (`&wire`) and returns the Rust-typed
+    /// expression to splice via `quote!`'s `#value` interpolation.
+    pub fn input(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
+        self.input = Some(Arc::new(body));
+        self
+    }
+
+    /// Build the rust → wire conversion body. `body` receives the ident of
+    /// the rust-typed value in scope and returns the wire-typed expression.
+    pub fn output(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
+        self.output = Some(Arc::new(body));
+        self
+    }
+}
+
+/// The result of one [`GenericTypeWrapperDecl`] `.input()`/`.output()`
+/// builder: either a binding-fallible bare value (the framework wraps it
+/// `Ok(...)` and any `?` inside routes to the framework's own error type), or
+/// a domain-fallible `Result` whose `Err` routes to the per-call error sink
+/// verbatim (the `Result<_, _>` peel is the one real user of this arm).
+pub enum WireBody {
+    Infallible(syn::Type, syn::Expr),
+    Fallible(syn::Type, syn::Type, syn::Expr),
+}
+
+impl WireBody {
+    pub fn infallible(wire: syn::Type, expr: syn::Expr) -> Self {
+        Self::Infallible(wire, expr)
+    }
+
+    pub fn fallible(wire: syn::Type, error: syn::Type, expr: syn::Expr) -> Self {
+        Self::Fallible(wire, error, expr)
+    }
+
+    pub(crate) fn into_tuple(self) -> (syn::Type, Option<syn::Type>, syn::Expr) {
+        match self {
+            Self::Infallible(wire, expr) => (wire, None, expr),
+            Self::Fallible(wire, err, expr) => (wire, Some(err), expr),
+        }
+    }
+}
+
+/// Trait selecting the arity-appropriate impl of
+/// [`GenericTypeWrapperDecl::input`] / [`GenericTypeWrapperDecl::output`].
+/// The phantom type parameter discriminates closures of arity 1..3 so a
+/// single public method name accepts any of them. Closures take the wildcard
+/// substitutions plus the in-scope value ident, and return a [`WireBody`].
+pub trait WrapperBuilder<Arity>: Send + Sync + 'static {
+    fn into_wrapper_fn(self) -> WrapperFn;
+    fn rank() -> usize;
+}
+
+/// Arity-discriminating marker types. `Arity1`/`2`/`3` carry that many `_`
+/// slots in the registered pattern (e.g. `Result<_, _>` is `Arity2`).
+pub(crate) struct Arity1;
+pub(crate) struct Arity2;
+pub(crate) struct Arity3;
+
+impl<F> WrapperBuilder<Arity1> for F
+where
+    F: Fn(&syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
+{
+    fn into_wrapper_fn(self) -> WrapperFn {
+        Arc::new(move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+            Some(self(&args[0], &wrapper_value_ident()).into_tuple())
+        })
+    }
+    fn rank() -> usize {
+        1
+    }
+}
+
+impl<F> WrapperBuilder<Arity2> for F
+where
+    F: Fn(&syn::Type, &syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
+{
+    fn into_wrapper_fn(self) -> WrapperFn {
+        Arc::new(move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+            Some(self(&args[0], &args[1], &wrapper_value_ident()).into_tuple())
+        })
+    }
+    fn rank() -> usize {
+        2
+    }
+}
+
+impl<F> WrapperBuilder<Arity3> for F
+where
+    F: Fn(&syn::Type, &syn::Type, &syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
+{
+    fn into_wrapper_fn(self) -> WrapperFn {
+        Arc::new(move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+            Some(self(&args[0], &args[1], &args[2], &wrapper_value_ident()).into_tuple())
+        })
+    }
+    fn rank() -> usize {
+        3
+    }
+}
+
+/// Declares how an existing structural wrapper (`Option`/`Result`/`Vec`/…) is
+/// peeled for one specific wildcard substitution — e.g. a per-error
+/// `Result<_, ConcreteErr>` override of the framework's built-in
+/// `Result<_, _>` peel. Declares nothing Kotlin-visible on its own (no
+/// `.kotlin_type()` — a structural override never names a type). Global —
+/// not part of any [`PackageDecl`].
+pub struct GenericTypeWrapperDecl {
+    pub(crate) pattern: syn::Type,
+    pub(crate) input: Option<(usize, WrapperFn)>,
+    pub(crate) output: Option<(usize, WrapperFn)>,
+}
+
+impl GenericTypeWrapperDecl {
+    /// `pattern` contains 1–3 `_` wildcard placeholders (e.g.
+    /// `Result<_, ConcreteErr>`).
+    pub fn new(pattern: syn::Type) -> Self {
+        Self {
+            pattern,
+            input: None,
+            output: None,
+        }
+    }
+
+    /// Register the input-direction (wire → rust) peel. The closure's arity
+    /// (1–3 leading `&syn::Type` params, one per `_` in `pattern`, plus a
+    /// trailing `&syn::Ident` for the value in scope) selects the rank.
+    pub fn input<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
+        self.input = Some((B::rank(), builder.into_wrapper_fn()));
+        self
+    }
+
+    /// Output-direction (rust → wire) counterpart of [`Self::input`].
+    pub fn output<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
+        self.output = Some((B::rank(), builder.into_wrapper_fn()));
+        self
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -687,7 +687,7 @@ impl ScalarTypeWrapperDecl {
     /// the type is a parameter). `body` gets the wire value's ident and
     /// returns the Rust expression, e.g.
     /// `|v| pq!(perftest_flat::Millis(*#v as u64))`.
-    pub fn input(
+    pub fn on_param(
         mut self,
         body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static,
     ) -> Self {
@@ -698,7 +698,7 @@ impl ScalarTypeWrapperDecl {
     /// How to turn the **Rust value into the wire value** (used when the type
     /// is returned). `body` gets the Rust value's ident and returns the wire
     /// expression, e.g. `|v| pq!(#v.0 as jni::sys::jlong)`.
-    pub fn output(
+    pub fn on_return(
         mut self,
         body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static,
     ) -> Self {

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -158,6 +158,42 @@ macro_rules! function_flatten_output {
     };
 }
 
+/// Build a [`PackageDecl`] directly: `package!("model")` is
+/// `PackageDecl::new("model")`; `package!()` (no args) is the base package
+/// (`PackageDecl::new("")`).
+#[macro_export]
+macro_rules! package {
+    () => {
+        $crate::lang::PackageDecl::new("")
+    };
+    ($name:expr) => {
+        $crate::lang::PackageDecl::new($name)
+    };
+}
+
+/// Build a [`ScalarTypeWrapperDecl`] directly from bare Rust types:
+/// `scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")` is
+/// `ScalarTypeWrapperDecl::new(<Millis as syn::Type>, <jni::sys::jlong as syn::Type>, "Long")`.
+#[macro_export]
+macro_rules! scalar_type_wrapper {
+    ($pattern:ty, $wire:ty, $kotlin_type:expr) => {
+        $crate::lang::ScalarTypeWrapperDecl::new(
+            $crate::__macro_support::parse_type(stringify!($pattern)),
+            $crate::__macro_support::parse_type(stringify!($wire)),
+            $kotlin_type,
+        )
+    };
+}
+
+/// Build a [`GenericTypeWrapperDecl`] directly from a bare wildcard type
+/// pattern: `generic_type_wrapper!(Result<_, ConcreteErr>)`.
+#[macro_export]
+macro_rules! generic_type_wrapper {
+    ($t:ty) => {
+        $crate::lang::GenericTypeWrapperDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Class-kind decls
 // ──────────────────────────────────────────────────────────────────────
@@ -712,7 +748,8 @@ pub struct PackageDecl {
 impl PackageDecl {
     /// `name` is dot-separated, relative to the base package set by
     /// [`JniGenConfig::package_prefix`]; the empty string is the base
-    /// package itself.
+    /// package itself. See [`crate::package!`] for the equivalent macro form
+    /// (`package!("model")` / `package!()`).
     pub fn new(name: impl Into<String>) -> Self {
         let name = name.into();
         let name = name.trim_matches('.').trim_matches('/').to_string();
@@ -794,6 +831,7 @@ impl ScalarTypeWrapperDecl {
     /// `wire` is the one wire type shared by both directions; `kotlin_type`
     /// is the Kotlin-visible type this pattern surfaces as (e.g. `"Long"`) —
     /// required, since a scalar mapping has no sensible auto-derived name.
+    /// See [`crate::scalar_type_wrapper!`] for the equivalent macro form.
     pub fn new(pattern: syn::Type, wire: syn::Type, kotlin_type: impl Into<String>) -> Self {
         reject_builtin_wrapper_pattern(&TypeKey::from_type(&pattern));
         Self {
@@ -920,7 +958,8 @@ pub struct GenericTypeWrapperDecl {
 
 impl GenericTypeWrapperDecl {
     /// `pattern` contains 1–3 `_` wildcard placeholders (e.g.
-    /// `Result<_, ConcreteErr>`).
+    /// `Result<_, ConcreteErr>`). See [`crate::generic_type_wrapper!`] for the
+    /// equivalent macro form.
     pub fn new(pattern: syn::Type) -> Self {
         Self {
             pattern,

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -35,20 +35,12 @@ pub(crate) enum LocalField {
     SelfField,
 }
 
-/// Push `rust_fun` onto `members` as a member of the given `kind`, shared by
-/// every class-kind decl's `.fun()`/`.constructor()`. The Kotlin-visible name
-/// comes from `rust_fun.name(...)` if set, else defaults to
-/// `snake_to_camel(rust_ident)` — the same default `PackageDecl::fun` uses.
-fn push_member(members: &mut Vec<ClassMember>, rust_fun: FunctionDecl, kind: MemberKind) {
-    let kotlin_name = rust_fun
-        .kotlin_name_override
-        .unwrap_or_else(|| snake_to_camel(&rust_fun.rust_ident.to_string()));
-    members.push(ClassMember {
-        rust_ident: rust_fun.rust_ident,
-        kotlin_name,
-        kind,
-    });
-}
+// Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
+// not a reduced ident+name record — so the `FunctionDecl`'s per-fn flatten
+// modifiers (`.flatten_output_suppress()`, `.flatten_input_suppress(param)`,
+// per-fn `.flatten_input`/`.flatten_output` overrides) survive to
+// `builder.rs`'s `accept_members`, which applies them exactly like
+// `accept_function` does for free package functions.
 
 // ──────────────────────────────────────────────────────────────────────
 // Decl constructor macros — one per decl type built from bare Rust syntax
@@ -160,7 +152,7 @@ macro_rules! generic_type_wrapper {
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
-    pub(crate) members: Vec<ClassMember>,
+    pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
     pub(crate) input_variants: Option<Vec<LocalVariant>>,
     pub(crate) output_fields: Option<Vec<LocalField>>,
 }
@@ -188,7 +180,7 @@ impl PtrClassDecl {
     /// method. The receiver binds to `this` and is excluded from
     /// input-flattening; any remaining params flatten normally.
     pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Fun);
+        self.members.push((rust_fun, MemberKind::Fun));
         self
     }
 
@@ -196,7 +188,7 @@ impl PtrClassDecl {
     /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
     /// from `.flatten_input(fun!(...))`.
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
+        self.members.push((rust_fun, MemberKind::Constructor));
         self
     }
 
@@ -335,7 +327,7 @@ pub struct ValueClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
     pub(crate) kotlin_type: Option<String>,
-    pub(crate) members: Vec<ClassMember>,
+    pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
 }
 
 impl ValueClassDecl {
@@ -361,12 +353,12 @@ impl ValueClassDecl {
     }
 
     pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Fun);
+        self.members.push((rust_fun, MemberKind::Fun));
         self
     }
 
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
+        self.members.push((rust_fun, MemberKind::Constructor));
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -17,7 +17,7 @@ use super::*;
 // by the accept logic in `builder.rs` once a decl is handed to `JniGen`)
 // ──────────────────────────────────────────────────────────────────────
 
-/// One arm of a `.flatten_input()`/`.flatten_input_with()` build-from list.
+/// One arm of a class-level or per-fn `.flatten_input()` build-from list.
 #[derive(Clone)]
 pub(crate) enum LocalVariant {
     /// Build via this declared constructor member / constructor fn.
@@ -26,7 +26,7 @@ pub(crate) enum LocalVariant {
     SelfIdentity,
 }
 
-/// One arm of a `.flatten_output()`/`.flatten_output_with()` field list.
+/// One arm of a class-level or per-fn `.flatten_output()` field list.
 #[derive(Clone)]
 pub(crate) enum LocalField {
     /// Include the named accessor's value as this leaf/field name.
@@ -99,24 +99,6 @@ macro_rules! value_class {
 macro_rules! fun {
     ($name:ident) => {
         $crate::lang::FunctionDecl::new($crate::ident!($name))
-    };
-}
-
-/// Build an empty [`FunctionFlattenInputDecl`] — shorthand for
-/// `FunctionFlattenInputDecl::new()`.
-#[macro_export]
-macro_rules! function_flatten_input {
-    () => {
-        $crate::lang::FunctionFlattenInputDecl::new()
-    };
-}
-
-/// Build an empty [`FunctionFlattenOutputDecl`] — shorthand for
-/// `FunctionFlattenOutputDecl::new()`.
-#[macro_export]
-macro_rules! function_flatten_output {
-    () => {
-        $crate::lang::FunctionFlattenOutputDecl::new()
     };
 }
 
@@ -485,14 +467,36 @@ impl FunctionDecl {
         self
     }
 
-    /// Replace the default input flatten of `param` with an explicit variant
-    /// list. `decl` is built independently via
-    /// [`FunctionFlattenInputDecl::new`] + `.variant(fn)` (build-from
-    /// constructor fns) / `.variant_self()` (accept the handle directly). May
-    /// be called more than once, for different params.
-    pub fn flatten_input_with(mut self, param: syn::Ident, decl: FunctionFlattenInputDecl) -> Self {
-        self.input_overrides.push((param, decl.variants));
+    /// Add one variant to `param`'s **input flatten** override: build via
+    /// this `#[prebindgen]` constructor fn directly. Call repeatedly to add
+    /// more variants for the same param, or for different params — the only
+    /// difference from [`PtrClassDecl::flatten_input`] is the leading param
+    /// ident, since a function may have several independently-overridden
+    /// handle params.
+    pub fn flatten_input(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
+        self.input_override_entry(param)
+            .push(LocalVariant::Ctor(ctor.rust_ident));
         self
+    }
+
+    /// Add the identity variant to `param`'s input flatten override: accept
+    /// an already-built handle directly.
+    pub fn flatten_input_self(mut self, param: syn::Ident) -> Self {
+        self.input_override_entry(param)
+            .push(LocalVariant::SelfIdentity);
+        self
+    }
+
+    /// The variant list of `param`'s input override, creating it on first use.
+    fn input_override_entry(&mut self, param: syn::Ident) -> &mut Vec<LocalVariant> {
+        let idx = match self.input_overrides.iter().position(|(p, _)| *p == param) {
+            Some(i) => i,
+            None => {
+                self.input_overrides.push((param, Vec::new()));
+                self.input_overrides.len() - 1
+            }
+        };
+        &mut self.input_overrides[idx].1
     }
 
     /// The return value skips output-flattening and stays a raw handle.
@@ -501,86 +505,27 @@ impl FunctionDecl {
         self
     }
 
-    /// Replace the default output flatten with an explicit field list.
-    /// `decl` is built independently via [`FunctionFlattenOutputDecl::new`] +
-    /// `.field(fn)` (accessor fns, named via `fn.name(...)`) /
-    /// `.field_self()` (the handle itself).
-    pub fn flatten_output_with(mut self, decl: FunctionFlattenOutputDecl) -> Self {
-        self.output_override = Some(decl.fields);
-        self
-    }
-}
-
-/// Standalone spec for [`FunctionDecl::flatten_input_with`], built
-/// independently and handed in as a value — needed because
-/// `flatten_input_with` is keyed **per parameter** (a function can have
-/// several, each independently overridden), unlike
-/// [`PtrClassDecl::flatten_input`] which is called directly, once per
-/// variant. `.variant(func)` names the `#[prebindgen]` constructor fn
-/// directly.
-pub struct FunctionFlattenInputDecl {
-    variants: Vec<LocalVariant>,
-}
-
-impl FunctionFlattenInputDecl {
-    pub fn new() -> Self {
-        Self {
-            variants: Vec::new(),
-        }
-    }
-
-    /// Build via this `#[prebindgen]` constructor function directly.
-    pub fn variant(mut self, func: FunctionDecl) -> Self {
-        self.variants.push(LocalVariant::Ctor(func.rust_ident));
-        self
-    }
-
-    /// Accept an already-built handle directly (the identity variant).
-    pub fn variant_self(mut self) -> Self {
-        self.variants.push(LocalVariant::SelfIdentity);
-        self
-    }
-}
-
-impl Default for FunctionFlattenInputDecl {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Standalone spec for [`FunctionDecl::flatten_output_with`] — the
-/// per-function output-side dual of [`FunctionFlattenInputDecl`].
-pub struct FunctionFlattenOutputDecl {
-    fields: Vec<LocalField>,
-}
-
-impl FunctionFlattenOutputDecl {
-    pub fn new() -> Self {
-        Self { fields: Vec::new() }
-    }
-
-    /// Include the value of the accessor fn `func` (the rust accessor fn
-    /// directly) as a field named via `func.name(...)` (default:
-    /// `snake_to_camel(rust_ident)`, same as everywhere else a `FunctionDecl`
-    /// supplies its own Kotlin-visible name).
-    pub fn field(mut self, func: FunctionDecl) -> Self {
-        let name = func
+    /// Add one field to this function's **output flatten** override: the
+    /// value of the accessor fn `field` (named via `field.name(...)`,
+    /// defaulting to `snake_to_camel(rust_ident)`). Call repeatedly to add
+    /// more fields — same shape as [`PtrClassDecl::flatten_output`].
+    pub fn flatten_output(mut self, field: FunctionDecl) -> Self {
+        let name = field
             .kotlin_name_override
-            .unwrap_or_else(|| snake_to_camel(&func.rust_ident.to_string()));
-        self.fields.push(LocalField::Named(func.rust_ident, name));
+            .unwrap_or_else(|| snake_to_camel(&field.rust_ident.to_string()));
+        self.output_override
+            .get_or_insert_with(Vec::new)
+            .push(LocalField::Named(field.rust_ident, name));
         self
     }
 
-    /// Include the handle itself as a field.
-    pub fn field_self(mut self) -> Self {
-        self.fields.push(LocalField::SelfField);
+    /// Add the return value itself as a field of this function's output
+    /// flatten override.
+    pub fn flatten_output_self(mut self) -> Self {
+        self.output_override
+            .get_or_insert_with(Vec::new)
+            .push(LocalField::SelfField);
         self
-    }
-}
-
-impl Default for FunctionFlattenOutputDecl {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -36,9 +36,9 @@ pub(crate) enum LocalField {
 }
 
 /// Push `rust_fun` onto `members` as a member of the given `kind`, shared by
-/// every class-kind decl's `.accessor()`/`.method()`/`.constructor()`. The
-/// Kotlin-visible name comes from `rust_fun.name(...)` if set, else defaults
-/// to `snake_to_camel(rust_ident)` — the same default `PackageDecl::fun` uses.
+/// every class-kind decl's `.fun()`/`.constructor()`. The Kotlin-visible name
+/// comes from `rust_fun.name(...)` if set, else defaults to
+/// `snake_to_camel(rust_ident)` — the same default `PackageDecl::fun` uses.
 fn push_member(members: &mut Vec<ClassMember>, rust_fun: FunctionDecl, kind: MemberKind) {
     let kotlin_name = rust_fun
         .kotlin_name_override
@@ -48,28 +48,6 @@ fn push_member(members: &mut Vec<ClassMember>, rust_fun: FunctionDecl, kind: Mem
         kotlin_name,
         kind,
     });
-}
-
-/// Resolve a member `name` of the given kind to its Rust ident, or panic with
-/// a clear build-script message. Shared by every class-kind decl's
-/// `.variant(name)`/`.field(name)` lookups.
-fn resolve_member(members: &[ClassMember], name: &str, kind: MemberKind, verb: &str) -> syn::Ident {
-    members
-        .iter()
-        .find(|m| m.kind == kind && m.kotlin_name == name)
-        .unwrap_or_else(|| {
-            let what = match kind {
-                MemberKind::Accessor => ".accessor",
-                MemberKind::Constructor => ".constructor",
-                MemberKind::Method => ".method",
-            };
-            panic!(
-                "{verb}(\"{name}\"): no `{what}(.., \"{name}\")` declared on this class before \
-                 referencing it here"
-            )
-        })
-        .rust_ident
-        .clone()
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -121,22 +99,6 @@ macro_rules! value_class {
 macro_rules! fun {
     ($name:ident) => {
         $crate::lang::FunctionDecl::new($crate::ident!($name))
-    };
-}
-
-/// Build an empty [`FlattenInputDecl`] — shorthand for `FlattenInputDecl::new()`.
-#[macro_export]
-macro_rules! flatten_input {
-    () => {
-        $crate::lang::FlattenInputDecl::new()
-    };
-}
-
-/// Build an empty [`FlattenOutputDecl`] — shorthand for `FlattenOutputDecl::new()`.
-#[macro_export]
-macro_rules! flatten_output {
-    () => {
-        $crate::lang::FlattenOutputDecl::new()
     };
 }
 
@@ -204,23 +166,14 @@ macro_rules! generic_type_wrapper {
 /// typed-handle class FQN. Feed it to a [`PackageDecl`] (via [`ClassDecl`])
 /// which in turn is handed to [`JniGen::package`].
 ///
-/// `.flatten_output`/`.flatten_input` take a
-/// [`FlattenOutputDecl`]/[`FlattenInputDecl`] spec built independently:
+/// `.flatten_output`/`.flatten_input` each take a [`FunctionDecl`] directly,
+/// one call per field/variant (call repeatedly to add more):
 ///
 /// ```
 /// let _ = prebindgen::ptr_class!(ZThing)
-///     .accessor(prebindgen::fun!(z_thing_name).name("name"))
-///     .flatten_output(prebindgen::flatten_output!().field_self().field("name"));
-/// ```
-///
-/// `.field()`/`.field_self()` only exist on [`FlattenOutputDecl`], not on
-/// `PtrClassDecl` itself, so there's no way to call them before a
-/// `.flatten_output(...)` exists to resolve them against:
-///
-/// ```compile_fail
-/// let _ = prebindgen::ptr_class!(ZThing)
-///     .accessor(prebindgen::fun!(z_thing_name).name("name"))
-///     .field("name"); // no such method on `PtrClassDecl`
+///     .fun(prebindgen::fun!(z_thing_name).name("name"))
+///     .flatten_output_self()
+///     .flatten_output(prebindgen::fun!(z_thing_name).name("name"));
 /// ```
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
@@ -249,147 +202,62 @@ impl PtrClassDecl {
         self
     }
 
-    /// Declare a `#[prebindgen]` **read accessor** (`f(&Self) -> R`) as an
-    /// instance method `name`. Usable as a `.flatten_output()` `.field(name)`.
-    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
-        self
-    }
-
-    /// Declare a `#[prebindgen]` **method** (`f(&Self, …) -> R`) as an
-    /// instance method `name`. Not usable as a flatten field.
-    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Method);
+    /// Declare a `#[prebindgen]` function (`f(&Self, …) -> R`) as an instance
+    /// method. The receiver binds to `this` and is excluded from
+    /// input-flattening; any remaining params flatten normally.
+    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Fun);
         self
     }
 
     /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
     /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
-    /// from `.flatten_input().variant(name)`.
+    /// from `.flatten_input(fun!(...))`.
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
         push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 
-    /// Set this class's default **input flatten**: how a parameter of this
-    /// class type is assembled at the boundary. `decl` is built independently
-    /// via [`FlattenInputDecl::new`] + `.variant(name)` (build via a declared
-    /// `.constructor`) / `.variant_self()` (accept the handle directly), then
-    /// resolved against this class's declared members here.
-    pub fn flatten_input(mut self, decl: FlattenInputDecl) -> Self {
-        self.input_variants = Some(
-            decl.variants
-                .into_iter()
-                .map(|v| match v {
-                    NamedVariant::Ctor(name) => {
-                        let func =
-                            resolve_member(&self.members, &name, MemberKind::Constructor, "variant");
-                        LocalVariant::Ctor(func)
-                    }
-                    NamedVariant::SelfIdentity => LocalVariant::SelfIdentity,
-                })
-                .collect(),
-        );
+    /// Add one variant to this class's default **input flatten**: build via
+    /// this declared `#[prebindgen]` constructor fn directly. Call repeatedly
+    /// to add more variants.
+    pub fn flatten_input(mut self, rust_fun: FunctionDecl) -> Self {
+        self.input_variants
+            .get_or_insert_with(Vec::new)
+            .push(LocalVariant::Ctor(rust_fun.rust_ident));
         self
     }
 
-    /// Set this class's default **output flatten**: how a returned/callback
-    /// value of this class is decomposed into fields. `decl` is built
-    /// independently via [`FlattenOutputDecl::new`] + `.field(name)` (a
-    /// declared `.accessor`'s value) / `.field_self()` (the handle itself),
-    /// then resolved against this class's declared members here.
-    pub fn flatten_output(mut self, decl: FlattenOutputDecl) -> Self {
-        self.output_fields = Some(
-            decl.fields
-                .into_iter()
-                .map(|f| match f {
-                    NamedField::Acc(name) => {
-                        let func = resolve_member(&self.members, &name, MemberKind::Accessor, "field");
-                        LocalField::Named(func, name)
-                    }
-                    NamedField::SelfField => LocalField::SelfField,
-                })
-                .collect(),
-        );
-        self
-    }
-}
-
-/// Standalone spec for [`PtrClassDecl::flatten_input`], built independently
-/// (`FlattenInputDecl::new().variant("of").variant_self()`, or
-/// `prebindgen::flatten_input!().variant("of").variant_self()`) and handed in
-/// as a value — `.variant()`/`.variant_self()` only exist on this type, so
-/// there is no way to call them before a `.flatten_input()` exists to resolve
-/// them against.
-pub struct FlattenInputDecl {
-    variants: Vec<NamedVariant>,
-}
-
-pub(crate) enum NamedVariant {
-    Ctor(String),
-    SelfIdentity,
-}
-
-impl FlattenInputDecl {
-    pub fn new() -> Self {
-        Self {
-            variants: Vec::new(),
-        }
-    }
-
-    /// Build via the constructor declared as `name` (see
-    /// [`PtrClassDecl::constructor`]).
-    pub fn variant(mut self, name: impl Into<String>) -> Self {
-        self.variants.push(NamedVariant::Ctor(name.into()));
+    /// Add the identity variant to this class's default input flatten:
+    /// accept an already-built handle directly.
+    pub fn flatten_input_self(mut self) -> Self {
+        self.input_variants
+            .get_or_insert_with(Vec::new)
+            .push(LocalVariant::SelfIdentity);
         self
     }
 
-    /// Accept an already-built handle directly (the identity variant).
-    pub fn variant_self(mut self) -> Self {
-        self.variants.push(NamedVariant::SelfIdentity);
-        self
-    }
-}
-
-impl Default for FlattenInputDecl {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Standalone spec for [`PtrClassDecl::flatten_output`] — the output-side
-/// dual of [`FlattenInputDecl`].
-pub struct FlattenOutputDecl {
-    fields: Vec<NamedField>,
-}
-
-pub(crate) enum NamedField {
-    Acc(String),
-    SelfField,
-}
-
-impl FlattenOutputDecl {
-    pub fn new() -> Self {
-        Self { fields: Vec::new() }
-    }
-
-    /// Include the value of the accessor declared as `name` (see
-    /// [`PtrClassDecl::accessor`]).
-    pub fn field(mut self, name: impl Into<String>) -> Self {
-        self.fields.push(NamedField::Acc(name.into()));
+    /// Add one field to this class's default **output flatten**: the value
+    /// of the accessor fn `rust_fun` (named via `rust_fun.name(...)`,
+    /// defaulting to `snake_to_camel(rust_ident)`). Call repeatedly to add
+    /// more fields.
+    pub fn flatten_output(mut self, rust_fun: FunctionDecl) -> Self {
+        let name = rust_fun
+            .kotlin_name_override
+            .unwrap_or_else(|| snake_to_camel(&rust_fun.rust_ident.to_string()));
+        self.output_fields
+            .get_or_insert_with(Vec::new)
+            .push(LocalField::Named(rust_fun.rust_ident, name));
         self
     }
 
-    /// Include the handle itself as a field.
-    pub fn field_self(mut self) -> Self {
-        self.fields.push(NamedField::SelfField);
+    /// Add the handle itself as a field to this class's default output
+    /// flatten.
+    pub fn flatten_output_self(mut self) -> Self {
+        self.output_fields
+            .get_or_insert_with(Vec::new)
+            .push(LocalField::SelfField);
         self
-    }
-}
-
-impl Default for FlattenOutputDecl {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -425,13 +293,8 @@ impl EnumClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
-        self
-    }
-
-    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Method);
+    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Fun);
         self
     }
 
@@ -479,13 +342,8 @@ impl DataClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
-        self
-    }
-
-    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Method);
+    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Fun);
         self
     }
 
@@ -535,13 +393,8 @@ impl ValueClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
-        self
-    }
-
-    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Method);
+    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Fun);
         self
     }
 
@@ -659,10 +512,12 @@ impl FunctionDecl {
 }
 
 /// Standalone spec for [`FunctionDecl::flatten_input_with`], built
-/// independently and handed in as a value — the per-param dual of
-/// [`FlattenInputDecl`], except `.variant(func)` names the `#[prebindgen]`
-/// constructor's Rust ident **directly** (a free function has no declared
-/// member list to resolve a name against, unlike a class).
+/// independently and handed in as a value — needed because
+/// `flatten_input_with` is keyed **per parameter** (a function can have
+/// several, each independently overridden), unlike
+/// [`PtrClassDecl::flatten_input`] which is called directly, once per
+/// variant. `.variant(func)` names the `#[prebindgen]` constructor fn
+/// directly.
 pub struct FunctionFlattenInputDecl {
     variants: Vec<LocalVariant>,
 }
@@ -694,8 +549,7 @@ impl Default for FunctionFlattenInputDecl {
 }
 
 /// Standalone spec for [`FunctionDecl::flatten_output_with`] — the
-/// per-function output-side dual of
-/// [`FunctionFlattenInputDecl`]/[`FlattenOutputDecl`].
+/// per-function output-side dual of [`FunctionFlattenInputDecl`].
 pub struct FunctionFlattenOutputDecl {
     fields: Vec<LocalField>,
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -17,7 +17,7 @@ use super::*;
 // by the accept logic in `builder.rs` once a decl is handed to `JniGen`)
 // ──────────────────────────────────────────────────────────────────────
 
-/// One arm of a class-level or per-fn `.flatten_input()` build-from list.
+/// One arm of a `.default_param_variant*`/`.param_variant*` build-from list.
 #[derive(Clone)]
 pub(crate) enum LocalVariant {
     /// Build via this declared constructor member / constructor fn.
@@ -26,7 +26,7 @@ pub(crate) enum LocalVariant {
     SelfIdentity,
 }
 
-/// One arm of a class-level or per-fn `.flatten_output()` field list.
+/// One arm of a `.default_return_field*`/`.return_field*` field list.
 #[derive(Clone)]
 pub(crate) enum LocalField {
     /// Include the named accessor's value as this leaf/field name.
@@ -36,11 +36,10 @@ pub(crate) enum LocalField {
 }
 
 // Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
-// not a reduced ident+name record — so the `FunctionDecl`'s per-fn flatten
-// modifiers (`.flatten_output_suppress()`, `.flatten_input_suppress(param)`,
-// per-fn `.flatten_input`/`.flatten_output` overrides) survive to
-// `builder.rs`'s `accept_members`, which applies them exactly like
-// `accept_function` does for free package functions.
+// not a reduced ident+name record — so the `FunctionDecl`'s per-fn
+// `.param_variant*`/`.return_field*` overrides survive to `builder.rs`'s
+// `accept_members`, which applies them exactly like `accept_function` does
+// for free package functions.
 
 // ──────────────────────────────────────────────────────────────────────
 // Decl constructor macros — one per decl type built from bare Rust syntax
@@ -140,14 +139,19 @@ macro_rules! generic_type_wrapper {
 /// typed-handle class FQN. Feed it to a [`PackageDecl`] (via [`ClassDecl`])
 /// which in turn is handed to [`JniGen::package`].
 ///
-/// `.flatten_output`/`.flatten_input` each take a [`FunctionDecl`] directly,
-/// one call per field/variant (call repeatedly to add more):
+/// A `PtrClassDecl` plays **two roles**: it defines the Kotlin class itself
+/// (`.name`/`.fun`/`.constructor`), and it sets the type's **default
+/// boundary behavior** — `.default_param_variant*` / `.default_return_field*`
+/// apply to *every* function where the type appears as a param, return,
+/// callback argument, or the `E` of a `Result` (overridable per-fn via
+/// [`FunctionDecl::param_variant`] / [`FunctionDecl::return_field`]). Each
+/// call adds one variant/field (call repeatedly to add more):
 ///
 /// ```
 /// let _ = prebindgen::ptr_class!(ZThing)
 ///     .fun(prebindgen::fun!(z_thing_name).name("name"))
-///     .flatten_output_self()
-///     .flatten_output(prebindgen::fun!(z_thing_name).name("name"));
+///     .default_return_field_self()
+///     .default_return_field(prebindgen::fun!(z_thing_name).name("name"));
 /// ```
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
@@ -186,36 +190,42 @@ impl PtrClassDecl {
 
     /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
     /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
-    /// from `.flatten_input(fun!(...))`.
+    /// from `.default_param_variant(fun!(...))`.
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Constructor));
         self
     }
 
-    /// Add one variant to this class's default **input flatten**: build via
-    /// this declared `#[prebindgen]` constructor fn directly. Call repeatedly
-    /// to add more variants.
-    pub fn flatten_input(mut self, rust_fun: FunctionDecl) -> Self {
+    /// Add one **default param variant**: a parameter of this class type
+    /// (in *any* declared function) also accepts what this `#[prebindgen]`
+    /// constructor fn takes, built via it at the boundary. Call repeatedly
+    /// to add more variants (2+ variants dispatch via a runtime selector).
+    /// Overridable per-fn via [`FunctionDecl::param_variant`].
+    pub fn default_param_variant(mut self, rust_fun: FunctionDecl) -> Self {
         self.input_variants
             .get_or_insert_with(Vec::new)
             .push(LocalVariant::Ctor(rust_fun.rust_ident));
         self
     }
 
-    /// Add the identity variant to this class's default input flatten:
-    /// accept an already-built handle directly.
-    pub fn flatten_input_self(mut self) -> Self {
+    /// Add the identity **default param variant**: a parameter of this class
+    /// type accepts an already-built handle directly. As the *only* declared
+    /// variant this is the plain-handle form (no selector) — the default
+    /// when nothing is declared, so alone it is a no-op made explicit.
+    pub fn default_param_variant_self(mut self) -> Self {
         self.input_variants
             .get_or_insert_with(Vec::new)
             .push(LocalVariant::SelfIdentity);
         self
     }
 
-    /// Add one field to this class's default **output flatten**: the value
+    /// Add one **default return field**: a returned/delivered value of this
+    /// class type (in *any* declared function, incl. callback args and the
+    /// `E` of a `Result`) decomposes into fields, this one being the value
     /// of the accessor fn `rust_fun` (named via `rust_fun.name(...)`,
     /// defaulting to `snake_to_camel(rust_ident)`). Call repeatedly to add
-    /// more fields.
-    pub fn flatten_output(mut self, rust_fun: FunctionDecl) -> Self {
+    /// more fields. Overridable per-fn via [`FunctionDecl::return_field`].
+    pub fn default_return_field(mut self, rust_fun: FunctionDecl) -> Self {
         let name = rust_fun
             .kotlin_name_override
             .unwrap_or_else(|| snake_to_camel(&rust_fun.rust_ident.to_string()));
@@ -225,9 +235,8 @@ impl PtrClassDecl {
         self
     }
 
-    /// Add the handle itself as a field to this class's default output
-    /// flatten.
-    pub fn flatten_output_self(mut self) -> Self {
+    /// Add the handle itself as a **default return field** of this class.
+    pub fn default_return_field_self(mut self) -> Self {
         self.output_fields
             .get_or_insert_with(Vec::new)
             .push(LocalField::SelfField);
@@ -410,12 +419,17 @@ impl From<ValueClassDecl> for ClassDecl {
 
 /// Declares a `#[prebindgen]` function as a free-standing package wrapper.
 /// Feed it to a [`PackageDecl`] via [`PackageDecl::fun`].
+///
+/// The `.param_variant*` / `.return_field*` methods **override, for this
+/// function only**, the class-level defaults declared via
+/// [`PtrClassDecl::default_param_variant`] /
+/// [`PtrClassDecl::default_return_field`]. An override consisting of only
+/// the `_self` form means "the plain handle, nothing else" — the raw wire
+/// shape, replacing what the class default would otherwise apply here.
 pub struct FunctionDecl {
     pub(crate) rust_ident: syn::Ident,
     pub(crate) kotlin_name_override: Option<String>,
-    pub(crate) input_suppressed: Vec<syn::Ident>,
     pub(crate) input_overrides: Vec<(syn::Ident, Vec<LocalVariant>)>,
-    pub(crate) output_suppressed: bool,
     pub(crate) output_override: Option<Vec<LocalField>>,
 }
 
@@ -424,9 +438,7 @@ impl FunctionDecl {
         Self {
             rust_ident,
             kotlin_name_override: None,
-            input_suppressed: Vec::new(),
             input_overrides: Vec::new(),
-            output_suppressed: false,
             output_override: None,
         }
     }
@@ -438,33 +450,30 @@ impl FunctionDecl {
         self
     }
 
-    /// `param` skips input-flattening and takes the raw handle.
-    pub fn flatten_input_suppress(mut self, param: syn::Ident) -> Self {
-        self.input_suppressed.push(param);
-        self
-    }
-
-    /// Add one variant to `param`'s **input flatten** override: build via
-    /// this `#[prebindgen]` constructor fn directly. Call repeatedly to add
-    /// more variants for the same param, or for different params — the only
-    /// difference from [`PtrClassDecl::flatten_input`] is the leading param
-    /// ident, since a function may have several independently-overridden
-    /// handle params.
-    pub fn flatten_input(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
+    /// Add one variant to `param`'s **param-variant override**, replacing
+    /// the class-level default for this function: build via this
+    /// `#[prebindgen]` constructor fn directly. Call repeatedly to add more
+    /// variants for the same param, or for different params — the only
+    /// difference from [`PtrClassDecl::default_param_variant`] is the
+    /// leading param ident, since a function may have several
+    /// independently-overridden handle params.
+    pub fn param_variant(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
         self.input_override_entry(param)
             .push(LocalVariant::Ctor(ctor.rust_ident));
         self
     }
 
-    /// Add the identity variant to `param`'s input flatten override: accept
-    /// an already-built handle directly.
-    pub fn flatten_input_self(mut self, param: syn::Ident) -> Self {
+    /// Add the identity variant to `param`'s override: accept an
+    /// already-built handle directly. As the *only* declared variant this is
+    /// the plain-handle form — i.e. it cancels the class-level default for
+    /// this param (no selector, no construction).
+    pub fn param_variant_self(mut self, param: syn::Ident) -> Self {
         self.input_override_entry(param)
             .push(LocalVariant::SelfIdentity);
         self
     }
 
-    /// The variant list of `param`'s input override, creating it on first use.
+    /// The variant list of `param`'s override, creating it on first use.
     fn input_override_entry(&mut self, param: syn::Ident) -> &mut Vec<LocalVariant> {
         let idx = match self.input_overrides.iter().position(|(p, _)| *p == param) {
             Some(i) => i,
@@ -476,17 +485,12 @@ impl FunctionDecl {
         &mut self.input_overrides[idx].1
     }
 
-    /// The return value skips output-flattening and stays a raw handle.
-    pub fn flatten_output_suppress(mut self) -> Self {
-        self.output_suppressed = true;
-        self
-    }
-
-    /// Add one field to this function's **output flatten** override: the
-    /// value of the accessor fn `field` (named via `field.name(...)`,
-    /// defaulting to `snake_to_camel(rust_ident)`). Call repeatedly to add
-    /// more fields — same shape as [`PtrClassDecl::flatten_output`].
-    pub fn flatten_output(mut self, field: FunctionDecl) -> Self {
+    /// Add one field to this function's **return-field override**, replacing
+    /// the class-level default: the value of the accessor fn `field` (named
+    /// via `field.name(...)`, defaulting to `snake_to_camel(rust_ident)`).
+    /// Call repeatedly to add more fields — same shape as
+    /// [`PtrClassDecl::default_return_field`].
+    pub fn return_field(mut self, field: FunctionDecl) -> Self {
         let name = field
             .kotlin_name_override
             .unwrap_or_else(|| snake_to_camel(&field.rust_ident.to_string()));
@@ -496,9 +500,12 @@ impl FunctionDecl {
         self
     }
 
-    /// Add the return value itself as a field of this function's output
-    /// flatten override.
-    pub fn flatten_output_self(mut self) -> Self {
+    /// Add the return value itself as a field of this function's return
+    /// override. As the *only* declared field this is the raw whole-handle
+    /// return — i.e. it cancels the class-level default for this function
+    /// (also the right spelling for borrowed `&T` returns, which cross by
+    /// cloning into a fresh owned handle).
+    pub fn return_field_self(mut self) -> Self {
         self.output_override
             .get_or_insert_with(Vec::new)
             .push(LocalField::SelfField);

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -185,7 +185,7 @@ impl PtrClassDecl {
     }
 
     /// Rename the generated Kotlin class. By default it is named after the
-    /// Rust type (via the `kotlin_ptr_class_name_mangle` hook); `.name("Foo")`
+    /// Rust type (via the [`JniGen::set_ptr_class_name_mangle`] hook); `.name("Foo")`
     /// sets it literally instead. Relative name, no dots — the package comes
     /// from the enclosing [`PackageDecl`].
     pub fn name(mut self, name: impl Into<String>) -> Self {
@@ -650,7 +650,8 @@ pub(crate) fn wrapper_value_ident() -> syn::Ident {
 /// any package.
 ///
 /// Build one with [`scalar_type_wrapper!`](crate::scalar_type_wrapper), then
-/// give it [`input`](Self::input) / [`output`](Self::output) conversions.
+/// give it [`on_param`](Self::on_param) / [`on_return`](Self::on_return)
+/// conversions.
 pub struct ScalarTypeWrapperDecl {
     pub(crate) pattern: syn::Type,
     // Stored as tokenized source text, not `syn::Type`: this workspace's

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -35,17 +35,17 @@ pub(crate) enum LocalField {
     SelfField,
 }
 
-/// Push `(rust_fun, name, kind)` onto `members`, shared by every class-kind
-/// decl's `.accessor()`/`.method()`/`.constructor()`.
-fn push_member(
-    members: &mut Vec<ClassMember>,
-    rust_fun: syn::Ident,
-    name: impl Into<String>,
-    kind: MemberKind,
-) {
+/// Push `rust_fun` onto `members` as a member of the given `kind`, shared by
+/// every class-kind decl's `.accessor()`/`.method()`/`.constructor()`. The
+/// Kotlin-visible name comes from `rust_fun.name(...)` if set, else defaults
+/// to `snake_to_camel(rust_ident)` — the same default `PackageDecl::fun` uses.
+fn push_member(members: &mut Vec<ClassMember>, rust_fun: FunctionDecl, kind: MemberKind) {
+    let kotlin_name = rust_fun
+        .kotlin_name_override
+        .unwrap_or_else(|| snake_to_camel(&rust_fun.rust_ident.to_string()));
     members.push(ClassMember {
-        rust_ident: rust_fun,
-        kotlin_name: name.into(),
+        rust_ident: rust_fun.rust_ident,
+        kotlin_name,
         kind,
     });
 }
@@ -73,6 +73,92 @@ fn resolve_member(members: &[ClassMember], name: &str, kind: MemberKind, verb: &
 }
 
 // ──────────────────────────────────────────────────────────────────────
+// Decl constructor macros — one per decl type built from bare Rust syntax
+// or with no arguments at all. Each is restricted at the `macro_rules!`
+// fragment level (`:ty` / `:ident`) and expands to a call with a hard-coded
+// concrete return type, so `syn::parse_quote!`/`syn::parse_str` never has to
+// infer its output type against a generic bound — there is no `E0283` risk
+// to route around here, unlike a bare `syn::parse_quote!(...)` would have if
+// fed into a generic `impl Into<T>` parameter.
+// ──────────────────────────────────────────────────────────────────────
+
+/// Build a [`PtrClassDecl`] directly from a bare Rust type: `ptr_class!(Foo)`
+/// is `PtrClassDecl::new(<Foo as a parsed syn::Type>)`.
+#[macro_export]
+macro_rules! ptr_class {
+    ($t:ty) => {
+        $crate::lang::PtrClassDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build an [`EnumClassDecl`] directly from a bare Rust type. See [`ptr_class!`].
+#[macro_export]
+macro_rules! enum_class {
+    ($t:ty) => {
+        $crate::lang::EnumClassDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build a [`DataClassDecl`] directly from a bare Rust type. See [`ptr_class!`].
+#[macro_export]
+macro_rules! data_class {
+    ($t:ty) => {
+        $crate::lang::DataClassDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build a [`ValueClassDecl`] directly from a bare Rust type. See [`ptr_class!`].
+#[macro_export]
+macro_rules! value_class {
+    ($t:ty) => {
+        $crate::lang::ValueClassDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build a [`FunctionDecl`] directly from a bare function ident: `fun!(foo)`
+/// is `FunctionDecl::new(prebindgen::ident!(foo))`.
+#[macro_export]
+macro_rules! fun {
+    ($name:ident) => {
+        $crate::lang::FunctionDecl::new($crate::ident!($name))
+    };
+}
+
+/// Build an empty [`FlattenInputDecl`] — shorthand for `FlattenInputDecl::new()`.
+#[macro_export]
+macro_rules! flatten_input {
+    () => {
+        $crate::lang::FlattenInputDecl::new()
+    };
+}
+
+/// Build an empty [`FlattenOutputDecl`] — shorthand for `FlattenOutputDecl::new()`.
+#[macro_export]
+macro_rules! flatten_output {
+    () => {
+        $crate::lang::FlattenOutputDecl::new()
+    };
+}
+
+/// Build an empty [`FunctionFlattenInputDecl`] — shorthand for
+/// `FunctionFlattenInputDecl::new()`.
+#[macro_export]
+macro_rules! function_flatten_input {
+    () => {
+        $crate::lang::FunctionFlattenInputDecl::new()
+    };
+}
+
+/// Build an empty [`FunctionFlattenOutputDecl`] — shorthand for
+/// `FunctionFlattenOutputDecl::new()`.
+#[macro_export]
+macro_rules! function_flatten_output {
+    () => {
+        $crate::lang::FunctionFlattenOutputDecl::new()
+    };
+}
+
+// ──────────────────────────────────────────────────────────────────────
 // Class-kind decls
 // ──────────────────────────────────────────────────────────────────────
 
@@ -82,28 +168,22 @@ fn resolve_member(members: &[ClassMember], name: &str, kind: MemberKind, verb: &
 /// typed-handle class FQN. Feed it to a [`PackageDecl`] (via [`ClassDecl`])
 /// which in turn is handed to [`JniGen::package`].
 ///
-/// `.flatten_output`/`.flatten_input` take a [`FlattenOutput`]/[`FlattenInput`]
-/// spec built independently:
+/// `.flatten_output`/`.flatten_input` take a
+/// [`FlattenOutputDecl`]/[`FlattenInputDecl`] spec built independently:
 ///
 /// ```
-/// use prebindgen::lang::{FlattenOutput, PtrClassDecl};
-/// use syn::parse_quote as pq;
-///
-/// let _ = PtrClassDecl::new(pq!(ZThing))
-///     .accessor(prebindgen::ident!(z_thing_name), "name")
-///     .flatten_output(FlattenOutput::new().field_self().field("name"));
+/// let _ = prebindgen::ptr_class!(ZThing)
+///     .accessor(prebindgen::fun!(z_thing_name).name("name"))
+///     .flatten_output(prebindgen::flatten_output!().field_self().field("name"));
 /// ```
 ///
-/// `.field()`/`.field_self()` only exist on [`FlattenOutput`], not on
+/// `.field()`/`.field_self()` only exist on [`FlattenOutputDecl`], not on
 /// `PtrClassDecl` itself, so there's no way to call them before a
 /// `.flatten_output(...)` exists to resolve them against:
 ///
 /// ```compile_fail
-/// use prebindgen::lang::{FlattenOutput, PtrClassDecl};
-/// use syn::parse_quote as pq;
-///
-/// let _ = PtrClassDecl::new(pq!(ZThing))
-///     .accessor(prebindgen::ident!(z_thing_name), "name")
+/// let _ = prebindgen::ptr_class!(ZThing)
+///     .accessor(prebindgen::fun!(z_thing_name).name("name"))
 ///     .field("name"); // no such method on `PtrClassDecl`
 /// ```
 pub struct PtrClassDecl {
@@ -135,47 +215,32 @@ impl PtrClassDecl {
 
     /// Declare a `#[prebindgen]` **read accessor** (`f(&Self) -> R`) as an
     /// instance method `name`. Usable as a `.flatten_output()` `.field(name)`.
-    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Accessor,
-        );
+    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
         self
     }
 
     /// Declare a `#[prebindgen]` **method** (`f(&Self, …) -> R`) as an
     /// instance method `name`. Not usable as a flatten field.
-    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Method,
-        );
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Method);
         self
     }
 
     /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
     /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
     /// from `.flatten_input().variant(name)`.
-    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Constructor,
-        );
+    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 
     /// Set this class's default **input flatten**: how a parameter of this
     /// class type is assembled at the boundary. `decl` is built independently
-    /// via [`FlattenInput::new`] + `.variant(name)` (build via a declared
+    /// via [`FlattenInputDecl::new`] + `.variant(name)` (build via a declared
     /// `.constructor`) / `.variant_self()` (accept the handle directly), then
     /// resolved against this class's declared members here.
-    pub fn flatten_input(mut self, decl: FlattenInput) -> Self {
+    pub fn flatten_input(mut self, decl: FlattenInputDecl) -> Self {
         self.input_variants = Some(
             decl.variants
                 .into_iter()
@@ -194,10 +259,10 @@ impl PtrClassDecl {
 
     /// Set this class's default **output flatten**: how a returned/callback
     /// value of this class is decomposed into fields. `decl` is built
-    /// independently via [`FlattenOutput::new`] + `.field(name)` (a declared
-    /// `.accessor`'s value) / `.field_self()` (the handle itself), then
-    /// resolved against this class's declared members here.
-    pub fn flatten_output(mut self, decl: FlattenOutput) -> Self {
+    /// independently via [`FlattenOutputDecl::new`] + `.field(name)` (a
+    /// declared `.accessor`'s value) / `.field_self()` (the handle itself),
+    /// then resolved against this class's declared members here.
+    pub fn flatten_output(mut self, decl: FlattenOutputDecl) -> Self {
         self.output_fields = Some(
             decl.fields
                 .into_iter()
@@ -215,11 +280,12 @@ impl PtrClassDecl {
 }
 
 /// Standalone spec for [`PtrClassDecl::flatten_input`], built independently
-/// (`FlattenInput::new().variant("of").variant_self()`) and handed in as a
-/// value — `.variant()`/`.variant_self()` only exist on this type, so there
-/// is no way to call them before a `.flatten_input()` exists to resolve them
-/// against.
-pub struct FlattenInput {
+/// (`FlattenInputDecl::new().variant("of").variant_self()`, or
+/// `prebindgen::flatten_input!().variant("of").variant_self()`) and handed in
+/// as a value — `.variant()`/`.variant_self()` only exist on this type, so
+/// there is no way to call them before a `.flatten_input()` exists to resolve
+/// them against.
+pub struct FlattenInputDecl {
     variants: Vec<NamedVariant>,
 }
 
@@ -228,7 +294,7 @@ pub(crate) enum NamedVariant {
     SelfIdentity,
 }
 
-impl FlattenInput {
+impl FlattenInputDecl {
     pub fn new() -> Self {
         Self {
             variants: Vec::new(),
@@ -249,15 +315,15 @@ impl FlattenInput {
     }
 }
 
-impl Default for FlattenInput {
+impl Default for FlattenInputDecl {
     fn default() -> Self {
         Self::new()
     }
 }
 
 /// Standalone spec for [`PtrClassDecl::flatten_output`] — the output-side
-/// dual of [`FlattenInput`].
-pub struct FlattenOutput {
+/// dual of [`FlattenInputDecl`].
+pub struct FlattenOutputDecl {
     fields: Vec<NamedField>,
 }
 
@@ -266,7 +332,7 @@ pub(crate) enum NamedField {
     SelfField,
 }
 
-impl FlattenOutput {
+impl FlattenOutputDecl {
     pub fn new() -> Self {
         Self { fields: Vec::new() }
     }
@@ -285,7 +351,7 @@ impl FlattenOutput {
     }
 }
 
-impl Default for FlattenOutput {
+impl Default for FlattenOutputDecl {
     fn default() -> Self {
         Self::new()
     }
@@ -323,33 +389,18 @@ impl EnumClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Accessor,
-        );
+    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
         self
     }
 
-    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Method,
-        );
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Method);
         self
     }
 
-    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Constructor,
-        );
+    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 }
@@ -392,33 +443,18 @@ impl DataClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Accessor,
-        );
+    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
         self
     }
 
-    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Method,
-        );
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Method);
         self
     }
 
-    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Constructor,
-        );
+    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 }
@@ -463,33 +499,18 @@ impl ValueClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Accessor,
-        );
+    pub fn accessor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Accessor);
         self
     }
 
-    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Method,
-        );
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Method);
         self
     }
 
-    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        push_member(
-            &mut self.members,
-            rust_fun.into().rust_ident,
-            name,
-            MemberKind::Constructor,
-        );
+    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
+        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 }
@@ -504,9 +525,9 @@ impl From<syn::Type> for ValueClassDecl {
 /// can expose a single entry point. Deliberately **no**
 /// `impl From<syn::Type> for ClassDecl` — a bare `syn::Type` alone doesn't
 /// say which of the four kinds it should become, so every declaration names
-/// its kind explicitly via the concrete constructor:
-/// `.class(PtrClassDecl::new(pq!(Storage)))`,
-/// `.class(EnumClassDecl::new(pq!(Priority)))`, etc.
+/// its kind explicitly via the matching constructor macro:
+/// `.class(prebindgen::ptr_class!(Storage))`,
+/// `.class(prebindgen::enum_class!(Priority))`, etc.
 pub enum ClassDecl {
     Ptr(PtrClassDecl),
     Enum(EnumClassDecl),
@@ -576,11 +597,11 @@ impl FunctionDecl {
     }
 
     /// Replace the default input flatten of `param` with an explicit variant
-    /// list. `decl` is built independently via [`FunctionFlattenInput::new`]
-    /// + `.variant(fn)` (build-from constructor fns) / `.variant_self()`
-    /// (accept the handle directly). May be called more than once, for
-    /// different params.
-    pub fn flatten_input_with(mut self, param: syn::Ident, decl: FunctionFlattenInput) -> Self {
+    /// list. `decl` is built independently via
+    /// [`FunctionFlattenInputDecl::new`] + `.variant(fn)` (build-from
+    /// constructor fns) / `.variant_self()` (accept the handle directly). May
+    /// be called more than once, for different params.
+    pub fn flatten_input_with(mut self, param: syn::Ident, decl: FunctionFlattenInputDecl) -> Self {
         self.input_overrides.push((param, decl.variants));
         self
     }
@@ -592,10 +613,10 @@ impl FunctionDecl {
     }
 
     /// Replace the default output flatten with an explicit field list.
-    /// `decl` is built independently via [`FunctionFlattenOutput::new`] +
-    /// `.field(fn, name)` (accessor fns with their leaf name) /
+    /// `decl` is built independently via [`FunctionFlattenOutputDecl::new`] +
+    /// `.field(fn)` (accessor fns, named via `fn.name(...)`) /
     /// `.field_self()` (the handle itself).
-    pub fn flatten_output_with(mut self, decl: FunctionFlattenOutput) -> Self {
+    pub fn flatten_output_with(mut self, decl: FunctionFlattenOutputDecl) -> Self {
         self.output_override = Some(decl.fields);
         self
     }
@@ -603,14 +624,14 @@ impl FunctionDecl {
 
 /// Standalone spec for [`FunctionDecl::flatten_input_with`], built
 /// independently and handed in as a value — the per-param dual of
-/// [`FlattenInput`], except `.variant(func)` names the `#[prebindgen]`
+/// [`FlattenInputDecl`], except `.variant(func)` names the `#[prebindgen]`
 /// constructor's Rust ident **directly** (a free function has no declared
 /// member list to resolve a name against, unlike a class).
-pub struct FunctionFlattenInput {
+pub struct FunctionFlattenInputDecl {
     variants: Vec<LocalVariant>,
 }
 
-impl FunctionFlattenInput {
+impl FunctionFlattenInputDecl {
     pub fn new() -> Self {
         Self {
             variants: Vec::new(),
@@ -618,8 +639,8 @@ impl FunctionFlattenInput {
     }
 
     /// Build via this `#[prebindgen]` constructor function directly.
-    pub fn variant(mut self, func: impl Into<FunctionDecl>) -> Self {
-        self.variants.push(LocalVariant::Ctor(func.into().rust_ident));
+    pub fn variant(mut self, func: FunctionDecl) -> Self {
+        self.variants.push(LocalVariant::Ctor(func.rust_ident));
         self
     }
 
@@ -630,28 +651,33 @@ impl FunctionFlattenInput {
     }
 }
 
-impl Default for FunctionFlattenInput {
+impl Default for FunctionFlattenInputDecl {
     fn default() -> Self {
         Self::new()
     }
 }
 
 /// Standalone spec for [`FunctionDecl::flatten_output_with`] — the
-/// per-function output-side dual of [`FunctionFlattenInput`]/[`FlattenOutput`].
-pub struct FunctionFlattenOutput {
+/// per-function output-side dual of
+/// [`FunctionFlattenInputDecl`]/[`FlattenOutputDecl`].
+pub struct FunctionFlattenOutputDecl {
     fields: Vec<LocalField>,
 }
 
-impl FunctionFlattenOutput {
+impl FunctionFlattenOutputDecl {
     pub fn new() -> Self {
         Self { fields: Vec::new() }
     }
 
     /// Include the value of the accessor fn `func` (the rust accessor fn
-    /// directly) as field `name`.
-    pub fn field(mut self, func: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
-        self.fields
-            .push(LocalField::Named(func.into().rust_ident, name.into()));
+    /// directly) as a field named via `func.name(...)` (default:
+    /// `snake_to_camel(rust_ident)`, same as everywhere else a `FunctionDecl`
+    /// supplies its own Kotlin-visible name).
+    pub fn field(mut self, func: FunctionDecl) -> Self {
+        let name = func
+            .kotlin_name_override
+            .unwrap_or_else(|| snake_to_camel(&func.rust_ident.to_string()));
+        self.fields.push(LocalField::Named(func.rust_ident, name));
         self
     }
 
@@ -662,15 +688,9 @@ impl FunctionFlattenOutput {
     }
 }
 
-impl Default for FunctionFlattenOutput {
+impl Default for FunctionFlattenOutputDecl {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl From<syn::Ident> for FunctionDecl {
-    fn from(rust_ident: syn::Ident) -> Self {
-        Self::new(rust_ident)
     }
 }
 
@@ -710,13 +730,11 @@ impl PackageDecl {
         self
     }
 
-    /// Add a free-function declaration. Accepts anything convertible into a
-    /// `FunctionDecl` — a bare function ident via [`crate::ident!`] (which,
-    /// unlike `syn::parse_quote!`, resolves to a concrete `syn::Ident` with
-    /// no inference ambiguity against this generic bound) or a fully
-    /// customized `FunctionDecl::new(pq!(ident)).name(...)....`.
-    pub fn fun(mut self, decl: impl Into<FunctionDecl>) -> Self {
-        self.functions.push(decl.into());
+    /// Add a free-function declaration — a bare function ident via
+    /// [`crate::fun!`] or a fully customized
+    /// `FunctionDecl::new(prebindgen::ident!(ident)).name(...)....`.
+    pub fn fun(mut self, decl: FunctionDecl) -> Self {
+        self.functions.push(decl);
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -90,7 +90,7 @@ fn resolve_member(members: &[ClassMember], name: &str, kind: MemberKind, verb: &
 /// use syn::parse_quote as pq;
 ///
 /// let _ = PtrClassDecl::new(pq!(ZThing))
-///     .accessor(pq!(z_thing_name), "name")
+///     .accessor(prebindgen::ident!(z_thing_name), "name")
 ///     .flatten_output(FlattenOutput::new().field_self().field("name"));
 /// ```
 ///
@@ -103,7 +103,7 @@ fn resolve_member(members: &[ClassMember], name: &str, kind: MemberKind, verb: &
 /// use syn::parse_quote as pq;
 ///
 /// let _ = PtrClassDecl::new(pq!(ZThing))
-///     .accessor(pq!(z_thing_name), "name")
+///     .accessor(prebindgen::ident!(z_thing_name), "name")
 ///     .field("name"); // no such method on `PtrClassDecl`
 /// ```
 pub struct PtrClassDecl {
@@ -135,23 +135,38 @@ impl PtrClassDecl {
 
     /// Declare a `#[prebindgen]` **read accessor** (`f(&Self) -> R`) as an
     /// instance method `name`. Usable as a `.flatten_output()` `.field(name)`.
-    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Accessor,
+        );
         self
     }
 
     /// Declare a `#[prebindgen]` **method** (`f(&Self, …) -> R`) as an
     /// instance method `name`. Not usable as a flatten field.
-    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Method,
+        );
         self
     }
 
     /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
     /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
     /// from `.flatten_input().variant(name)`.
-    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Constructor,
+        );
         self
     }
 
@@ -308,18 +323,33 @@ impl EnumClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Accessor,
+        );
         self
     }
 
-    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Method,
+        );
         self
     }
 
-    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Constructor,
+        );
         self
     }
 }
@@ -362,18 +392,33 @@ impl DataClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Accessor,
+        );
         self
     }
 
-    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Method,
+        );
         self
     }
 
-    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Constructor,
+        );
         self
     }
 }
@@ -418,18 +463,33 @@ impl ValueClassDecl {
         self
     }
 
-    pub fn accessor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Accessor);
+    pub fn accessor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Accessor,
+        );
         self
     }
 
-    pub fn method(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Method);
+    pub fn method(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Method,
+        );
         self
     }
 
-    pub fn constructor(mut self, rust_fun: syn::Ident, name: impl Into<String>) -> Self {
-        push_member(&mut self.members, rust_fun, name, MemberKind::Constructor);
+    pub fn constructor(mut self, rust_fun: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        push_member(
+            &mut self.members,
+            rust_fun.into().rust_ident,
+            name,
+            MemberKind::Constructor,
+        );
         self
     }
 }
@@ -558,8 +618,8 @@ impl FunctionFlattenInput {
     }
 
     /// Build via this `#[prebindgen]` constructor function directly.
-    pub fn variant(mut self, func: syn::Ident) -> Self {
-        self.variants.push(LocalVariant::Ctor(func));
+    pub fn variant(mut self, func: impl Into<FunctionDecl>) -> Self {
+        self.variants.push(LocalVariant::Ctor(func.into().rust_ident));
         self
     }
 
@@ -589,8 +649,9 @@ impl FunctionFlattenOutput {
 
     /// Include the value of the accessor fn `func` (the rust accessor fn
     /// directly) as field `name`.
-    pub fn field(mut self, func: syn::Ident, name: impl Into<String>) -> Self {
-        self.fields.push(LocalField::Named(func, name.into()));
+    pub fn field(mut self, func: impl Into<FunctionDecl>, name: impl Into<String>) -> Self {
+        self.fields
+            .push(LocalField::Named(func.into().rust_ident, name.into()));
         self
     }
 
@@ -649,15 +710,13 @@ impl PackageDecl {
         self
     }
 
-    /// Add a free-function declaration. Takes a `FunctionDecl` directly
-    /// (not `impl Into<FunctionDecl>` + a bare-`syn::Ident` bridge): with a
-    /// generic bound here, `syn::parse_quote!(ident)` can't infer whether to
-    /// target `syn::Ident` or `FunctionDecl`, so every declaration spells out
-    /// `FunctionDecl::new(pq!(ident))` — trivial for the common case
-    /// (`.fun(FunctionDecl::new(pq!(z_ping)))`), same "always name the
-    /// concrete type" rule `PackageDecl::class` already applies.
-    pub fn fun(mut self, decl: FunctionDecl) -> Self {
-        self.functions.push(decl);
+    /// Add a free-function declaration. Accepts anything convertible into a
+    /// `FunctionDecl` — a bare function ident via [`crate::ident!`] (which,
+    /// unlike `syn::parse_quote!`, resolves to a concrete `syn::Ident` with
+    /// no inference ambiguity against this generic bound) or a fully
+    /// customized `FunctionDecl::new(pq!(ident)).name(...)....`.
+    pub fn fun(mut self, decl: impl Into<FunctionDecl>) -> Self {
+        self.functions.push(decl.into());
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -254,10 +254,13 @@ impl From<syn::Type> for PtrClassDecl {
 /// explicit discriminants — the Kotlin emitter and the generated
 /// `TryFrom<i32>` decode rely on the discriminant values matching the jint
 /// wire.
+///
+/// No `.fun()`/`.constructor()` members: attached members are only emitted
+/// on typed-handle ([`PtrClassDecl`]) and value ([`ValueClassDecl`]) classes
+/// — a generated `enum class` carries no instance methods.
 pub struct EnumClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
-    pub(crate) members: Vec<ClassMember>,
 }
 
 impl EnumClassDecl {
@@ -265,23 +268,12 @@ impl EnumClassDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
-            members: Vec::new(),
         }
     }
 
     /// Override the Kotlin **class name** (relative, no dots).
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name_override = Some(name.into());
-        self
-    }
-
-    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Fun);
-        self
-    }
-
-    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 }
@@ -294,11 +286,15 @@ impl From<syn::Type> for EnumClassDecl {
 
 /// Declares a Rust struct that should appear in Kotlin as a `data class`.
 /// Only affects Kotlin emission — no Rust-side converter override.
+///
+/// No `.fun()`/`.constructor()` members: attached members are only emitted
+/// on typed-handle ([`PtrClassDecl`]) and value ([`ValueClassDecl`]) classes
+/// — a data class crosses decomposed into its fields and has no handle to
+/// hang an instance method on.
 pub struct DataClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
     pub(crate) kotlin_type: Option<String>,
-    pub(crate) members: Vec<ClassMember>,
 }
 
 impl DataClassDecl {
@@ -307,7 +303,6 @@ impl DataClassDecl {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
             kotlin_type: None,
-            members: Vec::new(),
         }
     }
 
@@ -321,16 +316,6 @@ impl DataClassDecl {
     /// instead of a class FQN — for generics/primitives/container types.
     pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
         self.kotlin_type = Some(expr.into());
-        self
-    }
-
-    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Fun);
-        self
-    }
-
-    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
-        push_member(&mut self.members, rust_fun, MemberKind::Constructor);
         self
     }
 }
@@ -645,6 +630,11 @@ impl ScalarTypeWrapperDecl {
     /// Build the wire → rust conversion body. `body` receives the ident of
     /// the wire-typed value in scope (`&wire`) and returns the Rust-typed
     /// expression to splice via `quote!`'s `#value` interpolation.
+    ///
+    /// The rank-0 (concrete pattern) counterpart of
+    /// [`GenericTypeWrapperDecl::input`] — same method name, simpler
+    /// contract: a plain expression closure, no wildcard args, no
+    /// [`WireBody`] fallibility choice.
     pub fn input(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
         self.input = Some(Arc::new(body));
         self
@@ -652,6 +642,8 @@ impl ScalarTypeWrapperDecl {
 
     /// Build the rust → wire conversion body. `body` receives the ident of
     /// the rust-typed value in scope and returns the wire-typed expression.
+    /// See [`Self::input`] for how this relates to
+    /// [`GenericTypeWrapperDecl::output`].
     pub fn output(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
         self.output = Some(Arc::new(body));
         self
@@ -769,7 +761,13 @@ impl GenericTypeWrapperDecl {
 
     /// Register the input-direction (wire → rust) peel. The closure's arity
     /// (1–3 leading `&syn::Type` params, one per `_` in `pattern`, plus a
-    /// trailing `&syn::Ident` for the value in scope) selects the rank.
+    /// trailing `&syn::Ident` for the value in scope) selects the rank; it
+    /// returns a [`WireBody`] choosing infallible vs domain-fallible.
+    ///
+    /// The wildcard-pattern counterpart of [`ScalarTypeWrapperDecl::input`] —
+    /// same method name, richer contract (wildcard substitutions +
+    /// fallibility), because a structural peel must adapt to what the `_`s
+    /// matched.
     pub fn input<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
         self.input = Some((B::rank(), builder.into_wrapper_fn()));
         self

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -201,7 +201,7 @@ impl PtrClassDecl {
     /// constructor fn takes, built via it at the boundary. Call repeatedly
     /// to add more variants (2+ variants dispatch via a runtime selector).
     /// Overridable per-fn via [`FunctionDecl::param_variant`].
-    pub fn default_param_variant(mut self, rust_fun: FunctionDecl) -> Self {
+    pub fn default_param_expand(mut self, rust_fun: FunctionDecl) -> Self {
         self.input_variants
             .get_or_insert_with(Vec::new)
             .push(LocalVariant::Ctor(rust_fun.rust_ident));
@@ -212,7 +212,7 @@ impl PtrClassDecl {
     /// type accepts an already-built handle directly. As the *only* declared
     /// variant this is the plain-handle form (no selector) — the default
     /// when nothing is declared, so alone it is a no-op made explicit.
-    pub fn default_param_variant_self(mut self) -> Self {
+    pub fn default_param_expand_self(mut self) -> Self {
         self.input_variants
             .get_or_insert_with(Vec::new)
             .push(LocalVariant::SelfIdentity);
@@ -225,7 +225,7 @@ impl PtrClassDecl {
     /// of the accessor fn `rust_fun` (named via `rust_fun.name(...)`,
     /// defaulting to `snake_to_camel(rust_ident)`). Call repeatedly to add
     /// more fields. Overridable per-fn via [`FunctionDecl::return_field`].
-    pub fn default_return_field(mut self, rust_fun: FunctionDecl) -> Self {
+    pub fn default_return_expand(mut self, rust_fun: FunctionDecl) -> Self {
         let name = rust_fun
             .kotlin_name_override
             .unwrap_or_else(|| snake_to_camel(&rust_fun.rust_ident.to_string()));
@@ -236,7 +236,7 @@ impl PtrClassDecl {
     }
 
     /// Add the handle itself as a **default return field** of this class.
-    pub fn default_return_field_self(mut self) -> Self {
+    pub fn default_return_expand_self(mut self) -> Self {
         self.output_fields
             .get_or_insert_with(Vec::new)
             .push(LocalField::SelfField);
@@ -457,7 +457,7 @@ impl FunctionDecl {
     /// difference from [`PtrClassDecl::default_param_variant`] is the
     /// leading param ident, since a function may have several
     /// independently-overridden handle params.
-    pub fn param_variant(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
+    pub fn param_expand(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
         self.input_override_entry(param)
             .push(LocalVariant::Ctor(ctor.rust_ident));
         self
@@ -467,7 +467,7 @@ impl FunctionDecl {
     /// already-built handle directly. As the *only* declared variant this is
     /// the plain-handle form — i.e. it cancels the class-level default for
     /// this param (no selector, no construction).
-    pub fn param_variant_self(mut self, param: syn::Ident) -> Self {
+    pub fn param_expand_self(mut self, param: syn::Ident) -> Self {
         self.input_override_entry(param)
             .push(LocalVariant::SelfIdentity);
         self
@@ -490,7 +490,7 @@ impl FunctionDecl {
     /// via `field.name(...)`, defaulting to `snake_to_camel(rust_ident)`).
     /// Call repeatedly to add more fields — same shape as
     /// [`PtrClassDecl::default_return_field`].
-    pub fn return_field(mut self, field: FunctionDecl) -> Self {
+    pub fn return_expand(mut self, field: FunctionDecl) -> Self {
         let name = field
             .kotlin_name_override
             .unwrap_or_else(|| snake_to_camel(&field.rust_ident.to_string()));
@@ -505,7 +505,7 @@ impl FunctionDecl {
     /// return — i.e. it cancels the class-level default for this function
     /// (also the right spelling for borrowed `&T` returns, which cross by
     /// cloning into a fresh owned handle).
-    pub fn return_field_self(mut self) -> Self {
+    pub fn return_expand_self(mut self) -> Self {
         self.output_override
             .get_or_insert_with(Vec::new)
             .push(LocalField::SelfField);

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -17,7 +17,7 @@ use super::*;
 // by the accept logic in `builder.rs` once a decl is handed to `JniGen`)
 // ──────────────────────────────────────────────────────────────────────
 
-/// One arm of a `.default_param_variant*`/`.param_variant*` build-from list.
+/// One arm of a `.default_param_expand*`/`.param_expand*` build-from list.
 #[derive(Clone)]
 pub(crate) enum LocalVariant {
     /// Build via this declared constructor member / constructor fn.
@@ -26,7 +26,7 @@ pub(crate) enum LocalVariant {
     SelfIdentity,
 }
 
-/// One arm of a `.default_return_field*`/`.return_field*` field list.
+/// One arm of a `.default_return_expand*`/`.return_expand*` field list.
 #[derive(Clone)]
 pub(crate) enum LocalField {
     /// Include the named accessor's value as this leaf/field name.
@@ -37,7 +37,7 @@ pub(crate) enum LocalField {
 
 // Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
 // not a reduced ident+name record — so the `FunctionDecl`'s per-fn
-// `.param_variant*`/`.return_field*` overrides survive to `builder.rs`'s
+// `.param_expand*`/`.return_expand*` overrides survive to `builder.rs`'s
 // `accept_members`, which applies them exactly like `accept_function` does
 // for free package functions.
 
@@ -133,25 +133,35 @@ macro_rules! generic_type_wrapper {
 // Class-kind decls
 // ──────────────────────────────────────────────────────────────────────
 
-/// Declares a typed Kotlin handle class backed by an opaque Rust type.
-/// Configures: jlong wire for both input and output, `Box::into_raw`/
-/// `Box::from_raw` lifecycle, the `instanceof` dispatch class, and the Kotlin
-/// typed-handle class FQN. Feed it to a [`PackageDecl`] (via [`ClassDecl`])
-/// which in turn is handed to [`JniGen::package`].
+/// Declares a Rust type as an **opaque handle**. In Kotlin it becomes a
+/// closeable class holding a pointer to the real object, which keeps living
+/// in Rust; the object crosses the boundary as that pointer, never copied.
+/// Use this for types with identity and a lifecycle — sessions, subscribers,
+/// configs, key expressions — that you pass around and eventually `close()`,
+/// as opposed to plain data you copy across ([`data_class!`](crate::data_class))
+/// or small `Copy` values ([`value_class!`](crate::value_class)).
 ///
-/// A `PtrClassDecl` plays **two roles**: it defines the Kotlin class itself
-/// (`.name`/`.fun`/`.constructor`), and it sets the type's **default
-/// boundary behavior** — `.default_param_variant*` / `.default_return_field*`
-/// apply to *every* function where the type appears as a param, return,
-/// callback argument, or the `E` of a `Result` (overridable per-fn via
-/// [`FunctionDecl::param_variant`] / [`FunctionDecl::return_field`]). Each
-/// call adds one variant/field (call repeatedly to add more):
+/// Build one with [`ptr_class!`](crate::ptr_class), add it to a
+/// [`PackageDecl`], and hand that to [`JniGen::package`].
+///
+/// A `PtrClassDecl` does two jobs:
+///
+/// 1. **Defines the Kotlin class** — its name ([`name`](Self::name)), its
+///    instance methods ([`fun`](Self::fun)), and its companion-object
+///    factories ([`constructor`](Self::constructor)).
+/// 2. **Sets the type's default behavior at every FFI boundary** — how a
+///    *parameter* of this type is accepted ([`default_param_expand`](Self::default_param_expand))
+///    and how a *returned* or callback-delivered value of it is handed to
+///    Kotlin ([`default_return_expand`](Self::default_return_expand)), for
+///    *every* function that mentions the type. Any single function can
+///    override its own copy of these defaults (see [`FunctionDecl`]).
 ///
 /// ```
-/// let _ = prebindgen::ptr_class!(ZThing)
-///     .fun(prebindgen::fun!(z_thing_name).name("name"))
-///     .default_return_field_self()
-///     .default_return_field(prebindgen::fun!(z_thing_name).name("name"));
+/// // A KeyExpr handle exposing `str()` as an instance method; by default a
+/// // KeyExpr returned to Kotlin is delivered as just the handle.
+/// let _ = prebindgen::ptr_class!(KeyExpr)
+///     .fun(prebindgen::fun!(keyexpr_get_str).name("str"))
+///     .default_return_expand_self();
 /// ```
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
@@ -172,35 +182,50 @@ impl PtrClassDecl {
         }
     }
 
-    /// Override the Kotlin **class name** (relative, no dots — the FQN is
-    /// derived from the [`PackageDecl`] this class is declared in). Used
-    /// literally; the `kotlin_ptr_class_name_mangle` hook does not apply.
+    /// Rename the generated Kotlin class. By default it is named after the
+    /// Rust type (via the `kotlin_ptr_class_name_mangle` hook); `.name("Foo")`
+    /// sets it literally instead. Relative name, no dots — the package comes
+    /// from the enclosing [`PackageDecl`].
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name_override = Some(name.into());
         self
     }
 
-    /// Declare a `#[prebindgen]` function (`f(&Self, …) -> R`) as an instance
-    /// method. The receiver binds to `this` and is excluded from
-    /// input-flattening; any remaining params flatten normally.
+    /// Expose a `#[prebindgen]` method as a Kotlin **instance method** of this
+    /// class. `rust_fun` must take `&Self` first — that receiver becomes
+    /// Kotlin's `this` and drops out of the signature; any further parameters
+    /// become the method's arguments. Name it with
+    /// `fun!(rust_name).name("kotlinName")` (default: the Rust name
+    /// camel-cased).
     pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Fun));
         self
     }
 
-    /// Declare a `#[prebindgen]` **constructor** (`f(…) -> Self` /
-    /// `Result<Self, E>`) as a companion-object factory `name`. Referenceable
-    /// from `.default_param_variant(fun!(...))`.
+    /// Expose a `#[prebindgen]` factory as a Kotlin **companion-object
+    /// factory** — callers write `Class.name(...)`. `rust_fun` returns `Self`
+    /// (or `Result<Self, E>`) and its parameters become the factory's
+    /// arguments. A constructor can also serve as a build option in
+    /// [`default_param_expand`](Self::default_param_expand).
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Constructor));
         self
     }
 
-    /// Add one **default param variant**: a parameter of this class type
-    /// (in *any* declared function) also accepts what this `#[prebindgen]`
-    /// constructor fn takes, built via it at the boundary. Call repeatedly
-    /// to add more variants (2+ variants dispatch via a runtime selector).
-    /// Overridable per-fn via [`FunctionDecl::param_variant`].
+    /// Let callers pass the **ingredients** of this type wherever a parameter
+    /// of it is expected, instead of having to build the handle first. Point
+    /// this at a `#[prebindgen]` constructor: at every such parameter, the
+    /// Kotlin signature gains that constructor's inputs and Rust builds the
+    /// value in the same call.
+    ///
+    /// For example, giving `KeyExpr` a `keyexpr_from_str(&str)` build option
+    /// lets every function taking a `KeyExpr` also accept a plain `String`.
+    ///
+    /// Call repeatedly to offer several ways to build the value (and add
+    /// [`default_param_expand_self`](Self::default_param_expand_self) to also
+    /// accept a ready-made handle); with more than one option the generated
+    /// Kotlin picks at runtime. Overridable per function via
+    /// [`FunctionDecl::param_expand`].
     pub fn default_param_expand(mut self, rust_fun: FunctionDecl) -> Self {
         self.input_variants
             .get_or_insert_with(Vec::new)
@@ -208,10 +233,11 @@ impl PtrClassDecl {
         self
     }
 
-    /// Add the identity **default param variant**: a parameter of this class
-    /// type accepts an already-built handle directly. As the *only* declared
-    /// variant this is the plain-handle form (no selector) — the default
-    /// when nothing is declared, so alone it is a no-op made explicit.
+    /// Also accept an **already-built handle** at parameters of this type —
+    /// the "…or just pass one you already have" option alongside the
+    /// [`default_param_expand`](Self::default_param_expand) build variants.
+    /// On its own this is simply the default (a bare handle), so declaring it
+    /// alone changes nothing; it earns its place only next to build variants.
     pub fn default_param_expand_self(mut self) -> Self {
         self.input_variants
             .get_or_insert_with(Vec::new)
@@ -219,12 +245,22 @@ impl PtrClassDecl {
         self
     }
 
-    /// Add one **default return field**: a returned/delivered value of this
-    /// class type (in *any* declared function, incl. callback args and the
-    /// `E` of a `Result`) decomposes into fields, this one being the value
-    /// of the accessor fn `rust_fun` (named via `rust_fun.name(...)`,
-    /// defaulting to `snake_to_camel(rust_ident)`). Call repeatedly to add
-    /// more fields. Overridable per-fn via [`FunctionDecl::return_field`].
+    /// Decompose this type into **named fields delivered in one FFI crossing**
+    /// wherever it is returned or handed to a callback — instead of returning
+    /// an opaque handle the caller must then query field by field with more
+    /// JNI calls.
+    ///
+    /// Point each call at a `#[prebindgen]` reader (`f(&Self) -> Field`); its
+    /// value becomes one field, named via `fun!(reader).name("field")`
+    /// (default: the reader's camel-cased name). For example, decomposing a
+    /// `Sample` into `keyExpr`, `payload`, `timestamp`, … hands a subscriber
+    /// callback the whole sample in a single call with no follow-up accessor
+    /// round-trips.
+    ///
+    /// Call repeatedly to add fields, and add
+    /// [`default_return_expand_self`](Self::default_return_expand_self) to
+    /// also include the live handle. Overridable per function via
+    /// [`FunctionDecl::return_expand`].
     pub fn default_return_expand(mut self, rust_fun: FunctionDecl) -> Self {
         let name = rust_fun
             .kotlin_name_override
@@ -235,7 +271,12 @@ impl PtrClassDecl {
         self
     }
 
-    /// Add the handle itself as a **default return field** of this class.
+    /// Include the **handle itself** among the decomposed fields, so the
+    /// consumer gets a live, closeable object in addition to the read-out
+    /// values (e.g. a `Query` delivered with its fields *and* the handle it
+    /// needs to reply). Declare it **last**, after any field that decomposes
+    /// a nested handle, so the generated Rust moves the value only after
+    /// those borrows.
     pub fn default_return_expand_self(mut self) -> Self {
         self.output_fields
             .get_or_insert_with(Vec::new)
@@ -250,15 +291,14 @@ impl From<syn::Type> for PtrClassDecl {
     }
 }
 
-/// Declares a `#[prebindgen]`-marked `enum` as a Kotlin `enum class`. The
-/// enum must be C-like (unit variants only) and `#[repr(i32)]`-alike with
-/// explicit discriminants — the Kotlin emitter and the generated
-/// `TryFrom<i32>` decode rely on the discriminant values matching the jint
-/// wire.
+/// Declares a Rust C-like `enum` as a Kotlin `enum class`. The variants
+/// cross the boundary as their `i32` discriminants and Kotlin gets a real
+/// `enum class` with a `fromInt(...)` companion. The enum must be
+/// unit-variant only and `#[repr(i32)]`-style with explicit discriminants,
+/// so both sides agree on the numbers.
 ///
-/// No `.fun()`/`.constructor()` members: attached members are only emitted
-/// on typed-handle ([`PtrClassDecl`]) and value ([`ValueClassDecl`]) classes
-/// — a generated `enum class` carries no instance methods.
+/// Has no `.fun`/`.constructor` — instance members are only meaningful on
+/// handle ([`PtrClassDecl`]) and value ([`ValueClassDecl`]) classes.
 pub struct EnumClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
@@ -285,13 +325,15 @@ impl From<syn::Type> for EnumClassDecl {
     }
 }
 
-/// Declares a Rust struct that should appear in Kotlin as a `data class`.
-/// Only affects Kotlin emission — no Rust-side converter override.
+/// Declares a Rust struct as a Kotlin `data class`. Its fields cross the
+/// boundary individually and Kotlin reassembles the object with a generated
+/// `fromParts(...)` — no Rust-side heap object, no handle to close. Use this
+/// for plain immutable data you copy across, as opposed to
+/// [`ptr_class!`](crate::ptr_class) handles or
+/// [`value_class!`](crate::value_class) blobs.
 ///
-/// No `.fun()`/`.constructor()` members: attached members are only emitted
-/// on typed-handle ([`PtrClassDecl`]) and value ([`ValueClassDecl`]) classes
-/// — a data class crosses decomposed into its fields and has no handle to
-/// hang an instance method on.
+/// Has no `.fun`/`.constructor` — a data class has no handle to hang an
+/// instance method on.
 pub struct DataClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
@@ -313,8 +355,9 @@ impl DataClassDecl {
         self
     }
 
-    /// Stamp a verbatim Kotlin type expression (e.g. `"List<ByteArray>"`)
-    /// instead of a class FQN — for generics/primitives/container types.
+    /// Surface this type as a verbatim Kotlin type instead of a generated
+    /// class — for when it should map onto an existing or container type,
+    /// e.g. `"List<ByteArray>"`.
     pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
         self.kotlin_type = Some(expr.into());
         self
@@ -327,11 +370,12 @@ impl From<syn::Type> for DataClassDecl {
     }
 }
 
-/// Declares a **`Copy` value class** type: a Rust type passed across the JNI
-/// boundary **by value as its raw memory bytes** in a `ByteArray`, rather
-/// than as a closeable `jlong` heap handle — the value-level peer of
-/// [`PtrClassDecl`]. The type **must be `Copy`** — the generator emits a
-/// compile-time assertion to that effect.
+/// Declares a small **`Copy`** Rust type that crosses **by value** — as its
+/// raw bytes in a `ByteArray` — rather than as a heap handle. The
+/// lightweight peer of [`PtrClassDecl`] for things like ids and timestamps
+/// that have no lifecycle to manage. The type must be `Copy` (the generator
+/// asserts it at compile time). Readers added with [`fun`](Self::fun) become
+/// instance methods on the Kotlin value class.
 pub struct ValueClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
@@ -355,17 +399,22 @@ impl ValueClassDecl {
         self
     }
 
-    /// Stamp a verbatim Kotlin type expression instead of a class FQN.
+    /// Surface this type as a verbatim Kotlin type instead of a generated
+    /// value class (see [`DataClassDecl::kotlin_type`]).
     pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
         self.kotlin_type = Some(expr.into());
         self
     }
 
+    /// Expose a `#[prebindgen]` reader (`f(&Self) -> R`) as an instance
+    /// method on the Kotlin value class (see [`PtrClassDecl::fun`]).
     pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Fun));
         self
     }
 
+    /// Expose a `#[prebindgen]` factory as a companion-object factory
+    /// (see [`PtrClassDecl::constructor`]).
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Constructor));
         self
@@ -417,15 +466,16 @@ impl From<ValueClassDecl> for ClassDecl {
 // Function decl
 // ──────────────────────────────────────────────────────────────────────
 
-/// Declares a `#[prebindgen]` function as a free-standing package wrapper.
-/// Feed it to a [`PackageDecl`] via [`PackageDecl::fun`].
+/// Declares one `#[prebindgen]` function to export. Add it to a package with
+/// [`PackageDecl::fun`], or attach it to a class as a method/factory with
+/// [`PtrClassDecl::fun`] / [`PtrClassDecl::constructor`].
 ///
-/// The `.param_variant*` / `.return_field*` methods **override, for this
-/// function only**, the class-level defaults declared via
-/// [`PtrClassDecl::default_param_variant`] /
-/// [`PtrClassDecl::default_return_field`]. An override consisting of only
-/// the `_self` form means "the plain handle, nothing else" — the raw wire
-/// shape, replacing what the class default would otherwise apply here.
+/// Build it from a bare Rust name with [`fun!`](crate::fun) and chain
+/// [`name`](Self::name) to set its Kotlin name. The `param_expand*` /
+/// `return_expand*` methods **override, for this one function**, the
+/// boundary defaults that its parameter/return types set on their
+/// `ptr_class!` — most often to opt back out (a lone `_self`) so this
+/// function sees the raw handle rather than the class's default expansion.
 pub struct FunctionDecl {
     pub(crate) rust_ident: syn::Ident,
     pub(crate) kotlin_name_override: Option<String>,
@@ -443,30 +493,30 @@ impl FunctionDecl {
         }
     }
 
-    /// Override the Kotlin-side function name. Default (without `.name(...)`)
-    /// is `snake_to_camel(rust_ident)`.
+    /// Set the Kotlin-side name. Default: the Rust name camel-cased
+    /// (`session_declare_publisher` → `sessionDeclarePublisher`).
     pub fn name(mut self, kotlin_name: impl Into<String>) -> Self {
         self.kotlin_name_override = Some(kotlin_name.into());
         self
     }
 
-    /// Add one variant to `param`'s **param-variant override**, replacing
-    /// the class-level default for this function: build via this
-    /// `#[prebindgen]` constructor fn directly. Call repeatedly to add more
-    /// variants for the same param, or for different params — the only
-    /// difference from [`PtrClassDecl::default_param_variant`] is the
-    /// leading param ident, since a function may have several
-    /// independently-overridden handle params.
+    /// Override, for `param` of this function only, how that parameter is
+    /// built — the same idea as [`PtrClassDecl::default_param_expand`], but
+    /// scoped here and keyed by which parameter (a function may have several
+    /// handle parameters, each overridden independently). Point at a
+    /// constructor to offer it as a build option; call again (same or a
+    /// different `param`) to add more.
     pub fn param_expand(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
         self.input_override_entry(param)
             .push(LocalVariant::Ctor(ctor.rust_ident));
         self
     }
 
-    /// Add the identity variant to `param`'s override: accept an
-    /// already-built handle directly. As the *only* declared variant this is
-    /// the plain-handle form — i.e. it cancels the class-level default for
-    /// this param (no selector, no construction).
+    /// Make `param` of this function accept **only a ready-made handle**,
+    /// ignoring the build variants its type would otherwise apply here. Use
+    /// it when one function needs the real object rather than something built
+    /// from ingredients — e.g. *un*-declaring a key expression needs the
+    /// handle, not a string.
     pub fn param_expand_self(mut self, param: syn::Ident) -> Self {
         self.input_override_entry(param)
             .push(LocalVariant::SelfIdentity);
@@ -485,11 +535,9 @@ impl FunctionDecl {
         &mut self.input_overrides[idx].1
     }
 
-    /// Add one field to this function's **return-field override**, replacing
-    /// the class-level default: the value of the accessor fn `field` (named
-    /// via `field.name(...)`, defaulting to `snake_to_camel(rust_ident)`).
-    /// Call repeatedly to add more fields — same shape as
-    /// [`PtrClassDecl::default_return_field`].
+    /// Override this function's return decomposition — the same idea as
+    /// [`PtrClassDecl::default_return_expand`], but for this function alone.
+    /// Add one field per call.
     pub fn return_expand(mut self, field: FunctionDecl) -> Self {
         let name = field
             .kotlin_name_override
@@ -500,11 +548,10 @@ impl FunctionDecl {
         self
     }
 
-    /// Add the return value itself as a field of this function's return
-    /// override. As the *only* declared field this is the raw whole-handle
-    /// return — i.e. it cancels the class-level default for this function
-    /// (also the right spelling for borrowed `&T` returns, which cross by
-    /// cloning into a fresh owned handle).
+    /// Return this function's result as the **raw handle**, overriding the
+    /// decomposition its return type would otherwise apply. Also the right
+    /// choice for a borrowed return (`&T` / `Option<&T>`), which crosses by
+    /// cloning into a fresh owned handle.
     pub fn return_expand_self(mut self) -> Self {
         self.output_override
             .get_or_insert_with(Vec::new)
@@ -517,11 +564,12 @@ impl FunctionDecl {
 // PackageDecl — aggregates the package-scoped decls
 // ──────────────────────────────────────────────────────────────────────
 
-/// A batch of class and function declarations under one Kotlin subpackage
-/// (or the base package, for `PackageDecl::new("")`). Built independently of
-/// `JniGen`, then handed to [`JniGen::package`], which **merges** it into
-/// whatever that package already holds — so the same subpackage name may be
-/// reopened across several `PackageDecl` values / `JniGen::package` calls.
+/// A batch of class and function declarations that land under one Kotlin
+/// subpackage. Build it with [`package!`](crate::package)
+/// (`package!("session")`, or `package!()` for the base package), fill it
+/// with [`class`](Self::class) and [`fun`](Self::fun), and hand it to
+/// [`JniGen::package`]. Reopening the same subpackage across several
+/// `PackageDecl`s is fine — they merge.
 pub struct PackageDecl {
     pub(crate) name: String,
     pub(crate) classes: Vec<ClassDecl>,
@@ -543,16 +591,17 @@ impl PackageDecl {
         }
     }
 
-    /// Add a class declaration (any of [`PtrClassDecl`]/[`EnumClassDecl`]/
-    /// [`DataClassDecl`]/[`ValueClassDecl`], via [`ClassDecl`]'s `From` impls).
+    /// Add a class to this package — any of [`ptr_class!`](crate::ptr_class) /
+    /// [`enum_class!`](crate::enum_class) / [`data_class!`](crate::data_class) /
+    /// [`value_class!`](crate::value_class).
     pub fn class(mut self, decl: impl Into<ClassDecl>) -> Self {
         self.classes.push(decl.into());
         self
     }
 
-    /// Add a free-function declaration — a bare function ident via
-    /// [`crate::fun!`] or a fully customized
-    /// `FunctionDecl::new(prebindgen::ident!(ident)).name(...)....`.
+    /// Add a free function to this package. Take a bare name via
+    /// [`fun!`](crate::fun), or a customized [`FunctionDecl`] when you need
+    /// `.name(...)` or per-function overrides.
     pub fn fun(mut self, decl: FunctionDecl) -> Self {
         self.functions.push(decl);
         self
@@ -590,11 +639,16 @@ pub(crate) fn wrapper_value_ident() -> syn::Ident {
     syn::Ident::new("v", Span::call_site())
 }
 
-/// Declares how one concrete Rust type (`pattern`) crosses the JNI boundary
-/// **as a custom scalar wire value** — the primitive-wire peer of
-/// [`ValueClassDecl`] (which does the same job for `ByteArray`-backed
-/// types). Global — not part of any [`PackageDecl`] (see the module doc for
-/// why `kotlin_type` needs no package placement).
+/// Teaches the generator to carry one Rust type across the boundary as a
+/// **plain scalar** — e.g. a `Millis(u64)` newtype that should surface in
+/// Kotlin as a `Long`, converted with your own expressions each way, with no
+/// generated class. The scalar peer of [`ValueClassDecl`] (which carries
+/// `Copy` types as `ByteArray`). Register it with
+/// [`JniGen::scalar_type_wrapper`]; it applies wherever the type appears, in
+/// any package.
+///
+/// Build one with [`scalar_type_wrapper!`](crate::scalar_type_wrapper), then
+/// give it [`input`](Self::input) / [`output`](Self::output) conversions.
 pub struct ScalarTypeWrapperDecl {
     pub(crate) pattern: syn::Type,
     // Stored as tokenized source text, not `syn::Type`: this workspace's
@@ -611,10 +665,11 @@ pub struct ScalarTypeWrapperDecl {
 }
 
 impl ScalarTypeWrapperDecl {
-    /// `wire` is the one wire type shared by both directions; `kotlin_type`
-    /// is the Kotlin-visible type this pattern surfaces as (e.g. `"Long"`) —
-    /// required, since a scalar mapping has no sensible auto-derived name.
-    /// See [`crate::scalar_type_wrapper!`] for the equivalent macro form.
+    /// `pattern` is the Rust type being mapped, `wire` is the primitive it
+    /// travels as (e.g. `jni::sys::jlong`), and `kotlin_type` is how it shows
+    /// up in Kotlin (e.g. `"Long"`). See
+    /// [`scalar_type_wrapper!`](crate::scalar_type_wrapper) for the macro
+    /// shorthand.
     pub fn new(pattern: syn::Type, wire: syn::Type, kotlin_type: impl Into<String>) -> Self {
         reject_builtin_wrapper_pattern(&TypeKey::from_type(&pattern));
         Self {
@@ -626,44 +681,43 @@ impl ScalarTypeWrapperDecl {
         }
     }
 
-    /// Build the wire → rust conversion body. `body` receives the ident of
-    /// the wire-typed value in scope (`&wire`) and returns the Rust-typed
-    /// expression to splice via `quote!`'s `#value` interpolation.
-    ///
-    /// The rank-0 (concrete pattern) counterpart of
-    /// [`GenericTypeWrapperDecl::input`] — same method name, simpler
-    /// contract: a plain expression closure, no wildcard args, no
-    /// [`WireBody`] fallibility choice.
+    /// How to turn the incoming **wire value into the Rust value** (used when
+    /// the type is a parameter). `body` gets the wire value's ident and
+    /// returns the Rust expression, e.g.
+    /// `|v| pq!(perftest_flat::Millis(*#v as u64))`.
     pub fn input(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
         self.input = Some(Arc::new(body));
         self
     }
 
-    /// Build the rust → wire conversion body. `body` receives the ident of
-    /// the rust-typed value in scope and returns the wire-typed expression.
-    /// See [`Self::input`] for how this relates to
-    /// [`GenericTypeWrapperDecl::output`].
+    /// How to turn the **Rust value into the wire value** (used when the type
+    /// is returned). `body` gets the Rust value's ident and returns the wire
+    /// expression, e.g. `|v| pq!(#v.0 as jni::sys::jlong)`.
     pub fn output(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
         self.output = Some(Arc::new(body));
         self
     }
 }
 
-/// The result of one [`GenericTypeWrapperDecl`] `.input()`/`.output()`
-/// builder: either a binding-fallible bare value (the framework wraps it
-/// `Ok(...)` and any `?` inside routes to the framework's own error type), or
-/// a domain-fallible `Result` whose `Err` routes to the per-call error sink
-/// verbatim (the `Result<_, _>` peel is the one real user of this arm).
+/// What a [`GenericTypeWrapperDecl`] conversion produces: the wire type plus
+/// the expression, and whether the conversion can fail with a **domain
+/// error** the caller should see. Use [`infallible`](Self::infallible) when
+/// it always succeeds, or [`fallible`](Self::fallible) to route an `Err` to
+/// the caller's error handler (as the built-in `Result` unwrap does).
 pub enum WireBody {
     Infallible(syn::Type, syn::Expr),
     Fallible(syn::Type, syn::Type, syn::Expr),
 }
 
 impl WireBody {
+    /// The conversion always succeeds. `wire` is the wire type, `expr` the
+    /// conversion expression.
     pub fn infallible(wire: syn::Type, expr: syn::Expr) -> Self {
         Self::Infallible(wire, expr)
     }
 
+    /// The conversion may fail: `expr` evaluates to `Result<wire, error>`,
+    /// and an `Err` is delivered to the caller's error handler.
     pub fn fallible(wire: syn::Type, error: syn::Type, expr: syn::Expr) -> Self {
         Self::Fallible(wire, error, expr)
     }
@@ -734,12 +788,15 @@ where
     }
 }
 
-/// Declares how an existing structural wrapper (`Option`/`Result`/`Vec`/…) is
-/// peeled for one specific wildcard substitution — e.g. a per-error
-/// `Result<_, ConcreteErr>` override of the framework's built-in
-/// `Result<_, _>` peel. Declares nothing Kotlin-visible on its own (no
-/// `.kotlin_type()` — a structural override never names a type). Global —
-/// not part of any [`PackageDecl`].
+/// An **advanced** override for how a generic wrapper (`Option`/`Result`/
+/// `Vec`/…) is unwrapped for one specific inner type — e.g. handle
+/// `Result<_, MyError>` your own way instead of through the built-in
+/// `Result` support. The `pattern` carries `_` wildcards for the parts that
+/// stay generic. Register it with [`JniGen::generic_type_wrapper`]; it names
+/// no Kotlin type of its own and belongs to no package.
+///
+/// Build one with [`generic_type_wrapper!`](crate::generic_type_wrapper),
+/// then supply [`input`](Self::input) / [`output`](Self::output).
 pub struct GenericTypeWrapperDecl {
     pub(crate) pattern: syn::Type,
     pub(crate) input: Option<(usize, WrapperFn)>,
@@ -758,21 +815,17 @@ impl GenericTypeWrapperDecl {
         }
     }
 
-    /// Register the input-direction (wire → rust) peel. The closure's arity
-    /// (1–3 leading `&syn::Type` params, one per `_` in `pattern`, plus a
-    /// trailing `&syn::Ident` for the value in scope) selects the rank; it
-    /// returns a [`WireBody`] choosing infallible vs domain-fallible.
-    ///
-    /// The wildcard-pattern counterpart of [`ScalarTypeWrapperDecl::input`] —
-    /// same method name, richer contract (wildcard substitutions +
-    /// fallibility), because a structural peel must adapt to what the `_`s
-    /// matched.
+    /// How to convert **into Rust** (used when the type is a parameter). The
+    /// closure receives one `&syn::Type` per `_` in `pattern` (so its arity
+    /// tells the generator how many wildcards there are), plus the value's
+    /// ident, and returns a [`WireBody`].
     pub fn input<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
         self.input = Some((B::rank(), builder.into_wrapper_fn()));
         self
     }
 
-    /// Output-direction (rust → wire) counterpart of [`Self::input`].
+    /// How to convert **out of Rust** (used when the type is returned) — the
+    /// counterpart of [`input`](Self::input).
     pub fn output<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
         self.output = Some((B::rank(), builder.into_wrapper_fn()));
         self

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -125,7 +125,9 @@ macro_rules! scalar_type_wrapper {
 #[macro_export]
 macro_rules! generic_type_wrapper {
     ($t:ty) => {
-        $crate::lang::GenericTypeWrapperDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+        $crate::lang::GenericTypeWrapperDecl::new($crate::__macro_support::parse_type(stringify!(
+            $t
+        )))
     };
 }
 
@@ -578,7 +580,7 @@ pub struct PackageDecl {
 
 impl PackageDecl {
     /// `name` is dot-separated, relative to the base package set by
-    /// [`JniGenConfig::package_prefix`]; the empty string is the base
+    /// [`JniGen::set_package_prefix`]; the empty string is the base
     /// package itself. See [`crate::package!`] for the equivalent macro form
     /// (`package!("model")` / `package!()`).
     pub fn new(name: impl Into<String>) -> Self {
@@ -685,7 +687,10 @@ impl ScalarTypeWrapperDecl {
     /// the type is a parameter). `body` gets the wire value's ident and
     /// returns the Rust expression, e.g.
     /// `|v| pq!(perftest_flat::Millis(*#v as u64))`.
-    pub fn input(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
+    pub fn input(
+        mut self,
+        body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static,
+    ) -> Self {
         self.input = Some(Arc::new(body));
         self
     }
@@ -693,7 +698,10 @@ impl ScalarTypeWrapperDecl {
     /// How to turn the **Rust value into the wire value** (used when the type
     /// is returned). `body` gets the Rust value's ident and returns the wire
     /// expression, e.g. `|v| pq!(#v.0 as jni::sys::jlong)`.
-    pub fn output(mut self, body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static) -> Self {
+    pub fn output(
+        mut self,
+        body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static,
+    ) -> Self {
         self.output = Some(Arc::new(body));
         self
     }
@@ -751,9 +759,11 @@ where
     F: Fn(&syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
 {
     fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-            Some(self(&args[0], &wrapper_value_ident()).into_tuple())
-        })
+        Arc::new(
+            move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                Some(self(&args[0], &wrapper_value_ident()).into_tuple())
+            },
+        )
     }
     fn rank() -> usize {
         1
@@ -765,9 +775,11 @@ where
     F: Fn(&syn::Type, &syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
 {
     fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-            Some(self(&args[0], &args[1], &wrapper_value_ident()).into_tuple())
-        })
+        Arc::new(
+            move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                Some(self(&args[0], &args[1], &wrapper_value_ident()).into_tuple())
+            },
+        )
     }
     fn rank() -> usize {
         2
@@ -779,9 +791,11 @@ where
     F: Fn(&syn::Type, &syn::Type, &syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
 {
     fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-            Some(self(&args[0], &args[1], &args[2], &wrapper_value_ident()).into_tuple())
-        })
+        Arc::new(
+            move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
+                Some(self(&args[0], &args[1], &args[2], &wrapper_value_ident()).into_tuple())
+            },
+        )
     }
     fn rank() -> usize {
         3

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -19,7 +19,7 @@ use super::*;
 /// Errors cannot reach a caller-side error sink (the declaring call already
 /// returned), so they are converted to `__JniErr` and logged via `tracing`.
 pub(crate) fn callback_input(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     args: &[syn::Type],
     registry: &Registry<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -314,10 +314,7 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
 /// `v: <ident>` signature — so binding crates can pick whichever
 /// upstream type a bare `<ident>` resolves to in their include-site
 /// `use` statements. Pairs with output body below.
-pub(crate) fn enum_input_body(
-    ext: &JniGen,
-    e: &syn::ItemEnum,
-) -> (syn::Type, syn::Expr) {
+pub(crate) fn enum_input_body(ext: &JniGen, e: &syn::ItemEnum) -> (syn::Type, syn::Expr) {
     assert_only_unit_variants(e);
     let ident = &e.ident;
     let ident_name = ident.to_string();
@@ -354,10 +351,7 @@ pub(crate) fn enum_input_body(
 /// upstream of the cast. The body works without naming the enum type
 /// at all — `v` is already typed via the wrapper signature, so the
 /// `as` cast picks up the right type by inference.
-pub(crate) fn enum_output_body(
-    _ext: &JniGen,
-    e: &syn::ItemEnum,
-) -> (syn::Type, syn::Expr) {
+pub(crate) fn enum_output_body(_ext: &JniGen, e: &syn::ItemEnum) -> (syn::Type, syn::Expr) {
     assert_only_unit_variants(e);
     let body: syn::Expr = syn::parse_quote!({ v as jni::sys::jint });
     (syn::parse_quote!(jni::sys::jint), body)

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -315,7 +315,7 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
 /// upstream type a bare `<ident>` resolves to in their include-site
 /// `use` statements. Pairs with output body below.
 pub(crate) fn enum_input_body(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     e: &syn::ItemEnum,
 ) -> (syn::Type, syn::Expr) {
     assert_only_unit_variants(e);
@@ -355,7 +355,7 @@ pub(crate) fn enum_input_body(
 /// at all — `v` is already typed via the wrapper signature, so the
 /// `as` cast picks up the right type by inference.
 pub(crate) fn enum_output_body(
-    _ext: &JniGen<impl JniGenState>,
+    _ext: &JniGen,
     e: &syn::ItemEnum,
 ) -> (syn::Type, syn::Expr) {
     assert_only_unit_variants(e);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -25,7 +25,7 @@ pub(crate) enum LeafDefault {
 
 /// Classify a leaf's binding-error default — see [`LeafDefault`].
 pub(crate) fn leaf_default(
-    _ext: &JniGen<impl JniGenState>,
+    _ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     leaf: &crate::api::core::unfold::UnfoldLeaf,
 ) -> LeafDefault {
@@ -70,7 +70,7 @@ pub(crate) fn leaf_default(
 /// 0 / `false` at every primitive slot. Construction failures fall back to
 /// null (cold path, OOM-class only).
 pub(crate) fn default_ze_jvalues(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::unfold::UnfoldPlan,
 ) -> Vec<TokenStream> {
@@ -124,7 +124,7 @@ pub(crate) fn default_ze_jvalues(
 /// [`UnfoldShape::Base`]: crate::api::core::unfold::UnfoldShape::Base
 /// [`UnfoldShape::Optional`]: crate::api::core::unfold::UnfoldShape::Optional
 pub(crate) fn emit_unfold_delivery(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::unfold::UnfoldPlan,
     call_expr: &TokenStream,
@@ -471,7 +471,7 @@ fn reach_leaf(
 /// arm of fallible externs (whose `fail` falls back to a binding-error
 /// `signal_error` with default ze values).
 pub(crate) fn encode_plan_leaves(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::unfold::UnfoldPlan,
     obj_idents: &[syn::Ident],

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -443,7 +443,8 @@ pub(crate) fn build_flat_input_plan(
         return None;
     }
     let dc_short = cfg
-        .and_then(|c| c.kotlin_name.clone())
+        .and_then(|c| c.name_spec.as_ref())
+        .map(|s| ext.fqn_of(s))
         .map(|fqn| fqn.rsplit('.').next().unwrap_or(&fqn).to_string())
         .unwrap_or_else(|| name.to_string());
     let entry_short = entry

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 pub(crate) fn struct_input_body(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     s: &syn::ItemStruct,
     registry: &Registry<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
@@ -333,7 +333,7 @@ pub(crate) fn kt_leaf_default(sig: &str, nullable: bool) -> Option<String> {
 /// absent struct yields `present = false` for every field.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn option_scalar_field_leaves(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     kt_param: &str,
@@ -404,7 +404,7 @@ pub(crate) fn option_scalar_field_leaves(
 /// the single source of truth shared by the native wrapper signature, the
 /// `JNINative` extern declaration, and the Kotlin call-site destructure.
 pub(crate) fn build_flat_input_plan(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg_ty: &syn::Type,
@@ -688,7 +688,7 @@ pub(crate) struct OptionScalarInputPlan {
 /// only the cases that *would* box are intercepted — niche cases (already
 /// unboxed / ABI-clean) and opaque/value projections are left untouched.
 pub(crate) fn build_option_scalar_input_plan(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg_ty: &syn::Type,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -61,7 +61,7 @@ impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
     }
 }
 
-pub(crate) fn mangle_jni_name(ext: &JniGen<impl JniGenState>, ident: &syn::Ident) -> syn::Ident {
+pub(crate) fn mangle_jni_name(ext: &JniGen, ident: &syn::Ident) -> syn::Ident {
     let camel = snake_to_camel(&ident.to_string());
     let mangled = ext.mangle_fun(&camel);
     let mut name = ext.jni_class_path.clone();
@@ -165,7 +165,7 @@ pub(crate) fn option_inner_ref_mutability(ty: &syn::Type) -> Option<bool> {
 /// value class but the projection still resolves the leaf — so the wrapper
 /// knows which inline field to unwrap (`<name>.bytes`).
 pub(crate) fn value_projection_field_for_leaf(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     leaf_key: &str,
 ) -> Option<String> {
     let key = TypeKey::parse(leaf_key);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -8,7 +8,7 @@ use super::*;
 /// the structured builders ([`JniGen::ptr_class`],
 /// [`JniGen::data_class`]) to derive a default Kotlin class name from
 /// the Rust type-key. Panics for non-path types (e.g. closures, references) —
-/// the per-kind `kotlin_*_name_mangle` closures see only path-shaped
+/// the per-kind `*_name_mangle` closures see only path-shaped
 /// shorts. For verbatim Kotlin expressions on non-path types, chain
 /// [`JniGen::kotlin_type`] after the structured builder.
 pub(crate) fn rust_short_name(key: &TypeKey) -> String {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -164,10 +164,7 @@ pub(crate) fn option_inner_ref_mutability(ty: &syn::Type) -> Option<bool> {
 /// Used for `Option<value-blob>` params where the written type isn't the bare
 /// value class but the projection still resolves the leaf — so the wrapper
 /// knows which inline field to unwrap (`<name>.bytes`).
-pub(crate) fn value_projection_field_for_leaf(
-    ext: &JniGen,
-    leaf_key: &str,
-) -> Option<String> {
+pub(crate) fn value_projection_field_for_leaf(ext: &JniGen, leaf_key: &str) -> Option<String> {
     let key = TypeKey::parse(leaf_key);
     let cfg = ext.types.get(&key)?;
     if cfg.value_blob {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -64,7 +64,7 @@ impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
 pub(crate) fn mangle_jni_name(ext: &JniGen, ident: &syn::Ident) -> syn::Ident {
     let camel = snake_to_camel(&ident.to_string());
     let mangled = ext.mangle_fun(&camel);
-    let mut name = ext.jni_class_path.clone();
+    let mut name = ext.jni_class_path();
     name.push('_');
     name.push_str(&mangled);
     syn::Ident::new(&name, Span::call_site())

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -371,13 +371,15 @@ pub(crate) fn struct_output_body(
     let registered_fqn = ext
         .types
         .get(&TypeKey::from_type(&struct_ty))
-        .and_then(|cfg| cfg.kotlin_name.clone());
+        .and_then(|cfg| cfg.name_spec.as_ref())
+        .map(|s| ext.fqn_of(s));
+    let java_class_prefix = ext.java_class_prefix();
     let java_class_name = if let Some(fqn) = registered_fqn {
         fqn.replace('.', "/")
-    } else if ext.java_class_prefix.is_empty() {
+    } else if java_class_prefix.is_empty() {
         struct_name.clone()
     } else {
-        format!("{}/{}", ext.java_class_prefix, struct_name)
+        format!("{}/{}", java_class_prefix, struct_name)
     };
 
     // Recursively flatten the whole object graph into leaf wires, then build it

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -9,7 +9,7 @@ use super::*;
 /// in `Nullable`) are encodable as a single `L<FQN>;` ctor arg; a
 /// collection layer (`Iterable`, i.e. `Vec<Handle>`) would need array
 /// codegen and is a loud build-time error until implemented.
-pub(crate) fn handle_field_fqn(ext: &JniGen<impl JniGenState>, h: &Projection) -> String {
+pub(crate) fn handle_field_fqn(ext: &JniGen, h: &Projection) -> String {
     fn assert_scalar(s: &FoldStrategy) {
         match s {
             FoldStrategy::Base => {}
@@ -80,7 +80,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 /// `registry.structs` — both populated before `resolve` — never the output
 /// converter table (not yet built at this stage).
 pub(crate) fn synth_value_struct_leaves(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
     path_prefix: &[syn::Ident],
@@ -158,7 +158,7 @@ pub(crate) fn synth_value_struct_leaves(
 /// plan `flatten_struct_factory` walks for the Kotlin side, so the slot
 /// order and JVM descriptors agree by construction.
 pub(crate) fn flatten_struct_encode(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
     access: &TokenStream,
@@ -357,7 +357,7 @@ fn encode_plan(
 }
 
 pub(crate) fn struct_output_body(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     s: &syn::ItemStruct,
     registry: &Registry<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
@@ -416,7 +416,7 @@ pub(crate) fn struct_output_body(
     Some((syn::parse_quote!(jni::objects::JObject), body))
 }
 
-pub(crate) fn struct_module_path(ext: &JniGen<impl JniGenState>, s: &syn::ItemStruct) -> syn::Path {
+pub(crate) fn struct_module_path(ext: &JniGen, s: &syn::ItemStruct) -> syn::Path {
     // Place the struct under <source_module>::<file_stem>::<Name>. Today's
     // pipeline derives the module from the source file stem; here we ride
     // on the same convention by inspecting the SourceLocation. Without a

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -104,11 +104,7 @@ pub(crate) fn vec_build_helpers(
 /// through [`JniGen::mangle_fun`] like every other extern. The Rust JNI symbol
 /// (see [`vec_helper_symbol`]) and the Kotlin call site both use this, so they
 /// agree.
-pub(crate) fn vec_helper_method_name(
-    ext: &JniGen,
-    base: &str,
-    suffix: &str,
-) -> String {
+pub(crate) fn vec_helper_method_name(ext: &JniGen, base: &str, suffix: &str) -> String {
     ext.mangle_fun(&format!("{base}{suffix}"))
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -87,7 +87,11 @@ pub(crate) fn vec_build_helpers(
 ) -> Option<VecBuildHelpers> {
     let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem, "__e")?;
     let key = TypeKey::from_type(elem);
-    let kt_fqn = ext.types.get(&key).and_then(|c| c.kotlin_name.clone())?;
+    let kt_fqn = ext
+        .types
+        .get(&key)
+        .and_then(|c| c.name_spec.as_ref())
+        .map(|s| ext.fqn_of(s))?;
     let short = kt_fqn.rsplit('.').next().unwrap_or(&kt_fqn);
     let mut chars = short.chars();
     let base_lc = match chars.next() {
@@ -115,7 +119,7 @@ pub(crate) fn vec_helper_method_name(ext: &JniGen, base: &str, suffix: &str) -> 
 fn vec_helper_symbol(ext: &JniGen, base: &str, suffix: &str) -> String {
     format!(
         "{}_{}",
-        ext.jni_class_path,
+        ext.jni_class_path(),
         vec_helper_method_name(ext, base, suffix)
     )
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -30,7 +30,7 @@ pub(crate) fn slice_or_vec_elem(arg_ty: &syn::Type) -> Option<(syn::Type, bool)>
 /// classifier, `render_extern_decl`, and the synthetic-extern emitter so all
 /// four sites agree on which params take the handle path.
 pub(crate) fn vec_build_elem(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     arg_ty: &syn::Type,
 ) -> Option<(syn::Type, bool)> {
@@ -46,7 +46,7 @@ pub(crate) fn vec_build_elem(
 /// Deduped by [`TypeKey`] and sorted for deterministic output (mirrors
 /// [`build_handle_destructor_items`]).
 pub(crate) fn collect_vec_build_elem_types(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Type> {
     let declared = ext.declared_functions();
@@ -81,7 +81,7 @@ pub(crate) struct VecBuildHelpers {
 /// from the element's **Kotlin** data-class short name (first char lowercased) so
 /// the generated methods read naturally (`Payload` → `payloadVec`).
 pub(crate) fn vec_build_helpers(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     elem: &syn::Type,
 ) -> Option<VecBuildHelpers> {
@@ -105,7 +105,7 @@ pub(crate) fn vec_build_helpers(
 /// (see [`vec_helper_symbol`]) and the Kotlin call site both use this, so they
 /// agree.
 pub(crate) fn vec_helper_method_name(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     base: &str,
     suffix: &str,
 ) -> String {
@@ -116,7 +116,7 @@ pub(crate) fn vec_helper_method_name(
 /// `Java_<pkg>_<JNINative>_…` scheme function wrappers use via
 /// [`mangle_jni_name`]); these helpers live on the `JNINative` object, so they
 /// share its class path.
-fn vec_helper_symbol(ext: &JniGen<impl JniGenState>, base: &str, suffix: &str) -> String {
+fn vec_helper_symbol(ext: &JniGen, base: &str, suffix: &str) -> String {
     format!(
         "{}_{}",
         ext.jni_class_path,
@@ -139,7 +139,7 @@ fn vec_helper_symbol(ext: &JniGen<impl JniGenState>, base: &str, suffix: &str) -
 /// shared across all callers of a given element type). This keeps the Kotlin
 /// push loop free of a per-element failure check.
 pub(crate) fn build_vec_build_helper_items(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -11,7 +11,7 @@ struct OutputLowering<'a> {
 }
 
 pub(crate) fn emit_jni_function_wrapper(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
 ) -> TokenStream {
@@ -340,7 +340,7 @@ fn unfold_builder_param(plan: &crate::api::core::unfold::UnfoldPlan) -> TokenStr
 /// other input — so the per-input handling stays a self-contained unit.
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     original_ident: &syn::Ident,
     input: &syn::FnArg,
@@ -586,7 +586,7 @@ fn emit_input_param(
 /// through the same error sink as any fallible input. The returned call
 /// argument is the built value (`&value` when the original parameter was `&T`).
 pub(crate) fn emit_expanded_param(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::expand::FoldPlan,
     orig_param: &syn::Ident,

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -130,7 +130,7 @@ pub(crate) fn is_kotlin_primitive_ty(t: &kt::KtType) -> bool {
 ///   optional) and a leaf reconstructs with its wrap.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn flatten_struct_factory(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
     prefix: &str,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -715,7 +715,7 @@ fn leaf_iface_param(
     if let kt::KtType::Named { fqn: bk_fqn, .. } = &builder_kt {
         if !bk_fqn.contains('.') {
             if let Some(reg_fqn) = ext.kotlin_fqn(&TypeKey::from_type(out_ty).to_string()) {
-                let reg_short = reg_fqn.rsplit('.').next().unwrap_or(reg_fqn);
+                let reg_short = reg_fqn.rsplit('.').next().unwrap_or(&reg_fqn);
                 if reg_fqn.contains('.') && reg_short == bk_fqn {
                     let raw = kt::KtType::cls(reg_fqn.to_string());
                     let raw = if builder_kt.is_nullable() {
@@ -816,7 +816,7 @@ pub(crate) fn callback_iface_spec(
                     other => other.clone(),
                 };
                 let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core).to_string())?;
-                let class_short = fqn.rsplit('.').next().unwrap_or(fqn).to_string();
+                let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
@@ -1051,7 +1051,7 @@ pub(crate) fn fixed_folder_typed_groups(
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans.get(decon)?;
     let fqn = ext.kotlin_fqn(&TypeKey::from_type(&spec.source).to_string())?;
-    let class_short = fqn.rsplit('.').next().unwrap_or(fqn).to_string();
+    let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
     Some(vec![
         TypedGroup {
             name: "acc".to_string(),

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -556,7 +556,7 @@ fn method_descr(params: &[IfaceParam], ret: &kt::KtType, type_params: &[String])
 /// The interface base name for a decomposition: the subject type's short
 /// name, extended by the deconstructor declaration's identity. The type's
 /// default declaration keeps the bare short; per-fn inline records
-/// (`.flatten_output_with()`) append the function's UpperCamel ident.
+/// (`.flatten_output()`) append the function's UpperCamel ident.
 /// This is what makes interface identity == declaration identity: functions
 /// sharing a declaration share the interface, differently-declared
 /// decompositions of one type get distinct interfaces.

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -556,7 +556,7 @@ fn method_descr(params: &[IfaceParam], ret: &kt::KtType, type_params: &[String])
 /// The interface base name for a decomposition: the subject type's short
 /// name, extended by the deconstructor declaration's identity. The type's
 /// default declaration keeps the bare short; per-fn inline records
-/// (`.flatten_output()`) append the function's UpperCamel ident.
+/// (`.return_field()`) append the function's UpperCamel ident.
 /// This is what makes interface identity == declaration identity: functions
 /// sharing a declaration share the interface, differently-declared
 /// decompositions of one type get distinct interfaces.

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -601,7 +601,7 @@ fn subject_short(ty: &syn::Type) -> String {
 
 /// Package a subject type's interface lives in: the package of the type's
 /// registered Kotlin FQN, the root `ext.package` otherwise.
-fn subject_package(ext: &JniGen<impl JniGenState>, subject: &syn::Type) -> String {
+fn subject_package(ext: &JniGen, subject: &syn::Type) -> String {
     let key =
         TypeKey::from_type(&crate::api::core::types_util::peel_ref_option_vec(subject)).to_string();
     ext.kotlin_fqn(&key)
@@ -612,7 +612,7 @@ fn subject_package(ext: &JniGen<impl JniGenState>, subject: &syn::Type) -> Strin
 /// The interface param list for a decomposition's leaves: names from
 /// [`plan_leaf_names`], typed + raw views per leaf.
 fn plan_leaf_params(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     leaves: &[crate::api::core::unfold::UnfoldLeaf],
 ) -> Option<Vec<IfaceParam>> {
@@ -647,7 +647,7 @@ fn plan_leaf_params(
 ///   the close-unless-taken contract needs the native side to `close()` the
 ///   wrapped object after the invoke.
 fn leaf_iface_param(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     name: String,
     out_ty: &syn::Type,
@@ -743,7 +743,7 @@ fn leaf_iface_param(
 /// `run` (close-unless-taken). Replaces the former Rust-side `new_object` +
 /// post-invoke `close()`. `None` if the arg's projection FQN can't be resolved.
 pub(crate) fn owned_handle_iface_param(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     name: String,
     out_ty: &syn::Type,
@@ -770,7 +770,7 @@ pub(crate) fn owned_handle_iface_param(
 /// returning `Unit`. Named `<ArgShorts>Callback` (`Fn()` → `VoidCallback`),
 /// placed in the first arg type's package (root for `Fn()`).
 pub(crate) fn callback_iface_spec(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     cb_args: &[syn::Type],
 ) -> Option<IfaceSpec> {
@@ -927,7 +927,7 @@ pub(crate) fn callback_iface_spec(
 /// function's own plan. Named `<decl-base>Builder`, placed in the source
 /// type's package.
 pub(crate) fn builder_iface_spec(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
@@ -953,7 +953,7 @@ pub(crate) fn builder_iface_spec(
 /// the element's deconstructor declaration. Named `<decl-base>Folder`,
 /// placed in the element type's package.
 pub(crate) fn folder_iface_spec(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
@@ -979,7 +979,7 @@ pub(crate) fn folder_iface_spec(
 /// without a deconstructor — no declaration involved):
 /// `run(acc: A, element): A`. One shape per element type by construction.
 pub(crate) fn whole_folder_iface_spec(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     element: &syn::Type,
 ) -> Option<IfaceSpec> {
@@ -1013,7 +1013,7 @@ pub(crate) fn whole_folder_iface_spec(
 /// element decomposes, whole-element otherwise. Thin dispatch — the
 /// derivation itself is keyed.
 pub(crate) fn folder_iface_for_plan(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &UnfoldPlan,
 ) -> Option<IfaceSpec> {
@@ -1045,7 +1045,7 @@ pub(crate) fn folder_iface_for_plan(
 /// emission (`write_iface_files`), keyed by the element's deconstructor so the
 /// two stay in lockstep.
 pub(crate) fn fixed_folder_typed_groups(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
@@ -1077,7 +1077,7 @@ pub(crate) fn fixed_folder_typed_groups(
 /// the decomposed error. Keyed by the error type's deconstructor declaration.
 /// Named `<decl-base>Handler`, placed in the error type's package.
 pub(crate) fn error_handler_iface_spec(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
@@ -1104,7 +1104,7 @@ pub(crate) fn error_handler_iface_spec(
 /// The shared infallible handler `JniErrorHandler<out R> { run(je: String?): R }`
 /// — every function without an error plan takes one; placed in the root
 /// package.
-pub(crate) fn jni_error_handler_iface_spec(ext: &JniGen<impl JniGenState>) -> IfaceSpec {
+pub(crate) fn jni_error_handler_iface_spec(ext: &JniGen) -> IfaceSpec {
     let params = vec![IfaceParam::same(
         "je".to_string(),
         kt::KtType::string().nullable(),
@@ -1122,7 +1122,7 @@ pub(crate) fn jni_error_handler_iface_spec(ext: &JniGen<impl JniGenState>) -> If
 /// declaration-keyed typed handler, or the shared
 /// [`jni_error_handler_iface_spec`].
 pub(crate) fn onerror_iface_spec(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     fn_ident: &syn::Ident,
 ) -> Option<IfaceSpec> {

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -556,7 +556,7 @@ fn method_descr(params: &[IfaceParam], ret: &kt::KtType, type_params: &[String])
 /// The interface base name for a decomposition: the subject type's short
 /// name, extended by the deconstructor declaration's identity. The type's
 /// default declaration keeps the bare short; per-fn inline records
-/// (`.return_field()`) append the function's UpperCamel ident.
+/// (`.return_expand()`) append the function's UpperCamel ident.
 /// This is what makes interface identity == declaration identity: functions
 /// sharing a declaration share the interface, differently-declared
 /// decompositions of one type get distinct interfaces.

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -51,7 +51,7 @@ pub(crate) struct TypedHandle<'a> {
     pub key: &'a TypeKey,
 }
 
-impl<S: JniGenState> JniGen<S> {
+impl JniGen {
     /// Unified Kotlin emission — single public entry point. Each per-kind
     /// emitter builds in-memory [`kt::KtFile`] model fragments; they are then
     /// merged into one file per package, rendered, and written under
@@ -366,7 +366,7 @@ pub(crate) struct OwnedTypedHandle {
     pub key: TypeKey,
 }
 
-impl<S: JniGenState> JniGen<S> {
+impl JniGen {
     /// Emit one Kotlin `enum class` file per `enum_class`-declared type.
     /// Variants render in declaration order using SCREAMING_SNAKE_CASE names; the
     /// constructor stores the Rust discriminant value (or the ordinal as

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -134,8 +134,8 @@ impl JniGen {
         );
 
         // The N-ary locking helper is only referenced when wrappers are
-        // emitted with locking on; skip it under `disable_handle_locks()` so it
-        // doesn't surface as an unused-`internal fun` warning.
+        // emitted with locking on; skip it under `set_emit_handle_locks(false)`
+        // so it doesn't surface as an unused-`internal fun` warning.
         if self.emit_handle_locks {
             file = file.decl(
                 KtFun::new("withSortedHandleLocks")

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -276,12 +276,9 @@ impl JniGen {
             if !members.is_empty() && !self.package.is_empty() {
                 imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
             }
-            // Promoted instance methods (`.accessor`/`.method`): receiver bound to
-            // `this`, passing `this.bytes` to the extern.
-            for m in members
-                .iter()
-                .filter(|m| matches!(m.kind, MemberKind::Accessor | MemberKind::Method))
-            {
+            // Promoted instance methods (`.fun`): receiver bound to `this`,
+            // passing `this.bytes` to the extern.
+            for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
                 if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                         self,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -890,7 +890,7 @@ impl JniGen {
     /// Emit the centralized Native-object Kotlin file under `output_dir`
     /// (class name from [`JniGen::jni_native_class_name`]). Holds one
     /// `external fun` per `#[prebindgen]` function — names mangled via
-    /// `kotlin_fun_name_mangle`, parameter and return types rendered at
+    /// [`JniGen::set_fun_name_mangle`], parameter and return types rendered at
     /// the JNI **wire** level so the declarations match the Rust extern
     /// symbols generated under
     /// `Java_<package>_<jni_native_class>_<name>`. Every generated native

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -248,9 +248,16 @@ impl JniGen {
             if !cfg.value_blob {
                 continue;
             }
-            let fqn = cfg.kotlin_name.clone().ok_or_else(|| {
-                WriteKotlinError::Other(format!("value_blob `{}` has no Kotlin FQN", key.as_str()))
-            })?;
+            let fqn = cfg
+                .name_spec
+                .as_ref()
+                .map(|s| self.fqn_of(s))
+                .ok_or_else(|| {
+                    WriteKotlinError::Other(format!(
+                        "value_blob `{}` has no Kotlin FQN",
+                        key.as_str()
+                    ))
+                })?;
             let (package, class_name) = match fqn.rsplit_once('.') {
                 Some((p, c)) => (p.to_string(), c.to_string()),
                 None => (String::new(), fqn.clone()),
@@ -333,7 +340,7 @@ impl JniGen {
             if cfg.opaque.is_none() {
                 continue;
             }
-            let Some(kotlin_fqn) = &cfg.kotlin_name else {
+            let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
             // rust_doc — short last-segment of the Rust type key (best
@@ -384,7 +391,7 @@ impl JniGen {
             if cfg.enum_cfg.is_none() {
                 continue;
             }
-            let Some(kotlin_fqn) = &cfg.kotlin_name else {
+            let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
             // Look up the syn::ItemEnum by the type-key's bare ident.
@@ -427,7 +434,7 @@ impl JniGen {
             if cfg.special_decl() {
                 continue;
             }
-            let Some(kotlin_fqn) = &cfg.kotlin_name else {
+            let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
 
@@ -725,7 +732,7 @@ impl JniGen {
                     TypeKey::from_type(source)
                 )
             });
-        let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
+        let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
         // The native side calls the raw twin's `run` (== the typed interface
         // when the builder needs no twin — synthesized data classes are
         // all-simple-leaf today). `fromParts` takes the raw wire types and
@@ -768,7 +775,7 @@ impl JniGen {
                     TypeKey::from_type(source)
                 )
             });
-        let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
+        let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
         // The native side calls the raw twin's `run(acc, leaves…)`; `acc` is the
         // accumulator list and the remaining params are the element leaves.
         let folder = spec.raw_name();

--- a/prebindgen/src/api/lang/jnigen/jni/metadata.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/metadata.rs
@@ -65,8 +65,8 @@ pub enum ProjectionKind {
 #[derive(Clone, Debug)]
 pub struct Projection {
     /// Canonical [`TypeKey`](crate::api::core::registry::TypeKey) string of the
-    /// leaf type (e.g. `"ZKeyExpr"`, `"ZenohId"`); look up
-    /// `JniGen::kotlin_type_fqns` for the typed Kotlin FQN.
+    /// leaf type (e.g. `"ZKeyExpr"`, `"ZenohId"`); derive the typed Kotlin
+    /// FQN via `JniGen::kotlin_fqn`.
     pub leaf_key: String,
     /// `false` for `&T` borrows of a handle — still a projection (param
     /// classification needs this), but not the holder's to close, so

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -227,314 +227,30 @@ pub(crate) type WrapperFn = Arc<
         + Sync,
 >;
 
-/// Closure that transforms a Kotlin short name. Installed via the
-/// per-kind setters ([`JniGen::kotlin_fun_name_mangle`],
-/// [`JniGen::kotlin_data_class_name_mangle`], etc.); the framework calls
-/// the matching closure wherever it needs to derive a Kotlin/JNI
-/// short name for a generated element. Closure-unset = identity.
+/// Closure that transforms a Kotlin short name. Installed via
+/// [`JniGenConfig`]'s per-kind setters; the framework calls the matching
+/// closure wherever it needs to derive a Kotlin/JNI short name for a
+/// generated element. Closure-unset = identity.
 pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 
-/// Trait selecting the arity-appropriate impl of
-/// [`JniGen::input_wrapper`] / [`JniGen::output_wrapper`]. The phantom
-/// type parameter discriminates closures of arity 0..3 so a single
-/// public method name accepts any of them. Closures take the wildcard
-/// substitutions plus the registry, and return `Some((ty, exc, body))`
-/// or `None` (defer to a later resolver phase). See [`WrapperFn`] for
-/// the triple's semantics.
-pub trait WrapperBuilder<Arity>: Send + Sync + 'static {
-    type NextState: WrapperReturnState;
-
-    fn into_wrapper_fn(self) -> WrapperFn;
-    fn rank() -> usize;
-}
-
-pub trait WrapperReturnState: Clone {
-    fn from_wrapper(key: TypeKey) -> Self;
-}
-
-impl WrapperReturnState for TypeMeta {
-    fn from_wrapper(key: TypeKey) -> Self {
-        Self {
-            key,
-            package: std::marker::PhantomData,
-        }
-    }
-}
-
-impl WrapperReturnState for WrapperNonMeta {
-    fn from_wrapper(_key: TypeKey) -> Self {
-        Self {
-            package: std::marker::PhantomData,
-        }
-    }
-}
-
-/// Arity-discriminating marker types. `Arity0` is for non-wildcard
-/// patterns (e.g. `"i32"`); `Arity1`/`2`/`3` carry that many `_` slots.
-pub struct Arity0;
-pub struct Arity1;
-pub struct Arity2;
-pub struct Arity3;
-
-impl<F> WrapperBuilder<Arity0> for F
-where
-    F: Fn(&Registry<KotlinMeta>) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)>
-        + Send
-        + Sync
-        + 'static,
-{
-    type NextState = TypeMeta;
-
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |_args: &[syn::Type], reg: &Registry<KotlinMeta>| self(reg))
-    }
-    fn rank() -> usize {
-        0
-    }
-}
-
-impl<F> WrapperBuilder<Arity1> for F
-where
-    F: Fn(&syn::Type, &Registry<KotlinMeta>) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)>
-        + Send
-        + Sync
-        + 'static,
-{
-    type NextState = WrapperNonMeta;
-
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |args: &[syn::Type], reg: &Registry<KotlinMeta>| self(&args[0], reg))
-    }
-    fn rank() -> usize {
-        1
-    }
-}
-
-impl<F> WrapperBuilder<Arity2> for F
-where
-    F: Fn(
-            &syn::Type,
-            &syn::Type,
-            &Registry<KotlinMeta>,
-        ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)>
-        + Send
-        + Sync
-        + 'static,
-{
-    type NextState = WrapperNonMeta;
-
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |args: &[syn::Type], reg: &Registry<KotlinMeta>| {
-            self(&args[0], &args[1], reg)
-        })
-    }
-    fn rank() -> usize {
-        2
-    }
-}
-
-impl<F> WrapperBuilder<Arity3> for F
-where
-    F: Fn(
-            &syn::Type,
-            &syn::Type,
-            &syn::Type,
-            &Registry<KotlinMeta>,
-        ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)>
-        + Send
-        + Sync
-        + 'static,
-{
-    type NextState = WrapperNonMeta;
-
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(move |args: &[syn::Type], reg: &Registry<KotlinMeta>| {
-            self(&args[0], &args[1], &args[2], reg)
-        })
-    }
-    fn rank() -> usize {
-        3
-    }
-}
-
-/// Root builder state: no package context is active yet.
-#[derive(Clone, Debug, Default)]
-pub struct Root;
-
-/// Package builder state: free functions and type declarations can be added.
-#[derive(Clone, Debug)]
-pub struct Package;
-
-/// Marker for builders with an active package/subpackage context.
-#[derive(Clone, Debug, Default)]
-pub struct InPackage;
-
-/// Pointer-class builder state.
-#[derive(Clone, Debug)]
-pub struct PtrClass<P = InPackage> {
-    pub(crate) key: TypeKey,
-    pub(crate) package: std::marker::PhantomData<P>,
-}
-
-/// Enum-class builder state.
-#[derive(Clone, Debug)]
-pub struct EnumClass<P = InPackage> {
-    pub(crate) key: TypeKey,
-    pub(crate) package: std::marker::PhantomData<P>,
-}
-
-/// Type-metadata builder state for data classes, value blobs, and rank-0
-/// wrappers.
-#[derive(Clone, Debug)]
-pub struct TypeMeta<P = InPackage> {
-    pub(crate) key: TypeKey,
-    pub(crate) package: std::marker::PhantomData<P>,
-}
-
-/// Function builder state.
-#[derive(Clone, Debug)]
-pub struct Function {
-    pub(crate) package: String,
-    pub(crate) index: usize,
-}
-
-/// Wrapper builder state for wildcard wrapper registrations that do not leave a
-/// concrete type metadata cursor live.
-#[derive(Clone, Debug, Default)]
-pub struct WrapperNonMeta<P = InPackage> {
-    pub(crate) package: std::marker::PhantomData<P>,
-}
-
-/// Builder states that can safely declare package functions with
-/// [`JniGen::fun`].
-pub trait PackageState: Clone {}
-
-impl PackageState for Package {}
-impl PackageState for PtrClass {}
-impl PackageState for EnumClass {}
-impl PackageState for TypeMeta {}
-impl PackageState for Function {}
-impl PackageState for WrapperNonMeta {}
-
-/// Builder states where type declarations are valid.
-pub trait TypeDeclState: Clone {}
-
-impl TypeDeclState for Root {}
-impl<T: PackageState> TypeDeclState for T {}
-
-/// Builder states that can be used as the final configured adapter.
-pub trait JniGenState: Clone {}
-
-impl JniGenState for Root {}
-impl<T: PackageState> JniGenState for T {}
-
-pub trait TypeKeyState: Clone {
-    fn type_key(&self) -> &TypeKey;
-}
-
-impl<P: Clone> TypeKeyState for PtrClass<P> {
-    fn type_key(&self) -> &TypeKey {
-        &self.key
-    }
-}
-
-impl<P: Clone> TypeKeyState for EnumClass<P> {
-    fn type_key(&self) -> &TypeKey {
-        &self.key
-    }
-}
-
-impl<P: Clone> TypeKeyState for TypeMeta<P> {
-    fn type_key(&self) -> &TypeKey {
-        &self.key
-    }
-}
-
-/// JNI back-end. Configure paths in the Rust crate (zresult, throw macro,
-/// source module the original fns live in) and the JNI/Kotlin classpath
-/// (java class prefix + output dir).
+/// JNI back-end. Accepts pre-built declaration objects (`PackageDecl`,
+/// `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see `decl.rs`) built
+/// independently of `JniGen` itself; there is no fluent typestate cursor.
 ///
-/// The builder is type-state based: methods that only make sense after a
-/// specific declaration are only available in that declaration's state. Invalid
-/// chains fail to compile instead of panicking at build-script runtime.
-///
-/// ```compile_fail
-/// use prebindgen::lang::JniGen;
+/// ```
+/// use prebindgen::lang::{FlattenOutput, JniGen, JniGenConfig, PackageDecl, PtrClassDecl};
 /// use syn::parse_quote as pq;
 ///
-/// // A function needs an active package context.
-/// let _ = JniGen::new().fun(pq!(z_open));
-/// ```
-///
-/// `.name(...)` applies to the current declaration — a function OR a type:
-///
-/// ```
-/// use prebindgen::lang::JniGen;
-/// use syn::parse_quote as pq;
-///
-/// // Per-class rename: the Kotlin class becomes `Session` (literal; the
-/// // mangle closures do not apply).
-/// let _ = JniGen::new().ptr_class(pq!(ZSession)).name("Session");
-/// ```
-///
-/// ```compile_fail
-/// use prebindgen::lang::JniGen;
-/// use syn::parse_quote as pq;
-///
-/// // Pointer-class output flatten requires a live `.ptr_class(...)` state.
-/// let _ = JniGen::new().package("session").fun(pq!(z_open)).flatten_output();
-/// ```
-///
-/// ```compile_fail
-/// use prebindgen::lang::JniGen;
-/// use syn::parse_quote as pq;
-///
-/// // `kotlin_type` is only for data/value classes and rank-0 wrappers — on a
-/// // ptr_class it would corrupt the FQN that typed-handle emission and
-/// // instanceof dispatch consume.
-/// let _ = JniGen::new().ptr_class(pq!(ZSession)).kotlin_type("Long");
-/// ```
-///
-/// Classes AND functions may be declared before any subpackage is selected
-/// (or after `.package("")`): both land in the **base** package set by
-/// [`JniGen::package_prefix`].
-///
-/// State types are public so large build scripts can be factored into helpers
-/// without losing type safety:
-///
-/// ```
-/// use prebindgen::lang::{JniGen, Package};
-/// use syn::parse_quote as pq;
-///
-/// fn add_keyexpr(jni: JniGen<Package>) -> JniGen<Package> {
-///     jni.ptr_class(pq!(ZKeyExpr))
-///         .accessor(pq!(z_keyexpr_as_str), "getStr")
-///         .flatten_output().field_self()
-///         .package("next")
-/// }
+/// let jni = JniGen::new(JniGenConfig::new().package_prefix("io.test.jni"))
+///     .package(
+///         PackageDecl::new("session")
+///             .class(PtrClassDecl::new(pq!(ZKeyExpr))
+///                 .accessor(pq!(z_keyexpr_as_str), "getStr")
+///                 .flatten_output(FlattenOutput::new().field_self())),
+///     );
 /// ```
 #[derive(Clone)]
-pub struct JniGen<S = Root> {
-    pub(crate) inner: JniGenInner,
-    pub(crate) state: S,
-}
-
-impl<S> std::ops::Deref for JniGen<S> {
-    type Target = JniGenInner;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<S> std::ops::DerefMut for JniGen<S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}
-
-#[derive(Clone)]
-pub struct JniGenInner {
+pub struct JniGen {
     /// Module path the original `#[prebindgen]` fns live under (e.g.
     /// the host crate of `#[prebindgen]` items). The wrapper body calls
     /// `<source_module>::<fn>(args)`.
@@ -559,58 +275,40 @@ pub struct JniGenInner {
     /// generated JNI extern symbols and matching Kotlin `external fun`s
     /// both pick up the `ViaJNI` suffix.
     pub(crate) kotlin_fun_name_mangle: Option<NameMangle>,
-    /// Mangler for Kotlin ptr-class names declared via
-    /// [`Self::ptr_class`]. Default = identity.
+    /// Mangler for Kotlin ptr-class names declared via a
+    /// `PtrClassDecl`. Default = identity.
     pub(crate) kotlin_ptr_class_name_mangle: Option<NameMangle>,
-    /// Mangler for Kotlin data-class names declared via
-    /// [`Self::data_class`]. Default = identity.
+    /// Mangler for Kotlin data-class names declared via a
+    /// `DataClassDecl`. Default = identity.
     pub(crate) kotlin_data_class_name_mangle: Option<NameMangle>,
-    /// Mangler for [`Self::enum_class`]-declared C-like enum class
+    /// Mangler for `EnumClassDecl`-declared C-like enum class
     /// names. Default = identity.
     pub(crate) kotlin_enum_name_mangle: Option<NameMangle>,
-    /// Mangler for rank-0 user-registered
-    /// [`Self::input_wrapper`] / [`Self::output_wrapper`] pattern names
-    /// — the Rust short name of the pattern (`Encoding`,
-    /// `SetIntersectionLevel`, …). Rank-N wrappers (`Option<_>`,
-    /// `ZResult<_>`, `Vec<_>`, `&_`) are NOT routed through any
-    /// mangler — they inherit from the inner type's metadata via the
-    /// existing rank-N handlers. Default = identity.
-    pub(crate) kotlin_wrapper_name_mangle: Option<NameMangle>,
     /// Mangler for the framework "harness" class name —
     /// `"Native"` (the centralized JNI extern holder). Default when
     /// unset = prepend `"JNI"`, so you get `JNINative`. Override to
     /// plug in a different convention.
     pub(crate) kotlin_harness_name_mangle: Option<NameMangle>,
     /// Derived `<rust-type-canonical-string> → <kotlin FQN>` view —
-    /// populated alongside [`Self::types`] by the structured builders
-    /// ([`Self::ptr_class`], [`Self::data_class`],
-    /// [`Self::input_wrapper`] / [`Self::output_wrapper`]). Internal
-    /// readers (`emit_into_dispatcher`) consume this flat list directly;
-    /// the structured `types` map is the source of truth.
+    /// populated alongside [`Self::types`] when accepting a `ClassDecl`
+    /// (ptr/enum/data/value). Internal readers (`emit_into_dispatcher`)
+    /// consume this flat list directly; the structured `types` map is the
+    /// source of truth.
     pub(crate) kotlin_type_fqns: Vec<(String, String)>,
 
     /// Structured per-type configuration keyed by canonical Rust type.
-    /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated by the
-    /// structured builders (`ptr_class`, `enum_class`,
-    /// `data_class`, `input_wrapper`, `output_wrapper`). Holds
-    /// opaque-handle config, enum config, and Kotlin names; the converter
-    /// bodies themselves live in [`Self::input_wrappers`] /
+    /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting
+    /// a `ClassDecl` or a `ScalarTypeWrapperDecl`. Holds opaque-handle
+    /// config, enum config, and Kotlin names; the converter bodies
+    /// themselves live in [`Self::input_wrappers`] /
     /// [`Self::output_wrappers`]. The rank-0 dispatch order is opaque →
     /// enum → wrapper-table → primitive → struct.
     pub(crate) types: HashMap<TypeKey, TypeConfig>,
 
-    /// Set by the first type / function / wrapper declaration. Guards the
-    /// order-sensitive global config ([`JniGen::package_prefix`] and the
-    /// `kotlin_*_name_mangle` closures): those are baked into each
-    /// declaration's FQN at declaration time, so setting them afterwards
-    /// would silently mis-name everything already declared — a hard panic
-    /// instead.
-    pub(crate) declarations_started: bool,
-
     /// Free-standing package-level wrappers, keyed by subpackage path
     /// (relative to [`Self::package`], dot-separated; the empty key is the
-    /// base package itself). Populated by [`Self::fun`] under the
-    /// currently-active [`Self::active_subpackage`].
+    /// base package itself). Populated by [`JniGen::package`], merging into
+    /// whatever the named subpackage already holds.
     pub(crate) packages: BTreeMap<String, PackageConfig>,
 
     /// Per-rank input converters — index `n` holds rank-`n` registrations
@@ -625,46 +323,37 @@ pub struct JniGenInner {
     /// Per-rank output converters. Same shape as [`Self::input_wrappers`].
     pub(crate) output_wrappers: [HashMap<TypeKey, WrapperFn>; 4],
 
-    /// The currently-active generated subpackage set by [`Self::package`].
-    /// Drives where [`Self::fun`] entries land and is folded into
-    /// the FQN of any class declared while it's `Some(_)`. Package
-    /// inheritance via chaining is **not** supported — each
-    /// `package` call overwrites the previous; nest via dotted
-    /// paths (`package("a.b")`) instead.
-    pub(crate) active_subpackage: Option<String>,
-
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`
     /// scaffold (deadlock-safe N-ary monitor acquisition + atomic
     /// consume). When `false`, the scaffold is omitted — wrappers emit
     /// only the raw `ptr` read + closed-handle null-check + native call.
-    /// Toggled via [`Self::handle_locks`].
+    /// Toggled via [`JniGenConfig::disable_handle_locks`].
     pub(crate) emit_handle_locks: bool,
 
     /// Optional Kotlin statement(s) to place inside an `init { … }` block of
     /// the generated centralized externs object (`JNINative`). Set via
-    /// [`Self::jni_native_init`]. Every generated native call routes through
-    /// that object, so its `<clinit>` is the single point at which a consumer
-    /// can trigger native-library loading (e.g.
+    /// [`JniGenConfig::jni_native_init`]. Every generated native call routes
+    /// through that object, so its `<clinit>` is the single point at which a
+    /// consumer can trigger native-library loading (e.g.
     /// `"io.zenoh.jni.NativeLibrary.ensureLoaded()"`). `None` (default) emits no
     /// init block — loading stays the consumer's responsibility.
     pub(crate) jni_native_init: Option<String>,
 
-    /// Constructor-expansion declarations (`.constructor`,
-    /// `.constructor`, `.expand`, …). Resolved into
+    /// Constructor-expansion declarations (`.flatten_input()` /
+    /// `.flatten_input_with()` on a class/function decl). Resolved into
     /// [`crate::api::core::expand::FoldPlan`]s on the registry during
     /// `write_rust` and consumed at the parameter-emission site.
     pub(crate) expansions: crate::api::core::expand::Expansions,
 
-    /// Output-expansion declarations (`.deconstructor`,
-    /// `.deconstructor_record*`, `.converter`, `.deconstruct_output`,
-    /// `.convert_output`, …). Resolved into
+    /// Output-expansion declarations (`.flatten_output()` /
+    /// `.flatten_output_with()` on a class/function decl). Resolved into
     /// [`crate::api::core::unfold::UnfoldPlan`]s on the registry during
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
 
-    /// Class members (accessors / methods / constructors) attached to a declared
-    /// class via [`JniGen::accessor`] / [`JniGen::method`] / [`JniGen::constructor`],
+    /// Class members (accessors / methods / constructors) attached to a
+    /// declared class via its decl's `.accessor()`/`.method()`/`.constructor()`,
     /// keyed by the class's canonical Rust type. Supplies the instance-method /
     /// companion-factory emission and the accessor/method/constructor membership
     /// sets for the flatten machinery (see [`ClassMember`]). Insertion order
@@ -676,6 +365,8 @@ pub struct JniGenInner {
 // ── Sibling submodules (carved from the former monolithic file) ─────────
 mod builder;
 mod classify;
+mod config;
+mod decl;
 mod emit;
 mod iface;
 mod prim;
@@ -691,6 +382,8 @@ mod struct_plan;
 
 pub(crate) use builder::*;
 pub(crate) use classify::*;
+pub use config::*;
+pub use decl::*;
 pub(crate) use emit::*;
 pub(crate) use fold::*;
 pub(crate) use iface::*;

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -126,10 +126,13 @@ impl MethodEntry {
 /// builder methods populate the ones they care about.
 #[derive(Clone, Default)]
 pub(crate) struct TypeConfig {
-    /// Short Kotlin name or FQN. Required for any type emitted in
-    /// Kotlin (`Sample` → `"io.zenoh.jni.Sample"`,
-    /// `Vec<u8>` → `"ByteArray"`).
-    pub kotlin_name: Option<String>,
+    /// Raw naming spec of the type as declared — verbatim Kotlin type or
+    /// settings-derived class name. Required for any type emitted in
+    /// Kotlin; the concrete FQN (`Sample` → `"io.zenoh.jni.Sample"`,
+    /// `Vec<u8>` → `"ByteArray"`) is materialized only at read time via
+    /// [`JniGen::fqn_of`], which is what makes the `set_*` settings
+    /// order-independent w.r.t. declarations.
+    pub name_spec: Option<NameSpec>,
     /// If `Some`, this is an opaque-handle type — gets jlong wire,
     /// `Box::into_raw`/`Box::from_raw` conventions, instanceof
     /// dispatch, and Kotlin typed-handle class emission.
@@ -260,17 +263,11 @@ pub struct JniGen {
     pub source_module: syn::Path,
     /// Single source of truth for the JVM/Kotlin namespace this binding
     /// targets, dot-separated (e.g. `io.zenoh.jni`). Empty = no prefix.
-    /// Drives every derived form: slash-separated for `FindClass`,
-    /// `_`-mangled for JNI extern idents, and dot-separated for Kotlin
-    /// `package` declarations.
+    /// Every derived form — slash-separated for `FindClass`
+    /// (`JniGen::java_class_prefix()`), `_`-mangled for JNI extern idents
+    /// (`JniGen::jni_class_path()`), dot-separated for Kotlin `package`
+    /// declarations — is computed from this at the point of use.
     pub package: String,
-    /// Derived: `package.replace('.', '/')`. Read by
-    /// [`struct_output_body`] when building `FindClass` strings.
-    pub(crate) java_class_prefix: String,
-    /// Derived: `"Java_" + package.replace('.', '_') + "_" +
-    /// mangle_harness("Native")`. Read by [`mangle_jni_name`] when
-    /// building the JNI extern symbol path for every emitted wrapper.
-    pub(crate) jni_class_path: String,
 
     /// Mangler for function names (scanned `#[prebindgen]` free fns and
     /// the synthetic `freePtr` destructor). Default = identity; in
@@ -292,27 +289,15 @@ pub struct JniGen {
     /// unset = prepend `"JNI"`, so you get `JNINative`. Override to
     /// plug in a different convention.
     pub(crate) kotlin_harness_name_mangle: Option<NameMangle>,
-    /// Derived `<rust-type-canonical-string> → <kotlin FQN>` view —
-    /// populated alongside [`Self::types`] when accepting a `ClassDecl`
-    /// (ptr/enum/data/value). Internal readers (`emit_into_dispatcher`)
-    /// consume this flat list directly; the structured `types` map is the
-    /// source of truth.
-    pub(crate) kotlin_type_fqns: Vec<(String, String)>,
-
-    /// Raw naming inputs of every accepted class declaration, in accept
-    /// order. Setting-derived names ([`Self::types`]' `kotlin_name`,
-    /// [`Self::kotlin_type_fqns`]) are re-derived from these whenever a
-    /// naming-relevant `set_*` method runs — this is what makes the setters
-    /// order-insensitive relative to declarations.
-    pub(crate) declared_class_names: Vec<DeclaredClassName>,
 
     /// Structured per-type configuration keyed by canonical Rust type.
     /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting
     /// a `ClassDecl` or a `ScalarTypeWrapperDecl`. Holds opaque-handle
-    /// config, enum config, and Kotlin names; the converter bodies
-    /// themselves live in [`Self::input_wrappers`] /
-    /// [`Self::output_wrappers`]. The rank-0 dispatch order is opaque →
-    /// enum → wrapper-table → primitive → struct.
+    /// config, enum config, and the raw [`NameSpec`] (Kotlin FQNs are
+    /// derived from it on read via [`JniGen::kotlin_fqn`] /
+    /// [`JniGen::fqn_of`]); the converter bodies themselves live in
+    /// [`Self::input_wrappers`] / [`Self::output_wrappers`]. The rank-0
+    /// dispatch order is opaque → enum → wrapper-table → primitive → struct.
     pub(crate) types: HashMap<TypeKey, TypeConfig>,
 
     /// Free-standing package-level wrappers, keyed by subpackage path

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -174,7 +174,7 @@ pub(crate) enum MemberKind {
     Fun,
     /// `f(…) -> T` / `Result<T,E>`: a factory emitted as a companion-object
     /// member returning the class; never output-flattened; referenceable by a
-    /// `.flatten_input(fun!(...))`.
+    /// `.default_param_variant(fun!(...))`.
     Constructor,
 }
 
@@ -190,8 +190,8 @@ pub(crate) struct ClassMember {
     pub rust_ident: syn::Ident,
     /// Kotlin-visible name of this instance method / companion factory
     /// (derived from `FunctionDecl.name()`, defaulting to
-    /// `snake_to_camel(rust_ident)`). Independent of any `.flatten_input`/
-    /// `.flatten_output` reference to the same underlying function — those
+    /// `snake_to_camel(rust_ident)`). Independent of any `.default_param_variant`/
+    /// `.default_return_field` reference to the same underlying function — those
     /// take a fresh `FunctionDecl` directly and don't consult this list.
     pub kotlin_name: String,
     /// Member kind (fun / constructor).
@@ -246,7 +246,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///         prebindgen::package!("session")
 ///             .class(prebindgen::ptr_class!(ZKeyExpr)
 ///                 .fun(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
-///                 .flatten_output_self()),
+///                 .default_return_field_self()),
 ///     );
 /// ```
 #[derive(Clone)]
@@ -340,14 +340,13 @@ pub struct JniGen {
     /// init block — loading stays the consumer's responsibility.
     pub(crate) jni_native_init: Option<String>,
 
-    /// Constructor-expansion declarations (`.flatten_input()` /
-    /// `.flatten_input()` on a class/function decl). Resolved into
+    /// Constructor-expansion declarations (`.default_param_variant()` /    /// `.param_variant()` on a class/function decl). Resolved into
     /// [`crate::api::core::expand::FoldPlan`]s on the registry during
     /// `write_rust` and consumed at the parameter-emission site.
     pub(crate) expansions: crate::api::core::expand::Expansions,
 
-    /// Output-expansion declarations (`.flatten_output()` /
-    /// `.flatten_output()` on a class/function decl). Resolved into
+    /// Output-expansion declarations (`.default_return_field()` /
+    /// `.return_field()` on a class/function decl). Resolved into
     /// [`crate::api::core::unfold::UnfoldPlan`]s on the registry during
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
@@ -370,8 +369,8 @@ pub struct JniGen {
     /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].
     pub(crate) ignored_class_types: std::collections::HashSet<TypeKey>,
 
-    /// Every function ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
-    /// `.flatten_output(...).field(...)` record (class- or
+    /// Every function ever referenced as a named leaf in a `.default_return_field(fun!(...))`/
+    /// `.return_field(...)` record (class- or
     /// function-scoped) — populated as `builder.rs` accepts each decl.
     /// Backs [`Prebindgen::accessor_functions`]: `core/unfold.rs`'s
     /// deconstructor gate requires every named record's function to be in

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -245,7 +245,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///     .package(
 ///         PackageDecl::new("session")
 ///             .class(PtrClassDecl::new(pq!(ZKeyExpr))
-///                 .accessor(pq!(z_keyexpr_as_str), "getStr")
+///                 .accessor(prebindgen::ident!(z_keyexpr_as_str), "getStr")
 ///                 .flatten_output(FlattenOutput::new().field_self())),
 ///     );
 /// ```

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -360,6 +360,16 @@ pub struct JniGen {
     /// iterates `types` by sorted key, so map order is irrelevant.
     pub(crate) class_members: HashMap<TypeKey, Vec<ClassMember>>,
 
+    /// `#[prebindgen]` fns the binding deliberately does NOT wrap, declared
+    /// via [`JniGen::ignore_fun`]. Backs [`Prebindgen::ignored_functions`]:
+    /// suppresses the registry's per-item "skipping undeclared" warning
+    /// without emitting anything.
+    pub(crate) ignored_fns: std::collections::HashSet<syn::Ident>,
+
+    /// `#[prebindgen]` types the binding deliberately does NOT declare,
+    /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].
+    pub(crate) ignored_class_types: std::collections::HashSet<TypeKey>,
+
     /// Every function ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
     /// `.flatten_output(...).field(...)` record (class- or
     /// function-scoped) — populated as `builder.rs` accepts each decl.

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -228,20 +228,23 @@ pub(crate) type WrapperFn = Arc<
         + Sync,
 >;
 
-/// Closure that transforms a Kotlin short name. Installed via
-/// [`JniGenConfig`]'s per-kind setters; the framework calls the matching
+/// Closure that transforms a Kotlin short name. Installed via [`JniGen`]'s
+/// per-kind `set_*_name_mangle` setters; the framework calls the matching
 /// closure wherever it needs to derive a Kotlin/JNI short name for a
 /// generated element. Closure-unset = identity.
 pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 
-/// JNI back-end. Accepts pre-built declaration objects (`PackageDecl`,
-/// `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see `decl.rs`) built
-/// independently of `JniGen` itself; there is no fluent typestate cursor.
+/// JNI back-end. Global settings are applied with the order-insensitive
+/// `set_*` methods; declarations are accepted as pre-built objects
+/// (`PackageDecl`, `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see
+/// `decl.rs`) built independently of `JniGen` itself; there is no fluent
+/// typestate cursor.
 ///
 /// ```
-/// use prebindgen::lang::{JniGen, JniGenConfig};
+/// use prebindgen::lang::JniGen;
 ///
-/// let jni = JniGen::new(JniGenConfig::new().package_prefix("io.test.jni"))
+/// let jni = JniGen::new()
+///     .set_package_prefix("io.test.jni")
 ///     .package(
 ///         prebindgen::package!("session")
 ///             .class(prebindgen::ptr_class!(ZKeyExpr)
@@ -296,6 +299,13 @@ pub struct JniGen {
     /// source of truth.
     pub(crate) kotlin_type_fqns: Vec<(String, String)>,
 
+    /// Raw naming inputs of every accepted class declaration, in accept
+    /// order. Setting-derived names ([`Self::types`]' `kotlin_name`,
+    /// [`Self::kotlin_type_fqns`]) are re-derived from these whenever a
+    /// naming-relevant `set_*` method runs — this is what makes the setters
+    /// order-insensitive relative to declarations.
+    pub(crate) declared_class_names: Vec<DeclaredClassName>,
+
     /// Structured per-type configuration keyed by canonical Rust type.
     /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting
     /// a `ClassDecl` or a `ScalarTypeWrapperDecl`. Holds opaque-handle
@@ -328,12 +338,12 @@ pub struct JniGen {
     /// scaffold (deadlock-safe N-ary monitor acquisition + atomic
     /// consume). When `false`, the scaffold is omitted — wrappers emit
     /// only the raw `ptr` read + closed-handle null-check + native call.
-    /// Toggled via [`JniGenConfig::disable_handle_locks`].
+    /// Toggled via [`JniGen::set_emit_handle_locks`].
     pub(crate) emit_handle_locks: bool,
 
     /// Optional Kotlin statement(s) to place inside an `init { … }` block of
     /// the generated centralized externs object (`JNINative`). Set via
-    /// [`JniGenConfig::jni_native_init`]. Every generated native call routes
+    /// [`JniGen::set_jni_native_init`]. Every generated native call routes
     /// through that object, so its `<clinit>` is the single point at which a
     /// consumer can trigger native-library loading (e.g.
     /// `"io.zenoh.jni.NativeLibrary.ensureLoaded()"`). `None` (default) emits no
@@ -401,7 +411,7 @@ mod struct_plan;
 
 pub(crate) use builder::*;
 pub(crate) use classify::*;
-pub use config::*;
+pub(crate) use config::*;
 pub use decl::*;
 pub(crate) use emit::*;
 pub(crate) use fold::*;

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -238,15 +238,14 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 /// independently of `JniGen` itself; there is no fluent typestate cursor.
 ///
 /// ```
-/// use prebindgen::lang::{FlattenOutput, JniGen, JniGenConfig, PackageDecl, PtrClassDecl};
-/// use syn::parse_quote as pq;
+/// use prebindgen::lang::{JniGen, JniGenConfig, PackageDecl};
 ///
 /// let jni = JniGen::new(JniGenConfig::new().package_prefix("io.test.jni"))
 ///     .package(
 ///         PackageDecl::new("session")
-///             .class(PtrClassDecl::new(pq!(ZKeyExpr))
-///                 .accessor(prebindgen::ident!(z_keyexpr_as_str), "getStr")
-///                 .flatten_output(FlattenOutput::new().field_self())),
+///             .class(prebindgen::ptr_class!(ZKeyExpr)
+///                 .accessor(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
+///                 .flatten_output(prebindgen::flatten_output!().field_self())),
 ///     );
 /// ```
 #[derive(Clone)]

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -166,34 +166,35 @@ pub(crate) struct PackageConfig {
 /// What kind of class member a [`ClassMember`] is.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MemberKind {
-    /// `f(&T) -> R` (single param): the only kind usable as an output flatten
-    /// field. Promoted to an instance method; never input/output-flattened.
-    Accessor,
-    /// `f(&T, …) -> R` (receiver + extra params): promoted to an instance method
-    /// (receiver→`this`); receiver excluded from input-flatten, other params
-    /// flatten like a function; not usable as a flatten field.
-    Method,
+    /// `f(&T, …) -> R`: promoted to an instance method, receiver bound to
+    /// `this` and excluded from input-flatten; any remaining params flatten
+    /// normally (a zero-extra-param fn is just the receiver-only case — no
+    /// separate arity tracking needed, since there's nothing left to
+    /// compose once the receiver is skipped).
+    Fun,
     /// `f(…) -> T` / `Result<T,E>`: a factory emitted as a companion-object
     /// member returning the class; never output-flattened; referenceable by a
-    /// `.flatten_input().variant(name)`.
+    /// `.flatten_input(fun!(...))`.
     Constructor,
 }
 
 /// One `#[prebindgen]` function attached to a declared class (`ptr_class` /
-/// `enum_class` / `value_class` / `data_class`) via [`JniGen::accessor`] /
-/// [`JniGen::method`] / [`JniGen::constructor`]. Accessors/methods become
-/// **instance methods** (receiver dropped→`this`); constructors become
-/// **companion factory** members. Each is also a real `#[prebindgen]` wrapper
-/// (Rust extern + `JNINative` extern + JSONL).
+/// `enum_class` / `value_class` / `data_class`) via [`JniGen::fun`] /
+/// [`JniGen::constructor`]. Funs become **instance methods** (receiver
+/// dropped→`this`); constructors become **companion factory** members. Each
+/// is also a real `#[prebindgen]` wrapper (Rust extern + `JNINative` extern +
+/// JSONL).
 #[derive(Clone, Debug)]
 pub(crate) struct ClassMember {
     /// Rust function ident (`registry.functions[ident]`).
     pub rust_ident: syn::Ident,
-    /// Kotlin member name on the owning class — for an accessor it is also the
-    /// leaf/parameter name when referenced by a flatten `.field(name)`; for a
-    /// constructor it is the name referenced by a flatten `.variant(name)`.
+    /// Kotlin-visible name of this instance method / companion factory
+    /// (derived from `FunctionDecl.name()`, defaulting to
+    /// `snake_to_camel(rust_ident)`). Independent of any `.flatten_input`/
+    /// `.flatten_output` reference to the same underlying function — those
+    /// take a fresh `FunctionDecl` directly and don't consult this list.
     pub kotlin_name: String,
-    /// Member kind (accessor / method / constructor).
+    /// Member kind (fun / constructor).
     pub kind: MemberKind,
 }
 
@@ -244,8 +245,8 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///     .package(
 ///         prebindgen::package!("session")
 ///             .class(prebindgen::ptr_class!(ZKeyExpr)
-///                 .accessor(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
-///                 .flatten_output(prebindgen::flatten_output!().field_self())),
+///                 .fun(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
+///                 .flatten_output_self()),
 ///     );
 /// ```
 #[derive(Clone)]
@@ -351,14 +352,24 @@ pub struct JniGen {
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
 
-    /// Class members (accessors / methods / constructors) attached to a
-    /// declared class via its decl's `.accessor()`/`.method()`/`.constructor()`,
-    /// keyed by the class's canonical Rust type. Supplies the instance-method /
-    /// companion-factory emission and the accessor/method/constructor membership
-    /// sets for the flatten machinery (see [`ClassMember`]). Insertion order
-    /// within a class is preserved (the Vec); class emission iterates `types` by
-    /// sorted key, so map order is irrelevant.
+    /// Class members (funs / constructors) attached to a declared class via
+    /// its decl's `.fun()`/`.constructor()`, keyed by the class's canonical
+    /// Rust type. Supplies the instance-method / companion-factory emission
+    /// and the receiver-skip set for input-flattening (see [`ClassMember`]).
+    /// Insertion order within a class is preserved (the Vec); class emission
+    /// iterates `types` by sorted key, so map order is irrelevant.
     pub(crate) class_members: HashMap<TypeKey, Vec<ClassMember>>,
+
+    /// Every function ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
+    /// `.flatten_output_with(...).field(...)` record (class- or
+    /// function-scoped) — populated as `builder.rs` accepts each decl.
+    /// Backs [`Prebindgen::accessor_functions`]: `core/unfold.rs`'s
+    /// deconstructor gate requires every named record's function to be in
+    /// this set (`RecordNotAccessor` otherwise), and `core/expand.rs` excludes
+    /// them from parameter composition. Derived from *usage*, not from any
+    /// separate declaration — a function need not also be a `.fun()` class
+    /// member to be referenced this way.
+    pub(crate) accessor_record_fns: std::collections::HashSet<syn::Ident>,
 }
 
 // ── Sibling submodules (carved from the former monolithic file) ─────────

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -274,21 +274,21 @@ pub struct JniGen {
     /// zenoh-jni the closure returns `format!("{name}ViaJNI")` so the
     /// generated JNI extern symbols and matching Kotlin `external fun`s
     /// both pick up the `ViaJNI` suffix.
-    pub(crate) kotlin_fun_name_mangle: Option<NameMangle>,
+    pub(crate) fun_name_mangle: Option<NameMangle>,
     /// Mangler for Kotlin ptr-class names declared via a
     /// `PtrClassDecl`. Default = identity.
-    pub(crate) kotlin_ptr_class_name_mangle: Option<NameMangle>,
+    pub(crate) ptr_class_name_mangle: Option<NameMangle>,
     /// Mangler for Kotlin data-class names declared via a
     /// `DataClassDecl`. Default = identity.
-    pub(crate) kotlin_data_class_name_mangle: Option<NameMangle>,
+    pub(crate) data_class_name_mangle: Option<NameMangle>,
     /// Mangler for `EnumClassDecl`-declared C-like enum class
     /// names. Default = identity.
-    pub(crate) kotlin_enum_name_mangle: Option<NameMangle>,
+    pub(crate) enum_name_mangle: Option<NameMangle>,
     /// Mangler for the framework "harness" class name —
     /// `"Native"` (the centralized JNI extern holder). Default when
     /// unset = prepend `"JNI"`, so you get `JNINative`. Override to
     /// plug in a different convention.
-    pub(crate) kotlin_harness_name_mangle: Option<NameMangle>,
+    pub(crate) harness_name_mangle: Option<NameMangle>,
 
     /// Structured per-type configuration keyed by canonical Rust type.
     /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -341,13 +341,13 @@ pub struct JniGen {
     pub(crate) jni_native_init: Option<String>,
 
     /// Constructor-expansion declarations (`.flatten_input()` /
-    /// `.flatten_input_with()` on a class/function decl). Resolved into
+    /// `.flatten_input()` on a class/function decl). Resolved into
     /// [`crate::api::core::expand::FoldPlan`]s on the registry during
     /// `write_rust` and consumed at the parameter-emission site.
     pub(crate) expansions: crate::api::core::expand::Expansions,
 
     /// Output-expansion declarations (`.flatten_output()` /
-    /// `.flatten_output_with()` on a class/function decl). Resolved into
+    /// `.flatten_output()` on a class/function decl). Resolved into
     /// [`crate::api::core::unfold::UnfoldPlan`]s on the registry during
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
@@ -361,7 +361,7 @@ pub struct JniGen {
     pub(crate) class_members: HashMap<TypeKey, Vec<ClassMember>>,
 
     /// Every function ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
-    /// `.flatten_output_with(...).field(...)` record (class- or
+    /// `.flatten_output(...).field(...)` record (class- or
     /// function-scoped) — populated as `builder.rs` accepts each decl.
     /// Backs [`Prebindgen::accessor_functions`]: `core/unfold.rs`'s
     /// deconstructor gate requires every named record's function to be in

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -174,7 +174,7 @@ pub(crate) enum MemberKind {
     Fun,
     /// `f(…) -> T` / `Result<T,E>`: a factory emitted as a companion-object
     /// member returning the class; never output-flattened; referenceable by a
-    /// `.default_param_variant(fun!(...))`.
+    /// `.default_param_expand(fun!(...))`.
     Constructor,
 }
 
@@ -190,8 +190,8 @@ pub(crate) struct ClassMember {
     pub rust_ident: syn::Ident,
     /// Kotlin-visible name of this instance method / companion factory
     /// (derived from `FunctionDecl.name()`, defaulting to
-    /// `snake_to_camel(rust_ident)`). Independent of any `.default_param_variant`/
-    /// `.default_return_field` reference to the same underlying function — those
+    /// `snake_to_camel(rust_ident)`). Independent of any `.default_param_expand`/
+    /// `.default_return_expand` reference to the same underlying function — those
     /// take a fresh `FunctionDecl` directly and don't consult this list.
     pub kotlin_name: String,
     /// Member kind (fun / constructor).
@@ -246,7 +246,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///         prebindgen::package!("session")
 ///             .class(prebindgen::ptr_class!(ZKeyExpr)
 ///                 .fun(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
-///                 .default_return_field_self()),
+///                 .default_return_expand_self()),
 ///     );
 /// ```
 #[derive(Clone)]
@@ -340,13 +340,13 @@ pub struct JniGen {
     /// init block — loading stays the consumer's responsibility.
     pub(crate) jni_native_init: Option<String>,
 
-    /// Constructor-expansion declarations (`.default_param_variant()` /    /// `.param_variant()` on a class/function decl). Resolved into
+    /// Constructor-expansion declarations (`.default_param_expand()` /    /// `.param_expand()` on a class/function decl). Resolved into
     /// [`crate::api::core::expand::FoldPlan`]s on the registry during
     /// `write_rust` and consumed at the parameter-emission site.
     pub(crate) expansions: crate::api::core::expand::Expansions,
 
-    /// Output-expansion declarations (`.default_return_field()` /
-    /// `.return_field()` on a class/function decl). Resolved into
+    /// Output-expansion declarations (`.default_return_expand()` /
+    /// `.return_expand()` on a class/function decl). Resolved into
     /// [`crate::api::core::unfold::UnfoldPlan`]s on the registry during
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
@@ -369,8 +369,8 @@ pub struct JniGen {
     /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].
     pub(crate) ignored_class_types: std::collections::HashSet<TypeKey>,
 
-    /// Every function ever referenced as a named leaf in a `.default_return_field(fun!(...))`/
-    /// `.return_field(...)` record (class- or
+    /// Every function ever referenced as a named leaf in a `.default_return_expand(fun!(...))`/
+    /// `.return_expand(...)` record (class- or
     /// function-scoped) — populated as `builder.rs` accepts each decl.
     /// Backs [`Prebindgen::accessor_functions`]: `core/unfold.rs`'s
     /// deconstructor gate requires every named record's function to be in

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -238,11 +238,11 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 /// independently of `JniGen` itself; there is no fluent typestate cursor.
 ///
 /// ```
-/// use prebindgen::lang::{JniGen, JniGenConfig, PackageDecl};
+/// use prebindgen::lang::{JniGen, JniGenConfig};
 ///
 /// let jni = JniGen::new(JniGenConfig::new().package_prefix("io.test.jni"))
 ///     .package(
-///         PackageDecl::new("session")
+///         prebindgen::package!("session")
 ///             .class(prebindgen::ptr_class!(ZKeyExpr)
 ///                 .accessor(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
 ///                 .flatten_output(prebindgen::flatten_output!().field_self())),

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1285,8 +1285,10 @@ fn build_native_call(ext: &JniGen, jni_call: &str, params: &[Param], out: &Outpu
         // class or value-class wrapper). The sentinel is the Kotlin
         // null-representation literal for the leaf wire — used only by
         // the `Niche+primitive` arm of `fold_projection_wrap`.
-        let leaf_fqn = ext.kotlin_fqn(&p.leaf_key).unwrap_or(&p.leaf_key);
-        let short = leaf_fqn.rsplit('.').next().unwrap_or(leaf_fqn).to_string();
+        let leaf_fqn = ext
+            .kotlin_fqn(&p.leaf_key)
+            .unwrap_or_else(|| p.leaf_key.clone());
+        let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
         let sentinel = projection_leaf_sentinel(p);
         call = fold_projection_wrap(&p.strategy, &call, &short, sentinel.as_deref());
     } else if out.is_enum_return {
@@ -1670,8 +1672,10 @@ pub(crate) fn unfold_leaf_kt(
         // Wrap class = the projection leaf's typed short name — NOT
         // `builder_kt` (which is `Short?` for an `Option<…>` leaf and would
         // leak the `?` into the constructor call).
-        let leaf_fqn = ext.kotlin_fqn(&p.leaf_key).unwrap_or(&p.leaf_key);
-        let short = leaf_fqn.rsplit('.').next().unwrap_or(leaf_fqn).to_string();
+        let leaf_fqn = ext
+            .kotlin_fqn(&p.leaf_key)
+            .unwrap_or_else(|| p.leaf_key.clone());
+        let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
         let sentinel = projection_leaf_sentinel(p);
         let mut wrap = fold_projection_wrap(&p.strategy, pk, &short, sentinel.as_deref());
         // A `nullable` leaf (an `Option` nesting step on its path) makes the

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -330,13 +330,10 @@ pub(crate) fn build_typed_handle(
         )
         .companion(companion);
 
-    // Promoted instance methods: each `.accessor(f, name)` / `.method(f, name)`
-    // becomes an instance method (receiver bound to `this`), delegating to the
-    // same centralized `JNINative` extern as a free wrapper would.
-    for m in members
-        .iter()
-        .filter(|m| matches!(m.kind, MemberKind::Accessor | MemberKind::Method))
-    {
+    // Promoted instance methods: each `.fun(f)` becomes an instance method
+    // (receiver bound to `this`), delegating to the same centralized
+    // `JNINative` extern as a free wrapper would.
+    for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
         if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
             if let Some(f) = render_wrapper_fn(
                 ext,

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -222,7 +222,7 @@ pub(crate) fn build_data_class(
 
 /// Render one typed-handle Kotlin source file. Pure-shell form (with
 /// the closure `|n| format!("{n}ViaJNI")` installed via
-/// [`JniGen::kotlin_fun_name_mangle`]):
+/// [`JniGen::set_fun_name_mangle`]):
 ///
 /// ```kotlin
 /// public class JNIFoo(initialPtr: Long) : NativeHandle(initialPtr) {

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1197,12 +1197,7 @@ fn classify_output(
 /// arg (or several, for a flattened data_class); the output plan's extra args
 /// and the trailing `__cap` follow; the result is wrapped per the return
 /// classification (projection / enum / erased-`Any` cast).
-fn build_native_call(
-    ext: &JniGen,
-    jni_call: &str,
-    params: &[Param],
-    out: &OutputPlan,
-) -> String {
+fn build_native_call(ext: &JniGen, jni_call: &str, params: &[Param], out: &OutputPlan) -> String {
     let mut args: Vec<String> = Vec::with_capacity(params.len());
     for p in params.iter() {
         // Flattened data_class param expands into multiple call args

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -56,7 +56,7 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
 /// Rust struct. Returns the class plus the FQN imports its (pre-shortened)
 /// field/factory type strings reference.
 pub(crate) fn build_data_class(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     class_name: &str,
     item_struct: &syn::ItemStruct,
     registry: &Registry<KotlinMeta>,
@@ -242,7 +242,7 @@ pub(crate) fn build_data_class(
 /// to the matching `Java_<pkg>_<class>_<mangle_fun("freePtr")>`
 /// extern on the Rust side (the auto-generated destructor).
 pub(crate) fn build_typed_handle(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     class_name: &str,
     rust_doc_name: &str,
@@ -406,7 +406,7 @@ pub(crate) fn is_iterable_fold(shape: &crate::api::core::unfold::UnfoldShape) ->
 }
 
 pub(crate) fn render_extern_decl(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -693,7 +693,7 @@ fn peel_receiver_key(ty: &syn::Type) -> TypeKey {
 /// or `this.bytes` for a `value_class` blob). The JNINative extern/call is
 /// unchanged (keyed on the Rust ident), so only the Kotlin wrapper relocates.
 pub(crate) fn render_wrapper_fn(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -804,7 +804,7 @@ struct ErrorSink {
 /// instance-method receiver (the first param whose peeled type matches
 /// `receiver_key`), which is bound to `this` and dropped from the signature.
 fn classify_params(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -1039,7 +1039,7 @@ fn classify_params(
 /// (`ZZenohId(raw)`) before the user callback. Leaves with no value_blob ⇒
 /// the callback is passed directly (M1–M4 unchanged).
 fn classify_output(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -1201,7 +1201,7 @@ fn classify_output(
 /// and the trailing `__cap` follow; the result is wrapped per the return
 /// classification (projection / enum / erased-`Any` cast).
 fn build_native_call(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     jni_call: &str,
     params: &[Param],
     out: &OutputPlan,
@@ -1371,7 +1371,7 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
 /// call — calls `onError.run(je, ze…)` and returns its `R` if a failure
 /// was recorded (no throw on the Rust upcall).
 fn error_sink_parts(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -1489,7 +1489,7 @@ fn render_value_stmt(bind: &str, body_expr: &str, opaques: &[Opaque]) -> kt::Cod
 /// statements are needed) so the caller can bind it to `__ret`, rethrow a
 /// captured sink error, then return.
 fn render_core_stmt(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     opaques: &[Opaque],
     body_expr: &str,
     imports: &mut BTreeSet<String>,
@@ -1578,7 +1578,7 @@ fn render_core_stmt(
 /// `mem::take`s it, leaving an empty `Vec` to drop). The transient handle is
 /// not a `NativeHandle`, so it never joins the lock set.
 fn render_body(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     params: &[Param],
     opaques: &[Opaque],
     sink: &ErrorSink,
@@ -1651,7 +1651,7 @@ fn render_body(
 /// `value_blob`, whose `@JvmInline value class` can't be built Rust-side).
 /// Shared by the unfold builder/fold lambda and the callback lambda params.
 pub(crate) fn unfold_leaf_kt(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     out_ty: &syn::Type,
     nullable: bool,
@@ -1800,7 +1800,7 @@ pub(crate) fn kotlin_for_wire(wire: &syn::Type) -> Option<kt::KtType> {
 ///   the inner wire's Kotlin name for `ValueClass`). `None` for plain
 ///   non-projection returns.
 pub(crate) fn classify_return(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     output: &syn::ReturnType,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -1863,7 +1863,7 @@ pub(crate) fn classify_return(
 /// via [`JniGen::enum_class`]. Enum returns cross the JNI wire as `jint` (Kotlin
 /// `Int`); the public wrapper must call `EnumType.fromInt(Int)` to convert back.
 pub(crate) fn return_is_kotlin_enum(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     output: &syn::ReturnType,
     registry: &Registry<KotlinMeta>,
 ) -> bool {
@@ -1875,7 +1875,7 @@ pub(crate) fn return_is_kotlin_enum(
 /// `box_jint`-boxed (null for `None`), so the extern returns `Int?` and the
 /// public wrapper converts back with `?.let { EnumType.fromInt(it) }`.
 pub(crate) fn return_is_kotlin_option_enum(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     output: &syn::ReturnType,
     registry: &Registry<KotlinMeta>,
 ) -> bool {

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -33,7 +33,7 @@ fn ref_wildcard(r: &syn::TypeReference) -> syn::Type {
     syn::Type::Reference(pr)
 }
 
-impl<S: JniGenState> JniGen<S> {
+impl JniGen {
     /// Select the input converter for `ty`: terminals, user wrappers, then
     /// built-in structural wrappers.
     pub(crate) fn select_input_type(

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -91,7 +91,7 @@ pub(crate) enum PlanFieldKind {
 /// name) — consistently for BOTH sides, where the former parallel walks
 /// could silently diverge on such edge cases.
 pub(crate) fn build_struct_plan(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
     depth: usize,

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -163,7 +163,9 @@ pub(crate) fn build_struct_plan(
                     fname
                 );
             }
-            let child_fqn = cfg.and_then(|c| c.kotlin_name.clone());
+            let child_fqn = cfg
+                .and_then(|c| c.name_spec.as_ref())
+                .map(|s| ext.fqn_of(s));
             let plan = build_struct_plan(ext, registry, &st.clone(), depth + 1)?;
             fields.push(PlanField {
                 fname,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -45,8 +45,9 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
                 crate::ptr_class!(ZThing)
                     // Canonical output: handle (identity) + its string form — a
                     // callback arg of ZThing decomposes into these 2 leaves.
-                    .accessor(crate::fun!(z_thing_name).name("name"))
-                    .flatten_output(crate::flatten_output!().field_self().field("name")),
+                    .fun(crate::fun!(z_thing_name).name("name"))
+                    .flatten_output_self()
+                    .flatten_output(crate::fun!(z_thing_name).name("name")),
             )
             // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
             .class(crate::ptr_class!(ZOther))
@@ -232,14 +233,16 @@ fn callback_root_identity_moved_after_nested_borrow() {
             // Child handle: canonical output = identity (clone) + its name string.
             .class(
                 crate::ptr_class!(ZChild)
-                    .accessor(crate::fun!(z_child_name).name("name"))
-                    .flatten_output(crate::flatten_output!().field_self().field("name")),
+                    .fun(crate::fun!(z_child_name).name("name"))
+                    .flatten_output_self()
+                    .flatten_output(crate::fun!(z_child_name).name("name")),
             )
             // Parent: a nested child-handle record, then its OWN root identity LAST.
             .class(
                 crate::ptr_class!(ZParent)
-                    .accessor(crate::fun!(z_parent_child).name("child"))
-                    .flatten_output(crate::flatten_output!().field("child").field_self()),
+                    .fun(crate::fun!(z_parent_child).name("child"))
+                    .flatten_output(crate::fun!(z_parent_child).name("child"))
+                    .flatten_output_self(),
             )
             .fun(crate::fun!(z_parent_sub)),
     );
@@ -318,38 +321,37 @@ fn callback_double_option_unwrap_pipeline() {
             .class(crate::value_class!(ZId))
             .class(
                 crate::ptr_class!(ZKeyExpr)
-                    .accessor(crate::fun!(z_keyexpr_as_str).name("asStr"))
-                    .flatten_output(crate::flatten_output!().field_self().field("asStr")),
+                    .fun(crate::fun!(z_keyexpr_as_str).name("asStr"))
+                    .flatten_output_self()
+                    .flatten_output(crate::fun!(z_keyexpr_as_str).name("asStr")),
             )
             .class(
                 crate::ptr_class!(ZTs)
-                    .accessor(crate::fun!(z_ts_ntp64).name("ntp64"))
-                    .flatten_output(crate::flatten_output!().field("ntp64")),
+                    .fun(crate::fun!(z_ts_ntp64).name("ntp64"))
+                    .flatten_output(crate::fun!(z_ts_ntp64).name("ntp64")),
             )
             .class(
                 crate::ptr_class!(ZSample)
-                    .accessor(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                    .accessor(crate::fun!(z_sample_timestamp).name("timestamp"))
-                    .flatten_output(crate::flatten_output!().field("keyExpr").field("timestamp")),
+                    .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                    .fun(crate::fun!(z_sample_timestamp).name("timestamp"))
+                    .flatten_output(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                    .flatten_output(crate::fun!(z_sample_timestamp).name("timestamp")),
             )
             .class(
                 crate::ptr_class!(ZErr)
-                    .accessor(crate::fun!(z_err_payload).name("payload"))
-                    .flatten_output(crate::flatten_output!().field("payload")),
+                    .fun(crate::fun!(z_err_payload).name("payload"))
+                    .flatten_output(crate::fun!(z_err_payload).name("payload")),
             )
             .class(
                 crate::ptr_class!(ZReply)
-                    .accessor(crate::fun!(z_reply_zid).name("zid"))
-                    .accessor(crate::fun!(z_reply_is_ok).name("isOk"))
-                    .accessor(crate::fun!(z_reply_sample).name("sample"))
-                    .accessor(crate::fun!(z_reply_err).name("err"))
-                    .flatten_output(
-                        crate::flatten_output!()
-                            .field("zid")
-                            .field("isOk")
-                            .field("sample")
-                            .field("err"),
-                    ),
+                    .fun(crate::fun!(z_reply_zid).name("zid"))
+                    .fun(crate::fun!(z_reply_is_ok).name("isOk"))
+                    .fun(crate::fun!(z_reply_sample).name("sample"))
+                    .fun(crate::fun!(z_reply_err).name("err"))
+                    .flatten_output(crate::fun!(z_reply_zid).name("zid"))
+                    .flatten_output(crate::fun!(z_reply_is_ok).name("isOk"))
+                    .flatten_output(crate::fun!(z_reply_sample).name("sample"))
+                    .flatten_output(crate::fun!(z_reply_err).name("err")),
             )
             .fun(crate::fun!(z_get)),
     );

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -42,16 +42,16 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
     .package(
         PackageDecl::new("thing")
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZThing))
+                crate::ptr_class!(ZThing)
                     // Canonical output: handle (identity) + its string form — a
                     // callback arg of ZThing decomposes into these 2 leaves.
-                    .accessor(crate::ident!(z_thing_name), "name")
-                    .flatten_output(FlattenOutput::new().field_self().field("name")),
+                    .accessor(crate::fun!(z_thing_name).name("name"))
+                    .flatten_output(crate::flatten_output!().field_self().field("name")),
             )
             // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
-            .class(PtrClassDecl::new(syn::parse_quote!(ZOther)))
-            .fun(FunctionDecl::new(syn::parse_quote!(z_thing_sub)))
-            .fun(FunctionDecl::new(syn::parse_quote!(z_other_sub))),
+            .class(crate::ptr_class!(ZOther))
+            .fun(crate::fun!(z_thing_sub))
+            .fun(crate::fun!(z_other_sub)),
     );
 
     let dir = unique_test_dir("jnigen_cb_snap");
@@ -231,17 +231,17 @@ fn callback_root_identity_moved_after_nested_borrow() {
         PackageDecl::new("thing")
             // Child handle: canonical output = identity (clone) + its name string.
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZChild))
-                    .accessor(crate::ident!(z_child_name), "name")
-                    .flatten_output(FlattenOutput::new().field_self().field("name")),
+                crate::ptr_class!(ZChild)
+                    .accessor(crate::fun!(z_child_name).name("name"))
+                    .flatten_output(crate::flatten_output!().field_self().field("name")),
             )
             // Parent: a nested child-handle record, then its OWN root identity LAST.
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZParent))
-                    .accessor(crate::ident!(z_parent_child), "child")
-                    .flatten_output(FlattenOutput::new().field("child").field_self()),
+                crate::ptr_class!(ZParent)
+                    .accessor(crate::fun!(z_parent_child).name("child"))
+                    .flatten_output(crate::flatten_output!().field("child").field_self()),
             )
-            .fun(FunctionDecl::new(syn::parse_quote!(z_parent_sub))),
+            .fun(crate::fun!(z_parent_sub)),
     );
 
     let dir = unique_test_dir("jnigen_root_id_order");
@@ -315,43 +315,43 @@ fn callback_double_option_unwrap_pipeline() {
     )
     .package(
         PackageDecl::new("query")
-            .class(ValueClassDecl::new(syn::parse_quote!(ZId)))
+            .class(crate::value_class!(ZId))
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZKeyExpr))
-                    .accessor(crate::ident!(z_keyexpr_as_str), "asStr")
-                    .flatten_output(FlattenOutput::new().field_self().field("asStr")),
+                crate::ptr_class!(ZKeyExpr)
+                    .accessor(crate::fun!(z_keyexpr_as_str).name("asStr"))
+                    .flatten_output(crate::flatten_output!().field_self().field("asStr")),
             )
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZTs))
-                    .accessor(crate::ident!(z_ts_ntp64), "ntp64")
-                    .flatten_output(FlattenOutput::new().field("ntp64")),
+                crate::ptr_class!(ZTs)
+                    .accessor(crate::fun!(z_ts_ntp64).name("ntp64"))
+                    .flatten_output(crate::flatten_output!().field("ntp64")),
             )
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZSample))
-                    .accessor(crate::ident!(z_sample_key_expr), "keyExpr")
-                    .accessor(crate::ident!(z_sample_timestamp), "timestamp")
-                    .flatten_output(FlattenOutput::new().field("keyExpr").field("timestamp")),
+                crate::ptr_class!(ZSample)
+                    .accessor(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                    .accessor(crate::fun!(z_sample_timestamp).name("timestamp"))
+                    .flatten_output(crate::flatten_output!().field("keyExpr").field("timestamp")),
             )
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZErr))
-                    .accessor(crate::ident!(z_err_payload), "payload")
-                    .flatten_output(FlattenOutput::new().field("payload")),
+                crate::ptr_class!(ZErr)
+                    .accessor(crate::fun!(z_err_payload).name("payload"))
+                    .flatten_output(crate::flatten_output!().field("payload")),
             )
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZReply))
-                    .accessor(crate::ident!(z_reply_zid), "zid")
-                    .accessor(crate::ident!(z_reply_is_ok), "isOk")
-                    .accessor(crate::ident!(z_reply_sample), "sample")
-                    .accessor(crate::ident!(z_reply_err), "err")
+                crate::ptr_class!(ZReply)
+                    .accessor(crate::fun!(z_reply_zid).name("zid"))
+                    .accessor(crate::fun!(z_reply_is_ok).name("isOk"))
+                    .accessor(crate::fun!(z_reply_sample).name("sample"))
+                    .accessor(crate::fun!(z_reply_err).name("err"))
                     .flatten_output(
-                        FlattenOutput::new()
+                        crate::flatten_output!()
                             .field("zid")
                             .field("isOk")
                             .field("sample")
                             .field("err"),
                     ),
             )
-            .fun(FunctionDecl::new(syn::parse_quote!(z_get))),
+            .fun(crate::fun!(z_get)),
     );
 
     let dir = unique_test_dir("jnigen_double_opt");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -46,8 +46,8 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
                     // Canonical output: handle (identity) + its string form — a
                     // callback arg of ZThing decomposes into these 2 leaves.
                     .fun(crate::fun!(z_thing_name).name("name"))
-                    .default_return_field_self()
-                    .default_return_field(crate::fun!(z_thing_name).name("name")),
+                    .default_return_expand_self()
+                    .default_return_expand(crate::fun!(z_thing_name).name("name")),
             )
             // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
             .class(crate::ptr_class!(ZOther))
@@ -234,15 +234,15 @@ fn callback_root_identity_moved_after_nested_borrow() {
             .class(
                 crate::ptr_class!(ZChild)
                     .fun(crate::fun!(z_child_name).name("name"))
-                    .default_return_field_self()
-                    .default_return_field(crate::fun!(z_child_name).name("name")),
+                    .default_return_expand_self()
+                    .default_return_expand(crate::fun!(z_child_name).name("name")),
             )
             // Parent: a nested child-handle record, then its OWN root identity LAST.
             .class(
                 crate::ptr_class!(ZParent)
                     .fun(crate::fun!(z_parent_child).name("child"))
-                    .default_return_field(crate::fun!(z_parent_child).name("child"))
-                    .default_return_field_self(),
+                    .default_return_expand(crate::fun!(z_parent_child).name("child"))
+                    .default_return_expand_self(),
             )
             .fun(crate::fun!(z_parent_sub)),
     );
@@ -322,25 +322,25 @@ fn callback_double_option_unwrap_pipeline() {
             .class(
                 crate::ptr_class!(ZKeyExpr)
                     .fun(crate::fun!(z_keyexpr_as_str).name("asStr"))
-                    .default_return_field_self()
-                    .default_return_field(crate::fun!(z_keyexpr_as_str).name("asStr")),
+                    .default_return_expand_self()
+                    .default_return_expand(crate::fun!(z_keyexpr_as_str).name("asStr")),
             )
             .class(
                 crate::ptr_class!(ZTs)
                     .fun(crate::fun!(z_ts_ntp64).name("ntp64"))
-                    .default_return_field(crate::fun!(z_ts_ntp64).name("ntp64")),
+                    .default_return_expand(crate::fun!(z_ts_ntp64).name("ntp64")),
             )
             .class(
                 crate::ptr_class!(ZSample)
                     .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
                     .fun(crate::fun!(z_sample_timestamp).name("timestamp"))
-                    .default_return_field(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                    .default_return_field(crate::fun!(z_sample_timestamp).name("timestamp")),
+                    .default_return_expand(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                    .default_return_expand(crate::fun!(z_sample_timestamp).name("timestamp")),
             )
             .class(
                 crate::ptr_class!(ZErr)
                     .fun(crate::fun!(z_err_payload).name("payload"))
-                    .default_return_field(crate::fun!(z_err_payload).name("payload")),
+                    .default_return_expand(crate::fun!(z_err_payload).name("payload")),
             )
             .class(
                 crate::ptr_class!(ZReply)
@@ -348,10 +348,10 @@ fn callback_double_option_unwrap_pipeline() {
                     .fun(crate::fun!(z_reply_is_ok).name("isOk"))
                     .fun(crate::fun!(z_reply_sample).name("sample"))
                     .fun(crate::fun!(z_reply_err).name("err"))
-                    .default_return_field(crate::fun!(z_reply_zid).name("zid"))
-                    .default_return_field(crate::fun!(z_reply_is_ok).name("isOk"))
-                    .default_return_field(crate::fun!(z_reply_sample).name("sample"))
-                    .default_return_field(crate::fun!(z_reply_err).name("err")),
+                    .default_return_expand(crate::fun!(z_reply_zid).name("zid"))
+                    .default_return_expand(crate::fun!(z_reply_is_ok).name("isOk"))
+                    .default_return_expand(crate::fun!(z_reply_sample).name("sample"))
+                    .default_return_expand(crate::fun!(z_reply_err).name("err")),
             )
             .fun(crate::fun!(z_get)),
     );

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -181,10 +181,10 @@ fn callback_snapshot_kotlin_side() {
 
 /// Regression: a callback-delivered type that has BOTH a nested handle identity
 /// (a child `ptr_class` reached by an accessor) AND its own root identity
-/// (`.default_return_field().field_self()`) must emit the root MOVE after every borrow of
+/// (`.default_return_expand().field_self()`) must emit the root MOVE after every borrow of
 /// the owned value — otherwise the nested child clone (which borrows the root)
 /// follows `Box::into_raw(Box::new(value))` and fails to compile with "use of
-/// moved value". Declaring `.default_return_field().field_self()` LAST guarantees the
+/// moved value". Declaring `.default_return_expand().field_self()` LAST guarantees the
 /// correct order (the emitter emits identity leaves in declaration order, after
 /// all non-identity leaves). This mirrors the zenoh-flat `ZQuery` queryable
 /// callback (handle + decomposed fields, nested `ZKeyExpr` identity).
@@ -437,7 +437,7 @@ fn callback_double_option_unwrap_pipeline() {
 // ────────────────────────────────────────────────────────────────────────
 // Declaration-keyed interfaces: a type may have several decompositions —
 // the default (unnamed) deconstructor and per-fn inline records
-// (`.return_field`). Interface identity follows the DECLARATION, so
+// (`.return_expand`). Interface identity follows the DECLARATION, so
 // differently-decomposed functions get distinct interfaces instead of
 // colliding on one type-keyed name.
 // ────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -34,21 +34,25 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("thing")
-        .ptr_class(syn::parse_quote!(ZThing))
-        // Canonical output: handle (identity) + its string form — a callback
-        // arg of ZThing decomposes into these 2 leaves.
-        .accessor(syn::parse_quote!(z_thing_name), "name")
-        .flatten_output()
-        .field_self()
-        .field("name")
-        // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
-        .ptr_class(syn::parse_quote!(ZOther))
-        .fun(syn::parse_quote!(z_thing_sub))
-        .fun(syn::parse_quote!(z_other_sub));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("thing")
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZThing))
+                    // Canonical output: handle (identity) + its string form — a
+                    // callback arg of ZThing decomposes into these 2 leaves.
+                    .accessor(syn::parse_quote!(z_thing_name), "name")
+                    .flatten_output(FlattenOutput::new().field_self().field("name")),
+            )
+            // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
+            .class(PtrClassDecl::new(syn::parse_quote!(ZOther)))
+            .fun(FunctionDecl::new(syn::parse_quote!(z_thing_sub)))
+            .fun(FunctionDecl::new(syn::parse_quote!(z_other_sub))),
+    );
 
     let dir = unique_test_dir("jnigen_cb_snap");
     let _ = std::fs::remove_dir_all(&dir);
@@ -218,23 +222,27 @@ fn callback_root_identity_moved_after_nested_borrow() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("thing")
-        // Child handle: canonical output = identity (clone) + its name string.
-        .ptr_class(syn::parse_quote!(ZChild))
-        .accessor(syn::parse_quote!(z_child_name), "name")
-        .flatten_output()
-        .field_self()
-        .field("name")
-        // Parent: a nested child-handle record, then its OWN root identity LAST.
-        .ptr_class(syn::parse_quote!(ZParent))
-        .accessor(syn::parse_quote!(z_parent_child), "child")
-        .flatten_output()
-        .field("child")
-        .field_self()
-        .fun(syn::parse_quote!(z_parent_sub));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("thing")
+            // Child handle: canonical output = identity (clone) + its name string.
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZChild))
+                    .accessor(syn::parse_quote!(z_child_name), "name")
+                    .flatten_output(FlattenOutput::new().field_self().field("name")),
+            )
+            // Parent: a nested child-handle record, then its OWN root identity LAST.
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZParent))
+                    .accessor(syn::parse_quote!(z_parent_child), "child")
+                    .flatten_output(FlattenOutput::new().field("child").field_self()),
+            )
+            .fun(FunctionDecl::new(syn::parse_quote!(z_parent_sub))),
+    );
 
     let dir = unique_test_dir("jnigen_root_id_order");
     let _ = std::fs::remove_dir_all(&dir);
@@ -300,41 +308,51 @@ fn callback_double_option_unwrap_pipeline() {
     ));
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("query")
-        .value_class(syn::parse_quote!(ZId))
-        .ptr_class(syn::parse_quote!(ZKeyExpr))
-        .accessor(syn::parse_quote!(z_keyexpr_as_str), "asStr")
-        .flatten_output()
-        .field_self()
-        .field("asStr")
-        .ptr_class(syn::parse_quote!(ZTs))
-        .accessor(syn::parse_quote!(z_ts_ntp64), "ntp64")
-        .flatten_output()
-        .field("ntp64")
-        .ptr_class(syn::parse_quote!(ZSample))
-        .accessor(syn::parse_quote!(z_sample_key_expr), "keyExpr")
-        .accessor(syn::parse_quote!(z_sample_timestamp), "timestamp")
-        .flatten_output()
-        .field("keyExpr")
-        .field("timestamp")
-        .ptr_class(syn::parse_quote!(ZErr))
-        .accessor(syn::parse_quote!(z_err_payload), "payload")
-        .flatten_output()
-        .field("payload")
-        .ptr_class(syn::parse_quote!(ZReply))
-        .accessor(syn::parse_quote!(z_reply_zid), "zid")
-        .accessor(syn::parse_quote!(z_reply_is_ok), "isOk")
-        .accessor(syn::parse_quote!(z_reply_sample), "sample")
-        .accessor(syn::parse_quote!(z_reply_err), "err")
-        .flatten_output()
-        .field("zid")
-        .field("isOk")
-        .field("sample")
-        .field("err")
-        .fun(syn::parse_quote!(z_get));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("query")
+            .class(ValueClassDecl::new(syn::parse_quote!(ZId)))
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZKeyExpr))
+                    .accessor(syn::parse_quote!(z_keyexpr_as_str), "asStr")
+                    .flatten_output(FlattenOutput::new().field_self().field("asStr")),
+            )
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZTs))
+                    .accessor(syn::parse_quote!(z_ts_ntp64), "ntp64")
+                    .flatten_output(FlattenOutput::new().field("ntp64")),
+            )
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZSample))
+                    .accessor(syn::parse_quote!(z_sample_key_expr), "keyExpr")
+                    .accessor(syn::parse_quote!(z_sample_timestamp), "timestamp")
+                    .flatten_output(FlattenOutput::new().field("keyExpr").field("timestamp")),
+            )
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZErr))
+                    .accessor(syn::parse_quote!(z_err_payload), "payload")
+                    .flatten_output(FlattenOutput::new().field("payload")),
+            )
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZReply))
+                    .accessor(syn::parse_quote!(z_reply_zid), "zid")
+                    .accessor(syn::parse_quote!(z_reply_is_ok), "isOk")
+                    .accessor(syn::parse_quote!(z_reply_sample), "sample")
+                    .accessor(syn::parse_quote!(z_reply_err), "err")
+                    .flatten_output(
+                        FlattenOutput::new()
+                            .field("zid")
+                            .field("isOk")
+                            .field("sample")
+                            .field("err"),
+                    ),
+            )
+            .fun(FunctionDecl::new(syn::parse_quote!(z_get))),
+    );
 
     let dir = unique_test_dir("jnigen_double_opt");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -437,7 +437,7 @@ fn callback_double_option_unwrap_pipeline() {
 // ────────────────────────────────────────────────────────────────────────
 // Declaration-keyed interfaces: a type may have several decompositions —
 // the default (unnamed) deconstructor and per-fn inline records
-// (`.flatten_output_with`). Interface identity follows the DECLARATION, so
+// (`.flatten_output`). Interface identity follows the DECLARATION, so
 // differently-decomposed functions get distinct interfaces instead of
 // colliding on one type-keyed name.
 // ────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -40,7 +40,7 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("thing")
+        crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
                     // Canonical output: handle (identity) + its string form — a
@@ -228,7 +228,7 @@ fn callback_root_identity_moved_after_nested_borrow() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("thing")
+        crate::package!("thing")
             // Child handle: canonical output = identity (clone) + its name string.
             .class(
                 crate::ptr_class!(ZChild)
@@ -314,7 +314,7 @@ fn callback_double_option_unwrap_pipeline() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("query")
+        crate::package!("query")
             .class(crate::value_class!(ZId))
             .class(
                 crate::ptr_class!(ZKeyExpr)

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -45,7 +45,7 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
                 PtrClassDecl::new(syn::parse_quote!(ZThing))
                     // Canonical output: handle (identity) + its string form — a
                     // callback arg of ZThing decomposes into these 2 leaves.
-                    .accessor(syn::parse_quote!(z_thing_name), "name")
+                    .accessor(crate::ident!(z_thing_name), "name")
                     .flatten_output(FlattenOutput::new().field_self().field("name")),
             )
             // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
@@ -232,13 +232,13 @@ fn callback_root_identity_moved_after_nested_borrow() {
             // Child handle: canonical output = identity (clone) + its name string.
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZChild))
-                    .accessor(syn::parse_quote!(z_child_name), "name")
+                    .accessor(crate::ident!(z_child_name), "name")
                     .flatten_output(FlattenOutput::new().field_self().field("name")),
             )
             // Parent: a nested child-handle record, then its OWN root identity LAST.
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZParent))
-                    .accessor(syn::parse_quote!(z_parent_child), "child")
+                    .accessor(crate::ident!(z_parent_child), "child")
                     .flatten_output(FlattenOutput::new().field("child").field_self()),
             )
             .fun(FunctionDecl::new(syn::parse_quote!(z_parent_sub))),
@@ -318,31 +318,31 @@ fn callback_double_option_unwrap_pipeline() {
             .class(ValueClassDecl::new(syn::parse_quote!(ZId)))
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZKeyExpr))
-                    .accessor(syn::parse_quote!(z_keyexpr_as_str), "asStr")
+                    .accessor(crate::ident!(z_keyexpr_as_str), "asStr")
                     .flatten_output(FlattenOutput::new().field_self().field("asStr")),
             )
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZTs))
-                    .accessor(syn::parse_quote!(z_ts_ntp64), "ntp64")
+                    .accessor(crate::ident!(z_ts_ntp64), "ntp64")
                     .flatten_output(FlattenOutput::new().field("ntp64")),
             )
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZSample))
-                    .accessor(syn::parse_quote!(z_sample_key_expr), "keyExpr")
-                    .accessor(syn::parse_quote!(z_sample_timestamp), "timestamp")
+                    .accessor(crate::ident!(z_sample_key_expr), "keyExpr")
+                    .accessor(crate::ident!(z_sample_timestamp), "timestamp")
                     .flatten_output(FlattenOutput::new().field("keyExpr").field("timestamp")),
             )
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZErr))
-                    .accessor(syn::parse_quote!(z_err_payload), "payload")
+                    .accessor(crate::ident!(z_err_payload), "payload")
                     .flatten_output(FlattenOutput::new().field("payload")),
             )
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZReply))
-                    .accessor(syn::parse_quote!(z_reply_zid), "zid")
-                    .accessor(syn::parse_quote!(z_reply_is_ok), "isOk")
-                    .accessor(syn::parse_quote!(z_reply_sample), "sample")
-                    .accessor(syn::parse_quote!(z_reply_err), "err")
+                    .accessor(crate::ident!(z_reply_zid), "zid")
+                    .accessor(crate::ident!(z_reply_is_ok), "isOk")
+                    .accessor(crate::ident!(z_reply_sample), "sample")
+                    .accessor(crate::ident!(z_reply_err), "err")
                     .flatten_output(
                         FlattenOutput::new()
                             .field("zid")

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -34,26 +34,24 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("thing")
-            .class(
-                crate::ptr_class!(ZThing)
-                    // Canonical output: handle (identity) + its string form — a
-                    // callback arg of ZThing decomposes into these 2 leaves.
-                    .fun(crate::fun!(z_thing_name).name("name"))
-                    .default_return_expand_self()
-                    .default_return_expand(crate::fun!(z_thing_name).name("name")),
-            )
-            // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
-            .class(crate::ptr_class!(ZOther))
-            .fun(crate::fun!(z_thing_sub))
-            .fun(crate::fun!(z_other_sub)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(
+                    crate::ptr_class!(ZThing)
+                        // Canonical output: handle (identity) + its string form — a
+                        // callback arg of ZThing decomposes into these 2 leaves.
+                        .fun(crate::fun!(z_thing_name).name("name"))
+                        .default_return_expand_self()
+                        .default_return_expand(crate::fun!(z_thing_name).name("name")),
+                )
+                // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
+                .class(crate::ptr_class!(ZOther))
+                .fun(crate::fun!(z_thing_sub))
+                .fun(crate::fun!(z_other_sub)),
+        );
 
     let dir = unique_test_dir("jnigen_cb_snap");
     let _ = std::fs::remove_dir_all(&dir);
@@ -223,29 +221,27 @@ fn callback_root_identity_moved_after_nested_borrow() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("thing")
-            // Child handle: canonical output = identity (clone) + its name string.
-            .class(
-                crate::ptr_class!(ZChild)
-                    .fun(crate::fun!(z_child_name).name("name"))
-                    .default_return_expand_self()
-                    .default_return_expand(crate::fun!(z_child_name).name("name")),
-            )
-            // Parent: a nested child-handle record, then its OWN root identity LAST.
-            .class(
-                crate::ptr_class!(ZParent)
-                    .fun(crate::fun!(z_parent_child).name("child"))
-                    .default_return_expand(crate::fun!(z_parent_child).name("child"))
-                    .default_return_expand_self(),
-            )
-            .fun(crate::fun!(z_parent_sub)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                // Child handle: canonical output = identity (clone) + its name string.
+                .class(
+                    crate::ptr_class!(ZChild)
+                        .fun(crate::fun!(z_child_name).name("name"))
+                        .default_return_expand_self()
+                        .default_return_expand(crate::fun!(z_child_name).name("name")),
+                )
+                // Parent: a nested child-handle record, then its OWN root identity LAST.
+                .class(
+                    crate::ptr_class!(ZParent)
+                        .fun(crate::fun!(z_parent_child).name("child"))
+                        .default_return_expand(crate::fun!(z_parent_child).name("child"))
+                        .default_return_expand_self(),
+                )
+                .fun(crate::fun!(z_parent_sub)),
+        );
 
     let dir = unique_test_dir("jnigen_root_id_order");
     let _ = std::fs::remove_dir_all(&dir);
@@ -311,50 +307,48 @@ fn callback_double_option_unwrap_pipeline() {
     ));
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("query")
-            .class(crate::value_class!(ZId))
-            .class(
-                crate::ptr_class!(ZKeyExpr)
-                    .fun(crate::fun!(z_keyexpr_as_str).name("asStr"))
-                    .default_return_expand_self()
-                    .default_return_expand(crate::fun!(z_keyexpr_as_str).name("asStr")),
-            )
-            .class(
-                crate::ptr_class!(ZTs)
-                    .fun(crate::fun!(z_ts_ntp64).name("ntp64"))
-                    .default_return_expand(crate::fun!(z_ts_ntp64).name("ntp64")),
-            )
-            .class(
-                crate::ptr_class!(ZSample)
-                    .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                    .fun(crate::fun!(z_sample_timestamp).name("timestamp"))
-                    .default_return_expand(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                    .default_return_expand(crate::fun!(z_sample_timestamp).name("timestamp")),
-            )
-            .class(
-                crate::ptr_class!(ZErr)
-                    .fun(crate::fun!(z_err_payload).name("payload"))
-                    .default_return_expand(crate::fun!(z_err_payload).name("payload")),
-            )
-            .class(
-                crate::ptr_class!(ZReply)
-                    .fun(crate::fun!(z_reply_zid).name("zid"))
-                    .fun(crate::fun!(z_reply_is_ok).name("isOk"))
-                    .fun(crate::fun!(z_reply_sample).name("sample"))
-                    .fun(crate::fun!(z_reply_err).name("err"))
-                    .default_return_expand(crate::fun!(z_reply_zid).name("zid"))
-                    .default_return_expand(crate::fun!(z_reply_is_ok).name("isOk"))
-                    .default_return_expand(crate::fun!(z_reply_sample).name("sample"))
-                    .default_return_expand(crate::fun!(z_reply_err).name("err")),
-            )
-            .fun(crate::fun!(z_get)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("query")
+                .class(crate::value_class!(ZId))
+                .class(
+                    crate::ptr_class!(ZKeyExpr)
+                        .fun(crate::fun!(z_keyexpr_as_str).name("asStr"))
+                        .default_return_expand_self()
+                        .default_return_expand(crate::fun!(z_keyexpr_as_str).name("asStr")),
+                )
+                .class(
+                    crate::ptr_class!(ZTs)
+                        .fun(crate::fun!(z_ts_ntp64).name("ntp64"))
+                        .default_return_expand(crate::fun!(z_ts_ntp64).name("ntp64")),
+                )
+                .class(
+                    crate::ptr_class!(ZSample)
+                        .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                        .fun(crate::fun!(z_sample_timestamp).name("timestamp"))
+                        .default_return_expand(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                        .default_return_expand(crate::fun!(z_sample_timestamp).name("timestamp")),
+                )
+                .class(
+                    crate::ptr_class!(ZErr)
+                        .fun(crate::fun!(z_err_payload).name("payload"))
+                        .default_return_expand(crate::fun!(z_err_payload).name("payload")),
+                )
+                .class(
+                    crate::ptr_class!(ZReply)
+                        .fun(crate::fun!(z_reply_zid).name("zid"))
+                        .fun(crate::fun!(z_reply_is_ok).name("isOk"))
+                        .fun(crate::fun!(z_reply_sample).name("sample"))
+                        .fun(crate::fun!(z_reply_err).name("err"))
+                        .default_return_expand(crate::fun!(z_reply_zid).name("zid"))
+                        .default_return_expand(crate::fun!(z_reply_is_ok).name("isOk"))
+                        .default_return_expand(crate::fun!(z_reply_sample).name("sample"))
+                        .default_return_expand(crate::fun!(z_reply_err).name("err")),
+                )
+                .fun(crate::fun!(z_get)),
+        );
 
     let dir = unique_test_dir("jnigen_double_opt");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -46,8 +46,8 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
                     // Canonical output: handle (identity) + its string form — a
                     // callback arg of ZThing decomposes into these 2 leaves.
                     .fun(crate::fun!(z_thing_name).name("name"))
-                    .flatten_output_self()
-                    .flatten_output(crate::fun!(z_thing_name).name("name")),
+                    .default_return_field_self()
+                    .default_return_field(crate::fun!(z_thing_name).name("name")),
             )
             // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
             .class(crate::ptr_class!(ZOther))
@@ -181,10 +181,10 @@ fn callback_snapshot_kotlin_side() {
 
 /// Regression: a callback-delivered type that has BOTH a nested handle identity
 /// (a child `ptr_class` reached by an accessor) AND its own root identity
-/// (`.flatten_output().field_self()`) must emit the root MOVE after every borrow of
+/// (`.default_return_field().field_self()`) must emit the root MOVE after every borrow of
 /// the owned value — otherwise the nested child clone (which borrows the root)
 /// follows `Box::into_raw(Box::new(value))` and fails to compile with "use of
-/// moved value". Declaring `.flatten_output().field_self()` LAST guarantees the
+/// moved value". Declaring `.default_return_field().field_self()` LAST guarantees the
 /// correct order (the emitter emits identity leaves in declaration order, after
 /// all non-identity leaves). This mirrors the zenoh-flat `ZQuery` queryable
 /// callback (handle + decomposed fields, nested `ZKeyExpr` identity).
@@ -234,15 +234,15 @@ fn callback_root_identity_moved_after_nested_borrow() {
             .class(
                 crate::ptr_class!(ZChild)
                     .fun(crate::fun!(z_child_name).name("name"))
-                    .flatten_output_self()
-                    .flatten_output(crate::fun!(z_child_name).name("name")),
+                    .default_return_field_self()
+                    .default_return_field(crate::fun!(z_child_name).name("name")),
             )
             // Parent: a nested child-handle record, then its OWN root identity LAST.
             .class(
                 crate::ptr_class!(ZParent)
                     .fun(crate::fun!(z_parent_child).name("child"))
-                    .flatten_output(crate::fun!(z_parent_child).name("child"))
-                    .flatten_output_self(),
+                    .default_return_field(crate::fun!(z_parent_child).name("child"))
+                    .default_return_field_self(),
             )
             .fun(crate::fun!(z_parent_sub)),
     );
@@ -322,25 +322,25 @@ fn callback_double_option_unwrap_pipeline() {
             .class(
                 crate::ptr_class!(ZKeyExpr)
                     .fun(crate::fun!(z_keyexpr_as_str).name("asStr"))
-                    .flatten_output_self()
-                    .flatten_output(crate::fun!(z_keyexpr_as_str).name("asStr")),
+                    .default_return_field_self()
+                    .default_return_field(crate::fun!(z_keyexpr_as_str).name("asStr")),
             )
             .class(
                 crate::ptr_class!(ZTs)
                     .fun(crate::fun!(z_ts_ntp64).name("ntp64"))
-                    .flatten_output(crate::fun!(z_ts_ntp64).name("ntp64")),
+                    .default_return_field(crate::fun!(z_ts_ntp64).name("ntp64")),
             )
             .class(
                 crate::ptr_class!(ZSample)
                     .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
                     .fun(crate::fun!(z_sample_timestamp).name("timestamp"))
-                    .flatten_output(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                    .flatten_output(crate::fun!(z_sample_timestamp).name("timestamp")),
+                    .default_return_field(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                    .default_return_field(crate::fun!(z_sample_timestamp).name("timestamp")),
             )
             .class(
                 crate::ptr_class!(ZErr)
                     .fun(crate::fun!(z_err_payload).name("payload"))
-                    .flatten_output(crate::fun!(z_err_payload).name("payload")),
+                    .default_return_field(crate::fun!(z_err_payload).name("payload")),
             )
             .class(
                 crate::ptr_class!(ZReply)
@@ -348,10 +348,10 @@ fn callback_double_option_unwrap_pipeline() {
                     .fun(crate::fun!(z_reply_is_ok).name("isOk"))
                     .fun(crate::fun!(z_reply_sample).name("sample"))
                     .fun(crate::fun!(z_reply_err).name("err"))
-                    .flatten_output(crate::fun!(z_reply_zid).name("zid"))
-                    .flatten_output(crate::fun!(z_reply_is_ok).name("isOk"))
-                    .flatten_output(crate::fun!(z_reply_sample).name("sample"))
-                    .flatten_output(crate::fun!(z_reply_err).name("err")),
+                    .default_return_field(crate::fun!(z_reply_zid).name("zid"))
+                    .default_return_field(crate::fun!(z_reply_is_ok).name("isOk"))
+                    .default_return_field(crate::fun!(z_reply_sample).name("sample"))
+                    .default_return_field(crate::fun!(z_reply_err).name("err")),
             )
             .fun(crate::fun!(z_get)),
     );
@@ -437,7 +437,7 @@ fn callback_double_option_unwrap_pipeline() {
 // ────────────────────────────────────────────────────────────────────────
 // Declaration-keyed interfaces: a type may have several decompositions —
 // the default (unnamed) deconstructor and per-fn inline records
-// (`.flatten_output`). Interface identity follows the DECLARATION, so
+// (`.return_field`). Interface identity follows the DECLARATION, so
 // differently-decomposed functions get distinct interfaces instead of
 // colliding on one type-keyed name.
 // ────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -1,46 +1,20 @@
 use super::*;
 
-/// Order-sensitive global config (`package_prefix`, the mangle closures) is
-/// baked into FQNs at declaration time — configuring it after the first
-/// declaration is a hard builder error, not a silent mis-naming.
-#[test]
-#[should_panic(expected = "package_prefix must be configured before")]
-fn late_package_prefix_panics() {
-    let _ = JniGen::new()
-        .ptr_class(syn::parse_quote!(ZThing))
-        .package_prefix("io.test.jni");
-}
-
-/// Same guard for the per-kind name-mangle closures.
-#[test]
-#[should_panic(expected = "kotlin_fun_name_mangle must be configured before")]
-fn late_mangle_closure_panics() {
-    let _ = JniGen::new()
-        .package("thing")
-        .fun(syn::parse_quote!(thing_get))
-        .kotlin_fun_name_mangle(|n| n.to_string());
-}
-
 /// A rank-0 wrapper on a Rust builtin generates a converter qualified with the
 /// `source_module` (`myflat::usize`) — invalid Rust — so the registration is
-/// rejected up front.
+/// rejected up front, at construction time.
 #[test]
-#[should_panic(expected = "wrapper on builtin `usize`")]
+#[should_panic(expected = "ScalarTypeWrapperDecl on builtin `usize`")]
 fn builtin_wrapper_pattern_panics() {
-    let _ = JniGen::new().output_wrapper(
+    let _ = ScalarTypeWrapperDecl::new(
         syn::parse_quote!(usize),
-        |_r: &Registry<KotlinMeta>| -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
-            Some((
-                syn::parse_quote!(jni::sys::jlong),
-                None,
-                syn::parse_quote!(v as jni::sys::jlong),
-            ))
-        },
+        syn::parse_quote!(jni::sys::jlong),
+        "Long",
     );
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn
-/// override) and base-package functions (`.fun` with no active subpackage —
+/// override) and base-package functions (`.fun` with the empty subpackage —
 /// mirroring class declarations, which could always live in the base package).
 #[test]
 fn per_class_name_and_base_package_fun() {
@@ -74,16 +48,19 @@ fn per_class_name_and_base_package_fun() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        // Rename the handle class; the mangle closures do NOT apply to it.
-        .kotlin_ptr_class_name_mangle(|n| format!("JNI{n}"))
-        .ptr_class(syn::parse_quote!(ZThing))
-        .name("Gadget")
-        // Base-package functions: no `package(...)` context active.
-        .fun(syn::parse_quote!(ping))
-        .fun(syn::parse_quote!(thing_new));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni")
+            // Rename the handle class; the mangle closures do NOT apply to it.
+            .kotlin_ptr_class_name_mangle(|n| format!("JNI{n}")),
+    )
+    .package(
+        PackageDecl::new("")
+            .class(PtrClassDecl::new(syn::parse_quote!(ZThing)).name("Gadget"))
+            .fun(FunctionDecl::new(syn::parse_quote!(ping)))
+            .fun(FunctionDecl::new(syn::parse_quote!(thing_new))),
+    );
 
     let dir = unique_test_dir("jnigen_class_name_base_fun");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -6,11 +6,7 @@ use super::*;
 #[test]
 #[should_panic(expected = "ScalarTypeWrapperDecl on builtin `usize`")]
 fn builtin_wrapper_pattern_panics() {
-    let _ = ScalarTypeWrapperDecl::new(
-        syn::parse_quote!(usize),
-        syn::parse_quote!(jni::sys::jlong),
-        "Long",
-    );
+    let _ = crate::scalar_type_wrapper!(usize, jni::sys::jlong, "Long");
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn
@@ -56,7 +52,7 @@ fn per_class_name_and_base_package_fun() {
             .kotlin_ptr_class_name_mangle(|n| format!("JNI{n}")),
     )
     .package(
-        PackageDecl::new("")
+        crate::package!()
             .class(crate::ptr_class!(ZThing).name("Gadget"))
             .fun(crate::fun!(ping))
             .fun(crate::fun!(thing_new)),

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -57,9 +57,9 @@ fn per_class_name_and_base_package_fun() {
     )
     .package(
         PackageDecl::new("")
-            .class(PtrClassDecl::new(syn::parse_quote!(ZThing)).name("Gadget"))
-            .fun(FunctionDecl::new(syn::parse_quote!(ping)))
-            .fun(FunctionDecl::new(syn::parse_quote!(thing_new))),
+            .class(crate::ptr_class!(ZThing).name("Gadget"))
+            .fun(crate::fun!(ping))
+            .fun(crate::fun!(thing_new)),
     );
 
     let dir = unique_test_dir("jnigen_class_name_base_fun");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -44,19 +44,17 @@ fn per_class_name_and_base_package_fun() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni")
-            // Rename the handle class; the mangle closures do NOT apply to it.
-            .kotlin_ptr_class_name_mangle(|n| format!("JNI{n}")),
-    )
-    .package(
-        crate::package!()
-            .class(crate::ptr_class!(ZThing).name("Gadget"))
-            .fun(crate::fun!(ping))
-            .fun(crate::fun!(thing_new)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        // Rename the handle class; the mangle closures do NOT apply to it.
+        .set_kotlin_ptr_class_name_mangle(|n| format!("JNI{n}"))
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZThing).name("Gadget"))
+                .fun(crate::fun!(ping))
+                .fun(crate::fun!(thing_new)),
+        );
 
     let dir = unique_test_dir("jnigen_class_name_base_fun");
     let _ = std::fs::remove_dir_all(&dir);
@@ -91,4 +89,68 @@ fn per_class_name_and_base_package_fun() {
         .expect("base package file");
     assert!(base.contains("fun ping("), "{base}");
     assert!(base.contains("fun thingNew("), "{base}");
+}
+
+/// Setters are order-insensitive: declaring the package FIRST and applying
+/// `set_package_prefix` + a class mangle AFTER must produce the same output
+/// as the conventional settings-first order — the setter re-derives every
+/// declared class's FQN from the retained raw declaration inputs.
+#[test]
+fn setters_after_declarations_apply() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThing {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn thing_new() -> ZThing {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+
+    // Declarations first, settings last.
+    let jni = JniGen::new()
+        .package(
+            crate::package!("things")
+                .class(crate::ptr_class!(ZThing))
+                .fun(crate::fun!(thing_new)),
+        )
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.late.jni")
+        .set_kotlin_ptr_class_name_mangle(|n| n.strip_prefix('Z').unwrap_or(n).to_string());
+
+    let dir = unique_test_dir("jnigen_setters_after_decls");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+
+    // The late-set package prefix drives the file layout...
+    let things = paths
+        .iter()
+        .find(|p| p.ends_with("io/late/jni/things.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("subpackage file under the late-set prefix");
+    // ...and the late-set mangle drives the class name (`ZThing` → `Thing`).
+    let tc: String = things.split_whitespace().collect();
+    assert!(tc.contains("classThing("), "{things}");
+    assert!(!tc.contains("classZThing("), "{things}");
+    assert!(
+        tc.contains("funthingNew(onError:JniErrorHandler<Thing>):Thing"),
+        "{things}"
+    );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -48,7 +48,7 @@ fn per_class_name_and_base_package_fun() {
         .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         // Rename the handle class; the mangle closures do NOT apply to it.
-        .set_kotlin_ptr_class_name_mangle(|n| format!("JNI{n}"))
+        .set_ptr_class_name_mangle(|n| format!("JNI{n}"))
         .package(
             crate::package!()
                 .class(crate::ptr_class!(ZThing).name("Gadget"))
@@ -128,7 +128,7 @@ fn setters_after_declarations_apply() {
         )
         .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.late.jni")
-        .set_kotlin_ptr_class_name_mangle(|n| n.strip_prefix('Z').unwrap_or(n).to_string());
+        .set_ptr_class_name_mangle(|n| n.strip_prefix('Z').unwrap_or(n).to_string());
 
     let dir = unique_test_dir("jnigen_setters_after_decls");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -22,26 +22,31 @@ fn inline_output_gets_own_builder() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("thing")
-        .ptr_class(syn::parse_quote!(ZThing))
-        .accessor(syn::parse_quote!(z_thing_name), "name")
-        .accessor(syn::parse_quote!(z_thing_size), "size")
-        // Default output: name + size (2 leaves ⇒ builder callback).
-        .flatten_output()
-        .field("name")
-        .field("size")
-        .fun(syn::parse_quote!(z_make_a))
-        // Per-fn inline fields: name + size + name again (different shape). The
-        // third field reuses the `z_thing_name` accessor but must carry a
-        // distinct (literal) leaf name — duplicate names are a hard error.
-        .fun(syn::parse_quote!(z_make_b))
-        .flatten_output_with()
-        .field(syn::parse_quote!(z_thing_name), "name")
-        .field(syn::parse_quote!(z_thing_size), "size")
-        .field(syn::parse_quote!(z_thing_name), "name2");
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("thing")
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZThing))
+                    .accessor(syn::parse_quote!(z_thing_name), "name")
+                    .accessor(syn::parse_quote!(z_thing_size), "size")
+                    // Default output: name + size (2 leaves ⇒ builder callback).
+                    .flatten_output(FlattenOutput::new().field("name").field("size")),
+            )
+            .fun(FunctionDecl::new(syn::parse_quote!(z_make_a)))
+            // Per-fn inline fields: name + size + name again (different shape). The
+            // third field reuses the `z_thing_name` accessor but must carry a
+            // distinct (literal) leaf name — duplicate names are a hard error.
+            .fun(FunctionDecl::new(syn::parse_quote!(z_make_b)).flatten_output_with(
+                FunctionFlattenOutput::new()
+                    .field(syn::parse_quote!(z_thing_name), "name")
+                    .field(syn::parse_quote!(z_thing_size), "size")
+                    .field(syn::parse_quote!(z_thing_name), "name2"),
+            )),
+    );
 
     let dir = unique_test_dir("jnigen_inline_out");
     let _ = std::fs::remove_dir_all(&dir);
@@ -110,24 +115,33 @@ fn error_unwrap_universal_records() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("errors")
-        .ptr_class(syn::parse_quote!(ZDetail))
-        .accessor(syn::parse_quote!(z_detail_code), "code")
-        .flatten_output()
-        .field("code")
-        .ptr_class(syn::parse_quote!(ZErr))
-        .accessor(syn::parse_quote!(z_err_message), "message")
-        .accessor(syn::parse_quote!(z_err_detail), "detail")
-        // Canonical error decomposition: the owned error handle itself, its
-        // message, and the Option-nested detail spliced to its code leaf.
-        .flatten_output()
-        .field_self()
-        .field("message")
-        .field("detail")
-        .fun(syn::parse_quote!(z_fallible));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("errors")
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZDetail))
+                    .accessor(syn::parse_quote!(z_detail_code), "code")
+                    .flatten_output(FlattenOutput::new().field("code")),
+            )
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZErr))
+                    .accessor(syn::parse_quote!(z_err_message), "message")
+                    .accessor(syn::parse_quote!(z_err_detail), "detail")
+                    // Canonical error decomposition: the owned error handle itself,
+                    // its message, and the Option-nested detail spliced to its code leaf.
+                    .flatten_output(
+                        FlattenOutput::new()
+                            .field_self()
+                            .field("message")
+                            .field("detail"),
+                    ),
+            )
+            .fun(FunctionDecl::new(syn::parse_quote!(z_fallible))),
+    );
 
     let dir = unique_test_dir("jnigen_err_universal");
     let _ = std::fs::remove_dir_all(&dir);
@@ -209,15 +223,10 @@ fn error_unwrap_universal_records() {
 #[test]
 #[should_panic(expected = "no `.accessor")]
 fn flatten_output_field_unknown_accessor_panics() {
-    let _ = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("thing")
-        .ptr_class(syn::parse_quote!(ZThing))
+    let _ = PtrClassDecl::new(syn::parse_quote!(ZThing))
         .accessor(syn::parse_quote!(z_thing_name), "name")
         // References a name that was never declared via `.accessor`.
-        .flatten_output()
-        .field("size");
+        .flatten_output(FlattenOutput::new().field("size"));
 }
 
 /// `.method(f, name)` binds the `&Class` receiver to `this` (dropped from the
@@ -244,21 +253,28 @@ fn method_constructor_and_inline_field_self() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("thing")
-        .ptr_class(syn::parse_quote!(ZThing))
-        .accessor(syn::parse_quote!(z_thing_name), "name")
-        // A method: `&ZThing` receiver + a `name: String` param.
-        .method(syn::parse_quote!(z_thing_rename), "rename")
-        // A constructor: factory returning ZThing.
-        .constructor(syn::parse_quote!(z_thing_make), "make")
-        // A free fn whose per-fn inline output decomposes to (handle, name).
-        .fun(syn::parse_quote!(z_get))
-        .flatten_output_with()
-        .field_self()
-        .field(syn::parse_quote!(z_thing_name), "name");
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("thing")
+            .class(
+                PtrClassDecl::new(syn::parse_quote!(ZThing))
+                    .accessor(syn::parse_quote!(z_thing_name), "name")
+                    // A method: `&ZThing` receiver + a `name: String` param.
+                    .method(syn::parse_quote!(z_thing_rename), "rename")
+                    // A constructor: factory returning ZThing.
+                    .constructor(syn::parse_quote!(z_thing_make), "make"),
+            )
+            // A free fn whose per-fn inline output decomposes to (handle, name).
+            .fun(FunctionDecl::new(syn::parse_quote!(z_get)).flatten_output_with(
+                FunctionFlattenOutput::new()
+                    .field_self()
+                    .field(syn::parse_quote!(z_thing_name), "name"),
+            )),
+    );
 
     let dir = unique_test_dir("jnigen_method_ctor");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -31,10 +31,11 @@ fn inline_output_gets_own_builder() {
         crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
-                    .accessor(crate::fun!(z_thing_name).name("name"))
-                    .accessor(crate::fun!(z_thing_size).name("size"))
+                    .fun(crate::fun!(z_thing_name).name("name"))
+                    .fun(crate::fun!(z_thing_size).name("size"))
                     // Default output: name + size (2 leaves ⇒ builder callback).
-                    .flatten_output(crate::flatten_output!().field("name").field("size")),
+                    .flatten_output(crate::fun!(z_thing_name).name("name"))
+                    .flatten_output(crate::fun!(z_thing_size).name("size")),
             )
             .fun(crate::fun!(z_make_a))
             // Per-fn inline fields: name + size + name again (different shape). The
@@ -124,21 +125,18 @@ fn error_unwrap_universal_records() {
         crate::package!("errors")
             .class(
                 crate::ptr_class!(ZDetail)
-                    .accessor(crate::fun!(z_detail_code).name("code"))
-                    .flatten_output(crate::flatten_output!().field("code")),
+                    .fun(crate::fun!(z_detail_code).name("code"))
+                    .flatten_output(crate::fun!(z_detail_code).name("code")),
             )
             .class(
                 crate::ptr_class!(ZErr)
-                    .accessor(crate::fun!(z_err_message).name("message"))
-                    .accessor(crate::fun!(z_err_detail).name("detail"))
+                    .fun(crate::fun!(z_err_message).name("message"))
+                    .fun(crate::fun!(z_err_detail).name("detail"))
                     // Canonical error decomposition: the owned error handle itself,
                     // its message, and the Option-nested detail spliced to its code leaf.
-                    .flatten_output(
-                        crate::flatten_output!()
-                            .field_self()
-                            .field("message")
-                            .field("detail"),
-                    ),
+                    .flatten_output_self()
+                    .flatten_output(crate::fun!(z_err_message).name("message"))
+                    .flatten_output(crate::fun!(z_err_detail).name("detail")),
             )
             .fun(crate::fun!(z_fallible)),
     );
@@ -218,21 +216,10 @@ fn error_unwrap_universal_records() {
     assert!(!all.contains("?:\"\""), "{all}");
 }
 
-/// `.flatten_output().field(name)` must reference an `.accessor` declared on the
-/// same class; an unknown name is a loud build-script panic.
-#[test]
-#[should_panic(expected = "no `.accessor")]
-fn flatten_output_field_unknown_accessor_panics() {
-    let _ = crate::ptr_class!(ZThing)
-        .accessor(crate::fun!(z_thing_name).name("name"))
-        // References a name that was never declared via `.accessor`.
-        .flatten_output(crate::flatten_output!().field("size"));
-}
-
-/// `.method(f, name)` binds the `&Class` receiver to `this` (dropped from the
+/// `.fun(f)` binds the `&Class` receiver to `this` (dropped from the
 /// signature, its handle locked) while keeping the non-receiver params; the
-/// method delegates to the same `JNINative` extern. `.constructor(f, name)`
-/// emits a companion-object factory returning the class. Per-fn
+/// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
+/// companion-object factory returning the class. Per-fn
 /// `.flatten_output_with().field_self()` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
@@ -262,9 +249,9 @@ fn method_constructor_and_inline_field_self() {
         crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
-                    .accessor(crate::fun!(z_thing_name).name("name"))
-                    // A method: `&ZThing` receiver + a `name: String` param.
-                    .method(crate::fun!(z_thing_rename).name("rename"))
+                    .fun(crate::fun!(z_thing_name).name("name"))
+                    // A fun with extra params: `&ZThing` receiver + a `name: String` param.
+                    .fun(crate::fun!(z_thing_rename).name("rename"))
                     // A constructor: factory returning ZThing.
                     .constructor(crate::fun!(z_thing_make).name("make")),
             )

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -31,8 +31,8 @@ fn inline_output_gets_own_builder() {
         PackageDecl::new("thing")
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZThing))
-                    .accessor(syn::parse_quote!(z_thing_name), "name")
-                    .accessor(syn::parse_quote!(z_thing_size), "size")
+                    .accessor(crate::ident!(z_thing_name), "name")
+                    .accessor(crate::ident!(z_thing_size), "size")
                     // Default output: name + size (2 leaves ⇒ builder callback).
                     .flatten_output(FlattenOutput::new().field("name").field("size")),
             )
@@ -42,9 +42,9 @@ fn inline_output_gets_own_builder() {
             // distinct (literal) leaf name — duplicate names are a hard error.
             .fun(FunctionDecl::new(syn::parse_quote!(z_make_b)).flatten_output_with(
                 FunctionFlattenOutput::new()
-                    .field(syn::parse_quote!(z_thing_name), "name")
-                    .field(syn::parse_quote!(z_thing_size), "size")
-                    .field(syn::parse_quote!(z_thing_name), "name2"),
+                    .field(crate::ident!(z_thing_name), "name")
+                    .field(crate::ident!(z_thing_size), "size")
+                    .field(crate::ident!(z_thing_name), "name2"),
             )),
     );
 
@@ -124,13 +124,13 @@ fn error_unwrap_universal_records() {
         PackageDecl::new("errors")
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZDetail))
-                    .accessor(syn::parse_quote!(z_detail_code), "code")
+                    .accessor(crate::ident!(z_detail_code), "code")
                     .flatten_output(FlattenOutput::new().field("code")),
             )
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZErr))
-                    .accessor(syn::parse_quote!(z_err_message), "message")
-                    .accessor(syn::parse_quote!(z_err_detail), "detail")
+                    .accessor(crate::ident!(z_err_message), "message")
+                    .accessor(crate::ident!(z_err_detail), "detail")
                     // Canonical error decomposition: the owned error handle itself,
                     // its message, and the Option-nested detail spliced to its code leaf.
                     .flatten_output(
@@ -224,7 +224,7 @@ fn error_unwrap_universal_records() {
 #[should_panic(expected = "no `.accessor")]
 fn flatten_output_field_unknown_accessor_panics() {
     let _ = PtrClassDecl::new(syn::parse_quote!(ZThing))
-        .accessor(syn::parse_quote!(z_thing_name), "name")
+        .accessor(crate::ident!(z_thing_name), "name")
         // References a name that was never declared via `.accessor`.
         .flatten_output(FlattenOutput::new().field("size"));
 }
@@ -262,17 +262,17 @@ fn method_constructor_and_inline_field_self() {
         PackageDecl::new("thing")
             .class(
                 PtrClassDecl::new(syn::parse_quote!(ZThing))
-                    .accessor(syn::parse_quote!(z_thing_name), "name")
+                    .accessor(crate::ident!(z_thing_name), "name")
                     // A method: `&ZThing` receiver + a `name: String` param.
-                    .method(syn::parse_quote!(z_thing_rename), "rename")
+                    .method(crate::ident!(z_thing_rename), "rename")
                     // A constructor: factory returning ZThing.
-                    .constructor(syn::parse_quote!(z_thing_make), "make"),
+                    .constructor(crate::ident!(z_thing_make), "make"),
             )
             // A free fn whose per-fn inline output decomposes to (handle, name).
             .fun(FunctionDecl::new(syn::parse_quote!(z_get)).flatten_output_with(
                 FunctionFlattenOutput::new()
                     .field_self()
-                    .field(syn::parse_quote!(z_thing_name), "name"),
+                    .field(crate::ident!(z_thing_name), "name"),
             )),
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Two fns returning the same type under different output decompositions:
-/// the default one and a per-fn `.default_return_field(...)` inline field list.
+/// the default one and a per-fn `.default_return_expand(...)` inline field list.
 /// Each gets its own builder interface.
 #[test]
 fn inline_output_gets_own_builder() {
@@ -220,7 +220,7 @@ fn error_unwrap_universal_records() {
 /// signature, its handle locked) while keeping the non-receiver params; the
 /// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
 /// companion-object factory returning the class. Per-fn
-/// `.default_return_field_self()` emits the handle leaf.
+/// `.default_return_expand_self()` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
     use crate::SourceLocation;

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -28,7 +28,7 @@ fn inline_output_gets_own_builder() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("thing")
+        crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
                     .accessor(crate::fun!(z_thing_name).name("name"))
@@ -121,7 +121,7 @@ fn error_unwrap_universal_records() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("errors")
+        crate::package!("errors")
             .class(
                 crate::ptr_class!(ZDetail)
                     .accessor(crate::fun!(z_detail_code).name("code"))
@@ -259,7 +259,7 @@ fn method_constructor_and_inline_field_self() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("thing")
+        crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
                     .accessor(crate::fun!(z_thing_name).name("name"))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -30,21 +30,21 @@ fn inline_output_gets_own_builder() {
     .package(
         PackageDecl::new("thing")
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZThing))
-                    .accessor(crate::ident!(z_thing_name), "name")
-                    .accessor(crate::ident!(z_thing_size), "size")
+                crate::ptr_class!(ZThing)
+                    .accessor(crate::fun!(z_thing_name).name("name"))
+                    .accessor(crate::fun!(z_thing_size).name("size"))
                     // Default output: name + size (2 leaves ⇒ builder callback).
-                    .flatten_output(FlattenOutput::new().field("name").field("size")),
+                    .flatten_output(crate::flatten_output!().field("name").field("size")),
             )
-            .fun(FunctionDecl::new(syn::parse_quote!(z_make_a)))
+            .fun(crate::fun!(z_make_a))
             // Per-fn inline fields: name + size + name again (different shape). The
             // third field reuses the `z_thing_name` accessor but must carry a
             // distinct (literal) leaf name — duplicate names are a hard error.
-            .fun(FunctionDecl::new(syn::parse_quote!(z_make_b)).flatten_output_with(
-                FunctionFlattenOutput::new()
-                    .field(crate::ident!(z_thing_name), "name")
-                    .field(crate::ident!(z_thing_size), "size")
-                    .field(crate::ident!(z_thing_name), "name2"),
+            .fun(crate::fun!(z_make_b).flatten_output_with(
+                crate::function_flatten_output!()
+                    .field(crate::fun!(z_thing_name).name("name"))
+                    .field(crate::fun!(z_thing_size).name("size"))
+                    .field(crate::fun!(z_thing_name).name("name2")),
             )),
     );
 
@@ -123,24 +123,24 @@ fn error_unwrap_universal_records() {
     .package(
         PackageDecl::new("errors")
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZDetail))
-                    .accessor(crate::ident!(z_detail_code), "code")
-                    .flatten_output(FlattenOutput::new().field("code")),
+                crate::ptr_class!(ZDetail)
+                    .accessor(crate::fun!(z_detail_code).name("code"))
+                    .flatten_output(crate::flatten_output!().field("code")),
             )
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZErr))
-                    .accessor(crate::ident!(z_err_message), "message")
-                    .accessor(crate::ident!(z_err_detail), "detail")
+                crate::ptr_class!(ZErr)
+                    .accessor(crate::fun!(z_err_message).name("message"))
+                    .accessor(crate::fun!(z_err_detail).name("detail"))
                     // Canonical error decomposition: the owned error handle itself,
                     // its message, and the Option-nested detail spliced to its code leaf.
                     .flatten_output(
-                        FlattenOutput::new()
+                        crate::flatten_output!()
                             .field_self()
                             .field("message")
                             .field("detail"),
                     ),
             )
-            .fun(FunctionDecl::new(syn::parse_quote!(z_fallible))),
+            .fun(crate::fun!(z_fallible)),
     );
 
     let dir = unique_test_dir("jnigen_err_universal");
@@ -223,10 +223,10 @@ fn error_unwrap_universal_records() {
 #[test]
 #[should_panic(expected = "no `.accessor")]
 fn flatten_output_field_unknown_accessor_panics() {
-    let _ = PtrClassDecl::new(syn::parse_quote!(ZThing))
-        .accessor(crate::ident!(z_thing_name), "name")
+    let _ = crate::ptr_class!(ZThing)
+        .accessor(crate::fun!(z_thing_name).name("name"))
         // References a name that was never declared via `.accessor`.
-        .flatten_output(FlattenOutput::new().field("size"));
+        .flatten_output(crate::flatten_output!().field("size"));
 }
 
 /// `.method(f, name)` binds the `&Class` receiver to `this` (dropped from the
@@ -261,18 +261,18 @@ fn method_constructor_and_inline_field_self() {
     .package(
         PackageDecl::new("thing")
             .class(
-                PtrClassDecl::new(syn::parse_quote!(ZThing))
-                    .accessor(crate::ident!(z_thing_name), "name")
+                crate::ptr_class!(ZThing)
+                    .accessor(crate::fun!(z_thing_name).name("name"))
                     // A method: `&ZThing` receiver + a `name: String` param.
-                    .method(crate::ident!(z_thing_rename), "rename")
+                    .method(crate::fun!(z_thing_rename).name("rename"))
                     // A constructor: factory returning ZThing.
-                    .constructor(crate::ident!(z_thing_make), "make"),
+                    .constructor(crate::fun!(z_thing_make).name("make")),
             )
             // A free fn whose per-fn inline output decomposes to (handle, name).
-            .fun(FunctionDecl::new(syn::parse_quote!(z_get)).flatten_output_with(
-                FunctionFlattenOutput::new()
+            .fun(crate::fun!(z_get).flatten_output_with(
+                crate::function_flatten_output!()
                     .field_self()
-                    .field(crate::ident!(z_thing_name), "name"),
+                    .field(crate::fun!(z_thing_name).name("name")),
             )),
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Two fns returning the same type under different output decompositions:
-/// the default one and a per-fn `.flatten_output_with(...)` inline field list.
+/// the default one and a per-fn `.flatten_output(...)` inline field list.
 /// Each gets its own builder interface.
 #[test]
 fn inline_output_gets_own_builder() {
@@ -41,12 +41,12 @@ fn inline_output_gets_own_builder() {
             // Per-fn inline fields: name + size + name again (different shape). The
             // third field reuses the `z_thing_name` accessor but must carry a
             // distinct (literal) leaf name — duplicate names are a hard error.
-            .fun(crate::fun!(z_make_b).flatten_output_with(
-                crate::function_flatten_output!()
-                    .field(crate::fun!(z_thing_name).name("name"))
-                    .field(crate::fun!(z_thing_size).name("size"))
-                    .field(crate::fun!(z_thing_name).name("name2")),
-            )),
+            .fun(
+                crate::fun!(z_make_b)
+                    .flatten_output(crate::fun!(z_thing_name).name("name"))
+                    .flatten_output(crate::fun!(z_thing_size).name("size"))
+                    .flatten_output(crate::fun!(z_thing_name).name("name2")),
+            ),
     );
 
     let dir = unique_test_dir("jnigen_inline_out");
@@ -220,7 +220,7 @@ fn error_unwrap_universal_records() {
 /// signature, its handle locked) while keeping the non-receiver params; the
 /// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
 /// companion-object factory returning the class. Per-fn
-/// `.flatten_output_with().field_self()` emits the handle leaf.
+/// `.flatten_output_self()` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
     use crate::SourceLocation;
@@ -256,11 +256,11 @@ fn method_constructor_and_inline_field_self() {
                     .constructor(crate::fun!(z_thing_make).name("make")),
             )
             // A free fn whose per-fn inline output decomposes to (handle, name).
-            .fun(crate::fun!(z_get).flatten_output_with(
-                crate::function_flatten_output!()
-                    .field_self()
-                    .field(crate::fun!(z_thing_name).name("name")),
-            )),
+            .fun(
+                crate::fun!(z_get)
+                    .flatten_output_self()
+                    .flatten_output(crate::fun!(z_thing_name).name("name")),
+            ),
     );
 
     let dir = unique_test_dir("jnigen_method_ctor");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -22,32 +22,30 @@ fn inline_output_gets_own_builder() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("thing")
-            .class(
-                crate::ptr_class!(ZThing)
-                    .fun(crate::fun!(z_thing_name).name("name"))
-                    .fun(crate::fun!(z_thing_size).name("size"))
-                    // Default output: name + size (2 leaves ⇒ builder callback).
-                    .default_return_expand(crate::fun!(z_thing_name).name("name"))
-                    .default_return_expand(crate::fun!(z_thing_size).name("size")),
-            )
-            .fun(crate::fun!(z_make_a))
-            // Per-fn inline fields: name + size + name again (different shape). The
-            // third field reuses the `z_thing_name` accessor but must carry a
-            // distinct (literal) leaf name — duplicate names are a hard error.
-            .fun(
-                crate::fun!(z_make_b)
-                    .return_expand(crate::fun!(z_thing_name).name("name"))
-                    .return_expand(crate::fun!(z_thing_size).name("size"))
-                    .return_expand(crate::fun!(z_thing_name).name("name2")),
-            ),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(
+                    crate::ptr_class!(ZThing)
+                        .fun(crate::fun!(z_thing_name).name("name"))
+                        .fun(crate::fun!(z_thing_size).name("size"))
+                        // Default output: name + size (2 leaves ⇒ builder callback).
+                        .default_return_expand(crate::fun!(z_thing_name).name("name"))
+                        .default_return_expand(crate::fun!(z_thing_size).name("size")),
+                )
+                .fun(crate::fun!(z_make_a))
+                // Per-fn inline fields: name + size + name again (different shape). The
+                // third field reuses the `z_thing_name` accessor but must carry a
+                // distinct (literal) leaf name — duplicate names are a hard error.
+                .fun(
+                    crate::fun!(z_make_b)
+                        .return_expand(crate::fun!(z_thing_name).name("name"))
+                        .return_expand(crate::fun!(z_thing_size).name("size"))
+                        .return_expand(crate::fun!(z_thing_name).name("name2")),
+                ),
+        );
 
     let dir = unique_test_dir("jnigen_inline_out");
     let _ = std::fs::remove_dir_all(&dir);
@@ -116,30 +114,28 @@ fn error_unwrap_universal_records() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("errors")
-            .class(
-                crate::ptr_class!(ZDetail)
-                    .fun(crate::fun!(z_detail_code).name("code"))
-                    .default_return_expand(crate::fun!(z_detail_code).name("code")),
-            )
-            .class(
-                crate::ptr_class!(ZErr)
-                    .fun(crate::fun!(z_err_message).name("message"))
-                    .fun(crate::fun!(z_err_detail).name("detail"))
-                    // Canonical error decomposition: the owned error handle itself,
-                    // its message, and the Option-nested detail spliced to its code leaf.
-                    .default_return_expand_self()
-                    .default_return_expand(crate::fun!(z_err_message).name("message"))
-                    .default_return_expand(crate::fun!(z_err_detail).name("detail")),
-            )
-            .fun(crate::fun!(z_fallible)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("errors")
+                .class(
+                    crate::ptr_class!(ZDetail)
+                        .fun(crate::fun!(z_detail_code).name("code"))
+                        .default_return_expand(crate::fun!(z_detail_code).name("code")),
+                )
+                .class(
+                    crate::ptr_class!(ZErr)
+                        .fun(crate::fun!(z_err_message).name("message"))
+                        .fun(crate::fun!(z_err_detail).name("detail"))
+                        // Canonical error decomposition: the owned error handle itself,
+                        // its message, and the Option-nested detail spliced to its code leaf.
+                        .default_return_expand_self()
+                        .default_return_expand(crate::fun!(z_err_message).name("message"))
+                        .default_return_expand(crate::fun!(z_err_detail).name("detail")),
+                )
+                .fun(crate::fun!(z_fallible)),
+        );
 
     let dir = unique_test_dir("jnigen_err_universal");
     let _ = std::fs::remove_dir_all(&dir);
@@ -240,28 +236,26 @@ fn method_constructor_and_inline_field_self() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("thing")
-            .class(
-                crate::ptr_class!(ZThing)
-                    .fun(crate::fun!(z_thing_name).name("name"))
-                    // A fun with extra params: `&ZThing` receiver + a `name: String` param.
-                    .fun(crate::fun!(z_thing_rename).name("rename"))
-                    // A constructor: factory returning ZThing.
-                    .constructor(crate::fun!(z_thing_make).name("make")),
-            )
-            // A free fn whose per-fn inline output decomposes to (handle, name).
-            .fun(
-                crate::fun!(z_get)
-                    .return_expand_self()
-                    .return_expand(crate::fun!(z_thing_name).name("name")),
-            ),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(
+                    crate::ptr_class!(ZThing)
+                        .fun(crate::fun!(z_thing_name).name("name"))
+                        // A fun with extra params: `&ZThing` receiver + a `name: String` param.
+                        .fun(crate::fun!(z_thing_rename).name("rename"))
+                        // A constructor: factory returning ZThing.
+                        .constructor(crate::fun!(z_thing_make).name("make")),
+                )
+                // A free fn whose per-fn inline output decomposes to (handle, name).
+                .fun(
+                    crate::fun!(z_get)
+                        .return_expand_self()
+                        .return_expand(crate::fun!(z_thing_name).name("name")),
+                ),
+        );
 
     let dir = unique_test_dir("jnigen_method_ctor");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Two fns returning the same type under different output decompositions:
-/// the default one and a per-fn `.flatten_output(...)` inline field list.
+/// the default one and a per-fn `.default_return_field(...)` inline field list.
 /// Each gets its own builder interface.
 #[test]
 fn inline_output_gets_own_builder() {
@@ -34,8 +34,8 @@ fn inline_output_gets_own_builder() {
                     .fun(crate::fun!(z_thing_name).name("name"))
                     .fun(crate::fun!(z_thing_size).name("size"))
                     // Default output: name + size (2 leaves ⇒ builder callback).
-                    .flatten_output(crate::fun!(z_thing_name).name("name"))
-                    .flatten_output(crate::fun!(z_thing_size).name("size")),
+                    .default_return_field(crate::fun!(z_thing_name).name("name"))
+                    .default_return_field(crate::fun!(z_thing_size).name("size")),
             )
             .fun(crate::fun!(z_make_a))
             // Per-fn inline fields: name + size + name again (different shape). The
@@ -43,9 +43,9 @@ fn inline_output_gets_own_builder() {
             // distinct (literal) leaf name — duplicate names are a hard error.
             .fun(
                 crate::fun!(z_make_b)
-                    .flatten_output(crate::fun!(z_thing_name).name("name"))
-                    .flatten_output(crate::fun!(z_thing_size).name("size"))
-                    .flatten_output(crate::fun!(z_thing_name).name("name2")),
+                    .return_field(crate::fun!(z_thing_name).name("name"))
+                    .return_field(crate::fun!(z_thing_size).name("size"))
+                    .return_field(crate::fun!(z_thing_name).name("name2")),
             ),
     );
 
@@ -126,7 +126,7 @@ fn error_unwrap_universal_records() {
             .class(
                 crate::ptr_class!(ZDetail)
                     .fun(crate::fun!(z_detail_code).name("code"))
-                    .flatten_output(crate::fun!(z_detail_code).name("code")),
+                    .default_return_field(crate::fun!(z_detail_code).name("code")),
             )
             .class(
                 crate::ptr_class!(ZErr)
@@ -134,9 +134,9 @@ fn error_unwrap_universal_records() {
                     .fun(crate::fun!(z_err_detail).name("detail"))
                     // Canonical error decomposition: the owned error handle itself,
                     // its message, and the Option-nested detail spliced to its code leaf.
-                    .flatten_output_self()
-                    .flatten_output(crate::fun!(z_err_message).name("message"))
-                    .flatten_output(crate::fun!(z_err_detail).name("detail")),
+                    .default_return_field_self()
+                    .default_return_field(crate::fun!(z_err_message).name("message"))
+                    .default_return_field(crate::fun!(z_err_detail).name("detail")),
             )
             .fun(crate::fun!(z_fallible)),
     );
@@ -220,7 +220,7 @@ fn error_unwrap_universal_records() {
 /// signature, its handle locked) while keeping the non-receiver params; the
 /// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
 /// companion-object factory returning the class. Per-fn
-/// `.flatten_output_self()` emits the handle leaf.
+/// `.default_return_field_self()` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
     use crate::SourceLocation;
@@ -258,8 +258,8 @@ fn method_constructor_and_inline_field_self() {
             // A free fn whose per-fn inline output decomposes to (handle, name).
             .fun(
                 crate::fun!(z_get)
-                    .flatten_output_self()
-                    .flatten_output(crate::fun!(z_thing_name).name("name")),
+                    .return_field_self()
+                    .return_field(crate::fun!(z_thing_name).name("name")),
             ),
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -34,8 +34,8 @@ fn inline_output_gets_own_builder() {
                     .fun(crate::fun!(z_thing_name).name("name"))
                     .fun(crate::fun!(z_thing_size).name("size"))
                     // Default output: name + size (2 leaves ⇒ builder callback).
-                    .default_return_field(crate::fun!(z_thing_name).name("name"))
-                    .default_return_field(crate::fun!(z_thing_size).name("size")),
+                    .default_return_expand(crate::fun!(z_thing_name).name("name"))
+                    .default_return_expand(crate::fun!(z_thing_size).name("size")),
             )
             .fun(crate::fun!(z_make_a))
             // Per-fn inline fields: name + size + name again (different shape). The
@@ -43,9 +43,9 @@ fn inline_output_gets_own_builder() {
             // distinct (literal) leaf name — duplicate names are a hard error.
             .fun(
                 crate::fun!(z_make_b)
-                    .return_field(crate::fun!(z_thing_name).name("name"))
-                    .return_field(crate::fun!(z_thing_size).name("size"))
-                    .return_field(crate::fun!(z_thing_name).name("name2")),
+                    .return_expand(crate::fun!(z_thing_name).name("name"))
+                    .return_expand(crate::fun!(z_thing_size).name("size"))
+                    .return_expand(crate::fun!(z_thing_name).name("name2")),
             ),
     );
 
@@ -126,7 +126,7 @@ fn error_unwrap_universal_records() {
             .class(
                 crate::ptr_class!(ZDetail)
                     .fun(crate::fun!(z_detail_code).name("code"))
-                    .default_return_field(crate::fun!(z_detail_code).name("code")),
+                    .default_return_expand(crate::fun!(z_detail_code).name("code")),
             )
             .class(
                 crate::ptr_class!(ZErr)
@@ -134,9 +134,9 @@ fn error_unwrap_universal_records() {
                     .fun(crate::fun!(z_err_detail).name("detail"))
                     // Canonical error decomposition: the owned error handle itself,
                     // its message, and the Option-nested detail spliced to its code leaf.
-                    .default_return_field_self()
-                    .default_return_field(crate::fun!(z_err_message).name("message"))
-                    .default_return_field(crate::fun!(z_err_detail).name("detail")),
+                    .default_return_expand_self()
+                    .default_return_expand(crate::fun!(z_err_message).name("message"))
+                    .default_return_expand(crate::fun!(z_err_detail).name("detail")),
             )
             .fun(crate::fun!(z_fallible)),
     );
@@ -258,8 +258,8 @@ fn method_constructor_and_inline_field_self() {
             // A free fn whose per-fn inline output decomposes to (handle, name).
             .fun(
                 crate::fun!(z_get)
-                    .return_field_self()
-                    .return_field(crate::fun!(z_thing_name).name("name")),
+                    .return_expand_self()
+                    .return_expand(crate::fun!(z_thing_name).name("name")),
             ),
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -45,22 +45,20 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!()
-            .class(crate::data_class!(Error))
-            .class(crate::ptr_class!(ZThing))
-            .class(crate::enum_class!(Color)),
-    )
-    .package(
-        crate::package!("thing")
-            .fun(crate::fun!(z_thing_new))
-            .fun(crate::fun!(z_thing_name)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Error))
+                .class(crate::ptr_class!(ZThing))
+                .class(crate::enum_class!(Color)),
+        )
+        .package(
+            crate::package!("thing")
+                .fun(crate::fun!(z_thing_new))
+                .fun(crate::fun!(z_thing_name)),
+        );
 
     let dir = unique_test_dir("jnigen_snap");
     let _ = std::fs::remove_dir_all(&dir);
@@ -226,17 +224,15 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("payload")
-            .class(crate::data_class!(Payload))
-            .fun(crate::fun!(payload_get))
-            .fun(crate::fun!(payload_put)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("payload")
+                .class(crate::data_class!(Payload))
+                .fun(crate::fun!(payload_get))
+                .fun(crate::fun!(payload_put)),
+        );
 
     let dir = unique_test_dir("jnigen_boxstr");
     let _ = std::fs::remove_dir_all(&dir);
@@ -309,17 +305,15 @@ fn slice_input_builds_vec_handle() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("foo")
-            .class(crate::data_class!(Foo))
-            .fun(crate::fun!(put_slice))
-            .fun(crate::fun!(put_vec)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("foo")
+                .class(crate::data_class!(Foo))
+                .fun(crate::fun!(put_slice))
+                .fun(crate::fun!(put_vec)),
+        );
 
     let dir = unique_test_dir("jnigen_slice_vec_handle");
     let _ = std::fs::remove_dir_all(&dir);
@@ -390,7 +384,7 @@ fn slice_input_builds_vec_handle() {
     );
 }
 
-/// `.jni_native_init(code)` injects an `init { code }` block into the generated
+/// `.set_jni_native_init(code)` injects an `init { code }` block into the generated
 /// centralized externs object (`JNINative`) — the single static-init point a
 /// consumer uses to trigger native-library loading. Unset (the `snapshot_*`
 /// tests) emits no init block.
@@ -408,13 +402,11 @@ fn jni_native_init_emits_init_block() {
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni")
-            .jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()"),
-    )
-    .package(crate::package!("thing").fun(crate::fun!(z_ping)));
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .set_jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()")
+        .package(crate::package!("thing").fun(crate::fun!(z_ping)));
 
     let dir = unique_test_dir("jnigen_native_init");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -45,15 +45,22 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .data_class(syn::parse_quote!(Error))
-        .ptr_class(syn::parse_quote!(ZThing))
-        .enum_class(syn::parse_quote!(Color))
-        .package("thing")
-        .fun(syn::parse_quote!(z_thing_new))
-        .fun(syn::parse_quote!(z_thing_name));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("")
+            .class(DataClassDecl::new(syn::parse_quote!(Error)))
+            .class(PtrClassDecl::new(syn::parse_quote!(ZThing)))
+            .class(EnumClassDecl::new(syn::parse_quote!(Color))),
+    )
+    .package(
+        PackageDecl::new("thing")
+            .fun(FunctionDecl::new(syn::parse_quote!(z_thing_new)))
+            .fun(FunctionDecl::new(syn::parse_quote!(z_thing_name))),
+    );
 
     let dir = unique_test_dir("jnigen_snap");
     let _ = std::fs::remove_dir_all(&dir);
@@ -219,13 +226,17 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .data_class(syn::parse_quote!(Payload))
-        .package("payload")
-        .fun(syn::parse_quote!(payload_get))
-        .fun(syn::parse_quote!(payload_put));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("payload")
+            .class(DataClassDecl::new(syn::parse_quote!(Payload)))
+            .fun(FunctionDecl::new(syn::parse_quote!(payload_get)))
+            .fun(FunctionDecl::new(syn::parse_quote!(payload_put))),
+    );
 
     let dir = unique_test_dir("jnigen_boxstr");
     let _ = std::fs::remove_dir_all(&dir);
@@ -298,13 +309,17 @@ fn slice_input_builds_vec_handle() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .data_class(syn::parse_quote!(Foo))
-        .package("foo")
-        .fun(syn::parse_quote!(put_slice))
-        .fun(syn::parse_quote!(put_vec));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("foo")
+            .class(DataClassDecl::new(syn::parse_quote!(Foo)))
+            .fun(FunctionDecl::new(syn::parse_quote!(put_slice)))
+            .fun(FunctionDecl::new(syn::parse_quote!(put_vec))),
+    );
 
     let dir = unique_test_dir("jnigen_slice_vec_handle");
     let _ = std::fs::remove_dir_all(&dir);
@@ -393,12 +408,13 @@ fn jni_native_init_emits_init_block() {
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()")
-        .package("thing")
-        .fun(syn::parse_quote!(z_ping));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni")
+            .jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()"),
+    )
+    .package(PackageDecl::new("thing").fun(FunctionDecl::new(syn::parse_quote!(z_ping))));
 
     let dir = unique_test_dir("jnigen_native_init");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -52,14 +52,14 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
     )
     .package(
         PackageDecl::new("")
-            .class(DataClassDecl::new(syn::parse_quote!(Error)))
-            .class(PtrClassDecl::new(syn::parse_quote!(ZThing)))
-            .class(EnumClassDecl::new(syn::parse_quote!(Color))),
+            .class(crate::data_class!(Error))
+            .class(crate::ptr_class!(ZThing))
+            .class(crate::enum_class!(Color)),
     )
     .package(
         PackageDecl::new("thing")
-            .fun(FunctionDecl::new(syn::parse_quote!(z_thing_new)))
-            .fun(FunctionDecl::new(syn::parse_quote!(z_thing_name))),
+            .fun(crate::fun!(z_thing_new))
+            .fun(crate::fun!(z_thing_name)),
     );
 
     let dir = unique_test_dir("jnigen_snap");
@@ -233,9 +233,9 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
     )
     .package(
         PackageDecl::new("payload")
-            .class(DataClassDecl::new(syn::parse_quote!(Payload)))
-            .fun(FunctionDecl::new(syn::parse_quote!(payload_get)))
-            .fun(FunctionDecl::new(syn::parse_quote!(payload_put))),
+            .class(crate::data_class!(Payload))
+            .fun(crate::fun!(payload_get))
+            .fun(crate::fun!(payload_put)),
     );
 
     let dir = unique_test_dir("jnigen_boxstr");
@@ -316,9 +316,9 @@ fn slice_input_builds_vec_handle() {
     )
     .package(
         PackageDecl::new("foo")
-            .class(DataClassDecl::new(syn::parse_quote!(Foo)))
-            .fun(FunctionDecl::new(syn::parse_quote!(put_slice)))
-            .fun(FunctionDecl::new(syn::parse_quote!(put_vec))),
+            .class(crate::data_class!(Foo))
+            .fun(crate::fun!(put_slice))
+            .fun(crate::fun!(put_vec)),
     );
 
     let dir = unique_test_dir("jnigen_slice_vec_handle");
@@ -414,7 +414,7 @@ fn jni_native_init_emits_init_block() {
             .package_prefix("io.test.jni")
             .jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()"),
     )
-    .package(PackageDecl::new("thing").fun(FunctionDecl::new(syn::parse_quote!(z_ping))));
+    .package(PackageDecl::new("thing").fun(crate::fun!(z_ping)));
 
     let dir = unique_test_dir("jnigen_native_init");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -51,13 +51,13 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("")
+        crate::package!()
             .class(crate::data_class!(Error))
             .class(crate::ptr_class!(ZThing))
             .class(crate::enum_class!(Color)),
     )
     .package(
-        PackageDecl::new("thing")
+        crate::package!("thing")
             .fun(crate::fun!(z_thing_new))
             .fun(crate::fun!(z_thing_name)),
     );
@@ -232,7 +232,7 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("payload")
+        crate::package!("payload")
             .class(crate::data_class!(Payload))
             .fun(crate::fun!(payload_get))
             .fun(crate::fun!(payload_put)),
@@ -315,7 +315,7 @@ fn slice_input_builds_vec_handle() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("foo")
+        crate::package!("foo")
             .class(crate::data_class!(Foo))
             .fun(crate::fun!(put_slice))
             .fun(crate::fun!(put_vec)),
@@ -414,7 +414,7 @@ fn jni_native_init_emits_init_block() {
             .package_prefix("io.test.jni")
             .jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()"),
     )
-    .package(PackageDecl::new("thing").fun(crate::fun!(z_ping)));
+    .package(crate::package!("thing").fun(crate::fun!(z_ping)));
 
     let dir = unique_test_dir("jnigen_native_init");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -32,13 +32,11 @@ fn option_scalar_param_crosses_as_present_value_pair() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(crate::package!().class(crate::enum_class!(Mode)))
-    .package(crate::package!("cfg").fun(crate::fun!(z_set_timeout)));
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().class(crate::enum_class!(Mode)))
+        .package(crate::package!("cfg").fun(crate::fun!(z_set_timeout)));
 
     let dir = unique_test_dir("jnigen_optscalar");
     let _ = std::fs::remove_dir_all(&dir);
@@ -134,17 +132,15 @@ fn vec_of_handle_output_folds_kotlin_side() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("thing")
-            .class(crate::ptr_class!(ZThing))
-            .fun(crate::fun!(thing_list))
-            .fun(crate::fun!(thing_list_opt)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(crate::ptr_class!(ZThing))
+                .fun(crate::fun!(thing_list))
+                .fun(crate::fun!(thing_list_opt)),
+        );
 
     let dir = unique_test_dir("jnigen_vec_handle_out");
     let _ = std::fs::remove_dir_all(&dir);
@@ -219,16 +215,14 @@ fn option_scalar_struct_field_flattens() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!()
-            .class(crate::data_class!(Opts))
-            .fun(crate::fun!(opts_put)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Opts))
+                .fun(crate::fun!(opts_put)),
+        );
 
     let dir = unique_test_dir("jnigen_optfield");
     let _ = std::fs::remove_dir_all(&dir);
@@ -342,22 +336,20 @@ fn fromparts_fallback_boxes_option_fields() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .package(
-        crate::package!("model")
-            .class(crate::enum_class!(Level))
-            .class(crate::data_class!(Inner))
-            .class(crate::data_class!(Job)),
-    )
-    .package(
-        crate::package!("job")
-            .fun(crate::fun!(job_make))
-            .fun(crate::fun!(job_mode)),
-    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("model")
+                .class(crate::enum_class!(Level))
+                .class(crate::data_class!(Inner))
+                .class(crate::data_class!(Job)),
+        )
+        .package(
+            crate::package!("job")
+                .fun(crate::fun!(job_make))
+                .fun(crate::fun!(job_mode)),
+        );
 
     let dir = unique_test_dir("jnigen_fromparts_optbox");
     let _ = std::fs::remove_dir_all(&dir);
@@ -439,16 +431,14 @@ fn output_only_wrapper_resolves_without_input_twin() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new(
-        JniGenConfig::new()
-            .source_module(syn::parse_quote!(myflat))
-            .package_prefix("io.test.jni"),
-    )
-    .scalar_type_wrapper(
-        crate::scalar_type_wrapper!(Len, jni::sys::jlong, "Long")
-            .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
-    )
-    .package(crate::package!("len").fun(crate::fun!(len_of)));
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .scalar_type_wrapper(
+            crate::scalar_type_wrapper!(Len, jni::sys::jlong, "Long")
+                .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
+        )
+        .package(crate::package!("len").fun(crate::fun!(len_of)));
     let dir = unique_test_dir("jnigen_outonly_wrapper");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -413,7 +413,7 @@ fn fromparts_fallback_boxes_option_fields() {
     assert!(kc.contains("?.let{Level.fromInt(it)}"), "{kotlin}");
 }
 
-/// An output-only wrapper type must resolve with only its `.output()`
+/// An output-only wrapper type must resolve with only its `.on_return()`
 /// registered: wrapper registrations are required per USAGE direction, unlike
 /// the four class declarators (always both). Regression: registering the
 /// wrapper used to add the type to `declared_types`, and the scan blanket-

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -436,7 +436,7 @@ fn output_only_wrapper_resolves_without_input_twin() {
         .set_package_prefix("io.test.jni")
         .scalar_type_wrapper(
             crate::scalar_type_wrapper!(Len, jni::sys::jlong, "Long")
-                .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
+                .on_return(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
         )
         .package(crate::package!("len").fun(crate::fun!(len_of)));
     let dir = unique_test_dir("jnigen_outonly_wrapper");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -37,8 +37,8 @@ fn option_scalar_param_crosses_as_present_value_pair() {
             .source_module(syn::parse_quote!(myflat))
             .package_prefix("io.test.jni"),
     )
-    .package(PackageDecl::new("").class(EnumClassDecl::new(syn::parse_quote!(Mode))))
-    .package(PackageDecl::new("cfg").fun(FunctionDecl::new(syn::parse_quote!(z_set_timeout))));
+    .package(PackageDecl::new("").class(crate::enum_class!(Mode)))
+    .package(PackageDecl::new("cfg").fun(crate::fun!(z_set_timeout)));
 
     let dir = unique_test_dir("jnigen_optscalar");
     let _ = std::fs::remove_dir_all(&dir);
@@ -141,9 +141,9 @@ fn vec_of_handle_output_folds_kotlin_side() {
     )
     .package(
         PackageDecl::new("thing")
-            .class(PtrClassDecl::new(syn::parse_quote!(ZThing)))
-            .fun(FunctionDecl::new(syn::parse_quote!(thing_list)))
-            .fun(FunctionDecl::new(syn::parse_quote!(thing_list_opt))),
+            .class(crate::ptr_class!(ZThing))
+            .fun(crate::fun!(thing_list))
+            .fun(crate::fun!(thing_list_opt)),
     );
 
     let dir = unique_test_dir("jnigen_vec_handle_out");
@@ -226,8 +226,8 @@ fn option_scalar_struct_field_flattens() {
     )
     .package(
         PackageDecl::new("")
-            .class(DataClassDecl::new(syn::parse_quote!(Opts)))
-            .fun(FunctionDecl::new(syn::parse_quote!(opts_put))),
+            .class(crate::data_class!(Opts))
+            .fun(crate::fun!(opts_put)),
     );
 
     let dir = unique_test_dir("jnigen_optfield");
@@ -349,14 +349,14 @@ fn fromparts_fallback_boxes_option_fields() {
     )
     .package(
         PackageDecl::new("model")
-            .class(EnumClassDecl::new(syn::parse_quote!(Level)))
-            .class(DataClassDecl::new(syn::parse_quote!(Inner)))
-            .class(DataClassDecl::new(syn::parse_quote!(Job))),
+            .class(crate::enum_class!(Level))
+            .class(crate::data_class!(Inner))
+            .class(crate::data_class!(Job)),
     )
     .package(
         PackageDecl::new("job")
-            .fun(FunctionDecl::new(syn::parse_quote!(job_make)))
-            .fun(FunctionDecl::new(syn::parse_quote!(job_mode))),
+            .fun(crate::fun!(job_make))
+            .fun(crate::fun!(job_mode)),
     );
 
     let dir = unique_test_dir("jnigen_fromparts_optbox");
@@ -452,7 +452,7 @@ fn output_only_wrapper_resolves_without_input_twin() {
         )
         .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
     )
-    .package(PackageDecl::new("len").fun(FunctionDecl::new(syn::parse_quote!(len_of))));
+    .package(PackageDecl::new("len").fun(crate::fun!(len_of)));
     let dir = unique_test_dir("jnigen_outonly_wrapper");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -32,12 +32,13 @@ fn option_scalar_param_crosses_as_present_value_pair() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .enum_class(syn::parse_quote!(Mode))
-        .package("cfg")
-        .fun(syn::parse_quote!(z_set_timeout));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(PackageDecl::new("").class(EnumClassDecl::new(syn::parse_quote!(Mode))))
+    .package(PackageDecl::new("cfg").fun(FunctionDecl::new(syn::parse_quote!(z_set_timeout))));
 
     let dir = unique_test_dir("jnigen_optscalar");
     let _ = std::fs::remove_dir_all(&dir);
@@ -133,13 +134,17 @@ fn vec_of_handle_output_folds_kotlin_side() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .ptr_class(syn::parse_quote!(ZThing))
-        .package("thing")
-        .fun(syn::parse_quote!(thing_list))
-        .fun(syn::parse_quote!(thing_list_opt));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("thing")
+            .class(PtrClassDecl::new(syn::parse_quote!(ZThing)))
+            .fun(FunctionDecl::new(syn::parse_quote!(thing_list)))
+            .fun(FunctionDecl::new(syn::parse_quote!(thing_list_opt))),
+    );
 
     let dir = unique_test_dir("jnigen_vec_handle_out");
     let _ = std::fs::remove_dir_all(&dir);
@@ -214,12 +219,16 @@ fn option_scalar_struct_field_flattens() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .data_class(syn::parse_quote!(Opts))
-        .package("opts")
-        .fun(syn::parse_quote!(opts_put));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("")
+            .class(DataClassDecl::new(syn::parse_quote!(Opts)))
+            .fun(FunctionDecl::new(syn::parse_quote!(opts_put))),
+    );
 
     let dir = unique_test_dir("jnigen_optfield");
     let _ = std::fs::remove_dir_all(&dir);
@@ -333,16 +342,22 @@ fn fromparts_fallback_boxes_option_fields() {
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .package("model")
-        .enum_class(syn::parse_quote!(Level))
-        .data_class(syn::parse_quote!(Inner))
-        .data_class(syn::parse_quote!(Job))
-        .package("job")
-        .fun(syn::parse_quote!(job_make))
-        .fun(syn::parse_quote!(job_mode));
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .package(
+        PackageDecl::new("model")
+            .class(EnumClassDecl::new(syn::parse_quote!(Level)))
+            .class(DataClassDecl::new(syn::parse_quote!(Inner)))
+            .class(DataClassDecl::new(syn::parse_quote!(Job))),
+    )
+    .package(
+        PackageDecl::new("job")
+            .fun(FunctionDecl::new(syn::parse_quote!(job_make)))
+            .fun(FunctionDecl::new(syn::parse_quote!(job_mode))),
+    );
 
     let dir = unique_test_dir("jnigen_fromparts_optbox");
     let _ = std::fs::remove_dir_all(&dir);
@@ -406,7 +421,7 @@ fn fromparts_fallback_boxes_option_fields() {
     assert!(kc.contains("?.let{Level.fromInt(it)}"), "{kotlin}");
 }
 
-/// An output-only wrapper type must resolve with only its `output_wrapper`
+/// An output-only wrapper type must resolve with only its `.output()`
 /// registered: wrapper registrations are required per USAGE direction, unlike
 /// the four class declarators (always both). Regression: registering the
 /// wrapper used to add the type to `declared_types`, and the scan blanket-
@@ -424,22 +439,20 @@ fn output_only_wrapper_resolves_without_input_twin() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .source_module(syn::parse_quote!(myflat))
-        .package_prefix("io.test.jni")
-        .output_wrapper(
+    let jni = JniGen::new(
+        JniGenConfig::new()
+            .source_module(syn::parse_quote!(myflat))
+            .package_prefix("io.test.jni"),
+    )
+    .scalar_type_wrapper(
+        ScalarTypeWrapperDecl::new(
             syn::parse_quote!(Len),
-            |_r: &Registry<KotlinMeta>| -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
-                Some((
-                    syn::parse_quote!(jni::sys::jlong),
-                    None,
-                    syn::parse_quote!(v.0 as jni::sys::jlong),
-                ))
-            },
+            syn::parse_quote!(jni::sys::jlong),
+            "Long",
         )
-        .kotlin_type("Long")
-        .package("len")
-        .fun(syn::parse_quote!(len_of));
+        .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
+    )
+    .package(PackageDecl::new("len").fun(FunctionDecl::new(syn::parse_quote!(len_of))));
     let dir = unique_test_dir("jnigen_outonly_wrapper");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -37,8 +37,8 @@ fn option_scalar_param_crosses_as_present_value_pair() {
             .source_module(syn::parse_quote!(myflat))
             .package_prefix("io.test.jni"),
     )
-    .package(PackageDecl::new("").class(crate::enum_class!(Mode)))
-    .package(PackageDecl::new("cfg").fun(crate::fun!(z_set_timeout)));
+    .package(crate::package!().class(crate::enum_class!(Mode)))
+    .package(crate::package!("cfg").fun(crate::fun!(z_set_timeout)));
 
     let dir = unique_test_dir("jnigen_optscalar");
     let _ = std::fs::remove_dir_all(&dir);
@@ -140,7 +140,7 @@ fn vec_of_handle_output_folds_kotlin_side() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("thing")
+        crate::package!("thing")
             .class(crate::ptr_class!(ZThing))
             .fun(crate::fun!(thing_list))
             .fun(crate::fun!(thing_list_opt)),
@@ -225,7 +225,7 @@ fn option_scalar_struct_field_flattens() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("")
+        crate::package!()
             .class(crate::data_class!(Opts))
             .fun(crate::fun!(opts_put)),
     );
@@ -348,13 +348,13 @@ fn fromparts_fallback_boxes_option_fields() {
             .package_prefix("io.test.jni"),
     )
     .package(
-        PackageDecl::new("model")
+        crate::package!("model")
             .class(crate::enum_class!(Level))
             .class(crate::data_class!(Inner))
             .class(crate::data_class!(Job)),
     )
     .package(
-        PackageDecl::new("job")
+        crate::package!("job")
             .fun(crate::fun!(job_make))
             .fun(crate::fun!(job_mode)),
     );
@@ -445,14 +445,10 @@ fn output_only_wrapper_resolves_without_input_twin() {
             .package_prefix("io.test.jni"),
     )
     .scalar_type_wrapper(
-        ScalarTypeWrapperDecl::new(
-            syn::parse_quote!(Len),
-            syn::parse_quote!(jni::sys::jlong),
-            "Long",
-        )
-        .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
+        crate::scalar_type_wrapper!(Len, jni::sys::jlong, "Long")
+            .output(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
     )
-    .package(PackageDecl::new("len").fun(crate::fun!(len_of)));
+    .package(crate::package!("len").fun(crate::fun!(len_of)));
     let dir = unique_test_dir("jnigen_outonly_wrapper");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -245,12 +245,12 @@ impl JniGen {
         let key = TypeKey::from_type(outer_ty);
         if let Some(cfg) = self.types.get(&key) {
             // Opaque-handle entries keep their typed FQN in
-            // `kotlin_name` for FQN-consumers, but the value-context
+            // `name_spec` for FQN-consumers, but the value-context
             // name is `"Long"` (set on the rank-0 handler's metadata).
             // Don't let that FQN leak into a wrapper's metadata.
             if cfg.opaque.is_none() {
-                if let Some(name) = &cfg.kotlin_name {
-                    return Some(kt::KtType::cls(name.clone()));
+                if let Some(spec) = &cfg.name_spec {
+                    return Some(kt::KtType::cls(self.fqn_of(spec)));
                 }
             }
         }
@@ -437,21 +437,21 @@ pub(crate) fn build_handle_destructor_items(
         if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
             continue;
         }
-        let class_short = cfg
-            .kotlin_name
-            .as_deref()
-            .and_then(|fqn| fqn.rsplit('.').next())
+        let class_fqn = cfg
+            .name_spec
+            .as_ref()
+            .map(|s| ext.fqn_of(s))
             .unwrap_or_else(|| {
                 panic!(
                     "build_handle_destructor_items: opaque handle `{}` has no \
-                     kotlin_name to derive a destructor symbol from",
+                     name spec to derive a destructor symbol from",
                     key.as_str()
                 )
             });
-        let class_pkg = cfg
-            .kotlin_name
-            .as_deref()
-            .and_then(|fqn| fqn.rsplit_once('.').map(|(pkg, _)| pkg))
+        let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
+        let class_pkg = class_fqn
+            .rsplit_once('.')
+            .map(|(pkg, _)| pkg)
             .unwrap_or("")
             .replace('.', "_");
         let symbol = if class_pkg.is_empty() {
@@ -835,7 +835,7 @@ impl Prebindgen for JniGen {
             // handle, an enum, nor a value blob.
             let is_data_class = matches!(
                 self.type_kind(registry, &source),
-                TypeKind::DataStruct { cfg: Some(c), .. } if c.kotlin_name.is_some()
+                TypeKind::DataStruct { cfg: Some(c), .. } if c.name_spec.is_some()
             );
             if !is_data_class {
                 continue;
@@ -1156,7 +1156,10 @@ impl JniGen {
                     if let Some((e, _)) = registry.enums.get(&name) {
                         let (wire, body) = enum_input_body(self, e);
                         let niches = default_niches_for_wire(&wire);
-                        let kotlin_name = cfg.kotlin_name.clone().map(kt::KtType::cls);
+                        let kotlin_name = cfg
+                            .name_spec
+                            .as_ref()
+                            .map(|s| kt::KtType::cls(self.fqn_of(s)));
                         return Some(ConverterImpl {
                             subs: vec![],
                             pre_stages: vec![],
@@ -1250,8 +1253,8 @@ impl JniGen {
                 let kotlin_name = self
                     .types
                     .get(&key)
-                    .and_then(|c| c.kotlin_name.clone())
-                    .map(kt::KtType::cls);
+                    .and_then(|c| c.name_spec.as_ref())
+                    .map(|s| kt::KtType::cls(self.fqn_of(s)));
                 return Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
@@ -1357,7 +1360,10 @@ impl JniGen {
                     if let Some((e, _)) = registry.enums.get(&name) {
                         let (wire, body) = enum_output_body(self, e);
                         let niches = default_niches_for_wire(&wire);
-                        let kotlin_name = cfg.kotlin_name.clone().map(kt::KtType::cls);
+                        let kotlin_name = cfg
+                            .name_spec
+                            .as_ref()
+                            .map(|s| kt::KtType::cls(self.fqn_of(s)));
                         return Some(ConverterImpl {
                             subs: vec![],
                             pre_stages: vec![],
@@ -1448,8 +1454,8 @@ impl JniGen {
                 let kotlin_name = self
                     .types
                     .get(&key)
-                    .and_then(|c| c.kotlin_name.clone())
-                    .map(kt::KtType::cls);
+                    .and_then(|c| c.name_spec.as_ref())
+                    .map(|s| kt::KtType::cls(self.fqn_of(s)));
                 return Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -930,8 +930,8 @@ impl Prebindgen for JniGen {
         out
     }
 
-    /// Functions ever referenced as a named leaf in a `.default_return_field(fun!(...))`/
-    /// `.return_field(...)` record — see
+    /// Functions ever referenced as a named leaf in a `.default_return_expand(fun!(...))`/
+    /// `.return_expand(...)` record — see
     /// `accessor_record_fns`'s doc (`jni/mod.rs`). Usage-derived, not tied to
     /// `.fun()` class-member declarations: a function need not also be
     /// exposed as an instance method to be referenced this way.

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -930,26 +930,23 @@ impl Prebindgen for JniGen {
         out
     }
 
-    /// Accessor members (`.accessor`) — emitted as class instance methods,
-    /// excluded from input-flattening, and the only functions a flatten field
-    /// may reference.
+    /// Functions ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
+    /// `.flatten_output_with(...).field(...)` record — see
+    /// `accessor_record_fns`'s doc (`jni/mod.rs`). Usage-derived, not tied to
+    /// `.fun()` class-member declarations: a function need not also be
+    /// exposed as an instance method to be referenced this way.
     fn accessor_functions(&self) -> std::collections::HashSet<syn::Ident> {
-        self.class_members
-            .values()
-            .flatten()
-            .filter(|m| m.kind == MemberKind::Accessor)
-            .map(|m| m.rust_ident.clone())
-            .collect()
+        self.accessor_record_fns.clone()
     }
 
-    /// Method members (`.method`) — their fn ident mapped to the owning class's
+    /// Fun members (`.fun`) — their fn ident mapped to the owning class's
     /// `TypeKey`, so input-flattening can skip the receiver parameter.
     fn method_receivers(&self) -> std::collections::HashMap<syn::Ident, TypeKey> {
         self.class_members
             .iter()
             .flat_map(|(key, ms)| {
                 ms.iter()
-                    .filter(|m| m.kind == MemberKind::Method)
+                    .filter(|m| m.kind == MemberKind::Fun)
                     .map(move |m| (m.rust_ident.clone(), key.clone()))
             })
             .collect()

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -11,7 +11,7 @@ use super::*;
 // and consuming-crate wrapper exts like ZenohJniExt).
 // ──────────────────────────────────────────────────────────────────────
 
-impl<S> JniGen<S> {
+impl JniGen {
     /// Build the standard JNI input-converter `fn`. Body assumes in-scope
     /// `env: &mut JNIEnv` and `v: &<wire>` (or `v: <wire>` for raw-pointer
     /// wires); produces a value of `rust`. Returned function has its name
@@ -422,7 +422,7 @@ pub(crate) fn build_signal_error_item() -> syn::Item {
 /// whose declare/undeclare fns are `#[cfg]`'d out of the scan) from
 /// producing destructors that reference types not in scope.
 pub(crate) fn build_handle_destructor_items(
-    ext: &JniGen<impl JniGenState>,
+    ext: &JniGen,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
     let free_ptr = ext.mangle_fun("freePtr");
@@ -486,7 +486,7 @@ pub(crate) fn build_handle_destructor_items(
 /// the two `Option<_>` sub-cases (direct-handle-by-value vs general), which
 /// share a pattern and so live together in [`JniGen::input_option`] to keep
 /// their original fall-through.
-impl<S: JniGenState> JniGen<S> {
+impl JniGen {
     /// `& _` / `& mut _` borrow: share T's resolved converter — `&T`'s entry
     /// points at the same `ItemFn` (the fn returns owned `T`; the call site in
     /// `emit_jni_function_wrapper` adds `&decoded`). Exists so the
@@ -771,7 +771,7 @@ impl<S: JniGenState> JniGen<S> {
 // Prebindgen impl
 // ──────────────────────────────────────────────────────────────────────
 
-impl<S: JniGenState> Prebindgen for JniGen<S> {
+impl Prebindgen for JniGen {
     /// Cross-language extras every JNI converter carries — currently
     /// the Kotlin value-context type name. Filled by the rank-N
     /// handlers at the same point they build the wire/body; the
@@ -1075,7 +1075,7 @@ impl<S: JniGenState> Prebindgen for JniGen<S> {
 /// Structural converter builders — the rank-0 terminal chains and the rank-1
 /// wrapper-shape handlers, now inherent helpers called by the structural
 /// [`Prebindgen::on_input_type`] / [`Prebindgen::on_output_type`].
-impl<S: JniGenState> JniGen<S> {
+impl JniGen {
     // ── Input converters ─────────────────────────────────────────────
 
     /// Whole-type **input** terminal categories (opaque handle, value-blob,

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -261,7 +261,7 @@ impl JniGen {
     /// for plugin wrapper exts that build `ConverterImpl::function`
     /// manually with a non-standard return type (e.g.
     /// `impl Into<…>` parameters that can't be expressed via
-    /// [`Self::input_wrapper`]'s fixed signature shape).
+    /// `input_wrapper_shape`'s fixed signature shape).
     pub fn input_converter_name(&self, rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
         input_name(rust, wire)
     }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -931,7 +931,7 @@ impl Prebindgen for JniGen {
     }
 
     /// Functions ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
-    /// `.flatten_output_with(...).field(...)` record — see
+    /// `.flatten_output(...).field(...)` record — see
     /// `accessor_record_fns`'s doc (`jni/mod.rs`). Usage-derived, not tied to
     /// `.fun()` class-member declarations: a function need not also be
     /// exposed as an instance method to be referenced this way.

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -930,8 +930,8 @@ impl Prebindgen for JniGen {
         out
     }
 
-    /// Functions ever referenced as a named leaf in a `.flatten_output(fun!(...))`/
-    /// `.flatten_output(...).field(...)` record — see
+    /// Functions ever referenced as a named leaf in a `.default_return_field(fun!(...))`/
+    /// `.return_field(...)` record — see
     /// `accessor_record_fns`'s doc (`jni/mod.rs`). Usage-derived, not tied to
     /// `.fun()` class-member declarations: a function need not also be
     /// exposed as an instance method to be referenced this way.

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -967,6 +967,17 @@ impl Prebindgen for JniGen {
             .collect()
     }
 
+    /// Fns acknowledged-but-unbound via [`JniGen::ignore_fun`] — suppresses
+    /// the registry's "skipping undeclared" warning, emits nothing.
+    fn ignored_functions(&self) -> std::collections::HashSet<syn::Ident> {
+        self.ignored_fns.clone()
+    }
+
+    /// Types acknowledged-but-undeclared via [`JniGen::ignore_class`].
+    fn ignored_types(&self) -> std::collections::HashSet<TypeKey> {
+        self.ignored_class_types.clone()
+    }
+
     /// Emit the `OwnedObject<T>` borrow wrapper used by
     /// [`Self::opaque_handle_input`] into the destination file.
     /// The struct is referenced by an unqualified `OwnedObject` from

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -22,9 +22,8 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FunctionDecl,
-    FunctionFlattenInputDecl, FunctionFlattenOutputDecl, GenericTypeWrapperDecl, JniBindingError,
-    JniGen, JniGenConfig, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
-    WireBody,
+    GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, PackageDecl, PtrClassDecl,
+    ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,10 +21,10 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FlattenInputDecl,
-    FlattenOutputDecl, FunctionDecl, FunctionFlattenInputDecl, FunctionFlattenOutputDecl,
-    GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, PackageDecl, PtrClassDecl,
-    ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
+    null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FunctionDecl,
+    FunctionFlattenInputDecl, FunctionFlattenOutputDecl, GenericTypeWrapperDecl, JniBindingError,
+    JniGen, JniGenConfig, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
+    WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,8 +21,8 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FlattenInput,
-    FlattenOutput, FunctionDecl, FunctionFlattenInput, FunctionFlattenOutput,
+    null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FlattenInputDecl,
+    FlattenOutputDecl, FunctionDecl, FunctionFlattenInputDecl, FunctionFlattenOutputDecl,
     GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, PackageDecl, PtrClassDecl,
     ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -22,7 +22,7 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FunctionDecl,
-    GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, PackageDecl, PtrClassDecl,
+    GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl,
     ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };
 

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,8 +21,10 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, EnumClass, Function, JniBindingError, JniGen, JniGenState,
-    Package, PackageState, PtrClass, Root, TypeDeclState, TypeKeyState, TypeMeta, WrapperNonMeta,
+    null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FlattenInput,
+    FlattenOutput, FunctionDecl, FunctionFlattenInput, FunctionFlattenOutput,
+    GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, PackageDecl, PtrClassDecl,
+    ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -259,8 +259,8 @@ pub mod lang {
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, DataClassDecl,
             EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen,
-            JniGenConfig, KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl,
-            ValueClassDecl, WireBody, WriteKotlinError,
+            KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
+            WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -258,9 +258,9 @@ pub mod lang {
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, DataClassDecl,
-            EnumClassDecl, FunctionDecl, FunctionFlattenInputDecl, FunctionFlattenOutputDecl,
-            GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, KotlinFile, PackageDecl,
-            PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
+            EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen,
+            JniGenConfig, KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl,
+            ValueClassDecl, WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -138,6 +138,41 @@ pub use crate::api::{
     utils::{edition::RustEdition, target_triple::TargetTriple},
 };
 
+/// Not part of the public API — referenced by the [`ident!`] macro expansion
+/// so callers don't need their own `proc-macro2` dependency just to build a
+/// `Span`.
+#[doc(hidden)]
+pub mod __macro_support {
+    pub use proc_macro2;
+}
+
+/// Build a `syn::Ident` from a bare identifier token. Unlike
+/// `syn::parse_quote!`, this always yields the concrete type `syn::Ident` —
+/// there's no external context needed to infer it — so it can be passed
+/// directly into a generic `impl Into<T>` parameter (e.g. anywhere this
+/// crate accepts `impl Into<lang::FunctionDecl>`) without hitting rustc's
+/// "type annotations needed" ambiguity. `syn::parse_quote!`'s output type
+/// has to be pinned by a *concrete* parameter type to infer successfully; a
+/// generic `impl Into<T>` bound doesn't give it anything to unify against.
+///
+/// ```
+/// use prebindgen::lang::{FlattenOutput, PtrClassDecl};
+/// use syn::parse_quote as pq;
+///
+/// let _ = PtrClassDecl::new(pq!(ZThing))
+///     .accessor(prebindgen::ident!(z_thing_name), "name")
+///     .flatten_output(FlattenOutput::new().field("name"));
+/// ```
+#[macro_export]
+macro_rules! ident {
+    ($name:ident) => {
+        ::syn::Ident::new(
+            stringify!($name),
+            $crate::__macro_support::proc_macro2::Span::call_site(),
+        )
+    };
+}
+
 /// Registry-based, **language-agnostic** converter pipeline.
 ///
 /// This module is the language-neutral core of prebindgen: it turns a stream of

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -258,10 +258,9 @@ pub mod lang {
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, DataClassDecl,
-            EnumClassDecl, FlattenInputDecl, FlattenOutputDecl, FunctionDecl,
-            FunctionFlattenInputDecl, FunctionFlattenOutputDecl, GenericTypeWrapperDecl,
-            JniBindingError, JniGen, JniGenConfig, KotlinFile, PackageDecl, PtrClassDecl,
-            ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
+            EnumClassDecl, FunctionDecl, FunctionFlattenInputDecl, FunctionFlattenOutputDecl,
+            GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig, KotlinFile, PackageDecl,
+            PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -140,28 +140,32 @@ pub use crate::api::{
 
 /// Not part of the public API — referenced by the [`ident!`] macro expansion
 /// so callers don't need their own `proc-macro2` dependency just to build a
-/// `Span`.
+/// `Span`, and by the `lang::jnigen` decl macros (`ptr_class!`, `fun!`, …) to
+/// parse a bare type token into a concrete `syn::Type`.
 #[doc(hidden)]
 pub mod __macro_support {
     pub use proc_macro2;
+
+    pub fn parse_type(s: &str) -> ::syn::Type {
+        ::syn::parse_str(s).unwrap_or_else(|e| panic!("prebindgen: invalid type `{s}`: {e}"))
+    }
 }
 
 /// Build a `syn::Ident` from a bare identifier token. Unlike
 /// `syn::parse_quote!`, this always yields the concrete type `syn::Ident` —
 /// there's no external context needed to infer it — so it can be passed
-/// directly into a generic `impl Into<T>` parameter (e.g. anywhere this
-/// crate accepts `impl Into<lang::FunctionDecl>`) without hitting rustc's
+/// directly into a generic `impl Into<T>` parameter without hitting rustc's
 /// "type annotations needed" ambiguity. `syn::parse_quote!`'s output type
 /// has to be pinned by a *concrete* parameter type to infer successfully; a
 /// generic `impl Into<T>` bound doesn't give it anything to unify against.
 ///
-/// ```
-/// use prebindgen::lang::{FlattenOutput, PtrClassDecl};
-/// use syn::parse_quote as pq;
+/// This is what powers the `lang::jnigen` [`fun!`](crate::fun) decl macro —
+/// see that macro (and `ptr_class!`/`enum_class!`/`data_class!`/`value_class!`,
+/// which apply the same trick to `syn::Type`) for the primary way this
+/// crate's builders are fed bare Rust names today.
 ///
-/// let _ = PtrClassDecl::new(pq!(ZThing))
-///     .accessor(prebindgen::ident!(z_thing_name), "name")
-///     .flatten_output(FlattenOutput::new().field("name"));
+/// ```
+/// let _: syn::Ident = prebindgen::ident!(z_thing_name);
 /// ```
 #[macro_export]
 macro_rules! ident {
@@ -254,10 +258,10 @@ pub mod lang {
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, DataClassDecl,
-            EnumClassDecl, FlattenInput, FlattenOutput, FunctionDecl, FunctionFlattenInput,
-            FunctionFlattenOutput, GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig,
-            KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
-            WireBody, WriteKotlinError,
+            EnumClassDecl, FlattenInputDecl, FlattenOutputDecl, FunctionDecl,
+            FunctionFlattenInputDecl, FunctionFlattenOutputDecl, GenericTypeWrapperDecl,
+            JniBindingError, JniGen, JniGenConfig, KotlinFile, PackageDecl, PtrClassDecl,
+            ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -218,9 +218,11 @@ pub mod lang {
         jnigen::{
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
-            null_byte_array, null_string, CachedIfaceMethod, EnumClass, Function, JniBindingError,
-            JniGen, JniGenState, KotlinFile, Package, PackageState, PtrClass, Root, TypeDeclState,
-            TypeKeyState, TypeMeta, WrapperNonMeta, WriteKotlinError,
+            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, DataClassDecl,
+            EnumClassDecl, FlattenInput, FlattenOutput, FunctionDecl, FunctionFlattenInput,
+            FunctionFlattenOutput, GenericTypeWrapperDecl, JniBindingError, JniGen, JniGenConfig,
+            KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
+            WireBody, WriteKotlinError,
         },
     };
 }


### PR DESCRIPTION
## Summary
- Replaces the `JniGen<S>` typestate-cursor builder with a flat, non-generic `JniGen` that accepts pre-built declaration objects: `JniGenConfig` (global config), `PackageDecl` (aggregates `PtrClassDecl`/`EnumClassDecl`/`DataClassDecl`/`ValueClassDecl`/`FunctionDecl` per Kotlin subpackage), and `ScalarTypeWrapperDecl`/`GenericTypeWrapperDecl` (split by rank, replacing `input_wrapper`/`output_wrapper`).
- Eliminates the runtime "set `package_prefix`/mangle closures before any declaration" panic — now structurally impossible, since `JniGenConfig` is built before `JniGen` exists.
- `flatten_input`/`flatten_output`/`flatten_input_with`/`flatten_output_with` now take a separately-built `FlattenInput`/`FlattenOutput`/`FunctionFlattenInput`/`FunctionFlattenOutput` spec as a parameter instead of returning `Self` — `.variant()`/`.field()` only exist on the spec types, so calling them before the matching `flatten_*` call is a compile error instead of a build-script-time panic.

## Test plan
- [x] `cargo test -p prebindgen` — 182 unit tests + doctests pass, including a new `compile_fail` doctest for the flatten-ordering guarantee.
- [x] `cargo build -p covertest-kotlin` — generated `generated_bindings.rs` and `kotlin/**` are byte-identical to before (only `build.rs`'s call-site syntax changed).
- [ ] `examples/perftest-kotlin` and the separate `zenoh-flat-jni` consumer are **expected to fail to compile** until a follow-up migration to the new API — not fixed in this PR (confirmed isolated: `cargo build --workspace` fails only on `perftest-kotlin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)