### PR TITLE
jnigen: constant support — Rust consts, function-backed and expression-backed Kotlin vals

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -30,6 +30,7 @@
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `PackageDecl::constant` (`constant!`) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
+//! | `PackageDecl::constant_fun` | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
 //! | `.param_expand_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
 //! | `.return_expand_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.param_expand(param, …)` (+`_self`)| `storage_expect_summary` |
@@ -170,6 +171,11 @@ fn main() {
                 // (`COVER_MAGIC: Long`, `COVER_TAG: String`) in the base package.
                 .constant(constant!(COVER_MAGIC))
                 .constant(constant!(COVER_TAG))
+                // Function-backed constant: a nullary `#[prebindgen]` fn
+                // surfaced as an eagerly-initialized top-level `val`
+                // (`COVER_TAG_RUNTIME: String`) — the value comes from the
+                // fn at class-load, not from a Rust `const`.
+                .constant_fun(fun!(cover_tag_runtime).name("COVER_TAG_RUNTIME"))
                 .class(
                     ptr_class!(Storage)
                         .fun(fun!(storage_len).name("len"))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -29,6 +29,7 @@
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
+//! | `PackageDecl::constant` (`constant!`) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
 //! | `.param_expand_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
 //! | `.return_expand_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.param_expand(param, …)` (+`_self`)| `storage_expect_summary` |
@@ -68,10 +69,8 @@
 //! emitting nothing.
 
 use prebindgen::{
-    core::Registry,
-    data_class, enum_class, fun,
-    lang::JniGen,
-    package, ptr_class, scalar_type_wrapper, value_class,
+    constant, core::Registry, data_class, enum_class, fun, lang::JniGen, package, ptr_class,
+    scalar_type_wrapper, value_class,
 };
 use syn::parse_quote as pq;
 
@@ -79,191 +78,196 @@ fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
     let jni = JniGen::new()
-            .set_source_module(pq!(perftest_flat))
-            .set_package_prefix("io.prebindgen.covertest")
-            .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
-            // All five per-kind name-mangle hooks are registered. The harness hook
-            // is a real transform (`Native` → `CovNative`, an internal symbol so it
-            // needs no Kotlin-side coordination); the other four are the identity
-            // (the domain names are already the desired Kotlin names) — registering
-            // them still exercises the customization API and its `Some(closure)`
-            // path.
-            .set_harness_name_mangle(|n| format!("Cov{n}"))
-            .set_fun_name_mangle(|n| n.to_string())
-            .set_ptr_class_name_mangle(|n| n.to_string())
-            .set_data_class_name_mangle(|n| n.to_string())
-            .set_enum_name_mangle(|n| n.to_string())
-    // `Millis` newtype: a custom scalar wire mapping to a bare `Long` (no
-    // generated class) — global, not tied to any package (see the `decl`
-    // module doc for why a scalar wrapper never needs package placement).
-    .scalar_type_wrapper(
-        scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")
-            .on_param(|v| pq!(perftest_flat::Millis(*#v as u64)))
-            .on_return(|v| pq!(#v.0 as jni::sys::jlong)),
-    )
-    // ── Base-package types ──────────────────────────────────────────────
-    // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
-    // reassembled via a generated `fromParts`).
-    .package(package!().class(data_class!(Payload)))
-    // ── Subpackage `model`: enum + value class + nested data class ──────
-    .package(
-        package!("model")
-            // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
-            .class(enum_class!(Priority))
-            // `Annotated` exercises a NESTED data-class field (`payload`,
-            // recursive fromParts / recursive leaf decode) plus Option<prim> and
-            // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
-            .class(data_class!(Annotated))
-            // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
-            // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
-            // surfaces as `List<ByteArray>`.
-            .class(
-                value_class!(Stamp)
-                    .fun(fun!(stamp_secs).name("secs"))
-                    .fun(fun!(stamp_nanos).name("nanos")),
+        .set_source_module(pq!(perftest_flat))
+        .set_package_prefix("io.prebindgen.covertest")
+        .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
+        // All five per-kind name-mangle hooks are registered. The harness hook
+        // is a real transform (`Native` → `CovNative`, an internal symbol so it
+        // needs no Kotlin-side coordination); the other four are the identity
+        // (the domain names are already the desired Kotlin names) — registering
+        // them still exercises the customization API and its `Some(closure)`
+        // path.
+        .set_harness_name_mangle(|n| format!("Cov{n}"))
+        .set_fun_name_mangle(|n| n.to_string())
+        .set_ptr_class_name_mangle(|n| n.to_string())
+        .set_data_class_name_mangle(|n| n.to_string())
+        .set_enum_name_mangle(|n| n.to_string())
+        // `Millis` newtype: a custom scalar wire mapping to a bare `Long` (no
+        // generated class) — global, not tied to any package (see the `decl`
+        // module doc for why a scalar wrapper never needs package placement).
+        .scalar_type_wrapper(
+            scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")
+                .on_param(|v| pq!(perftest_flat::Millis(*#v as u64)))
+                .on_return(|v| pq!(#v.0 as jni::sys::jlong)),
+        )
+        // ── Base-package types ──────────────────────────────────────────────
+        // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
+        // reassembled via a generated `fromParts`).
+        .package(package!().class(data_class!(Payload)))
+        // ── Subpackage `model`: enum + value class + nested data class ──────
+        .package(
+            package!("model")
+                // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
+                .class(enum_class!(Priority))
+                // `Annotated` exercises a NESTED data-class field (`payload`,
+                // recursive fromParts / recursive leaf decode) plus Option<prim> and
+                // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
+                .class(data_class!(Annotated))
+                // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
+                // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
+                // surfaces as `List<ByteArray>`.
+                .class(
+                    value_class!(Stamp)
+                        .fun(fun!(stamp_secs).name("secs"))
+                        .fun(fun!(stamp_nanos).name("nanos")),
+                ),
+        )
+        // ── Subpackage `errors`: the Result error channel ───────────────────
+        .package(
+            package!("errors").class(
+                // `StorageError` is the `E` of a fallible `Result`. Declaring it a
+                // ptr_class with a a default return-field list makes the generated `onError`
+                // handler receive the decomposed fields: the `message` string plus —
+                // via `.default_return_expand_self()` — the error handle itself (an
+                // owned `StorageError` the handler must `close()`).
+                ptr_class!(StorageError)
+                    .fun(fun!(storage_error_message).name("message"))
+                    .default_return_expand(fun!(storage_error_message).name("message"))
+                    .default_return_expand_self(),
             ),
-    )
-    // ── Subpackage `errors`: the Result error channel ───────────────────
-    .package(
-        package!("errors").class(
-            // `StorageError` is the `E` of a fallible `Result`. Declaring it a
-            // ptr_class with a a default return-field list makes the generated `onError`
-            // handler receive the decomposed fields: the `message` string plus —
-            // via `.default_return_expand_self()` — the error handle itself (an
-            // owned `StorageError` the handler must `close()`).
-            ptr_class!(StorageError)
-                .fun(fun!(storage_error_message).name("message"))
-                .default_return_expand(fun!(storage_error_message).name("message"))
-                .default_return_expand_self(),
-        ),
-    )
-    // ── Subpackage `analytics`: param-variant / return-field defaults on `Summary`
-    .package(
-        package!("analytics")
-            // `Summary` is an opaque handle whose default boundary shape is its
-            // `(count, total)` leaves: the return-field default decomposes it, the param-variant default
-            // rebuilds it (via the `of` constructor) or accepts a handle.
-            .class(
-                ptr_class!(Summary)
-                    .constructor(fun!(summary_new).name("of"))
-                    .fun(fun!(summary_count).name("count"))
-                    .fun(fun!(summary_total).name("total"))
-                    .fun(fun!(summary_scaled).name("scaled"))
-                    .default_param_expand(fun!(summary_new))
-                    .default_param_expand_self()
-                    .default_return_expand(fun!(summary_count).name("count"))
-                    .default_return_expand(fun!(summary_total).name("total")),
-            )
-            // `Archive` holds the latest `Summary` and returns it BORROWED
-            // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
-            // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
-            // RENAMED via the per-declaration `.name()` override (the type-level
-            // dual of the per-fn `.name`; literal, bypasses the mangle closures).
-            .class(ptr_class!(Archive).name("SummaryVault")),
-    )
-    // ── Base-package handle type: `Storage` + scalar members ────────────
-    // Back in the base package so the typed handle classes live alongside
-    // `Payload`.
-    .package(
-        package!()
-            .class(
-                ptr_class!(Storage)
-                    .fun(fun!(storage_len).name("len"))
-                    .fun(fun!(storage_contains).name("contains"))
-                    .constructor(fun!(storage_with_payload).name("withPayload")),
-            )
-            // The callback-handler handles (single payload / whole batch / owned
-            // storage handle).
-            .class(ptr_class!(PayloadHandler))
-            // `StorageHandler`'s callback receives an OWNED opaque handle
-            // (`Fn(Storage)`): the raw pointer crosses and the generated Kotlin
-            // proxy wraps it into a typed `Storage` and closes it after `run`.
-            .class(ptr_class!(StorageHandler))
-            .class(ptr_class!(PayloadVecHandler)),
-    )
-    // ── Free functions, grouped by subpackage ───────────────────────────
-    // model: enum return/param/option + value-class return + Vec<value> +
-    //        Option<scalar>.
-    .package(
-        package!("model")
-            .fun(fun!(payload_priority))
-            .fun(fun!(priority_weight))
-            .fun(fun!(priority_or))
-            .fun(fun!(stamp_new))
-            .fun(fun!(stamp_series))
-            .fun(fun!(payload_label_len))
-            .fun(fun!(annotated_new))
-            .fun(fun!(annotated_ttl))
-            .fun(fun!(annotated_priority))
-            .fun(fun!(annotated_payload_value)),
-    )
-    // analytics: the param-variant / return-field matrix (class default / raw-self override / per-fn override, in + out).
-    .package(
-        package!("analytics")
-            .fun(fun!(storage_summary))
-            .fun(fun!(storage_matches_summary))
-            .fun(fun!(storage_summary_handle).return_expand_self())
-            .fun(fun!(summary_total_raw).param_expand_self(pq!(s)))
-            .fun(
-                fun!(storage_summary_full)
-                    .return_expand(fun!(summary_count).name("count"))
-                    .return_expand(fun!(summary_total).name("total"))
-                    .return_expand_self(),
-            )
-            .fun(
-                fun!(storage_expect_summary)
-                    .param_expand(pq!(expected), fun!(summary_new))
-                    .param_expand_self(pq!(expected)),
-            )
-            // The borrowed-accessor trio. `archive_latest` suppresses the default
-            // Summary return-field default so the BORROWED handle path (clone into a
-            // fresh owned handle, null when absent) is what crosses.
-            .fun(fun!(archive_new))
-            .fun(fun!(archive_store))
-            .fun(fun!(archive_latest).return_expand_self()),
-    )
-    // storage: the perf surface (handles, callbacks, Vec, Option) plus the
-    // fallible constructor and the Millis wrapper.
-    .package(
-        package!("storage")
-            .fun(fun!(storage_new))
-            .fun(fun!(storage_get))
-            .fun(fun!(storage_put_by_take))
-            .fun(fun!(storage_put_by_read))
-            .fun(fun!(storage_put_slice))
-            .fun(fun!(storage_get_vec))
-            .fun(fun!(payload_handler_new))
-            .fun(fun!(storage_callback))
-            .fun(fun!(payload_vec_handler_new))
-            .fun(fun!(storage_callback_vec))
-            .fun(fun!(storage_try_with_label))
-            // Vec<opaque-handle> returns (plain + under the Option niche).
-            .fun(fun!(storage_shards))
-            .fun(fun!(storage_shards_opt))
-            // Owned-handle-in-callback pair.
-            .fun(fun!(storage_handler_new))
-            .fun(fun!(storage_emit))
-            // A 3-opaque-handle call (sorted N-ary handle locking).
-            .fun(fun!(storage_total_len))
-            // Vec<String> return (single-leaf string fold).
-            .fun(fun!(storage_labels))
-            // Option<data-class> input.
-            .fun(fun!(storage_put_opt))
-            // `.name(...)`: per-function Kotlin rename override. The default name
-            // would be `millisAdd`; force it to `addMillis` to exercise the
-            // override path (the Rust symbol/extern is unaffected).
-            .fun(fun!(millis_add).name("addMillis")),
-    )
-    // Plain String return, declared in the BASE package (mirroring the
-    // base-package classes).
-    .package(package!().fun(fun!(string_new)))
-    // The deliberately-unbound group (C-tier shapes with no JVM mapping):
-    // acknowledged so the build log stays free of "skipping undeclared"
-    // warnings without emitting anything.
-    .ignore_fun(fun!(string_len))
-    .ignore_fun(fun!(storage_get_into_init))
-    .ignore_fun(fun!(storage_get_into_uninit))
-    .ignore_fun(fun!(storage_put_by_read_and_update));
+        )
+        // ── Subpackage `analytics`: param-variant / return-field defaults on `Summary`
+        .package(
+            package!("analytics")
+                // `Summary` is an opaque handle whose default boundary shape is its
+                // `(count, total)` leaves: the return-field default decomposes it, the param-variant default
+                // rebuilds it (via the `of` constructor) or accepts a handle.
+                .class(
+                    ptr_class!(Summary)
+                        .constructor(fun!(summary_new).name("of"))
+                        .fun(fun!(summary_count).name("count"))
+                        .fun(fun!(summary_total).name("total"))
+                        .fun(fun!(summary_scaled).name("scaled"))
+                        .default_param_expand(fun!(summary_new))
+                        .default_param_expand_self()
+                        .default_return_expand(fun!(summary_count).name("count"))
+                        .default_return_expand(fun!(summary_total).name("total")),
+                )
+                // `Archive` holds the latest `Summary` and returns it BORROWED
+                // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
+                // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
+                // RENAMED via the per-declaration `.name()` override (the type-level
+                // dual of the per-fn `.name`; literal, bypasses the mangle closures).
+                .class(ptr_class!(Archive).name("SummaryVault")),
+        )
+        // ── Base-package handle type: `Storage` + scalar members ────────────
+        // Back in the base package so the typed handle classes live alongside
+        // `Payload`.
+        .package(
+            package!()
+                // `#[prebindgen]` consts: each surfaces as a generated nullary JNI
+                // getter extern + an eagerly-initialized top-level Kotlin `val`
+                // (`COVER_MAGIC: Long`, `COVER_TAG: String`) in the base package.
+                .constant(constant!(COVER_MAGIC))
+                .constant(constant!(COVER_TAG))
+                .class(
+                    ptr_class!(Storage)
+                        .fun(fun!(storage_len).name("len"))
+                        .fun(fun!(storage_contains).name("contains"))
+                        .constructor(fun!(storage_with_payload).name("withPayload")),
+                )
+                // The callback-handler handles (single payload / whole batch / owned
+                // storage handle).
+                .class(ptr_class!(PayloadHandler))
+                // `StorageHandler`'s callback receives an OWNED opaque handle
+                // (`Fn(Storage)`): the raw pointer crosses and the generated Kotlin
+                // proxy wraps it into a typed `Storage` and closes it after `run`.
+                .class(ptr_class!(StorageHandler))
+                .class(ptr_class!(PayloadVecHandler)),
+        )
+        // ── Free functions, grouped by subpackage ───────────────────────────
+        // model: enum return/param/option + value-class return + Vec<value> +
+        //        Option<scalar>.
+        .package(
+            package!("model")
+                .fun(fun!(payload_priority))
+                .fun(fun!(priority_weight))
+                .fun(fun!(priority_or))
+                .fun(fun!(stamp_new))
+                .fun(fun!(stamp_series))
+                .fun(fun!(payload_label_len))
+                .fun(fun!(annotated_new))
+                .fun(fun!(annotated_ttl))
+                .fun(fun!(annotated_priority))
+                .fun(fun!(annotated_payload_value)),
+        )
+        // analytics: the param-variant / return-field matrix (class default / raw-self override / per-fn override, in + out).
+        .package(
+            package!("analytics")
+                .fun(fun!(storage_summary))
+                .fun(fun!(storage_matches_summary))
+                .fun(fun!(storage_summary_handle).return_expand_self())
+                .fun(fun!(summary_total_raw).param_expand_self(pq!(s)))
+                .fun(
+                    fun!(storage_summary_full)
+                        .return_expand(fun!(summary_count).name("count"))
+                        .return_expand(fun!(summary_total).name("total"))
+                        .return_expand_self(),
+                )
+                .fun(
+                    fun!(storage_expect_summary)
+                        .param_expand(pq!(expected), fun!(summary_new))
+                        .param_expand_self(pq!(expected)),
+                )
+                // The borrowed-accessor trio. `archive_latest` suppresses the default
+                // Summary return-field default so the BORROWED handle path (clone into a
+                // fresh owned handle, null when absent) is what crosses.
+                .fun(fun!(archive_new))
+                .fun(fun!(archive_store))
+                .fun(fun!(archive_latest).return_expand_self()),
+        )
+        // storage: the perf surface (handles, callbacks, Vec, Option) plus the
+        // fallible constructor and the Millis wrapper.
+        .package(
+            package!("storage")
+                .fun(fun!(storage_new))
+                .fun(fun!(storage_get))
+                .fun(fun!(storage_put_by_take))
+                .fun(fun!(storage_put_by_read))
+                .fun(fun!(storage_put_slice))
+                .fun(fun!(storage_get_vec))
+                .fun(fun!(payload_handler_new))
+                .fun(fun!(storage_callback))
+                .fun(fun!(payload_vec_handler_new))
+                .fun(fun!(storage_callback_vec))
+                .fun(fun!(storage_try_with_label))
+                // Vec<opaque-handle> returns (plain + under the Option niche).
+                .fun(fun!(storage_shards))
+                .fun(fun!(storage_shards_opt))
+                // Owned-handle-in-callback pair.
+                .fun(fun!(storage_handler_new))
+                .fun(fun!(storage_emit))
+                // A 3-opaque-handle call (sorted N-ary handle locking).
+                .fun(fun!(storage_total_len))
+                // Vec<String> return (single-leaf string fold).
+                .fun(fun!(storage_labels))
+                // Option<data-class> input.
+                .fun(fun!(storage_put_opt))
+                // `.name(...)`: per-function Kotlin rename override. The default name
+                // would be `millisAdd`; force it to `addMillis` to exercise the
+                // override path (the Rust symbol/extern is unaffected).
+                .fun(fun!(millis_add).name("addMillis")),
+        )
+        // Plain String return, declared in the BASE package (mirroring the
+        // base-package classes).
+        .package(package!().fun(fun!(string_new)))
+        // The deliberately-unbound group (C-tier shapes with no JVM mapping):
+        // acknowledged so the build log stays free of "skipping undeclared"
+        // warnings without emitting anything.
+        .ignore_fun(fun!(string_len))
+        .ignore_fun(fun!(storage_get_into_init))
+        .ignore_fun(fun!(storage_get_into_uninit))
+        .ignore_fun(fun!(storage_put_by_read_and_update));
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -31,6 +31,7 @@
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `PackageDecl::constant` (`constant!`) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
 //! | `PackageDecl::constant_fun` | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
+//! | `PackageDecl::constant_expr` (`constant_expr!`) | `COVER_BANNER` = binding-defined `format!` expression |
 //! | `.param_expand_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
 //! | `.return_expand_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.param_expand(param, …)` (+`_self`)| `storage_expect_summary` |
@@ -70,8 +71,8 @@
 //! emitting nothing.
 
 use prebindgen::{
-    constant, core::Registry, data_class, enum_class, fun, lang::JniGen, package, ptr_class,
-    scalar_type_wrapper, value_class,
+    constant, constant_expr, core::Registry, data_class, enum_class, fun, lang::JniGen, package,
+    ptr_class, scalar_type_wrapper, value_class,
 };
 use syn::parse_quote as pq;
 
@@ -176,6 +177,13 @@ fn main() {
                 // (`COVER_TAG_RUNTIME: String`) — the value comes from the
                 // fn at class-load, not from a Rust `const`.
                 .constant_fun(fun!(cover_tag_runtime).name("COVER_TAG_RUNTIME"))
+                // Expression-backed constant: an arbitrary binding-defined
+                // expression (composing source-crate items via
+                // `use perftest_flat::*;`) evaluated once at class-load —
+                // no dedicated accessor fn in the source crate.
+                .constant_expr(
+                    constant_expr!(COVER_BANNER: String = format!("{COVER_TAG}:{COVER_MAGIC:#x}")),
+                )
                 .class(
                     ptr_class!(Storage)
                         .fun(fun!(storage_len).name("len"))

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -343,6 +343,26 @@ public fun stringNew(s: String, onError: JniErrorHandler<String>): String {
     return __ret
 }
 
+private fun constGetCoverMagic(onError: JniErrorHandler<Long>): Long {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverMagic(__cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/** Mirrors the Rust `#[prebindgen]` const `COVER_MAGIC` (read once through the generated JNI getter). */
+public val COVER_MAGIC: Long = constGetCoverMagic(JniErrorHandler { je -> error(je ?: "const COVER_MAGIC: JNI getter failed") })
+
+private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverTag(__cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/** Mirrors the Rust `#[prebindgen]` const `COVER_TAG` (read once through the generated JNI getter). */
+public val COVER_TAG: String = constGetCoverTag(JniErrorHandler { je -> error(je ?: "const COVER_TAG: JNI getter failed") })
+
 internal object CovNative {
     init {
         io.prebindgen.covertest.NativeLibrary.ensureLoaded()
@@ -487,6 +507,8 @@ internal object CovNative {
     external fun summaryScaled(s: Long, factor: Double, errorSink: Any): Double
     external fun summaryTotal(s: Long, errorSink: Any): Double
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double
+    external fun constGetCoverMagic(errorSink: Any): Long
+    external fun constGetCoverTag(errorSink: Any): String
     external fun payloadVecNew(cap: Int): Long
     external fun payloadVecPush(handle: Long, eId: Long, eSeq: Int, eValue: Double, eFlag: Boolean, eLabel: String?)
     external fun payloadVecFree(handle: Long)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -363,6 +363,16 @@ private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
 /** Mirrors the Rust `#[prebindgen]` const `COVER_TAG` (read once through the generated JNI getter). */
 public val COVER_TAG: String = constGetCoverTag(JniErrorHandler { je -> error(je ?: "const COVER_TAG: JNI getter failed") })
 
+private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.coverTagRuntime(__cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/** Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated once through the generated JNI wrapper). */
+public val COVER_TAG_RUNTIME: String = coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") })
+
 internal object CovNative {
     init {
         io.prebindgen.covertest.NativeLibrary.ensureLoaded()
@@ -395,6 +405,7 @@ internal object CovNative {
         s1: Long,
         errorSink: Any,
     )
+    external fun coverTagRuntime(errorSink: Any): String
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
     external fun payloadHandlerNew(f: Any, errorSink: Any): Long
     external fun payloadLabelLen(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -373,6 +373,16 @@ private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
 /** Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated once through the generated JNI wrapper). */
 public val COVER_TAG_RUNTIME: String = coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") })
 
+private fun constGetCoverBanner(onError: JniErrorHandler<String>): String {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverBanner(__cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/** Binding-defined constant: `format ! ("{COVER_TAG}:{COVER_MAGIC:#x}")` (evaluated once through the generated JNI getter). */
+public val COVER_BANNER: String = constGetCoverBanner(JniErrorHandler { je -> error(je ?: "const COVER_BANNER: JNI getter failed") })
+
 internal object CovNative {
     init {
         io.prebindgen.covertest.NativeLibrary.ensureLoaded()
@@ -520,6 +530,7 @@ internal object CovNative {
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double
     external fun constGetCoverMagic(errorSink: Any): Long
     external fun constGetCoverTag(errorSink: Any): String
+    external fun constGetCoverBanner(errorSink: Any): String
     external fun payloadVecNew(cap: Int): Long
     external fun payloadVecPush(handle: Long, eId: Long, eSeq: Int, eValue: Double, eFlag: Boolean, eLabel: String?)
     external fun payloadVecFree(handle: Long)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -91,6 +91,7 @@ fun main() {
         check(COVER_MAGIC == 0xC0FFEE.toLong())
         check(COVER_TAG == "covertest")
         check(COVER_TAG_RUNTIME == "covertest-runtime")
+        check(COVER_BANNER == "covertest:0xc0ffee")
     }
 
     // ── data_class: fields cross as leaves, reassembled via fromParts ─────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -84,6 +84,15 @@ private fun payload(id: Long, seq: Int, value: Double, flag: Boolean, label: Str
 fun main() {
     println("covertest-kotlin: exercising every JniGen feature")
 
+    // ── consts: eagerly-initialized top-level vals — const-backed (generated
+    // nullary getters over Rust consts) and function-backed (constant_fun:
+    // the value comes from a nullary #[prebindgen] fn at class-load) ─────────
+    section("top-level const vals (const- and function-backed)") {
+        check(COVER_MAGIC == 0xC0FFEE.toLong())
+        check(COVER_TAG == "covertest")
+        check(COVER_TAG_RUNTIME == "covertest-runtime")
+    }
+
     // ── data_class: fields cross as leaves, reassembled via fromParts ─────────
     section("data_class Payload") {
         val p = Payload(1L, 2, 3.5, true, "hello")

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2189,6 +2189,39 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::cover_tag_runtime();
+    match String_to_JString_c7f3ca43(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -5931,7 +5964,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
     }
 }
 /// The storage capacity limit advertised to bindings (a primitive const).
-pub const COVER_MAGIC: i64 = 0xC0FFEE;
+pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverMagic<'a>(
@@ -5966,7 +5999,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverMag
     }
 }
 /// The coverage surface's tag string (a string const).
-pub const COVER_TAG: &str = "covertest";
+pub const COVER_TAG: &str = perftest_flat::COVER_TAG;
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverTag<'a>(

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -239,6 +239,43 @@ const _: () = {
     const fn __assert_copy<T: ::core::marker::Copy>() {}
     __assert_copy::<perftest_flat::Stamp>();
 };
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBanner<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = {
+        #[allow(unused_imports)]
+        use perftest_flat::*;
+        format!("{COVER_TAG}:{COVER_MAGIC:#x}")
+    };
+    match String_to_JString_c7f3ca43(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Annotated_to_JObject_b543f0d9<'a>(
     env: &mut jni::JNIEnv<'a>,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1572,6 +1572,20 @@ pub(crate) unsafe fn std_boxed_Box_std_string_String_to_JString_cfbab680<'a>(
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: &str,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn unit_to_unit_9ecccf8e<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: (),
@@ -5913,6 +5927,76 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
                 &__zd,
             );
             0.0 as jni::sys::jdouble
+        }
+    }
+}
+/// The storage capacity limit advertised to bindings (a primitive const).
+pub const COVER_MAGIC: i64 = 0xC0FFEE;
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverMagic<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::COVER_MAGIC;
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+/// The coverage surface's tag string (a string const).
+pub const COVER_TAG: &str = "covertest";
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverTag<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::COVER_TAG;
+    match str_to_JString_7b77dc67(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -750,6 +750,10 @@ pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut strin
     __ret = __cbg_out_String(__v);
     __ret
 }
+/// The storage capacity limit advertised to bindings (a primitive const).
+pub const COVER_MAGIC: i64 = 0xC0FFEE;
+/// The coverage surface's tag string (a string const).
+pub const COVER_TAG: &str = "covertest";
 const _: () = {
     konst::assertc_eq!(
         perftest_flat::FEATURES, "",

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -751,9 +751,9 @@ pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut strin
     __ret
 }
 /// The storage capacity limit advertised to bindings (a primitive const).
-pub const COVER_MAGIC: i64 = 0xC0FFEE;
+pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;
 /// The coverage surface's tag string (a string const).
-pub const COVER_TAG: &str = "covertest";
+pub const COVER_TAG: &str = perftest_flat::COVER_TAG;
 const _: () = {
     konst::assertc_eq!(
         perftest_flat::FEATURES, "",

--- a/examples/perftest-c/include/perftest.h
+++ b/examples/perftest-c/include/perftest.h
@@ -12,10 +12,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/**
- * The storage capacity limit advertised to bindings (a primitive const).
- */
-#define COVER_MAGIC 12648430
+
 
 typedef struct payload_handler_t {
   uint8_t _private[0];
@@ -52,6 +49,8 @@ typedef struct closure_payload_vec_t {
   void (*call)(const struct payload_t*, uintptr_t, void*);
   void (*drop)(void*);
 } closure_payload_vec_t;
+
+
 
 void perftest_free(void *p);
 

--- a/examples/perftest-c/include/perftest.h
+++ b/examples/perftest-c/include/perftest.h
@@ -12,6 +12,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * The storage capacity limit advertised to bindings (a primitive const).
+ */
+#define COVER_MAGIC 12648430
+
 typedef struct payload_handler_t {
   uint8_t _private[0];
 } payload_handler_t;

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -487,6 +487,15 @@ pub const COVER_MAGIC: i64 = 0xC0FFEE;
 #[prebindgen]
 pub const COVER_TAG: &str = "covertest";
 
+/// The tag with a runtime-computed suffix — a constant value no Rust `const`
+/// can express (built through `format!`). Exercises
+/// `PackageDecl::constant_fun`: a nullary fn surfaced as an
+/// eagerly-initialized Kotlin top-level `val`.
+#[prebindgen]
+pub fn cover_tag_runtime() -> String {
+    format!("{COVER_TAG}-runtime")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -474,6 +474,19 @@ pub fn storage_put_opt(s: &mut Storage, p: Option<Payload>) -> bool {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Consts — declared via `PackageDecl::constant`, surfacing as generated JNI
+// getters + eagerly-initialized Kotlin top-level `val`s.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The storage capacity limit advertised to bindings (a primitive const).
+#[prebindgen]
+pub const COVER_MAGIC: i64 = 0xC0FFEE;
+
+/// The coverage surface's tag string (a string const).
+#[prebindgen]
+pub const COVER_TAG: &str = "covertest";
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -16,79 +16,74 @@
 //! JniGen maps `Box<String>` → Kotlin `String` and `Option<Box<String>>` →
 //! `String?` automatically.
 
-use prebindgen::{
-    core::Registry,
-    data_class, fun,
-    lang::JniGen,
-    package, ptr_class,
-};
+use prebindgen::{core::Registry, data_class, fun, lang::JniGen, package, ptr_class};
 use syn::parse_quote as pq;
 
 fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
     let jni = JniGen::new()
-            .set_source_module(pq!(perftest_flat))
-            .set_package_prefix("io.prebindgen.perftest")
-            // Trigger native-library loading from the generated `JNINative` static
-            // init (the single choke point through which every JNI call routes).
-            .set_jni_native_init("io.prebindgen.perftest.NativeLibrary.ensureLoaded()")
-    // Base-package types.
-    .package(
-        package!()
-            // `Payload` as a Kotlin `data class` with a `fromParts` companion factory:
-            // returning/accepting it crosses its fields as decoupled leaves and the
-            // object is (re)assembled on the Kotlin side — no Java object is built on
-            // the Rust side.
-            .class(data_class!(Payload))
-            // `Storage` as an opaque Kotlin handle class (`NativeHandle`, closeable);
-            // the functions read/write the payload it owns.
-            .class(ptr_class!(Storage))
-            // `PayloadHandler` as an opaque Kotlin handle class: a prepared callback built
-            // once via `payloadHandlerNew` and fired by `storageCallback` — the
-            // registered-subscriber pattern (the JNI trampoline is built once, not per call).
-            .class(ptr_class!(PayloadHandler))
-            // `PayloadVecHandler`: a prepared WHOLE-BATCH callback fired by
-            // `storageCallbackVec` — its `PayloadListCallback.run(List<Payload>)` receives
-            // the entire batch in one upcall. Because `Payload` is a `data_class!`, the
-            // `List` is assembled by a **fold**: the trampoline allocates the list and
-            // folds each element's raw leaves through the hoisted folder (Kotlin does
-            // `fromParts` + `add`) — no per-element Java object is built on the Rust side.
-            .class(ptr_class!(PayloadVecHandler)),
-    )
-    // Only the value/ref-input put forms map to JNI: `storage_put_by_take`
-    // (by-value `Payload`) and `storage_put_by_read` (`&Payload`). The
-    // `&mut Payload` / `&mut MaybeUninit<Payload>` out-param forms
-    // (`storage_put_by_read_and_update`, `storage_get_into_*`) are C-only — a
-    // Kotlin `data class` is an immutable value with no out-param/uninit
-    // semantics — so they are left undeclared here.
-    //
-    // `payload_handler_new(impl Fn(&Payload)) -> PayloadHandler` prepares the callback
-    // ONCE (decodes the JVM callback into the reusable native trampoline); then
-    // `storage_callback(s, &PayloadHandler)` fires it. The callback arg still crosses
-    // as decoupled leaves reassembled into a whole `PayloadCallback.run(Payload)` — only
-    // WHERE the trampoline is built changes (once, in `payloadHandlerNew`).
-    .package(
-        package!("storage")
-            .fun(fun!(storage_new))
-            .fun(fun!(storage_get))
-            .fun(fun!(storage_put_by_take))
-            .fun(fun!(storage_put_by_read))
-            .fun(fun!(payload_handler_new))
-            .fun(fun!(storage_callback))
-            // Array (slice / Vec) API. `storage_put_slice(&[Payload])` takes a
-            // `List<Payload>` (decoded element-by-element into an owned `Vec`, then
-            // borrowed as a slice); `storage_get_vec() -> Option<Vec<Payload>>` returns
-            // a `List<Payload>?`. The element is a `data class`, so the return is a
-            // **fixed fold**: each element's fields cross as decoupled raw leaves and a
-            // hoisted Kotlin folder reassembles them via `fromParts` and appends to the
-            // list — no `ArrayList` and no per-element Java object on the Rust side.
-            .fun(fun!(storage_put_slice))
-            .fun(fun!(storage_get_vec))
-            // Whole-batch callback: prepared once, fired with the entire `List<Payload>`.
-            .fun(fun!(payload_vec_handler_new))
-            .fun(fun!(storage_callback_vec)),
-    );
+        .set_source_module(pq!(perftest_flat))
+        .set_package_prefix("io.prebindgen.perftest")
+        // Trigger native-library loading from the generated `JNINative` static
+        // init (the single choke point through which every JNI call routes).
+        .set_jni_native_init("io.prebindgen.perftest.NativeLibrary.ensureLoaded()")
+        // Base-package types.
+        .package(
+            package!()
+                // `Payload` as a Kotlin `data class` with a `fromParts` companion factory:
+                // returning/accepting it crosses its fields as decoupled leaves and the
+                // object is (re)assembled on the Kotlin side — no Java object is built on
+                // the Rust side.
+                .class(data_class!(Payload))
+                // `Storage` as an opaque Kotlin handle class (`NativeHandle`, closeable);
+                // the functions read/write the payload it owns.
+                .class(ptr_class!(Storage))
+                // `PayloadHandler` as an opaque Kotlin handle class: a prepared callback built
+                // once via `payloadHandlerNew` and fired by `storageCallback` — the
+                // registered-subscriber pattern (the JNI trampoline is built once, not per call).
+                .class(ptr_class!(PayloadHandler))
+                // `PayloadVecHandler`: a prepared WHOLE-BATCH callback fired by
+                // `storageCallbackVec` — its `PayloadListCallback.run(List<Payload>)` receives
+                // the entire batch in one upcall. Because `Payload` is a `data_class!`, the
+                // `List` is assembled by a **fold**: the trampoline allocates the list and
+                // folds each element's raw leaves through the hoisted folder (Kotlin does
+                // `fromParts` + `add`) — no per-element Java object is built on the Rust side.
+                .class(ptr_class!(PayloadVecHandler)),
+        )
+        // Only the value/ref-input put forms map to JNI: `storage_put_by_take`
+        // (by-value `Payload`) and `storage_put_by_read` (`&Payload`). The
+        // `&mut Payload` / `&mut MaybeUninit<Payload>` out-param forms
+        // (`storage_put_by_read_and_update`, `storage_get_into_*`) are C-only — a
+        // Kotlin `data class` is an immutable value with no out-param/uninit
+        // semantics — so they are left undeclared here.
+        //
+        // `payload_handler_new(impl Fn(&Payload)) -> PayloadHandler` prepares the callback
+        // ONCE (decodes the JVM callback into the reusable native trampoline); then
+        // `storage_callback(s, &PayloadHandler)` fires it. The callback arg still crosses
+        // as decoupled leaves reassembled into a whole `PayloadCallback.run(Payload)` — only
+        // WHERE the trampoline is built changes (once, in `payloadHandlerNew`).
+        .package(
+            package!("storage")
+                .fun(fun!(storage_new))
+                .fun(fun!(storage_get))
+                .fun(fun!(storage_put_by_take))
+                .fun(fun!(storage_put_by_read))
+                .fun(fun!(payload_handler_new))
+                .fun(fun!(storage_callback))
+                // Array (slice / Vec) API. `storage_put_slice(&[Payload])` takes a
+                // `List<Payload>` (decoded element-by-element into an owned `Vec`, then
+                // borrowed as a slice); `storage_get_vec() -> Option<Vec<Payload>>` returns
+                // a `List<Payload>?`. The element is a `data class`, so the return is a
+                // **fixed fold**: each element's fields cross as decoupled raw leaves and a
+                // hoisted Kotlin folder reassembles them via `fromParts` and appends to the
+                // list — no `ArrayList` and no per-element Java object on the Rust side.
+                .fun(fun!(storage_put_slice))
+                .fun(fun!(storage_get_vec))
+                // Whole-batch callback: prepared once, fired with the entire `List<Payload>`.
+                .fun(fun!(payload_vec_handler_new))
+                .fun(fun!(storage_callback_vec)),
+        );
 
     let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -33,6 +33,6 @@ pub(crate) mod write;
 pub use self::{
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
-    prebindgen::{ConverterImpl, Prebindgen, Stage},
+    prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},
     registry::{Direction, Registry, ScanError, TypeEntry, TypeKey, WriteRustError},
 };

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -111,6 +111,23 @@ pub struct ConverterImpl<M = ()> {
     pub subs: Vec<syn::Type>,
 }
 
+/// Re-emit a captured `#[prebindgen]` const as a **path-alias** to its
+/// source-of-truth: same attributes (doc comments), visibility, name and
+/// type, with the initializer replaced by `<source_module>::<ident>`. Used
+/// by [`Prebindgen::on_const`] implementations so consts whose initializers
+/// reference source-crate internals (private helpers, upstream constants)
+/// still compile in the generated file.
+pub fn const_path_alias(c: &syn::ItemConst, source_module: &syn::Path) -> TokenStream {
+    let attrs = &c.attrs;
+    let vis = &c.vis;
+    let ident = &c.ident;
+    let ty = &c.ty;
+    quote::quote! {
+        #(#attrs)*
+        #vis const #ident: #ty = #source_module::#ident;
+    }
+}
+
 /// The single extension point of the pipeline: implement this trait once per
 /// **destination language** (C/cbindgen, JNI/Kotlin, Swift, Python, …) to teach
 /// the language-agnostic [`Registry`] how that language represents Rust types
@@ -257,9 +274,10 @@ pub trait Prebindgen {
     /// Idents of `#[prebindgen]` consts the adapter claims for emission.
     ///
     /// * `None` (default) — the adapter has **no const declaration
-    ///   mechanism**: every indexed const is re-emitted verbatim into the
-    ///   generated Rust, none drives type resolution, and no skip warnings
-    ///   are printed.
+    ///   mechanism**: every indexed const is re-emitted into the generated
+    ///   Rust via [`Self::on_const`] (a path-alias when
+    ///   [`Self::source_module`] is available, verbatim otherwise), none
+    ///   drives type resolution, and no skip warnings are printed.
     /// * `Some(set)` — declared-only, symmetric with functions: a declared
     ///   const's type is scanned as a required **output** type, only
     ///   declared consts reach [`Self::on_const`], and undeclared ones get
@@ -311,6 +329,16 @@ pub trait Prebindgen {
     /// inside function bodies are covered.
     fn post_process_item(&self, _item: &mut syn::Item) {}
 
+    /// Absolute path under which the source crate's items are reachable
+    /// from the generated file (e.g. `zenoh_flat`), for adapters that
+    /// qualify emitted references against one. Drives the default
+    /// [`Self::on_const`]: with a source module available, a named const
+    /// re-emits as a path-alias to the source item instead of copying its
+    /// initializer tokens. Default: `None`.
+    fn source_module(&self) -> Option<&syn::Path> {
+        None
+    }
+
     // ── Item methods ───────────────────────────────────────────────
 
     /// Wrap a `#[prebindgen]` fn into the destination-language wrapper
@@ -324,10 +352,19 @@ pub trait Prebindgen {
     /// Per-enum emission.
     fn on_enum(&self, e: &syn::ItemEnum, registry: &Registry<Self::Metadata>) -> TokenStream;
 
-    /// Per-const emission. Default: pass-through.
+    /// Per-const emission. Default: a named const re-emits as a path-alias
+    /// (see [`const_path_alias`]) when [`Self::source_module`] is available —
+    /// initializer tokens are never copied, so a const whose initializer
+    /// references source-crate internals stays valid in the generated file.
+    /// Unnamed `const _` items (self-contained infrastructure guards, e.g.
+    /// the injected `konst::assertc_eq!` feature check) and adapters without
+    /// a source module pass through verbatim.
     fn on_const(&self, c: &syn::ItemConst, _registry: &Registry<Self::Metadata>) -> TokenStream {
         use quote::ToTokens;
-        c.to_token_stream()
+        match self.source_module() {
+            Some(m) if c.ident != "_" => const_path_alias(c, m),
+            _ => c.to_token_stream(),
+        }
     }
 
     // ── Structural type resolution (the converter-resolution surface) ──

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -254,6 +254,31 @@ pub trait Prebindgen {
         HashSet::new()
     }
 
+    /// Idents of `#[prebindgen]` consts the adapter claims for emission.
+    ///
+    /// * `None` (default) — the adapter has **no const declaration
+    ///   mechanism**: every indexed const is re-emitted verbatim into the
+    ///   generated Rust, none drives type resolution, and no skip warnings
+    ///   are printed.
+    /// * `Some(set)` — declared-only, symmetric with functions: a declared
+    ///   const's type is scanned as a required **output** type, only
+    ///   declared consts reach [`Self::on_const`], and undeclared ones get
+    ///   a `cargo:warning=` skip line (suppressed via
+    ///   [`Self::ignored_consts`]).
+    fn declared_consts(&self) -> Option<HashSet<syn::Ident>> {
+        None
+    }
+
+    /// Idents of `#[prebindgen]` consts the adapter explicitly knows about
+    /// but intentionally does not emit — suppresses the "skipping
+    /// undeclared" warning. Only meaningful when [`Self::declared_consts`]
+    /// returns `Some`.
+    ///
+    /// Default: empty.
+    fn ignored_consts(&self) -> HashSet<syn::Ident> {
+        HashSet::new()
+    }
+
     /// Canonical keys of types (structs / enums) the adapter claims for
     /// emission. Matched against `Registry::structs` and `Registry::enums`
     /// by bare-ident lookup. Anything not in this set is left in the

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -297,6 +297,16 @@ pub trait Prebindgen {
         HashSet::new()
     }
 
+    /// Extra types the adapter requires in the **output** direction beyond
+    /// what scanning the declared items discovers — for adapter-synthesized
+    /// values that have no `#[prebindgen]` item to scan (e.g. the declared
+    /// value type of a binding-defined expression constant).
+    ///
+    /// Default: none.
+    fn required_output_types(&self) -> Vec<syn::Type> {
+        Vec::new()
+    }
+
     /// Canonical keys of types (structs / enums) the adapter claims for
     /// emission. Matched against `Registry::structs` and `Registry::enums`
     /// by bare-ident lookup. Anything not in this set is left in the

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -378,6 +378,10 @@ struct DeclaredItems {
     /// [`Prebindgen::declared_consts`].
     consts: Option<HashSet<syn::Ident>>,
     ignored_consts: HashSet<syn::Ident>,
+    /// Adapter-required extra output types (no `#[prebindgen]` item to
+    /// scan — e.g. expression-constant value types); see
+    /// [`Prebindgen::required_output_types`].
+    required_output_types: Vec<syn::Type>,
 }
 
 impl DeclaredItems {
@@ -394,6 +398,7 @@ impl DeclaredItems {
             ignored_types: adapter.ignored_types(),
             consts: adapter.declared_consts(),
             ignored_consts: adapter.ignored_consts(),
+            required_output_types: adapter.required_output_types(),
         };
 
         if let Some(name) = declared
@@ -513,6 +518,12 @@ impl<M> Registry<M> {
                     );
                 }
             }
+        }
+
+        // Adapter-required extra output types — synthesized values with no
+        // `#[prebindgen]` item behind them (e.g. expression constants).
+        for ty in &declared.required_output_types {
+            self.ensure_entry(Direction::Output, ty, true, &SourceLocation::default());
         }
 
         // Scan declared types.

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -373,6 +373,11 @@ struct DeclaredItems {
     method_receivers: HashMap<syn::Ident, TypeKey>,
     types: HashSet<TypeKey>,
     ignored_types: HashSet<TypeKey>,
+    /// `None` = the adapter has no const declaration mechanism (all consts
+    /// re-emitted verbatim, no scan, no warnings) — see
+    /// [`Prebindgen::declared_consts`].
+    consts: Option<HashSet<syn::Ident>>,
+    ignored_consts: HashSet<syn::Ident>,
 }
 
 impl DeclaredItems {
@@ -387,6 +392,8 @@ impl DeclaredItems {
             method_receivers: adapter.method_receivers(),
             types: adapter.declared_types(),
             ignored_types: adapter.ignored_types(),
+            consts: adapter.declared_consts(),
+            ignored_consts: adapter.ignored_consts(),
         };
 
         if let Some(name) = declared
@@ -484,6 +491,30 @@ impl<M> Registry<M> {
             }
         }
 
+        // Scan declared consts (only when the adapter has a const
+        // declaration mechanism): a const is a nullary source of its type,
+        // so the type is required in the output direction only.
+        if let Some(decl_consts) = &declared.consts {
+            for ident in decl_consts {
+                if let Some((item_const, loc)) = self.consts.get(ident).cloned() {
+                    self.ensure_entry(Direction::Output, &item_const.ty, true, &loc);
+                } else {
+                    println!(
+                        "cargo:warning=prebindgen: declared const `{}` not found among #[prebindgen] items",
+                        ident
+                    );
+                }
+            }
+            for ident in &declared.ignored_consts {
+                if !self.consts.contains_key(ident) {
+                    println!(
+                        "cargo:warning=prebindgen: ignored const `{}` not found among #[prebindgen] items",
+                        ident
+                    );
+                }
+            }
+        }
+
         // Scan declared types.
         for key in &declared.types {
             let ty = key.to_type();
@@ -561,6 +592,27 @@ impl<M> Registry<M> {
                 "cargo:warning=prebindgen: skipping undeclared #[prebindgen] struct/enum `{}`",
                 name
             );
+        }
+
+        if let Some(decl_consts) = &declared.consts {
+            let mut skipped_consts: Vec<String> = self
+                .consts
+                .keys()
+                // Unnamed consts (`const _`, e.g. the injected feature
+                // guard) are infrastructure: not declarable, always emitted
+                // verbatim — never a skip.
+                .filter(|k| {
+                    *k != "_" && !decl_consts.contains(*k) && !declared.ignored_consts.contains(*k)
+                })
+                .map(|k| k.to_string())
+                .collect();
+            skipped_consts.sort();
+            for name in &skipped_consts {
+                println!(
+                    "cargo:warning=prebindgen: skipping undeclared #[prebindgen] const `{}`",
+                    name
+                );
+            }
         }
 
         Ok(())

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -95,12 +95,24 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
             .filter(|(ident, _)| declared_types.contains(&TypeKey::parse(&ident.to_string())))
             .map(|(_, (item, _))| ext.on_enum(item, registry)),
     )?);
-    // Consts: always emit verbatim — declaration mechanism for consts
-    // is future work (see plan).
+    // Consts: an adapter WITH a const declaration mechanism
+    // (`declared_consts() == Some(set)`) emits declared consts only,
+    // symmetric with functions; an adapter without one (`None`) gets every
+    // const passed through verbatim via the default `on_const`. Unnamed
+    // consts (`const _`, e.g. the injected `konst::assertc_eq!` feature
+    // guard) are infrastructure, not declarable API — they bypass the gate
+    // and always emit.
+    let declared_consts = ext.declared_consts();
     items.extend(parse_items_from_tokens(
         "on_const",
         sorted_items_by_ident(&registry.consts)
             .into_iter()
+            .filter(|(ident, _)| {
+                *ident == "_"
+                    || declared_consts
+                        .as_ref()
+                        .is_none_or(|set| set.contains(*ident))
+            })
             .map(|(_, (item, _))| ext.on_const(item, registry)),
     )?);
 

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -747,6 +747,16 @@ impl Cbindgen {
 impl Prebindgen for Cbindgen {
     type Metadata = ();
 
+    // Consts have no declaration mechanism here (`declared_consts` stays
+    // `None`), so every indexed const re-emits through the default
+    // `on_const` — a path-alias against this source module, keeping consts
+    // with non-portable initializers valid in the generated file. (cbindgen
+    // cannot evaluate a path initializer, so aliased consts don't surface
+    // as `#define`s in the C header.)
+    fn source_module(&self) -> Option<&syn::Path> {
+        self.source_module.as_ref()
+    }
+
     // ── Structural type resolution ──────────────────────────────────────
     // The adapter peels `ty` itself: a rank-0 terminal category, else a
     // wrapper shape (`Option<_>`, `&`/`&mut`/`&[_]`/`&str`). See `in_wrappers`

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -63,6 +63,7 @@ impl JniGen {
             class_members: HashMap::new(),
             ignored_fns: std::collections::HashSet::new(),
             ignored_class_types: std::collections::HashSet::new(),
+            ignored_const_idents: std::collections::HashSet::new(),
             accessor_record_fns: std::collections::HashSet::new(),
         };
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
@@ -166,7 +167,7 @@ impl Default for JniGen {
 // ── Accepting a `PackageDecl` ────────────────────────────────────────────
 
 impl JniGen {
-    /// Register a package's worth of classes and functions (a
+    /// Register a package's worth of classes, functions and consts (a
     /// [`PackageDecl`], built with [`package!`](crate::package)). Call it once
     /// per package, or several times for the same package name — the
     /// declarations merge, so you can split a large package across calls.
@@ -175,6 +176,7 @@ impl JniGen {
             name,
             classes,
             functions,
+            constants,
         } = decl;
         self.packages.entry(name.clone()).or_default();
         for class in classes {
@@ -182,6 +184,15 @@ impl JniGen {
         }
         for func in functions {
             self.accept_function(&name, func);
+        }
+        for c in constants {
+            let mut entry = MethodEntry::new(c.rust_ident);
+            entry.kotlin_name_override = c.kotlin_name_override;
+            self.packages
+                .entry(name.clone())
+                .or_default()
+                .constants
+                .push(entry);
         }
         self
     }
@@ -200,6 +211,14 @@ impl JniGen {
     pub fn ignore_class(mut self, rust_type: syn::Type) -> Self {
         self.ignored_class_types
             .insert(TypeKey::from_type(&rust_type));
+        self
+    }
+
+    /// Acknowledge a `#[prebindgen]` const this binding deliberately does
+    /// NOT expose — the const-level dual of [`Self::ignore_fun`]. E.g.
+    /// `.ignore_const(constant!(INTERNAL_MAGIC))`.
+    pub fn ignore_const(mut self, decl: ConstDecl) -> Self {
+        self.ignored_const_idents.insert(decl.rust_ident);
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -178,6 +178,7 @@ impl JniGen {
             functions,
             constants,
             constant_functions,
+            constant_exprs,
         } = decl;
         self.packages.entry(name.clone()).or_default();
         for class in classes {
@@ -203,6 +204,13 @@ impl JniGen {
                 .or_default()
                 .constant_functions
                 .push(entry);
+        }
+        for e in constant_exprs {
+            self.packages
+                .entry(name.clone())
+                .or_default()
+                .constant_exprs
+                .push(e);
         }
         self
     }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -177,6 +177,7 @@ impl JniGen {
             classes,
             functions,
             constants,
+            constant_functions,
         } = decl;
         self.packages.entry(name.clone()).or_default();
         for class in classes {
@@ -192,6 +193,15 @@ impl JniGen {
                 .entry(name.clone())
                 .or_default()
                 .constants
+                .push(entry);
+        }
+        for f in constant_functions {
+            let mut entry = MethodEntry::new(f.rust_ident);
+            entry.kotlin_name_override = f.kotlin_name_override;
+            self.packages
+                .entry(name.clone())
+                .or_default()
+                .constant_functions
                 .push(entry);
         }
         self

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -619,6 +619,7 @@ pub struct PackageDecl {
     pub(crate) classes: Vec<ClassDecl>,
     pub(crate) functions: Vec<FunctionDecl>,
     pub(crate) constants: Vec<ConstDecl>,
+    pub(crate) constant_functions: Vec<FunctionDecl>,
 }
 
 impl PackageDecl {
@@ -634,6 +635,7 @@ impl PackageDecl {
             classes: Vec::new(),
             functions: Vec::new(),
             constants: Vec::new(),
+            constant_functions: Vec::new(),
         }
     }
 
@@ -659,6 +661,29 @@ impl PackageDecl {
     /// customized [`ConstDecl`] when you need `.name(...)`.
     pub fn constant(mut self, decl: ConstDecl) -> Self {
         self.constants.push(decl);
+        self
+    }
+
+    /// Add a **function-backed constant** to this package: a **nullary**
+    /// `#[prebindgen]` fn whose result surfaces as an eagerly-initialized
+    /// top-level Kotlin `val` (computed once, at package-file class-load,
+    /// through the ordinary generated wrapper) instead of a callable `fun`.
+    /// Use it for constant values a Rust `const` cannot express — e.g. a
+    /// string only obtainable through a runtime `Display`.
+    ///
+    /// `.name(...)` sets the val name; the default is the fn ident verbatim
+    /// (you almost always want an explicit SCREAMING_SNAKE name). The same
+    /// restrictions as [`Self::constant`] apply to the return type
+    /// (opaque-handle results are rejected), the fn must take no parameters,
+    /// and flatten overrides are meaningless here — both are hard errors.
+    pub fn constant_fun(mut self, decl: FunctionDecl) -> Self {
+        assert!(
+            decl.input_overrides.is_empty() && decl.output_override.is_none(),
+            "constant_fun `{}`: flatten overrides don't apply to a constant — \
+             declare a plain `FunctionDecl` (optionally with `.name(...)`)",
+            decl.rust_ident
+        );
+        self.constant_functions.push(decl);
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -102,6 +102,22 @@ macro_rules! constant {
     };
 }
 
+/// Build a [`ConstExprDecl`] in val-declaration syntax:
+/// `constant_expr!(BANNER: String = format!("{COVER_TAG}:{COVER_MAGIC}"))` is
+/// `ConstExprDecl::new("BANNER", <String>, <the expression>)`. The expression
+/// is evaluated inside the generated getter with `use <source_module>::*;`
+/// in scope.
+#[macro_export]
+macro_rules! constant_expr {
+    ($name:ident : $ty:ty = $expr:expr) => {
+        $crate::lang::ConstExprDecl::new(
+            stringify!($name),
+            ::syn::parse_quote!($ty),
+            ::syn::parse_quote!($expr),
+        )
+    };
+}
+
 /// Build a [`PackageDecl`] directly: `package!("model")` is
 /// `PackageDecl::new("model")`; `package!()` (no args) is the base package
 /// (`PackageDecl::new("")`).
@@ -603,6 +619,41 @@ impl ConstDecl {
     }
 }
 
+/// Declares one **expression-backed constant**: an arbitrary binding-defined
+/// Rust expression, evaluated once inside a generated nullary JNI getter and
+/// surfaced as an eagerly-initialized top-level Kotlin `val`. The expression
+/// runs with `use <source_module>::*;` in scope, so it composes the source
+/// crate's `#[prebindgen]` items freely without the source crate having to
+/// export a dedicated accessor per constant — e.g.
+/// `encoding_to_string(encoding_const_text_plain())`.
+///
+/// Build one with [`constant_expr!`](crate::constant_expr) (literal form) or
+/// [`ConstExprDecl::new`] (runtime form, for declaration loops) and add it to
+/// a [`PackageDecl`] via [`PackageDecl::constant_expr`]. The value type is
+/// declared explicitly and flows through the ordinary output-converter
+/// machinery; opaque-handle and `Result` types are rejected like every other
+/// constant kind.
+#[derive(Clone)]
+pub struct ConstExprDecl {
+    pub(crate) kotlin_name: String,
+    pub(crate) ty: syn::Type,
+    pub(crate) expr: syn::Expr,
+}
+
+impl ConstExprDecl {
+    /// `kotlin_name` is the top-level `val` name (also the seed of the
+    /// extern symbol, so it must be unique among the binding's constants);
+    /// `ty` is the Rust value type the expression yields; `expr` is the
+    /// initializer expression, resolved against the source module.
+    pub fn new(kotlin_name: impl Into<String>, ty: syn::Type, expr: syn::Expr) -> Self {
+        Self {
+            kotlin_name: kotlin_name.into(),
+            ty,
+            expr,
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // PackageDecl — aggregates the package-scoped decls
 // ──────────────────────────────────────────────────────────────────────
@@ -620,6 +671,7 @@ pub struct PackageDecl {
     pub(crate) functions: Vec<FunctionDecl>,
     pub(crate) constants: Vec<ConstDecl>,
     pub(crate) constant_functions: Vec<FunctionDecl>,
+    pub(crate) constant_exprs: Vec<ConstExprDecl>,
 }
 
 impl PackageDecl {
@@ -636,6 +688,7 @@ impl PackageDecl {
             functions: Vec::new(),
             constants: Vec::new(),
             constant_functions: Vec::new(),
+            constant_exprs: Vec::new(),
         }
     }
 
@@ -684,6 +737,17 @@ impl PackageDecl {
             decl.rust_ident
         );
         self.constant_functions.push(decl);
+        self
+    }
+
+    /// Add an **expression-backed constant** to this package: an arbitrary
+    /// binding-defined Rust expression evaluated once (at package-file
+    /// class-load) inside a generated nullary JNI getter, surfacing as an
+    /// eagerly-initialized top-level Kotlin `val`. See [`ConstExprDecl`];
+    /// build one with [`constant_expr!`](crate::constant_expr) or
+    /// [`ConstExprDecl::new`].
+    pub fn constant_expr(mut self, decl: ConstExprDecl) -> Self {
+        self.constant_exprs.push(decl);
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -93,6 +93,15 @@ macro_rules! fun {
     };
 }
 
+/// Build a [`ConstDecl`] directly from a bare const ident:
+/// `constant!(MAX_LEN)` is `ConstDecl::new(prebindgen::ident!(MAX_LEN))`.
+#[macro_export]
+macro_rules! constant {
+    ($name:ident) => {
+        $crate::lang::ConstDecl::new($crate::ident!($name))
+    };
+}
+
 /// Build a [`PackageDecl`] directly: `package!("model")` is
 /// `PackageDecl::new("model")`; `package!()` (no args) is the base package
 /// (`PackageDecl::new("")`).
@@ -562,20 +571,54 @@ impl FunctionDecl {
     }
 }
 
+/// Declares one `#[prebindgen]` **const** for emission: on the Rust side a
+/// nullary JNI getter extern is generated (the const's type goes through the
+/// ordinary output-converter machinery, exactly like a function return); on
+/// the Kotlin side the const surfaces as an eagerly-initialized top-level
+/// `val` in its package's `.kt` file.
+///
+/// Build one with [`constant!`](crate::constant) and add it to a
+/// [`PackageDecl`] via [`PackageDecl::constant`]. Opaque-handle-typed consts
+/// are rejected (a shared closeable `val` is semantically wrong) — expose a
+/// factory function instead.
+pub struct ConstDecl {
+    pub(crate) rust_ident: syn::Ident,
+    pub(crate) kotlin_name_override: Option<String>,
+}
+
+impl ConstDecl {
+    pub fn new(rust_ident: syn::Ident) -> Self {
+        Self {
+            rust_ident,
+            kotlin_name_override: None,
+        }
+    }
+
+    /// Set the Kotlin-side name. Default: the Rust const ident verbatim
+    /// (`MAX_LEN` → `val MAX_LEN` — SCREAMING_SNAKE is the Kotlin constant
+    /// convention too).
+    pub fn name(mut self, kotlin_name: impl Into<String>) -> Self {
+        self.kotlin_name_override = Some(kotlin_name.into());
+        self
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // PackageDecl — aggregates the package-scoped decls
 // ──────────────────────────────────────────────────────────────────────
 
-/// A batch of class and function declarations that land under one Kotlin
-/// subpackage. Build it with [`package!`](crate::package)
+/// A batch of class, function and const declarations that land under one
+/// Kotlin subpackage. Build it with [`package!`](crate::package)
 /// (`package!("session")`, or `package!()` for the base package), fill it
-/// with [`class`](Self::class) and [`fun`](Self::fun), and hand it to
+/// with [`class`](Self::class) / [`fun`](Self::fun) /
+/// [`constant`](Self::constant), and hand it to
 /// [`JniGen::package`]. Reopening the same subpackage across several
 /// `PackageDecl`s is fine — they merge.
 pub struct PackageDecl {
     pub(crate) name: String,
     pub(crate) classes: Vec<ClassDecl>,
     pub(crate) functions: Vec<FunctionDecl>,
+    pub(crate) constants: Vec<ConstDecl>,
 }
 
 impl PackageDecl {
@@ -590,6 +633,7 @@ impl PackageDecl {
             name,
             classes: Vec::new(),
             functions: Vec::new(),
+            constants: Vec::new(),
         }
     }
 
@@ -606,6 +650,15 @@ impl PackageDecl {
     /// `.name(...)` or per-function overrides.
     pub fn fun(mut self, decl: FunctionDecl) -> Self {
         self.functions.push(decl);
+        self
+    }
+
+    /// Add a `#[prebindgen]` const to this package: a top-level Kotlin `val`
+    /// in the package file, initialized through a generated nullary JNI
+    /// getter. Take a bare name via [`constant!`](crate::constant), or a
+    /// customized [`ConstDecl`] when you need `.name(...)`.
+    pub fn constant(mut self, decl: ConstDecl) -> Self {
+        self.constants.push(decl);
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -783,6 +783,10 @@ pub(crate) fn wrapper_value_ident() -> syn::Ident {
     syn::Ident::new("v", Span::call_site())
 }
 
+/// A [`ScalarTypeWrapperDecl`] conversion body: given the in-scope value
+/// ident, produce the conversion expression.
+pub(crate) type ScalarConvFn = Arc<dyn Fn(&syn::Ident) -> syn::Expr + Send + Sync>;
+
 /// Teaches the generator to carry one Rust type across the boundary as a
 /// **plain scalar** — e.g. a `Millis(u64)` newtype that should surface in
 /// Kotlin as a `Long`, converted with your own expressions each way, with no
@@ -805,8 +809,8 @@ pub struct ScalarTypeWrapperDecl {
     // re-parsed fresh at lookup time instead.
     pub(crate) wire: String,
     pub(crate) kotlin_type: String,
-    pub(crate) input: Option<Arc<dyn Fn(&syn::Ident) -> syn::Expr + Send + Sync>>,
-    pub(crate) output: Option<Arc<dyn Fn(&syn::Ident) -> syn::Expr + Send + Sync>>,
+    pub(crate) input: Option<ScalarConvFn>,
+    pub(crate) output: Option<ScalarConvFn>,
 }
 
 impl ScalarTypeWrapperDecl {
@@ -855,6 +859,10 @@ impl ScalarTypeWrapperDecl {
 /// error** the caller should see. Use [`infallible`](Self::infallible) when
 /// it always succeeds, or [`fallible`](Self::fallible) to route an `Err` to
 /// the caller's error handler (as the built-in `Result` unwrap does).
+// large_enum_variant: a transient codegen-time value immediately destructured
+// by `into_tuple`; boxing the `syn` payloads would only complicate the public
+// variant shape.
+#[allow(clippy::large_enum_variant)]
 pub enum WireBody {
     Infallible(syn::Type, syn::Expr),
     Fallible(syn::Type, syn::Type, syn::Expr),

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -39,19 +39,14 @@ pub(crate) fn const_getter_fn(c: &syn::ItemConst) -> syn::ItemFn {
 /// `close()` is it?). Expose a factory function instead — the established
 /// idiom (e.g. zenoh's `encoding_const_*` companion factories).
 pub(crate) fn reject_handle_const(ext: &JniGen, c: &syn::ItemConst) {
-    reject_handle_constant_type(ext, &c.ty, "const", &c.ident);
+    reject_handle_constant_type(ext, &c.ty, "const", &c.ident.to_string());
 }
 
 /// The constant-value handle check shared by both constant kinds: peel
 /// `&`/`Option`/`Vec` layers off `ty` and reject if what remains is a
 /// declared opaque handle. `what`/`ident` shape the error message
 /// (`const MAX_LEN` / `constant fn encoding_const_x_str`).
-pub(crate) fn reject_handle_constant_type(
-    ext: &JniGen,
-    ty: &syn::Type,
-    what: &str,
-    ident: &syn::Ident,
-) {
+pub(crate) fn reject_handle_constant_type(ext: &JniGen, ty: &syn::Type, what: &str, name: &str) {
     let mut ty = ty.clone();
     loop {
         if let syn::Type::Reference(r) = &ty {
@@ -76,10 +71,9 @@ pub(crate) fn reject_handle_constant_type(
         .is_some();
     assert!(
         !is_handle,
-        "{what} `{}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \
+        "{what} `{name}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \
          not supported. Expose a `#[prebindgen]` factory function returning the constant and \
          declare it as a companion constructor instead.",
-        ident,
         key.as_str()
     );
 }
@@ -105,8 +99,34 @@ pub(crate) fn validate_constant_fn(ext: &JniGen, f: &syn::ItemFn) {
              infallible (declare it with `.fun(...)` instead if it can fail)",
             f.sig.ident
         );
-        reject_handle_constant_type(ext, ty, "constant fn", &f.sig.ident);
+        reject_handle_constant_type(ext, ty, "constant fn", &f.sig.ident.to_string());
     }
+}
+
+/// The synthetic nullary getter signature an **expression constant**
+/// ([`ConstExprDecl`](crate::lang::ConstExprDecl)) is emitted through:
+/// `pub fn const_get_<val_name_lower>() -> <ty>` — the same convention as
+/// const-backed getters, so both sides derive the extern symbol from the one
+/// val name. The body is never used.
+pub(crate) fn const_expr_getter_fn(kotlin_name: &str, ty: &syn::Type) -> syn::ItemFn {
+    let ident = format_ident!("const_get_{}", kotlin_name.to_lowercase());
+    syn::parse_quote! {
+        pub fn #ident() -> #ty {
+            unimplemented!()
+        }
+    }
+}
+
+/// Validates an expression constant's declared value type (checked on both
+/// write paths): not a `Result` (a domain-fallible value is not a constant),
+/// not (peeled to) a declared opaque handle.
+pub(crate) fn validate_constant_expr(ext: &JniGen, kotlin_name: &str, ty: &syn::Type) {
+    assert!(
+        result_ok_type(ty).is_none(),
+        "constant expr `{kotlin_name}`: type is a `Result` — an expression constant must be \
+         infallible (declare a real function with `.fun(...)` instead if it can fail)"
+    );
+    reject_handle_constant_type(ext, ty, "constant expr", kotlin_name);
 }
 
 /// [`emit_jni_function_wrapper`] with the raw callee expression overridable:

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -15,6 +15,74 @@ pub(crate) fn emit_jni_function_wrapper(
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
 ) -> TokenStream {
+    emit_jni_function_wrapper_with_callee(ext, f, registry, None)
+}
+
+/// The synthetic nullary getter signature a declared const is emitted
+/// through: `pub fn const_get_<ident_lower>() -> <const ty>`. Both sides —
+/// the Rust extern ([`JniGen::on_const`] via
+/// [`emit_jni_function_wrapper_with_callee`]) and the Kotlin `val`
+/// initializer (`render_const_val`) — derive the extern symbol from this one
+/// ident, so they stay in sync by construction. The body is never used.
+pub(crate) fn const_getter_fn(c: &syn::ItemConst) -> syn::ItemFn {
+    let ident = format_ident!("const_get_{}", c.ident.to_string().to_lowercase());
+    let ty = &c.ty;
+    syn::parse_quote! {
+        pub fn #ident() -> #ty {
+            unimplemented!()
+        }
+    }
+}
+
+/// A const whose (peeled) type is a declared opaque handle is rejected: an
+/// eagerly-initialized shared closeable `val` is semantically wrong (whose
+/// `close()` is it?). Expose a factory function instead — the established
+/// idiom (e.g. zenoh's `encoding_const_*` companion factories).
+pub(crate) fn reject_handle_const(ext: &JniGen, c: &syn::ItemConst) {
+    let mut ty = (*c.ty).clone();
+    loop {
+        if let syn::Type::Reference(r) = &ty {
+            ty = (*r.elem).clone();
+            continue;
+        }
+        if let Some(inner) = option_inner_type(&ty) {
+            ty = inner;
+            continue;
+        }
+        if let Some(inner) = vec_inner_type(&ty) {
+            ty = inner;
+            continue;
+        }
+        break;
+    }
+    let key = TypeKey::from_type(&ty);
+    let is_handle = ext
+        .types
+        .get(&key)
+        .and_then(|cfg| cfg.opaque.as_ref())
+        .is_some();
+    assert!(
+        !is_handle,
+        "const `{}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \
+         not supported. Expose a `#[prebindgen]` factory function returning the constant and \
+         declare it as a companion constructor instead.",
+        c.ident,
+        key.as_str()
+    );
+}
+
+/// [`emit_jni_function_wrapper`] with the raw callee expression overridable:
+/// `None` = the ordinary `<source_module>::<fn ident>(args)` call; `Some(e)`
+/// splices `e` verbatim as the value the output phase converts. Used by the
+/// const getter emission (`JniGen::on_const`), whose synthetic nullary `f`
+/// carries the signature while the value comes from
+/// `<source_module>::<CONST_IDENT>` — a path, not a call.
+pub(crate) fn emit_jni_function_wrapper_with_callee(
+    ext: &JniGen,
+    f: &syn::ItemFn,
+    registry: &Registry<KotlinMeta>,
+    callee: Option<syn::Expr>,
+) -> TokenStream {
     let original_ident = &f.sig.ident;
     let wrapper_ident = mangle_jni_name(ext, original_ident);
     let source_module = &ext.source_module;
@@ -77,7 +145,10 @@ pub(crate) fn emit_jni_function_wrapper(
         call_args.push(call_arg);
     }
 
-    let raw_call = quote!(#source_module::#original_ident(#(#call_args),*));
+    let raw_call = match &callee {
+        Some(e) => quote!(#e),
+        None => quote!(#source_module::#original_ident(#(#call_args),*)),
+    };
     // For `convert_output` (Return), the value the output converter sees is the
     // **deconstructed** single value (the converter's accessor applied to the
     // raw return, lifted through the shape) — not the raw return. Build that

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -39,7 +39,20 @@ pub(crate) fn const_getter_fn(c: &syn::ItemConst) -> syn::ItemFn {
 /// `close()` is it?). Expose a factory function instead — the established
 /// idiom (e.g. zenoh's `encoding_const_*` companion factories).
 pub(crate) fn reject_handle_const(ext: &JniGen, c: &syn::ItemConst) {
-    let mut ty = (*c.ty).clone();
+    reject_handle_constant_type(ext, &c.ty, "const", &c.ident);
+}
+
+/// The constant-value handle check shared by both constant kinds: peel
+/// `&`/`Option`/`Vec` layers off `ty` and reject if what remains is a
+/// declared opaque handle. `what`/`ident` shape the error message
+/// (`const MAX_LEN` / `constant fn encoding_const_x_str`).
+pub(crate) fn reject_handle_constant_type(
+    ext: &JniGen,
+    ty: &syn::Type,
+    what: &str,
+    ident: &syn::Ident,
+) {
+    let mut ty = ty.clone();
     loop {
         if let syn::Type::Reference(r) = &ty {
             ty = (*r.elem).clone();
@@ -63,12 +76,37 @@ pub(crate) fn reject_handle_const(ext: &JniGen, c: &syn::ItemConst) {
         .is_some();
     assert!(
         !is_handle,
-        "const `{}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \
+        "{what} `{}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \
          not supported. Expose a `#[prebindgen]` factory function returning the constant and \
          declare it as a companion constructor instead.",
-        c.ident,
+        ident,
         key.as_str()
     );
+}
+
+/// Validates a [`PackageDecl::constant_fun`] declaration against the real
+/// signature: the fn must be **nullary** (a constant has no inputs), must
+/// not return a `Result` (a domain-fallible value is not a constant — and
+/// the `val` initializer's throwing `JniErrorHandler` only fits the
+/// infallible wrapper shape), and its return type must not peel to a
+/// declared opaque handle (same rationale as [`reject_handle_const`]).
+pub(crate) fn validate_constant_fn(ext: &JniGen, f: &syn::ItemFn) {
+    assert!(
+        f.sig.inputs.is_empty(),
+        "constant fn `{}`: takes {} parameter(s) — a function-backed constant must be nullary \
+         (declare it with `.fun(...)` instead if it is a real function)",
+        f.sig.ident,
+        f.sig.inputs.len()
+    );
+    if let syn::ReturnType::Type(_, ty) = &f.sig.output {
+        assert!(
+            result_ok_type(ty).is_none(),
+            "constant fn `{}`: returns a `Result` — a function-backed constant must be \
+             infallible (declare it with `.fun(...)` instead if it can fail)",
+            f.sig.ident
+        );
+        reject_handle_constant_type(ext, ty, "constant fn", &f.sig.ident);
+    }
 }
 
 /// [`emit_jni_function_wrapper`] with the raw callee expression overridable:

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -83,7 +83,7 @@ impl JniGen {
         fragments.extend(self.write_typed_handles(registry, &typed_handles));
         fragments.extend(self.write_callback_ifaces(registry));
         for (subpackage, pkg_cfg) in &self.packages {
-            if pkg_cfg.functions.is_empty() {
+            if pkg_cfg.functions.is_empty() && pkg_cfg.constants.is_empty() {
                 continue;
             }
             fragments.push(self.write_jni_package(registry, subpackage, pkg_cfg));
@@ -880,6 +880,28 @@ impl JniGen {
                 file = file.decl(f);
             }
         }
+        // Declared consts: a private nullary helper + the public
+        // eagerly-initialized `val` (see `render_const_val`).
+        for entry in &pkg_cfg.constants {
+            let (item_const, _loc) = registry.consts.get(&entry.rust_ident).unwrap_or_else(|| {
+                panic!(
+                    "write_jni_package: const `{}` registered via .constant(...) is \
+                     not in the prebindgen registry — check the spelling against the \
+                     matching `#[prebindgen]` Rust const name.",
+                    entry.rust_ident,
+                )
+            });
+            reject_handle_const(self, item_const);
+            if let Some((helper, prop)) = render_const_val(
+                self,
+                item_const,
+                registry,
+                &mut imports,
+                entry.kotlin_name_override.as_deref(),
+            ) {
+                file = file.decl(helper).decl(prop);
+            }
+        }
         // The wrapper bodies call the centralized Native object.
         if !self.package.is_empty() {
             imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
@@ -914,6 +936,26 @@ impl JniGen {
             }
             let (item_fn, _loc) = &registry.functions[ident];
             if let Some(code) = render_extern_decl(self, item_fn, registry, &mut imports) {
+                externs = externs.push(code);
+            }
+        }
+
+        // Declared consts: one `external fun` per generated nullary getter,
+        // derived from the same synthetic signature (`const_getter_fn`) the
+        // Rust extern is emitted from — both sides stay in sync by
+        // construction.
+        let mut const_idents: Vec<&syn::Ident> = self
+            .packages
+            .values()
+            .flat_map(|p| p.constants.iter().map(|e| &e.rust_ident))
+            .collect();
+        const_idents.sort_by_key(|i| i.to_string());
+        for ident in const_idents {
+            let Some((item_const, _loc)) = registry.consts.get(ident) else {
+                continue; // missing decl already warned by the scan
+            };
+            let getter = crate::api::lang::jnigen::jni::const_getter_fn(item_const);
+            if let Some(code) = render_extern_decl(self, &getter, registry, &mut imports) {
                 externs = externs.push(code);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -86,6 +86,7 @@ impl JniGen {
             if pkg_cfg.functions.is_empty()
                 && pkg_cfg.constants.is_empty()
                 && pkg_cfg.constant_functions.is_empty()
+                && pkg_cfg.constant_exprs.is_empty()
             {
                 continue;
             }
@@ -932,6 +933,17 @@ impl JniGen {
                 file = file.decl(helper).decl(prop);
             }
         }
+        // Expression constants: a private nullary helper over the synthetic
+        // getter + the public eagerly-initialized `val` (see
+        // `render_const_expr_val`). The value is a binding-defined expression
+        // evaluated Rust-side (`prerequisites`).
+        for decl in &pkg_cfg.constant_exprs {
+            validate_constant_expr(self, &decl.kotlin_name, &decl.ty);
+            if let Some((helper, prop)) = render_const_expr_val(self, decl, registry, &mut imports)
+            {
+                file = file.decl(helper).decl(prop);
+            }
+        }
         // The wrapper bodies call the centralized Native object.
         if !self.package.is_empty() {
             imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
@@ -985,6 +997,21 @@ impl JniGen {
                 continue; // missing decl already warned by the scan
             };
             let getter = crate::api::lang::jnigen::jni::const_getter_fn(item_const);
+            if let Some(code) = render_extern_decl(self, &getter, registry, &mut imports) {
+                externs = externs.push(code);
+            }
+        }
+
+        // Expression constants: same synthetic const_get_* getter shape,
+        // seeded from the val name (no Rust item behind them).
+        let mut expr_decls: Vec<_> = self
+            .packages
+            .values()
+            .flat_map(|p| &p.constant_exprs)
+            .collect();
+        expr_decls.sort_by(|a, b| a.kotlin_name.cmp(&b.kotlin_name));
+        for decl in expr_decls {
+            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
             if let Some(code) = render_extern_decl(self, &getter, registry, &mut imports) {
                 externs = externs.push(code);
             }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -83,7 +83,10 @@ impl JniGen {
         fragments.extend(self.write_typed_handles(registry, &typed_handles));
         fragments.extend(self.write_callback_ifaces(registry));
         for (subpackage, pkg_cfg) in &self.packages {
-            if pkg_cfg.functions.is_empty() && pkg_cfg.constants.is_empty() {
+            if pkg_cfg.functions.is_empty()
+                && pkg_cfg.constants.is_empty()
+                && pkg_cfg.constant_functions.is_empty()
+            {
                 continue;
             }
             fragments.push(self.write_jni_package(registry, subpackage, pkg_cfg));
@@ -895,6 +898,33 @@ impl JniGen {
             if let Some((helper, prop)) = render_const_val(
                 self,
                 item_const,
+                registry,
+                &mut imports,
+                entry.kotlin_name_override.as_deref(),
+            ) {
+                file = file.decl(helper).decl(prop);
+            }
+        }
+        // Function-backed constants: the declared nullary fn's ordinary
+        // wrapper demoted to a private helper + the public eagerly-initialized
+        // `val` (see `render_constant_fn_val`). The JNINative extern and the
+        // Rust wrapper are the plain declared-function ones.
+        for entry in &pkg_cfg.constant_functions {
+            let (item_fn, _loc) = registry
+                .functions
+                .get(&entry.rust_ident)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "write_jni_package: constant fn `{}` registered via .constant_fun(...) \
+                         is not in the prebindgen registry — check the spelling against the \
+                         matching `#[prebindgen]` Rust fn name.",
+                        entry.rust_ident,
+                    )
+                });
+            validate_constant_fn(self, item_fn);
+            if let Some((helper, prop)) = render_constant_fn_val(
+                self,
+                item_fn,
                 registry,
                 &mut imports,
                 entry.kotlin_name_override.as_deref(),

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -169,6 +169,12 @@ pub(crate) struct PackageConfig {
     /// initialized through a generated nullary JNI getter. `MethodEntry`
     /// is reused as-is (rust ident + Kotlin-name override).
     pub constants: Vec<MethodEntry>,
+    /// Function-backed constants declared via [`PackageDecl::constant_fun`]:
+    /// nullary `#[prebindgen]` fns whose result surfaces as a top-level
+    /// Kotlin `val` (eagerly initialized through the fn's ordinary generated
+    /// wrapper) instead of a callable `fun`. Rust-side emission and the
+    /// `JNINative` extern are the plain declared-function ones.
+    pub constant_functions: Vec<MethodEntry>,
 }
 
 /// What kind of class member a [`ClassMember`] is.

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -164,6 +164,11 @@ pub(crate) struct PackageConfig {
     /// `#[prebindgen]` fns declared as free-standing wrappers under this
     /// subpackage via [`JniGen::fun`].
     pub functions: Vec<MethodEntry>,
+    /// `#[prebindgen]` consts declared under this subpackage via
+    /// [`PackageDecl::constant`] — each surfaces as a top-level Kotlin `val`
+    /// initialized through a generated nullary JNI getter. `MethodEntry`
+    /// is reused as-is (rust ident + Kotlin-name override).
+    pub constants: Vec<MethodEntry>,
 }
 
 /// What kind of class member a [`ClassMember`] is.
@@ -363,6 +368,10 @@ pub struct JniGen {
     /// `#[prebindgen]` types the binding deliberately does NOT declare,
     /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].
     pub(crate) ignored_class_types: std::collections::HashSet<TypeKey>,
+
+    /// `#[prebindgen]` consts the binding deliberately does NOT declare,
+    /// via [`JniGen::ignore_const`]. Backs [`Prebindgen::ignored_consts`].
+    pub(crate) ignored_const_idents: std::collections::HashSet<syn::Ident>,
 
     /// Every function ever referenced as a named leaf in a `.default_return_expand(fun!(...))`/
     /// `.return_expand(...)` record (class- or

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -175,6 +175,13 @@ pub(crate) struct PackageConfig {
     /// wrapper) instead of a callable `fun`. Rust-side emission and the
     /// `JNINative` extern are the plain declared-function ones.
     pub constant_functions: Vec<MethodEntry>,
+    /// Expression-backed constants declared via
+    /// [`PackageDecl::constant_expr`](super::jni::decl::PackageDecl::constant_expr):
+    /// binding-defined expressions evaluated once inside a generated nullary
+    /// getter (extern symbol seeded from the val name), surfacing as
+    /// top-level Kotlin `val`s. Stored as the full decl — there is no Rust
+    /// item behind them.
+    pub constant_exprs: Vec<super::jni::decl::ConstExprDecl>,
 }
 
 /// What kind of class member a [`ClassMember`] is.

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -809,6 +809,27 @@ pub(crate) fn render_constant_fn_val(
     render_val_over_helper(ext, helper, val_name, kdoc, imports)
 }
 
+/// Render one expression-backed constant (see `PackageDecl::constant_expr`):
+/// a private nullary helper over the synthetic `const_get_*` getter (seeded
+/// from the val name), plus the public eagerly-initialized `val` — the value
+/// is the binding-defined expression, evaluated once at package-file
+/// class-load through the generated getter.
+pub(crate) fn render_const_expr_val(
+    ext: &JniGen,
+    decl: &crate::api::lang::jnigen::jni::decl::ConstExprDecl,
+    registry: &Registry<KotlinMeta>,
+    imports: &mut BTreeSet<String>,
+) -> Option<(kt::KtFun, kt::KtProperty)> {
+    let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
+    let helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
+    let expr = decl.expr.to_token_stream();
+    let kdoc = format!(
+        "Binding-defined constant: `{expr}` (evaluated once through the \
+         generated JNI getter)."
+    );
+    render_val_over_helper(ext, helper, decl.kotlin_name.clone(), kdoc, imports)
+}
+
 /// Shared val-rendering core for both constant kinds (`ConstDecl` /
 /// `PackageDecl::constant_fun`): demote the rendered wrapper to a private
 /// helper and emit the public eagerly-initialized `val` that calls it once

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -773,15 +773,60 @@ pub(crate) fn render_const_val(
     kotlin_name_override: Option<&str>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
     let getter = const_getter_fn(c);
-    let mut helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
-    helper.vis = kt::Vis::Private;
-    let helper_name = helper.name.clone();
-    // A const always carries a value type; a helper with no return would
-    // mean the type never resolved — skip like an unresolvable fn.
-    let val_ty = helper.ret.clone()?;
+    let helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| c.ident.to_string());
+    let kdoc = format!(
+        "Mirrors the Rust `#[prebindgen]` const `{}` (read once through the \
+         generated JNI getter).",
+        c.ident
+    );
+    render_val_over_helper(ext, helper, val_name, kdoc, imports)
+}
+
+/// Render one function-backed constant (see `PackageDecl::constant_fun`):
+/// the declared nullary fn's ordinary wrapper demoted to a **private**
+/// helper, plus the public eagerly-initialized `val` holding its result —
+/// computed once, at package-file class-load, through the ordinary generated
+/// wrapper (one JNI call, exactly like a const getter).
+pub(crate) fn render_constant_fn_val(
+    ext: &JniGen,
+    f: &syn::ItemFn,
+    registry: &Registry<KotlinMeta>,
+    imports: &mut BTreeSet<String>,
+    kotlin_name_override: Option<&str>,
+) -> Option<(kt::KtFun, kt::KtProperty)> {
+    let helper = render_wrapper_fn(ext, f, registry, imports, None, None)?;
+    let val_name = kotlin_name_override
+        .map(str::to_string)
+        .unwrap_or_else(|| f.sig.ident.to_string());
+    let kdoc = format!(
+        "Mirrors the Rust `#[prebindgen]` fn `{}()` (evaluated once through the \
+         generated JNI wrapper).",
+        f.sig.ident
+    );
+    render_val_over_helper(ext, helper, val_name, kdoc, imports)
+}
+
+/// Shared val-rendering core for both constant kinds (`ConstDecl` /
+/// `PackageDecl::constant_fun`): demote the rendered wrapper to a private
+/// helper and emit the public eagerly-initialized `val` that calls it once
+/// with a throwing `JniErrorHandler` (dead code for infallible converts; a
+/// binding-layer failure surfaces as `IllegalStateException` via
+/// `error(...)`).
+fn render_val_over_helper(
+    ext: &JniGen,
+    mut helper: kt::KtFun,
+    val_name: String,
+    kdoc: String,
+    imports: &mut BTreeSet<String>,
+) -> Option<(kt::KtFun, kt::KtProperty)> {
+    helper.vis = kt::Vis::Private;
+    let helper_name = helper.name.clone();
+    // A constant always carries a value type; a helper with no return would
+    // mean the type never resolved — skip like an unresolvable fn.
+    let val_ty = helper.ret.clone()?;
     let spec = jni_error_handler_iface_spec(ext);
     imports.insert(spec.fqn());
     let init = format!(
@@ -791,11 +836,7 @@ pub(crate) fn render_const_val(
         .ty(val_ty)
         .vis(kt::Vis::Public)
         .initializer(init)
-        .kdoc(format!(
-            "Mirrors the Rust `#[prebindgen]` const `{}` (read once through the \
-             generated JNI getter).",
-            c.ident
-        ));
+        .kdoc(kdoc);
     Some((helper, prop))
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -758,6 +758,47 @@ pub(crate) fn render_wrapper_fn(
     Some(fun.body(body))
 }
 
+/// Render one declared const (see `ConstDecl`): a **private** nullary helper
+/// — the standard wrapper fn over the synthetic getter signature
+/// ([`const_getter_fn`]), reused verbatim so the const's type crosses through
+/// the ordinary output machinery — plus the public eagerly-initialized `val`
+/// that calls it once with a throwing `JniErrorHandler` (dead code for
+/// infallible converts; a binding-layer failure surfaces as
+/// `IllegalStateException` via `error(...)`).
+pub(crate) fn render_const_val(
+    ext: &JniGen,
+    c: &syn::ItemConst,
+    registry: &Registry<KotlinMeta>,
+    imports: &mut BTreeSet<String>,
+    kotlin_name_override: Option<&str>,
+) -> Option<(kt::KtFun, kt::KtProperty)> {
+    let getter = const_getter_fn(c);
+    let mut helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
+    helper.vis = kt::Vis::Private;
+    let helper_name = helper.name.clone();
+    // A const always carries a value type; a helper with no return would
+    // mean the type never resolved — skip like an unresolvable fn.
+    let val_ty = helper.ret.clone()?;
+    let val_name = kotlin_name_override
+        .map(str::to_string)
+        .unwrap_or_else(|| c.ident.to_string());
+    let spec = jni_error_handler_iface_spec(ext);
+    imports.insert(spec.fqn());
+    let init = format!(
+        "{helper_name}(JniErrorHandler {{ je -> error(je ?: \"const {val_name}: JNI getter failed\") }})"
+    );
+    let prop = kt::KtProperty::val(&val_name)
+        .ty(val_ty)
+        .vis(kt::Vis::Public)
+        .initializer(init)
+        .kdoc(format!(
+            "Mirrors the Rust `#[prebindgen]` const `{}` (read once through the \
+             generated JNI getter).",
+            c.ident
+        ));
+    Some((helper, prop))
+}
+
 /// The classified output side of a wrapper: return type, projection wrap,
 /// output-expansion (builder/fold) params, and the extra call-site args —
 /// everything the call-expression builder and the signature assembly must

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -46,8 +46,22 @@ fn declared_consts_emit_getter_and_val() {
         .write_rust(&jni, dir.join("gen.rs"))
         .expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
-    // Verbatim const re-emission + one extern getter each.
-    assert!(rust.contains("pub const MAX_LEN"), "{rust}");
+    // Path-alias const re-emission (the initializer tokens are never
+    // copied — they may reference source-crate internals) + one extern
+    // getter each.
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("pubconstMAX_LEN:i64=myflat::MAX_LEN;"),
+        "{rust}"
+    );
+    assert!(
+        rc.contains("pubconstGREETING:&str=myflat::GREETING;"),
+        "{rust}"
+    );
+    assert!(
+        !rc.contains("=42"),
+        "initializer must not be copied: {rust}"
+    );
     assert!(
         rust.contains("Java_io_test_jni_JNINative_constGetMaxLen"),
         "{rust}"
@@ -115,6 +129,131 @@ fn undeclared_const_not_emitted() {
         .map(|p| std::fs::read_to_string(p).unwrap())
         .collect();
     assert!(!all.contains("GREETING"), "{all}");
+}
+
+/// End-to-end for function-backed constants (`PackageDecl::constant_fun`):
+/// a declared nullary fn surfaces as a private helper + public
+/// eagerly-initialized `val` in the package file; the extern and the Rust
+/// wrapper are the ordinary declared-function ones (`myflat::tag()` call).
+#[test]
+fn constant_fun_emits_val_over_ordinary_wrapper() {
+    let loc = crate::SourceLocation::default();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn tag() -> String {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("cfg").constant_fun(crate::fun!(tag).name("THE_TAG")));
+
+    let dir = unique_test_dir("jnigen_constant_fun_basic");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    // Ordinary declared-function wrapper: an extern calling `myflat::tag()`.
+    assert!(rust.contains("Java_io_test_jni_JNINative_tag"), "{rust}");
+    assert!(rust.contains("myflat::tag()"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let pkg = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni/cfg.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("cfg package file");
+    let pc: String = pkg.split_whitespace().collect();
+    // Public eagerly-initialized val named by `.name()`, over a PRIVATE
+    // helper — no public callable fun.
+    assert!(pc.contains("valTHE_TAG:String=tag("), "{pkg}");
+    assert!(pc.contains("privatefuntag("), "{pkg}");
+    assert!(!pc.contains("publicfuntag("), "{pkg}");
+    // JNINative declares the ordinary extern.
+    let native = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("base package file");
+    let nc: String = native.split_whitespace().collect();
+    assert!(nc.contains("externalfuntag("), "{native}");
+}
+
+/// A non-nullary fn cannot be a constant.
+#[test]
+#[should_panic(expected = "must be nullary")]
+fn constant_fun_non_nullary_rejected() {
+    let loc = crate::SourceLocation::default();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn scaled(factor: i64) -> i64 {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("cfg").constant_fun(crate::fun!(scaled)));
+    let dir = unique_test_dir("jnigen_constant_fun_arity_reject");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let _ = jni.write_kotlin(&registry, &dir.join("kotlin"));
+}
+
+/// A fn returning a declared opaque handle cannot be a constant — same
+/// rejection (and guidance) as a handle-typed const.
+#[test]
+#[should_panic(expected = "declared opaque handle")]
+fn constant_fun_handle_return_rejected() {
+    let loc = crate::SourceLocation::default();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThing {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn default_thing() -> ZThing {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("things")
+                .class(crate::ptr_class!(ZThing))
+                .constant_fun(crate::fun!(default_thing)),
+        );
+    let dir = unique_test_dir("jnigen_constant_fun_handle_reject");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let _ = jni.write_kotlin(&registry, &dir.join("kotlin"));
 }
 
 /// A const whose type is a declared opaque handle is rejected with guidance

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -256,6 +256,114 @@ fn constant_fun_handle_return_rejected() {
     let _ = jni.write_kotlin(&registry, &dir.join("kotlin"));
 }
 
+/// End-to-end for expression-backed constants (`PackageDecl::constant_expr`):
+/// the binding-defined expression is evaluated inside a generated nullary
+/// getter (with `use <source_module>::*;` in scope, composing source items
+/// without the source crate exporting a dedicated accessor), and surfaces as
+/// a private helper + public eagerly-initialized `val`.
+#[test]
+fn constant_expr_emits_getter_and_val() {
+    let loc = crate::SourceLocation::default();
+    // Only `tag_of` exists in the source crate; the constant composes it.
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn tag_of(n: i64) -> String {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("cfg")
+                .fun(crate::fun!(tag_of))
+                .constant_expr(crate::constant_expr!(DEFAULT_TAG: String = tag_of(7))),
+        );
+
+    let dir = unique_test_dir("jnigen_constant_expr_basic");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // The getter extern is seeded from the val name and evaluates the
+    // expression with the source module's items in scope.
+    assert!(
+        rust.contains("Java_io_test_jni_JNINative_constGetDefaultTag"),
+        "{rust}"
+    );
+    assert!(rc.contains("usemyflat::*;"), "{rust}");
+    assert!(rc.contains("tag_of(7)"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let pkg = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni/cfg.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("cfg package file");
+    let pc: String = pkg.split_whitespace().collect();
+    assert!(
+        pc.contains("valDEFAULT_TAG:String=constGetDefaultTag("),
+        "{pkg}"
+    );
+    assert!(pc.contains("privatefunconstGetDefaultTag("), "{pkg}");
+    // JNINative declares the getter extern.
+    let native = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("base package file");
+    let nc: String = native.split_whitespace().collect();
+    assert!(nc.contains("externalfunconstGetDefaultTag("), "{native}");
+}
+
+/// An expression constant whose declared type is an opaque handle is
+/// rejected like every other constant kind.
+#[test]
+#[should_panic(expected = "declared opaque handle")]
+fn constant_expr_handle_type_rejected() {
+    let loc = crate::SourceLocation::default();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThing {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn thing_new() -> ZThing {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("things")
+                .class(crate::ptr_class!(ZThing))
+                .fun(crate::fun!(thing_new))
+                .constant_expr(crate::constant_expr!(DEFAULT_THING: ZThing = thing_new())),
+        );
+    let dir = unique_test_dir("jnigen_constant_expr_handle_reject");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+}
+
 /// A const whose type is a declared opaque handle is rejected with guidance
 /// to use a factory function instead.
 #[test]

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -1,0 +1,166 @@
+//! Declared-const emission: a `#[prebindgen] const` declared via
+//! `package!().constant(constant!(X))` surfaces as a Rust nullary JNI
+//! getter extern plus a Kotlin top-level eagerly-initialized `val`.
+
+use super::*;
+
+fn const_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = crate::SourceLocation::default();
+    vec![
+        (
+            syn::Item::Const(syn::parse_quote!(
+                pub const MAX_LEN: i64 = 42;
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Const(syn::parse_quote!(
+                pub const GREETING: &str = "hi";
+            )),
+            loc.clone(),
+        ),
+    ]
+}
+
+/// End-to-end: both consts declared — the generated Rust contains the
+/// verbatim consts and one getter extern each; the Kotlin package file
+/// contains the two `val`s (typed `Int` / `String`) initialized through the
+/// private helpers, and `JNINative` declares the matching `external fun`s.
+#[test]
+fn declared_consts_emit_getter_and_val() {
+    let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("cfg")
+                .constant(crate::constant!(MAX_LEN))
+                .constant(crate::constant!(GREETING).name("HELLO")),
+        );
+
+    let dir = unique_test_dir("jnigen_consts_basic");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    // Verbatim const re-emission + one extern getter each.
+    assert!(rust.contains("pub const MAX_LEN"), "{rust}");
+    assert!(
+        rust.contains("Java_io_test_jni_JNINative_constGetMaxLen"),
+        "{rust}"
+    );
+    assert!(
+        rust.contains("Java_io_test_jni_JNINative_constGetGreeting"),
+        "{rust}"
+    );
+    // The getter's value comes from the const path, not a call.
+    assert!(rust.contains("myflat::MAX_LEN"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let pkg = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni/cfg.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("cfg package file");
+    let pc: String = pkg.split_whitespace().collect();
+    // Public eagerly-initialized vals, typed from the output converters;
+    // the `.name()` override applies to the val, not the extern.
+    assert!(pc.contains("valMAX_LEN:Long=constGetMaxLen("), "{pkg}");
+    assert!(pc.contains("valHELLO:String=constGetGreeting("), "{pkg}");
+    // The helpers are private wrapper functions.
+    assert!(pc.contains("privatefunconstGetMaxLen("), "{pkg}");
+    // JNINative declares the extern halves.
+    let native = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("base package file");
+    let nc: String = native.split_whitespace().collect();
+    assert!(nc.contains("externalfunconstGetMaxLen("), "{native}");
+    assert!(nc.contains("externalfunconstGetGreeting("), "{native}");
+}
+
+/// An undeclared const emits nothing (JniGen has a const declaration
+/// mechanism, so const emission is declared-only); `ignore_const`
+/// acknowledges it without emitting.
+#[test]
+fn undeclared_const_not_emitted() {
+    let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("cfg").constant(crate::constant!(MAX_LEN)))
+        .ignore_const(crate::constant!(GREETING));
+
+    let dir = unique_test_dir("jnigen_consts_undeclared");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    assert!(rust.contains("pub const MAX_LEN"), "{rust}");
+    // The ignored const neither re-emits nor gets a getter.
+    assert!(!rust.contains("GREETING"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect();
+    assert!(!all.contains("GREETING"), "{all}");
+}
+
+/// A const whose type is a declared opaque handle is rejected with guidance
+/// to use a factory function instead.
+#[test]
+#[should_panic(expected = "declared opaque handle")]
+fn handle_const_rejected() {
+    let loc = crate::SourceLocation::default();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThing {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Const(syn::parse_quote!(
+                pub const DEFAULT_THING: ZThing = ZThing { _p: 0 };
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn thing_new() -> ZThing {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("things")
+                .class(crate::ptr_class!(ZThing))
+                .fun(crate::fun!(thing_new))
+                .constant(crate::constant!(DEFAULT_THING)),
+        );
+
+    let dir = unique_test_dir("jnigen_consts_handle_reject");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -11,6 +11,7 @@ use crate::api::{
 
 mod callbacks;
 mod config;
+mod consts;
 mod flatten;
 mod niches;
 mod snapshots;

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -915,6 +915,12 @@ impl Prebindgen for JniGen {
             for m in &pkg.functions {
                 out.insert(m.rust_ident.clone());
             }
+            // Function-backed constants (`constant_fun`) are ordinary
+            // declared functions on the Rust/extern side; only their Kotlin
+            // surface differs (an eagerly-initialized top-level `val`).
+            for m in &pkg.constant_functions {
+                out.insert(m.rust_ident.clone());
+            }
         }
         // Class members (accessor/method/constructor) are declared via
         // `.accessor`/`.method`/`.constructor` (not `.fun`) but are still real
@@ -1073,12 +1079,17 @@ impl Prebindgen for JniGen {
         TokenStream::new()
     }
 
+    fn source_module(&self) -> Option<&syn::Path> {
+        Some(&self.source_module)
+    }
+
     /// Declared consts only reach here (write gating via
-    /// [`Prebindgen::declared_consts`]): re-emit the const verbatim AND emit
-    /// its nullary JNI getter extern. The getter reuses the whole function-
-    /// wrapper pipeline (so the const's type flows through the ordinary
-    /// output-converter machinery); only the callee expression differs — a
-    /// path to the const, not a call.
+    /// [`Prebindgen::declared_consts`]): re-emit the const as a path-alias
+    /// to its source-of-truth (initializer tokens are never copied — they
+    /// may reference source-crate internals) AND emit its nullary JNI getter
+    /// extern. The getter reuses the whole function-wrapper pipeline (so the
+    /// const's type flows through the ordinary output-converter machinery);
+    /// only the callee expression differs — a path to the const, not a call.
     fn on_const(&self, c: &syn::ItemConst, registry: &Registry<KotlinMeta>) -> TokenStream {
         // Unnamed infrastructure consts (`const _`, e.g. the injected
         // `konst::assertc_eq!` feature guard) pass through verbatim — no
@@ -1092,9 +1103,9 @@ impl Prebindgen for JniGen {
         let source_module = &self.source_module;
         let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
         let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
-        let verbatim = c.to_token_stream();
+        let alias = crate::api::core::const_path_alias(c, source_module);
         quote! {
-            #verbatim
+            #alias
             #wrapper
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -967,6 +967,26 @@ impl Prebindgen for JniGen {
             .collect()
     }
 
+    /// Union of every `.constant(...)` list across all
+    /// [`Self::package`] subpackage contexts. `Some` even when empty — JniGen
+    /// HAS a const declaration mechanism, so const emission is declared-only
+    /// and undeclared consts get the skip warning (see
+    /// [`Prebindgen::declared_consts`]).
+    fn declared_consts(&self) -> Option<std::collections::HashSet<syn::Ident>> {
+        let mut out = std::collections::HashSet::new();
+        for pkg in self.packages.values() {
+            for c in &pkg.constants {
+                out.insert(c.rust_ident.clone());
+            }
+        }
+        Some(out)
+    }
+
+    /// Consts acknowledged-but-unexposed via [`JniGen::ignore_const`].
+    fn ignored_consts(&self) -> std::collections::HashSet<syn::Ident> {
+        self.ignored_const_idents.clone()
+    }
+
     /// Fns acknowledged-but-unbound via [`JniGen::ignore_fun`] — suppresses
     /// the registry's "skipping undeclared" warning, emits nothing.
     fn ignored_functions(&self) -> std::collections::HashSet<syn::Ident> {
@@ -1053,8 +1073,30 @@ impl Prebindgen for JniGen {
         TokenStream::new()
     }
 
-    fn on_const(&self, c: &syn::ItemConst, _registry: &Registry<KotlinMeta>) -> TokenStream {
-        c.to_token_stream()
+    /// Declared consts only reach here (write gating via
+    /// [`Prebindgen::declared_consts`]): re-emit the const verbatim AND emit
+    /// its nullary JNI getter extern. The getter reuses the whole function-
+    /// wrapper pipeline (so the const's type flows through the ordinary
+    /// output-converter machinery); only the callee expression differs — a
+    /// path to the const, not a call.
+    fn on_const(&self, c: &syn::ItemConst, registry: &Registry<KotlinMeta>) -> TokenStream {
+        // Unnamed infrastructure consts (`const _`, e.g. the injected
+        // `konst::assertc_eq!` feature guard) pass through verbatim — no
+        // getter, no Kotlin surface.
+        if c.ident == "_" {
+            return c.to_token_stream();
+        }
+        reject_handle_const(self, c);
+        let getter = const_getter_fn(c);
+        let const_ident = &c.ident;
+        let source_module = &self.source_module;
+        let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
+        let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
+        let verbatim = c.to_token_stream();
+        quote! {
+            #verbatim
+            #wrapper
+        }
     }
 
     fn dispatch_fn_input(

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -978,6 +978,17 @@ impl Prebindgen for JniGen {
     /// HAS a const declaration mechanism, so const emission is declared-only
     /// and undeclared consts get the skip warning (see
     /// [`Prebindgen::declared_consts`]).
+    /// The declared value types of every expression constant
+    /// (`PackageDecl::constant_expr`) — they have no `#[prebindgen]` item to
+    /// scan, so the resolver is told directly to produce their output
+    /// converters.
+    fn required_output_types(&self) -> Vec<syn::Type> {
+        self.packages
+            .values()
+            .flat_map(|p| p.constant_exprs.iter().map(|e| e.ty.clone()))
+            .collect()
+    }
+
     fn declared_consts(&self) -> Option<std::collections::HashSet<syn::Ident>> {
         let mut out = std::collections::HashSet::new();
         for pkg in self.packages.values() {
@@ -1054,6 +1065,28 @@ impl Prebindgen for JniGen {
                     };
                 ));
             }
+        }
+        // Expression constants — one nullary JNI getter extern per
+        // `PackageDecl::constant_expr`, its value the binding-defined
+        // expression evaluated with `use <source_module>::*;` in scope (so
+        // it composes the source crate's items without qualification). The
+        // getter reuses the whole function-wrapper pipeline via the
+        // synthetic signature, exactly like a const-backed getter.
+        let source_module = &self.source_module;
+        for decl in self.packages.values().flat_map(|p| &p.constant_exprs) {
+            validate_constant_expr(self, &decl.kotlin_name, &decl.ty);
+            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
+            let expr = &decl.expr;
+            let callee: syn::Expr = syn::parse_quote!({
+                #[allow(unused_imports)]
+                use #source_module::*;
+                #expr
+            });
+            let wrapper =
+                emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
+            items.push(syn::parse2::<syn::Item>(wrapper).expect(
+                "constant_expr: generated getter wrapper is a single item by construction",
+            ));
         }
         items
     }

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,8 +21,8 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, ClassDecl, DataClassDecl, EnumClassDecl, FunctionDecl,
-    GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl,
+    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, DataClassDecl, EnumClassDecl,
+    FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl,
     ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };
 

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,9 +21,9 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, DataClassDecl, EnumClassDecl,
-    FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl,
-    ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
+    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, DataClassDecl,
+    EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl,
+    PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -257,10 +257,10 @@ pub mod lang {
         jnigen::{
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
-            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, DataClassDecl,
-            EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen,
-            KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
-            WriteKotlinError,
+            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl,
+            DataClassDecl, EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError,
+            JniGen, KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
+            WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -257,7 +257,7 @@ pub mod lang {
         jnigen::{
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
-            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, DataClassDecl,
+            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, DataClassDecl,
             EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen,
             KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
             WriteKotlinError,


### PR DESCRIPTION
## Why

The `lang::JniGen` adapter had no way to surface constants: a `#[prebindgen] const` was invisible to the Kotlin side, and constant values that a Rust `const` cannot express at all — a string only obtainable through a runtime `Display`, or a value composed from the source crate's factory functions — had no channel whatsoever. This PR adds three progressively more expressive constant kinds, all surfacing as **eagerly-initialized top-level Kotlin `val`s** and sharing one validation and emission core.

## What

### 1. Rust-const-backed: `PackageDecl::constant` (`constant!`)

A named `#[prebindgen] const` declared via `.constant(constant!(X))` (with the universal `.name()` override, and an `ignore_const` opt-out on the builder) emits a nullary JNI getter extern on the Rust side — reusing the standard output-converter machinery, so `String`, enums, value types etc. all work — and a top-level Kotlin `val` on the binding side. Opaque-handle-typed consts are rejected with a clear error: a handle constant would be a shared mutable global with lifecycle burden; use a factory function instead.

Core support: new `Prebindgen::declared_consts() -> Option<HashSet<String>>` hook. `None` (the default, e.g. `lang::Cbindgen`) means the adapter has no const mechanism and every captured const re-emits verbatim as before; `Some(set)` gates re-emission to the declared ones. Unnamed `const _` items (the injected `konst` feature guard) always pass through ungated.

### 2. Function-backed: `PackageDecl::constant_fun`

A nullary `#[prebindgen]` fn surfaced as a Kotlin `val` instead of a function — for constant values a Rust `const` cannot express. The Rust extern and `JNINative` declaration are the ordinary declared-function ones; only the Kotlin rendering diverts, sharing the const-val emission core. Validation: must be nullary, must not return `Result`, opaque-handle returns rejected (shared `reject_handle_constant_type`).

Also in this commit: named `#[prebindgen]` consts now re-emit into consumer generated files as **path aliases** (`pub const X: T = source::X;`) via the new `Prebindgen::source_module()` hook, so const initializers may reference source-crate internals (private helpers, upstream constants) instead of having to be literal. `const _` guards keep verbatim re-emission. Cbindgen consumers no longer surface such consts as C `#define`s — a path initializer is not evaluable by cbindgen.

### 3. Expression-backed: `PackageDecl::constant_expr` (`constant_expr!`)

An arbitrary **binding-defined** Rust expression in val-declaration syntax — `.constant_expr(constant_expr!(NAME: Type = expr))` — evaluated once inside a generated nullary JNI getter with `use <source_module>::*;` in scope, and surfaced as a Kotlin `val`. This lets a binding compose the source crate's existing `#[prebindgen]` items into constants — e.g. `encoding_to_string(encoding_const_text_plain())` — without the source crate exporting a dedicated accessor fn per constant. The getter is emitted via `prerequisites()` (there is no `#[prebindgen]` item behind it); the extern symbol is seeded from the val name (`const_get_<name>`).

Core support: new `Prebindgen::required_output_types()` hook, so adapter-synthesized values can register their value types for output-converter resolution.

## Verification

- `covertest-kotlin` gains sections asserting all three kinds at JVM runtime (`COVER_MAGIC`/`COVER_TAG` const-backed, `COVER_TAG_RUNTIME` function-backed, `COVER_BANNER` expression-backed); its build.rs coverage table updated.
- Committed example goldens regenerated (covertest-kotlin Rust+Kotlin, perftest-c `.rs`/`.h` picking up the path-alias re-emission).
- Full workspace test suite green (`cargo test --all --all-features`), including the new `jni/tests/consts.rs` suite.
