### PR TITLE
JniGen API cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "examples/perftest-flat",
     "examples/perftest-c",
     "examples/perftest-kotlin",
+    "examples/covertest-helpers",
     "examples/covertest-kotlin",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ fn main() {
         .function(pq!(calculator_new))
         .function(pq!(calculator_get_value)).panic();
 
-    // Resolve types and write the Rust file of `extern "C"` wrappers.
-    let mut registry =
-        prebindgen::core::Registry::from_items(source.items_all()).unwrap();
-    let bindings_file = registry.write_rust(&cbindgen, "example_flat.rs").unwrap();
+    // Resolve types, then write the Rust file of `extern "C"` wrappers.
+    let generation = prebindgen::core::Registry::from_items(source.items_all())
+        .unwrap()
+        .resolve(cbindgen)
+        .unwrap();
+    let bindings_file = generation.write_rust("example_flat.rs").unwrap();
 
     // Pass the generated file to cbindgen for C header generation.
     generate_c_headers(&bindings_file);

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -502,6 +502,20 @@ function's real signature; typos surface late (or as warnings).
 `set_emit_handle_locks(bool)` is all-or-nothing; the known per-call lock
 overhead on hot paths can't be traded per class or function.
 
+> **Resolution (2026-07-15): premise tested and found false — toggle
+> re-documented as verification-only, no granularity added.** The "known
+> per-call lock overhead" was measured (perftest Kotlin leg, N = 5M per
+> op, best of two runs per config, JDK 21 / macOS arm64): locks-on vs
+> locks-off deltas ranged −3.2%…+3.6% with **mixed sign** — i.e. within
+> run-to-run noise (which itself exceeded 30% on the cheapest op across
+> passes). The tightest bound comes from `put native.null` (~33 ns/call,
+> no string, no real work): ~1 ns for the entire uncontended
+> `withSortedHandleLocks` pair + closed-handle guard. Every op doing real
+> work is dominated by the JNI crossing. Per-class/per-fn lock granularity
+> is therefore a knob without a payoff and is rejected;
+> `set_emit_handle_locks(false)` stays global, documented as existing so
+> anyone can independently re-verify this claim on their own workload.
+
 ### C7. No introspection
 
 Canonical inputs/outputs "AUTO-APPLY" at a distance; the only way to learn what

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -149,9 +149,10 @@ trait impl or as a plain fn in the binding crate. Each direction now picks
 one of: a `#[prebindgen]` fn (`.input`/`.output`), an `Into`/`From` impl
 (`.input_from(ty!(i32))`/`.output_into(...)`), a fallible `TryInto`/`TryFrom`
 impl (`.input_try_from(...)` — the associated `Error` routes to `onError`),
-or a binding-local callable (`.input_with(ty!(String), path!(crate::f))` —
-works because the generated file compiles inside the binding crate; closes
-the "helpers need a separate crate" gap for infallible by-value cases). All
+or a binding-local callable (`.input_with(ty!(String), path!(crate::f))`,
+fallible via `.input_try_with(repr, error, path)` with the error type stated
+in the decl — works because the generated file compiles inside the binding
+crate; closes the "helpers need a separate crate" gap entirely). All
 three new kinds are demonstrated in covertest (`Celsius`/`Percent`/`Label`)
 with JVM assertions including the TryFrom error path.
 

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -108,6 +108,41 @@ extern are gone.
 Their direction pairs are also named inconsistently: `on_param`/`on_return` vs
 `input`/`output` vs `param_expand`/`return_expand`.
 
+**Resolution (2026-07-13): the wrapper tier is gone; conversions are named
+functions.** Investigation deepened the finding: the scalar decl's position
+words (`on_param`/`on_return`) were actively misleading (converters are
+direction-things — the "return" body also runs for callback *arguments*), the
+generic tier had zero users and zero tests anywhere, and the injected
+`syn`/`quote` expression bodies were unchecked splices (most of C3). The
+replacement is `convert!`:
+
+```rust
+.convert(convert!(Millis)
+    .input(fun!(millis_from_long))    // fn(i64) -> Millis (or Result<Millis, E>)
+    .output(fun!(millis_value)))      // fn(&Millis) -> i64
+```
+
+— ordinary `#[prebindgen]` functions, type-checked by rustc; the wire and
+Kotlin surface derive from the signature's other-side type through its own
+converter chain (no verbatim strings). `convert!` is the type's **canonical
+single-value aspect**, orthogonal to the `expand_*!` boundary decls: a type
+may declare both — expansion wins at the fn boundaries where declared, the
+conversion serves everything else (`Result`-Ok, struct fields, `Option`/`Vec`
+nesting). Direction words (`input`/`output`) are kept deliberately, against
+the expand family's position words, and documented.
+
+Conversion fns the flat crate doesn't provide live in a **helper crate**
+(same-crate `#[prebindgen]` markers cannot feed the same crate's build.rs —
+macro expansion runs after it): `Registry::from_sources` ingests several
+sources, records per-fn origin crates, and generated calls qualify each fn
+with its defining crate. Proven in covertest via `examples/covertest-helpers`.
+
+Scope cut, recorded: deleting `GenericTypeWrapperDecl` removes user-defined
+*wildcard* wrapper patterns (`MyWrapper<_>`). The rank tables and the built-in
+`Result<_,_>` peel remain internal, so a function-based wildcard door can be
+reopened when a real consumer needs one; concrete instantiations are already
+coverable by `convert!`.
+
 ### M6. Two "package" concepts
 
 `.package(package!("bytes"))` adds a declaration batch under a *sub*package;

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -133,8 +133,12 @@ a consumer comment.
 **Correction (2026-07-13):** overstated — the generator already owns this
 invariant with a decl-time hard error (`UnfoldError::RootIdentityBeforeNested`,
 message includes the fix), so the wrong order never reaches non-compiling
-Rust. The consumer comment predates that check. Remaining question for this
-item: keep the hard error, or silently sort identity leaves last.
+Rust. The consumer comment predates that check.
+
+**Resolution (2026-07-13): keep the hard error, no code change.** Declaration
+order defines leaf order everywhere else, so silently re-sorting the `_self`
+leaf would make declaration order and emitted order diverge; the error message
+already names the fix.
 
 ### I3. Flipped receivers, hidden temporal coupling
 

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -306,6 +306,24 @@ enforces the order.
 a function reference coexist (`fun!(x)`, `FunctionDecl::new(ident!(x))`, `pq!`
 for params) — the consumer file uses three of them.
 
+> **Resolution (2026-07-15): fixed — one `.ignore(impl Into<IgnoreDecl>)`
+> acceptor**, the kind carried by what you built (mirroring `.class` /
+> `.constant` / `.expand` / `.convert`): `fun!(x)` / `ty!(T)` /
+> `constant!(X)` for exact items, plus `matching(|n| …)` — a **universal**
+> name-family predicate covering ANY undeclared item kind (fn, struct/enum,
+> const). Kind-agnosticism costs nothing: prebindgen items live in one flat
+> namespace, so a name filter needs no kind; the fn-only
+> `ignore_funs_where` from I7's first cut is superseded (core hook renamed
+> `ignored_name_predicates`, applied in all three skip-warning filters).
+> The four `ignore_*` methods are deleted. Surface overrides on ignored
+> decls (`.name()`, expand overrides, const value sources) are decl-time
+> panics — an ignore names a bare source item. Spelling standard recorded:
+> decl macros (`fun!`/`ty!`/`constant!`) are the normal form,
+> `FunctionDecl::new` / `ConstDecl::named` the runtime loop forms; the
+> `pq!` spelling survives only in the Cbindgen builder
+> (`ignore_function(syn::Ident)` / `ignore_type(syn::Type)`), a different
+> pre-decl-macro model, out of this item's scope.
+
 ### I5. Member support varies by class kind for implementation reasons
 
 `data_class` forbids `.fun`/`.constructor` ("no handle to hang a method on")

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -331,6 +331,30 @@ while `value_class` — equally handle-less — allows them. `.kotlin_type()` (m
 onto an existing Kotlin type) exists only on data/value classes; enums and ptr
 classes can't be mapped onto existing types.
 
+> **Resolution (2026-07-15): fixed — the matrix now follows two rules.**
+>
+> | capability | ptr | data | value | enum |
+> |---|---|---|---|---|
+> | `.fun` / `.constructor` | ✓ | ✓ *(new)* | ✓ | ✗ by rule |
+> | `.kotlin_type()` | ✗ by rule | ✓ | ✓ | ✓ *(new)* |
+>
+> **Rule 1 — members**: meaningful wherever an instance can re-enter Rust.
+> A ptr receiver re-enters as its handle, a value receiver as its blob, a
+> data receiver as its **field leaves** — the same call-site destructuring
+> a data-class *parameter* already got, rebased to `this` (implemented;
+> zero new wire machinery, the extern is unchanged). An enum value is a
+> bare scalar with no object identity — a "method" is just a free fn.
+> **Rule 2 — `.kotlin_type()`**: meaningful wherever the generated class is
+> pure surface. Data/value/enum all qualify (the enum mapping only requires
+> the target type to honor the `fromInt`/`.value` protocol; implemented, no
+> file generated). A ptr class is NOT pure surface — it owns a lifecycle
+> contract (NativeHandle base, `ptr` slot, `close()`, lock protocol, paired
+> `freePtr`) an existing type can't be assumed to honor.
+> `.kotlin_type()` + members is rejected (a mapped type has no generated
+> class to hold them; assert added to data AND value). Demonstrated in
+> covertest: `Payload.labelLen()` — the free fn moved into the data class,
+> regen diff is exactly the receiver rebasing to `this.id, this.seq, …`.
+
 ### I6. Three overlapping const mechanisms
 
 `constant`, `constant_fun`, `constant_expr`: the flagship consumer only needed

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -648,6 +648,26 @@ returns `Self` at declaration; mistakes surface as resolver errors during
 `write_rust`, far from the offending decl. The locking scaffold has no
 JVM-runtime test (design-verified only).
 
+> **Resolution (2026-07-15): half 1 fixed; half 2 was already stale.**
+> The member-shape gap was worse than stated: a receiver-less `.fun()`
+> didn't even hit a resolver error — `classify_params` never bound the
+> receiver and the method emitted with ALL params, silently ignoring
+> `this`; a wrong-return `.constructor()` emitted a factory of the wrong
+> type. Fixed via a new core hook `Prebindgen::validate(&self, registry)
+> -> Result<(), String>` (called by `Registry::resolve` right after the
+> declaration scan — the earliest signatures exist, per the C5 reasoning;
+> `Err` surfaces as `ScanError::AdapterInvariant` verbatim). jnigen's impl
+> checks every class member: a `.fun()` target must have a parameter whose
+> peeled type is the class (error names the class, the fn, and what it
+> actually took); a `.constructor()` must return `Self` or
+> `Result<Self, E>` (error names the actual return). The full 233-test
+> suite passing under the new validation is itself the proof it accepts
+> every legitimate member shape. The JVM-runtime lock test exists since
+> the covertest-hardening round: Test.kt's "3-handle locking + 2-thread
+> smoke" (4 workers with opposite lock orders + a writer, 30 s join
+> timeout catching deadlock, consistency counters), run by the covertest
+> CI job — the critique line predates it.
+
 ---
 
 ## What the API gets right

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -133,9 +133,10 @@ the expand family's position words, and documented.
 
 Conversion fns the flat crate doesn't provide live in a **helper crate**
 (same-crate `#[prebindgen]` markers cannot feed the same crate's build.rs —
-macro expansion runs after it): `Registry::from_sources` ingests several
-sources, records per-fn origin crates, and generated calls qualify each fn
-with its defining crate. Proven in covertest via `examples/covertest-helpers`.
+macro expansion runs after it): the helper's item stream is chained into the
+same `Registry::from_items` call, per-item origin crates are recorded, and
+generated calls qualify each fn with its defining crate. Proven in covertest
+via `examples/covertest-helpers`.
 
 Scope cut, recorded: deleting `GenericTypeWrapperDecl` removes user-defined
 *wildcard* wrapper patterns (`MyWrapper<_>`). The rank tables and the built-in
@@ -157,7 +158,7 @@ three new kinds are demonstrated in covertest (`Celsius`/`Percent`/`Label`)
 with JVM assertions including the TryFrom error path.
 
 **Follow-up (2026-07-14): `set_source_module` removed entirely.** With
-per-item origins recorded for every named item at `from_sources` ingestion,
+per-item origins recorded for every named item at multi-source ingestion,
 the setter had no information the registry didn't already own. The first
 source doubles as the default module (declared-but-unindexed types,
 deliberately unmarked types); item-level registries (`from_items`, tests)
@@ -165,6 +166,19 @@ use `Registry::set_default_module`. `constant_expr` getters now glob-import
 every source module, so binding-defined expressions compose items from all
 sources. One less setting, one less way for the declaration to disagree
 with the data.
+
+**Follow-up (2026-07-14): `from_sources`/`add_source` removed — origins
+ride the stream.** Taking whole `Source` objects bypassed the item-stream
+design (`from_items` exists precisely so callers prefilter by group, cfg,
+or any hand-rolled chain). Instead, `Source` stamps its crate name into
+each yielded item's `SourceLocation` (`crate_name: Option<String>`; not
+part of the captured JSONL — the proc-macro can't know the name consumers
+see), so streams stay plain `(syn::Item, SourceLocation)` values that
+compose with ordinary iterator combinators:
+`Registry::from_items(flat.items_all().chain(helpers.items_all()))`.
+`from_items` records per-item origins and the first-seen origin as the
+default module; duplicate-name errors still name both crates. One
+constructor, full prefiltering, multi-source for free.
 
 ### M6. Two "package" concepts
 

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -481,6 +481,17 @@ The consumer must `remove_dir_all` the Kotlin root itself to avoid stale files
 after package moves; `write_kotlin` returns paths written but offers no prune
 option.
 
+> **Resolution (2026-07-15): fixed — the Kotlin root is generator-owned.**
+> `write_kotlin` (via `kt::write_files`) deletes and recreates `kotlin_root`
+> on every run, so stale files from a renamed package or removed
+> declaration can never linger and the identical `remove_dir_all`
+> boilerplate is gone from all three consumers. The contract is documented
+> on both entry points: point the root at a dedicated directory (the
+> established `kotlin/generated/` convention), never at hand-written
+> sources. A marker-based selective prune was considered and rejected as
+> too complex for the problem — whole-directory ownership is the simple,
+> predictable rule.
+
 ### C5. Parameters named by bare ident
 
 `param_expand_self(pq!(key_expr))` — no decl-time validation against the

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -180,6 +180,20 @@ compose with ordinary iterator combinators:
 default module; duplicate-name errors still name both crates. One
 constructor, full prefiltering, multi-source for free.
 
+**Follow-up (2026-07-15): rename override moved to the `Source` builder —
+`Registry::set_default_module` removed.** The stamped origin is the source
+crate's `CARGO_PKG_NAME` at capture time, which breaks when the binding
+crate renames the dependency (`cov_helpers = { package =
+"covertest-helpers", .. }`). The registry-level override could only fix
+the *default* (first) module — incomplete with chained multi-source
+streams — so the override now lives where the stamp is made:
+`Source::builder(dir).crate_name("cov_helpers")`, per-source and therefore
+complete. It also fixes the features-guard qualification
+(`cov_helpers::FEATURES`) in one move. Proven in covertest: the helpers
+dependency is renamed in Cargo.toml on purpose. Hand-built origin-less
+streams (tests) stamp `SourceLocation.crate_name` directly — the same
+mechanism production uses.
+
 ### M6. Two "package" concepts
 
 `.package(package!("bytes"))` adds a declaration batch under a *sub*package;

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -624,6 +624,23 @@ output-side `Option<prim>` boxing deliberately not done.
 `set_package_prefix`'s trimming; `pub mod jni` exposes undocumented internals
 (`MethodEntry`, `WireBody` plumbing) beyond the curated `lang::` re-export list.
 
+> **Resolution (2026-07-15): fixed — one field sealed; the rest was
+> already sealed by earlier rounds.** Audit of the flagged leaks:
+> `source_module` no longer exists (deleted with `set_source_module`,
+> M5 follow-up); `WireBody` died with the wrapper tier (M5); the module
+> leak is structurally closed — `lib.rs` declares `pub(crate) mod api`, so
+> `lang::jnigen::jni` is not a public path and the ONLY public surface is
+> the curated `lang::{…}` re-export list (`MethodEntry`/`TypeConfig`'s pub
+> fields are crate-internal convention, unreachable from outside). The one
+> real remaining leak was `JniGen.package: pub String` — `JniGen` itself
+> is publicly reachable, so a direct field write compiled and bypassed
+> `set_package_prefix`'s trimming, corrupting every derived form
+> (FindClass paths, extern idents, Kotlin package lines). Sealed to
+> `pub(crate)`. Sweep of the rest of the curated list (decl types,
+> `Cbindgen`, `JniBindingError`, `CachedIfaceMethod`) found no other pub
+> fields; `KotlinFile`'s model fields are its deliberate surface. A stale
+> doc-comment path in covertest (`lang::jnigen::jni::decl`) corrected.
+
 ### N5. Decl-time validation gaps
 
 Nothing checks a `.fun()` target takes `&Self` first or a `.constructor()`

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -76,6 +76,15 @@ public fun sessionPut(
 (`0, "key", null`). No overloads, no sealed type. If this tier is meant to be
 hand-wrapped, the decl docs shouldn't be phrased in end-user ergonomics terms.
 
+**Resolution (2026-07-14): docs rephrased in wire terms.** The
+`ExpandParamDecl` type doc and `variant()` method doc now state the actual
+generated shape — the parameter crosses as a selector `Int` plus one nullable
+slot per arm (`keyExprSel: Int, keyExpr0: String?, keyExpr1: KeyExpr?`), and
+say explicitly that this is wire-level dispatch: idiomatic overloads / sealed
+types are a hand-written SDK tier's job. Since N1 the generated wrapper's KDoc
+shape-notes document the exact slots per function, so callers see the real
+prototype at the call site too. No behavior change.
+
 ### M4. Error support requires declaring a phantom class
 
 To make `Result<T, Error>` resolve, `Error` must be declared `ptr_class!(Error)`
@@ -220,11 +229,36 @@ renamed away long ago. The `JniGen` doc example (`jni/mod.rs`) uses
 `ZKeyExpr`/`z_keyexpr_as_str` — pre-de-prefix names that no longer exist
 anywhere in the workspace.
 
+**Resolution (2026-07-14): full sweep, verified by `cargo doc`.** The
+`kotlin_emit.rs` "via `.method(...)`" line now describes the current
+vocabulary (`.fun`/`.constructor` on a class decl, `PackageDecl::fun` for free
+functions). The `JniGen` doc example was already de-prefixed by an earlier
+round. Beyond the critique's two anchors, the sweep fixed every stale
+reference this cleanup's own renames introduced: `PackageDecl::constant_expr`
+/ `constant_fun` → `ConstDecl::expr` / `ConstDecl::fun` (I6),
+`JniGen::ignore_fun` / `ignore_class` / `ignore_const` /
+`ignore_funs_where` → `JniGen::ignore` / `matching` (I4), and
+`Registry::write_rust` → `Registry::resolve` / `Generation::write_rust` (I3).
+`cargo doc -p prebindgen` now reports zero unresolved intradoc links.
+
 ### M8. Generator internals leak into the public generated API
 
 `ErrorHandler.run(je: String?, message: String)` — `je` ("JNI error") is an
 internal abbreviation in a public Kotlin signature; capture fields `ze0`,
 `__cap.ze0!!` force-unwraps.
+
+**Resolution (2026-07-14): keep `je`, document the contract.** Renaming was
+rejected: `je` is load-bearing shorthand used consistently across the whole
+error model (docs, capture classes, generated Rust), and any longer name still
+needs the null-contract explanation to mean anything. Instead every generated
+handler `fun interface` now carries a KDoc stating the contract: `je != null`
+⇒ a binding/system-tier failure (`je` is its message, remaining parameters
+carry defaults); `je == null` ⇒ a domain error (remaining parameters carry the
+decomposed error, the typed handler's KDoc names the type); throwing from
+`run` is safe because it executes after the native call has returned. The
+`ze{i}` capture fields were already non-public (`internal … Capture` classes),
+so no generated *public* signature leaks them. Plumbing: `IfaceSpec.kdoc` →
+`KtFunInterface.kdoc`.
 
 ---
 

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -143,6 +143,16 @@ Scope cut, recorded: deleting `GenericTypeWrapperDecl` removes user-defined
 reopened when a real consumer needs one; concrete instantiations are already
 coverable by `convert!`.
 
+**Follow-up (2026-07-14): `set_source_module` removed entirely.** With
+per-item origins recorded for every named item at `from_sources` ingestion,
+the setter had no information the registry didn't already own. The first
+source doubles as the default module (declared-but-unindexed types,
+deliberately unmarked types); item-level registries (`from_items`, tests)
+use `Registry::set_default_module`. `constant_expr` getters now glob-import
+every source module, so binding-defined expressions compose items from all
+sources. One less setting, one less way for the declaration to disagree
+with the data.
+
 ### M6. Two "package" concepts
 
 `.package(package!("bytes"))` adds a declaration batch under a *sub*package;

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -598,6 +598,21 @@ can't be built through by the recursive input fold (forces Sample's
 identity-only input); opaque-handle consts rejected; `&mut [T]` unsupported;
 output-side `Option<prim>` boxing deliberately not done.
 
+> **Resolution (2026-07-15): catalogued in
+> [issue #33](https://github.com/milyin/prebindgen/issues/33) — feature
+> work, not API-shape defects; tracked outside this cleanup PR.** Triage:
+> *deferred gaps* — `Vec<handle>` INPUT (loud panic with hint; output side
+> already folds Kotlin-side), `Option<ptr_class>` through the recursive
+> fold (loud `UnsupportedOptional`; per-fn identity-only opt-out is the
+> workaround), `&mut [T]`/`&mut T` (falls through to the generic
+> unresolved-type error — a targeted reject-with-hint is the issue's first
+> sub-task, per the I7 policy); *by-design exclusions* — opaque-handle
+> consts (a shared closeable `val` is semantically wrong; the loaning
+> factory + `constant!(N).expr(…)` idiom is the pattern) and output-side
+> `Option<prim>` boxing (inherent to the single-value return channel;
+> revisit only with a benchmark). Each entry in the issue carries the
+> failure-mode anchor, the workaround, and an implementation sketch.
+
 ### N3. API split across branches
 
 **Resolution (2026-07-13): already resolved before this effort started** —

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -22,6 +22,13 @@ runtime-dispatched variants), while repeated `.default_return_expand(accessor)`
 calls accumulate *fields* (AND — all delivered in one crossing). Identical call
 shape, sum-vs-product semantics; nothing in the names distinguishes them.
 
+**Resolution (2026-07-13, with I1):** the type-level declarations are now
+dedicated builders whose arm names carry the semantics — `param_expand!(T)`
+accumulates `.variant()` arms (OR), `return_expand!(T)` accumulates `.field()`
+entries (AND). The per-fn overrides keep the `param_expand(param, …)` /
+`return_expand(…)` names; their differing shapes (param-keyed vs not) already
+distinguish them.
+
 ### M2. `_self` means three different things
 
 - Class-level `.default_param_expand_self()` alone: a documented **no-op**
@@ -102,6 +109,18 @@ Constructors doubling as param variants also repeat
 `.default_param_expand(fun!(zbytes_new_from_vec))`). Roughly a third of the
 consumer's decl text is restatement.
 
+**Resolution (2026-07-13):** rather than a member-modifier shortcut (rejected:
+a second way to say the same thing), the two jobs were separated. A class decl
+now declares only the Kotlin surface; the boundary shape is declared once,
+per direction, at the generator level:
+`.param_expand(param_expand!(T).variant(fun!(ctor)).variant_self())` and
+`.return_expand(return_expand!(T).field(fun!(get)).field_self())`. A
+`.field(fun!(x))` inherits its Kotlin name from the class member declaration
+of the same fn (explicit `.name()` wins), so the name is written once. The
+declarations remain order-independent: `JniGen` stores boundary decls raw and
+assembles the expansion sets at the point of use (the `Prebindgen` trait's
+`expansions()`/`deconstructors()` hooks now return by value).
+
 ### I2. Order-independence advertised where it's cheap, absent where it's load-bearing
 
 Settings are "order-independent by construction" (`config.rs` doc) — but
@@ -110,6 +129,12 @@ fields, or the generated Rust fails with "use of moved value". The consumer's
 build.rs carries a shouting ORDER MATTERS comment. The generator could sort
 identity leaves last, or hard-error with a hint; instead the invariant lives in
 a consumer comment.
+
+**Correction (2026-07-13):** overstated — the generator already owns this
+invariant with a decl-time hard error (`UnfoldError::RootIdentityBeforeNested`,
+message includes the fix), so the wrong order never reaches non-compiling
+Rust. The consumer comment predates that check. Remaining question for this
+item: keep the hard error, or silently sort identity leaves last.
 
 ### I3. Flipped receivers, hidden temporal coupling
 

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -129,13 +129,20 @@ consumer's decl text is restatement.
 a second way to say the same thing), the two jobs were separated. A class decl
 now declares only the Kotlin surface; the boundary shape is declared once,
 per direction, at the generator level:
-`.param_expand(param_expand!(T).variant(fun!(ctor)).variant_self())` and
-`.return_expand(return_expand!(T).field(fun!(get)).field_self())`. A
+`.expand(param_expand!(T).variant(fun!(ctor)).variant_self())` and
+`.expand(return_expand!(T).field(fun!(get)).field_self())`. A
 `.field(fun!(x))` inherits its Kotlin name from the class member declaration
 of the same fn (explicit `.name()` wins), so the name is written once. The
 declarations remain order-independent: `JniGen` stores boundary decls raw and
 assembles the expansion sets at the point of use (the `Prebindgen` trait's
 `expansions()`/`deconstructors()` hooks now return by value).
+
+**Follow-up (2026-07-13):** the two acceptors were unified into a single
+`JniGen::expand(impl Into<ExpandDecl>)`, the direction carried by the decl
+object — the same pattern as `PackageDecl::class(impl Into<ClassDecl>)` with
+its four class-kind macros. The `param_expand!` / `return_expand!` macros are
+unchanged; `ExpandDecl` deliberately has no `From<syn::Type>` (a bare type
+doesn't say which direction it describes).
 
 ### I2. Order-independence advertised where it's cheap, absent where it's load-bearing
 

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -68,6 +68,22 @@ NativeHandle` with `close()`, `take()`, `freePtr()` — a dead class with a
 public raw-pointer constructor no user can legitimately call. Errors deserve a
 first-class declaration.
 
+**Resolution (2026-07-13): generalized rather than special-cased.** A
+dedicated error declaration (and an `.internal()` marker on `ptr_class!`) were
+both rejected — the former makes errors special for no reason, the latter
+keeps pretending there is Kotlin wrapping where none happens. Instead,
+boundary decls now work for **rust-side-only types**: `param_expand!` /
+`return_expand!` accept types not declared in any package. Such a type is
+always built from its ingredients on input and decomposed into its fields on
+output (including the `Result<_, E>` error channel); it never materializes in
+Kotlin — no class, no handle, no `freePtr`. The one structural restriction:
+`variant_self()` / `field_self()` hard-error (there is no Kotlin object to
+pass or deliver). Derived interfaces (`<T>Handler`, `<T>Builder`) land in the
+base package. zenoh-flat-jni's `Error` is now exactly this: one
+`return_expand!(Error).field(fun!(error_get_message).name("message"))` line;
+the dead Kotlin class, its uncallable `message()` method, and its `freePtr`
+extern are gone.
+
 ### M5. "wrapper" is overloaded
 
 `ScalarTypeWrapperDecl` = a conversion rule for a *concrete* type;

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -286,6 +286,20 @@ two halves of one generation run with inverted receivers, and `write_kotlin`
 silently requires the resolution `write_rust` performed. Nothing in the types
 enforces the order.
 
+> **Resolution (2026-07-15): fixed — `Generation` object.**
+> `Registry::resolve(self, adapter)` consumes both halves (scan + plans +
+> type resolution) and returns `Generation<E>`; `gen.write_rust(path)` and
+> `gen.write_kotlin(root)` (an inherent impl on `Generation<JniGen>`) are
+> pure emissions on ONE receiver. The resolve-before-write coupling is
+> enforced by construction — the old entry points no longer exist — and the
+> two writes commute: the write phase was verified to take `&Registry`
+> (all mutation happens in resolve), the adapter holds no interior
+> mutability, and a test asserts byte-identical output with the calls
+> flipped. The adapter is named once (`resolve(jni)`) instead of being
+> re-passed to every call; cbindgen consumers chain
+> `from_items(…)?.resolve(cbindgen)?.write_rust(…)?`. Escape hatches:
+> `gen.registry()` / `gen.adapter()`.
+
 ### I4. Inconsistent argument kinds for the same concept
 
 `ignore_fun(FunctionDecl)` vs `ignore_class(syn::Type)`. Several ways to spell

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -143,6 +143,18 @@ Scope cut, recorded: deleting `GenericTypeWrapperDecl` removes user-defined
 reopened when a real consumer needs one; concrete instantiations are already
 coverable by `convert!`.
 
+**Follow-up (2026-07-14): four conversion sources.** Requiring a
+`#[prebindgen]` fn was too narrow — the conversion may already exist as a
+trait impl or as a plain fn in the binding crate. Each direction now picks
+one of: a `#[prebindgen]` fn (`.input`/`.output`), an `Into`/`From` impl
+(`.input_from(ty!(i32))`/`.output_into(...)`), a fallible `TryInto`/`TryFrom`
+impl (`.input_try_from(...)` — the associated `Error` routes to `onError`),
+or a binding-local callable (`.input_with(ty!(String), path!(crate::f))` —
+works because the generated file compiles inside the binding crate; closes
+the "helpers need a separate crate" gap for infallible by-value cases). All
+three new kinds are demonstrated in covertest (`Celsius`/`Percent`/`Label`)
+with JVM assertions including the TryFrom error path.
+
 **Follow-up (2026-07-14): `set_source_module` removed entirely.** With
 per-item origins recorded for every named item at `from_sources` ingestion,
 the setter had no information the registry didn't already own. The first

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -425,6 +425,27 @@ class's Rust name; it could strip `<class>_get_` / `<class>_` prefixes for
 members, or offer a member-name mangle hook (five global mangle hooks exist;
 none applies here).
 
+> **Resolution (2026-07-15): fixed — namespace-relative member names +
+> `set_member_name_mangle`.** The default rule is a statement about
+> namespaces, not string munging: a flat Rust crate spells the type
+> namespace inside the ident (`storage_len`, `keyexpr_intersects`)
+> precisely because flat FFI has no method syntax; a Kotlin member already
+> lives in its class's namespace, so the default removes exactly that
+> prefix — nothing else — and camel-cases the rest. Matching is
+> underscore-insensitive on both sides (class `KeyExpr` strips `keyexpr_*`
+> AND `key_expr_*`); no prefix ⇒ full-ident camelCase as before; the
+> extern/`JNINative` tier keeps the full ident (it's the JNI symbol).
+> `get_`/`new_` dropping is deliberately NOT automatic — zenoh itself keeps
+> `get` in `getSchema`/`getStr` and drops it in `id` — those are style
+> choices for `.name()` or the new **sixth mangle hook**
+> `set_member_name_mangle` (same `Fn(&str) -> String` shape as the other
+> five, receives the stripped camelCase default, skipped by `.name()`,
+> order-independent — `ClassMember` now stores the raw override and the
+> effective name derives at point of use; expand `.field(fun!(x))`
+> inheritance follows it automatically). Validated by byte-identical
+> regen after deleting the now-redundant `.name()`s: 10 in covertest, 13
+> in zenoh-flat-jni (the 45 remaining are genuine renames).
+
 ### C2. No bulk/pattern ignore
 
 53 hand-enumerated `ident!(encoding_const_*)` calls exist only to silence

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -497,6 +497,29 @@ option.
 `param_expand_self(pq!(key_expr))` — no decl-time validation against the
 function's real signature; typos surface late (or as warnings).
 
+> **Resolution (2026-07-15): already fixed by M2/I7/I3 — no change; test
+> gaps filled.** The example API is gone (M2 replaced the modal
+> `param_expand_*` methods). Every bare-ident reference a declaration
+> writes is now checked against the registry when `Registry::resolve`
+> runs — the earliest moment signatures exist (decl objects are built
+> before any source is read, so literal decl-time validation is
+> structurally impossible; resolve-time hard errors are what the critique
+> was actually asking for). The map, all hard `Err`s out of `.resolve()`:
+>
+> | reference | validation |
+> |---|---|
+> | declared fn / member / const / helper fn | `ScanError::DeclaredNotFound` (I7) |
+> | `.expand_param("name", …)` param string | `ExpandError::UnknownParam` |
+> | per-fn expand decl type | `ParamTypeMismatch` / `ReturnTypeMismatch` (M2) |
+> | `expand_param!` variant ctor | `UnknownConstructor` / `TargetMismatch` / `NoConstructor` |
+> | `expand_return!` field accessor | `UnfoldError::UnknownAccessor` / `AccessorTargetMismatch` / `RecordNotAccessor` |
+> | output leaf names | `DuplicateLeafName` (explicit-literal rule) |
+> | exact `.ignore(...)` entries | warning **by design** (an ignore is bookkeeping, not a claim) |
+>
+> Gap-fill: `UnknownConstructor`, ctor `TargetMismatch`, and
+> `UnknownAccessor` had no direct tests — added (core expand/unfold test
+> modules); the rest were already covered.
+
 ### C6. Global-only lock toggle
 
 `set_emit_handle_locks(bool)` is all-or-nothing; the known per-call lock

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -1,0 +1,262 @@
+# JniGen API critique
+
+An analysis of the `prebindgen::lang::JniGen` public API: where it is misleading,
+illogical, inconvenient, or incomplete. Evidence base: the builder/decl/config
+surface (`prebindgen/src/api/lang/jnigen/jni/{builder,decl,config,mod,selector,kotlin_emit}.rs`),
+the real consumer ([zenoh-flat-jni](https://github.com/ZettaScaleLabs/zenoh-flat-jni)
+`build.rs`, ~600 lines), and the Kotlin that consumer generates.
+
+Each finding has a stable ID (`M*` misleading, `I*` illogical, `C*` inconvenient,
+`N*` incomplete) referenced from the tracking PR's checklist. Findings are kept
+even after being fixed, with a **Resolution** note appended, so the document
+remains a design-decision record.
+
+---
+
+## Misleading
+
+### M1. Symmetric names, opposite composition semantics
+
+Repeated `.default_param_expand(ctor)` calls accumulate *alternatives* (OR —
+runtime-dispatched variants), while repeated `.default_return_expand(accessor)`
+calls accumulate *fields* (AND — all delivered in one crossing). Identical call
+shape, sum-vs-product semantics; nothing in the names distinguishes them.
+
+### M2. `_self` means three different things
+
+- Class-level `.default_param_expand_self()` alone: a documented **no-op**
+  (identity is already the default; `builder.rs` skips it) — yet the consumer
+  calls it anyway, "for documentation".
+- Fn-level `.param_expand_self(param)`: a meaningful **opt-out** of the class's
+  default variants.
+- Fn-level `.return_expand_self()`: "the raw handle" — but for borrowed returns
+  (`&T`) it actually means **clone into a fresh owned handle**: a hidden
+  allocation behind a name that says "identity".
+
+### M3. `default_param_expand` docs oversell ergonomics
+
+Doc: "lets every function taking a KeyExpr also accept a plain String."
+Generated reality:
+
+```kotlin
+public fun sessionPut(
+    session: Session,
+    keyExprSel: Int,
+    keyExpr0: String?,
+    keyExpr1: KeyExpr?,
+    ...
+)
+```
+
+— the caller passes a manual discriminator int plus per-variant nullable slots
+(`0, "key", null`). No overloads, no sealed type. If this tier is meant to be
+hand-wrapped, the decl docs shouldn't be phrased in end-user ergonomics terms.
+
+### M4. Error support requires declaring a phantom class
+
+To make `Result<T, Error>` resolve, `Error` must be declared `ptr_class!(Error)`
+— but the handle "never actually crosses" (consumer's own comment). The
+generator still emits a full public `class Error(initialPtr: Long) :
+NativeHandle` with `close()`, `take()`, `freePtr()` — a dead class with a
+public raw-pointer constructor no user can legitimately call. Errors deserve a
+first-class declaration.
+
+### M5. "wrapper" is overloaded
+
+`ScalarTypeWrapperDecl` = a conversion rule for a *concrete* type;
+`GenericTypeWrapperDecl` = a rule for Rust *wrapper types* (`Option`/`Result`).
+Their direction pairs are also named inconsistently: `on_param`/`on_return` vs
+`input`/`output` vs `param_expand`/`return_expand`.
+
+### M6. Two "package" concepts
+
+`.package(package!("bytes"))` adds a declaration batch under a *sub*package;
+`set_package_prefix` sets the actual package. `package!()` (no args) means
+"no subpackage", not "no package".
+
+### M7. Stale docs inside the API
+
+`kotlin_emit.rs` module doc says functions get a home "via `.method(...)`" —
+renamed away long ago. The `JniGen` doc example (`jni/mod.rs`) uses
+`ZKeyExpr`/`z_keyexpr_as_str` — pre-de-prefix names that no longer exist
+anywhere in the workspace.
+
+### M8. Generator internals leak into the public generated API
+
+`ErrorHandler.run(je: String?, message: String)` — `je` ("JNI error") is an
+internal abbreviation in a public Kotlin signature; capture fields `ze0`,
+`__cap.ze0!!` force-unwraps.
+
+---
+
+## Illogical / inconsistent
+
+### I1. The same fact must be declared twice
+
+Sample's 13 getters each appear as `.fun(fun!(sample_get_payload).name("payload"))`
+*and* `.default_return_expand(fun!(sample_get_payload).name("payload"))` — 26
+declarations, `.name()` repeated verbatim (same pattern for Query, Reply, Hello,
+Encoding). The `ClassMember` docs confirm records "don't consult this list".
+Constructors doubling as param variants also repeat
+(`.constructor(fun!(zbytes_new_from_vec).name("fromVec"))` +
+`.default_param_expand(fun!(zbytes_new_from_vec))`). Roughly a third of the
+consumer's decl text is restatement.
+
+### I2. Order-independence advertised where it's cheap, absent where it's load-bearing
+
+Settings are "order-independent by construction" (`config.rs` doc) — but
+`.default_return_expand_self()` MUST be declared *last* after nested-handle
+fields, or the generated Rust fails with "use of moved value". The consumer's
+build.rs carries a shouting ORDER MATTERS comment. The generator could sort
+identity leaves last, or hard-error with a hint; instead the invariant lives in
+a consumer comment.
+
+### I3. Flipped receivers, hidden temporal coupling
+
+`registry.write_rust(&jni, path)` but `jni.write_kotlin(&registry, path)` — the
+two halves of one generation run with inverted receivers, and `write_kotlin`
+silently requires the resolution `write_rust` performed. Nothing in the types
+enforces the order.
+
+### I4. Inconsistent argument kinds for the same concept
+
+`ignore_fun(FunctionDecl)` vs `ignore_class(syn::Type)`. Several ways to spell
+a function reference coexist (`fun!(x)`, `FunctionDecl::new(ident!(x))`, `pq!`
+for params) — the consumer file uses three of them.
+
+### I5. Member support varies by class kind for implementation reasons
+
+`data_class` forbids `.fun`/`.constructor` ("no handle to hang a method on")
+while `value_class` — equally handle-less — allows them. `.kotlin_type()` (map
+onto an existing Kotlin type) exists only on data/value classes; enums and ptr
+classes can't be mapped onto existing types.
+
+### I6. Three overlapping const mechanisms
+
+`constant`, `constant_fun`, `constant_expr`: the flagship consumer only needed
+`constant_expr` for the non-trivial cases; the superseded `constant_fun` /
+path-alias rounds shipped anyway.
+
+### I7. Mixed failure modes with no policy
+
+Dotted `.name()` → panic at decl time; builtin scalar-wrapper pattern → panic;
+typo'd `fun!(name)` → **cargo warning + silent omission** (`registry.rs`
+"declared function not found"); non-`Copy` value_class → compile error inside
+`generated_bindings.rs`; malformed value-blob bytes → runtime Kotlin error;
+wildcard rank > 3 → silent `return None`. A *declared*-but-missing function is
+explicit intent gone wrong and should be a hard error.
+
+---
+
+## Inconvenient
+
+### C1. `.name()` needed on nearly every member
+
+Default Kotlin name is `snake_to_camel` of the full Rust ident —
+`sample_get_payload` becomes `sampleGetPayload` *on the Sample class*, so
+effectively every `.fun()` carries a manual `.name()`. The generator knows the
+class's Rust name; it could strip `<class>_get_` / `<class>_` prefixes for
+members, or offer a member-name mangle hook (five global mangle hooks exist;
+none applies here).
+
+### C2. No bulk/pattern ignore
+
+53 hand-enumerated `ident!(encoding_const_*)` calls exist only to silence
+undeclared-fn warnings — and the same 53 names appear a second time (lowercase)
+to build the consts. No prefix/regex ignore, no way to derive one list from the
+other.
+
+### C3. The advanced wrapper tier demands syn/quote fluency
+
+Bodies are token-interpolation closures (`|v| pq!(Millis(*#v as u64))`) with a
+fixed value-ident convention, `jni::sys::*` wire names, patterns matched by
+*exact canonical path equality* (no short-name matching — invisible until
+nothing resolves), and closure arity encoding rank via phantom-typed
+`WrapperBuilder<Arity1..3>` — a wrong arity yields an opaque
+unsatisfied-trait-bound error.
+
+### C4. Manual output hygiene
+
+The consumer must `remove_dir_all` the Kotlin root itself to avoid stale files
+after package moves; `write_kotlin` returns paths written but offers no prune
+option.
+
+### C5. Parameters named by bare ident
+
+`param_expand_self(pq!(key_expr))` — no decl-time validation against the
+function's real signature; typos surface late (or as warnings).
+
+### C6. Global-only lock toggle
+
+`set_emit_handle_locks(bool)` is all-or-nothing; the known per-call lock
+overhead on hot paths can't be traded per class or function.
+
+### C7. No introspection
+
+Canonical inputs/outputs "AUTO-APPLY" at a distance; the only way to learn what
+a decl produces is to run generation and diff. The extensive prose comments in
+the consumer's build.rs are compensating for a missing explain/dry-run mode.
+
+---
+
+## Incomplete
+
+### N1. Doc comments dropped
+
+`#[prebindgen]` items carry `///` docs (e.g. `session_put`), but the generated
+Kotlin functions have no KDoc — a real gap for a published Maven artifact.
+
+### N2. Acknowledged coverage holes
+
+`Vec<closeable-handle>` is an explicit `panic!`; `Option<ptr_class>` params
+can't be built through by the recursive input fold (forces Sample's
+identity-only input); opaque-handle consts rejected; `&mut [T]` unsupported;
+output-side `Option<prim>` boxing deliberately not done.
+
+### N3. API split across branches
+
+**Resolution (2026-07-13): already resolved before this effort started** —
+`const_support` was squash-merged to `main` as PR #31 (`e90ce85`).
+
+### N4. Public-surface hygiene
+
+`JniGen.source_module`/`package` are `pub` fields — direct writes bypass
+`set_package_prefix`'s trimming; `pub mod jni` exposes undocumented internals
+(`MethodEntry`, `WireBody` plumbing) beyond the curated `lang::` re-export list.
+
+### N5. Decl-time validation gaps
+
+Nothing checks a `.fun()` target takes `&Self` first or a `.constructor()`
+returns `Self` at declaration; mistakes surface as resolver errors during
+`write_rust`, far from the offending decl. The locking scaffold has no
+JVM-runtime test (design-verified only).
+
+---
+
+## What the API gets right
+
+Plain-value decls with no typestate cursor (the consumer's encoding-const loop
+is ordinary Rust); order-independent settings via derived-at-read names;
+mergeable packages; the macro layer genuinely dodging E0283; deterministic
+most-specific-first pattern ordering; warnings instead of silence for
+undeclared items; the single `JNINative` choke point with the `init{}` loading
+hook.
+
+## Ranked recommendations
+
+1. **Kill the double declaration (I1):** let a member decl opt into being a
+   return-field record, e.g. `.fun(fun!(x).name("y").as_return_field())`, or
+   have `default_return_expand(fun!(x))` reuse the member's `.name()`.
+2. **Own the field-ordering invariant (I2):** emit identity leaves last
+   automatically, or hard-error with the fix in the message.
+3. **First-class error declaration (M4):** an error-type declaration that feeds
+   the resolver without emitting a phantom handle class.
+4. **Hard-error on declared-not-found + pattern ignore (I7, C2).**
+5. **Member-name prefix stripping or a member-name mangle hook (C1).**
+6. **Rename for semantics (M1/M2/M5):** e.g. `param_accepts(ctor)` /
+   `param_accepts_self()` (variants, OR) vs `return_field(accessor)` /
+   `return_with_self()` (fields, AND); a distinct name for the borrowed-return
+   clone case.
+7. **Carry `///` docs into KDoc (N1).**
+8. **Fix stale docs/examples (M7); privatize `pub` fields (N4); add a
+   `write_kotlin` prune option (C4).**

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -172,6 +172,19 @@ with the data.
 `set_package_prefix` sets the actual package. `package!()` (no args) means
 "no subpackage", not "no package".
 
+> **Resolution (2026-07-14): intended design, no change.** The
+> absolute-base + relative-subpackage structure is deliberate: one knob
+> (`set_package_prefix`) relocates the whole binding tree, and a declaration
+> cannot accidentally land outside it. The naming friction this item flags is
+> real but already mitigated: the `set_` convention marks the prefix as a
+> generator-wide setting vs. `.package(...)` as a surface declaration
+> (`config.rs` module doc), and the `package!` / `PackageDecl` docs state
+> explicitly that the argument is relative to `set_package_prefix` and that
+> `package!()` is the base package — not the JVM default package. The one
+> rename that would dissolve the `package!()` misreading (`subpackage!`) was
+> rejected: it trades this asymmetry for a method/macro mismatch
+> (`.package(subpackage!("model"))`) and a breaking rename across consumers.
+
 ### M7. Stale docs inside the API
 
 `kotlin_emit.rs` module doc says functions get a home "via `.method(...)`" —

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -40,6 +40,23 @@ distinguish them.
   (`&T`) it actually means **clone into a fresh owned handle**: a hidden
   allocation behind a name that says "identity".
 
+**Resolution (2026-07-13):** the per-fn override mechanism was rebuilt to be
+symmetric with the type level: `FunctionDecl::expand_param("param", decl)` /
+`expand_return(decl)` take the **same expand-decl objects** as
+`JniGen::expand` (macro family renamed `expand_param!` / `expand_return!`).
+One rule now holds at both scopes and directions — *the decl states the
+complete variant/field set*; an identity-only set (`.variant_self()` /
+`.field_self()` alone) **is** the plain form and normalizes to it. This
+dissolves the modal flips: `_self` is always just an element of a stated set,
+and "opt-out" is simply "the set is {self}". The decl's type is cross-checked
+against the actual parameter/return type (hard errors `ParamTypeMismatch` /
+`ReturnTypeMismatch`), unknown parameter names error, duplicate per-fn decls
+panic at decl time, and per-fn `.field(fun!(x))` inherits member Kotlin names
+like the type level. The borrowed-return clone semantics of `field_self` is
+now documented in one place (`ExpandReturnDecl::field_self` /
+`FunctionDecl::expand_return`); a rename for the clone case was considered
+out of scope.
+
 ### M3. `default_param_expand` docs oversell ergonomics
 
 Doc: "lets every function taking a KeyExpr also accept a plain String."

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -305,6 +305,33 @@ classes can't be mapped onto existing types.
 `constant_expr` for the non-trivial cases; the superseded `constant_fun` /
 path-alias rounds shipped anyway.
 
+> **Resolution (2026-07-15): one mechanism, source-kinded — aligned with
+> `convert!`.** Constants and conversions are the nullary and unary edges of
+> one source-kind vocabulary, so the three acceptors collapsed into one
+> `PackageDecl::constant(ConstDecl)` with the source carried by the decl:
+>
+> | source | `convert!` (unary) | `constant!` (nullary) |
+> |---|---|---|
+> | prebindgen item | — | `constant!(MAX_LEN)` (bare) |
+> | prebindgen fn | `.input_fun(fun!)` / `.output_fun(fun!)` | `.fun(fun!)` |
+> | trait impl | `.input_from` / `.output_into` / `_try_` | — (nothing flows in) |
+> | binding-local fn | `.input_with(ty!, path!)` / `_try_with` | `.with(ty!, path!)` |
+> | expression | — | `.expr(ty!, expr!)` |
+>
+> `convert!`'s bare `.input`/`.output` were renamed `input_fun`/`output_fun`
+> so the fn source is named uniformly. The `.expr` source (new root `expr!`
+> macro, one simple argument like `ty!`/`path!`) exists ONLY for constants:
+> an expression binds no arguments exactly when nothing flows in — a unary
+> expr source would resurrect the value-ident closure convention M5 deleted.
+> `.with` lowers to `.expr(path())` internally, but stays a distinct decl
+> (same "(stated type, named callable)" pair as convert's `_with`). Macro
+> style rule adopted: decl macros take ONE simple argument — the
+> `constant_expr!(N: T = e)` val-decl DSL arm was rejected and deleted;
+> loops use `ConstDecl::named(name).expr(ty, expr)`. All four sources
+> demonstrated in covertest (`COVER_MAGIC`/`COVER_TAG_RUNTIME`/
+> `COVER_VERSION`/`COVER_BANNER`); zenoh's 106-val loop unchanged in
+> spirit, one call shorter in form.
+
 ### I7. Mixed failure modes with no policy
 
 Dotted `.name()` → panic at decl time; builtin scalar-wrapper pattern → panic;

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -545,6 +545,24 @@ Canonical inputs/outputs "AUTO-APPLY" at a distance; the only way to learn what
 a decl produces is to run generation and diff. The extensive prose comments in
 the consumer's build.rs are compensating for a missing explain/dry-run mode.
 
+> **Resolution (2026-07-15): fixed — `Generation::<JniGen>::report()`.**
+> The missing explain mode, computed from the resolved registry after
+> `resolve()`: per package/class every wrapper's FINAL Kotlin signature —
+> rendered through the same `render_wrapper_fn` the emitters use, so it
+> cannot drift from real output — plus `shaped by:` provenance (param
+> expansions with variant lists, return decompositions with leaf names and
+> delivery, error decompositions), then the type table (kind / FQN / wire),
+> `convert!` sources, and rust-side-only types. Deterministic; consumers
+> commit `kotlin/REPORT.md` next to the regen (covertest + zenoh-flat-jni),
+> so a decl's effect is reviewable in a PR without reading generated Kotlin
+> and drift is caught by regen-check. Placement is the `write_kotlin` seam
+> (I3): an inherent method on `Generation<JniGen>`, not a core trait hook —
+> the *pattern* (describe your resolved surface) is adapter-universal, the
+> *content* is intrinsically destination-language vocabulary, so each
+> adapter implements its own (`Generation<Cbindgen>::report()` is a natural
+> future twin); a language-neutral core dump was rejected as describing the
+> machinery rather than the surface.
+
 ---
 
 ## Incomplete

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -572,6 +572,25 @@ the consumer's build.rs are compensating for a missing explain/dry-run mode.
 `#[prebindgen]` items carry `///` docs (e.g. `session_put`), but the generated
 Kotlin functions have no KDoc — a real gap for a published Maven artifact.
 
+> **Resolution (2026-07-15): fixed — KDoc = author prose + shape notes.**
+> The `///` docs were already captured (as `#[doc]` attrs in the JSONL) and
+> the `kt` model already rendered `kdoc` — the gap was pure plumbing. Every
+> wrapper fn, class member, companion factory, data/enum/value/ptr class,
+> and const `val` now carries the Rust item's doc verbatim; where the
+> generator writes a framework line (typed handle, enum surface, value
+> blob, const mirror), author prose comes first, framework line after. On
+> top of the prose, **shape notes** document the REAL prototype after all
+> expansions (user addition): every position a plan reshaped gets a
+> caller-phrased note — expanded params ("pass EITHER its `summary_new`
+> inputs OR an existing `Summary` — the selector chooses the arm"),
+> decomposed returns ("the builder callback receives (`count`, `total`)"),
+> error decompositions ("`onError` receives `je` plus the decomposed
+> `StorageError` (…)"). Sourced from the same resolved plan maps as C7's
+> report, but phrased for the caller rather than as provenance. An
+> undocumented, unshaped fn keeps no KDoc. Callback/handler interfaces are
+> out of scope (framework-documented protocol types); enum *variant* docs
+> are skipped (entries carry no kdoc slot).
+
 ### N2. Acknowledged coverage holes
 
 `Vec<closeable-handle>` is an explicit `panic!`; `Option<ptr_class>` params

--- a/docs/jnigen-api-critique.md
+++ b/docs/jnigen-api-critique.md
@@ -286,6 +286,21 @@ typo'd `fun!(name)` → **cargo warning + silent omission** (`registry.rs`
 wildcard rank > 3 → silent `return None`. A *declared*-but-missing function is
 explicit intent gone wrong and should be a hard error.
 
+> **Resolution (2026-07-14): fixed — declared-but-missing is now a hard
+> error.** Policy: a *declaration* names a specific item, so its target
+> being absent is always a bug and fails the scan
+> (`ScanError::DeclaredNotFound`) — declared functions, `convert!`/boundary
+> helper functions, and declared constants; all missing names are collected
+> into ONE error (sorted) so a broken build.rs is fixed in a single pass.
+> An *ignore*, by contrast, is bookkeeping about something deliberately
+> unused — a stale entry keeps its soft `cargo:warning`. jnigen's
+> boundary-referenced fns (`expand_*!` ctors/accessors) were rerouted from
+> the ignore channel to the helper channel so a typo'd `fun!` inside an
+> expand decl is also a hard error. Two of the flagged examples were
+> already stale: the scalar-wrapper panic died with the wrapper tier (M5),
+> and the rank > 3 silent `None` died with the rank resolver (the
+> structural resolver hard-errors via `ResolveError::Unresolved`).
+
 ---
 
 ## Inconvenient
@@ -305,6 +320,19 @@ none applies here).
 undeclared-fn warnings — and the same 53 names appear a second time (lowercase)
 to build the consts. No prefix/regex ignore, no way to derive one list from the
 other.
+
+> **Resolution (2026-07-14): fixed —
+> `.ignore_funs_where(|name| name.starts_with("encoding_const_"))`.** A
+> plain-Rust closure predicate (no glob/regex mini-dialect to learn), in
+> the style of the existing mangle hooks; core hook
+> `Prebindgen::ignored_function_predicates` (`NamePredicate` alias).
+> Semantics: a predicate is a *filter*, not a claim — matching undeclared
+> fns are acknowledged skips, a declared fn matching a predicate is
+> unaffected (declaration wins), and a predicate matching nothing is
+> silent (unlike an exact-name ignore, which warns when stale — match
+> counts legitimately vary across feature configs). zenoh-flat-jni's
+> 53-line loop is now one line; covertest demonstrates both mechanisms
+> (`storage_get_into_*` via predicate, the two loners via `ignore_fun`).
 
 ### C3. The advanced wrapper tier demands syn/quote fluency
 

--- a/examples/covertest-helpers/Cargo.toml
+++ b/examples/covertest-helpers/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "covertest-helpers"
+version = { workspace = true }
+edition = { workspace = true }
+build = "build.rs"
+
+[dependencies]
+perftest-flat = { path = "../perftest-flat" }
+prebindgen = { workspace = true }
+prebindgen-proc-macro = { workspace = true }
+
+[build-dependencies]
+prebindgen = { workspace = true }

--- a/examples/covertest-helpers/build.rs
+++ b/examples/covertest-helpers/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    prebindgen::init_prebindgen_out_dir();
+}

--- a/examples/covertest-helpers/src/lib.rs
+++ b/examples/covertest-helpers/src/lib.rs
@@ -2,9 +2,9 @@
 //! `#[prebindgen]` source crate** layered on top of [`perftest_flat`].
 //!
 //! This crate exists to prove the multi-source model: a binding crate's
-//! `build.rs` ingests SEVERAL prebindgen sources
-//! (`Registry::from_sources([&flat, &helpers])`) and the generated Rust
-//! qualifies each function with its origin crate
+//! `build.rs` chains SEVERAL prebindgen source streams into one registry
+//! (`Registry::from_items(flat.items_all().chain(helpers.items_all()))`) and
+//! the generated Rust qualifies each function with its origin crate
 //! (`perftest_flat::…` vs `covertest_helpers::…`).
 //!
 //! Why a separate crate at all: `#[prebindgen]` markers are captured during a

--- a/examples/covertest-helpers/src/lib.rs
+++ b/examples/covertest-helpers/src/lib.rs
@@ -1,0 +1,41 @@
+//! Binding-side conversion helpers for `covertest-kotlin` — a **separate
+//! `#[prebindgen]` source crate** layered on top of [`perftest_flat`].
+//!
+//! This crate exists to prove the multi-source model: a binding crate's
+//! `build.rs` ingests SEVERAL prebindgen sources
+//! (`Registry::from_sources([&flat, &helpers])`) and the generated Rust
+//! qualifies each function with its origin crate
+//! (`perftest_flat::…` vs `covertest_helpers::…`).
+//!
+//! Why a separate crate at all: `#[prebindgen]` markers are captured during a
+//! crate's own compilation, which happens *after* its `build.rs` runs — so a
+//! binding crate can never feed its own markers into its own generation.
+//! Helper conversions therefore live either in the flat crate itself or in a
+//! small helper crate like this one, consumed as both a normal and a build
+//! dependency (exactly like the flat crate).
+
+use perftest_flat::Millis;
+use prebindgen_proc_macro::{features, prebindgen};
+
+/// Output directory with the prebindgen data of this crate.
+pub const PREBINDGEN_OUT_DIR: &str = prebindgen_proc_macro::prebindgen_out_dir!();
+
+/// Enabled Cargo features of this crate (referenced by the generated
+/// `konst` feature guard, like every prebindgen source crate).
+pub const FEATURES: &str = features!();
+
+/// Canonical input conversion for [`Millis`]: build it from the raw
+/// millisecond count. Referenced by covertest's
+/// `convert!(Millis).input(fun!(millis_from_long))`.
+#[prebindgen]
+pub fn millis_from_long(v: i64) -> Millis {
+    Millis(v as u64)
+}
+
+/// Canonical output conversion for [`Millis`]: read the raw millisecond
+/// count. Referenced by covertest's
+/// `convert!(Millis).output(fun!(millis_value))`.
+#[prebindgen]
+pub fn millis_value(m: &Millis) -> i64 {
+    m.0 as i64
+}

--- a/examples/covertest-helpers/src/lib.rs
+++ b/examples/covertest-helpers/src/lib.rs
@@ -4,8 +4,12 @@
 //! This crate exists to prove the multi-source model: a binding crate's
 //! `build.rs` chains SEVERAL prebindgen source streams into one registry
 //! (`Registry::from_items(flat.items_all().chain(helpers.items_all()))`) and
-//! the generated Rust qualifies each function with its origin crate
-//! (`perftest_flat::…` vs `covertest_helpers::…`).
+//! the generated Rust qualifies each function with its origin crate.
+//! covertest-kotlin additionally RENAMES this dependency
+//! (`cov_helpers = { package = "covertest-helpers", .. }`) and overrides the
+//! stamped origin via `Source::builder(..).crate_name("cov_helpers")` — so
+//! generated calls read `perftest_flat::…` vs `cov_helpers::…`, proving the
+//! per-source rename escape hatch.
 //!
 //! Why a separate crate at all: `#[prebindgen]` markers are captured during a
 //! crate's own compilation, which happens *after* its `build.rs` runs — so a

--- a/examples/covertest-kotlin/Cargo.toml
+++ b/examples/covertest-kotlin/Cargo.toml
@@ -11,7 +11,10 @@ crate-type = ["cdylib"]
 [dependencies]
 prebindgen = { workspace = true }
 perftest-flat = { path = "../perftest-flat" }
-covertest-helpers = { path = "../covertest-helpers" }
+# Renamed dependency ON PURPOSE: proves `Source::builder(..).crate_name(..)`
+# — generated code must qualify helper calls with the RENAMED module
+# (`cov_helpers::…`), the name this crate actually references it by.
+cov_helpers = { package = "covertest-helpers", path = "../covertest-helpers" }
 jni = "0.21.1"
 konst = "0.3.0"
 # The generated JNI error path logs via `tracing::error!`.
@@ -21,7 +24,7 @@ tracing = "0.1"
 prebindgen = { workspace = true }
 syn = { workspace = true }
 perftest-flat = { path = "../perftest-flat" }
-covertest-helpers = { path = "../covertest-helpers" }
+cov_helpers = { package = "covertest-helpers", path = "../covertest-helpers" }
 
 # NOTE: a production JNI crate should set `[profile.release] panic = "abort"`
 # (a Rust panic unwinding into the JVM is UB). That profile key is only honored

--- a/examples/covertest-kotlin/Cargo.toml
+++ b/examples/covertest-kotlin/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 prebindgen = { workspace = true }
 perftest-flat = { path = "../perftest-flat" }
+covertest-helpers = { path = "../covertest-helpers" }
 jni = "0.21.1"
 konst = "0.3.0"
 # The generated JNI error path logs via `tracing::error!`.
@@ -20,6 +21,7 @@ tracing = "0.1"
 prebindgen = { workspace = true }
 syn = { workspace = true }
 perftest-flat = { path = "../perftest-flat" }
+covertest-helpers = { path = "../covertest-helpers" }
 
 # NOTE: a production JNI crate should set `[profile.release] panic = "abort"`
 # (a Rust panic unwinding into the JVM is UB). That profile key is only honored

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -24,8 +24,8 @@
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
-//! | `.default_param_expand()` (+`_self`)| `Summary` default input |
-//! | `.default_return_expand()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
+//! | `param_expand!` `.variant()` (+`_self`)| `Summary` default input |
+//! | `return_expand!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
@@ -72,7 +72,7 @@
 
 use prebindgen::{
     constant, constant_expr, core::Registry, data_class, enum_class, fun, lang::JniGen, package,
-    ptr_class, scalar_type_wrapper, value_class,
+    param_expand, ptr_class, return_expand, scalar_type_wrapper, value_class,
 };
 use syn::parse_quote as pq;
 
@@ -127,33 +127,34 @@ fn main() {
         // ── Subpackage `errors`: the Result error channel ───────────────────
         .package(
             package!("errors").class(
-                // `StorageError` is the `E` of a fallible `Result`. Declaring it a
-                // ptr_class with a a default return-field list makes the generated `onError`
-                // handler receive the decomposed fields: the `message` string plus —
-                // via `.default_return_expand_self()` — the error handle itself (an
-                // owned `StorageError` the handler must `close()`).
-                ptr_class!(StorageError)
-                    .fun(fun!(storage_error_message).name("message"))
-                    .default_return_expand(fun!(storage_error_message).name("message"))
-                    .default_return_expand_self(),
+                // `StorageError` is the `E` of a fallible `Result`; its
+                // boundary shape is declared with `return_expand!` below.
+                ptr_class!(StorageError).fun(fun!(storage_error_message).name("message")),
             ),
+        )
+        // `StorageError`'s default return fields make the generated `onError`
+        // handler receive the decomposed error: the `message` string (name
+        // inherited from the class member) plus — via `.field_self()` — the
+        // error handle itself (an owned `StorageError` the handler must
+        // `close()`).
+        .return_expand(
+            return_expand!(StorageError)
+                .field(fun!(storage_error_message))
+                .field_self(),
         )
         // ── Subpackage `analytics`: param-variant / return-field defaults on `Summary`
         .package(
             package!("analytics")
-                // `Summary` is an opaque handle whose default boundary shape is its
-                // `(count, total)` leaves: the return-field default decomposes it, the param-variant default
-                // rebuilds it (via the `of` constructor) or accepts a handle.
+                // `Summary` is an opaque handle; its default boundary shape —
+                // decomposed `(count, total)` leaves out, rebuilt via the `of`
+                // constructor (or an existing handle) in — is declared with
+                // `param_expand!` / `return_expand!` below.
                 .class(
                     ptr_class!(Summary)
                         .constructor(fun!(summary_new).name("of"))
                         .fun(fun!(summary_count).name("count"))
                         .fun(fun!(summary_total).name("total"))
-                        .fun(fun!(summary_scaled).name("scaled"))
-                        .default_param_expand(fun!(summary_new))
-                        .default_param_expand_self()
-                        .default_return_expand(fun!(summary_count).name("count"))
-                        .default_return_expand(fun!(summary_total).name("total")),
+                        .fun(fun!(summary_scaled).name("scaled")),
                 )
                 // `Archive` holds the latest `Summary` and returns it BORROWED
                 // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -161,6 +162,20 @@ fn main() {
                 // RENAMED via the per-declaration `.name()` override (the type-level
                 // dual of the per-fn `.name`; literal, bypasses the mangle closures).
                 .class(ptr_class!(Archive).name("SummaryVault")),
+        )
+        // `Summary` default input: rebuilt from the `of` constructor's
+        // ingredients OR passed as an existing handle (runtime-selected).
+        .param_expand(
+            param_expand!(Summary)
+                .variant(fun!(summary_new))
+                .variant_self(),
+        )
+        // `Summary` default output: decomposed `(count, total)` leaves, names
+        // inherited from the class members.
+        .return_expand(
+            return_expand!(Summary)
+                .field(fun!(summary_count))
+                .field(fun!(summary_total)),
         )
         // ── Base-package handle type: `Storage` + scalar members ────────────
         // Back in the base package so the typed handle classes live alongside

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -12,7 +12,7 @@
 //!
 //! | JniGen feature                       | Exercised by |
 //! |--------------------------------------|--------------|
-//! | `JniGen::set_source_module`        | `perftest_flat` |
+//! | default module (first `from_sources` src) | `perftest_flat` |
 //! | `JniGen::set_package_prefix`       | `io.prebindgen.covertest` |
 //! | `JniGen::package` (subpackages)      | `model` / `errors` / `analytics` / `storage` |
 //! | `JniGen::set_jni_native_init`      | `NativeLibrary.ensureLoaded()` |
@@ -73,7 +73,6 @@ use prebindgen::{
     constant, constant_expr, convert, core::Registry, data_class, enum_class, expand_param,
     expand_return, fun, lang::JniGen, package, ptr_class, value_class,
 };
-use syn::parse_quote as pq;
 
 fn main() {
     // Two prebindgen sources: the flat crate plus the binding-side helper
@@ -84,7 +83,6 @@ fn main() {
     let helpers = prebindgen::Source::new(covertest_helpers::PREBINDGEN_OUT_DIR);
 
     let jni = JniGen::new()
-        .set_source_module(pq!(perftest_flat))
         .set_package_prefix("io.prebindgen.covertest")
         .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
         // All five per-kind name-mangle hooks are registered. The harness hook

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -383,11 +383,8 @@ fn main() {
     let kotlin_root = std::path::Path::new(&crate_dir)
         .join("kotlin")
         .join("generated");
-    if let Err(err) = std::fs::remove_dir_all(&kotlin_root) {
-        if err.kind() != std::io::ErrorKind::NotFound {
-            panic!("cleanup kotlin/generated failed: {err}");
-        }
-    }
+    // The root is generator-owned: `write_kotlin` deletes and recreates it,
+    // so no consumer-side cleanup is needed.
     for path in gen.write_kotlin(&kotlin_root).expect("write_kotlin failed") {
         println!("cargo:warning=Wrote {}", path.display());
     }

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -51,8 +51,8 @@
 //! | `String` return                      | `string_new` |
 //! | binding-error channel (`je != null`) | malformed `Stamp` bytes (value-blob length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
-//! | `JniGen::ignore_fun`                 | `string_len` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
-//! | `JniGen::ignore_funs_where`          | the `storage_get_into_*` group (one predicate instead of per-name lines) |
+//! | `JniGen::ignore` (exact)              | `string_len` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
+//! | `JniGen::ignore` + `matching(…)`      | the `storage_get_into_*` group (one name predicate, any item kind) |
 //!
 //! One feature is deliberately left at its default and documented rather than
 //! toggled, because it is mutually exclusive with a richer path this example
@@ -72,13 +72,13 @@
 //! with no JVM mapping (`string_len`'s `&String` param / `usize` return, the
 //! `storage_get_into_*` out-param group, `storage_put_by_read_and_update`'s
 //! read-write borrow). The two loners are acknowledged per-name via
-//! `JniGen::ignore_fun`; the `storage_get_into_*` naming family via one
-//! `JniGen::ignore_funs_where` predicate. Both suppress the per-item
+//! `.ignore(fun!(…))`; the `storage_get_into_*` naming family via one
+//! `.ignore(matching(…))` predicate. Both suppress the per-item
 //! "skipping undeclared" build warning while emitting nothing.
 
 use prebindgen::{
     constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
-    fun, lang::JniGen, package, path, ptr_class, ty, value_class,
+    fun, lang::JniGen, matching, package, path, ptr_class, ty, value_class,
 };
 
 fn main() {
@@ -354,9 +354,9 @@ fn main() {
         // The deliberately-unbound group (C-tier shapes with no JVM mapping):
         // acknowledged so the build log stays free of "skipping undeclared"
         // warnings without emitting anything.
-        .ignore_fun(fun!(string_len))
-        .ignore_funs_where(|name| name.starts_with("storage_get_into_"))
-        .ignore_fun(fun!(storage_put_by_read_and_update));
+        .ignore(fun!(string_len))
+        .ignore(matching(|name| name.starts_with("storage_get_into_")))
+        .ignore(fun!(storage_put_by_read_and_update));
 
     let registry = Registry::from_items(source.items_all().chain(helpers.items_all()))
         .expect("scan prebindgen items");

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -22,6 +22,9 @@
 //! | `EnumClassDecl`                      | `Priority` |
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `convert!` + multi-source (`from_sources`) | `Millis` ⇄ `Long` via `covertest-helpers` fns |
+//! | `convert!` `.input_from`/`.output_into` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
+//! | `convert!` `.input_try_from` (fallible)  | `Percent` ⇄ `Int`; out-of-range → `onError` |
+//! | `convert!` `.input_with`/`.output_with` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`) |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
@@ -71,7 +74,7 @@
 
 use prebindgen::{
     constant, constant_expr, convert, core::Registry, data_class, enum_class, expand_param,
-    expand_return, fun, lang::JniGen, package, ptr_class, value_class,
+    expand_return, fun, lang::JniGen, package, path, ptr_class, ty, value_class,
 };
 
 fn main() {
@@ -106,6 +109,23 @@ fn main() {
             convert!(Millis)
                 .input(fun!(millis_from_long))
                 .output(fun!(millis_value)),
+        )
+        // `Celsius`: canonical conversion via `From`/`Into` impls in the flat
+        // crate — the repr (`i32`) is stated, the impls do the work.
+        .convert(convert!(Celsius).input_from(ty!(i32)).output_into(ty!(i32)))
+        // `Percent`: fallible input via `TryFrom<i32>` (out-of-range values
+        // from the JVM route the impl's Error to onError); infallible output.
+        .convert(
+            convert!(Percent)
+                .input_try_from(ty!(i32))
+                .output_into(ty!(i32)),
+        )
+        // `Label`: conversions are plain fns in THIS binding crate (see
+        // src/lib.rs) — no #[prebindgen], no helper crate.
+        .convert(
+            convert!(Label)
+                .input_with(ty!(String), path!(crate::label_in))
+                .output_with(ty!(String), path!(crate::label_out)),
         )
         // ── Base-package types ──────────────────────────────────────────────
         // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
@@ -228,6 +248,11 @@ fn main() {
                 .fun(fun!(stamp_new))
                 .fun(fun!(stamp_series))
                 .fun(fun!(payload_label_len))
+                // The three convert!-source-kind fns (conversions declared
+                // below): Into/From traits, TryFrom trait, binding-local fns.
+                .fun(fun!(celsius_double))
+                .fun(fun!(percent_scale))
+                .fun(fun!(label_reverse))
                 .fun(fun!(annotated_new))
                 .fun(fun!(annotated_ttl))
                 .fun(fun!(annotated_priority))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -49,7 +49,8 @@
 //! | `String` return                      | `string_new` |
 //! | binding-error channel (`je != null`) | malformed `Stamp` bytes (value-blob length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
-//! | `JniGen::ignore_fun`                 | `string_len` / `storage_get_into_*` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
+//! | `JniGen::ignore_fun`                 | `string_len` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
+//! | `JniGen::ignore_funs_where`          | the `storage_get_into_*` group (one predicate instead of per-name lines) |
 //!
 //! One feature is deliberately left at its default and documented rather than
 //! toggled, because it is mutually exclusive with a richer path this example
@@ -68,9 +69,10 @@
 //! Four functions are deliberately NOT wrapped — their shapes are C-tier
 //! with no JVM mapping (`string_len`'s `&String` param / `usize` return, the
 //! `storage_get_into_*` out-param group, `storage_put_by_read_and_update`'s
-//! read-write borrow) — and are acknowledged via `JniGen::ignore_fun`, which
-//! suppresses the per-item "skipping undeclared" build warning while
-//! emitting nothing.
+//! read-write borrow). The two loners are acknowledged per-name via
+//! `JniGen::ignore_fun`; the `storage_get_into_*` naming family via one
+//! `JniGen::ignore_funs_where` predicate. Both suppress the per-item
+//! "skipping undeclared" build warning while emitting nothing.
 
 use prebindgen::{
     constant, constant_expr, convert, core::Registry, data_class, enum_class, expand_param,
@@ -339,8 +341,7 @@ fn main() {
         // acknowledged so the build log stays free of "skipping undeclared"
         // warnings without emitting anything.
         .ignore_fun(fun!(string_len))
-        .ignore_fun(fun!(storage_get_into_init))
-        .ignore_fun(fun!(storage_get_into_uninit))
+        .ignore_funs_where(|name| name.starts_with("storage_get_into_"))
         .ignore_fun(fun!(storage_put_by_read_and_update));
 
     let mut registry = Registry::from_sources([&source, &helpers]).expect("scan prebindgen items");

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -358,7 +358,7 @@ fn main() {
         .ignore_funs_where(|name| name.starts_with("storage_get_into_"))
         .ignore_fun(fun!(storage_put_by_read_and_update));
 
-    let mut registry = Registry::from_items(source.items_all().chain(helpers.items_all()))
+    let registry = Registry::from_items(source.items_all().chain(helpers.items_all()))
         .expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -367,9 +367,8 @@ fn main() {
     let rust_dest = std::path::Path::new(&crate_dir)
         .join("src")
         .join("generated_bindings.rs");
-    let rust_path = registry
-        .write_rust(&jni, &rust_dest)
-        .expect("write_rust failed");
+    let gen = registry.resolve(jni).expect("resolve failed");
+    let rust_path = gen.write_rust(&rust_dest).expect("write_rust failed");
     println!(
         "cargo:warning=Generated bindings at: {}",
         rust_path.display()
@@ -384,10 +383,7 @@ fn main() {
             panic!("cleanup kotlin/generated failed: {err}");
         }
     }
-    for path in jni
-        .write_kotlin(&registry, &kotlin_root)
-        .expect("write_kotlin failed")
-    {
+    for path in gen.write_kotlin(&kotlin_root).expect("write_kotlin failed") {
         println!("cargo:warning=Wrote {}", path.display());
     }
 }

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -51,6 +51,8 @@
 //! | `String` return                      | `string_new` |
 //! | binding-error channel (`je != null`) | malformed `Stamp` bytes (value-blob length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
+//! | `data_class` instance member          | `Payload.labelLen()` (receiver crosses as `this` field leaves) |
+//! | `enum_class!(T).kotlin_type(…)`       | lib-tested (maps enum onto an existing Kotlin type; no file) |
 //! | `JniGen::ignore` (exact)              | `string_len` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
 //! | `JniGen::ignore` + `matching(…)`      | the `storage_get_into_*` group (one name predicate, any item kind) |
 //!
@@ -143,8 +145,12 @@ fn main() {
         )
         // ── Base-package types ──────────────────────────────────────────────
         // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
-        // reassembled via a generated `fromParts`).
-        .package(package!().class(data_class!(Payload)))
+        // reassembled via a generated `fromParts`). A data class can carry
+        // members like any re-enterable kind: the instance method's receiver
+        // crosses as `this`'s field leaves (I5).
+        .package(
+            package!().class(data_class!(Payload).fun(fun!(payload_label_len).name("labelLen"))),
+        )
         // ── Subpackage `model`: enum + value class + nested data class ──────
         .package(
             package!("model")
@@ -266,7 +272,6 @@ fn main() {
                 .fun(fun!(priority_or))
                 .fun(fun!(stamp_new))
                 .fun(fun!(stamp_series))
-                .fun(fun!(payload_label_len))
                 // The three convert!-source-kind fns (conversions declared
                 // below): Into/From traits, TryFrom trait, binding-local fns.
                 .fun(fun!(celsius_double))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -30,6 +30,7 @@
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
+//! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | namespace-relative member names (C1)  | `storage_len`→`len`, `stamp_secs`→`secs`, … (no `.name()`); `summary_new`→`.name("of")` still overrides |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
@@ -390,4 +391,14 @@ fn main() {
     for path in gen.write_kotlin(&kotlin_root).expect("write_kotlin failed") {
         println!("cargo:warning=Wrote {}", path.display());
     }
+
+    // The resolved-surface report (C7): committed next to the regen so a
+    // decl's effect is reviewable in a PR without reading generated Kotlin.
+    std::fs::write(
+        std::path::Path::new(&crate_dir)
+            .join("kotlin")
+            .join("REPORT.md"),
+        gen.report(),
+    )
+    .expect("write REPORT.md");
 }

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -24,18 +24,18 @@
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
-//! | `param_expand!` `.variant()` (+`_self`)| `Summary` default input |
-//! | `return_expand!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
+//! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
+//! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `PackageDecl::constant` (`constant!`) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
 //! | `PackageDecl::constant_fun` | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
 //! | `PackageDecl::constant_expr` (`constant_expr!`) | `COVER_BANNER` = binding-defined `format!` expression |
-//! | `.param_expand_self(param)` alone   | `summary_total_raw` (raw handle param, overrides the class default) |
-//! | `.return_expand_self()` alone         | `storage_summary_handle` / `archive_latest` (raw handle return) |
-//! | per-fn `.param_expand(param, …)` (+`_self`)| `storage_expect_summary` |
-//! | per-fn `.return_expand(…)` (+`_self`) | `storage_summary_full` |
+//! | per-fn `.expand_param(name, …)` identity-only | `summary_total_raw` (raw handle param, overrides the type default) |
+//! | per-fn `.expand_return(…)` identity-only | `storage_summary_handle` / `archive_latest` (raw handle return) |
+//! | per-fn `.expand_param(name, …)` variants | `storage_expect_summary` |
+//! | per-fn `.expand_return(…)` fields+self | `storage_summary_full` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -71,8 +71,8 @@
 //! emitting nothing.
 
 use prebindgen::{
-    constant, constant_expr, core::Registry, data_class, enum_class, fun, lang::JniGen, package,
-    param_expand, ptr_class, return_expand, scalar_type_wrapper, value_class,
+    constant, constant_expr, core::Registry, data_class, enum_class, expand_param, expand_return,
+    fun, lang::JniGen, package, ptr_class, scalar_type_wrapper, value_class,
 };
 use syn::parse_quote as pq;
 
@@ -127,7 +127,7 @@ fn main() {
         // ── Subpackage `errors`: the Result error channel ───────────────────
         .package(package!("errors").class(
             // `StorageError` is the `E` of a fallible `Result`; its
-            // boundary shape is declared with `return_expand!` below.
+            // boundary shape is declared with `expand_return!` below.
             ptr_class!(StorageError).fun(fun!(storage_error_message).name("message")),
         ))
         // `StorageError`'s default return fields make the generated `onError`
@@ -136,7 +136,7 @@ fn main() {
         // error handle itself (an owned `StorageError` the handler must
         // `close()`).
         .expand(
-            return_expand!(StorageError)
+            expand_return!(StorageError)
                 .field(fun!(storage_error_message))
                 .field_self(),
         )
@@ -146,7 +146,7 @@ fn main() {
                 // `Summary` is an opaque handle; its default boundary shape —
                 // decomposed `(count, total)` leaves out, rebuilt via the `of`
                 // constructor (or an existing handle) in — is declared with
-                // `param_expand!` / `return_expand!` below.
+                // `expand_param!` / `expand_return!` below.
                 .class(
                     ptr_class!(Summary)
                         .constructor(fun!(summary_new).name("of"))
@@ -164,14 +164,14 @@ fn main() {
         // `Summary` default input: rebuilt from the `of` constructor's
         // ingredients OR passed as an existing handle (runtime-selected).
         .expand(
-            param_expand!(Summary)
+            expand_param!(Summary)
                 .variant(fun!(summary_new))
                 .variant_self(),
         )
         // `Summary` default output: decomposed `(count, total)` leaves, names
         // inherited from the class members.
         .expand(
-            return_expand!(Summary)
+            expand_return!(Summary)
                 .field(fun!(summary_count))
                 .field(fun!(summary_total)),
         )
@@ -228,30 +228,42 @@ fn main() {
                 .fun(fun!(annotated_priority))
                 .fun(fun!(annotated_payload_value)),
         )
-        // analytics: the param-variant / return-field matrix (class default / raw-self override / per-fn override, in + out).
+        // analytics: the param-variant / return-field matrix (type default /
+        // per-fn override, in + out). Per-fn overrides reuse the SAME
+        // expand-decl objects as the type defaults (complete-set rule): an
+        // identity-only set is the plain form.
         .package(
             package!("analytics")
                 .fun(fun!(storage_summary))
                 .fun(fun!(storage_matches_summary))
-                .fun(fun!(storage_summary_handle).return_expand_self())
-                .fun(fun!(summary_total_raw).param_expand_self(pq!(s)))
                 .fun(
-                    fun!(storage_summary_full)
-                        .return_expand(fun!(summary_count).name("count"))
-                        .return_expand(fun!(summary_total).name("total"))
-                        .return_expand_self(),
+                    fun!(storage_summary_handle)
+                        .expand_return(expand_return!(Summary).field_self()),
                 )
                 .fun(
-                    fun!(storage_expect_summary)
-                        .param_expand(pq!(expected), fun!(summary_new))
-                        .param_expand_self(pq!(expected)),
+                    fun!(summary_total_raw)
+                        .expand_param("s", expand_param!(Summary).variant_self()),
                 )
+                .fun(fun!(storage_summary_full).expand_return(
+                    expand_return!(Summary)
+                        .field(fun!(summary_count).name("count"))
+                        .field(fun!(summary_total).name("total"))
+                        .field_self(),
+                ))
+                .fun(fun!(storage_expect_summary).expand_param(
+                    "expected",
+                    expand_param!(Summary)
+                        .variant(fun!(summary_new))
+                        .variant_self(),
+                ))
                 // The borrowed-accessor trio. `archive_latest` suppresses the default
                 // Summary return-field default so the BORROWED handle path (clone into a
                 // fresh owned handle, null when absent) is what crosses.
                 .fun(fun!(archive_new))
                 .fun(fun!(archive_store))
-                .fun(fun!(archive_latest).return_expand_self()),
+                .fun(
+                    fun!(archive_latest).expand_return(expand_return!(Summary).field_self()),
+                ),
         )
         // storage: the perf surface (handles, callbacks, Vec, Option) plus the
         // fallible constructor and the Millis wrapper.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -7,9 +7,8 @@
 //! including the coverage-only items in `perftest_flat::ext` — through the full
 //! adapter surface. `JniGen` accepts pre-built declaration objects (see
 //! `prebindgen::lang::jnigen::jni::decl`) rather than a fluent typestate
-//! chain — each row below is a `PackageDecl`/`ScalarTypeWrapperDecl`/etc. built
-//! independently and then handed to `jni.package(...)` /
-//! `jni.scalar_type_wrapper(...)`:
+//! chain — each row below is a `PackageDecl`/`ConvertDecl`/etc. built
+//! independently and then handed to `jni.package(...)` / `jni.convert(...)`:
 //!
 //! | JniGen feature                       | Exercised by |
 //! |--------------------------------------|--------------|
@@ -22,7 +21,7 @@
 //! | `PtrClassDecl`                       | `Storage` / `Summary` / `StorageError` / `Archive` / handlers |
 //! | `EnumClassDecl`                      | `Priority` |
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
-//! | `ScalarTypeWrapperDecl`              | `Millis` ⇄ `Long` |
+//! | `convert!` + multi-source (`from_sources`) | `Millis` ⇄ `Long` via `covertest-helpers` fns |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
@@ -71,13 +70,18 @@
 //! emitting nothing.
 
 use prebindgen::{
-    constant, constant_expr, core::Registry, data_class, enum_class, expand_param, expand_return,
-    fun, lang::JniGen, package, ptr_class, scalar_type_wrapper, value_class,
+    constant, constant_expr, convert, core::Registry, data_class, enum_class, expand_param,
+    expand_return, fun, lang::JniGen, package, ptr_class, value_class,
 };
 use syn::parse_quote as pq;
 
 fn main() {
+    // Two prebindgen sources: the flat crate plus the binding-side helper
+    // crate (conversion fns for `convert!`). The registry records each fn's
+    // origin so generated calls qualify with the defining crate
+    // (`perftest_flat::…` vs `covertest_helpers::…`).
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
+    let helpers = prebindgen::Source::new(covertest_helpers::PREBINDGEN_OUT_DIR);
 
     let jni = JniGen::new()
         .set_source_module(pq!(perftest_flat))
@@ -94,13 +98,16 @@ fn main() {
         .set_ptr_class_name_mangle(|n| n.to_string())
         .set_data_class_name_mangle(|n| n.to_string())
         .set_enum_name_mangle(|n| n.to_string())
-        // `Millis` newtype: a custom scalar wire mapping to a bare `Long` (no
-        // generated class) — global, not tied to any package (see the `decl`
-        // module doc for why a scalar wrapper never needs package placement).
-        .scalar_type_wrapper(
-            scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")
-                .on_param(|v| pq!(perftest_flat::Millis(*#v as u64)))
-                .on_return(|v| pq!(#v.0 as jni::sys::jlong)),
+        // `Millis` newtype: a canonical single-value conversion to a bare
+        // `Long` (no generated class) via two ordinary `#[prebindgen]` fns —
+        // defined in the SEPARATE `covertest-helpers` source crate, proving
+        // the multi-source model (generated calls carry the
+        // `covertest_helpers::` prefix). The Kotlin surface (`Long`) derives
+        // from the fns' `i64` side; nothing is stated verbatim.
+        .convert(
+            convert!(Millis)
+                .input(fun!(millis_from_long))
+                .output(fun!(millis_value)),
         )
         // ── Base-package types ──────────────────────────────────────────────
         // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
@@ -244,26 +251,28 @@ fn main() {
                     fun!(summary_total_raw)
                         .expand_param("s", expand_param!(Summary).variant_self()),
                 )
-                .fun(fun!(storage_summary_full).expand_return(
-                    expand_return!(Summary)
-                        .field(fun!(summary_count).name("count"))
-                        .field(fun!(summary_total).name("total"))
-                        .field_self(),
-                ))
-                .fun(fun!(storage_expect_summary).expand_param(
-                    "expected",
-                    expand_param!(Summary)
-                        .variant(fun!(summary_new))
-                        .variant_self(),
-                ))
+                .fun(
+                    fun!(storage_summary_full).expand_return(
+                        expand_return!(Summary)
+                            .field(fun!(summary_count).name("count"))
+                            .field(fun!(summary_total).name("total"))
+                            .field_self(),
+                    ),
+                )
+                .fun(
+                    fun!(storage_expect_summary).expand_param(
+                        "expected",
+                        expand_param!(Summary)
+                            .variant(fun!(summary_new))
+                            .variant_self(),
+                    ),
+                )
                 // The borrowed-accessor trio. `archive_latest` suppresses the default
                 // Summary return-field default so the BORROWED handle path (clone into a
                 // fresh owned handle, null when absent) is what crosses.
                 .fun(fun!(archive_new))
                 .fun(fun!(archive_store))
-                .fun(
-                    fun!(archive_latest).expand_return(expand_return!(Summary).field_self()),
-                ),
+                .fun(fun!(archive_latest).expand_return(expand_return!(Summary).field_self())),
         )
         // storage: the perf surface (handles, callbacks, Vec, Option) plus the
         // fallible constructor and the Millis wrapper.
@@ -308,7 +317,7 @@ fn main() {
         .ignore_fun(fun!(storage_get_into_uninit))
         .ignore_fun(fun!(storage_put_by_read_and_update));
 
-    let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
+    let mut registry = Registry::from_sources([&source, &helpers]).expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -5,8 +5,8 @@
 //! Unlike `examples/perftest-kotlin` (which maps only the lean perf surface in
 //! the performance-optimal shape), this binding maps the *same* flat library —
 //! including the coverage-only items in `perftest_flat::ext` — through the full
-//! adapter surface. `JniGen` accepts pre-built declaration objects (see
-//! `prebindgen::lang::jnigen::jni::decl`) rather than a fluent typestate
+//! adapter surface. `JniGen` accepts pre-built declaration objects (the
+//! `prebindgen::lang` decl types, built by the root decl macros) rather than a fluent typestate
 //! chain — each row below is a `PackageDecl`/`ConvertDecl`/etc. built
 //! independently and then handed to `jni.package(...)` / `jni.convert(...)`:
 //!

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -30,6 +30,7 @@
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
+//! | namespace-relative member names (C1)  | `storage_len`→`len`, `stamp_secs`→`secs`, … (no `.name()`); `summary_new`→`.name("of")` still overrides |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `constant!` (bare = `#[prebindgen]` const) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
@@ -112,6 +113,7 @@ fn main() {
         .set_ptr_class_name_mangle(|n| n.to_string())
         .set_data_class_name_mangle(|n| n.to_string())
         .set_enum_name_mangle(|n| n.to_string())
+        .set_member_name_mangle(|n| n.to_string())
         // `Millis` newtype: a canonical single-value conversion to a bare
         // `Long` (no generated class) via two ordinary `#[prebindgen]` fns —
         // defined in the SEPARATE `covertest-helpers` source crate, proving
@@ -148,9 +150,7 @@ fn main() {
         // reassembled via a generated `fromParts`). A data class can carry
         // members like any re-enterable kind: the instance method's receiver
         // crosses as `this`'s field leaves (I5).
-        .package(
-            package!().class(data_class!(Payload).fun(fun!(payload_label_len).name("labelLen"))),
-        )
+        .package(package!().class(data_class!(Payload).fun(fun!(payload_label_len))))
         // ── Subpackage `model`: enum + value class + nested data class ──────
         .package(
             package!("model")
@@ -165,15 +165,15 @@ fn main() {
                 // surfaces as `List<ByteArray>`.
                 .class(
                     value_class!(Stamp)
-                        .fun(fun!(stamp_secs).name("secs"))
-                        .fun(fun!(stamp_nanos).name("nanos")),
+                        .fun(fun!(stamp_secs))
+                        .fun(fun!(stamp_nanos)),
                 ),
         )
         // ── Subpackage `errors`: the Result error channel ───────────────────
         .package(package!("errors").class(
             // `StorageError` is the `E` of a fallible `Result`; its
             // boundary shape is declared with `expand_return!` below.
-            ptr_class!(StorageError).fun(fun!(storage_error_message).name("message")),
+            ptr_class!(StorageError).fun(fun!(storage_error_message)),
         ))
         // `StorageError`'s default return fields make the generated `onError`
         // handler receive the decomposed error: the `message` string (name
@@ -195,9 +195,9 @@ fn main() {
                 .class(
                     ptr_class!(Summary)
                         .constructor(fun!(summary_new).name("of"))
-                        .fun(fun!(summary_count).name("count"))
-                        .fun(fun!(summary_total).name("total"))
-                        .fun(fun!(summary_scaled).name("scaled")),
+                        .fun(fun!(summary_count))
+                        .fun(fun!(summary_total))
+                        .fun(fun!(summary_scaled)),
                 )
                 // `Archive` holds the latest `Summary` and returns it BORROWED
                 // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -249,9 +249,9 @@ fn main() {
                 )
                 .class(
                     ptr_class!(Storage)
-                        .fun(fun!(storage_len).name("len"))
-                        .fun(fun!(storage_contains).name("contains"))
-                        .constructor(fun!(storage_with_payload).name("withPayload")),
+                        .fun(fun!(storage_len))
+                        .fun(fun!(storage_contains))
+                        .constructor(fun!(storage_with_payload)),
                 )
                 // The callback-handler handles (single payload / whole batch / owned
                 // storage handle).

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -24,7 +24,7 @@
 //! | `convert!` + multi-source (`from_sources`) | `Millis` ⇄ `Long` via `covertest-helpers` fns |
 //! | `convert!` `.input_from`/`.output_into` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | `convert!` `.input_try_from` (fallible)  | `Percent` ⇄ `Int`; out-of-range → `onError` |
-//! | `convert!` `.input_with`/`.output_with` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`) |
+//! | `convert!` `.input_try_with`/`.output_with` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
@@ -121,10 +121,13 @@ fn main() {
                 .output_into(ty!(i32)),
         )
         // `Label`: conversions are plain fns in THIS binding crate (see
-        // src/lib.rs) — no #[prebindgen], no helper crate.
+        // src/lib.rs) — no #[prebindgen], no helper crate. The input is
+        // FALLIBLE (`fn(String) -> Result<Label, String>`; the error type is
+        // stated — a bare path carries no signature to read); empty labels
+        // route the Err to onError.
         .convert(
             convert!(Label)
-                .input_with(ty!(String), path!(crate::label_in))
+                .input_try_with(ty!(String), ty!(String), path!(crate::label_in))
                 .output_with(ty!(String), path!(crate::label_out)),
         )
         // ── Base-package types ──────────────────────────────────────────────

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -32,9 +32,10 @@
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
-//! | `PackageDecl::constant` (`constant!`) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
-//! | `PackageDecl::constant_fun` | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
-//! | `PackageDecl::constant_expr` (`constant_expr!`) | `COVER_BANNER` = binding-defined `format!` expression |
+//! | `constant!` (bare = `#[prebindgen]` const) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
+//! | `constant!(N).fun(fun!(…))`           | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
+//! | `constant!(N).with(ty!, path!)`       | `val COVER_VERSION` from binding-local `crate::cover_version()` |
+//! | `constant!(N).expr(ty!, expr!)`       | `COVER_BANNER` = binding-defined `format!` expression |
 //! | per-fn `.expand_param(name, …)` identity-only | `summary_total_raw` (raw handle param, overrides the type default) |
 //! | per-fn `.expand_return(…)` identity-only | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.expand_param(name, …)` variants | `storage_expect_summary` |
@@ -76,8 +77,8 @@
 //! "skipping undeclared" build warning while emitting nothing.
 
 use prebindgen::{
-    constant, constant_expr, convert, core::Registry, data_class, enum_class, expand_param,
-    expand_return, fun, lang::JniGen, package, path, ptr_class, ty, value_class,
+    constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
+    fun, lang::JniGen, package, path, ptr_class, ty, value_class,
 };
 
 fn main() {
@@ -117,8 +118,8 @@ fn main() {
         // from the fns' `i64` side; nothing is stated verbatim.
         .convert(
             convert!(Millis)
-                .input(fun!(millis_from_long))
-                .output(fun!(millis_value)),
+                .input_fun(fun!(millis_from_long))
+                .output_fun(fun!(millis_value)),
         )
         // `Celsius`: canonical conversion via `From`/`Into` impls in the flat
         // crate — the repr (`i32`) is stated, the impls do the work.
@@ -223,17 +224,22 @@ fn main() {
                 // (`COVER_MAGIC: Long`, `COVER_TAG: String`) in the base package.
                 .constant(constant!(COVER_MAGIC))
                 .constant(constant!(COVER_TAG))
-                // Function-backed constant: a nullary `#[prebindgen]` fn
-                // surfaced as an eagerly-initialized top-level `val`
+                // Fn-sourced constant: a nullary `#[prebindgen]` fn surfaced
+                // as an eagerly-initialized top-level `val`
                 // (`COVER_TAG_RUNTIME: String`) — the value comes from the
                 // fn at class-load, not from a Rust `const`.
-                .constant_fun(fun!(cover_tag_runtime).name("COVER_TAG_RUNTIME"))
-                // Expression-backed constant: an arbitrary binding-defined
+                .constant(constant!(COVER_TAG_RUNTIME).fun(fun!(cover_tag_runtime)))
+                // Binding-local-fn-sourced constant (`.with`, the const
+                // analog of convert!'s `_with`): a nullary fn in THIS crate,
+                // named by path, stated value type.
+                .constant(constant!(COVER_VERSION).with(ty!(String), path!(crate::cover_version)))
+                // Expression-sourced constant: an arbitrary binding-defined
                 // expression (composing source-crate items via
                 // `use perftest_flat::*;`) evaluated once at class-load —
                 // no dedicated accessor fn in the source crate.
-                .constant_expr(
-                    constant_expr!(COVER_BANNER: String = format!("{COVER_TAG}:{COVER_MAGIC:#x}")),
+                .constant(
+                    constant!(COVER_BANNER)
+                        .expr(ty!(String), expr!(format!("{COVER_TAG}:{COVER_MAGIC:#x}"))),
                 )
                 .class(
                     ptr_class!(Storage)

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -12,7 +12,7 @@
 //!
 //! | JniGen feature                       | Exercised by |
 //! |--------------------------------------|--------------|
-//! | default module (first `from_sources` src) | `perftest_flat` |
+//! | default module (first stream origin)  | `perftest_flat` |
 //! | `JniGen::set_package_prefix`       | `io.prebindgen.covertest` |
 //! | `JniGen::package` (subpackages)      | `model` / `errors` / `analytics` / `storage` |
 //! | `JniGen::set_jni_native_init`      | `NativeLibrary.ensureLoaded()` |
@@ -21,7 +21,7 @@
 //! | `PtrClassDecl`                       | `Storage` / `Summary` / `StorageError` / `Archive` / handlers |
 //! | `EnumClassDecl`                      | `Priority` |
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
-//! | `convert!` + multi-source (`from_sources`) | `Millis` ⇄ `Long` via `covertest-helpers` fns |
+//! | `convert!` + chained source streams   | `Millis` ⇄ `Long` via `covertest-helpers` fns |
 //! | `convert!` `.input_from`/`.output_into` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | `convert!` `.input_try_from` (fallible)  | `Percent` ⇄ `Int`; out-of-range → `onError` |
 //! | `convert!` `.input_try_with`/`.output_with` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
@@ -344,7 +344,8 @@ fn main() {
         .ignore_funs_where(|name| name.starts_with("storage_get_into_"))
         .ignore_fun(fun!(storage_put_by_read_and_update));
 
-    let mut registry = Registry::from_sources([&source, &helpers]).expect("scan prebindgen items");
+    let mut registry = Registry::from_items(source.items_all().chain(helpers.items_all()))
+        .expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -63,7 +63,9 @@
 //!   * `JniGen::set_emit_handle_locks` — kept ENABLED (default). Toggling
 //!     it OFF would remove the `withSortedHandleLocks` codegen this example
 //!     asserts against; a single binding can only be in one lock mode, so we
-//!     keep the locked one.
+//!     keep the locked one. (The toggle is a verification aid, not an
+//!     optimization: benchmarks show the locks cost ~1 ns/call — see
+//!     `set_emit_handle_locks` docs.)
 //!
 //! `perftest-kotlin`'s declared surface is a strict subset of this binding
 //! (verified 2026-07-03): its only unique configurations are the unset

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -125,13 +125,11 @@ fn main() {
                 ),
         )
         // ── Subpackage `errors`: the Result error channel ───────────────────
-        .package(
-            package!("errors").class(
-                // `StorageError` is the `E` of a fallible `Result`; its
-                // boundary shape is declared with `return_expand!` below.
-                ptr_class!(StorageError).fun(fun!(storage_error_message).name("message")),
-            ),
-        )
+        .package(package!("errors").class(
+            // `StorageError` is the `E` of a fallible `Result`; its
+            // boundary shape is declared with `return_expand!` below.
+            ptr_class!(StorageError).fun(fun!(storage_error_message).name("message")),
+        ))
         // `StorageError`'s default return fields make the generated `onError`
         // handler receive the decomposed error: the `message` string (name
         // inherited from the class member) plus — via `.field_self()` — the

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -135,7 +135,7 @@ fn main() {
         // inherited from the class member) plus — via `.field_self()` — the
         // error handle itself (an owned `StorageError` the handler must
         // `close()`).
-        .return_expand(
+        .expand(
             return_expand!(StorageError)
                 .field(fun!(storage_error_message))
                 .field_self(),
@@ -163,14 +163,14 @@ fn main() {
         )
         // `Summary` default input: rebuilt from the `of` constructor's
         // ingredients OR passed as an existing handle (runtime-selected).
-        .param_expand(
+        .expand(
             param_expand!(Summary)
                 .variant(fun!(summary_new))
                 .variant_self(),
         )
         // `Summary` default output: decomposed `(count, total)` leaves, names
         // inherited from the class members.
-        .return_expand(
+        .expand(
             return_expand!(Summary)
                 .field(fun!(summary_count))
                 .field(fun!(summary_total)),

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -22,6 +22,7 @@
 //! | `EnumClassDecl`                      | `Priority` |
 //! | `ValueClassDecl`                     | `Stamp` (+ `Vec<Stamp>` → `List<ByteArray>`) |
 //! | `convert!` + chained source streams   | `Millis` ⇄ `Long` via `covertest-helpers` fns |
+//! | `Source::builder().crate_name()`      | the helpers dep is RENAMED to `cov_helpers` in Cargo.toml |
 //! | `convert!` `.input_from`/`.output_into` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | `convert!` `.input_try_from` (fallible)  | `Percent` ⇄ `Int`; out-of-range → `onError` |
 //! | `convert!` `.input_try_with`/`.output_with` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
@@ -82,10 +83,17 @@ use prebindgen::{
 fn main() {
     // Two prebindgen sources: the flat crate plus the binding-side helper
     // crate (conversion fns for `convert!`). The registry records each fn's
-    // origin so generated calls qualify with the defining crate
-    // (`perftest_flat::…` vs `covertest_helpers::…`).
+    // origin from the stream's `SourceLocation` stamps so generated calls
+    // qualify with the defining crate (`perftest_flat::…` vs
+    // `cov_helpers::…`). The helper dependency is RENAMED in Cargo.toml
+    // (`cov_helpers = { package = "covertest-helpers", .. }`), so the stamp
+    // recorded at capture time (`covertest-helpers`) would not resolve from
+    // this crate — `.crate_name()` overrides it with the name this crate
+    // actually uses.
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
-    let helpers = prebindgen::Source::new(covertest_helpers::PREBINDGEN_OUT_DIR);
+    let helpers = prebindgen::Source::builder(cov_helpers::PREBINDGEN_OUT_DIR)
+        .crate_name("cov_helpers")
+        .build();
 
     let jni = JniGen::new()
         .set_package_prefix("io.prebindgen.covertest")
@@ -105,7 +113,7 @@ fn main() {
         // `Long` (no generated class) via two ordinary `#[prebindgen]` fns —
         // defined in the SEPARATE `covertest-helpers` source crate, proving
         // the multi-source model (generated calls carry the
-        // `covertest_helpers::` prefix). The Kotlin surface (`Long`) derives
+        // `cov_helpers::` prefix). The Kotlin surface (`Long`) derives
         // from the fns' `i64` side; nothing is stated verbatim.
         .convert(
             convert!(Millis)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -1,0 +1,120 @@
+# JniGen binding report
+
+Base package: `io.prebindgen.covertest`
+
+## package `io.prebindgen.covertest`
+
+- `string_new` — `fun stringNew(s: String, onError: io.prebindgen.covertest.JniErrorHandler<String>): String`
+- `val COVER_BANNER: String` — binding expression
+- `val COVER_MAGIC` — `#[prebindgen]` const `COVER_MAGIC`
+- `val COVER_TAG_RUNTIME` — nullary `#[prebindgen]` fn `cover_tag_runtime`
+- `val COVER_TAG` — `#[prebindgen]` const `COVER_TAG`
+- `val COVER_VERSION: String` — binding expression
+
+## package `io.prebindgen.covertest.analytics`
+
+- `archive_latest` — `fun archiveLatest(a: SummaryVault, onError: io.prebindgen.covertest.JniErrorHandler<Summary?>): Summary?`
+- `archive_new` — `fun archiveNew(onError: io.prebindgen.covertest.JniErrorHandler<SummaryVault>): SummaryVault`
+- `archive_store` — `fun archiveStore(a: SummaryVault, sSel: Int, s00: Long?, s01: Double?, s1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+  - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
+- `storage_expect_summary` — `fun storageExpectSummary(s: Storage, expectedSel: Int, expected00: Long?, expected01: Double?, expected1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Boolean>): Boolean`
+  - shaped by: param `expected` expanded from `Summary` — variants [summary_new, self]
+- `storage_matches_summary` — `fun storageMatchesSummary(s: Storage, expectedSel: Int, expected00: Long?, expected01: Double?, expected1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Boolean>): Boolean`
+  - shaped by: param `expected` expanded from `Summary` — variants [summary_new, self]
+- `storage_summary` — `fun <R> storageSummary(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryBuilder<R>): R`
+  - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
+- `storage_summary_full` — `fun <R> storageSummaryFull(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryStorageSummaryFullBuilder<R>): R`
+  - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
+- `storage_summary_handle` — `fun storageSummaryHandle(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
+- `summary_total_raw` — `fun summaryTotalRaw(s: Summary, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
+
+## package `io.prebindgen.covertest.model`
+
+- `annotated_new` — `fun annotatedNew(payload: Payload, ttl: Long?, priority: Priority?, onError: io.prebindgen.covertest.JniErrorHandler<Annotated>): Annotated`
+- `annotated_payload_value` — `fun annotatedPayloadValue(a: Annotated, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
+- `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: io.prebindgen.covertest.JniErrorHandler<Priority?>): Priority?`
+- `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: io.prebindgen.covertest.JniErrorHandler<Long?>): Long?`
+- `celsius_double` — `fun celsiusDouble(c: Int, onError: io.prebindgen.covertest.JniErrorHandler<Int>): Int`
+- `label_reverse` — `fun labelReverse(l: String, onError: io.prebindgen.covertest.JniErrorHandler<String>): String`
+- `payload_priority` — `fun payloadPriority(p: Payload, onError: io.prebindgen.covertest.JniErrorHandler<Priority>): Priority`
+- `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: io.prebindgen.covertest.JniErrorHandler<Int>): Int`
+- `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: io.prebindgen.covertest.JniErrorHandler<Priority>): Priority`
+- `priority_weight` — `fun priorityWeight(p: Priority, onError: io.prebindgen.covertest.JniErrorHandler<Int>): Int`
+- `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: io.prebindgen.covertest.JniErrorHandler<Stamp>): Stamp`
+- `stamp_series` — `fun stampSeries(count: Long, onError: io.prebindgen.covertest.JniErrorHandler<List<Stamp>>): List<Stamp>`
+  - shaped by: return `Stamp` decomposed → [] (Callback delivery)
+
+## package `io.prebindgen.covertest.storage`
+
+- `millis_add` — `fun addMillis(a: Long, b: Long, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+- `payload_handler_new` — `fun payloadHandlerNew(f: io.prebindgen.covertest.PayloadCallback, onError: io.prebindgen.covertest.JniErrorHandler<PayloadHandler>): PayloadHandler`
+- `payload_vec_handler_new` — `fun payloadVecHandlerNew(f: io.prebindgen.covertest.PayloadListCallback, onError: io.prebindgen.covertest.JniErrorHandler<PayloadVecHandler>): PayloadVecHandler`
+- `storage_callback` — `fun storageCallback(s: Storage, handler: PayloadHandler, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+- `storage_callback_vec` — `fun storageCallbackVec(s: Storage, handler: PayloadVecHandler, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+- `storage_emit` — `fun storageEmit(n: Long, h: StorageHandler, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+- `storage_get` — `fun storageGet(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<Payload?>): Payload?`
+  - shaped by: return `Payload` decomposed → [id, seq, value, flag, label] (Callback delivery)
+- `storage_get_vec` — `fun storageGetVec(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<List<Payload>?>): List<Payload>?`
+  - shaped by: return `Payload` decomposed → [id, seq, value, flag, label] (Callback delivery)
+- `storage_handler_new` — `fun storageHandlerNew(f: io.prebindgen.covertest.StorageCallback, onError: io.prebindgen.covertest.JniErrorHandler<StorageHandler>): StorageHandler`
+- `storage_labels` — `fun storageLabels(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<List<String>>): List<String>`
+  - shaped by: return `String` decomposed → [] (Callback delivery)
+- `storage_new` — `fun storageNew(onError: io.prebindgen.covertest.JniErrorHandler<Storage>): Storage`
+- `storage_put_by_read` — `fun storagePutByRead(s: Storage, payload: Payload, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+- `storage_put_by_take` — `fun storagePutByTake(s: Storage, payload: Payload, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+- `storage_put_opt` — `fun storagePutOpt(s: Storage, p: Payload?, onError: io.prebindgen.covertest.JniErrorHandler<Boolean>): Boolean`
+- `storage_put_slice` — `fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: io.prebindgen.covertest.JniErrorHandler<Unit>)`
+- `storage_shards` — `fun storageShards(count: Long, each: Long, onError: io.prebindgen.covertest.JniErrorHandler<List<Storage>>): List<Storage>`
+  - shaped by: return `Storage` decomposed → [] (Callback delivery)
+- `storage_shards_opt` — `fun storageShardsOpt(count: Long, each: Long, onError: io.prebindgen.covertest.JniErrorHandler<List<Storage>?>): List<Storage>?`
+  - shaped by: return `Storage` decomposed → [] (Callback delivery)
+- `storage_total_len` — `fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+- `storage_try_with_label` — `fun storageTryWithLabel(label: String, onError: io.prebindgen.covertest.errors.StorageErrorHandler<Storage>): Storage`
+  - shaped by: error `StorageError` decomposed → [je, message, handle]
+
+## class `io.prebindgen.covertest.Payload` (data_class, Rust `Payload`)
+
+- `payload_label_len` — `fun labelLen(onError: io.prebindgen.covertest.JniErrorHandler<Long?>): Long?`
+
+## class `io.prebindgen.covertest.model.Stamp` (value_class, Rust `Stamp`)
+
+- `stamp_nanos` — `fun nanos(onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+- `stamp_secs` — `fun secs(onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+
+## class `io.prebindgen.covertest.Storage` (ptr_class, Rust `Storage`)
+
+- `storage_contains` — `fun contains(id: Long, onError: io.prebindgen.covertest.JniErrorHandler<Boolean>): Boolean`
+- `storage_len` — `fun len(onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+- `storage_with_payload` — `fun withPayload(payload: Payload, onError: io.prebindgen.covertest.JniErrorHandler<Storage>): Storage`
+
+## class `io.prebindgen.covertest.errors.StorageError` (ptr_class, Rust `StorageError`)
+
+- `storage_error_message` — `fun message(onError: io.prebindgen.covertest.JniErrorHandler<String>): String`
+
+## class `io.prebindgen.covertest.analytics.Summary` (ptr_class, Rust `Summary`)
+
+- `summary_count` — `fun count(onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+- `summary_new` — `fun of(count: Long, total: Double, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
+- `summary_scaled` — `fun scaled(factor: Double, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
+- `summary_total` — `fun total(onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
+
+## types
+
+- `Annotated`: data_class → `io.prebindgen.covertest.model.Annotated` (wire `jni :: objects :: JObject`)
+- `Archive`: ptr_class → `io.prebindgen.covertest.analytics.SummaryVault` (wire `jni :: sys :: jlong`)
+- `Payload`: data_class → `io.prebindgen.covertest.Payload` (wire `jni :: objects :: JObject`)
+- `PayloadHandler`: ptr_class → `io.prebindgen.covertest.PayloadHandler` (wire `jni :: sys :: jlong`)
+- `PayloadVecHandler`: ptr_class → `io.prebindgen.covertest.PayloadVecHandler` (wire `jni :: sys :: jlong`)
+- `Priority`: enum_class → `io.prebindgen.covertest.model.Priority` (wire `jni :: sys :: jint`)
+- `Stamp`: value_class → `io.prebindgen.covertest.model.Stamp` (wire `jni :: objects :: JByteArray`)
+- `Storage`: ptr_class → `io.prebindgen.covertest.Storage` (wire `jni :: sys :: jlong`)
+- `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)
+- `StorageHandler`: ptr_class → `io.prebindgen.covertest.StorageHandler` (wire `jni :: sys :: jlong`)
+- `Summary`: ptr_class → `io.prebindgen.covertest.analytics.Summary` (wire `jni :: sys :: jlong`)
+
+## conversions
+
+- `convert!(Celsius)`: input `Into` ⇄ `i32`, output `Into` ⇄ `i32`
+- `convert!(Label)`: input binding-local `crate :: label_in` ⇄ `String` (fallible), output binding-local `crate :: label_out` ⇄ `String`
+- `convert!(Millis)`: input `#[prebindgen]` fn `millis_from_long`, output `#[prebindgen]` fn `millis_value`
+- `convert!(Percent)`: input `TryInto` ⇄ `i32`, output `Into` ⇄ `i32`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -349,6 +349,12 @@ internal object __StringFolderHolder {
     StringFolder { acc, element -> acc.add(element); acc }
 }
 
+/**
+ * Error callback for wrappers without a declared error type. `je` is the
+ * binding/system failure message (any converter in the chain may fail). The
+ * wrapper returns whatever `run` returns; throwing from `run` is safe (it
+ * executes after the native call has returned).
+ */
 public fun interface JniErrorHandler<out R> {
     public fun run(je: String?): R
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -60,6 +60,20 @@ internal inline fun <R> withSortedHandleLocks(
 }
 
 public data class Payload(val id: Long, val seq: Int, val value: Double, val flag: Boolean, val label: String?) {
+    public fun labelLen(onError: JniErrorHandler<Long?>): Long? {
+        val __cap = JniErrorHandlerCapture.acquire()
+        val __ret = CovNative.payloadLabelLen(
+            this.id,
+            this.seq,
+            this.value,
+            this.flag,
+            this.label,
+            __cap,
+        )
+        if (__cap.failed) return onError.run(__cap.je)
+        return __ret
+    }
+
     public companion object {
         @JvmStatic
         public fun fromParts(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -415,7 +415,9 @@ internal object CovNative {
         s1: Long,
         errorSink: Any,
     )
+    external fun celsiusDouble(c: Int, errorSink: Any): Int
     external fun coverTagRuntime(errorSink: Any): String
+    external fun labelReverse(l: String, errorSink: Any): String
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
     external fun payloadHandlerNew(f: Any, errorSink: Any): Long
     external fun payloadLabelLen(
@@ -435,6 +437,7 @@ internal object CovNative {
         errorSink: Any,
     ): Int
     external fun payloadVecHandlerNew(f: Any, errorSink: Any): Long
+    external fun percentScale(p: Int, factor: Int, errorSink: Any): Int
     external fun priorityOr(pPresent: Boolean, pValue: Int, fallback: Int, errorSink: Any): Int
     external fun priorityWeight(p: Int, errorSink: Any): Int
     external fun stampNanos(s: ByteArray, errorSink: Any): Long

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -59,7 +59,18 @@ internal inline fun <R> withSortedHandleLocks(
     return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }
 }
 
+/**
+ * A by-value, FFI-safe payload. Scalars cross the C ABI as themselves; the
+ * `label` string crosses as an opaque pointer (`Option<Box<String>>` ⇒ a nullable
+ * `string_t *`). Being `#[repr(C)]`, the whole struct is passed by direct
+ * reinterpret (zero-copy) — see `perftest-c`'s `.repr_c_struct(Payload)`.
+ */
 public data class Payload(val id: Long, val seq: Int, val value: Double, val flag: Boolean, val label: String?) {
+    /**
+     * Length of a payload's label, or `None` when it is unlabeled. Exercises an
+     * `Option<i64>` (nullable primitive) return, distinct from the `Option<handle>`
+     * / `Option<data-class>` shapes elsewhere.
+     */
     public fun labelLen(onError: JniErrorHandler<Long?>): Long? {
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = CovNative.payloadLabelLen(
@@ -152,6 +163,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
         return Storage(p)
     }
 
+    /** Number of stored payloads (an **accessor** on `Storage`). */
     public fun len(onError: JniErrorHandler<Long>): Long {
         if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
@@ -163,6 +175,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
         return __ret
     }
 
+    /** Whether any stored payload has the given id (a **method** on `Storage`). */
     public fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean {
         if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
@@ -178,6 +191,10 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
         @JvmStatic
         external fun freePtr(ptr: Long)
 
+        /**
+         * Build a storage holding a single payload (a **constructor** / companion
+         * factory on `Storage`).
+         */
         public fun withPayload(payload: Payload, onError: JniErrorHandler<Storage>): Storage {
             val __cap = JniErrorHandlerCapture.acquire()
             val __ret = Storage(
@@ -350,6 +367,10 @@ internal class JniErrorHandlerCapture : JniErrorHandler<Unit> {
     }
 }
 
+/**
+ * Build the opaque string the C side stores in [`Payload::label`]. To C this
+ * returns a `string_t *` (since `String` is declared `opaque_ptr`).
+ */
 public fun stringNew(s: String, onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.stringNew(s, __cap)
@@ -364,7 +385,11 @@ private fun constGetCoverMagic(onError: JniErrorHandler<Long>): Long {
     return __ret
 }
 
-/** Mirrors the Rust `#[prebindgen]` const `COVER_MAGIC` (read once through the generated JNI getter). */
+/**
+ * The storage capacity limit advertised to bindings (a primitive const).
+ *
+ * Mirrors the Rust `#[prebindgen]` const `COVER_MAGIC` (read once through the generated JNI getter).
+ */
 public val COVER_MAGIC: Long = constGetCoverMagic(JniErrorHandler { je -> error(je ?: "const COVER_MAGIC: JNI getter failed") })
 
 private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
@@ -374,9 +399,19 @@ private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
     return __ret
 }
 
-/** Mirrors the Rust `#[prebindgen]` const `COVER_TAG` (read once through the generated JNI getter). */
+/**
+ * The coverage surface's tag string (a string const).
+ *
+ * Mirrors the Rust `#[prebindgen]` const `COVER_TAG` (read once through the generated JNI getter).
+ */
 public val COVER_TAG: String = constGetCoverTag(JniErrorHandler { je -> error(je ?: "const COVER_TAG: JNI getter failed") })
 
+/**
+ * The tag with a runtime-computed suffix — a constant value no Rust `const`
+ * can express (built through `format!`). Exercises
+ * `PackageDecl::constant_fun`: a nullary fn surfaced as an
+ * eagerly-initialized Kotlin top-level `val`.
+ */
 private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.coverTagRuntime(__cap)
@@ -384,7 +419,14 @@ private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
     return __ret
 }
 
-/** Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated once through the generated JNI wrapper). */
+/**
+ * The tag with a runtime-computed suffix — a constant value no Rust `const`
+ * can express (built through `format!`). Exercises
+ * `PackageDecl::constant_fun`: a nullary fn surfaced as an
+ * eagerly-initialized Kotlin top-level `val`.
+ *
+ * Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated once through the generated JNI wrapper).
+ */
 public val COVER_TAG_RUNTIME: String = coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") })
 
 private fun constGetCoverVersion(onError: JniErrorHandler<String>): String {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -373,6 +373,16 @@ private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
 /** Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated once through the generated JNI wrapper). */
 public val COVER_TAG_RUNTIME: String = coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") })
 
+private fun constGetCoverVersion(onError: JniErrorHandler<String>): String {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverVersion(__cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/** Binding-defined constant: `crate :: cover_version ()` (evaluated once through the generated JNI getter). */
+public val COVER_VERSION: String = constGetCoverVersion(JniErrorHandler { je -> error(je ?: "const COVER_VERSION: JNI getter failed") })
+
 private fun constGetCoverBanner(onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.constGetCoverBanner(__cap)
@@ -534,6 +544,7 @@ internal object CovNative {
     external fun constGetCoverMagic(errorSink: Any): Long
     external fun constGetCoverTag(errorSink: Any): String
     external fun constGetCoverBanner(errorSink: Any): String
+    external fun constGetCoverVersion(errorSink: Any): String
     external fun payloadVecNew(cap: Int): Long
     external fun payloadVecPush(handle: Long, eId: Long, eSeq: Int, eValue: Double, eFlag: Boolean, eLabel: String?)
     external fun payloadVecFree(handle: Long)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -50,6 +50,7 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
         return Summary(p)
     }
 
+    /** Number of payloads (flatten-output **field** / **accessor**). */
     public fun count(onError: JniErrorHandler<Long>): Long {
         if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
@@ -61,6 +62,7 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
         return __ret
     }
 
+    /** Sum of payload values (flatten-output **field** / **accessor**). */
     public fun total(onError: JniErrorHandler<Double>): Double {
         if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
@@ -72,6 +74,7 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
         return __ret
     }
 
+    /** Total scaled by a factor (an instance **method**: `&Self` receiver + arg). */
     public fun scaled(factor: Double, onError: JniErrorHandler<Double>): Double {
         if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
@@ -87,6 +90,10 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
         @JvmStatic
         external fun freePtr(ptr: Long)
 
+        /**
+         * Construct a [`Summary`] from its parts (declared a **constructor** /
+         * companion factory, and the build-from **variant** of the flatten-input).
+         */
         public fun of(count: Long, total: Double, onError: JniErrorHandler<Summary>): Summary {
             val __cap = JniErrorHandlerCapture.acquire()
             val __ret = Summary(CovNative.summaryNew(count, total, __cap))
@@ -120,6 +127,12 @@ public fun <R> SummaryStorageSummaryFullBuilder<R>.asRaw(): SummaryStorageSummar
         )
     }
 
+/**
+ * Summarize a storage (returns a `Summary`; the binding's **default
+ * flatten-output** turns it into `(count, total)` leaves).
+ *
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`).
+ */
 @Suppress("UNCHECKED_CAST")
 public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: SummaryBuilder<R>): R {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
@@ -132,6 +145,13 @@ public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: Su
     return __ret
 }
 
+/**
+ * Whether `expected` matches the storage's live summary (takes a `Summary`
+ * **parameter**; the binding's **default flatten-input** rebuilds it from
+ * `(count, total)` or accepts a handle).
+ *
+ * Parameter `expected` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `expectedSel`, `expected00`, `expected01`, `expected1`).
+ */
 public fun storageMatchesSummary(
     s: Storage,
     expectedSel: Int,
@@ -172,6 +192,10 @@ public fun storageMatchesSummary(
     return __ret
 }
 
+/**
+ * Like [`storage_summary`] but the binding keeps the result as a raw opaque
+ * handle (per-fn **flatten-output-suppress**).
+ */
 public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): Summary {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -183,6 +207,10 @@ public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): 
     return __ret
 }
 
+/**
+ * Read a summary's total through a raw handle (per-fn **flatten-input-suppress**
+ * on the `Summary` parameter).
+ */
 public fun summaryTotalRaw(s: Summary, onError: JniErrorHandler<Double>): Double {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -198,6 +226,12 @@ public fun summaryTotalRaw(s: Summary, onError: JniErrorHandler<Double>): Double
     return __ret
 }
 
+/**
+ * Like [`storage_summary`] but the binding decomposes it with a **custom**
+ * field set that also keeps the handle (per-fn **flatten-output-with**).
+ *
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`, `handle`).
+ */
 @Suppress("UNCHECKED_CAST")
 public fun <R> storageSummaryFull(
     s: Storage,
@@ -214,6 +248,13 @@ public fun <R> storageSummaryFull(
     return __ret
 }
 
+/**
+ * Set the storage's "expected" summary, accepting a `Summary` built via an
+ * explicit per-fn **flatten-input-with** variant list. Returns whether it
+ * matched the live summary before being consumed.
+ *
+ * Parameter `expected` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `expectedSel`, `expected00`, `expected01`, `expected1`).
+ */
 public fun storageExpectSummary(
     s: Storage,
     expectedSel: Int,
@@ -254,6 +295,7 @@ public fun storageExpectSummary(
     return __ret
 }
 
+/** Create an empty archive. */
 public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = SummaryVault(CovNative.archiveNew(__cap))
@@ -261,6 +303,11 @@ public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
     return __ret
 }
 
+/**
+ * Store a summary, consuming it (owned-handle input).
+ *
+ * Parameter `s` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `sSel`, `s00`, `s01`, `s1`).
+ */
 public fun archiveStore(
     a: SummaryVault,
     sSel: Int,
@@ -298,6 +345,10 @@ public fun archiveStore(
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * The stored summary, borrowed (`Option<&Summary>` **return** — `None` when
+ * empty, otherwise cloned into a fresh owned handle by the JVM binding).
+ */
 public fun archiveLatest(a: SummaryVault, onError: JniErrorHandler<Summary?>): Summary? {
     if (a.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
@@ -25,6 +25,10 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
         return StorageError(p)
     }
 
+    /**
+     * Render a [`StorageError`] as its message (the error's flatten-output
+     * **accessor**, fed to `onError`).
+     */
     public fun message(onError: JniErrorHandler<String>): String {
         if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
@@ -46,6 +46,13 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
     }
 }
 
+/**
+ * Error callback. Contract: `je != null` ⇒ a binding/system-tier failure — `je` is
+ * its message and the remaining parameters carry defaults; `je == null` ⇒ a domain
+ * error — the remaining parameters carry the decomposed `StorageError`. The
+ * wrapper returns whatever `run` returns; throwing from `run` is safe (it executes
+ * after the native call has returned).
+ */
 public fun interface StorageErrorHandler<out R> {
     public fun run(je: String?, message: String, handle: StorageError): R
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -128,6 +128,27 @@ public fun payloadLabelLen(p: Payload, onError: JniErrorHandler<Long?>): Long? {
     return __ret
 }
 
+public fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.celsiusDouble(c, __cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+public fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.percentScale(p, factor, __cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.labelReverse(l, __cap)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
 public fun annotatedNew(
     payload: Payload,
     ttl: Long?,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -6,7 +6,13 @@ import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.Payload
 
-/** JVM-side surface for the native Rust `Priority` enum. */
+/**
+ * Coarse importance bucket derived from a payload's `value`. A C-like
+ * `#[repr(i32)]` enum with explicit discriminants, mapped by the binding to a
+ * Kotlin `enum class` (and a C enum).
+ *
+ * JVM-side surface for the native Rust `Priority` enum.
+ */
 public enum class Priority(public val value: Int) {
     LOW(0),
     NORMAL(1),
@@ -18,6 +24,13 @@ public enum class Priority(public val value: Int) {
     }
 }
 
+/**
+ * A [`Payload`] with optional delivery metadata. As a `data_class` it
+ * exercises the shapes flat `Payload` cannot: a **nested** data-class field
+ * (`payload`, recursive `fromParts` on output / recursive leaf decode on
+ * input) and `Option<primitive>` / `Option<enum>` **fields** (each crossing
+ * as a decoupled `(present, value)` leaf pair).
+ */
 public data class Annotated(val payload: Payload, val ttl: Long?, val priority: Priority?) {
     public companion object {
         @JvmStatic
@@ -34,11 +47,16 @@ public data class Annotated(val payload: Payload, val ttl: Long?, val priority: 
 }
 
 /**
+ * A plain `Copy` timestamp. Declared `value_class` in the binding, so it
+ * crosses **by value as its raw bytes** in a `ByteArray` (no heap handle, no
+ * `close()`), and `Vec<Stamp>` surfaces as `List<ByteArray>`.
+ *
  * Typed by-value wrapper for the native Rust `Stamp` (a `Copy` blob carried
  * as its raw bytes; `@JvmInline`-erased to `ByteArray` at the JNI boundary).
  */
 @JvmInline
 public value class Stamp(public val bytes: ByteArray) {
+    /** Seconds component (value-class **accessor**, receiver = the value bytes). */
     public fun secs(onError: JniErrorHandler<Long>): Long {
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = CovNative.stampSecs(this.bytes, __cap)
@@ -46,6 +64,7 @@ public value class Stamp(public val bytes: ByteArray) {
         return __ret
     }
 
+    /** Nanoseconds component (value-class **accessor**). */
     public fun nanos(onError: JniErrorHandler<Long>): Long {
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = CovNative.stampNanos(this.bytes, __cap)
@@ -78,6 +97,7 @@ internal object __StampFolderRawHolder {
     StampFolderRaw { acc, element -> acc.add(Stamp(element)); acc }
 }
 
+/** Classify a payload by magnitude of its `value` (enum **return**). */
 public fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = Priority.fromInt(
@@ -87,6 +107,7 @@ public fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Prio
     return __ret
 }
 
+/** Numeric weight of a priority (enum **by-value parameter**). */
 public fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.priorityWeight(p.value, __cap)
@@ -94,6 +115,7 @@ public fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int {
     return __ret
 }
 
+/** Resolve an optional priority against a fallback (`Option<enum>` parameter). */
 public fun priorityOr(
     p: Priority?,
     fallback: Priority,
@@ -107,6 +129,7 @@ public fun priorityOr(
     return __ret
 }
 
+/** Build a [`Stamp`] (value-class **return**). */
 public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = Stamp(CovNative.stampNew(secs, nanos, __cap))
@@ -114,6 +137,10 @@ public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): S
     return __ret
 }
 
+/**
+ * A monotonically increasing run of stamps (`Vec<value-class>` →
+ * `List<ByteArray>`).
+ */
 public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp> {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = (CovNative.stampSeries(count, ArrayList<Stamp>(), __StampFolderRawHolder.instance, __cap) as List<Stamp>)
@@ -121,6 +148,10 @@ public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List
     return __ret
 }
 
+/**
+ * Double a temperature (exercises the `Into`-based conversion on a
+ * parameter and the return).
+ */
 public fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.celsiusDouble(c, __cap)
@@ -128,6 +159,10 @@ public fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int {
     return __ret
 }
 
+/**
+ * Scale a percentage, saturating at 100 (exercises the `TryInto`-based
+ * input conversion — including its error path — and the `Into` output).
+ */
 public fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.percentScale(p, factor, __cap)
@@ -135,6 +170,10 @@ public fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int
     return __ret
 }
 
+/**
+ * Reverse a label's characters (exercises the binding-local conversion on
+ * a parameter and the return).
+ */
 public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.labelReverse(l, __cap)
@@ -142,6 +181,10 @@ public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
     return __ret
 }
 
+/**
+ * Assemble an [`Annotated`] (nested data-class **output** + bare
+ * `Option<scalar>` / `Option<enum>` inputs).
+ */
 public fun annotatedNew(
     payload: Payload,
     ttl: Long?,
@@ -165,6 +208,10 @@ public fun annotatedNew(
     return __ret
 }
 
+/**
+ * The metadata TTL (`Option<prim>` field read back through a data-class
+ * **input**).
+ */
 public fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long? {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.annotatedTtl(a, __cap)
@@ -172,6 +219,7 @@ public fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long? {
     return __ret
 }
 
+/** The metadata priority (`Option<enum>` **return**). */
 public fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority? {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.annotatedPriority(a, __cap)?.let { Priority.fromInt(it) }
@@ -179,6 +227,10 @@ public fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>):
     return __ret
 }
 
+/**
+ * The nested payload's `value` (proves the nested field survived the
+ * input decode).
+ */
 public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>): Double {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.annotatedPayloadValue(a, __cap)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -121,13 +121,6 @@ public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List
     return __ret
 }
 
-public fun payloadLabelLen(p: Payload, onError: JniErrorHandler<Long?>): Long? {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.payloadLabelLen(p.id, p.seq, p.value, p.flag, p.label, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
-    return __ret
-}
-
 public fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.celsiusDouble(c, __cap)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
@@ -22,6 +22,7 @@ import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.errors.StorageErrorHandlerRawCapture
 import io.prebindgen.covertest.withSortedHandleLocks
 
+/** Create a new, empty storage handle. */
 public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = Storage(CovNative.storageNew(__cap))
@@ -29,6 +30,15 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
     return __ret
 }
 
+/**
+ * Return a clone of the **first** stored payload, or `None` if the storage is empty
+ * (by value; crosses by reinterpret, the `label` becoming a fresh owned `string_t *`
+ * the C caller must drop). Across the C ABI an `Option<Payload>` lowers to
+ * `bool storage_get(const storage_t *, payload_t *out)` (true + writes `*out` if
+ * present); in Kotlin it surfaces as a nullable `Payload?`.
+ *
+ * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
+ */
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -40,6 +50,12 @@ public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? 
     return __ret
 }
 
+/**
+ * Move `payload` into the storage. Taken **by value**: across the C ABI this is a
+ * consume — Rust reads the `payload_t` out through a `*mut` and writes a gravestone
+ * back (nulling the owned `label` pointer) so the caller's later free is a no-op
+ * (see `perftest-c`'s `.repr_c_struct(Payload)` — owned-ness is inferred from `label`).
+ */
 public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -58,6 +74,10 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Store a clone of `payload`, read through a shared borrow (`const payload_t *`).
+ * The caller's payload is left untouched.
+ */
 public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -76,6 +96,10 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Replace the stored batch with a clone of `payloads`. The single-payload puts
+ * are the array-of-one case of this.
+ */
 public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -101,6 +125,16 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Return a clone of the **whole** stored batch, or `None` if the storage is empty
+ * (each `label` becoming a fresh owned `string_t *` the C caller must drop). A
+ * returned `Some` is always non-empty (empty storage is `None`). [`storage_get`] is
+ * the first-element case of this. Across the C ABI `Option<Vec<Payload>>` lowers to
+ * `bool storage_get_vec(const storage_t *, payload_t **out, size_t *out_len)`; in
+ * Kotlin it surfaces as a nullable `List<Payload>?`.
+ *
+ * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
+ */
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -112,6 +146,13 @@ public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): 
     return __ret
 }
 
+/**
+ * Prepare a reusable [`PayloadHandler`] from a callback `f`. The (foreign) closure
+ * is decoded into the handler **once** here — reuse the handler across many
+ * [`storage_callback`] calls instead of passing a fresh callback each time. This
+ * is the "declare the subscriber once" step (its trampoline + per-call setup are
+ * built here, amortized over every later delivery).
+ */
 public fun payloadHandlerNew(
     f: PayloadCallback,
     onError: JniErrorHandler<PayloadHandler>,
@@ -122,6 +163,16 @@ public fun payloadHandlerNew(
     return __ret
 }
 
+/**
+ * Invoke the prepared `handler` once **per stored payload** with a borrow of each
+ * — reuses the handler's already-built foreign trampoline, so there is **no
+ * per-call callback decoding** (only firing). After a single-payload put this
+ * fires exactly once; after a [`storage_put_slice`] it fires once per slice
+ * element. In C the closure receives a `const payload_t *` (zero-copy); in Kotlin
+ * the borrowed `Payload` is delivered whole to the handler's
+ * `PayloadCallback.run(Payload)` (its fields cross as decoupled leaves and are
+ * reassembled on the Kotlin side — see `prebindgen::lang::JniGen`).
+ */
 public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     if (handler.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
@@ -134,6 +185,11 @@ public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErro
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Prepare a reusable [`PayloadVecHandler`] from a whole-batch callback `f`. Like
+ * [`payload_handler_new`], the foreign closure is decoded **once** here; reuse the
+ * handler across many [`storage_callback_vec`] calls.
+ */
 public fun payloadVecHandlerNew(
     f: PayloadListCallback,
     onError: JniErrorHandler<PayloadVecHandler>,
@@ -144,6 +200,13 @@ public fun payloadVecHandlerNew(
     return __ret
 }
 
+/**
+ * Invoke the prepared `handler` **once** with the whole stored batch as a slice
+ * (the dual of [`storage_callback`], which fires once per element). In C the closure
+ * receives the slice **by reference** — `const payload_t *` + `size_t`, zero-copy, no
+ * per-element materialization; in Kotlin the batch is delivered as a `List<Payload>`
+ * to the handler's `PayloadVecCallback.run(List<Payload>)`.
+ */
 public fun storageCallbackVec(
     s: Storage,
     handler: PayloadVecHandler,
@@ -160,6 +223,12 @@ public fun storageCallbackVec(
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Build a storage seeded with a single labelled payload, **failing** on an
+ * empty label (`Result<T, E>` routing + a `&str` input).
+ *
+ * On failure `onError` receives `je` plus the decomposed Rust `StorageError` error (`message`, `handle`).
+ */
 public fun storageTryWithLabel(label: String, onError: StorageErrorHandler<Storage>): Storage {
     val __cap = StorageErrorHandlerRawCapture.acquire()
     val __ret = Storage(CovNative.storageTryWithLabel(label, __cap))
@@ -167,6 +236,11 @@ public fun storageTryWithLabel(label: String, onError: StorageErrorHandler<Stora
     return __ret
 }
 
+/**
+ * Build `count` independent storages of `each` payloads (a
+ * `Vec<opaque-handle>` **return** — each element crosses as a raw pointer the
+ * Kotlin folder wraps into a typed `Storage` handle).
+ */
 public fun storageShards(
     count: Long,
     each: Long,
@@ -178,6 +252,10 @@ public fun storageShards(
     return __ret
 }
 
+/**
+ * Like [`storage_shards`] but `None` when `count == 0`
+ * (`Option<Vec<opaque-handle>>` — the fold under the null niche).
+ */
 public fun storageShardsOpt(
     count: Long,
     each: Long,
@@ -189,6 +267,7 @@ public fun storageShardsOpt(
     return __ret
 }
 
+/** Wrap a `Fn(Storage)` closure into a reusable [`StorageHandler`]. */
 public fun storageHandlerNew(
     f: StorageCallback,
     onError: JniErrorHandler<StorageHandler>,
@@ -199,6 +278,10 @@ public fun storageHandlerNew(
     return __ret
 }
 
+/**
+ * Build a synthetic storage of `n` payloads and hand **ownership** of it to
+ * the handler's callback.
+ */
 public fun storageEmit(n: Long, h: StorageHandler, onError: JniErrorHandler<Unit>) {
     if (h.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -209,6 +292,10 @@ public fun storageEmit(n: Long, h: StorageHandler, onError: JniErrorHandler<Unit
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Combined length of three storages (a **3-opaque-handle** call — the
+ * generated wrapper must sort-lock all three).
+ */
 public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniErrorHandler<Long>): Long {
     if (a.ptr == 0L) return onError.run("Operation on a closed native handle.")
     if (b.ptr == 0L) return onError.run("Operation on a closed native handle.")
@@ -224,6 +311,10 @@ public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniError
     return __ret
 }
 
+/**
+ * All present labels, in storage order (`Vec<String>` **return** — the
+ * single-leaf string fold).
+ */
 public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): List<String> {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -235,6 +326,7 @@ public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): Li
     return __ret
 }
 
+/** Push `p` if present; whether it was pushed (`Option<data-class>` **input**). */
 public fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boolean>): Boolean {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -255,6 +347,10 @@ public fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boole
     return __ret
 }
 
+/**
+ * Sum two durations (exercises the custom wrapper on both a **parameter** and
+ * the **return**).
+ */
 public fun addMillis(a: Long, b: Long, onError: JniErrorHandler<Long>): Long {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.millisAdd(a, b, __cap)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -305,9 +305,17 @@ fun main() {
             "percentScale(150) must report the range error, got: $msg"
         }
     }
-    section("convert! via binding-local fns (Label -> String)") {
+    section("convert! via binding-local fns (Label -> String, fallible input)") {
         check(labelReverse("abc", boom) == "cba")
-        check(labelReverse("", boom) == "")
+        // Empty label: the local fn's Err(String) routes to onError.
+        var msg: String? = null
+        labelReverse("") { je ->
+            msg = je
+            ""
+        }
+        check(msg?.contains("label must not be empty") == true) {
+            "labelReverse(\"\") must report the empty-label error, got: $msg"
+        }
     }
 
     // ── Vec<opaque-handle> return: the Kotlin-side handle fold ───────────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -16,6 +16,9 @@ import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.annotatedNew
+import io.prebindgen.covertest.model.celsiusDouble
+import io.prebindgen.covertest.model.labelReverse
+import io.prebindgen.covertest.model.percentScale
 import io.prebindgen.covertest.model.annotatedPayloadValue
 import io.prebindgen.covertest.model.annotatedPriority
 import io.prebindgen.covertest.model.annotatedTtl
@@ -280,6 +283,31 @@ fun main() {
     section("input/output wrapper Millis -> Long (+ .name rename)") {
         check(addMillis(100L, 50L, boom) == 150L)
         check(addMillis(0L, 0L, boom) == 0L)
+    }
+
+    // ── convert! source kinds: trait impls and binding-local fns ────────────
+    section("convert! via From/Into impls (Celsius -> Int)") {
+        check(celsiusDouble(21, boom) == 42)
+        check(celsiusDouble(-5, boom) == -10)
+    }
+    section("convert! via TryFrom (Percent -> Int, fallible input)") {
+        check(percentScale(50, 2, boom) == 100)
+        check(percentScale(30, 2, boom) == 60)
+        // Out-of-range input: the TryFrom impl's Err(String) routes to
+        // onError through the converter's error slot (je carries the
+        // Display'd message).
+        var msg: String? = null
+        percentScale(150, 1) { je ->
+            msg = je
+            0
+        }
+        check(msg?.contains("percent out of range: 150") == true) {
+            "percentScale(150) must report the range error, got: $msg"
+        }
+    }
+    section("convert! via binding-local fns (Label -> String)") {
+        check(labelReverse("abc", boom) == "cba")
+        check(labelReverse("", boom) == "")
     }
 
     // ── Vec<opaque-handle> return: the Kotlin-side handle fold ───────────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -22,7 +22,6 @@ import io.prebindgen.covertest.model.percentScale
 import io.prebindgen.covertest.model.annotatedPayloadValue
 import io.prebindgen.covertest.model.annotatedPriority
 import io.prebindgen.covertest.model.annotatedTtl
-import io.prebindgen.covertest.model.payloadLabelLen
 import io.prebindgen.covertest.model.payloadPriority
 import io.prebindgen.covertest.model.priorityOr
 import io.prebindgen.covertest.model.priorityWeight
@@ -133,10 +132,11 @@ fun main() {
         check(stampSeries(0L, boom).isEmpty())
     }
 
-    // ── Option<scalar>: nullable primitive return ────────────────────────────
-    section("Option<i64> payloadLabelLen") {
-        check(payloadLabelLen(payload(1L, 0, 0.0, false, "abcd"), boom) == 4L)
-        check(payloadLabelLen(payload(1L, 0, 0.0, false, null), boom) == null)
+    // ── Option<scalar> nullable primitive return + data_class instance
+    // member (I5): the receiver crosses as `this`'s field leaves ────────────
+    section("Option<i64> Payload.labelLen") {
+        check(payload(1L, 0, 0.0, false, "abcd").labelLen(boom) == 4L)
+        check(payload(1L, 0, 0.0, false, null).labelLen(boom) == null)
     }
 
     // ── ptr_class members + Option<Payload>/Option<Vec>/Vec round-trips ──────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -87,13 +87,14 @@ private fun payload(id: Long, seq: Int, value: Double, flag: Boolean, label: Str
 fun main() {
     println("covertest-kotlin: exercising every JniGen feature")
 
-    // ── consts: eagerly-initialized top-level vals — const-backed (generated
-    // nullary getters over Rust consts) and function-backed (constant_fun:
-    // the value comes from a nullary #[prebindgen] fn at class-load) ─────────
-    section("top-level const vals (const- and function-backed)") {
+    // ── consts: eagerly-initialized top-level vals, one per value source —
+    // #[prebindgen] const (bare constant!), nullary #[prebindgen] fn (.fun),
+    // binding-local fn by path (.with), binding-defined expression (.expr) ────
+    section("top-level const vals (all four value sources)") {
         check(COVER_MAGIC == 0xC0FFEE.toLong())
         check(COVER_TAG == "covertest")
         check(COVER_TAG_RUNTIME == "covertest-runtime")
+        check(COVER_VERSION.startsWith("cover-"))
         check(COVER_BANNER == "covertest:0xc0ffee")
     }
 

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1381,8 +1381,8 @@ pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
 pub(crate) unsafe fn String_to_Label_c1a79668<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: String,
-) -> ::core::result::Result<perftest_flat::Label, __JniErr> {
-    Ok(crate::label_in(v))
+) -> ::core::result::Result<perftest_flat::Label, String> {
+    crate::label_in(v)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Summary_to_jlong_3cb103b9<'a>(

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -241,6 +241,45 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverVersion<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = {
+        #[allow(unused_imports)]
+        use perftest_flat::*;
+        #[allow(unused_imports)]
+        use cov_helpers::*;
+        crate::cover_version()
+    };
+    match String_to_JString_c7f3ca43(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBanner<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBan
         #[allow(unused_imports)]
         use perftest_flat::*;
         #[allow(unused_imports)]
-        use covertest_helpers::*;
+        use cov_helpers::*;
         format!("{COVER_TAG}:{COVER_MAGIC:#x}")
     };
     match String_to_JString_c7f3ca43(&mut env, __out) {
@@ -1131,7 +1131,7 @@ pub(crate) unsafe fn Millis_to_i64_61ecf054<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Millis,
 ) -> ::core::result::Result<i64, __JniErr> {
-    Ok(covertest_helpers::millis_value(&v))
+    Ok(cov_helpers::millis_value(&v))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
@@ -1522,7 +1522,7 @@ pub(crate) unsafe fn i64_to_Millis_bb88777a<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: i64,
 ) -> ::core::result::Result<perftest_flat::Millis, __JniErr> {
-    Ok(covertest_helpers::millis_from_long(v))
+    Ok(cov_helpers::millis_from_long(v))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn i64_to_jlong_fbf9a9bc<'a>(
@@ -6439,7 +6439,7 @@ const _: () = {
 };
 const _: () = {
     konst::assertc_eq!(
-        covertest_helpers::FEATURES, "",
+        cov_helpers::FEATURES, "",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -343,6 +343,13 @@ pub(crate) unsafe fn Archive_to_jlong_cd73502c<'a>(
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Celsius,
+) -> ::core::result::Result<i32, __JniErr> {
+    Ok(<perftest_flat::Celsius as ::core::convert::Into<i32>>::into(v))
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn JByteArray_to_Stamp_2fc9bd18<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JByteArray<'v>,
@@ -1113,6 +1120,13 @@ pub(crate) unsafe fn JString_to_std_boxed_Box_std_string_String_cfbab680<'env, '
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Label_to_String_63dec766<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Label,
+) -> ::core::result::Result<String, __JniErr> {
+    Ok(crate::label_out(v))
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Millis_to_i64_61ecf054<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Millis,
@@ -1288,6 +1302,13 @@ pub(crate) unsafe fn Payload_to_JObject_98f64326<'a>(
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Percent_to_i32_01484801<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Percent,
+) -> ::core::result::Result<i32, __JniErr> {
+    Ok(<perftest_flat::Percent as ::core::convert::Into<i32>>::into(v))
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Priority_to_jint_447102d2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Priority,
@@ -1355,6 +1376,13 @@ pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
                 >>::from(format!("encode_string: {}", e))
             })?
     })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn String_to_Label_c1a79668<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: String,
+) -> ::core::result::Result<perftest_flat::Label, __JniErr> {
+    Ok(crate::label_in(v))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Summary_to_jlong_3cb103b9<'a>(
@@ -1464,6 +1492,23 @@ pub(crate) unsafe fn f64_to_jdouble_9e4a8f70<'a>(
     v: f64,
 ) -> ::core::result::Result<jni::sys::jdouble, __JniErr> {
     Ok(v as jni::sys::jdouble)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn i32_to_Celsius_8c363100<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: i32,
+) -> ::core::result::Result<perftest_flat::Celsius, __JniErr> {
+    Ok(<i32 as ::core::convert::Into<perftest_flat::Celsius>>::into(v))
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn i32_to_Percent_db3641cc<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: i32,
+) -> ::core::result::Result<
+    perftest_flat::Percent,
+    <i32 as ::core::convert::TryInto<perftest_flat::Percent>>::Error,
+> {
+    <i32 as ::core::convert::TryInto<perftest_flat::Percent>>::try_into(v)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn i32_to_jint_a3e3b6ef<'a>(
@@ -2228,6 +2273,88 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    c: jni::sys::jint,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jint {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __c_s0 = match jint_to_i32_a3e3b6ef(&mut env, &c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let c = match i32_to_Celsius_8c363100(&mut env, __c_s0) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __out = perftest_flat::celsius_double(c);
+    let __out_s0 = match Celsius_to_i32_88c8e884(&mut env, __out) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    match i32_to_jint_a3e3b6ef(&mut env, __out_s0) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jint
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -2243,6 +2370,88 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::cover_tag_runtime();
     match String_to_JString_c7f3ca43(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    l: jni::objects::JString<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __l_s0 = match JString_to_String_c7f3ca43(&mut env, &l) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let l = match String_to_Label_c1a79668(&mut env, __l_s0) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::label_reverse(l);
+    let __out_s0 = match Label_to_String_63dec766(&mut env, __out) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    match String_to_JString_c7f3ca43(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             let __zd = __ze_defaults(&mut env);
@@ -2721,6 +2930,105 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecHandle
                 &__zd,
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    p: jni::sys::jint,
+    factor: jni::sys::jint,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jint {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __p_s0 = match jint_to_i32_a3e3b6ef(&mut env, &p) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let p = match i32_to_Percent_db3641cc(&mut env, __p_s0) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let factor = match jint_to_i32_a3e3b6ef(&mut env, &factor) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __out = perftest_flat::percent_scale(p, factor);
+    let __out_s0 = match Percent_to_i32_01484801(&mut env, __out) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    match i32_to_jint_a3e3b6ef(&mut env, __out_s0) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jint
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1111,11 +1111,11 @@ pub(crate) unsafe fn JString_to_std_boxed_Box_std_string_String_cfbab680<'env, '
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
-pub(crate) unsafe fn Millis_to_jlong_a7037db5<'a>(
+pub(crate) unsafe fn Millis_to_i64_61ecf054<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Millis,
-) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
-    Ok(v.0 as jni::sys::jlong)
+) -> ::core::result::Result<i64, __JniErr> {
+    Ok(covertest_helpers::millis_value(&v))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
@@ -1471,6 +1471,13 @@ pub(crate) unsafe fn i32_to_jint_a3e3b6ef<'a>(
     Ok(v as jni::sys::jint)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn i64_to_Millis_bb88777a<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: i64,
+) -> ::core::result::Result<perftest_flat::Millis, __JniErr> {
+    Ok(covertest_helpers::millis_from_long(v))
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn i64_to_jlong_fbf9a9bc<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: i64,
@@ -1524,13 +1531,6 @@ pub(crate) unsafe fn jlong_to_Archive_cd73502c<'env, 'v>(
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::Archive>, __JniErr> {
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Archive) })
-}
-#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
-pub(crate) unsafe fn jlong_to_Millis_a7037db5<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Millis, __JniErr> {
-    Ok(perftest_flat::Millis(*v as u64))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
@@ -2274,7 +2274,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let a = match jlong_to_Millis_a7037db5(&mut env, &a) {
+    let __a_s0 = match jlong_to_i64_fbf9a9bc(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             let __zd = __ze_defaults(&mut env);
@@ -2290,7 +2290,39 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
             return 0 as jni::sys::jlong;
         }
     };
-    let b = match jlong_to_Millis_a7037db5(&mut env, &b) {
+    let a = match i64_to_Millis_bb88777a(&mut env, __a_s0) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __b_s0 = match jlong_to_i64_fbf9a9bc(&mut env, &b) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let b = match i64_to_Millis_bb88777a(&mut env, __b_s0) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             let __zd = __ze_defaults(&mut env);
@@ -2307,7 +2339,23 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
         }
     };
     let __out = perftest_flat::millis_add(a, b);
-    match Millis_to_jlong_a7037db5(&mut env, __out) {
+    let __out_s0 = match Millis_to_i64_61ecf054(&mut env, __out) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    match i64_to_jlong_fbf9a9bc(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             let __zd = __ze_defaults(&mut env);
@@ -6073,6 +6121,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverTag
 const _: () = {
     konst::assertc_eq!(
         perftest_flat::FEATURES, "",
+        "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
+                        This usually happens if source crate is compiled with different feature set\n\
+                        for build dependencies and for library usage. You may need to explicitly set\n\
+                        the necessary features."
+    );
+};
+const _: () = {
+    konst::assertc_eq!(
+        covertest_helpers::FEATURES, "",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -257,6 +257,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBan
     let __out = {
         #[allow(unused_imports)]
         use perftest_flat::*;
+        #[allow(unused_imports)]
+        use covertest_helpers::*;
         format!("{COVER_TAG}:{COVER_MAGIC:#x}")
     };
     match String_to_JString_c7f3ca43(&mut env, __out) {

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -3,12 +3,17 @@
 #![allow(clippy::all)]
 
 // Binding-local conversion fns for `Label` — referenced by build.rs as
-// `.convert(convert!(Label).input_with(ty!(String), path!(crate::label_in))…)`.
+// `.convert(convert!(Label).input_try_with(…, path!(crate::label_in))…)`.
 // NOT `#[prebindgen]`-marked: the generated file compiles inside this crate,
-// so plain `crate::` paths resolve; no helper crate needed for infallible
-// by-value conversions.
-pub fn label_in(s: String) -> perftest_flat::Label {
-    perftest_flat::Label(s)
+// so plain `crate::` paths resolve; no helper crate needed. The input is the
+// FALLIBLE local form (`fn(Repr) -> Result<T, E>`, E stated in the decl);
+// the output is the infallible one.
+pub fn label_in(s: String) -> Result<perftest_flat::Label, String> {
+    if s.is_empty() {
+        Err("label must not be empty".to_string())
+    } else {
+        Ok(perftest_flat::Label(s))
+    }
 }
 pub fn label_out(l: perftest_flat::Label) -> String {
     l.0

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -19,6 +19,13 @@ pub fn label_out(l: perftest_flat::Label) -> String {
     l.0
 }
 
+// Binding-local nullary fn backing the `.with`-sourced constant
+// `COVER_VERSION` (build.rs: `constant!(COVER_VERSION).with(ty!(String),
+// path!(crate::cover_version))`) — the const analog of convert!'s `_with`.
+pub fn cover_version() -> String {
+    format!("cover-{}", env!("CARGO_PKG_VERSION"))
+}
+
 // The generated JNI bindings, written by build.rs from perftest-flat's
 // #[prebindgen] surface (the perf surface plus the `ext` coverage surface). The
 // generated code refers to source types fully qualified by each item's origin

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -2,8 +2,20 @@
 // belong to the generator, not to this file.
 #![allow(clippy::all)]
 
+// Binding-local conversion fns for `Label` — referenced by build.rs as
+// `.convert(convert!(Label).input_with(ty!(String), path!(crate::label_in))…)`.
+// NOT `#[prebindgen]`-marked: the generated file compiles inside this crate,
+// so plain `crate::` paths resolve; no helper crate needed for infallible
+// by-value conversions.
+pub fn label_in(s: String) -> perftest_flat::Label {
+    perftest_flat::Label(s)
+}
+pub fn label_out(l: perftest_flat::Label) -> String {
+    l.0
+}
+
 // The generated JNI bindings, written by build.rs from perftest-flat's
 // #[prebindgen] surface (the perf surface plus the `ext` coverage surface). The
-// generated code refers to source types fully qualified through the
-// `source_module` (e.g. `perftest_flat::Payload`), so no extra `use` is needed.
+// generated code refers to source types fully qualified by each item's origin
+// crate (e.g. `perftest_flat::Payload`), so no extra `use` is needed.
 include!("generated_bindings.rs");

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -122,12 +122,14 @@ fn generate_ffi_bindings() -> PathBuf {
         cbindgen = cbindgen.function(function).panic();
     }
 
-    let mut registry =
+    let registry =
         prebindgen::core::Registry::from_items(source.items_all()).expect("scan prebindgen items");
     // Always written to OUT_DIR under a stable name too, so the commented-out
     // `include!(OUT_DIR ...)` alternative in `lib.rs` works for any target.
     let out_file = registry
-        .write_rust(&cbindgen, "example_flat.rs")
+        .resolve(cbindgen)
+        .expect("resolve prebindgen items")
+        .write_rust("example_flat.rs")
         .expect("write generated bindings");
 
     // Publish the generated Rust into the crate tree under a per-target-arch name

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct foo_t {
     pub id: u64,
     pub aarch64_field: u64,
-    pub stable_field: u64,
+    pub unstable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -97,7 +97,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         aarch64_field: v.aarch64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -208,7 +208,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         aarch64_field: v.aarch64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -429,6 +429,17 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
+    let c = match __cbg_in___mut_Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    example_flat::calculator_reset(c);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -480,7 +491,7 @@ pub unsafe extern "C" fn inside_foo_value(x: inside_foo_t) -> i32 {
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "",
+        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -37,7 +37,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t aarch64_field;
-  uint64_t stable_field;
+  uint64_t unstable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -69,6 +69,8 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
+
+void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/perftest-c/build.rs
+++ b/examples/perftest-c/build.rs
@@ -121,10 +121,12 @@ fn generate_ffi_bindings() -> PathBuf {
     cbindgen = cbindgen.function(pq!(payload_vec_handler_new));
     cbindgen = cbindgen.function(pq!(storage_callback_vec)).panic();
 
-    let mut registry =
+    let registry =
         prebindgen::core::Registry::from_items(source.items_all()).expect("scan prebindgen items");
     let out_file = registry
-        .write_rust(&cbindgen, "perftest.rs")
+        .resolve(cbindgen)
+        .expect("resolve prebindgen items")
+        .write_rust("perftest.rs")
         .expect("write generated bindings");
 
     // Publish the generated Rust into the crate tree (committed artifact `lib.rs`

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -286,6 +286,77 @@ pub fn millis_add(a: Millis, b: Millis) -> Millis {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// convert! source-kind fixtures — one type per conversion source. Like
+// `Millis`, none of these types is `#[prebindgen]`-marked: each crosses the
+// boundary only through its declared canonical conversion.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A temperature. Crosses via its `From`/`Into` impls
+/// (`convert!(Celsius).input_from(ty!(i32)).output_into(ty!(i32))`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Celsius(pub i32);
+
+impl From<i32> for Celsius {
+    fn from(v: i32) -> Self {
+        Celsius(v)
+    }
+}
+impl From<Celsius> for i32 {
+    fn from(c: Celsius) -> Self {
+        c.0
+    }
+}
+
+/// Double a temperature (exercises the `Into`-based conversion on a
+/// parameter and the return).
+#[prebindgen]
+pub fn celsius_double(c: Celsius) -> Celsius {
+    Celsius(c.0 * 2)
+}
+
+/// A percentage, range-invariant 0..=100. Crosses via a fallible
+/// `TryFrom<i32>` on input (out-of-range i32 from the JVM → the caller's
+/// error handler) and an infallible `Into<i32>` on output.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Percent(pub u8);
+
+impl TryFrom<i32> for Percent {
+    type Error = String;
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        if (0..=100).contains(&v) {
+            Ok(Percent(v as u8))
+        } else {
+            Err(format!("percent out of range: {v} (expected 0..=100)"))
+        }
+    }
+}
+impl From<Percent> for i32 {
+    fn from(p: Percent) -> Self {
+        p.0 as i32
+    }
+}
+
+/// Scale a percentage, saturating at 100 (exercises the `TryInto`-based
+/// input conversion — including its error path — and the `Into` output).
+#[prebindgen]
+pub fn percent_scale(p: Percent, factor: i32) -> Percent {
+    Percent(((p.0 as i32) * factor).clamp(0, 100) as u8)
+}
+
+/// A text label. Crosses via plain conversion fns declared **in the binding
+/// crate** (`convert!(Label).input_with(ty!(String), path!(crate::label_in))…`)
+/// — no `#[prebindgen]` marking anywhere in the conversion.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Label(pub String);
+
+/// Reverse a label's characters (exercises the binding-local conversion on
+/// a parameter and the return).
+#[prebindgen]
+pub fn label_reverse(l: Label) -> Label {
+    Label(l.0.chars().rev().collect())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Option<scalar> — a nullable primitive return.
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -84,7 +84,7 @@ fn main() {
                 .fun(fun!(storage_callback_vec)),
         );
 
-    let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
+    let registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
@@ -92,9 +92,8 @@ fn main() {
     let rust_dest = std::path::Path::new(&crate_dir)
         .join("src")
         .join("generated_bindings.rs");
-    let rust_path = registry
-        .write_rust(&jni, &rust_dest)
-        .expect("write_rust failed");
+    let gen = registry.resolve(jni).expect("resolve failed");
+    let rust_path = gen.write_rust(&rust_dest).expect("write_rust failed");
     println!(
         "cargo:warning=Generated bindings at: {}",
         rust_path.display()
@@ -109,10 +108,7 @@ fn main() {
             panic!("cleanup kotlin/generated failed: {err}");
         }
     }
-    for path in jni
-        .write_kotlin(&registry, &kotlin_root)
-        .expect("write_kotlin failed")
-    {
+    for path in gen.write_kotlin(&kotlin_root).expect("write_kotlin failed") {
         println!("cargo:warning=Wrote {}", path.display());
     }
 }

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -84,7 +84,7 @@ fn main() {
                 .fun(fun!(storage_callback_vec)),
         );
 
-    let mut registry = Registry::from_sources([&source]).expect("scan prebindgen items");
+    let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -23,7 +23,6 @@ fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
 
     let jni = JniGen::new()
-        .set_source_module(pq!(perftest_flat))
         .set_package_prefix("io.prebindgen.perftest")
         // Trigger native-library loading from the generated `JNINative` static
         // init (the single choke point through which every JNI call routes).
@@ -85,7 +84,7 @@ fn main() {
                 .fun(fun!(storage_callback_vec)),
         );
 
-    let mut registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
+    let mut registry = Registry::from_sources([&source]).expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -103,11 +103,6 @@ fn main() {
     let kotlin_root = std::path::Path::new(&crate_dir)
         .join("kotlin")
         .join("generated");
-    if let Err(err) = std::fs::remove_dir_all(&kotlin_root) {
-        if err.kind() != std::io::ErrorKind::NotFound {
-            panic!("cleanup kotlin/generated failed: {err}");
-        }
-    }
     for path in gen.write_kotlin(&kotlin_root).expect("write_kotlin failed") {
         println!("cargo:warning=Wrote {}", path.display());
     }

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -17,7 +17,6 @@
 //! `String?` automatically.
 
 use prebindgen::{core::Registry, data_class, fun, lang::JniGen, package, ptr_class};
-use syn::parse_quote as pq;
 
 fn main() {
     let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -53,6 +53,12 @@ internal inline fun <R> withSortedHandleLocks(
     return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }
 }
 
+/**
+ * A by-value, FFI-safe payload. Scalars cross the C ABI as themselves; the
+ * `label` string crosses as an opaque pointer (`Option<Box<String>>` ⇒ a nullable
+ * `string_t *`). Being `#[repr(C)]`, the whole struct is passed by direct
+ * reinterpret (zero-copy) — see `perftest-c`'s `.repr_c_struct(Payload)`.
+ */
 public data class Payload(val id: Long, val seq: Int, val value: Double, val flag: Boolean, val label: String?) {
     public companion object {
         @JvmStatic

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -203,6 +203,12 @@ internal object __PayloadFolderRawHolder {
     PayloadFolderRaw { acc, id, seq, value, flag, label -> acc.add(Payload.fromParts(id, seq, value, flag, label)); acc }
 }
 
+/**
+ * Error callback for wrappers without a declared error type. `je` is the
+ * binding/system failure message (any converter in the chain may fail). The
+ * wrapper returns whatever `run` returns; throwing from `run` is safe (it
+ * executes after the native call has returned).
+ */
 public fun interface JniErrorHandler<out R> {
     public fun run(je: String?): R
 }

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
@@ -15,6 +15,7 @@ import io.prebindgen.perftest.__PayloadFolderRawHolder
 import io.prebindgen.perftest.asRaw
 import io.prebindgen.perftest.withSortedHandleLocks
 
+/** Create a new, empty storage handle. */
 public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = Storage(JNINative.storageNew(__cap))
@@ -22,6 +23,15 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
     return __ret
 }
 
+/**
+ * Return a clone of the **first** stored payload, or `None` if the storage is empty
+ * (by value; crosses by reinterpret, the `label` becoming a fresh owned `string_t *`
+ * the C caller must drop). Across the C ABI an `Option<Payload>` lowers to
+ * `bool storage_get(const storage_t *, payload_t *out)` (true + writes `*out` if
+ * present); in Kotlin it surfaces as a nullable `Payload?`.
+ *
+ * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
+ */
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -33,6 +43,12 @@ public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? 
     return __ret
 }
 
+/**
+ * Move `payload` into the storage. Taken **by value**: across the C ABI this is a
+ * consume — Rust reads the `payload_t` out through a `*mut` and writes a gravestone
+ * back (nulling the owned `label` pointer) so the caller's later free is a no-op
+ * (see `perftest-c`'s `.repr_c_struct(Payload)` — owned-ness is inferred from `label`).
+ */
 public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -51,6 +67,10 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Store a clone of `payload`, read through a shared borrow (`const payload_t *`).
+ * The caller's payload is left untouched.
+ */
 public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -69,6 +89,13 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Prepare a reusable [`PayloadHandler`] from a callback `f`. The (foreign) closure
+ * is decoded into the handler **once** here — reuse the handler across many
+ * [`storage_callback`] calls instead of passing a fresh callback each time. This
+ * is the "declare the subscriber once" step (its trampoline + per-call setup are
+ * built here, amortized over every later delivery).
+ */
 public fun payloadHandlerNew(
     f: PayloadCallback,
     onError: JniErrorHandler<PayloadHandler>,
@@ -79,6 +106,16 @@ public fun payloadHandlerNew(
     return __ret
 }
 
+/**
+ * Invoke the prepared `handler` once **per stored payload** with a borrow of each
+ * — reuses the handler's already-built foreign trampoline, so there is **no
+ * per-call callback decoding** (only firing). After a single-payload put this
+ * fires exactly once; after a [`storage_put_slice`] it fires once per slice
+ * element. In C the closure receives a `const payload_t *` (zero-copy); in Kotlin
+ * the borrowed `Payload` is delivered whole to the handler's
+ * `PayloadCallback.run(Payload)` (its fields cross as decoupled leaves and are
+ * reassembled on the Kotlin side — see `prebindgen::lang::JniGen`).
+ */
 public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     if (handler.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
@@ -91,6 +128,10 @@ public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErro
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Replace the stored batch with a clone of `payloads`. The single-payload puts
+ * are the array-of-one case of this.
+ */
 public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>) {
     if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
@@ -116,6 +157,16 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
     if (__cap.failed) return onError.run(__cap.je)
 }
 
+/**
+ * Return a clone of the **whole** stored batch, or `None` if the storage is empty
+ * (each `label` becoming a fresh owned `string_t *` the C caller must drop). A
+ * returned `Some` is always non-empty (empty storage is `None`). [`storage_get`] is
+ * the first-element case of this. Across the C ABI `Option<Vec<Payload>>` lowers to
+ * `bool storage_get_vec(const storage_t *, payload_t **out, size_t *out_len)`; in
+ * Kotlin it surfaces as a nullable `List<Payload>?`.
+ *
+ * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
+ */
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
     if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
@@ -127,6 +178,11 @@ public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): 
     return __ret
 }
 
+/**
+ * Prepare a reusable [`PayloadVecHandler`] from a whole-batch callback `f`. Like
+ * [`payload_handler_new`], the foreign closure is decoded **once** here; reuse the
+ * handler across many [`storage_callback_vec`] calls.
+ */
 public fun payloadVecHandlerNew(
     f: PayloadListCallback,
     onError: JniErrorHandler<PayloadVecHandler>,
@@ -137,6 +193,13 @@ public fun payloadVecHandlerNew(
     return __ret
 }
 
+/**
+ * Invoke the prepared `handler` **once** with the whole stored batch as a slice
+ * (the dual of [`storage_callback`], which fires once per element). In C the closure
+ * receives the slice **by reference** — `const payload_t *` + `size_t`, zero-copy, no
+ * per-element materialization; in Kotlin the batch is delivered as a `List<Payload>`
+ * to the handler's `PayloadVecCallback.run(List<Payload>)`.
+ */
 public fun storageCallbackVec(
     s: Storage,
     handler: PayloadVecHandler,

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -4,8 +4,8 @@
 //!
 //! A *constructor* is any `#[prebindgen]` function `f(p0, …) -> T` (or
 //! `-> Result<T, E>`) that builds a target type `T`. A type's input flatten
-//! (a type-level `param_expand!` `.variant*` list, or the per-fn
-//! `.param_expand(param, …)` override) replaces a parameter of that type —
+//! (a type-level `expand_param!` `.variant*` list, or the per-fn
+//! `.expand_param(param, …)` override) replaces a parameter of that type —
 //! in the generated foreign signature only — with the constructor's inputs,
 //! flattened. The generated wrapper decodes those inputs, runs the
 //! constructor Rust-side (the **fold**), and passes the built value to the
@@ -63,7 +63,7 @@ struct ConstructorDecl {
     target: syn::Type,
     variants: Vec<Variant>,
     /// Auto-`construct` every matching param of every declared fn. Always
-    /// `true` for type-level default (`param_expand!` `.variant*`) declarations.
+    /// `true` for type-level default (`expand_param!` `.variant*`) declarations.
     default: bool,
 }
 
@@ -72,7 +72,7 @@ struct ConstructorDecl {
 enum ExpandSel {
     /// Use the target type's default constructor (error if none/ambiguous).
     TopLevel,
-    /// Per-fn override (`.param_expand`): use exactly these build-from
+    /// Per-fn override (`.expand_param`): use exactly these build-from
     /// variants (constructor fns and/or the identity/self arm).
     Subset(Vec<Variant>),
 }
@@ -81,6 +81,11 @@ enum ExpandSel {
 struct ExpandDecl {
     func: syn::Ident,
     param: syn::Ident,
+    /// The type the per-fn decl was declared for (`expand_param!(T)`) —
+    /// cross-checked against the named param's peeled type in [`apply`].
+    /// `None` for the internal `TopLevel` form (the type comes from the
+    /// param itself).
+    declared_target: Option<syn::Type>,
     sel: ExpandSel,
 }
 
@@ -93,7 +98,7 @@ pub struct Expansions {
     expands: Vec<ExpandDecl>,
     /// Cursor for the constructor builder (`.constructor_variant*` / `.default`).
     cur_constructor: Option<usize>,
-    /// Cursor for an in-progress per-fn input subset (`.param_expand(...)`
+    /// Cursor for an in-progress per-fn input subset (`.expand_param(...)`
     /// → `.variant`/`.variant_self`): index into [`Self::expands`].
     cur_expand: Option<usize>,
     /// `.skip_default_construct(param)` opt-outs: `(fn, param)` excluded from a
@@ -123,13 +128,14 @@ impl Expansions {
         }
     }
 
-    /// identity-only `.param_expand_self(param)` — exclude
-    /// `(func, param)` from constructor default auto-apply.
+    /// Exclude `(func, param)` from constructor default auto-apply — the
+    /// lowered form of an identity-only per-fn variant set (the plain
+    /// handle, no selector).
     pub fn add_skip_default_construct(&mut self, func: syn::Ident, param: syn::Ident) {
         self.skip_construct.insert((func, param));
     }
 
-    /// `param_expand!` `.variant(fun)` — add a constructor-function arm.
+    /// `expand_param!` `.variant(fun)` — add a constructor-function arm.
     pub fn add_constructor_variant(&mut self, func: syn::Ident) {
         let i = self
             .cur_constructor
@@ -137,7 +143,7 @@ impl Expansions {
         self.constructors[i].variants.push(Variant::Ctor(func));
     }
 
-    /// `param_expand!` `.variant_self()` — add the identity arm
+    /// `expand_param!` `.variant_self()` — add the identity arm
     /// (pass the target value straight through).
     pub fn add_constructor_variant_id(&mut self) {
         let i = self
@@ -146,22 +152,31 @@ impl Expansions {
         self.constructors[i].variants.push(Variant::Identity);
     }
 
-    /// Begin a per-fn input override (`.param_expand(param, …)`): construct
-    /// `param` from an explicit, incrementally-built variant list (constructor
-    /// arms via [`Self::push_subset_variant`] and/or the identity/self arm via
-    /// [`Self::push_subset_self`]). Recorded as an explicit decl so the
-    /// auto-`default` skips it, and leaves the expand cursor on it.
-    pub fn begin_subset(&mut self, func: syn::Ident, param: syn::Ident) {
+    /// Begin a per-fn input override (`.expand_param(param, expand_param!(T)…)`):
+    /// construct `param` from an explicit, incrementally-built variant list
+    /// (constructor arms via [`Self::push_subset_variant`] and/or the
+    /// identity/self arm via [`Self::push_subset_self`]). `declared_target`
+    /// is the decl's `T`, cross-checked against the param's peeled type in
+    /// [`apply`]. Recorded as an explicit decl so the auto-`default` skips
+    /// it, and leaves the expand cursor on it. An identity-only list lowers
+    /// to the skip-default plain form in [`apply`].
+    pub fn begin_subset(
+        &mut self,
+        func: syn::Ident,
+        param: syn::Ident,
+        declared_target: syn::Type,
+    ) {
         self.expands.push(ExpandDecl {
             func,
             param,
+            declared_target: Some(declared_target),
             sel: ExpandSel::Subset(Vec::new()),
         });
         self.cur_constructor = None;
         self.cur_expand = Some(self.expands.len() - 1);
     }
 
-    /// `.param_expand(param, fn)` — append a build-from
+    /// `.expand_param` `.variant(fun)` — append a build-from
     /// constructor arm to the current per-fn input subset.
     pub fn push_subset_variant(&mut self, func: syn::Ident) {
         let i = self
@@ -172,8 +187,8 @@ impl Expansions {
         }
     }
 
-    /// `.param_expand_self(param)` (with other variants) — append the
-    /// identity (pass-the-handle-through) arm to the current per-fn subset.
+    /// `.expand_param` `.variant_self()` — append the identity
+    /// (pass-the-handle-through) arm to the current per-fn subset.
     pub fn push_subset_self(&mut self) {
         let i = self
             .cur_expand
@@ -204,6 +219,7 @@ pub fn apply<M>(
     method_receivers: &std::collections::HashMap<syn::Ident, TypeKey>,
 ) -> Result<(), ExpandError> {
     let mut done: HashSet<(String, String)> = HashSet::new();
+    let mut skip_construct = exp.skip_construct.clone();
     for ed in &exp.expands {
         // A `.fun_accessor` is never parameter-composed — an explicit
         // `.construct(param)` on one is a build error.
@@ -211,6 +227,41 @@ pub fn apply<M>(
             return Err(ExpandError::ConstructOnAccessor {
                 func: ed.func.clone(),
             });
+        }
+        // Per-fn decl cross-check: the named param must exist and its peeled
+        // (`Option`/`&`) type must equal the decl's declared type — the
+        // typo guard for both coordinates of `.expand_param(name, decl)`.
+        if let Some(declared) = &ed.declared_target {
+            let (item_fn, _) = registry
+                .functions
+                .get(&ed.func)
+                .cloned()
+                .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
+            let param_ty = find_param_type(&item_fn, &ed.param)
+                .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
+            let inner = option_inner_type(&param_ty).unwrap_or(param_ty);
+            let bare = match &inner {
+                syn::Type::Reference(r) => (*r.elem).clone(),
+                other => other.clone(),
+            };
+            if TypeKey::from_type(&bare) != TypeKey::from_type(declared) {
+                return Err(ExpandError::ParamTypeMismatch {
+                    func: ed.func.clone(),
+                    param: ed.param.clone(),
+                    declared: TypeKey::from_type(declared).as_str().to_string(),
+                    actual: TypeKey::from_type(&bare).as_str().to_string(),
+                });
+            }
+        }
+        // Identity-only variant set = the plain form: no selector, the param
+        // crosses as the bare value — lowered to the skip-default opt-out
+        // (the complete-set rule: "the set is {self}").
+        if let ExpandSel::Subset(v) = &ed.sel {
+            if matches!(v.as_slice(), [Variant::Identity]) {
+                skip_construct.insert((ed.func.clone(), ed.param.clone()));
+                done.insert((ed.func.to_string(), ed.param.to_string()));
+                continue;
+            }
         }
         process_expand(registry, exp, ed)?;
         done.insert((ed.func.to_string(), ed.param.to_string()));
@@ -249,7 +300,7 @@ pub fn apply<M>(
                 if bare_key != ckey {
                     continue;
                 }
-                if exp.skip_construct.contains(&(func.clone(), pname.clone())) {
+                if skip_construct.contains(&(func.clone(), pname.clone())) {
                     continue;
                 }
                 if !done.insert((func.to_string(), pname.to_string())) {
@@ -258,6 +309,7 @@ pub fn apply<M>(
                 let ed = ExpandDecl {
                     func: func.clone(),
                     param: pname,
+                    declared_target: None,
                     sel: ExpandSel::TopLevel,
                 };
                 process_expand(registry, exp, &ed)?;

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -4,7 +4,7 @@
 //!
 //! A *constructor* is any `#[prebindgen]` function `f(p0, …) -> T` (or
 //! `-> Result<T, E>`) that builds a target type `T`. A type's input flatten
-//! (`.default_param_expand*` on a class decl, or the per-fn
+//! (a type-level `param_expand!` `.variant*` list, or the per-fn
 //! `.param_expand(param, …)` override) replaces a parameter of that type —
 //! in the generated foreign signature only — with the constructor's inputs,
 //! flattened. The generated wrapper decodes those inputs, runs the
@@ -63,7 +63,7 @@ struct ConstructorDecl {
     target: syn::Type,
     variants: Vec<Variant>,
     /// Auto-`construct` every matching param of every declared fn. Always
-    /// `true` for class-default (`.default_param_expand*`) declarations.
+    /// `true` for type-level default (`param_expand!` `.variant*`) declarations.
     default: bool,
 }
 
@@ -103,7 +103,7 @@ pub struct Expansions {
 
 impl Expansions {
     /// Find-or-create the default (always-`default`) constructor for `target`
-    /// and set the cursor to it. Idempotent across a `.default_param_expand` chain —
+    /// and set the cursor to it. Idempotent across a `.variant*` chain —
     /// the first call creates it, subsequent ones reuse it so variants accumulate.
     pub fn ensure_default_constructor(&mut self, target: syn::Type) {
         let key = TypeKey::from_type(&target);
@@ -129,7 +129,7 @@ impl Expansions {
         self.skip_construct.insert((func, param));
     }
 
-    /// `.default_param_expand(fun)` — add a constructor-function arm.
+    /// `param_expand!` `.variant(fun)` — add a constructor-function arm.
     pub fn add_constructor_variant(&mut self, func: syn::Ident) {
         let i = self
             .cur_constructor
@@ -137,7 +137,7 @@ impl Expansions {
         self.constructors[i].variants.push(Variant::Ctor(func));
     }
 
-    /// `.default_param_expand_self()` — add the identity arm
+    /// `param_expand!` `.variant_self()` — add the identity arm
     /// (pass the target value straight through).
     pub fn add_constructor_variant_id(&mut self) {
         let i = self

--- a/prebindgen/src/api/core/expand/error.rs
+++ b/prebindgen/src/api/core/expand/error.rs
@@ -27,6 +27,14 @@ pub enum ExpandError {
     ConstructOnAccessor {
         func: syn::Ident,
     },
+    /// A per-fn `.expand_param(name, expand_param!(T))` decl whose `T` does
+    /// not match the named parameter's peeled type.
+    ParamTypeMismatch {
+        func: syn::Ident,
+        param: syn::Ident,
+        declared: String,
+        actual: String,
+    },
     /// Recursive input reached a type already on the build chain (`A → … → A`).
     InputCycle {
         ty: String,
@@ -65,6 +73,18 @@ impl std::fmt::Display for ExpandError {
             ExpandError::UnknownParam(func, param) => write!(
                 f,
                 "expand: function `{}` has no parameter named `{}`",
+                func, param
+            ),
+            ExpandError::ParamTypeMismatch {
+                func,
+                param,
+                declared,
+                actual,
+            } => write!(
+                f,
+                "expand: `{}`.expand_param(\"{}\", expand_param!({declared})): the parameter's \
+                 type is `{actual}`, not `{declared}` — declare the decl for the parameter's \
+                 actual type",
                 func, param
             ),
             ExpandError::UnknownConstructor(name) => write!(

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -15,8 +15,12 @@ fn single_constructor_plan_and_fold() {
     ]);
     let mut exp = Expansions::default();
     // Single build-from variant = one Ctor arm (no selector), declared
-    // per-fn (`.param_expand`).
-    exp.begin_subset(ident("z_keyexpr_intersects"), ident("a"));
+    // per-fn (`.expand_param`).
+    exp.begin_subset(
+        ident("z_keyexpr_intersects"),
+        ident("a"),
+        syn::parse_quote!(ZKeyExpr),
+    );
     exp.push_subset_variant(ident("z_keyexpr_try_from"));
 
     apply(
@@ -52,7 +56,11 @@ fn constructor_plan_and_fold() {
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(ident("z_keyexpr_intersects"), ident("a"));
+    exp.begin_subset(
+        ident("z_keyexpr_intersects"),
+        ident("a"),
+        syn::parse_quote!(ZKeyExpr),
+    );
     exp.push_subset_variant(ident("z_keyexpr_try_from"));
     exp.push_subset_self();
 
@@ -109,7 +117,11 @@ fn optional_byvalue_single_ctor() {
         "fn z_session_delete(s: &ZSession, attachment: Option<ZZBytes>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(ident("z_session_delete"), ident("attachment"));
+    exp.begin_subset(
+        ident("z_session_delete"),
+        ident("attachment"),
+        syn::parse_quote!(ZZBytes),
+    );
     exp.push_subset_variant(ident("z_zbytes_from_vec"));
 
     apply(
@@ -155,7 +167,11 @@ fn optional_byref_single_ctor() {
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(ident("z_session_put"), ident("encoding"));
+    exp.begin_subset(
+        ident("z_session_put"),
+        ident("encoding"),
+        syn::parse_quote!(ZEncoding),
+    );
     exp.push_subset_variant(ident("z_encoding_from_string"));
 
     apply(
@@ -194,7 +210,11 @@ fn optional_byref_multi_arg_ctor() {
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(ident("z_session_put"), ident("encoding"));
+    exp.begin_subset(
+        ident("z_session_put"),
+        ident("encoding"),
+        syn::parse_quote!(ZEncoding),
+    );
     exp.push_subset_variant(ident("z_encoding_from_id"));
 
     apply(
@@ -249,7 +269,11 @@ fn optional_combined_rejected() {
         "fn z_session_get(s: &ZSession, ke: Option<ZKeyExpr>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(ident("z_session_get"), ident("ke"));
+    exp.begin_subset(
+        ident("z_session_get"),
+        ident("ke"),
+        syn::parse_quote!(ZKeyExpr),
+    );
     exp.push_subset_variant(ident("z_keyexpr_try_from"));
     exp.push_subset_self();
 
@@ -376,7 +400,11 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
         "fn z_keyexpr_clone(ke: &ZKeyExpr) -> ZKeyExpr { todo!() }",
     ]);
     let mut exp2 = Expansions::default();
-    exp2.begin_subset(ident("z_keyexpr_clone"), ident("ke"));
+    exp2.begin_subset(
+        ident("z_keyexpr_clone"),
+        ident("ke"),
+        syn::parse_quote!(ZKeyExpr),
+    );
     exp2.push_subset_variant(ident("z_keyexpr_try_from"));
     let err = apply(&mut reg2, &exp2, &declared, &accessor, &Default::default()).unwrap_err();
     assert!(matches!(err, ExpandError::ConstructOnAccessor { .. }));

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -511,3 +511,57 @@ fn recursive_input_cycle_errors() {
     .unwrap_err();
     assert!(matches!(err, ExpandError::InputCycle { .. }), "got {err:?}");
 }
+
+/// C5 validation map: a variant ctor ident that names no `#[prebindgen]`
+/// fn is a hard `UnknownConstructor` at resolve time — a typo'd
+/// `expand_param!(...).variant(fun!(…))` cannot silently vanish.
+#[test]
+fn unknown_constructor_errors() {
+    use crate::api::core::types_util::ident;
+    let mut reg =
+        reg_with(&["fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }"]);
+    let mut exp = Expansions::default();
+    exp.begin_subset(
+        ident("z_keyexpr_intersects"),
+        ident("a"),
+        syn::parse_quote!(ZKeyExpr),
+    );
+    exp.push_subset_variant(ident("z_keyexpr_try_from_typo"));
+    let err = apply(
+        &mut reg,
+        &exp,
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, ExpandError::UnknownConstructor(_)), "{err}");
+}
+
+/// C5 validation map: a variant ctor that exists but does not produce the
+/// expanded type is a hard `TargetMismatch` — the ctor's return is
+/// cross-checked against the parameter's type.
+#[test]
+fn constructor_target_mismatch_errors() {
+    use crate::api::core::types_util::ident;
+    let mut reg = reg_with(&[
+        "fn z_sample_new(s: String) -> ZSample { todo!() }",
+        "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
+    ]);
+    let mut exp = Expansions::default();
+    exp.begin_subset(
+        ident("z_keyexpr_intersects"),
+        ident("a"),
+        syn::parse_quote!(ZKeyExpr),
+    );
+    exp.push_subset_variant(ident("z_sample_new"));
+    let err = apply(
+        &mut reg,
+        &exp,
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, ExpandError::TargetMismatch { .. }), "{err}");
+}

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -34,5 +34,5 @@ pub use self::{
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},
-    registry::{Direction, Registry, ScanError, TypeEntry, TypeKey, WriteRustError},
+    registry::{Direction, Generation, Registry, ScanError, TypeEntry, TypeKey, WriteRustError},
 };

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -26,6 +26,11 @@ use crate::api::core::{
     registry::{Direction, Registry, TypeKey},
 };
 
+/// A shared predicate over an item name, as used by
+/// [`Prebindgen::ignored_function_predicates`] (bulk ignores keyed on the
+/// fn-name family rather than an exact ident).
+pub type NamePredicate = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
 /// One link in a converter's [stage chain](`ConverterImpl::pre_stages`) —
 /// a value-inspecting step that sits between the rust value the
 /// `#[prebindgen]` fn yields/receives and the wire-facing
@@ -275,6 +280,19 @@ pub trait Prebindgen {
     /// Default: empty.
     fn ignored_functions(&self) -> HashSet<syn::Ident> {
         HashSet::new()
+    }
+
+    /// Bulk form of [`Self::ignored_functions`]: predicates over the fn
+    /// name — every *undeclared* `#[prebindgen]` fn whose name matches any
+    /// predicate is an acknowledged skip (no "skipping undeclared" warning).
+    /// A declared fn matching a predicate is unaffected (declaration wins),
+    /// and a predicate matching nothing is silent — it is a filter, not a
+    /// claim, so unlike an exact-name ignore there is no "not found"
+    /// warning.
+    ///
+    /// Default: empty.
+    fn ignored_function_predicates(&self) -> Vec<NamePredicate> {
+        Vec::new()
     }
 
     /// Idents of `#[prebindgen]` **helper** functions: called from the

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -27,8 +27,8 @@ use crate::api::core::{
 };
 
 /// A shared predicate over an item name, as used by
-/// [`Prebindgen::ignored_function_predicates`] (bulk ignores keyed on the
-/// fn-name family rather than an exact ident).
+/// [`Prebindgen::ignored_name_predicates`] (bulk ignores keyed on a naming
+/// family rather than an exact ident).
 pub type NamePredicate = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
 /// One link in a converter's [stage chain](`ConverterImpl::pre_stages`) —
@@ -282,16 +282,18 @@ pub trait Prebindgen {
         HashSet::new()
     }
 
-    /// Bulk form of [`Self::ignored_functions`]: predicates over the fn
-    /// name — every *undeclared* `#[prebindgen]` fn whose name matches any
-    /// predicate is an acknowledged skip (no "skipping undeclared" warning).
-    /// A declared fn matching a predicate is unaffected (declaration wins),
+    /// Bulk form of the `ignored_*` sets: predicates over the item NAME —
+    /// every *undeclared* `#[prebindgen]` item (function, struct/enum, or
+    /// const) whose name matches any predicate is an acknowledged skip (no
+    /// "skipping undeclared" warning). Kind-agnostic by design: prebindgen
+    /// items live in one flat namespace, so a name filter needs no kind. A
+    /// declared item matching a predicate is unaffected (declaration wins),
     /// and a predicate matching nothing is silent — it is a filter, not a
     /// claim, so unlike an exact-name ignore there is no "not found"
     /// warning.
     ///
     /// Default: empty.
-    fn ignored_function_predicates(&self) -> Vec<NamePredicate> {
+    fn ignored_name_predicates(&self) -> Vec<NamePredicate> {
         Vec::new()
     }
 

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -388,7 +388,7 @@ pub trait Prebindgen {
     /// converter bodies compile in the binding crate's scope. Walks the
     /// entire AST, not just signatures, so type ascriptions and casts
     /// inside function bodies are covered.
-    fn post_process_item(&self, _item: &mut syn::Item) {}
+    fn post_process_item(&self, _item: &mut syn::Item, _registry: &Registry<Self::Metadata>) {}
 
     /// Absolute path under which the source crate's items are reachable
     /// from the generated file (e.g. `zenoh_flat`), for adapters that

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -410,6 +410,20 @@ pub trait Prebindgen {
     /// inside function bodies are covered.
     fn post_process_item(&self, _item: &mut syn::Item, _registry: &Registry<Self::Metadata>) {}
 
+    /// Adapter-invariant checks that need registry **signatures** — the
+    /// earliest they can run (decl objects are built before any source is
+    /// read). Called by `Registry::resolve` right after the declaration
+    /// scan (so a missing fn has already hard-errored; validate sees only
+    /// indexed items) and before plan application. An `Err` aborts the
+    /// resolve as `ScanError::AdapterInvariant` with the message verbatim
+    /// — e.g. jnigen rejects a `.fun()` member whose target has no
+    /// receiver parameter of the class type.
+    ///
+    /// Default: no checks.
+    fn validate(&self, _registry: &Registry<Self::Metadata>) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Absolute path under which the source crate's items are reachable
     /// from the generated file (e.g. `zenoh_flat`), for adapters that
     /// qualify emitted references against one. Drives the default

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -23,7 +23,7 @@ use proc_macro2::TokenStream;
 
 use crate::api::core::{
     niches::Niches,
-    registry::{Registry, TypeKey},
+    registry::{Direction, Registry, TypeKey},
 };
 
 /// One link in a converter's [stage chain](`ConverterImpl::pre_stages`) —
@@ -275,6 +275,33 @@ pub trait Prebindgen {
     /// Default: empty.
     fn ignored_functions(&self) -> HashSet<syn::Ident> {
         HashSet::new()
+    }
+
+    /// Idents of `#[prebindgen]` **helper** functions: called from the
+    /// adapter's generated converter bodies rather than exported. No
+    /// extern/wrapper is emitted for them and the "skipping undeclared"
+    /// warning is suppressed; the specific types a helper makes the adapter
+    /// depend on are registered via [`Self::extra_required_types`] (a full
+    /// signature scan would over-require — e.g. an output conversion fn's
+    /// `&T` parameter has no input-direction meaning).
+    ///
+    /// Default: empty.
+    fn helper_functions(&self) -> HashSet<syn::Ident> {
+        HashSet::new()
+    }
+
+    /// Extra converter requirements the adapter derives from its own decls
+    /// **with registry access** (e.g. a `convert!` conversion fn's
+    /// other-side type, in the conversion's direction, read from the fn's
+    /// registry signature). Consulted by `write_rust` after the adapter's
+    /// plans are applied and before resolution.
+    ///
+    /// Default: none.
+    fn extra_required_types(
+        &self,
+        _registry: &Registry<Self::Metadata>,
+    ) -> Vec<(Direction, syn::Type)> {
+        Vec::new()
     }
 
     /// Idents of `#[prebindgen]` consts the adapter claims for emission.

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -334,6 +334,24 @@ pub trait Prebindgen {
         HashSet::new()
     }
 
+    /// Canonical keys of the adapter's **boundary-only** (rust-side-only)
+    /// types: types the adapter converts exclusively through its
+    /// expansion/deconstruction plans — built from ingredients on input,
+    /// decomposed into fields on output — so the value itself never crosses
+    /// the boundary and has no destination-language representation.
+    ///
+    /// `write_rust` treats them as acknowledged (no "skipping undeclared"
+    /// warning) and, after the adapter's plans are applied, drops their
+    /// direct converter requirements in both directions
+    /// ([`crate::api::core::registry::Registry`]'s `unrequire_input` /
+    /// `unrequire_output`) — a direct converter for such a type is genuinely
+    /// not needed and typically cannot resolve.
+    ///
+    /// Default: empty.
+    fn boundary_only_types(&self) -> HashSet<TypeKey> {
+        HashSet::new()
+    }
+
     /// Final post-processing pass applied to every emitted item right
     /// before write. Default: no-op.
     ///

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -175,8 +175,12 @@ pub trait Prebindgen {
     /// [`crate::api::core::expand::FoldPlan`] on the registry and its leaf
     /// types are registered as required inputs.
     ///
+    /// Returned by value so the adapter may assemble it on demand from its
+    /// raw declarations (keeping its builder free of stored derived state);
+    /// it is consulted exactly once per `write_rust`.
+    ///
     /// Default: `None`.
-    fn expansions(&self) -> Option<&crate::api::core::expand::Expansions> {
+    fn expansions(&self) -> Option<crate::api::core::expand::Expansions> {
         None
     }
 
@@ -187,8 +191,10 @@ pub trait Prebindgen {
     /// [`crate::api::core::unfold::UnfoldPlan`] on the registry and its leaf
     /// types are registered as required outputs.
     ///
+    /// Returned by value, same as [`Self::expansions`].
+    ///
     /// Default: `None`.
-    fn deconstructors(&self) -> Option<&crate::api::core::unfold::Deconstructors> {
+    fn deconstructors(&self) -> Option<crate::api::core::unfold::Deconstructors> {
         None
     }
 

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -305,6 +305,11 @@ pub enum ScanError {
     UnsupportedParamPattern {
         loc: SourceLocation,
     },
+    /// An adapter-invariant check failed — see [`Prebindgen::validate`].
+    /// The message is adapter-authored and printed verbatim.
+    AdapterInvariant {
+        message: String,
+    },
     /// Explicitly declared items (functions, helper functions, constants)
     /// that match no indexed `#[prebindgen]` item. A declaration is a
     /// statement of intent — its target being absent is always a bug (a
@@ -356,6 +361,7 @@ impl fmt::Display for ScanError {
             ScanError::UnsupportedParamPattern { loc } => {
                 write!(f, "non-ident parameter pattern is not supported at {}", loc)
             }
+            ScanError::AdapterInvariant { message } => write!(f, "{}", message),
             ScanError::DeclaredNotFound { entries } => {
                 writeln!(
                     f,
@@ -1154,6 +1160,9 @@ impl<M> Registry<M> {
     {
         let declared = DeclaredItems::from_adapter(&adapter)?;
         self.scan_declared_items(&declared)?;
+        adapter
+            .validate(&self)
+            .map_err(|message| ScanError::AdapterInvariant { message })?;
         self.apply_adapter_plans(&adapter, &declared)?;
         crate::api::core::resolve::resolve(&mut self, &adapter)?;
         Ok(Generation {

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -174,14 +174,22 @@ pub struct Registry<M = ()> {
     /// Anything else (use, mod, type alias, macro_rules) — passed through.
     pub passthrough: Vec<(syn::Item, SourceLocation)>,
 
-    /// Origin crate name of each function, recorded when items are ingested
-    /// via [`Self::from_sources`] / [`Self::add_source`] (absent for
-    /// [`Self::from_items`], whose items all belong to the adapter's default
-    /// `source_module`). Adapters consult [`Self::fn_origin`] so generated
-    /// calls qualify each function with the module of the crate that
-    /// actually defines it — the multi-source model, where a binding layers
-    /// helper `#[prebindgen]` crates on top of the flat crate.
-    pub(crate) fn_origins: HashMap<syn::Ident, String>,
+    /// Origin crate name of each named item (fn/struct/enum/const),
+    /// recorded when items are ingested via [`Self::from_sources`] /
+    /// [`Self::add_source`] (absent for [`Self::from_items`]). Adapters
+    /// consult [`Self::origin_module`] so generated references qualify each
+    /// item with the module of the crate that actually defines it — the
+    /// multi-source model, where a binding layers helper `#[prebindgen]`
+    /// crates on top of the flat crate.
+    pub(crate) item_origins: HashMap<syn::Ident, String>,
+
+    /// Module name of every ingested source, in ingestion order (crate
+    /// names, dashes normalized to underscores). The FIRST entry doubles as
+    /// the **default module** for references with no recorded origin (e.g.
+    /// a declared type with no `#[prebindgen]` item). Settable directly via
+    /// [`Self::set_default_module`] for item-level construction
+    /// ([`Self::from_items`]).
+    pub(crate) source_modules: Vec<String>,
 
     /// Type tables, one per direction. Each scanned type maps to its resolved
     /// [`TypeEntry`] (`Some`) or stays unresolved (`None`) until the structural
@@ -245,7 +253,8 @@ impl<M> Default for Registry<M> {
             enums: HashMap::new(),
             consts: HashMap::new(),
             passthrough: Vec::new(),
-            fn_origins: HashMap::new(),
+            item_origins: HashMap::new(),
+            source_modules: Vec::new(),
             input_types: Default::default(),
             output_types: Default::default(),
             type_locations: HashMap::new(),
@@ -487,29 +496,67 @@ impl<M> Registry<M> {
     }
 
     /// Ingest one [`Source`]'s items, recording the source's crate name as
-    /// each function's origin. See [`Self::from_sources`].
+    /// each named item's origin (and the first ingested source as the
+    /// default module). See [`Self::from_sources`].
     ///
     /// [`Source`]: crate::Source
     pub fn add_source(&mut self, source: &crate::api::source::Source) -> Result<(), ScanError> {
         let crate_name = source.crate_name().to_string();
+        self.source_modules.push(crate_name.replace('-', "_"));
         for (item, loc) in source.items_all() {
-            if let syn::Item::Fn(f) = &item {
-                self.fn_origins
-                    .insert(f.sig.ident.clone(), crate_name.clone());
+            let named: Option<&syn::Ident> = match &item {
+                syn::Item::Fn(f) => Some(&f.sig.ident),
+                syn::Item::Struct(s) => Some(&s.ident),
+                syn::Item::Enum(e) => Some(&e.ident),
+                syn::Item::Const(c) if c.ident != "_" => Some(&c.ident),
+                _ => None,
+            };
+            if let Some(ident) = named {
+                self.item_origins.insert(ident.clone(), crate_name.clone());
             }
             self.index_item(item, loc)?;
         }
         Ok(())
     }
 
-    /// The origin crate's **module path** for a function ingested via
-    /// [`Self::from_sources`] (crate name with dashes replaced by
-    /// underscores), or `None` when unknown — the adapter then falls back to
-    /// its configured default source module.
-    pub fn fn_origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
-        let crate_name = self.fn_origins.get(ident)?;
+    /// Set the default module for generated references when the registry is
+    /// built item-by-item ([`Self::from_items`]) — the module the items'
+    /// crate is reachable under from the generated file. With
+    /// [`Self::from_sources`] this is derived automatically (the first
+    /// source), so calling it is only needed to override.
+    pub fn set_default_module(&mut self, module: &str) {
+        let module = module.replace('-', "_");
+        if self.source_modules.first().map(String::as_str) == Some(module.as_str()) {
+            return;
+        }
+        self.source_modules.insert(0, module);
+    }
+
+    /// The origin crate's **module path** for an item ingested via
+    /// [`Self::from_sources`], or `None` when unknown — callers then fall
+    /// back to [`Self::default_module`].
+    pub fn origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
+        let crate_name = self.item_origins.get(ident)?;
         let module = crate_name.replace('-', "_");
         syn::parse_str(&module).ok()
+    }
+
+    /// The default module for references with no recorded origin: the first
+    /// ingested source's module (or the [`Self::set_default_module`]
+    /// override). `None` for an origin-less item-level registry.
+    pub fn default_module(&self) -> Option<syn::Path> {
+        self.source_modules
+            .first()
+            .and_then(|m| syn::parse_str(m).ok())
+    }
+
+    /// Module paths of every ingested source, ingestion order — e.g. for a
+    /// glob import that must see all sources' items.
+    pub fn all_source_modules(&self) -> Vec<syn::Path> {
+        self.source_modules
+            .iter()
+            .filter_map(|m| syn::parse_str(m).ok())
+            .collect()
     }
 
     /// Scan the signature/body of every item declared by the adapter.

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -184,12 +184,12 @@ pub struct Registry<M = ()> {
     /// crates on top of the flat crate.
     pub(crate) item_origins: HashMap<syn::Ident, String>,
 
-    /// Module name of every ingested source, in ingestion order (crate
-    /// names, dashes normalized to underscores). The FIRST entry doubles as
-    /// the **default module** for references with no recorded origin (e.g.
-    /// a declared type with no `#[prebindgen]` item). Settable directly via
-    /// [`Self::set_default_module`] for item-level construction
-    /// ([`Self::from_items`]).
+    /// Module name of every ingested source, in first-seen stream order
+    /// (crate names, dashes normalized to underscores). The FIRST entry
+    /// doubles as the **default module** for references with no recorded
+    /// origin (e.g. a declared type with no `#[prebindgen]` item);
+    /// origin-less hand-built streams leave it empty and adapters fall
+    /// back to `crate`.
     pub(crate) source_modules: Vec<String>,
 
     /// Type tables, one per direction. Each scanned type maps to its resolved
@@ -522,9 +522,11 @@ impl<M> Registry<M> {
     /// by [`Source`](crate::Source) when parsing records): named items get
     /// their origin recorded for qualified references in generated code
     /// (`flat_crate::…` vs `helper_crate::…`), and the first origin seen
-    /// becomes the default module ([`Self::default_module`];
-    /// [`Self::set_default_module`] overrides — needed for hand-built,
-    /// origin-less item streams).
+    /// becomes the default module ([`Self::default_module`]). When a
+    /// dependency is renamed in Cargo.toml, override the stamp at the
+    /// source: `Source::builder(dir).crate_name("myflat")` — being
+    /// per-source, it composes across chained streams (a registry-level
+    /// override could only fix one module).
     ///
     /// This step only populates the item maps (`functions`, `structs`,
     /// `enums`, `consts`, `passthrough`). Signature/body scanning that
@@ -571,20 +573,6 @@ impl<M> Registry<M> {
         Ok(registry)
     }
 
-    /// Set the default module for generated references when the item stream
-    /// carries no origins (hand-built items, tests) — the module the items'
-    /// crate is reachable under from the generated file. With
-    /// [`Source`](crate::Source)-backed streams this is derived
-    /// automatically (the first item's origin), so calling it is only
-    /// needed to override.
-    pub fn set_default_module(&mut self, module: &str) {
-        let module = module.replace('-', "_");
-        if self.source_modules.first().map(String::as_str) == Some(module.as_str()) {
-            return;
-        }
-        self.source_modules.insert(0, module);
-    }
-
     /// The origin crate's **module path** for an item ingested via
     /// the item's [`SourceLocation`] stamp, or `None` when unknown —
     /// callers then fall
@@ -595,9 +583,13 @@ impl<M> Registry<M> {
         syn::parse_str(&module).ok()
     }
 
-    /// The default module for references with no recorded origin: the first
-    /// ingested source's module (or the [`Self::set_default_module`]
-    /// override). `None` for an origin-less item-level registry.
+    /// The default module for references with no recorded origin: the
+    /// first-seen item origin. `None` for an origin-less item-level
+    /// registry (adapters then fall back to `crate`). To change a module
+    /// name, override it at the source — a stream's origin stamps
+    /// (`Source::builder(dir).crate_name("myflat")`) — never here: a
+    /// registry-level override could only fix ONE module, which is
+    /// incomplete with chained multi-source streams.
     pub fn default_module(&self) -> Option<syn::Path> {
         self.source_modules
             .first()

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -174,6 +174,15 @@ pub struct Registry<M = ()> {
     /// Anything else (use, mod, type alias, macro_rules) — passed through.
     pub passthrough: Vec<(syn::Item, SourceLocation)>,
 
+    /// Origin crate name of each function, recorded when items are ingested
+    /// via [`Self::from_sources`] / [`Self::add_source`] (absent for
+    /// [`Self::from_items`], whose items all belong to the adapter's default
+    /// `source_module`). Adapters consult [`Self::fn_origin`] so generated
+    /// calls qualify each function with the module of the crate that
+    /// actually defines it — the multi-source model, where a binding layers
+    /// helper `#[prebindgen]` crates on top of the flat crate.
+    pub(crate) fn_origins: HashMap<syn::Ident, String>,
+
     /// Type tables, one per direction. Each scanned type maps to its resolved
     /// [`TypeEntry`] (`Some`) or stays unresolved (`None`) until the structural
     /// resolver fills it.
@@ -236,6 +245,7 @@ impl<M> Default for Registry<M> {
             enums: HashMap::new(),
             consts: HashMap::new(),
             passthrough: Vec::new(),
+            fn_origins: HashMap::new(),
             input_types: Default::default(),
             output_types: Default::default(),
             type_locations: HashMap::new(),
@@ -369,6 +379,8 @@ impl From<crate::api::core::write::WriteError> for WriteRustError {
 struct DeclaredItems {
     functions: HashSet<syn::Ident>,
     ignored_functions: HashSet<syn::Ident>,
+    /// Signature-scanned but not emitted — see [`Prebindgen::helper_functions`].
+    helper_functions: HashSet<syn::Ident>,
     accessors: HashSet<syn::Ident>,
     method_receivers: HashMap<syn::Ident, TypeKey>,
     types: HashSet<TypeKey>,
@@ -397,6 +409,7 @@ impl DeclaredItems {
         let declared = Self {
             functions: adapter.declared_functions(),
             ignored_functions: adapter.ignored_functions(),
+            helper_functions: adapter.helper_functions(),
             accessors: adapter.accessor_functions(),
             method_receivers: adapter.method_receivers(),
             types: adapter.declared_types(),
@@ -453,6 +466,52 @@ impl<M> Registry<M> {
         Ok(registry)
     }
 
+    /// Construct a `Registry` from one or more prebindgen [`Source`]s,
+    /// recording each function's **origin crate**. This is the multi-source
+    /// form of [`Self::from_items`]: a binding may layer helper
+    /// `#[prebindgen]` crates on top of the flat crate (conversion helpers
+    /// the flat crate doesn't provide), and the generated Rust must qualify
+    /// each call with the module of the crate that defines it
+    /// (`flat_crate::…` vs `helper_crate::…` — see [`Self::fn_origin`]).
+    ///
+    /// [`Source`]: crate::Source
+    pub fn from_sources<'a, I>(sources: I) -> Result<Self, ScanError>
+    where
+        I: IntoIterator<Item = &'a crate::api::source::Source>,
+    {
+        let mut registry = Registry::default();
+        for source in sources {
+            registry.add_source(source)?;
+        }
+        Ok(registry)
+    }
+
+    /// Ingest one [`Source`]'s items, recording the source's crate name as
+    /// each function's origin. See [`Self::from_sources`].
+    ///
+    /// [`Source`]: crate::Source
+    pub fn add_source(&mut self, source: &crate::api::source::Source) -> Result<(), ScanError> {
+        let crate_name = source.crate_name().to_string();
+        for (item, loc) in source.items_all() {
+            if let syn::Item::Fn(f) = &item {
+                self.fn_origins
+                    .insert(f.sig.ident.clone(), crate_name.clone());
+            }
+            self.index_item(item, loc)?;
+        }
+        Ok(())
+    }
+
+    /// The origin crate's **module path** for a function ingested via
+    /// [`Self::from_sources`] (crate name with dashes replaced by
+    /// underscores), or `None` when unknown — the adapter then falls back to
+    /// its configured default source module.
+    pub fn fn_origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
+        let crate_name = self.fn_origins.get(ident)?;
+        let module = crate_name.replace('-', "_");
+        syn::parse_str(&module).ok()
+    }
+
     /// Scan the signature/body of every item declared by the adapter.
     ///
     /// * For each ident in `adapter.declared_functions()` ∩ indexed functions,
@@ -497,6 +556,18 @@ impl<M> Registry<M> {
             if !self.functions.contains_key(ident) {
                 println!(
                     "cargo:warning=prebindgen: ignored function `{}` not found among #[prebindgen] items",
+                    ident
+                );
+            }
+        }
+
+        // Helper functions: never emitted, no blanket signature scan (the
+        // adapter registers the specific requirements via
+        // `extra_required_types`) — but a typo'd name still warns.
+        for ident in &declared.helper_functions {
+            if !self.functions.contains_key(ident) {
+                println!(
+                    "cargo:warning=prebindgen: helper function `{}` not found among #[prebindgen] items",
                     ident
                 );
             }
@@ -578,7 +649,9 @@ impl<M> Registry<M> {
             .functions
             .keys()
             .filter(|k| {
-                !declared.functions.contains(*k) && !declared.ignored_functions.contains(*k)
+                !declared.functions.contains(*k)
+                    && !declared.ignored_functions.contains(*k)
+                    && !declared.helper_functions.contains(*k)
             })
             .map(|k| k.to_string())
             .collect();
@@ -740,6 +813,13 @@ impl<M> Registry<M> {
                 Ok(())
             }
             syn::Item::Const(c) => {
+                // Unnamed `const _` items (each source's injected `konst`
+                // feature guard) live outside the flat namespace: several
+                // sources may each carry one, all passed through verbatim.
+                if c.ident == "_" {
+                    self.passthrough.push((syn::Item::Const(c), loc));
+                    return Ok(());
+                }
                 self.check_no_duplicate(&c.ident, &loc)?;
                 self.consts.insert(c.ident.clone(), (c, loc));
                 Ok(())
@@ -1008,6 +1088,15 @@ impl<M> Registry<M> {
                 leaf_elements,
                 &declared.functions,
             )?;
+        }
+        // Adapter-derived extra requirements (registry-aware — e.g. the
+        // other-side types of `convert!` conversion fns, per direction).
+        for (dir, ty) in ext.extra_required_types(self) {
+            let loc = SourceLocation::default();
+            match dir {
+                Direction::Input => self.require_input(&ty, &loc),
+                Direction::Output => self.require_output(&ty, &loc),
+            }
         }
         // Boundary-only types: every crossing is now covered by a plan (fold
         // in, unfold out / error channel), so the scan-time direct converter

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -373,6 +373,11 @@ struct DeclaredItems {
     method_receivers: HashMap<syn::Ident, TypeKey>,
     types: HashSet<TypeKey>,
     ignored_types: HashSet<TypeKey>,
+    /// Types converted exclusively through the adapter's plans (built from
+    /// ingredients / decomposed into fields); acknowledged for warning
+    /// purposes and un-required after plans — see
+    /// [`Prebindgen::boundary_only_types`].
+    boundary_only_types: HashSet<TypeKey>,
     /// `None` = the adapter has no const declaration mechanism (all consts
     /// re-emitted verbatim, no scan, no warnings) — see
     /// [`Prebindgen::declared_consts`].
@@ -396,6 +401,7 @@ impl DeclaredItems {
             method_receivers: adapter.method_receivers(),
             types: adapter.declared_types(),
             ignored_types: adapter.ignored_types(),
+            boundary_only_types: adapter.boundary_only_types(),
             consts: adapter.declared_consts(),
             ignored_consts: adapter.ignored_consts(),
             required_output_types: adapter.required_output_types(),
@@ -585,15 +591,20 @@ impl<M> Registry<M> {
         }
 
         let mut skipped_types: Vec<String> = Vec::new();
+        let type_acknowledged = |key: &TypeKey| {
+            declared.types.contains(key)
+                || declared.ignored_types.contains(key)
+                || declared.boundary_only_types.contains(key)
+        };
         for ident in self.structs.keys() {
             let key = TypeKey::parse(&ident.to_string());
-            if !declared.types.contains(&key) && !declared.ignored_types.contains(&key) {
+            if !type_acknowledged(&key) {
                 skipped_types.push(ident.to_string());
             }
         }
         for ident in self.enums.keys() {
             let key = TypeKey::parse(&ident.to_string());
-            if !declared.types.contains(&key) && !declared.ignored_types.contains(&key) {
+            if !type_acknowledged(&key) {
                 skipped_types.push(ident.to_string());
             }
         }
@@ -699,6 +710,16 @@ impl<M> Registry<M> {
     /// JObject-shaped), so requiring it would wrongly fail resolution.
     pub(crate) fn unrequire_output(&mut self, ty: &syn::Type) {
         self.required_outputs_scan.remove(&TypeKey::from_type(ty));
+    }
+
+    /// Drop `ty` from the required-input scan set — the input-side peer of
+    /// [`Self::unrequire_output`]. Used by [`Self::apply_adapter_plans`] for
+    /// the adapter's boundary-only types: a fold plan replaces every direct
+    /// crossing of the type with its ingredients, so the type's own input
+    /// converter is genuinely not needed (and for an undeclared type cannot
+    /// resolve at all).
+    pub(crate) fn unrequire_input(&mut self, ty: &syn::Type) {
+        self.required_inputs_scan.remove(&TypeKey::from_type(ty));
     }
 
     fn index_item(&mut self, item: syn::Item, loc: SourceLocation) -> Result<(), ScanError> {
@@ -987,6 +1008,17 @@ impl<M> Registry<M> {
                 leaf_elements,
                 &declared.functions,
             )?;
+        }
+        // Boundary-only types: every crossing is now covered by a plan (fold
+        // in, unfold out / error channel), so the scan-time direct converter
+        // requirement is stale — and typically unresolvable, since the type
+        // has no destination-language representation. Drop it both ways; the
+        // entry stays in the table, so a converter is still produced if one
+        // happens to resolve.
+        for key in &declared.boundary_only_types {
+            let ty = key.to_type();
+            self.unrequire_input(&ty);
+            self.unrequire_output(&ty);
         }
         Ok(())
     }

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1136,25 +1136,32 @@ impl<M> Registry<M> {
         out
     }
 
-    /// One-shot: resolve every required type using an adapter, then write the
-    /// generated Rust bindings file. The single public entry point for
-    /// language-specific binding generation — language-agnostic because
-    /// `ext` is any [`crate::api::core::prebindgen::Prebindgen`] impl
+    /// Resolve the binding: scan the adapter's declarations, apply its
+    /// plans, and run type resolution — consuming both the registry and the
+    /// adapter into a [`Generation`], whose `write_*` methods are pure,
+    /// order-free emissions. This is the single public entry point for
+    /// language-specific binding generation; language-agnostic because
+    /// `adapter` is any [`crate::api::core::prebindgen::Prebindgen`] impl
     /// whose `Metadata` matches this registry's `M` parameter.
-    pub fn write_rust<E>(
-        &mut self,
-        ext: &E,
-        out_path: impl AsRef<std::path::Path>,
-    ) -> Result<std::path::PathBuf, WriteRustError>
+    ///
+    /// ```ignore
+    /// let gen = Registry::from_items(source.items_all())?.resolve(jni)?;
+    /// gen.write_rust(&rust_dest)?;
+    /// gen.write_kotlin(&kotlin_root)?;   // JNI adapter's second artifact
+    /// ```
+    pub fn resolve<E>(mut self, adapter: E) -> Result<Generation<E>, WriteRustError>
     where
         E: Prebindgen<Metadata = M>,
         M: Clone + Default,
     {
-        let declared = DeclaredItems::from_adapter(ext)?;
+        let declared = DeclaredItems::from_adapter(&adapter)?;
         self.scan_declared_items(&declared)?;
-        self.apply_adapter_plans(ext, &declared)?;
-        crate::api::core::resolve::resolve(self, ext)?;
-        Ok(crate::api::core::write::write_rust(self, ext, out_path)?)
+        self.apply_adapter_plans(&adapter, &declared)?;
+        crate::api::core::resolve::resolve(&mut self, &adapter)?;
+        Ok(Generation {
+            registry: self,
+            adapter,
+        })
     }
 
     fn apply_adapter_plans<E>(
@@ -1295,6 +1302,53 @@ pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
         args
     } else {
         None
+    }
+}
+
+/// A **resolved** binding generation: the [`Registry`] after
+/// [`Registry::resolve`] ran the adapter's scan, plans, and type
+/// resolution, bound together with the adapter that produced it. Both
+/// halves of a generation run are methods here — [`Self::write_rust`] and
+/// any adapter-specific artifact (e.g. `write_kotlin` for the JNI
+/// adapter) — so the resolve-before-write ordering is enforced by
+/// construction, and the writes themselves are pure reads that may run in
+/// any order.
+pub struct Generation<E: Prebindgen> {
+    registry: Registry<E::Metadata>,
+    adapter: E,
+}
+
+// Opaque — exists so `Result<Generation, _>::expect_err` works in tests.
+impl<E: Prebindgen> fmt::Debug for Generation<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Generation(..)")
+    }
+}
+
+impl<E: Prebindgen> Generation<E> {
+    /// Write the generated Rust bindings file. `out_path` may be relative
+    /// (resolved against `OUT_DIR`) or absolute; returns the path actually
+    /// written. Pure emission — the registry was fully resolved by
+    /// [`Registry::resolve`].
+    pub fn write_rust(
+        &self,
+        out_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, WriteRustError> {
+        Ok(crate::api::core::write::write_rust(
+            &self.registry,
+            &self.adapter,
+            out_path,
+        )?)
+    }
+
+    /// The resolved registry (converter tables, plans, item maps).
+    pub fn registry(&self) -> &Registry<E::Metadata> {
+        &self.registry
+    }
+
+    /// The adapter this generation was resolved with.
+    pub fn adapter(&self) -> &E {
+        &self.adapter
     }
 }
 

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -435,11 +435,12 @@ impl From<crate::api::core::write::WriteError> for WriteRustError {
 struct DeclaredItems {
     functions: HashSet<syn::Ident>,
     ignored_functions: HashSet<syn::Ident>,
-    /// Bulk-ignore predicates over fn names — every matching *undeclared*
-    /// fn is an acknowledged skip (no warning). A declared fn matching a
-    /// predicate is unaffected: declaration wins. See
-    /// [`Prebindgen::ignored_function_predicates`].
-    ignored_fn_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
+    /// Bulk-ignore predicates over item names — every matching *undeclared*
+    /// item (fn, struct/enum, const) is an acknowledged skip (no warning).
+    /// Kind-agnostic: prebindgen names live in one flat namespace. A
+    /// declared item matching a predicate is unaffected: declaration wins.
+    /// See [`Prebindgen::ignored_name_predicates`].
+    ignored_name_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
     /// Signature-scanned but not emitted — see [`Prebindgen::helper_functions`].
     helper_functions: HashSet<syn::Ident>,
     accessors: HashSet<syn::Ident>,
@@ -470,7 +471,7 @@ impl DeclaredItems {
         let declared = Self {
             functions: adapter.declared_functions(),
             ignored_functions: adapter.ignored_functions(),
-            ignored_fn_predicates: adapter.ignored_function_predicates(),
+            ignored_name_predicates: adapter.ignored_name_predicates(),
             helper_functions: adapter.helper_functions(),
             accessors: adapter.accessor_functions(),
             method_receivers: adapter.method_receivers(),
@@ -741,14 +742,13 @@ impl<M> Registry<M> {
         }
 
         // Warn about indexed items that the adapter never claimed. An
-        // ignore *predicate* acknowledges every matching fn in bulk; a
-        // predicate matching nothing is silent by design (it is a filter,
+        // ignore *predicate* acknowledges every matching item in bulk —
+        // kind-agnostic, since prebindgen names live in one flat namespace;
+        // a predicate matching nothing is silent by design (it is a filter,
         // not a claim — match counts vary across feature configurations).
-        let pred_ignored = |k: &syn::Ident| {
-            !declared.ignored_fn_predicates.is_empty() && {
-                let name = k.to_string();
-                declared.ignored_fn_predicates.iter().any(|p| p(&name))
-            }
+        let pred_ignored = |name: &str| {
+            !declared.ignored_name_predicates.is_empty()
+                && declared.ignored_name_predicates.iter().any(|p| p(name))
         };
         let mut skipped_fns: Vec<String> = self
             .functions
@@ -757,7 +757,7 @@ impl<M> Registry<M> {
                 !declared.functions.contains(*k)
                     && !declared.ignored_functions.contains(*k)
                     && !declared.helper_functions.contains(*k)
-                    && !pred_ignored(k)
+                    && !pred_ignored(&k.to_string())
             })
             .map(|k| k.to_string())
             .collect();
@@ -775,16 +775,11 @@ impl<M> Registry<M> {
                 || declared.ignored_types.contains(key)
                 || declared.boundary_only_types.contains(key)
         };
-        for ident in self.structs.keys() {
-            let key = TypeKey::parse(&ident.to_string());
-            if !type_acknowledged(&key) {
-                skipped_types.push(ident.to_string());
-            }
-        }
-        for ident in self.enums.keys() {
-            let key = TypeKey::parse(&ident.to_string());
-            if !type_acknowledged(&key) {
-                skipped_types.push(ident.to_string());
+        for ident in self.structs.keys().chain(self.enums.keys()) {
+            let name = ident.to_string();
+            let key = TypeKey::parse(&name);
+            if !type_acknowledged(&key) && !pred_ignored(&name) {
+                skipped_types.push(name);
             }
         }
         skipped_types.sort();
@@ -803,7 +798,10 @@ impl<M> Registry<M> {
                 // guard) are infrastructure: not declarable, always emitted
                 // verbatim — never a skip.
                 .filter(|k| {
-                    *k != "_" && !decl_consts.contains(*k) && !declared.ignored_consts.contains(*k)
+                    *k != "_"
+                        && !decl_consts.contains(*k)
+                        && !declared.ignored_consts.contains(*k)
+                        && !pred_ignored(&k.to_string())
                 })
                 .map(|k| k.to_string())
                 .collect();

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -175,8 +175,9 @@ pub struct Registry<M = ()> {
     pub passthrough: Vec<(syn::Item, SourceLocation)>,
 
     /// Origin crate name of each named item (fn/struct/enum/const),
-    /// recorded when items are ingested via [`Self::from_sources`] /
-    /// [`Self::add_source`] (absent for [`Self::from_items`]). Adapters
+    /// recorded by [`Self::from_items`] from each item's
+    /// [`SourceLocation::crate_name`] stamp (absent for hand-built,
+    /// origin-less item streams). Adapters
     /// consult [`Self::origin_module`] so generated references qualify each
     /// item with the module of the crate that actually defines it — the
     /// multi-source model, where a binding layers helper `#[prebindgen]`
@@ -277,7 +278,7 @@ pub struct DuplicateNameError {
     pub first: SourceLocation,
     pub second: SourceLocation,
     /// Origin crates of the colliding items, when known (multi-source
-    /// ingestion via [`Registry::from_sources`]) — the `SourceLocation`
+    /// ingestion via [`Registry::from_items`]) — the `SourceLocation`
     /// file paths are crate-relative, so with several sources they alone
     /// may not identify the colliding crates.
     pub first_crate: Option<String>,
@@ -508,7 +509,22 @@ impl<M> Registry<M> {
     /// Callers feed any `(syn::Item, SourceLocation)` iterator — typically
     /// `source.items_all()`, `source.items_except_groups(...)`, or a
     /// hand-rolled filter chain — so item-level selection happens upstream
-    /// of the registry rather than inside it.
+    /// of the registry rather than inside it. Streams from several sources
+    /// combine with plain iterator composition:
+    ///
+    /// ```ignore
+    /// let registry = Registry::from_items(
+    ///     flat.items_all().chain(helpers.items_all()),
+    /// )?;
+    /// ```
+    ///
+    /// Each item's **origin crate** rides its [`SourceLocation`] (stamped
+    /// by [`Source`](crate::Source) when parsing records): named items get
+    /// their origin recorded for qualified references in generated code
+    /// (`flat_crate::…` vs `helper_crate::…`), and the first origin seen
+    /// becomes the default module ([`Self::default_module`];
+    /// [`Self::set_default_module`] overrides — needed for hand-built,
+    /// origin-less item streams).
     ///
     /// This step only populates the item maps (`functions`, `structs`,
     /// `enums`, `consts`, `passthrough`). Signature/body scanning that
@@ -522,40 +538,13 @@ impl<M> Registry<M> {
     {
         let mut registry = Registry::default();
         for (item, loc) in items {
-            registry.index_item(item, loc)?;
-        }
-        Ok(registry)
-    }
-
-    /// Construct a `Registry` from one or more prebindgen [`Source`]s,
-    /// recording each function's **origin crate**. This is the multi-source
-    /// form of [`Self::from_items`]: a binding may layer helper
-    /// `#[prebindgen]` crates on top of the flat crate (conversion helpers
-    /// the flat crate doesn't provide), and the generated Rust must qualify
-    /// each call with the module of the crate that defines it
-    /// (`flat_crate::…` vs `helper_crate::…` — see [`Self::fn_origin`]).
-    ///
-    /// [`Source`]: crate::Source
-    pub fn from_sources<'a, I>(sources: I) -> Result<Self, ScanError>
-    where
-        I: IntoIterator<Item = &'a crate::api::source::Source>,
-    {
-        let mut registry = Registry::default();
-        for source in sources {
-            registry.add_source(source)?;
-        }
-        Ok(registry)
-    }
-
-    /// Ingest one [`Source`]'s items, recording the source's crate name as
-    /// each named item's origin (and the first ingested source as the
-    /// default module). See [`Self::from_sources`].
-    ///
-    /// [`Source`]: crate::Source
-    pub fn add_source(&mut self, source: &crate::api::source::Source) -> Result<(), ScanError> {
-        let crate_name = source.crate_name().to_string();
-        self.source_modules.push(crate_name.replace('-', "_"));
-        for (item, loc) in source.items_all() {
+            let crate_name = loc.crate_name.clone();
+            if let Some(crate_name) = &crate_name {
+                let module = crate_name.replace('-', "_");
+                if !registry.source_modules.contains(&module) {
+                    registry.source_modules.push(module);
+                }
+            }
             let named: Option<syn::Ident> = match &item {
                 syn::Item::Fn(f) => Some(f.sig.ident.clone()),
                 syn::Item::Struct(s) => Some(s.ident.clone()),
@@ -563,30 +552,31 @@ impl<M> Registry<M> {
                 syn::Item::Const(c) if c.ident != "_" => Some(c.ident.clone()),
                 _ => None,
             };
-            match self.index_item(item, loc) {
+            match registry.index_item(item, loc) {
                 Ok(()) => {
                     // Only after successful indexing — a collision must keep
                     // the FIRST item's origin for the error below.
-                    if let Some(ident) = named {
-                        self.item_origins.insert(ident, crate_name.clone());
+                    if let (Some(ident), Some(crate_name)) = (named, crate_name) {
+                        registry.item_origins.insert(ident, crate_name);
                     }
                 }
                 Err(ScanError::DuplicateName(mut e)) => {
-                    e.first_crate = self.item_origins.get(&e.name).cloned();
-                    e.second_crate = Some(crate_name);
+                    e.first_crate = registry.item_origins.get(&e.name).cloned();
+                    e.second_crate = crate_name;
                     return Err(ScanError::DuplicateName(e));
                 }
                 Err(e) => return Err(e),
             }
         }
-        Ok(())
+        Ok(registry)
     }
 
-    /// Set the default module for generated references when the registry is
-    /// built item-by-item ([`Self::from_items`]) — the module the items'
+    /// Set the default module for generated references when the item stream
+    /// carries no origins (hand-built items, tests) — the module the items'
     /// crate is reachable under from the generated file. With
-    /// [`Self::from_sources`] this is derived automatically (the first
-    /// source), so calling it is only needed to override.
+    /// [`Source`](crate::Source)-backed streams this is derived
+    /// automatically (the first item's origin), so calling it is only
+    /// needed to override.
     pub fn set_default_module(&mut self, module: &str) {
         let module = module.replace('-', "_");
         if self.source_modules.first().map(String::as_str) == Some(module.as_str()) {
@@ -596,7 +586,8 @@ impl<M> Registry<M> {
     }
 
     /// The origin crate's **module path** for an item ingested via
-    /// [`Self::from_sources`], or `None` when unknown — callers then fall
+    /// the item's [`SourceLocation`] stamp, or `None` when unknown —
+    /// callers then fall
     /// back to [`Self::default_module`].
     pub fn origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
         let crate_name = self.item_origins.get(ident)?;
@@ -956,7 +947,7 @@ impl<M> Registry<M> {
 
     fn check_no_duplicate(&self, name: &syn::Ident, loc: &SourceLocation) -> Result<(), ScanError> {
         if let Some(first) = self.first_seen_loc(name) {
-            // Origin crates are unknown at this level; `add_source` enriches
+            // Origin crates are unknown at this level; `from_items` enriches
             // the error with them (the locations alone are crate-relative).
             return Err(ScanError::DuplicateName(Box::new(DuplicateNameError {
                 name: name.clone(),

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -383,7 +383,7 @@ impl fmt::Display for ScanError {
 
 impl std::error::Error for ScanError {}
 
-/// Combined error surfaced by [`Registry::write_rust`].
+/// Combined error surfaced by [`Registry::resolve`] / [`Generation::write_rust`].
 #[derive(Debug)]
 pub enum WriteRustError {
     Scan(ScanError),

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -288,11 +288,31 @@ pub struct DuplicateNameError {
 #[derive(Debug)]
 pub enum ScanError {
     DuplicateName(Box<DuplicateNameError>),
-    ConflictingFunctionIntent { name: syn::Ident },
-    ConflictingTypeIntent { key: TypeKey },
-    DisallowedImplTrait { ty: String, loc: SourceLocation },
-    UnsupportedReceiver { loc: SourceLocation },
-    UnsupportedParamPattern { loc: SourceLocation },
+    ConflictingFunctionIntent {
+        name: syn::Ident,
+    },
+    ConflictingTypeIntent {
+        key: TypeKey,
+    },
+    DisallowedImplTrait {
+        ty: String,
+        loc: SourceLocation,
+    },
+    UnsupportedReceiver {
+        loc: SourceLocation,
+    },
+    UnsupportedParamPattern {
+        loc: SourceLocation,
+    },
+    /// Explicitly declared items (functions, helper functions, constants)
+    /// that match no indexed `#[prebindgen]` item. A declaration is a
+    /// statement of intent — its target being absent is always a bug (a
+    /// typo in build.rs, or the item was renamed/removed in the source
+    /// crate), so this is a hard error, unlike the soft warnings for stale
+    /// *ignore* entries. All missing names are collected before failing.
+    DeclaredNotFound {
+        entries: Vec<(&'static str, String)>,
+    },
 }
 
 impl fmt::Display for ScanError {
@@ -334,6 +354,21 @@ impl fmt::Display for ScanError {
             }
             ScanError::UnsupportedParamPattern { loc } => {
                 write!(f, "non-ident parameter pattern is not supported at {}", loc)
+            }
+            ScanError::DeclaredNotFound { entries } => {
+                writeln!(
+                    f,
+                    "{} declared item(s) not found among #[prebindgen] items:",
+                    entries.len()
+                )?;
+                for (kind, name) in entries {
+                    writeln!(f, "  - {kind} `{name}`")?;
+                }
+                write!(
+                    f,
+                    "a declaration names an item that does not exist — typo in build.rs, \
+                     or renamed/removed in the source crate?"
+                )
             }
         }
     }
@@ -399,6 +434,11 @@ impl From<crate::api::core::write::WriteError> for WriteRustError {
 struct DeclaredItems {
     functions: HashSet<syn::Ident>,
     ignored_functions: HashSet<syn::Ident>,
+    /// Bulk-ignore predicates over fn names — every matching *undeclared*
+    /// fn is an acknowledged skip (no warning). A declared fn matching a
+    /// predicate is unaffected: declaration wins. See
+    /// [`Prebindgen::ignored_function_predicates`].
+    ignored_fn_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
     /// Signature-scanned but not emitted — see [`Prebindgen::helper_functions`].
     helper_functions: HashSet<syn::Ident>,
     accessors: HashSet<syn::Ident>,
@@ -429,6 +469,7 @@ impl DeclaredItems {
         let declared = Self {
             functions: adapter.declared_functions(),
             ignored_functions: adapter.ignored_functions(),
+            ignored_fn_predicates: adapter.ignored_function_predicates(),
             helper_functions: adapter.helper_functions(),
             accessors: adapter.accessor_functions(),
             method_receivers: adapter.method_receivers(),
@@ -609,15 +650,18 @@ impl<M> Registry<M> {
     }
 
     fn scan_declared_items(&mut self, declared: &DeclaredItems) -> Result<(), ScanError> {
+        // Declared-but-missing items are collected across all three loops and
+        // reported together as one hard error (see
+        // [`ScanError::DeclaredNotFound`]); stale *ignore* entries below only
+        // warn.
+        let mut missing: Vec<(&'static str, String)> = Vec::new();
+
         // Scan declared functions.
         for ident in &declared.functions {
             if let Some((item_fn, loc)) = self.functions.get(ident).cloned() {
                 self.scan_fn_signature(&item_fn, &loc)?;
             } else {
-                println!(
-                    "cargo:warning=prebindgen: declared function `{}` not found among #[prebindgen] items",
-                    ident
-                );
+                missing.push(("function", ident.to_string()));
             }
         }
 
@@ -632,13 +676,11 @@ impl<M> Registry<M> {
 
         // Helper functions: never emitted, no blanket signature scan (the
         // adapter registers the specific requirements via
-        // `extra_required_types`) — but a typo'd name still warns.
+        // `extra_required_types`) — but they are referenced by name from
+        // adapter declarations, so a missing one is a hard error.
         for ident in &declared.helper_functions {
             if !self.functions.contains_key(ident) {
-                println!(
-                    "cargo:warning=prebindgen: helper function `{}` not found among #[prebindgen] items",
-                    ident
-                );
+                missing.push(("helper function", ident.to_string()));
             }
         }
 
@@ -650,10 +692,7 @@ impl<M> Registry<M> {
                 if let Some((item_const, loc)) = self.consts.get(ident).cloned() {
                     self.ensure_entry(Direction::Output, &item_const.ty, true, &loc);
                 } else {
-                    println!(
-                        "cargo:warning=prebindgen: declared const `{}` not found among #[prebindgen] items",
-                        ident
-                    );
+                    missing.push(("constant", ident.to_string()));
                 }
             }
             for ident in &declared.ignored_consts {
@@ -664,6 +703,11 @@ impl<M> Registry<M> {
                     );
                 }
             }
+        }
+
+        if !missing.is_empty() {
+            missing.sort();
+            return Err(ScanError::DeclaredNotFound { entries: missing });
         }
 
         // Adapter-required extra output types — synthesized values with no
@@ -713,7 +757,16 @@ impl<M> Registry<M> {
             }
         }
 
-        // Warn about indexed items that the adapter never claimed.
+        // Warn about indexed items that the adapter never claimed. An
+        // ignore *predicate* acknowledges every matching fn in bulk; a
+        // predicate matching nothing is silent by design (it is a filter,
+        // not a claim — match counts vary across feature configurations).
+        let pred_ignored = |k: &syn::Ident| {
+            !declared.ignored_fn_predicates.is_empty() && {
+                let name = k.to_string();
+                declared.ignored_fn_predicates.iter().any(|p| p(&name))
+            }
+        };
         let mut skipped_fns: Vec<String> = self
             .functions
             .keys()
@@ -721,6 +774,7 @@ impl<M> Registry<M> {
                 !declared.functions.contains(*k)
                     && !declared.ignored_functions.contains(*k)
                     && !declared.helper_functions.contains(*k)
+                    && !pred_ignored(k)
             })
             .map(|k| k.to_string())
             .collect();

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -269,48 +269,36 @@ impl<M> Default for Registry<M> {
     }
 }
 
+/// Payload of [`ScanError::DuplicateName`], boxed to keep the error enum
+/// small (`clippy::result_large_err`).
+#[derive(Debug)]
+pub struct DuplicateNameError {
+    pub name: syn::Ident,
+    pub first: SourceLocation,
+    pub second: SourceLocation,
+    /// Origin crates of the colliding items, when known (multi-source
+    /// ingestion via [`Registry::from_sources`]) — the `SourceLocation`
+    /// file paths are crate-relative, so with several sources they alone
+    /// may not identify the colliding crates.
+    pub first_crate: Option<String>,
+    pub second_crate: Option<String>,
+}
+
 /// Errors surfaced by the scan phase.
 #[derive(Debug)]
 pub enum ScanError {
-    DuplicateName {
-        name: syn::Ident,
-        first: SourceLocation,
-        second: SourceLocation,
-        /// Origin crates of the colliding items, when known (multi-source
-        /// ingestion via [`Registry::from_sources`]) — the `SourceLocation`
-        /// file paths are crate-relative, so with several sources they alone
-        /// may not identify the colliding crates.
-        first_crate: Option<String>,
-        second_crate: Option<String>,
-    },
-    ConflictingFunctionIntent {
-        name: syn::Ident,
-    },
-    ConflictingTypeIntent {
-        key: TypeKey,
-    },
-    DisallowedImplTrait {
-        ty: String,
-        loc: SourceLocation,
-    },
-    UnsupportedReceiver {
-        loc: SourceLocation,
-    },
-    UnsupportedParamPattern {
-        loc: SourceLocation,
-    },
+    DuplicateName(Box<DuplicateNameError>),
+    ConflictingFunctionIntent { name: syn::Ident },
+    ConflictingTypeIntent { key: TypeKey },
+    DisallowedImplTrait { ty: String, loc: SourceLocation },
+    UnsupportedReceiver { loc: SourceLocation },
+    UnsupportedParamPattern { loc: SourceLocation },
 }
 
 impl fmt::Display for ScanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ScanError::DuplicateName {
-                name,
-                first,
-                second,
-                first_crate,
-                second_crate,
-            } => {
+            ScanError::DuplicateName(e) => {
                 let in_crate = |c: &Option<String>| match c {
                     Some(c) => format!(" in crate `{c}`"),
                     None => String::new(),
@@ -319,11 +307,11 @@ impl fmt::Display for ScanError {
                     f,
                     "duplicate prebindgen name `{}`: first{} at {}, second{} at {} — prebindgen \
                      items live in one flat namespace across all sources; rename one of them",
-                    name,
-                    in_crate(first_crate),
-                    first,
-                    in_crate(second_crate),
-                    second
+                    e.name,
+                    in_crate(&e.first_crate),
+                    e.first,
+                    in_crate(&e.second_crate),
+                    e.second
                 )
             }
             ScanError::ConflictingFunctionIntent { name } => write!(
@@ -542,20 +530,10 @@ impl<M> Registry<M> {
                         self.item_origins.insert(ident, crate_name.clone());
                     }
                 }
-                Err(ScanError::DuplicateName {
-                    name,
-                    first,
-                    second,
-                    ..
-                }) => {
-                    let first_crate = self.item_origins.get(&name).cloned();
-                    return Err(ScanError::DuplicateName {
-                        name,
-                        first,
-                        second,
-                        first_crate,
-                        second_crate: Some(crate_name),
-                    });
+                Err(ScanError::DuplicateName(mut e)) => {
+                    e.first_crate = self.item_origins.get(&e.name).cloned();
+                    e.second_crate = Some(crate_name);
+                    return Err(ScanError::DuplicateName(e));
                 }
                 Err(e) => return Err(e),
             }
@@ -926,13 +904,13 @@ impl<M> Registry<M> {
         if let Some(first) = self.first_seen_loc(name) {
             // Origin crates are unknown at this level; `add_source` enriches
             // the error with them (the locations alone are crate-relative).
-            return Err(ScanError::DuplicateName {
+            return Err(ScanError::DuplicateName(Box::new(DuplicateNameError {
                 name: name.clone(),
                 first,
                 second: loc.clone(),
                 first_crate: None,
                 second_crate: None,
-            });
+            })));
         }
         Ok(())
     }

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -276,6 +276,12 @@ pub enum ScanError {
         name: syn::Ident,
         first: SourceLocation,
         second: SourceLocation,
+        /// Origin crates of the colliding items, when known (multi-source
+        /// ingestion via [`Registry::from_sources`]) — the `SourceLocation`
+        /// file paths are crate-relative, so with several sources they alone
+        /// may not identify the colliding crates.
+        first_crate: Option<String>,
+        second_crate: Option<String>,
     },
     ConflictingFunctionIntent {
         name: syn::Ident,
@@ -298,11 +304,28 @@ pub enum ScanError {
 impl fmt::Display for ScanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ScanError::DuplicateName { name, first, second } => write!(
-                f,
-                "duplicate prebindgen name `{}`: first at {}, second at {}",
-                name, first, second
-            ),
+            ScanError::DuplicateName {
+                name,
+                first,
+                second,
+                first_crate,
+                second_crate,
+            } => {
+                let in_crate = |c: &Option<String>| match c {
+                    Some(c) => format!(" in crate `{c}`"),
+                    None => String::new(),
+                };
+                write!(
+                    f,
+                    "duplicate prebindgen name `{}`: first{} at {}, second{} at {} — prebindgen \
+                     items live in one flat namespace across all sources; rename one of them",
+                    name,
+                    in_crate(first_crate),
+                    first,
+                    in_crate(second_crate),
+                    second
+                )
+            }
             ScanError::ConflictingFunctionIntent { name } => write!(
                 f,
                 "function `{}` cannot be both declared and ignored",
@@ -504,17 +527,38 @@ impl<M> Registry<M> {
         let crate_name = source.crate_name().to_string();
         self.source_modules.push(crate_name.replace('-', "_"));
         for (item, loc) in source.items_all() {
-            let named: Option<&syn::Ident> = match &item {
-                syn::Item::Fn(f) => Some(&f.sig.ident),
-                syn::Item::Struct(s) => Some(&s.ident),
-                syn::Item::Enum(e) => Some(&e.ident),
-                syn::Item::Const(c) if c.ident != "_" => Some(&c.ident),
+            let named: Option<syn::Ident> = match &item {
+                syn::Item::Fn(f) => Some(f.sig.ident.clone()),
+                syn::Item::Struct(s) => Some(s.ident.clone()),
+                syn::Item::Enum(e) => Some(e.ident.clone()),
+                syn::Item::Const(c) if c.ident != "_" => Some(c.ident.clone()),
                 _ => None,
             };
-            if let Some(ident) = named {
-                self.item_origins.insert(ident.clone(), crate_name.clone());
+            match self.index_item(item, loc) {
+                Ok(()) => {
+                    // Only after successful indexing — a collision must keep
+                    // the FIRST item's origin for the error below.
+                    if let Some(ident) = named {
+                        self.item_origins.insert(ident, crate_name.clone());
+                    }
+                }
+                Err(ScanError::DuplicateName {
+                    name,
+                    first,
+                    second,
+                    ..
+                }) => {
+                    let first_crate = self.item_origins.get(&name).cloned();
+                    return Err(ScanError::DuplicateName {
+                        name,
+                        first,
+                        second,
+                        first_crate,
+                        second_crate: Some(crate_name),
+                    });
+                }
+                Err(e) => return Err(e),
             }
-            self.index_item(item, loc)?;
         }
         Ok(())
     }
@@ -880,10 +924,14 @@ impl<M> Registry<M> {
 
     fn check_no_duplicate(&self, name: &syn::Ident, loc: &SourceLocation) -> Result<(), ScanError> {
         if let Some(first) = self.first_seen_loc(name) {
+            // Origin crates are unknown at this level; `add_source` enriches
+            // the error with them (the locations alone are crate-relative).
             return Err(ScanError::DuplicateName {
                 name: name.clone(),
                 first,
                 second: loc.clone(),
+                first_crate: None,
+                second_crate: None,
             });
         }
         Ok(())

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -962,14 +962,14 @@ impl<M> Registry<M> {
         if let Some(exp) = ext.expansions() {
             crate::api::core::expand::apply(
                 self,
-                exp,
+                &exp,
                 &declared.functions,
                 &declared.accessors,
                 &declared.method_receivers,
             )?;
         }
         if let Some(dec) = ext.deconstructors() {
-            crate::api::core::unfold::apply(self, dec, &declared.functions, &declared.accessors)?;
+            crate::api::core::unfold::apply(self, &dec, &declared.functions, &declared.accessors)?;
         }
         // Synthesized by-value `data_class` decompositions: build the leaves
         // (immutable borrow), then wire them into fixed-builder plans.

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -249,7 +249,7 @@ fn duplicate_name_across_sources_names_both_crates() {
             },
             None,
         );
-        crate::api::utils::jsonl::write_to_jsonl_file(&dir.join("default_1.jsonl"), &[&record])
+        crate::api::utils::jsonl::write_to_jsonl_file(dir.join("default_1.jsonl"), &[&record])
             .unwrap();
         crate::Source::new(&dir)
     };

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -15,6 +15,9 @@ use crate::api::core::{
 struct StubExt {
     functions: HashSet<syn::Ident>,
     ignored_functions: HashSet<syn::Ident>,
+    ignored_fn_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
+    helper_functions: HashSet<syn::Ident>,
+    consts: Option<HashSet<syn::Ident>>,
     types: HashSet<TypeKey>,
     ignored_types: HashSet<TypeKey>,
 }
@@ -27,6 +30,15 @@ impl Prebindgen for StubExt {
     }
     fn ignored_functions(&self) -> HashSet<syn::Ident> {
         self.ignored_functions.clone()
+    }
+    fn ignored_function_predicates(&self) -> Vec<crate::api::core::prebindgen::NamePredicate> {
+        self.ignored_fn_predicates.clone()
+    }
+    fn helper_functions(&self) -> HashSet<syn::Ident> {
+        self.helper_functions.clone()
+    }
+    fn declared_consts(&self) -> Option<HashSet<syn::Ident>> {
+        self.consts.clone()
     }
     fn declared_types(&self) -> HashSet<TypeKey> {
         self.types.clone()
@@ -160,6 +172,84 @@ fn scan_declared_rejects_type_declared_and_ignored_overlap() {
         Err(ScanError::ConflictingTypeIntent { key: actual }) if actual == key => (),
         other => panic!("expected ConflictingTypeIntent, got {:?}", other),
     }
+}
+
+/// A declared function that matches no indexed item is a hard error, not a
+/// warning — explicit intent gone wrong (I7).
+#[test]
+fn scan_declared_missing_function_is_hard_error() {
+    let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("good").unwrap());
+    ext.functions.insert(syn::parse_str("typo_fn").unwrap());
+    match reg.scan_declared(&ext) {
+        Err(ScanError::DeclaredNotFound { entries }) => {
+            assert_eq!(entries, vec![("function", "typo_fn".to_string())]);
+        }
+        other => panic!("expected DeclaredNotFound, got {:?}", other),
+    }
+}
+
+/// All missing declared items (fn, helper fn, const) are collected into ONE
+/// error, sorted, so a broken build.rs is fixed in a single pass.
+#[test]
+fn scan_declared_collects_all_missing_kinds_in_one_error() {
+    let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("typo_fn").unwrap());
+    ext.helper_functions
+        .insert(syn::parse_str("typo_helper").unwrap());
+    ext.consts = Some(HashSet::from([syn::parse_str("TYPO_CONST").unwrap()]));
+    match reg.scan_declared(&ext) {
+        Err(ScanError::DeclaredNotFound { entries }) => {
+            assert_eq!(
+                entries,
+                vec![
+                    ("constant", "TYPO_CONST".to_string()),
+                    ("function", "typo_fn".to_string()),
+                    ("helper function", "typo_helper".to_string()),
+                ]
+            );
+            // The message lists every entry.
+            let msg = ScanError::DeclaredNotFound { entries }.to_string();
+            assert!(msg.contains("typo_fn") && msg.contains("TYPO_CONST"));
+        }
+        other => panic!("expected DeclaredNotFound, got {:?}", other),
+    }
+}
+
+/// A stale *ignore* entry stays a warning: the scan succeeds.
+#[test]
+fn scan_declared_missing_ignore_is_not_an_error() {
+    let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.ignored_functions
+        .insert(syn::parse_str("gone_fn").unwrap());
+    reg.scan_declared(&ext)
+        .expect("stale ignore must only warn");
+}
+
+/// An ignore predicate acknowledges matching undeclared fns (C2) and is
+/// silent when it matches nothing — it is a filter, not a claim.
+#[test]
+fn scan_declared_accepts_ignore_predicates() {
+    let items = vec![
+        fn_item("fn helper_a(x: u64) -> u64 { x }"),
+        fn_item("fn helper_b(x: u64) -> u64 { x }"),
+    ];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.ignored_fn_predicates
+        .push(std::sync::Arc::new(|n: &str| n.starts_with("helper_")));
+    // Matches both fns — and a second, zero-match predicate is fine too.
+    ext.ignored_fn_predicates
+        .push(std::sync::Arc::new(|n: &str| n.starts_with("nothing_")));
+    reg.scan_declared(&ext).expect("predicates must scan clean");
+    // Nothing was declared, so nothing became required.
+    assert!(reg.required_inputs_scan.is_empty());
 }
 
 #[test]

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -314,10 +314,11 @@ fn type_entry_helpers_expose_converter_chain_contract() {
     );
 }
 
-/// A name collision across two sources fails registry construction with an
-/// error that names BOTH origin crates — the `SourceLocation` file paths are
-/// crate-relative (both may read `src/lib.rs`), so the crates are the only
-/// unambiguous coordinates.
+/// A name collision across two chained source streams fails registry
+/// construction with an error that names BOTH origin crates — the
+/// `SourceLocation` file paths are crate-relative (both may read
+/// `src/lib.rs`), so the crates (stamped into each stream item's location
+/// by `Source`) are the only unambiguous coordinates.
 #[test]
 fn duplicate_name_across_sources_names_both_crates() {
     use crate::{
@@ -338,6 +339,7 @@ fn duplicate_name_across_sources_names_both_crates() {
                 file: "src/lib.rs".to_string(),
                 line: 1,
                 column: 1,
+                crate_name: None,
             },
             None,
         );
@@ -348,11 +350,53 @@ fn duplicate_name_across_sources_names_both_crates() {
 
     let a = make_source("first-crate");
     let b = make_source("second-crate");
-    let msg = match Registry::<()>::from_sources([&a, &b]) {
+    let msg = match Registry::<()>::from_items(a.items_all().chain(b.items_all())) {
         Ok(_) => panic!("collision must fail"),
         Err(e) => e.to_string(),
     };
     assert!(msg.contains("same_name"), "{msg}");
     assert!(msg.contains("first-crate"), "{msg}");
     assert!(msg.contains("second-crate"), "{msg}");
+}
+
+/// Chained streams from two sources feed ONE `from_items` call: per-item
+/// origins come from the `SourceLocation` stamps, and the first item's
+/// origin becomes the default module.
+#[test]
+fn from_items_records_origins_from_location_stamps() {
+    let loc = |krate: &str| SourceLocation {
+        file: "src/lib.rs".to_string(),
+        line: 1,
+        column: 1,
+        crate_name: Some(krate.to_string()),
+    };
+    let f_a: syn::ItemFn = syn::parse_str("fn from_flat(x: u64) -> u64 { x }").unwrap();
+    let f_b: syn::ItemFn = syn::parse_str("fn from_helper(x: u64) -> u64 { x }").unwrap();
+    let a = vec![(syn::Item::Fn(f_a), loc("flat-crate"))];
+    let b = vec![(syn::Item::Fn(f_b), loc("helper-crate"))];
+    let reg: Registry<()> = Registry::from_items(a.into_iter().chain(b)).unwrap();
+
+    let path = |p: syn::Path| p.to_token_stream().to_string();
+    assert_eq!(
+        reg.origin_module(&syn::parse_str("from_flat").unwrap())
+            .map(path),
+        Some("flat_crate".to_string())
+    );
+    assert_eq!(
+        reg.origin_module(&syn::parse_str("from_helper").unwrap())
+            .map(path),
+        Some("helper_crate".to_string())
+    );
+    // First origin seen = default module; both modules listed in order.
+    assert_eq!(
+        reg.default_module().map(path),
+        Some("flat_crate".to_string())
+    );
+    assert_eq!(
+        reg.all_source_modules()
+            .into_iter()
+            .map(path)
+            .collect::<Vec<_>>(),
+        vec!["flat_crate".to_string(), "helper_crate".to_string()]
+    );
 }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -15,7 +15,7 @@ use crate::api::core::{
 struct StubExt {
     functions: HashSet<syn::Ident>,
     ignored_functions: HashSet<syn::Ident>,
-    ignored_fn_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
+    ignored_name_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
     helper_functions: HashSet<syn::Ident>,
     consts: Option<HashSet<syn::Ident>>,
     types: HashSet<TypeKey>,
@@ -31,8 +31,8 @@ impl Prebindgen for StubExt {
     fn ignored_functions(&self) -> HashSet<syn::Ident> {
         self.ignored_functions.clone()
     }
-    fn ignored_function_predicates(&self) -> Vec<crate::api::core::prebindgen::NamePredicate> {
-        self.ignored_fn_predicates.clone()
+    fn ignored_name_predicates(&self) -> Vec<crate::api::core::prebindgen::NamePredicate> {
+        self.ignored_name_predicates.clone()
     }
     fn helper_functions(&self) -> HashSet<syn::Ident> {
         self.helper_functions.clone()
@@ -232,20 +232,33 @@ fn scan_declared_missing_ignore_is_not_an_error() {
         .expect("stale ignore must only warn");
 }
 
-/// An ignore predicate acknowledges matching undeclared fns (C2) and is
-/// silent when it matches nothing — it is a filter, not a claim.
+/// An ignore predicate acknowledges matching undeclared items of EVERY
+/// kind — fn, struct/enum, const (one flat namespace, so a name filter
+/// needs no kind) — and is silent when it matches nothing: a filter, not a
+/// claim.
 #[test]
 fn scan_declared_accepts_ignore_predicates() {
+    let s: syn::ItemStruct = syn::parse_str("struct HelperThing { v: u64 }").unwrap();
+    let c: syn::ItemConst = syn::parse_str("const HELPER_MAX: u64 = 1;").unwrap();
     let items = vec![
         fn_item("fn helper_a(x: u64) -> u64 { x }"),
         fn_item("fn helper_b(x: u64) -> u64 { x }"),
+        (syn::Item::Struct(s), SourceLocation::default()),
+        (syn::Item::Const(c), SourceLocation::default()),
     ];
     let mut reg: Registry<()> = Registry::from_items(items).unwrap();
-    let mut ext = StubExt::default();
-    ext.ignored_fn_predicates
-        .push(std::sync::Arc::new(|n: &str| n.starts_with("helper_")));
-    // Matches both fns — and a second, zero-match predicate is fine too.
-    ext.ignored_fn_predicates
+    // Const skip-warnings only run for adapters WITH a const mechanism.
+    let mut ext = StubExt {
+        consts: Some(HashSet::new()),
+        ..StubExt::default()
+    };
+    ext.ignored_name_predicates
+        .push(std::sync::Arc::new(|n: &str| {
+            let l = n.to_lowercase();
+            l.starts_with("helper")
+        }));
+    // A second, zero-match predicate is fine too.
+    ext.ignored_name_predicates
         .push(std::sync::Arc::new(|n: &str| n.starts_with("nothing_")));
     reg.scan_declared(&ext).expect("predicates must scan clean");
     // Nothing was declared, so nothing became required.

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -223,3 +223,44 @@ fn type_entry_helpers_expose_converter_chain_contract() {
         vec!["Rust", "Mid"]
     );
 }
+
+/// A name collision across two sources fails registry construction with an
+/// error that names BOTH origin crates — the `SourceLocation` file paths are
+/// crate-relative (both may read `src/lib.rs`), so the crates are the only
+/// unambiguous coordinates.
+#[test]
+fn duplicate_name_across_sources_names_both_crates() {
+    use crate::api::record::{Record, RecordKind};
+    use crate::SourceLocation;
+
+    let make_source = |crate_name: &str| -> crate::Source {
+        let dir = crate::api::test_util::unique_test_dir(&format!("dup_src_{crate_name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("crate_name.txt"), crate_name).unwrap();
+        let record = Record::new(
+            RecordKind::Function,
+            "same_name".to_string(),
+            "pub fn same_name() -> i32 { 1 }".to_string(),
+            SourceLocation {
+                file: "src/lib.rs".to_string(),
+                line: 1,
+                column: 1,
+            },
+            None,
+        );
+        crate::api::utils::jsonl::write_to_jsonl_file(&dir.join("default_1.jsonl"), &[&record])
+            .unwrap();
+        crate::Source::new(&dir)
+    };
+
+    let a = make_source("first-crate");
+    let b = make_source("second-crate");
+    let msg = match Registry::<()>::from_sources([&a, &b]) {
+        Ok(_) => panic!("collision must fail"),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("same_name"), "{msg}");
+    assert!(msg.contains("first-crate"), "{msg}");
+    assert!(msg.contains("second-crate"), "{msg}");
+}

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -413,3 +413,39 @@ fn from_items_records_origins_from_location_stamps() {
         vec!["flat_crate".to_string(), "helper_crate".to_string()]
     );
 }
+
+/// N5: `Prebindgen::validate` runs during `resolve` after the scan; an
+/// adapter-invariant failure surfaces as `ScanError::AdapterInvariant`
+/// with the adapter's message verbatim.
+#[test]
+fn resolve_surfaces_adapter_invariant_errors() {
+    struct FailingExt(StubExt);
+    impl Prebindgen for FailingExt {
+        type Metadata = ();
+        fn validate(&self, _registry: &Registry<()>) -> Result<(), String> {
+            Err("member fun `f` has no receiver".to_string())
+        }
+        fn on_function(&self, f: &syn::ItemFn, r: &Registry<()>) -> TokenStream {
+            self.0.on_function(f, r)
+        }
+        fn on_struct(&self, s: &syn::ItemStruct, r: &Registry<()>) -> TokenStream {
+            self.0.on_struct(s, r)
+        }
+        fn on_enum(&self, e: &syn::ItemEnum, r: &Registry<()>) -> TokenStream {
+            self.0.on_enum(e, r)
+        }
+        fn on_input_type(&self, t: &syn::Type, r: &Registry<()>) -> Option<ConverterImpl<()>> {
+            self.0.on_input_type(t, r)
+        }
+        fn on_output_type(&self, t: &syn::Type, r: &Registry<()>) -> Option<ConverterImpl<()>> {
+            self.0.on_output_type(t, r)
+        }
+    }
+    let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
+    let reg: Registry<()> = Registry::from_items(items).unwrap();
+    let err = reg
+        .resolve(FailingExt(StubExt::default()))
+        .expect_err("validate Err must abort resolve");
+    let msg = format!("{err}");
+    assert!(msg.contains("member fun `f` has no receiver"), "{msg}");
+}

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -230,8 +230,10 @@ fn type_entry_helpers_expose_converter_chain_contract() {
 /// unambiguous coordinates.
 #[test]
 fn duplicate_name_across_sources_names_both_crates() {
-    use crate::api::record::{Record, RecordKind};
-    use crate::SourceLocation;
+    use crate::{
+        api::record::{Record, RecordKind},
+        SourceLocation,
+    };
 
     let make_source = |crate_name: &str| -> crate::Source {
         let dir = crate::api::test_util::unique_test_dir(&format!("dup_src_{crate_name}"));

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -2,8 +2,8 @@
 //! (`api/core/expand.rs`). A function returning a rich type is *decomposed* by a
 //! **deconstructor** into a set of leaf values.
 //!
-//! A **deconstructor** (a type-level `return_expand!` `.field*` list,
-//! or the per-fn `.return_expand*` override) is a
+//! A **deconstructor** (a type-level `expand_return!` `.field*` list,
+//! or the per-fn `.expand_return` override) is a
 //! **deterministic product**: every record always runs and contributes its leaf
 //! — there is no selector (unlike a *constructor*, whose selector picks one
 //! variant). A record's accessor is a `#[prebindgen]` function `f(&T) -> &F` (a
@@ -66,18 +66,18 @@ struct DeconstructorDecl {
     records: Vec<DeconRecord>,
     /// Auto-apply this deconstructor to every matching declared fn (`Some`
     /// carries the inferred `(target-position, delivery)` to use). Always
-    /// `Some` for type-level default (`return_expand!`) declarations.
+    /// `Some` for type-level default (`expand_return!`) declarations.
     default: Option<(DeconTarget, Delivery)>,
 }
 
 /// How an output expansion chooses the deconstructor for a function's return
-/// type: the type's default (`return_expand!`-declared) or a per-fn
-/// inline record list (`.return_expand*`).
+/// type: the type's default (`expand_return!`-declared) or a per-fn
+/// inline record list (`.expand_return`).
 #[derive(Clone)]
 enum DeconSel {
     /// Use the return type's unique deconstructor (error if ambiguous).
     TopLevel,
-    /// Per-fn override (`.return_expand`): use exactly these
+    /// Per-fn override (`.expand_return`): use exactly these
     /// accessor-fn records.
     Inline(Vec<DeconRecord>),
 }
@@ -109,6 +109,11 @@ struct OutputDecl {
     sel: DeconSel,
     target: DeconTarget,
     delivery: Delivery,
+    /// The type the per-fn decl was declared for (`expand_return!(T)`) —
+    /// cross-checked against the fn's peeled return type in [`apply`].
+    /// `None` for internally-synthesized decls (the type comes from the
+    /// return itself).
+    declared_source: Option<syn::Type>,
 }
 
 /// Deconstructor / converter / output-expansion declarations gathered from a
@@ -119,13 +124,14 @@ struct OutputDecl {
 pub struct Deconstructors {
     deconstructors: Vec<DeconstructorDecl>,
     outputs: Vec<OutputDecl>,
-    /// Cursor for the type-level default builder (`return_expand!` →
+    /// Cursor for the type-level default builder (`expand_return!` →
     /// `.field`/`.field_self`).
     cur_deconstructor: Option<usize>,
-    /// Cursor for an in-progress per-fn inline output override    /// (`.return_expand`/`.return_expand_self`): index into
+    /// Cursor for an in-progress per-fn inline output override
+    /// (`.expand_return`): index into
     /// [`Self::outputs`].
     cur_output: Option<usize>,
-    /// identity-only `.return_expand_self()` opt-outs: fns excluded from the
+    /// Identity-only per-fn field-set opt-outs: fns excluded from the
     /// default auto-apply.
     skip_output: std::collections::HashSet<syn::Ident>,
 }
@@ -160,13 +166,13 @@ impl Deconstructors {
         }
     }
 
-    /// identity-only `.return_expand_self()` — exclude `func` from output-position
-    /// default auto-apply.
+    /// Exclude `func` from output-position default auto-apply — the lowered
+    /// form of an identity-only per-fn field set (the raw whole-value return).
     pub fn add_skip_default_output(&mut self, func: syn::Ident) {
         self.skip_output.insert(func);
     }
 
-    /// `return_expand!` `.field(fun)` — add an accessor-function
+    /// `expand_return!` `.field(fun)` — add an accessor-function
     /// record with the resolved (literal) leaf `name`.
     pub fn add_deconstructor_record(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
@@ -178,7 +184,7 @@ impl Deconstructors {
         });
     }
 
-    /// `return_expand!` `.field_self()` — add the identity record
+    /// `expand_return!` `.field_self()` — add the identity record
     /// (the value itself).
     pub fn add_deconstructor_record_id(&mut self) {
         let i = self
@@ -187,23 +193,27 @@ impl Deconstructors {
         self.deconstructors[i].records.push(DeconRecord::Identity);
     }
 
-    /// Begin a per-fn inline output override (`.return_expand`):
+    /// Begin a per-fn inline output override (`.expand_return(expand_return!(T)…)`):
     /// decompose `func`'s return via an incrementally-built record list
     /// (accessor fields via [`Self::push_inline_field`] and/or the identity/self
-    /// field via [`Self::push_inline_field_self`]). Recorded as an explicit decl
-    /// so the auto-`default` skips it, and leaves the output cursor on it.
-    pub fn begin_inline_output(&mut self, func: syn::Ident) {
+    /// field via [`Self::push_inline_field_self`]). `declared_source` is the
+    /// decl's `T`, cross-checked against the fn's peeled return type in
+    /// [`apply`]. Recorded as an explicit decl so the auto-`default` skips it,
+    /// and leaves the output cursor on it. An identity-only field list lowers
+    /// to the raw whole-value return in [`apply`].
+    pub fn begin_inline_output(&mut self, func: syn::Ident, declared_source: syn::Type) {
         self.outputs.push(OutputDecl {
             func,
             sel: DeconSel::Inline(Vec::new()),
             target: DeconTarget::Output,
             delivery: Delivery::Callback,
+            declared_source: Some(declared_source),
         });
         self.cur_deconstructor = None;
         self.cur_output = Some(self.outputs.len() - 1);
     }
 
-    /// `.return_expand(fun)` — append an
+    /// `.expand_return` `.field(fun)` — append an
     /// accessor-function field (named `name`) to the current per-fn inline output.
     pub fn push_inline_field(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
@@ -217,7 +227,7 @@ impl Deconstructors {
         }
     }
 
-    /// `.return_expand_self()` — append the identity
+    /// `.expand_return` `.field_self()` — append the identity
     /// (the handle itself) field to the current per-fn inline output.
     pub fn push_inline_field_self(&mut self) {
         let i = self
@@ -274,11 +284,39 @@ pub fn apply<M>(
     // for the same `(fn, target)`.
     let mut done: std::collections::HashSet<(syn::Ident, DeconTarget)> = Default::default();
     for ed in &acc.outputs {
+        // Per-fn decl cross-check: the decl's declared type must match the
+        // fn's peeled (`Option`/`Vec`/`&`) return type — the typo guard for
+        // `.expand_return(expand_return!(T)…)`.
+        if let Some(declared) = &ed.declared_source {
+            let (item_fn, _) = registry
+                .functions
+                .get(&ed.func)
+                .cloned()
+                .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
+            let ret = fn_return(&item_fn);
+            if !returns_type(&ret, &TypeKey::from_type(declared)) {
+                return Err(UnfoldError::ReturnTypeMismatch {
+                    func: ed.func.clone(),
+                    declared: TypeKey::from_type(declared).as_str().to_string(),
+                    actual: quote::quote!(#ret).to_string(),
+                });
+            }
+        }
+        // Identity-only field set = the raw whole-value return (the
+        // complete-set rule: "the set is {self}"): no plan — mark done so the
+        // type default doesn't re-apply, and let the return cross through the
+        // type's ordinary output converter (borrowed-`&T`-capable).
+        if let DeconSel::Inline(records) = &ed.sel {
+            if matches!(records.as_slice(), [DeconRecord::Identity]) {
+                done.insert((ed.func.clone(), ed.target));
+                continue;
+            }
+        }
         process_decl(registry, acc, ed)?;
         done.insert((ed.func.clone(), ed.target));
     }
 
-    // Default auto-apply: a type's deconstructor (`return_expand!`) is
+    // Default auto-apply: a type's deconstructor (`expand_return!`) is
     // applied to every declared fn that returns it (Output) or has it as a
     // `Result<_, E>` error (Error), unless the fn is `fun_accessor` or has a
     // per-fn override. `Delivery` is recomputed from leaf count inside
@@ -311,6 +349,7 @@ pub fn apply<M>(
                             sel: sel.clone(),
                             target: DeconTarget::Error,
                             delivery: Delivery::Callback,
+                            declared_source: None,
                         },
                     )?;
                 }
@@ -329,6 +368,7 @@ pub fn apply<M>(
                         sel: sel.clone(),
                         target: DeconTarget::Output,
                         delivery: Delivery::Callback,
+                        declared_source: None,
                     },
                 )?;
             }
@@ -388,6 +428,7 @@ pub fn apply<M>(
                     sel: DeconSel::TopLevel,
                     target: DeconTarget::Output,
                     delivery: Delivery::Callback,
+                    declared_source: None,
                 };
                 let decon = decl_id(&core_key, d);
                 let records = d.records.clone();

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -2,7 +2,7 @@
 //! (`api/core/expand.rs`). A function returning a rich type is *decomposed* by a
 //! **deconstructor** into a set of leaf values.
 //!
-//! A **deconstructor** (a type's `.default_return_expand*` list /
+//! A **deconstructor** (a type-level `return_expand!` `.field*` list,
 //! or the per-fn `.return_expand*` override) is a
 //! **deterministic product**: every record always runs and contributes its leaf
 //! — there is no selector (unlike a *constructor*, whose selector picks one
@@ -66,12 +66,12 @@ struct DeconstructorDecl {
     records: Vec<DeconRecord>,
     /// Auto-apply this deconstructor to every matching declared fn (`Some`
     /// carries the inferred `(target-position, delivery)` to use). Always
-    /// `Some` for class-default (`.default_return_expand*`) declarations.
+    /// `Some` for type-level default (`return_expand!`) declarations.
     default: Option<(DeconTarget, Delivery)>,
 }
 
 /// How an output expansion chooses the deconstructor for a function's return
-/// type: the type's default (`.default_return_expand*`) or a per-fn
+/// type: the type's default (`return_expand!`-declared) or a per-fn
 /// inline record list (`.return_expand*`).
 #[derive(Clone)]
 enum DeconSel {
@@ -119,7 +119,7 @@ struct OutputDecl {
 pub struct Deconstructors {
     deconstructors: Vec<DeconstructorDecl>,
     outputs: Vec<OutputDecl>,
-    /// Cursor for the type-level default builder (`.default_return_expand` →
+    /// Cursor for the type-level default builder (`return_expand!` →
     /// `.field`/`.field_self`).
     cur_deconstructor: Option<usize>,
     /// Cursor for an in-progress per-fn inline output override    /// (`.return_expand`/`.return_expand_self`): index into
@@ -132,7 +132,7 @@ pub struct Deconstructors {
 
 impl Deconstructors {
     /// Find-or-create the default (always-`default`) deconstructor for `target`
-    /// and set the cursor to it. Idempotent across a `.default_return_expand` chain.
+    /// and set the cursor to it. Idempotent across a `.field*` chain.
     /// Delivery is derived from leaf count at emit time (1 ⇒ return, N ⇒ callback),
     /// so the stored `Delivery` is just a marker.
     pub fn ensure_default_deconstructor(&mut self, target: syn::Type) {
@@ -166,8 +166,8 @@ impl Deconstructors {
         self.skip_output.insert(func);
     }
 
-    /// `.default_return_expand(fun)` — add an accessor-function
-    /// record with the author-supplied (literal) leaf `name`.
+    /// `return_expand!` `.field(fun)` — add an accessor-function
+    /// record with the resolved (literal) leaf `name`.
     pub fn add_deconstructor_record(&mut self, func: syn::Ident, name: impl Into<String>) {
         let i = self
             .cur_deconstructor
@@ -178,7 +178,7 @@ impl Deconstructors {
         });
     }
 
-    /// `.default_return_expand_self()` — add the identity record
+    /// `return_expand!` `.field_self()` — add the identity record
     /// (the value itself).
     pub fn add_deconstructor_record_id(&mut self) {
         let i = self
@@ -217,7 +217,7 @@ impl Deconstructors {
         }
     }
 
-    /// `.default_return_expand_self()` — append the identity
+    /// `.return_expand_self()` — append the identity
     /// (the handle itself) field to the current per-fn inline output.
     pub fn push_inline_field_self(&mut self) {
         let i = self
@@ -278,7 +278,7 @@ pub fn apply<M>(
         done.insert((ed.func.clone(), ed.target));
     }
 
-    // Default auto-apply: a type's deconstructor (`.default_return_expand*`) is
+    // Default auto-apply: a type's deconstructor (`return_expand!`) is
     // applied to every declared fn that returns it (Output) or has it as a
     // `Result<_, E>` error (Error), unless the fn is `fun_accessor` or has a
     // per-fn override. `Delivery` is recomputed from leaf count inside

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -126,7 +126,7 @@ impl std::fmt::Display for UnfoldError {
             ),
             UnfoldError::RootIdentityBeforeNested { target } => write!(
                 f,
-                "return-field list of `{}`: `.default_return_expand_self()` (the root identity) must be \
+                "return-field list of `{}`: `.field_self()` (the root identity) must be \
                  declared AFTER fields that splice a nested identity — the root identity moves the owned \
                  value while nested identities borrow it, so this order would generate \
                  non-compiling Rust. Declare the `_self` field last.",

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -57,6 +57,13 @@ pub enum UnfoldError {
     RootIdentityBeforeNested {
         target: String,
     },
+    /// A per-fn `.expand_return(expand_return!(T)…)` decl whose `T` does not
+    /// match the function's peeled return type.
+    ReturnTypeMismatch {
+        func: syn::Ident,
+        declared: String,
+        actual: String,
+    },
 }
 
 impl std::fmt::Display for UnfoldError {
@@ -71,6 +78,17 @@ impl std::fmt::Display for UnfoldError {
                 f,
                 "output expansion: accessor `{}` is not a #[prebindgen] item",
                 name
+            ),
+            UnfoldError::ReturnTypeMismatch {
+                func,
+                declared,
+                actual,
+            } => write!(
+                f,
+                "output expansion: `{}`.expand_return(expand_return!({declared})): the \
+                 function's return type is `{actual}`, not `{declared}` — declare the decl \
+                 for the actual return type",
+                func
             ),
             UnfoldError::NoDeconstructor { func, target } => write!(
                 f,

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -27,9 +27,9 @@ pub use crate::api::core::shape::Shape as UnfoldShape;
 /// string.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DeconId {
-    /// The type's default (`return_expand!`-declared) deconstructor.
+    /// The type's default (`expand_return!`-declared) deconstructor.
     Default(String),
-    /// Per-fn inline records (`.return_expand*`) — unique to the
+    /// Per-fn inline records (`.expand_return`) — unique to the
     /// function (second field = the fn ident).
     PerFn(String, String),
 }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -27,7 +27,7 @@ pub use crate::api::core::shape::Shape as UnfoldShape;
 /// string.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DeconId {
-    /// The type's default (`.default_return_expand*`-declared) deconstructor.
+    /// The type's default (`return_expand!`-declared) deconstructor.
     Default(String),
     /// Per-fn inline records (`.return_expand*`) — unique to the
     /// function (second field = the fn ident).

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1088,3 +1088,25 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
         "pre-existing plan preserved (not overwritten)"
     );
 }
+
+/// C5 validation map: a field accessor ident that names no `#[prebindgen]`
+/// fn is a hard `UnknownAccessor` at resolve time — a typo'd
+/// `expand_return!(...).field(fun!(…))` cannot silently vanish. (At the
+/// jnigen level a registry-absent fn is caught even earlier, by the scan's
+/// `DeclaredNotFound` on the helper channel; this is the core-tier guard
+/// that stands on its own for any adapter.)
+#[test]
+fn unknown_accessor_errors() {
+    let mut reg = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
+    let mut acc = Deconstructors::default();
+    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
+    acc.add_deconstructor_record(ident("z_keyexpr_as_str_typo"), "as_str");
+    let err = apply(
+        &mut reg,
+        &acc,
+        &[ident("z_foo")].into_iter().collect(),
+        &[ident("z_keyexpr_as_str_typo")].into_iter().collect(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, UnfoldError::UnknownAccessor(_)), "{err}");
+}

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -497,7 +497,7 @@ fn iterable_whole_element_plan() {
     // deconstructor of its own.
     let mut reg = reg_with(&["fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }"]);
     let mut acc = Deconstructors::default();
-    acc.begin_inline_output(ident("z_session_peers_zid"));
+    acc.begin_inline_output(ident("z_session_peers_zid"), syn::parse_quote!(ZZenohId));
 
     apply(
         &mut reg,

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -124,7 +124,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     // 4. Cross-cutting post-process pass. Adapters use this to qualify
     //    bare type references etc. — see Prebindgen::post_process_item.
     for item in &mut items {
-        ext.post_process_item(item);
+        ext.post_process_item(item, registry);
     }
 
     let dest: Destination = items.into_iter().collect();

--- a/prebindgen/src/api/gen/kotlin/file.rs
+++ b/prebindgen/src/api/gen/kotlin/file.rs
@@ -110,7 +110,18 @@ pub fn merged_file_path(kotlin_root: &Path, file: &KtFile, fallback_name: &str) 
 }
 
 /// Render and write every merged file; returns the written paths.
+///
+/// `kotlin_root` is **generator-owned**: it is deleted and recreated on
+/// every run, so stale files from a previous generation (a renamed
+/// package, a removed declaration) can never linger. Point it at a
+/// dedicated directory (the established convention is
+/// `kotlin/generated/`), never at a tree containing hand-written sources.
 pub fn write_files(files: &[KtFile], kotlin_root: &Path) -> Result<Vec<PathBuf>, WriteKotlinError> {
+    match std::fs::remove_dir_all(kotlin_root) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
     let mut written = Vec::new();
     for f in files {
         let fallback = f

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -191,7 +191,8 @@ enum ErrRoute<'a> {
 
 /// C / cbindgen language adapter. Build it with [`Cbindgen::new`], declare the
 /// items to convert with the fluent methods, then drive it through
-/// [`Registry::write_rust`](crate::core::Registry::write_rust).
+/// [`Registry::resolve`](crate::core::Registry::resolve) →
+/// [`Generation::write_rust`](crate::core::Generation::write_rust).
 #[derive(Default)]
 pub struct Cbindgen {
     /// Module path the original `#[prebindgen]` items live under. Used to

--- a/prebindgen/src/api/lang/cbindgen/tests/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/builder.rs
@@ -10,13 +10,13 @@ fn function_name_renames_symbol() {
             unimplemented!()
         }
     );
-    let mut reg =
+    let reg =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
     let cb = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(rust_init))
         .base_name("z_init");
-    let src = write(&cb, &mut reg, "fnname");
+    let src = write(cb, reg, "fnname");
     let compact: String = src.split_whitespace().collect();
     assert!(compact.contains("extern\"C\"fnz_init("), "{src}");
     assert!(compact.contains("zenoh_flat::rust_init("), "{src}");
@@ -81,7 +81,7 @@ fn free_memory_function_required() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -96,7 +96,9 @@ fn free_memory_function_required() {
         .function(syn::parse_quote!(z_describe));
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let _ = registry.write_rust(&cbindgen, std::env::temp_dir().join("nofree.rs"));
+        let _ = registry
+            .resolve(cbindgen)
+            .and_then(|gen| gen.write_rust(std::env::temp_dir().join("nofree.rs")));
     }));
     assert!(
         result.is_err(),
@@ -120,7 +122,7 @@ fn manglers_generate_all_names() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -164,7 +166,7 @@ fn manglers_generate_all_names() {
         .callback(syn::parse_quote!(impl Fn() + Send + Sync + 'static))
         .function(syn::parse_quote!(z_sub));
 
-    let src = write(&cbindgen, &mut registry, "manglers");
+    let src = write(cbindgen, registry, "manglers");
     let compact: String = src.split_whitespace().collect();
 
     // Type-name mangler over the base (note `keyexpr`, not `key_expr`).

--- a/prebindgen/src/api/lang/cbindgen/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/callbacks.rs
@@ -17,7 +17,7 @@ fn takeable_callback_param() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(func), loc.clone()),
     ])
@@ -31,7 +31,7 @@ fn takeable_callback_param() {
         .takeable_param(0)
         .function(syn::parse_quote!(z_declare_sub));
 
-    let src = write(&cbindgen, &mut registry, "takeable");
+    let src = write(cbindgen, registry, "takeable");
     let compact: String = src.split_whitespace().collect();
 
     // Closure `call` receives the sample as an owned pointer.
@@ -77,7 +77,7 @@ fn callback_subscriber_emits_closure_structs() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -101,7 +101,7 @@ fn callback_subscriber_emits_closure_structs() {
         .base_name("z_closure_drop_t")
         .function(syn::parse_quote!(z_sub));
 
-    let src = write(&cbindgen, &mut registry, "cb_sub");
+    let src = write(cbindgen, registry, "cb_sub");
     let compact: String = src.split_whitespace().collect();
 
     // Closure structs: sample carries the owned handle wire; drop is zero-arg.
@@ -173,7 +173,7 @@ fn callback_scalar_arg_not_module_qualified() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -189,7 +189,7 @@ fn callback_scalar_arg_not_module_qualified() {
         .base_name("z_closure_value_t")
         .function(syn::parse_quote!(z_on_value));
 
-    let src = write(&cbindgen, &mut registry, "cb_scalar");
+    let src = write(cbindgen, registry, "cb_scalar");
     let compact: String = src.split_whitespace().collect();
 
     // The bug was `f64` qualified to `zenoh_flat::f64`.
@@ -218,7 +218,7 @@ fn callback_struct_name_defaults_generically() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -240,7 +240,7 @@ fn callback_struct_name_defaults_generically() {
         .callback(syn::parse_quote!(impl Fn(ZSample) + Send + Sync + 'static))
         .function(syn::parse_quote!(z_sub2));
 
-    let src = write(&cbindgen, &mut registry, "cb_default");
+    let src = write(cbindgen, registry, "cb_default");
     let compact: String = src.split_whitespace().collect();
 
     // Composed from the arg's configured C name `z_sample_t`.

--- a/prebindgen/src/api/lang/cbindgen/tests/errors.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/errors.rs
@@ -10,7 +10,7 @@ fn result_error_not_declared_is_build_error() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -27,7 +27,9 @@ fn result_error_not_declared_is_build_error() {
         .function(syn::parse_quote!(z_keyexpr_try_from));
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let _ = registry.write_rust(&cbindgen, std::env::temp_dir().join("nope.rs"));
+        let _ = registry
+            .resolve(cbindgen)
+            .and_then(|gen| gen.write_rust(std::env::temp_dir().join("nope.rs")));
     }));
     assert!(
         result.is_err(),
@@ -47,24 +49,26 @@ fn fallible_input_without_result_needs_panic() {
     );
 
     // No `.panic()` → build error.
-    let mut reg1 = Registry::<()>::from_items([(syn::Item::Fn(func.clone()), loc.clone())])
+    let reg1 = Registry::<()>::from_items([(syn::Item::Fn(func.clone()), loc.clone())])
         .expect("index items");
     let cb1 = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(z_log));
     let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let _ = reg1.write_rust(&cb1, std::env::temp_dir().join("nope2.rs"));
+        let _ = reg1
+            .resolve(cb1)
+            .and_then(|gen| gen.write_rust(std::env::temp_dir().join("nope2.rs")));
     }));
     assert!(err.is_err(), "expected a build error without .panic()");
 
     // With `.panic()` → wrapper aborts on decode failure.
-    let mut reg2 =
+    let reg2 =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
     let cb2 = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(z_log))
         .panic();
-    let src = write(&cb2, &mut reg2, "panicfn");
+    let src = write(cb2, reg2, "panicfn");
     let compact: String = src.split_whitespace().collect();
     assert!(compact.contains("extern\"C\"fnz_log"), "{src}");
     assert!(compact.contains("panic!("), "{src}");
@@ -91,7 +95,7 @@ fn error_out_param_is_null_guarded() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(ptr_fn), loc.clone()),
         (syn::Item::Fn(unit_fn), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
@@ -109,7 +113,7 @@ fn error_out_param_is_null_guarded() {
         .function(syn::parse_quote!(z_keyexpr_try_from))
         .function(syn::parse_quote!(z_unit_op));
 
-    let src = write(&cbindgen, &mut registry, "err_null_guard");
+    let src = write(cbindgen, registry, "err_null_guard");
     let compact: String = src.split_whitespace().collect();
 
     // Pointer-return Err arm: guarded write, then NULL.

--- a/prebindgen/src/api/lang/cbindgen/tests/inputs.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/inputs.rs
@@ -10,7 +10,7 @@ fn slice_u8_input_two_params() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -19,7 +19,7 @@ fn slice_u8_input_two_params() {
         .base_name("z_zbytes")
         .function(syn::parse_quote!(z_zbytes_from_bytes));
 
-    let src = write(&cbindgen, &mut registry, "slice_u8");
+    let src = write(cbindgen, registry, "slice_u8");
     let compact: String = src.split_whitespace().collect();
 
     // Two params: pointer + length.
@@ -46,7 +46,7 @@ fn option_opaque_input_reuses_pointer() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -62,7 +62,7 @@ fn option_opaque_input_reuses_pointer() {
         .error()
         .function(syn::parse_quote!(z_op));
 
-    let src = write(&cbindgen, &mut registry, "option_in_opaque");
+    let src = write(cbindgen, registry, "option_in_opaque");
     let compact: String = src.split_whitespace().collect();
 
     // Param reuses the bare handle pointer; NULL ⇒ None.
@@ -90,14 +90,14 @@ fn option_scalar_input_boxed_pointer() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(z_op));
 
-    let src = write(&cbindgen, &mut registry, "option_in_scalar");
+    let src = write(cbindgen, registry, "option_in_scalar");
     let compact: String = src.split_whitespace().collect();
 
     // Boxed behind a const pointer; NULL ⇒ None, else `Some(*v)`.
@@ -121,7 +121,7 @@ fn str_borrow_input_lowering() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -129,7 +129,7 @@ fn str_borrow_input_lowering() {
         .function(syn::parse_quote!(z_init_logs))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "str_borrow");
+    let src = write(cbindgen, registry, "str_borrow");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("extern\"C\"fnz_init_logs"), "{src}");
@@ -161,7 +161,7 @@ fn relation_to_lowering() {
         }
     );
 
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Enum(enum_item), loc.clone()),
     ])
@@ -176,7 +176,7 @@ fn relation_to_lowering() {
         .function(syn::parse_quote!(z_keyexpr_relation_to))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "relation_to");
+    let src = write(cbindgen, registry, "relation_to");
     let compact: String = src.split_whitespace().collect();
 
     // repr(C) enum mirror with discriminants — renamed via `.base_name()`.
@@ -214,7 +214,7 @@ fn mutable_opaque_borrow_input_lowering() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -230,7 +230,7 @@ fn mutable_opaque_borrow_input_lowering() {
         .error()
         .function(syn::parse_quote!(z_config_insert_json5));
 
-    let src = write(&cbindgen, &mut registry, "mut_opaque_borrow");
+    let src = write(cbindgen, registry, "mut_opaque_borrow");
     let compact: String = src.split_whitespace().collect();
 
     assert!(

--- a/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
@@ -4,8 +4,8 @@ use super::*;
 #[test]
 fn empty_adapter_writes_empty_file() {
     let cbindgen = Cbindgen::new();
-    let mut registry: Registry<()> = Registry::default();
-    let src = write(&cbindgen, &mut registry, "empty");
+    let registry: Registry<()> = Registry::default();
+    let src = write(cbindgen, registry, "empty");
     assert!(src.trim().is_empty(), "expected empty output, got:\n{src}");
 }
 
@@ -21,7 +21,7 @@ fn keyexpr_try_from_lowering() {
         }
     );
 
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -37,7 +37,7 @@ fn keyexpr_try_from_lowering() {
         .error()
         .function(syn::parse_quote!(z_keyexpr_try_from));
 
-    let src = write(&cbindgen, &mut registry, "keyexpr");
+    let src = write(cbindgen, registry, "keyexpr");
     // Whitespace-insensitive haystack (the file is prettyplease-formatted).
     let compact: String = src.split_whitespace().collect();
 
@@ -93,7 +93,7 @@ fn opaque_error_lowering() {
         }
     );
 
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -107,7 +107,7 @@ fn opaque_error_lowering() {
         )
         .function(syn::parse_quote!(z_keyexpr_try_from));
 
-    let src = write(&cbindgen, &mut registry, "opaque_error");
+    let src = write(cbindgen, registry, "opaque_error");
     let compact: String = src.split_whitespace().collect();
 
     // Pointer-return wrapper; the error out-param is a bare `char **e`.

--- a/prebindgen/src/api/lang/cbindgen/tests/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/mod.rs
@@ -9,11 +9,12 @@ mod lowering;
 mod returns;
 mod structs;
 
-fn write(cbindgen: &Cbindgen, registry: &mut Registry<()>, tag: &str) -> String {
+fn write(cbindgen: Cbindgen, registry: Registry<()>, tag: &str) -> String {
     let dir = unique_test_dir(&format!("cbindgen_{tag}"));
     std::fs::create_dir_all(&dir).unwrap();
     let out = dir.join(format!("{tag}.rs"));
-    let path = registry.write_rust(cbindgen, &out).expect("write_rust");
+    let gen = registry.resolve(cbindgen).expect("resolve");
+    let path = gen.write_rust(&out).expect("write_rust");
     std::fs::read_to_string(&path).unwrap()
 }
 

--- a/prebindgen/src/api/lang/cbindgen/tests/returns.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/returns.rs
@@ -10,7 +10,7 @@ fn result_unit_omits_out_param() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -24,7 +24,7 @@ fn result_unit_omits_out_param() {
         .error()
         .function(syn::parse_quote!(z_unit_op));
 
-    let src = write(&cbindgen, &mut registry, "resultunit");
+    let src = write(cbindgen, registry, "resultunit");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("extern\"C\"fnz_unit_op"), "{src}");
@@ -47,7 +47,7 @@ fn result_string_uses_owned_string_wire() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -61,7 +61,7 @@ fn result_string_uses_owned_string_wire() {
         .error()
         .function(syn::parse_quote!(z_config_get_json));
 
-    let src = write(&cbindgen, &mut registry, "result_string");
+    let src = write(cbindgen, registry, "result_string");
     let compact: String = src.split_whitespace().collect();
 
     assert!(!compact.contains("cbg_string_t"), "{src}");
@@ -93,7 +93,7 @@ fn option_string_returns_pointer_null_for_none() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -104,7 +104,7 @@ fn option_string_returns_pointer_null_for_none() {
         .function(syn::parse_quote!(z_encoding_schema))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "option_string");
+    let src = write(cbindgen, registry, "option_string");
     let compact: String = src.split_whitespace().collect();
 
     // Plain-Option wrapper: `char*` return, no out-param, no error param.
@@ -136,7 +136,7 @@ fn result_option_uses_out_param() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -152,7 +152,7 @@ fn result_option_uses_out_param() {
         .error()
         .function(syn::parse_quote!(z_get_opt));
 
-    let src = write(&cbindgen, &mut registry, "result_option");
+    let src = write(cbindgen, registry, "result_option");
     let compact: String = src.split_whitespace().collect();
 
     // Value-wire shape: bool return, pointer-to-pointer out-param, error param.
@@ -183,7 +183,7 @@ fn vec_string_returns_ptr_and_len() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -194,7 +194,7 @@ fn vec_string_returns_ptr_and_len() {
         .function(syn::parse_quote!(z_hello_locators))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "vec_string");
+    let src = write(cbindgen, registry, "vec_string");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("extern\"C\"fnz_hello_locators"), "{src}");
@@ -231,7 +231,7 @@ fn vec_u8_returns_scalar_array() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -242,7 +242,7 @@ fn vec_u8_returns_scalar_array() {
         .function(syn::parse_quote!(z_zbytes_to_bytes))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "vec_u8");
+    let src = write(cbindgen, registry, "vec_u8");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("->*mutu8"), "{src}");
@@ -259,7 +259,7 @@ fn cow_u8_returns_scalar_array() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -270,7 +270,7 @@ fn cow_u8_returns_scalar_array() {
         .function(syn::parse_quote!(z_zbytes_as_bytes))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "cow_u8");
+    let src = write(cbindgen, registry, "cow_u8");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("->*mutu8"), "{src}");
@@ -292,7 +292,7 @@ fn result_vec_uses_out_params() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -308,7 +308,7 @@ fn result_vec_uses_out_params() {
         .error()
         .function(syn::parse_quote!(z_things));
 
-    let src = write(&cbindgen, &mut registry, "result_vec");
+    let src = write(cbindgen, registry, "result_vec");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("->bool"), "{src}");
@@ -333,7 +333,7 @@ fn option_vec_uses_present_and_out() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -346,7 +346,7 @@ fn option_vec_uses_present_and_out() {
         .function(syn::parse_quote!(z_maybe_things))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "option_vec");
+    let src = write(cbindgen, registry, "option_vec");
     let compact: String = src.split_whitespace().collect();
 
     // `bool` return is the `present` flag; the array rides `out`/`out_len`.
@@ -371,7 +371,7 @@ fn result_option_vec_full() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -387,7 +387,7 @@ fn result_option_vec_full() {
         .error()
         .function(syn::parse_quote!(z_full));
 
-    let src = write(&cbindgen, &mut registry, "result_option_vec");
+    let src = write(cbindgen, registry, "result_option_vec");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("->bool"), "{src}");
@@ -412,7 +412,7 @@ fn result_pointer_returns_null_on_error() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
     ])
@@ -428,7 +428,7 @@ fn result_pointer_returns_null_on_error() {
         .error()
         .function(syn::parse_quote!(z_keyexpr_try_from));
 
-    let src = write(&cbindgen, &mut registry, "ptr_null");
+    let src = write(cbindgen, registry, "ptr_null");
     let compact: String = src.split_whitespace().collect();
 
     assert!(compact.contains("->*mutz_keyexpr"), "{src}");
@@ -450,7 +450,7 @@ fn borrowed_ref_output_is_const_non_owning() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -462,7 +462,7 @@ fn borrowed_ref_output_is_const_non_owning() {
         .function(syn::parse_quote!(z_sample_payload))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "borrow_ret");
+    let src = write(cbindgen, registry, "borrow_ret");
     let compact: String = src.split_whitespace().collect();
 
     // Const, non-owning return; the return path goes through the reinterpret
@@ -488,7 +488,7 @@ fn borrowed_option_ref_output_nullable() {
             unimplemented!()
         }
     );
-    let mut registry =
+    let registry =
         Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -500,7 +500,7 @@ fn borrowed_option_ref_output_nullable() {
         .function(syn::parse_quote!(z_sample_timestamp))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "borrow_opt_ret");
+    let src = write(cbindgen, registry, "borrow_opt_ret");
     let compact: String = src.split_whitespace().collect();
 
     // Nullable const loaned pointer rides the return (no out-param needed:

--- a/prebindgen/src/api/lang/cbindgen/tests/structs.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/structs.rs
@@ -22,7 +22,7 @@ fn opaque_owned_transmute_by_value() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(out_fn), loc.clone()),
         (syn::Item::Fn(in_fn), loc.clone()),
@@ -37,7 +37,7 @@ fn opaque_owned_transmute_by_value() {
         .function(syn::parse_quote!(z_payload_take))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "value_opaque");
+    let src = write(cbindgen, registry, "value_opaque");
     let compact: String = src.split_whitespace().collect();
 
     // Fail-closed size + align asserts against the opaque counterpart.
@@ -117,7 +117,7 @@ fn opaque_data_no_gravestone_writeback() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(out_fn), loc.clone()),
         (syn::Item::Fn(in_fn), loc.clone()),
@@ -132,7 +132,7 @@ fn opaque_data_no_gravestone_writeback() {
         .function(syn::parse_quote!(z_stamp_take))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "opaque_data_struct");
+    let src = write(cbindgen, registry, "opaque_data_struct");
     let compact: String = src.split_whitespace().collect();
 
     // Same transmute glue + asserts as an owned type.
@@ -196,7 +196,7 @@ fn repr_c_struct_visible_mirror_and_zero_copy_borrow() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(make_fn), loc.clone()),
         (syn::Item::Fn(put_fn), loc.clone()),
@@ -220,7 +220,7 @@ fn repr_c_struct_visible_mirror_and_zero_copy_borrow() {
         .function(syn::parse_quote!(foo_cb))
         .function(syn::parse_quote!(string_make));
 
-    let src = write(&cbindgen, &mut registry, "repr_c_struct");
+    let src = write(cbindgen, registry, "repr_c_struct");
     let compact: String = src.split_whitespace().collect();
 
     // Visible `#[repr(C)]` mirror: scalar passes through, the `Option<Box<String>>`
@@ -284,7 +284,7 @@ fn repr_c_struct_owned_inferred_field_nulls_without_default() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(put_fn), loc.clone()),
         (syn::Item::Fn(string_fn), loc.clone()),
@@ -302,7 +302,7 @@ fn repr_c_struct_owned_inferred_field_nulls_without_default() {
         .panic()
         .function(syn::parse_quote!(string_make));
 
-    let src = write(&cbindgen, &mut registry, "owned_inferred");
+    let src = write(cbindgen, registry, "owned_inferred");
     let compact: String = src.split_whitespace().collect();
 
     // By-value consume: takes `*mut foo_t`, moves the value out, and nulls only the
@@ -337,7 +337,7 @@ fn repr_c_struct_plain_data_has_no_writeback() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(take_fn), loc.clone()),
     ])
@@ -352,7 +352,7 @@ fn repr_c_struct_plain_data_has_no_writeback() {
         .function(syn::parse_quote!(pt_sum))
         .panic();
 
-    let src = write(&cbindgen, &mut registry, "plain_data");
+    let src = write(cbindgen, registry, "plain_data");
     let compact: String = src.split_whitespace().collect();
 
     // The consume moves the value out with no clean-up of the moved-from slot.
@@ -385,7 +385,7 @@ fn repr_c_struct_bare_box_field_keeps_full_gravestone() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(put_fn), loc.clone()),
         (syn::Item::Fn(string_fn), loc.clone()),
@@ -403,7 +403,7 @@ fn repr_c_struct_bare_box_field_keeps_full_gravestone() {
         .panic()
         .function(syn::parse_quote!(string_make));
 
-    let src = write(&cbindgen, &mut registry, "bare_box");
+    let src = write(cbindgen, registry, "bare_box");
     let compact: String = src.split_whitespace().collect();
 
     // A bare `Box<String>` field falls back to the full gravestone write + impl.
@@ -450,7 +450,7 @@ fn repr_c_struct_mut_ref_and_maybe_uninit_out_param() {
             unimplemented!()
         }
     );
-    let mut registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(upd_fn), loc.clone()),
         (syn::Item::Fn(into_fn), loc.clone()),
@@ -471,7 +471,7 @@ fn repr_c_struct_mut_ref_and_maybe_uninit_out_param() {
         .panic()
         .function(syn::parse_quote!(string_make));
 
-    let src = write(&cbindgen, &mut registry, "repr_c_struct_mut");
+    let src = write(cbindgen, registry, "repr_c_struct_mut");
     let compact: String = src.split_whitespace().collect();
 
     // Both lower to a `*mut foo_t` wire.

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -503,14 +503,36 @@ impl JniGen {
             .map(|m| m.kotlin_name.clone())
     }
 
+    /// Whether `key` was declared as a class in some package (any of the four
+    /// class kinds). A boundary decl on a type without a class declaration
+    /// makes it **rust-side-only**: the value is always built from
+    /// ingredients / decomposed into fields at the boundary and never
+    /// materializes in Kotlin — so the `_self` arms are structurally
+    /// impossible for it.
+    fn is_class_declared(&self, key: &TypeKey) -> bool {
+        self.types.get(key).is_some_and(|c| c.class_decl)
+    }
+
     /// Assemble the full [`Expansions`] set at the point of use: the eagerly
     /// accumulated per-fn overrides plus the raw type-level
     /// [`ParamExpandDecl`]s. Building on demand keeps declarations
     /// order-independent — a `param_expand` may precede or follow the
-    /// `package` that declares its constructors.
+    /// `package` that declares its constructors (which is also why the
+    /// rust-side-only `_self` check lives here and not at accept time).
     pub(crate) fn build_expansions(&self) -> crate::api::core::expand::Expansions {
         let mut exp = self.expansions.clone();
         for decl in &self.param_expand_decls {
+            assert!(
+                self.is_class_declared(&decl.key)
+                    || !decl
+                        .variants
+                        .iter()
+                        .any(|v| matches!(v, LocalVariant::SelfIdentity)),
+                "param_expand!({k}).variant_self(): `{k}` has no class declaration, so there is \
+                 no Kotlin object to pass — drop .variant_self() (the type is rust-side-only) \
+                 or declare the type in a package",
+                k = decl.key.as_str()
+            );
             // Identity-only normalization: `.variant_self()` alone declares
             // the plain-handle form — exactly the default when nothing is
             // declared, so registering it would only add a degenerate
@@ -538,6 +560,17 @@ impl JniGen {
     pub(crate) fn build_deconstructors(&self) -> crate::api::core::unfold::Deconstructors {
         let mut dec = self.deconstructors.clone();
         for decl in &self.return_expand_decls {
+            assert!(
+                self.is_class_declared(&decl.key)
+                    || !decl
+                        .fields
+                        .iter()
+                        .any(|f| matches!(f, LocalField::SelfField)),
+                "return_expand!({k}).field_self(): `{k}` has no class declaration, so there is \
+                 no Kotlin object to deliver — drop .field_self() (the type is rust-side-only) \
+                 or declare the type in a package",
+                k = decl.key.as_str()
+            );
             dec.ensure_default_deconstructor(decl.key.to_type());
             for f in &decl.fields {
                 match f {
@@ -553,6 +586,42 @@ impl JniGen {
             }
         }
         dec
+    }
+
+    /// Type keys of boundary decls (`param_expand!` / `return_expand!`) whose
+    /// type has no class declaration — the **rust-side-only** types. Unioned
+    /// into [`Prebindgen::ignored_types`] so the registry treats them as
+    /// acknowledged (no "skipping undeclared" warning, no direct converter
+    /// requirement, no Kotlin emission).
+    pub(crate) fn rust_side_only_types(&self) -> impl Iterator<Item = TypeKey> + '_ {
+        self.param_expand_decls
+            .iter()
+            .map(|d| &d.key)
+            .chain(self.return_expand_decls.iter().map(|d| &d.key))
+            .filter(|k| !self.is_class_declared(k))
+            .cloned()
+    }
+
+    /// Function idents referenced only inside boundary decls — `return_expand!`
+    /// field accessors and `param_expand!` variant ctors. They are called
+    /// Rust-side by the generated fold/unfold code and need no extern of
+    /// their own; when not otherwise declared they are unioned into
+    /// [`Prebindgen::ignored_functions`] so the registry's "skipping
+    /// undeclared fn" warning stays quiet.
+    pub(crate) fn boundary_referenced_fns(&self) -> impl Iterator<Item = syn::Ident> + '_ {
+        let ctors = self.param_expand_decls.iter().flat_map(|d| {
+            d.variants.iter().filter_map(|v| match v {
+                LocalVariant::Ctor(f) => Some(f.clone()),
+                LocalVariant::SelfIdentity => None,
+            })
+        });
+        let accessors = self.return_expand_decls.iter().flat_map(|d| {
+            d.fields.iter().filter_map(|f| match f {
+                LocalField::Named(func, _) => Some(func.clone()),
+                LocalField::SelfField => None,
+            })
+        });
+        ctors.chain(accessors)
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -13,7 +13,7 @@ impl JniGen {
     /// qualified with: the fn's **origin crate** as recorded from its
     /// stream's `SourceLocation` stamp (multi-source bindings — helper
     /// crates layered on the flat crate), else the registry's default
-    /// module ([`crate::core::Registry::set_default_module`]).
+    /// module (first-seen stream origin), else `crate`.
     pub(crate) fn fn_module(
         &self,
         registry: &Registry<KotlinMeta>,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -2,8 +2,7 @@
 //!
 //! [`JniGen::new`] starts from defaults; global settings are applied with
 //! the `set_*` methods (`config.rs`) and declarations are *accepted* as
-//! pre-built objects (`decl.rs`) via [`JniGen::package`],
-//! [`JniGen::param_expand`], [`JniGen::return_expand`],
+//! pre-built objects (`decl.rs`) via [`JniGen::package`], [`JniGen::expand`],
 //! [`JniGen::scalar_type_wrapper`], and [`JniGen::generic_type_wrapper`] —
 //! there is no fluent typestate cursor. Carved from the former monolithic
 //! JNI module; shares the `jni` namespace via `use super::*`.
@@ -458,37 +457,41 @@ impl JniGen {
 // ── Accepting boundary decls ─────────────────────────────────────────────
 
 impl JniGen {
-    /// Declare a type's **default input boundary** (a [`ParamExpandDecl`],
-    /// built with [`param_expand!`](crate::param_expand)): how a parameter of
-    /// that type may be supplied, as an OR-list of build variants. Applies to
-    /// every function with a parameter of the type, in any package; a single
-    /// function overrides via [`FunctionDecl::param_expand`] /
-    /// [`FunctionDecl::param_expand_self`].
-    pub fn param_expand(mut self, decl: ParamExpandDecl) -> Self {
-        assert!(
-            !decl.variants.is_empty(),
-            "param_expand!({}) declares no variants — add .variant(fun!(...)) and/or \
-             .variant_self()",
-            decl.key.as_str()
-        );
-        self.param_expand_decls.push(decl);
-        self
-    }
-
-    /// Declare a type's **default output boundary** (a [`ReturnExpandDecl`],
-    /// built with [`return_expand!`](crate::return_expand)): the AND-set of
-    /// fields a returned / callback-delivered value of that type decomposes
-    /// into. Applies to every function returning the type, in any package; a
-    /// single function overrides via [`FunctionDecl::return_expand`] /
-    /// [`FunctionDecl::return_expand_self`].
-    pub fn return_expand(mut self, decl: ReturnExpandDecl) -> Self {
-        assert!(
-            !decl.fields.is_empty(),
-            "return_expand!({}) declares no fields — add .field(fun!(...)) and/or \
-             .field_self()",
-            decl.key.as_str()
-        );
-        self.return_expand_decls.push(decl);
+    /// Declare a type's **default boundary behavior** — either of the two
+    /// [`ExpandDecl`] directions, the direction carried by the decl object
+    /// (the boundary-decl peer of [`PackageDecl::class`]):
+    ///
+    /// * [`param_expand!`](crate::param_expand) — the input side: how a
+    ///   parameter of the type may be supplied, as an OR-list of build
+    ///   variants.
+    /// * [`return_expand!`](crate::return_expand) — the output side: the
+    ///   AND-set of fields a returned / callback-delivered / `Result`-error
+    ///   value of the type decomposes into.
+    ///
+    /// Applies to every function mentioning the type, in any package; a
+    /// single function overrides via the [`FunctionDecl`] `param_expand*` /
+    /// `return_expand*` methods.
+    pub fn expand(mut self, decl: impl Into<ExpandDecl>) -> Self {
+        match decl.into() {
+            ExpandDecl::Param(decl) => {
+                assert!(
+                    !decl.variants.is_empty(),
+                    "param_expand!({}) declares no variants — add .variant(fun!(...)) and/or \
+                     .variant_self()",
+                    decl.key.as_str()
+                );
+                self.param_expand_decls.push(decl);
+            }
+            ExpandDecl::Return(decl) => {
+                assert!(
+                    !decl.fields.is_empty(),
+                    "return_expand!({}) declares no fields — add .field(fun!(...)) and/or \
+                     .field_self()",
+                    decl.key.as_str()
+                );
+                self.return_expand_decls.push(decl);
+            }
+        }
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -204,8 +204,6 @@ impl JniGen {
             classes,
             functions,
             constants,
-            constant_functions,
-            constant_exprs,
         } = decl;
         self.packages.entry(name.clone()).or_default();
         for class in classes {
@@ -214,30 +212,30 @@ impl JniGen {
         for func in functions {
             self.accept_function(&name, func);
         }
+        // One acceptor, dispatched on the decl's value source. The `.with`
+        // source was already lowered to an expression (`path()`) at decl
+        // time, so only three storage kinds exist internally.
         for c in constants {
-            let mut entry = MethodEntry::new(c.rust_ident);
-            entry.kotlin_name_override = c.kotlin_name_override;
-            self.packages
-                .entry(name.clone())
-                .or_default()
-                .constants
-                .push(entry);
-        }
-        for f in constant_functions {
-            let mut entry = MethodEntry::new(f.rust_ident);
-            entry.kotlin_name_override = f.kotlin_name_override;
-            self.packages
-                .entry(name.clone())
-                .or_default()
-                .constant_functions
-                .push(entry);
-        }
-        for e in constant_exprs {
-            self.packages
-                .entry(name.clone())
-                .or_default()
-                .constant_exprs
-                .push(e);
+            let pkg = self.packages.entry(name.clone()).or_default();
+            match c.source {
+                super::decl::ConstSource::Item => {
+                    let mut entry = MethodEntry::new(c.rust_ident);
+                    entry.kotlin_name_override = c.kotlin_name_override;
+                    pkg.constants.push(entry);
+                }
+                super::decl::ConstSource::Fun(ref fn_ident) => {
+                    let mut entry = MethodEntry::new(fn_ident.clone());
+                    entry.kotlin_name_override = Some(c.val_name());
+                    pkg.constant_functions.push(entry);
+                }
+                super::decl::ConstSource::Expr { ref ty, ref expr } => {
+                    pkg.constant_exprs.push(super::decl::ConstExprDecl {
+                        kotlin_name: c.val_name(),
+                        ty: ty.clone(),
+                        expr: expr.clone(),
+                    });
+                }
+            }
         }
         self
     }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -743,40 +743,69 @@ impl JniGen {
         registry: &Registry<KotlinMeta>,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
-        let f = decl.input.as_ref()?;
-        let (item_fn, _) = registry.functions.get(f).unwrap_or_else(|| {
-            panic!(
-                "convert!({}).input({f}): function not found among #[prebindgen] items",
-                key.as_str()
-            )
-        });
-        let (param_ty, by_ref) = convert_single_param(key, f, item_fn, "input");
-        // Return: `T` (infallible) or `Result<T, E>` (fallible — E routes to
-        // the caller's error handler through the standard exc slot).
-        let ret = fn_return_type(item_fn);
-        let (ok_ty, exc) = match crate::api::core::types_util::result_ok_type(&ret) {
-            Some(ok) => (
-                ok,
-                Some(
-                    crate::api::core::types_util::result_err_type(&ret)
-                        .expect("result_ok_type implies result_err_type"),
-                ),
-            ),
-            None => (ret, None),
-        };
-        assert!(
-            TypeKey::from_type(&ok_ty) == *key,
-            "convert!({k}).input({f}): the function produces `{got}`, not `{k}`",
-            k = key.as_str(),
-            got = TypeKey::from_type(&ok_ty).as_str()
-        );
-        let module = self.fn_module(registry, f);
-        let body: syn::Expr = if by_ref {
-            syn::parse_quote!(#module::#f(&v))
-        } else {
-            syn::parse_quote!(#module::#f(v))
-        };
-        Some((param_ty, exc, body))
+        let target = key.to_type();
+        match decl.input.as_ref()? {
+            ConvertSpec::PrebindgenFn(f) => {
+                let (item_fn, _) = registry.functions.get(f).unwrap_or_else(|| {
+                    panic!(
+                        "convert!({}).input({f}): function not found among #[prebindgen] items",
+                        key.as_str()
+                    )
+                });
+                let (param_ty, by_ref) = convert_single_param(key, f, item_fn, "input");
+                // Return: `T` (infallible) or `Result<T, E>` (fallible — E
+                // routes to the caller's error handler via the exc slot).
+                let ret = fn_return_type(item_fn);
+                let (ok_ty, exc) = match crate::api::core::types_util::result_ok_type(&ret) {
+                    Some(ok) => (
+                        ok,
+                        Some(
+                            crate::api::core::types_util::result_err_type(&ret)
+                                .expect("result_ok_type implies result_err_type"),
+                        ),
+                    ),
+                    None => (ret, None),
+                };
+                assert!(
+                    TypeKey::from_type(&ok_ty) == *key,
+                    "convert!({k}).input({f}): the function produces `{got}`, not `{k}`",
+                    k = key.as_str(),
+                    got = TypeKey::from_type(&ok_ty).as_str()
+                );
+                let module = self.fn_module(registry, f);
+                let body: syn::Expr = if by_ref {
+                    syn::parse_quote!(#module::#f(&v))
+                } else {
+                    syn::parse_quote!(#module::#f(v))
+                };
+                Some((param_ty, exc, body))
+            }
+            // `Into`/`TryInto` impls: the repr is stated in the decl; the
+            // fully-qualified call form pins both type parameters so the
+            // right impl is selected regardless of what else is in scope.
+            ConvertSpec::Trait { repr, fallible } => {
+                if *fallible {
+                    let exc: syn::Type = syn::parse_quote!(
+                        <#repr as ::core::convert::TryInto<#target>>::Error
+                    );
+                    let body: syn::Expr = syn::parse_quote!(
+                        <#repr as ::core::convert::TryInto<#target>>::try_into(v)
+                    );
+                    Some((repr.clone(), Some(exc), body))
+                } else {
+                    let body: syn::Expr = syn::parse_quote!(
+                        <#repr as ::core::convert::Into<#target>>::into(v)
+                    );
+                    Some((repr.clone(), None, body))
+                }
+            }
+            // Binding-local callable: emitted verbatim (multi-segment paths
+            // pass the qualification visitor untouched).
+            ConvertSpec::LocalFn { repr, path } => {
+                let body: syn::Expr = syn::parse_quote!(#path(v));
+                Some((repr.clone(), None, body))
+            }
+        }
     }
 
     /// Output-direction peer of [`Self::convert_input_body`]: the conversion
@@ -787,42 +816,71 @@ impl JniGen {
         registry: &Registry<KotlinMeta>,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
-        let g = decl.output.as_ref()?;
-        let (item_fn, _) = registry.functions.get(g).unwrap_or_else(|| {
-            panic!(
-                "convert!({}).output({g}): function not found among #[prebindgen] items",
-                key.as_str()
-            )
-        });
-        let (param_ty, by_ref) = convert_single_param_any(g, item_fn);
-        assert!(
-            TypeKey::from_type(&param_ty) == *key,
-            "convert!({k}).output({g}): the function takes `{got}`, not `{k}`",
-            k = key.as_str(),
-            got = TypeKey::from_type(&param_ty).as_str()
-        );
-        let ret = fn_return_type(item_fn);
-        assert!(
-            TypeKey::from_type(&ret) != *key,
-            "convert!({k}).output({g}): the function must return the converted form, not `{k}`",
-            k = key.as_str()
-        );
-        let module = self.fn_module(registry, g);
-        let body: syn::Expr = if by_ref {
-            syn::parse_quote!(#module::#g(&v))
-        } else {
-            syn::parse_quote!(#module::#g(v))
-        };
-        Some((ret, None, body))
+        let target = key.to_type();
+        match decl.output.as_ref()? {
+            ConvertSpec::PrebindgenFn(g) => {
+                let (item_fn, _) = registry.functions.get(g).unwrap_or_else(|| {
+                    panic!(
+                        "convert!({}).output({g}): function not found among #[prebindgen] items",
+                        key.as_str()
+                    )
+                });
+                let (param_ty, by_ref) = convert_single_param_any(g, item_fn);
+                assert!(
+                    TypeKey::from_type(&param_ty) == *key,
+                    "convert!({k}).output({g}): the function takes `{got}`, not `{k}`",
+                    k = key.as_str(),
+                    got = TypeKey::from_type(&param_ty).as_str()
+                );
+                let ret = fn_return_type(item_fn);
+                assert!(
+                    TypeKey::from_type(&ret) != *key,
+                    "convert!({k}).output({g}): the function must return the converted form, \
+                     not `{k}`",
+                    k = key.as_str()
+                );
+                let module = self.fn_module(registry, g);
+                let body: syn::Expr = if by_ref {
+                    syn::parse_quote!(#module::#g(&v))
+                } else {
+                    syn::parse_quote!(#module::#g(v))
+                };
+                Some((ret, None, body))
+            }
+            ConvertSpec::Trait { repr, fallible } => {
+                if *fallible {
+                    let exc: syn::Type = syn::parse_quote!(
+                        <#target as ::core::convert::TryInto<#repr>>::Error
+                    );
+                    let body: syn::Expr = syn::parse_quote!(
+                        <#target as ::core::convert::TryInto<#repr>>::try_into(v)
+                    );
+                    Some((repr.clone(), Some(exc), body))
+                } else {
+                    let body: syn::Expr = syn::parse_quote!(
+                        <#target as ::core::convert::Into<#repr>>::into(v)
+                    );
+                    Some((repr.clone(), None, body))
+                }
+            }
+            ConvertSpec::LocalFn { repr, path } => {
+                let body: syn::Expr = syn::parse_quote!(#path(v));
+                Some((repr.clone(), None, body))
+            }
+        }
     }
 
-    /// Idents of every `convert!` conversion function — scanned as helper
-    /// functions ([`Prebindgen::helper_functions`]) so their signature types
-    /// resolve without emitting externs for them.
+    /// Idents of every `#[prebindgen]`-fn conversion source — scanned as
+    /// helper functions ([`Prebindgen::helper_functions`]) so their extern
+    /// emission is suppressed. Trait/local-fn sources have no registry item.
     pub(crate) fn convert_fns(&self) -> impl Iterator<Item = syn::Ident> + '_ {
         self.convert_decls
             .iter()
-            .flat_map(|d| d.input.iter().chain(d.output.iter()).cloned())
+            .flat_map(|d| d.input.iter().chain(d.output.iter()))
+            .filter_map(|spec| match spec {
+                ConvertSpec::PrebindgenFn(f) => Some(f.clone()),
+                _ => None,
+            })
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -91,7 +91,7 @@ impl JniGen {
             fn_return_expands: Vec::new(),
             class_members: HashMap::new(),
             ignored_fns: std::collections::HashSet::new(),
-            ignored_fn_predicates: Vec::new(),
+            ignored_name_predicates: Vec::new(),
             ignored_class_types: std::collections::HashSet::new(),
             ignored_const_idents: std::collections::HashSet::new(),
         };
@@ -241,43 +241,28 @@ impl JniGen {
         self
     }
 
-    /// Acknowledge a `#[prebindgen]` function this binding deliberately does
-    /// NOT wrap: nothing is emitted for it and the registry's per-item
-    /// "skipping undeclared" warning is suppressed. Global — an ignored fn
-    /// belongs to no package. E.g. `.ignore_fun(fun!(string_len))`.
-    pub fn ignore_fun(mut self, decl: FunctionDecl) -> Self {
-        self.ignored_fns.insert(decl.rust_ident);
-        self
-    }
-
-    /// Bulk form of [`Self::ignore_fun`]: acknowledge every `#[prebindgen]`
-    /// function whose name matches the predicate — e.g.
-    /// `.ignore_funs_where(|n| n.starts_with("encoding_const_"))` instead of
-    /// one `ignore_fun` line per member of a naming family. A *declared*
-    /// function matching the predicate is unaffected (declaration wins), and
-    /// unlike an exact-name ignore, a predicate matching nothing is silent —
-    /// it is a filter, not a claim about a specific item.
-    pub fn ignore_funs_where<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> bool + Send + Sync + 'static,
-    {
-        self.ignored_fn_predicates.push(Arc::new(f));
-        self
-    }
-
-    /// Acknowledge a `#[prebindgen]` type this binding deliberately does NOT
-    /// declare as a class — the type-level dual of [`Self::ignore_fun`].
-    pub fn ignore_class(mut self, rust_type: syn::Type) -> Self {
-        self.ignored_class_types
-            .insert(TypeKey::from_type(&rust_type));
-        self
-    }
-
-    /// Acknowledge a `#[prebindgen]` const this binding deliberately does
-    /// NOT expose — the const-level dual of [`Self::ignore_fun`]. E.g.
-    /// `.ignore_const(constant!(INTERNAL_MAGIC))`.
-    pub fn ignore_const(mut self, decl: ConstDecl) -> Self {
-        self.ignored_const_idents.insert(decl.rust_ident);
+    /// Acknowledge a `#[prebindgen]` item this binding deliberately does
+    /// NOT bind: nothing is emitted for it and the registry's per-item
+    /// "skipping undeclared" warning is suppressed. Global — an ignored
+    /// item belongs to no package. One acceptor, the kind carried by the
+    /// decl (see [`IgnoreDecl`]): `fun!` / `ty!` / `constant!` for exact
+    /// items, [`matching`](crate::lang::matching) for a name-family
+    /// predicate over ANY item kind.
+    pub fn ignore(mut self, decl: impl Into<IgnoreDecl>) -> Self {
+        match decl.into().0 {
+            super::decl::IgnoreKind::Fun(ident) => {
+                self.ignored_fns.insert(ident);
+            }
+            super::decl::IgnoreKind::Type(key) => {
+                self.ignored_class_types.insert(key);
+            }
+            super::decl::IgnoreKind::Const(ident) => {
+                self.ignored_const_idents.insert(ident);
+            }
+            super::decl::IgnoreKind::Matching(pred) => {
+                self.ignored_name_predicates.push(pred);
+            }
+        }
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -10,9 +10,9 @@ use super::*;
 
 impl JniGen {
     /// The module path a generated call to `#[prebindgen]` fn `ident` must be
-    /// qualified with: the fn's **origin crate** when the registry was built
-    /// from [`crate::core::Registry::from_sources`] (multi-source bindings —
-    /// helper crates layered on the flat crate), else the registry's default
+    /// qualified with: the fn's **origin crate** as recorded from its
+    /// stream's `SourceLocation` stamp (multi-source bindings — helper
+    /// crates layered on the flat crate), else the registry's default
     /// module ([`crate::core::Registry::set_default_module`]).
     pub(crate) fn fn_module(
         &self,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -330,15 +330,19 @@ impl JniGen {
              a type can be one or the other, not both",
             short
         );
-        self.register_class_name(
-            &key,
-            NameSpec::Class {
+        // An explicit `kotlin_type` maps the enum onto an existing Kotlin
+        // type (verbatim FQN, no file generated); the jint wire and the
+        // `fromInt`/`.value` call protocol are identical either way.
+        let spec = match decl.kotlin_type {
+            Some(expr) => NameSpec::Verbatim(expr),
+            None => NameSpec::Class {
                 subpackage: subpackage.to_string(),
                 short,
                 name_override: decl.name_override,
                 kind: NameKind::Enum,
             },
-        );
+        };
+        self.register_class_name(&key, spec);
         self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
@@ -368,14 +372,25 @@ impl JniGen {
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
+        assert!(
+            decl.kotlin_type.is_none() || decl.members.is_empty(),
+            "data_class `{short}`: .kotlin_type() maps onto an EXISTING type — there is no \
+             generated class to hold members"
+        );
         let spec =
             Self::data_value_name_spec(subpackage, short, decl.name_override, decl.kotlin_type);
         self.register_class_name(&key, spec);
+        self.accept_members(&key, decl.members);
     }
 
     fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
+        assert!(
+            decl.kotlin_type.is_none() || decl.members.is_empty(),
+            "value_class `{short}`: .kotlin_type() maps onto an EXISTING type — there is no \
+             generated class to hold members"
+        );
         let spec =
             Self::data_value_name_spec(subpackage, short, decl.name_override, decl.kotlin_type);
         self.register_class_name(&key, spec);
@@ -386,11 +401,11 @@ impl JniGen {
         self.accept_members(&key, decl.members);
     }
 
-    /// Shared tail of `accept_ptr_class`/`accept_value_class` (the two class
-    /// kinds whose members are emitted): each member's per-fn expand
-    /// overrides apply exactly as a free function's would; a constructor
-    /// member's return is additionally never output-flattened (it's a
-    /// factory); then the members join the class's registered set.
+    /// Shared tail of the member-bearing class kinds (`ptr` / `value` /
+    /// `data` — every kind whose instance can re-enter Rust): each member's
+    /// per-fn expand overrides apply exactly as a free function's would; a
+    /// constructor member's return is additionally never output-flattened
+    /// (it's a factory); then the members join the class's registered set.
     fn accept_members(&mut self, key: &TypeKey, members: Vec<(FunctionDecl, MemberKind)>) {
         for (decl, kind) in members {
             let rust_ident = decl.rust_ident.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -90,6 +90,7 @@ impl JniGen {
             fn_return_expands: Vec::new(),
             class_members: HashMap::new(),
             ignored_fns: std::collections::HashSet::new(),
+            ignored_fn_predicates: Vec::new(),
             ignored_class_types: std::collections::HashSet::new(),
             ignored_const_idents: std::collections::HashSet::new(),
         };
@@ -247,6 +248,21 @@ impl JniGen {
     /// belongs to no package. E.g. `.ignore_fun(fun!(string_len))`.
     pub fn ignore_fun(mut self, decl: FunctionDecl) -> Self {
         self.ignored_fns.insert(decl.rust_ident);
+        self
+    }
+
+    /// Bulk form of [`Self::ignore_fun`]: acknowledge every `#[prebindgen]`
+    /// function whose name matches the predicate — e.g.
+    /// `.ignore_funs_where(|n| n.starts_with("encoding_const_"))` instead of
+    /// one `ignore_fun` line per member of a naming family. A *declared*
+    /// function matching the predicate is unaffected (declaration wins), and
+    /// unlike an exact-name ignore, a predicate matching nothing is silent —
+    /// it is a filter, not a claim about a specific item.
+    pub fn ignore_funs_where<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> bool + Send + Sync + 'static,
+    {
+        self.ignored_fn_predicates.push(Arc::new(f));
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -12,16 +12,26 @@ impl JniGen {
     /// The module path a generated call to `#[prebindgen]` fn `ident` must be
     /// qualified with: the fn's **origin crate** when the registry was built
     /// from [`crate::core::Registry::from_sources`] (multi-source bindings —
-    /// helper crates layered on the flat crate), else the configured
-    /// [`Self::set_source_module`] default.
+    /// helper crates layered on the flat crate), else the registry's default
+    /// module ([`crate::core::Registry::set_default_module`]).
     pub(crate) fn fn_module(
         &self,
         registry: &Registry<KotlinMeta>,
         ident: &syn::Ident,
     ) -> syn::Path {
         registry
-            .fn_origin_module(ident)
-            .unwrap_or_else(|| self.source_module.clone())
+            .origin_module(ident)
+            .or_else(|| registry.default_module())
+            .unwrap_or_else(|| syn::parse_quote!(crate))
+    }
+
+    /// The module for source references with no per-item origin (declared
+    /// types with no `#[prebindgen]` item, glob imports): the registry's
+    /// default module (first source), `crate` for an origin-less registry.
+    pub(crate) fn default_module(&self, registry: &Registry<KotlinMeta>) -> syn::Path {
+        registry
+            .default_module()
+            .unwrap_or_else(|| syn::parse_quote!(crate))
     }
 
     /// Whether `ty` was registered via an `EnumClassDecl` — used by the
@@ -38,8 +48,8 @@ impl JniGen {
 }
 
 impl JniGen {
-    /// Start a binding generator with default settings: `source_module =
-    /// crate`, empty base package, no `JNINative` init block, identity
+    /// Start a binding generator with default settings: empty base
+    /// package, no `JNINative` init block, identity
     /// name-mangling, handle locks enabled. Adjust settings with the `set_*`
     /// methods, add declarations with [`package`](Self::package),
     /// [`expand`](Self::expand), [`convert`](Self::convert), etc., then run the
@@ -49,7 +59,6 @@ impl JniGen {
     /// point of use.
     pub fn new() -> Self {
         let mut jni = Self {
-            source_module: syn::parse_str("crate").unwrap(),
             package: String::new(),
             fun_name_mangle: None,
             ptr_class_name_mangle: None,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -3,6 +3,7 @@
 //! [`JniGen::new`] starts from defaults; global settings are applied with
 //! the `set_*` methods (`config.rs`) and declarations are *accepted* as
 //! pre-built objects (`decl.rs`) via [`JniGen::package`],
+//! [`JniGen::param_expand`], [`JniGen::return_expand`],
 //! [`JniGen::scalar_type_wrapper`], and [`JniGen::generic_type_wrapper`] —
 //! there is no fluent typestate cursor. Carved from the former monolithic
 //! JNI module; shares the `jni` namespace via `use super::*`.
@@ -60,6 +61,8 @@ impl JniGen {
             jni_native_init: None,
             expansions: crate::api::core::expand::Expansions::default(),
             deconstructors: crate::api::core::unfold::Deconstructors::default(),
+            param_expand_decls: Vec::new(),
+            return_expand_decls: Vec::new(),
             class_members: HashMap::new(),
             ignored_fns: std::collections::HashSet::new(),
             ignored_class_types: std::collections::HashSet::new(),
@@ -291,35 +294,6 @@ impl JniGen {
             .expect("register_class_name created the entry")
             .opaque = Some(OpaqueConfig::default());
         self.accept_members(&key, decl.members);
-
-        if let Some(variants) = decl.input_variants {
-            // Identity-only normalization: `.default_param_expand_self()`
-            // alone declares the plain-handle form — exactly the default
-            // when nothing is declared, so registering it would only add a
-            // degenerate 1-variant selector to every param of this type.
-            if !matches!(variants.as_slice(), [LocalVariant::SelfIdentity]) {
-                self.expansions.ensure_default_constructor(key.to_type());
-                for v in variants {
-                    match v {
-                        LocalVariant::Ctor(f) => self.expansions.add_constructor_variant(f),
-                        LocalVariant::SelfIdentity => self.expansions.add_constructor_variant_id(),
-                    }
-                }
-            }
-        }
-        if let Some(fields) = decl.output_fields {
-            self.deconstructors
-                .ensure_default_deconstructor(key.to_type());
-            for f in fields {
-                match f {
-                    LocalField::Named(func, name) => {
-                        self.accessor_record_fns.insert(func.clone());
-                        self.deconstructors.add_deconstructor_record(func, name)
-                    }
-                    LocalField::SelfField => self.deconstructors.add_deconstructor_record_id(),
-                }
-            }
-        }
     }
 
     fn accept_enum_class(&mut self, subpackage: &str, decl: EnumClassDecl) {
@@ -471,12 +445,114 @@ impl JniGen {
                 match f {
                     LocalField::Named(func, name) => {
                         self.accessor_record_fns.insert(func.clone());
+                        let name = name.unwrap_or_else(|| snake_to_camel(&func.to_string()));
                         self.deconstructors.push_inline_field(func, name)
                     }
                     LocalField::SelfField => self.deconstructors.push_inline_field_self(),
                 }
             }
         }
+    }
+}
+
+// ── Accepting boundary decls ─────────────────────────────────────────────
+
+impl JniGen {
+    /// Declare a type's **default input boundary** (a [`ParamExpandDecl`],
+    /// built with [`param_expand!`](crate::param_expand)): how a parameter of
+    /// that type may be supplied, as an OR-list of build variants. Applies to
+    /// every function with a parameter of the type, in any package; a single
+    /// function overrides via [`FunctionDecl::param_expand`] /
+    /// [`FunctionDecl::param_expand_self`].
+    pub fn param_expand(mut self, decl: ParamExpandDecl) -> Self {
+        assert!(
+            !decl.variants.is_empty(),
+            "param_expand!({}) declares no variants — add .variant(fun!(...)) and/or \
+             .variant_self()",
+            decl.key.as_str()
+        );
+        self.param_expand_decls.push(decl);
+        self
+    }
+
+    /// Declare a type's **default output boundary** (a [`ReturnExpandDecl`],
+    /// built with [`return_expand!`](crate::return_expand)): the AND-set of
+    /// fields a returned / callback-delivered value of that type decomposes
+    /// into. Applies to every function returning the type, in any package; a
+    /// single function overrides via [`FunctionDecl::return_expand`] /
+    /// [`FunctionDecl::return_expand_self`].
+    pub fn return_expand(mut self, decl: ReturnExpandDecl) -> Self {
+        assert!(
+            !decl.fields.is_empty(),
+            "return_expand!({}) declares no fields — add .field(fun!(...)) and/or \
+             .field_self()",
+            decl.key.as_str()
+        );
+        self.return_expand_decls.push(decl);
+        self
+    }
+
+    /// The Kotlin name of `func` as a declared member (`.fun`/`.constructor`)
+    /// of the class keyed by `key`, if it is one — the name-inheritance
+    /// source for [`ReturnExpandDecl::field`].
+    fn member_kotlin_name(&self, key: &TypeKey, func: &syn::Ident) -> Option<String> {
+        self.class_members
+            .get(key)?
+            .iter()
+            .find(|m| &m.rust_ident == func)
+            .map(|m| m.kotlin_name.clone())
+    }
+
+    /// Assemble the full [`Expansions`] set at the point of use: the eagerly
+    /// accumulated per-fn overrides plus the raw type-level
+    /// [`ParamExpandDecl`]s. Building on demand keeps declarations
+    /// order-independent — a `param_expand` may precede or follow the
+    /// `package` that declares its constructors.
+    pub(crate) fn build_expansions(&self) -> crate::api::core::expand::Expansions {
+        let mut exp = self.expansions.clone();
+        for decl in &self.param_expand_decls {
+            // Identity-only normalization: `.variant_self()` alone declares
+            // the plain-handle form — exactly the default when nothing is
+            // declared, so registering it would only add a degenerate
+            // 1-variant selector to every param of this type.
+            if matches!(decl.variants.as_slice(), [LocalVariant::SelfIdentity]) {
+                continue;
+            }
+            exp.ensure_default_constructor(decl.key.to_type());
+            for v in &decl.variants {
+                match v {
+                    LocalVariant::Ctor(f) => exp.add_constructor_variant(f.clone()),
+                    LocalVariant::SelfIdentity => exp.add_constructor_variant_id(),
+                }
+            }
+        }
+        exp
+    }
+
+    /// Assemble the full [`Deconstructors`] set at the point of use — the
+    /// output-side peer of [`Self::build_expansions`]. Field names resolve
+    /// here, against the complete declaration set: explicit `.name()` first,
+    /// then the class member's Kotlin name (a getter that is both a method
+    /// and a field is named once, on the member), else the camel-cased Rust
+    /// name.
+    pub(crate) fn build_deconstructors(&self) -> crate::api::core::unfold::Deconstructors {
+        let mut dec = self.deconstructors.clone();
+        for decl in &self.return_expand_decls {
+            dec.ensure_default_deconstructor(decl.key.to_type());
+            for f in &decl.fields {
+                match f {
+                    LocalField::Named(func, name_override) => {
+                        let name = name_override
+                            .clone()
+                            .or_else(|| self.member_kotlin_name(&decl.key, func))
+                            .unwrap_or_else(|| snake_to_camel(&func.to_string()));
+                        dec.add_deconstructor_record(func.clone(), name);
+                    }
+                    LocalField::SelfField => dec.add_deconstructor_record_id(),
+                }
+            }
+        }
+        dec
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -53,7 +53,8 @@ impl JniGen {
     /// name-mangling, handle locks enabled. Adjust settings with the `set_*`
     /// methods, add declarations with [`package`](Self::package),
     /// [`expand`](Self::expand), [`convert`](Self::convert), etc., then run the
-    /// result through `Registry::write_rust` / `write_kotlin`. Settings and
+    /// result through `Registry::resolve` → `Generation::write_rust` /
+    /// `write_kotlin`. Settings and
     /// declarations may be interleaved in any order — the builder stores
     /// only raw inputs, and every setting-derived name is computed at the
     /// point of use.

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -62,11 +62,12 @@ impl JniGen {
             deconstructors: crate::api::core::unfold::Deconstructors::default(),
             param_expand_decls: Vec::new(),
             return_expand_decls: Vec::new(),
+            fn_param_expands: Vec::new(),
+            fn_return_expands: Vec::new(),
             class_members: HashMap::new(),
             ignored_fns: std::collections::HashSet::new(),
             ignored_class_types: std::collections::HashSet::new(),
             ignored_const_idents: std::collections::HashSet::new(),
-            accessor_record_fns: std::collections::HashSet::new(),
         };
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
         // as T and routes E to the error-sink on Err. Consumers may override
@@ -363,8 +364,8 @@ impl JniGen {
     }
 
     /// Shared tail of `accept_ptr_class`/`accept_value_class` (the two class
-    /// kinds whose members are emitted): each member's per-fn flatten
-    /// modifiers apply exactly as a free function's would; a constructor
+    /// kinds whose members are emitted): each member's per-fn expand
+    /// overrides apply exactly as a free function's would; a constructor
     /// member's return is additionally never output-flattened (it's a
     /// factory); then the members join the class's registered set.
     fn accept_members(&mut self, key: &TypeKey, members: Vec<(FunctionDecl, MemberKind)>) {
@@ -374,7 +375,7 @@ impl JniGen {
                 .kotlin_name_override
                 .clone()
                 .unwrap_or_else(|| snake_to_camel(&rust_ident.to_string()));
-            self.apply_fn_flatten_modifiers(decl);
+            self.accept_fn_expands(decl);
             if kind == MemberKind::Constructor {
                 self.deconstructors
                     .add_skip_default_output(rust_ident.clone());
@@ -398,58 +399,30 @@ impl JniGen {
             .or_default()
             .functions
             .push(entry);
-        self.apply_fn_flatten_modifiers(decl);
+        self.accept_fn_expands(decl);
     }
 
-    /// Replay a [`FunctionDecl`]'s per-fn overrides (per-param
-    /// `.param_expand*` / `.return_expand*`) into the
-    /// expansion/deconstruction bookkeeping. Shared by [`Self::accept_function`]
-    /// (free package fns) and [`Self::accept_members`] (class members) — the
-    /// overrides mean the same thing in both positions.
-    ///
-    /// Identity-only normalization: an override consisting of only the
-    /// `_self` form means "the plain handle, nothing else" and lowers to the
-    /// skip-default opt-out — no selector on the input side, the raw
-    /// whole-handle return (borrowed-`&T`-capable) on the output side.
-    fn apply_fn_flatten_modifiers(&mut self, decl: FunctionDecl) {
+    /// Move a [`FunctionDecl`]'s per-fn expand overrides
+    /// (`.expand_param(name, …)` / `.expand_return(…)`) into raw storage.
+    /// Shared by [`Self::accept_function`] (free package fns) and
+    /// [`Self::accept_members`] (class members) — the overrides mean the same
+    /// thing in both positions. Nothing is lowered here: variant/field lists
+    /// are interpreted at the point of use ([`Self::build_expansions`] /
+    /// [`Self::build_deconstructors`]) so field-name inheritance and the
+    /// rust-side-only checks see the complete declaration set.
+    fn accept_fn_expands(&mut self, decl: FunctionDecl) {
         let FunctionDecl {
             rust_ident,
             kotlin_name_override: _,
-            input_overrides,
-            output_override,
+            param_expands,
+            return_expand,
         } = decl;
-
-        for (param, variants) in input_overrides {
-            if matches!(variants.as_slice(), [LocalVariant::SelfIdentity]) {
-                self.expansions
-                    .add_skip_default_construct(rust_ident.clone(), param);
-                continue;
-            }
-            self.expansions.begin_subset(rust_ident.clone(), param);
-            for v in variants {
-                match v {
-                    LocalVariant::Ctor(f) => self.expansions.push_subset_variant(f),
-                    LocalVariant::SelfIdentity => self.expansions.push_subset_self(),
-                }
-            }
+        for (param, pdecl) in param_expands {
+            self.fn_param_expands
+                .push((rust_ident.clone(), param, pdecl));
         }
-        if let Some(fields) = output_override {
-            if matches!(fields.as_slice(), [LocalField::SelfField]) {
-                self.deconstructors
-                    .add_skip_default_output(rust_ident.clone());
-                return;
-            }
-            self.deconstructors.begin_inline_output(rust_ident.clone());
-            for f in fields {
-                match f {
-                    LocalField::Named(func, name) => {
-                        self.accessor_record_fns.insert(func.clone());
-                        let name = name.unwrap_or_else(|| snake_to_camel(&func.to_string()));
-                        self.deconstructors.push_inline_field(func, name)
-                    }
-                    LocalField::SelfField => self.deconstructors.push_inline_field_self(),
-                }
-            }
+        if let Some(rdecl) = return_expand {
+            self.fn_return_expands.push((rust_ident.clone(), rdecl));
         }
     }
 }
@@ -461,10 +434,10 @@ impl JniGen {
     /// [`ExpandDecl`] directions, the direction carried by the decl object
     /// (the boundary-decl peer of [`PackageDecl::class`]):
     ///
-    /// * [`param_expand!`](crate::param_expand) — the input side: how a
+    /// * [`expand_param!`](crate::expand_param) — the input side: how a
     ///   parameter of the type may be supplied, as an OR-list of build
     ///   variants.
-    /// * [`return_expand!`](crate::return_expand) — the output side: the
+    /// * [`expand_return!`](crate::expand_return) — the output side: the
     ///   AND-set of fields a returned / callback-delivered / `Result`-error
     ///   value of the type decomposes into.
     ///
@@ -476,7 +449,7 @@ impl JniGen {
             ExpandDecl::Param(decl) => {
                 assert!(
                     !decl.variants.is_empty(),
-                    "param_expand!({}) declares no variants — add .variant(fun!(...)) and/or \
+                    "expand_param!({}) declares no variants — add .variant(fun!(...)) and/or \
                      .variant_self()",
                     decl.key.as_str()
                 );
@@ -485,7 +458,7 @@ impl JniGen {
             ExpandDecl::Return(decl) => {
                 assert!(
                     !decl.fields.is_empty(),
-                    "return_expand!({}) declares no fields — add .field(fun!(...)) and/or \
+                    "expand_return!({}) declares no fields — add .field(fun!(...)) and/or \
                      .field_self()",
                     decl.key.as_str()
                 );
@@ -497,7 +470,7 @@ impl JniGen {
 
     /// The Kotlin name of `func` as a declared member (`.fun`/`.constructor`)
     /// of the class keyed by `key`, if it is one — the name-inheritance
-    /// source for [`ReturnExpandDecl::field`].
+    /// source for [`ExpandReturnDecl::field`].
     fn member_kotlin_name(&self, key: &TypeKey, func: &syn::Ident) -> Option<String> {
         self.class_members
             .get(key)?
@@ -518,7 +491,7 @@ impl JniGen {
 
     /// Assemble the full [`Expansions`] set at the point of use: the eagerly
     /// accumulated per-fn overrides plus the raw type-level
-    /// [`ParamExpandDecl`]s. Building on demand keeps declarations
+    /// [`ExpandParamDecl`]s. Building on demand keeps declarations
     /// order-independent — a `param_expand` may precede or follow the
     /// `package` that declares its constructors (which is also why the
     /// rust-side-only `_self` check lives here and not at accept time).
@@ -531,7 +504,7 @@ impl JniGen {
                         .variants
                         .iter()
                         .any(|v| matches!(v, LocalVariant::SelfIdentity)),
-                "param_expand!({k}).variant_self(): `{k}` has no class declaration, so there is \
+                "expand_param!({k}).variant_self(): `{k}` has no class declaration, so there is \
                  no Kotlin object to pass — drop .variant_self() (the type is rust-side-only) \
                  or declare the type in a package",
                 k = decl.key.as_str()
@@ -548,6 +521,30 @@ impl JniGen {
                 match v {
                     LocalVariant::Ctor(f) => exp.add_constructor_variant(f.clone()),
                     LocalVariant::SelfIdentity => exp.add_constructor_variant_id(),
+                }
+            }
+        }
+        // Per-fn overrides: same decl shape, complete-set semantics; the
+        // param-name/type cross-check and the identity-only lowering happen
+        // in `core/expand.rs`'s `apply` (which sees the fn signatures).
+        for (func, param, decl) in &self.fn_param_expands {
+            assert!(
+                self.is_class_declared(&decl.key)
+                    || !decl
+                        .variants
+                        .iter()
+                        .any(|v| matches!(v, LocalVariant::SelfIdentity)),
+                "fun!({func}).expand_param(\"{param}\", expand_param!({k}).variant_self()): `{k}` \
+                 has no class declaration, so there is no Kotlin object to pass — drop \
+                 .variant_self() (the type is rust-side-only) or declare the type in a package",
+                k = decl.key.as_str()
+            );
+            let param_ident = syn::Ident::new(param, Span::call_site());
+            exp.begin_subset(func.clone(), param_ident, decl.key.to_type());
+            for v in &decl.variants {
+                match v {
+                    LocalVariant::Ctor(f) => exp.push_subset_variant(f.clone()),
+                    LocalVariant::SelfIdentity => exp.push_subset_self(),
                 }
             }
         }
@@ -569,7 +566,7 @@ impl JniGen {
                         .fields
                         .iter()
                         .any(|f| matches!(f, LocalField::SelfField)),
-                "return_expand!({k}).field_self(): `{k}` has no class declaration, so there is \
+                "expand_return!({k}).field_self(): `{k}` has no class declaration, so there is \
                  no Kotlin object to deliver — drop .field_self() (the type is rust-side-only) \
                  or declare the type in a package",
                 k = decl.key.as_str()
@@ -588,43 +585,102 @@ impl JniGen {
                 }
             }
         }
+        // Per-fn overrides: same decl shape and name inheritance; the
+        // return-type cross-check and the identity-only lowering happen in
+        // `core/unfold.rs`'s `apply` (which sees the fn signatures).
+        for (func, decl) in &self.fn_return_expands {
+            assert!(
+                self.is_class_declared(&decl.key)
+                    || !decl
+                        .fields
+                        .iter()
+                        .any(|f| matches!(f, LocalField::SelfField)),
+                "fun!({func}).expand_return(expand_return!({k}).field_self()): `{k}` has no \
+                 class declaration, so there is no Kotlin object to deliver — drop \
+                 .field_self() (the type is rust-side-only) or declare the type in a package",
+                k = decl.key.as_str()
+            );
+            dec.begin_inline_output(func.clone(), decl.key.to_type());
+            for f in &decl.fields {
+                match f {
+                    LocalField::Named(afunc, name_override) => {
+                        let name = name_override
+                            .clone()
+                            .or_else(|| self.member_kotlin_name(&decl.key, afunc))
+                            .unwrap_or_else(|| snake_to_camel(&afunc.to_string()));
+                        dec.push_inline_field(afunc.clone(), name);
+                    }
+                    LocalField::SelfField => dec.push_inline_field_self(),
+                }
+            }
+        }
         dec
     }
 
-    /// Type keys of boundary decls (`param_expand!` / `return_expand!`) whose
-    /// type has no class declaration — the **rust-side-only** types. Unioned
-    /// into [`Prebindgen::ignored_types`] so the registry treats them as
-    /// acknowledged (no "skipping undeclared" warning, no direct converter
-    /// requirement, no Kotlin emission).
+    /// Type keys of boundary decls (`expand_param!` / `expand_return!`,
+    /// type-level and per-fn) whose type has no class declaration — the
+    /// **rust-side-only** types. Unioned into [`Prebindgen::ignored_types`]
+    /// so the registry treats them as acknowledged (no "skipping undeclared"
+    /// warning, no direct converter requirement, no Kotlin emission).
     pub(crate) fn rust_side_only_types(&self) -> impl Iterator<Item = TypeKey> + '_ {
         self.param_expand_decls
             .iter()
             .map(|d| &d.key)
             .chain(self.return_expand_decls.iter().map(|d| &d.key))
+            .chain(self.fn_param_expands.iter().map(|(_, _, d)| &d.key))
+            .chain(self.fn_return_expands.iter().map(|(_, d)| &d.key))
             .filter(|k| !self.is_class_declared(k))
             .cloned()
     }
 
-    /// Function idents referenced only inside boundary decls — `return_expand!`
-    /// field accessors and `param_expand!` variant ctors. They are called
-    /// Rust-side by the generated fold/unfold code and need no extern of
-    /// their own; when not otherwise declared they are unioned into
-    /// [`Prebindgen::ignored_functions`] so the registry's "skipping
-    /// undeclared fn" warning stays quiet.
+    /// Function idents referenced only inside boundary decls (type-level and
+    /// per-fn) — `expand_return!` field accessors and `expand_param!` variant
+    /// ctors. They are called Rust-side by the generated fold/unfold code and
+    /// need no extern of their own; when not otherwise declared they are
+    /// unioned into [`Prebindgen::ignored_functions`] so the registry's
+    /// "skipping undeclared fn" warning stays quiet.
     pub(crate) fn boundary_referenced_fns(&self) -> impl Iterator<Item = syn::Ident> + '_ {
-        let ctors = self.param_expand_decls.iter().flat_map(|d| {
-            d.variants.iter().filter_map(|v| match v {
+        let ctors = self
+            .param_expand_decls
+            .iter()
+            .map(|d| &d.variants)
+            .chain(self.fn_param_expands.iter().map(|(_, _, d)| &d.variants))
+            .flatten()
+            .filter_map(|v| match v {
                 LocalVariant::Ctor(f) => Some(f.clone()),
                 LocalVariant::SelfIdentity => None,
-            })
-        });
-        let accessors = self.return_expand_decls.iter().flat_map(|d| {
-            d.fields.iter().filter_map(|f| match f {
+            });
+        let accessors = self
+            .return_expand_decls
+            .iter()
+            .map(|d| &d.fields)
+            .chain(self.fn_return_expands.iter().map(|(_, d)| &d.fields))
+            .flatten()
+            .filter_map(|f| match f {
+                LocalField::Named(func, _) => Some(func.clone()),
+                LocalField::SelfField => None,
+            });
+        ctors.chain(accessors)
+    }
+
+    /// Every function referenced as a named field in any `expand_return!`
+    /// decl (type-level or per-fn) — the accessor set. Backs
+    /// [`Prebindgen::accessor_functions`]: `core/unfold.rs`'s deconstructor
+    /// gate requires every named record's function to be in this set
+    /// (`RecordNotAccessor` otherwise), and `core/expand.rs` excludes them
+    /// from parameter composition. Derived from *usage* — a function need not
+    /// also be a `.fun()` class member to be referenced this way.
+    pub(crate) fn field_accessor_fns(&self) -> std::collections::HashSet<syn::Ident> {
+        self.return_expand_decls
+            .iter()
+            .map(|d| &d.fields)
+            .chain(self.fn_return_expands.iter().map(|(_, d)| &d.fields))
+            .flatten()
+            .filter_map(|f| match f {
                 LocalField::Named(func, _) => Some(func.clone()),
                 LocalField::SelfField => None,
             })
-        });
-        ctors.chain(accessors)
+            .collect()
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -3,13 +3,27 @@
 //! [`JniGen::new`] starts from defaults; global settings are applied with
 //! the `set_*` methods (`config.rs`) and declarations are *accepted* as
 //! pre-built objects (`decl.rs`) via [`JniGen::package`], [`JniGen::expand`],
-//! [`JniGen::scalar_type_wrapper`], and [`JniGen::generic_type_wrapper`] —
-//! there is no fluent typestate cursor. Carved from the former monolithic
+//! and [`JniGen::convert`] — there is no fluent typestate cursor. Carved from the former monolithic
 //! JNI module; shares the `jni` namespace via `use super::*`.
 
 use super::*;
 
 impl JniGen {
+    /// The module path a generated call to `#[prebindgen]` fn `ident` must be
+    /// qualified with: the fn's **origin crate** when the registry was built
+    /// from [`crate::core::Registry::from_sources`] (multi-source bindings —
+    /// helper crates layered on the flat crate), else the configured
+    /// [`Self::set_source_module`] default.
+    pub(crate) fn fn_module(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        ident: &syn::Ident,
+    ) -> syn::Path {
+        registry
+            .fn_origin_module(ident)
+            .unwrap_or_else(|| self.source_module.clone())
+    }
+
     /// Whether `ty` was registered via an `EnumClassDecl` — used by the
     /// Kotlin wrapper generator to decide if a parameter needs a `.value`
     /// projection between the typed enum (Kotlin signature) and the `Int`
@@ -28,7 +42,7 @@ impl JniGen {
     /// crate`, empty base package, no `JNINative` init block, identity
     /// name-mangling, handle locks enabled. Adjust settings with the `set_*`
     /// methods, add declarations with [`package`](Self::package),
-    /// [`scalar_type_wrapper`](Self::scalar_type_wrapper), etc., then run the
+    /// [`expand`](Self::expand), [`convert`](Self::convert), etc., then run the
     /// result through `Registry::write_rust` / `write_kotlin`. Settings and
     /// declarations may be interleaved in any order — the builder stores
     /// only raw inputs, and every setting-derived name is computed at the
@@ -60,6 +74,7 @@ impl JniGen {
             jni_native_init: None,
             expansions: crate::api::core::expand::Expansions::default(),
             deconstructors: crate::api::core::unfold::Deconstructors::default(),
+            convert_decls: Vec::new(),
             param_expand_decls: Vec::new(),
             return_expand_decls: Vec::new(),
             fn_param_expands: Vec::new(),
@@ -70,10 +85,9 @@ impl JniGen {
             ignored_const_idents: std::collections::HashSet::new(),
         };
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
-        // as T and routes E to the error-sink on Err. Consumers may override
-        // per-binding by registering a more specific rank-1
-        // `GenericTypeWrapperDecl::new(pq!(Result<_, ConcreteErr>))` (rank-1
-        // fires before rank-2 in resolve and short-circuits this).
+        // as T and routes E to the error-sink on Err. The rank tables are
+        // internal — this is their only entry; `convert!` covers concrete
+        // types at rank 0.
         let pattern: syn::Type = syn::parse_quote!(Result<_, _>);
         let key = TypeKey::from_type(&pattern);
         jni.output_wrappers[2].insert(
@@ -684,61 +698,169 @@ impl JniGen {
     }
 }
 
-// ── Accepting wrapper decls ──────────────────────────────────────────────
+// ── Accepting the convert decl ───────────────────────────────────────────
 
 impl JniGen {
-    /// Teach the generator how a **custom scalar type** crosses the boundary
-    /// — e.g. a newtype like `Millis(u64)` that should travel as a plain
-    /// `Long` rather than as a class. You supply the wire type and the
-    /// convert-in / convert-out expressions (see [`ScalarTypeWrapperDecl`]).
-    /// Applies wherever that type appears; not tied to any package.
-    pub fn scalar_type_wrapper(mut self, decl: ScalarTypeWrapperDecl) -> Self {
-        let key = TypeKey::from_type(&decl.pattern);
-        if let Some(input) = decl.input {
-            let wire_src = decl.wire.clone();
-            self.input_wrappers[0].insert(
-                key.clone(),
-                Arc::new(
-                    move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                        let wire: syn::Type =
-                            syn::parse_str(&wire_src).expect("stored wire type re-parses");
-                        Some((wire, None, input(&wrapper_value_ident())))
-                    },
-                ),
-            );
-        }
-        if let Some(output) = decl.output {
-            let wire_src = decl.wire.clone();
-            self.output_wrappers[0].insert(
-                key.clone(),
-                Arc::new(
-                    move |_args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                        let wire: syn::Type =
-                            syn::parse_str(&wire_src).expect("stored wire type re-parses");
-                        Some((wire, None, output(&wrapper_value_ident())))
-                    },
-                ),
-            );
-        }
-        let entry = self.types.entry(key.clone()).or_default();
-        entry.name_spec = Some(NameSpec::Verbatim(decl.kotlin_type));
+    /// Declare a type's **canonical single-value conversion** (a
+    /// [`ConvertDecl`], built with [`convert!`](crate::convert)): a pair of
+    /// `#[prebindgen]` functions carrying one value of the type across the
+    /// boundary wherever a single value is needed (params, returns,
+    /// `Option`/`Vec` elements, the `Result<T, E>` success position,
+    /// `data_class` fields). Applies wherever the type appears; not tied to
+    /// any package. See [`ConvertDecl`] for the relation to the
+    /// [`expand`](Self::expand) boundary decls.
+    pub fn convert(mut self, decl: ConvertDecl) -> Self {
+        assert!(
+            decl.input.is_some() || decl.output.is_some(),
+            "convert!({}) declares no conversions — add .input(fun!(...)) and/or \
+             .output(fun!(...))",
+            decl.key.as_str()
+        );
+        self.convert_decls.push(decl);
         self
     }
 
-    /// Override how a **generic wrapper type** is unwrapped for a specific
-    /// inner type — e.g. peel `Result<_, MyError>` your own way rather than
-    /// through the built-in `Result` handling. You give a pattern with
-    /// wildcards and the convert bodies (see [`GenericTypeWrapperDecl`]).
-    /// Not tied to any package.
-    pub fn generic_type_wrapper(mut self, decl: GenericTypeWrapperDecl) -> Self {
-        let key = TypeKey::from_type(&decl.pattern);
-        if let Some((rank, f)) = decl.input {
-            self.input_wrappers[rank].insert(key.clone(), f);
-        }
-        if let Some((rank, f)) = decl.output {
-            self.output_wrappers[rank].insert(key, f);
-        }
-        self
+    /// Derive the rank-0 **input** converter body for a `convert!`-declared
+    /// type: `(continue_ty, exc, body)` where `continue_ty` is the conversion
+    /// fn's parameter type (by value) — the composed-converter machinery
+    /// chains it through that type's own converter, so the wire and the
+    /// Kotlin surface derive from it. Consulted by [`Self::lookup_input`]
+    /// before the wrapper tables; signatures are read from the registry at
+    /// lookup time (order-independent, and multi-source qualification via
+    /// [`Self::fn_module`]).
+    pub(crate) fn convert_input_body(
+        &self,
+        key: &TypeKey,
+        registry: &Registry<KotlinMeta>,
+    ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
+        let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
+        let f = decl.input.as_ref()?;
+        let (item_fn, _) = registry.functions.get(f).unwrap_or_else(|| {
+            panic!(
+                "convert!({}).input({f}): function not found among #[prebindgen] items",
+                key.as_str()
+            )
+        });
+        let (param_ty, by_ref) = convert_single_param(key, f, item_fn, "input");
+        // Return: `T` (infallible) or `Result<T, E>` (fallible — E routes to
+        // the caller's error handler through the standard exc slot).
+        let ret = fn_return_type(item_fn);
+        let (ok_ty, exc) = match crate::api::core::types_util::result_ok_type(&ret) {
+            Some(ok) => (
+                ok,
+                Some(
+                    crate::api::core::types_util::result_err_type(&ret)
+                        .expect("result_ok_type implies result_err_type"),
+                ),
+            ),
+            None => (ret, None),
+        };
+        assert!(
+            TypeKey::from_type(&ok_ty) == *key,
+            "convert!({k}).input({f}): the function produces `{got}`, not `{k}`",
+            k = key.as_str(),
+            got = TypeKey::from_type(&ok_ty).as_str()
+        );
+        let module = self.fn_module(registry, f);
+        let body: syn::Expr = if by_ref {
+            syn::parse_quote!(#module::#f(&v))
+        } else {
+            syn::parse_quote!(#module::#f(v))
+        };
+        Some((param_ty, exc, body))
+    }
+
+    /// Output-direction peer of [`Self::convert_input_body`]: the conversion
+    /// fn takes `&T` (or `T`) and returns the continue type.
+    pub(crate) fn convert_output_body(
+        &self,
+        key: &TypeKey,
+        registry: &Registry<KotlinMeta>,
+    ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
+        let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
+        let g = decl.output.as_ref()?;
+        let (item_fn, _) = registry.functions.get(g).unwrap_or_else(|| {
+            panic!(
+                "convert!({}).output({g}): function not found among #[prebindgen] items",
+                key.as_str()
+            )
+        });
+        let (param_ty, by_ref) = convert_single_param_any(g, item_fn);
+        assert!(
+            TypeKey::from_type(&param_ty) == *key,
+            "convert!({k}).output({g}): the function takes `{got}`, not `{k}`",
+            k = key.as_str(),
+            got = TypeKey::from_type(&param_ty).as_str()
+        );
+        let ret = fn_return_type(item_fn);
+        assert!(
+            TypeKey::from_type(&ret) != *key,
+            "convert!({k}).output({g}): the function must return the converted form, not `{k}`",
+            k = key.as_str()
+        );
+        let module = self.fn_module(registry, g);
+        let body: syn::Expr = if by_ref {
+            syn::parse_quote!(#module::#g(&v))
+        } else {
+            syn::parse_quote!(#module::#g(v))
+        };
+        Some((ret, None, body))
+    }
+
+    /// Idents of every `convert!` conversion function — scanned as helper
+    /// functions ([`Prebindgen::helper_functions`]) so their signature types
+    /// resolve without emitting externs for them.
+    pub(crate) fn convert_fns(&self) -> impl Iterator<Item = syn::Ident> + '_ {
+        self.convert_decls
+            .iter()
+            .flat_map(|d| d.input.iter().chain(d.output.iter()).cloned())
+    }
+}
+
+/// The single typed parameter of a conversion fn, peeled of a leading `&`;
+/// asserts arity 1. Returns `(peeled_type, was_by_ref)`.
+fn convert_single_param_any(f: &syn::Ident, item_fn: &syn::ItemFn) -> (syn::Type, bool) {
+    let params: Vec<&syn::PatType> = item_fn
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|i| match i {
+            syn::FnArg::Typed(pt) => Some(pt),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        params.len() == 1,
+        "convert fn `{f}` must take exactly one parameter, it takes {}",
+        params.len()
+    );
+    match &*params[0].ty {
+        syn::Type::Reference(r) => ((*r.elem).clone(), true),
+        other => (other.clone(), false),
+    }
+}
+
+/// [`convert_single_param_any`] + the direction-specific error context.
+fn convert_single_param(
+    key: &TypeKey,
+    f: &syn::Ident,
+    item_fn: &syn::ItemFn,
+    dir: &str,
+) -> (syn::Type, bool) {
+    let (ty, by_ref) = convert_single_param_any(f, item_fn);
+    assert!(
+        TypeKey::from_type(&ty) != *key,
+        "convert!({k}).{dir}({f}): the function must take the converted form, not `{k}` itself",
+        k = key.as_str()
+    );
+    (ty, by_ref)
+}
+
+/// A fn's return type (`()` for none).
+fn fn_return_type(item_fn: &syn::ItemFn) -> syn::Type {
+    match &item_fn.sig.output {
+        syn::ReturnType::Default => syn::parse_quote!(()),
+        syn::ReturnType::Type(_, t) => (**t).clone(),
     }
 }
 
@@ -828,8 +950,20 @@ impl JniGen {
             return None;
         }
         let key = TypeKey::from_type(pat);
-        let f = self.input_wrappers[rank].get(&key)?;
-        let (ty, exc_ty, body) = f(args, registry)?;
+        // A `convert!`-declared conversion takes precedence at rank 0 (its
+        // signature-derived body is equivalent to a rank-0 registration,
+        // just computed at the point of use).
+        let (ty, exc_ty, body) = match if rank == 0 {
+            self.convert_input_body(&key, registry)
+        } else {
+            None
+        } {
+            Some(t) => t,
+            None => {
+                let f = self.input_wrappers[rank].get(&key)?;
+                f(args, registry)?
+            }
+        };
         // The closure's middle slot carries the `Result`'s raw Rust error
         // type (or `None` for the framework `__JniErr`); it feeds the
         // converter signature `Result<_, E>` directly — no registration.
@@ -945,8 +1079,19 @@ impl JniGen {
             return None;
         }
         let key = TypeKey::from_type(pat);
-        let f = self.output_wrappers[rank].get(&key)?;
-        let (ty, exc_ty, body) = f(args, registry)?;
+        // A `convert!`-declared conversion takes precedence at rank 0 — see
+        // [`Self::lookup_input`].
+        let (ty, exc_ty, body) = match if rank == 0 {
+            self.convert_output_body(&key, registry)
+        } else {
+            None
+        } {
+            Some(t) => t,
+            None => {
+                let f = self.output_wrappers[rank].get(&key)?;
+                f(args, registry)?
+            }
+        };
         // The closure's middle slot carries the `Result`'s raw Rust error
         // type (or `None` for the framework `__JniErr`) — see lookup_input.
         let exc = exc_ty.as_ref();

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -65,6 +65,7 @@ impl JniGen {
             ptr_class_name_mangle: None,
             data_class_name_mangle: None,
             enum_name_mangle: None,
+            member_name_mangle: None,
             harness_name_mangle: None,
             types: HashMap::new(),
             packages: BTreeMap::new(),
@@ -141,6 +142,15 @@ impl JniGen {
     /// or `name` verbatim when unset.
     pub(crate) fn mangle_enum(&self, name: &str) -> String {
         match &self.enum_name_mangle {
+            Some(f) => f(name),
+            None => name.to_string(),
+        }
+    }
+    /// Apply the member mangle closure to `name` (the namespace-stripped
+    /// camelCase default), returning the closure result or `name` verbatim
+    /// when unset.
+    pub(crate) fn mangle_member(&self, name: &str) -> String {
+        match &self.member_name_mangle {
             Some(f) => f(name),
             None => name.to_string(),
         }
@@ -409,10 +419,7 @@ impl JniGen {
     fn accept_members(&mut self, key: &TypeKey, members: Vec<(FunctionDecl, MemberKind)>) {
         for (decl, kind) in members {
             let rust_ident = decl.rust_ident.clone();
-            let kotlin_name = decl
-                .kotlin_name_override
-                .clone()
-                .unwrap_or_else(|| snake_to_camel(&rust_ident.to_string()));
+            let kotlin_name_override = decl.kotlin_name_override.clone();
             self.accept_fn_expands(decl);
             if kind == MemberKind::Constructor {
                 self.deconstructors
@@ -423,7 +430,7 @@ impl JniGen {
                 .or_default()
                 .push(ClassMember {
                     rust_ident,
-                    kotlin_name,
+                    kotlin_name_override,
                     kind,
                 });
         }
@@ -514,7 +521,26 @@ impl JniGen {
             .get(key)?
             .iter()
             .find(|m| &m.rust_ident == func)
-            .map(|m| m.kotlin_name.clone())
+            .map(|m| self.effective_member_name(key, m))
+    }
+
+    /// The effective Kotlin name of a class member, derived at point of
+    /// use (order-independent w.r.t. `set_member_name_mangle`): the
+    /// per-member `.name()` override verbatim, else the member-mangle hook
+    /// over the **namespace-relative** camelCase default — the class's
+    /// Rust-name prefix is stripped from the fn ident first
+    /// ([`strip_type_prefix`]), because a flat crate spells the type
+    /// namespace inside the ident while a Kotlin member already lives in
+    /// its class. No prefix match ⇒ the full ident camel-cases as before.
+    pub(crate) fn effective_member_name(&self, key: &TypeKey, m: &ClassMember) -> String {
+        if let Some(name) = &m.kotlin_name_override {
+            return name.clone();
+        }
+        let ident = m.rust_ident.to_string();
+        let short = rust_short_name(key);
+        let base = crate::api::lang::jnigen::util::strip_type_prefix(&ident, &short)
+            .unwrap_or(ident.as_str());
+        self.mangle_member(&snake_to_camel(base))
     }
 
     /// Whether `key` was declared as a class in some package (any of the four

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -800,10 +800,12 @@ impl JniGen {
                 }
             }
             // Binding-local callable: emitted verbatim (multi-segment paths
-            // pass the qualification visitor untouched).
-            ConvertSpec::LocalFn { repr, path } => {
+            // pass the qualification visitor untouched). With a declared
+            // error type the fn returns `Result<T, E>` — emitted as-is, `E`
+            // riding the standard exc slot.
+            ConvertSpec::LocalFn { repr, path, error } => {
                 let body: syn::Expr = syn::parse_quote!(#path(v));
-                Some((repr.clone(), None, body))
+                Some((repr.clone(), error.clone(), body))
             }
         }
     }
@@ -863,9 +865,9 @@ impl JniGen {
                     Some((repr.clone(), None, body))
                 }
             }
-            ConvertSpec::LocalFn { repr, path } => {
+            ConvertSpec::LocalFn { repr, path, error } => {
                 let body: syn::Expr = syn::parse_quote!(#path(v));
-                Some((repr.clone(), None, body))
+                Some((repr.clone(), error.clone(), body))
             }
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -131,6 +131,21 @@ impl JniGen {
         self
     }
 
+    /// Set the closure that mangles **class member** names (instance
+    /// methods and companion factories). Receives the derived camelCase
+    /// name AFTER the class-namespace prefix was stripped from the fn
+    /// ident (`storage_len` on class `Storage` arrives as `"len"`); runs
+    /// only for members without a per-member `.name()` (which is always
+    /// verbatim). Default = identity. The sixth hook of the name-mangle
+    /// family, covering the one name tier the other five don't.
+    pub fn set_member_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.member_name_mangle = Some(Arc::new(f));
+        self
+    }
+
     /// Toggle the per-call locking the generator wraps around every handle a
     /// wrapper touches (which guards against a handle being `close()`d on
     /// another thread mid-call). Defaults to `true`; pass `false` only if

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -1,4 +1,4 @@
-//! Global settings of a [`JniGen`] instance — the source module, target
+//! Global settings of a [`JniGen`] instance — the target
 //! package, name-mangling rules, native-init hook and handle-lock toggle.
 //!
 //! Every setter carries the `set_` prefix: unlike the declaration methods
@@ -43,14 +43,6 @@ pub(crate) enum NameSpec {
 }
 
 impl JniGen {
-    /// Set the Rust module path that contains the original `#[prebindgen]`
-    /// items. Generated Rust wrappers call functions as
-    /// `<source_module>::<function>(...)`; defaults to `crate`.
-    pub fn set_source_module(mut self, p: syn::Path) -> Self {
-        self.source_module = p;
-        self
-    }
-
     /// Set the JVM/Kotlin **base** package (dot-separated, e.g.
     /// `"io.zenoh.jni"`). All derived forms (slash-separated `FindClass`
     /// paths, `_`-mangled JNI extern idents, Kotlin `package` declarations)

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -148,9 +148,16 @@ impl JniGen {
 
     /// Toggle the per-call locking the generator wraps around every handle a
     /// wrapper touches (which guards against a handle being `close()`d on
-    /// another thread mid-call). Defaults to `true`; pass `false` only if
-    /// you know your handles are never used concurrently and want the
-    /// overhead gone.
+    /// another thread mid-call). Defaults to `true`.
+    ///
+    /// The locks are **not** a performance trade-off: benchmarks (perftest,
+    /// N = 5M per op, JDK 21 / macOS arm64, 2026-07-15) show locks-on vs
+    /// locks-off deltas within run-to-run noise on every op that does real
+    /// work (±3%, mixed sign); the cheapest op (`put` with no string field,
+    /// ~33 ns/call) bounds the whole uncontended lock pair at about one
+    /// nanosecond. This setting exists so that claim can be independently
+    /// re-verified on your own workload — generate once with `false`,
+    /// benchmark both, and keep the default — not as an optimization knob.
     pub fn set_emit_handle_locks(mut self, emit: bool) -> Self {
         self.emit_handle_locks = emit;
         self

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -42,6 +42,15 @@ pub(crate) enum NameSpec {
     },
 }
 
+impl NameSpec {
+    /// True for a `kotlin_type`-mapped declaration: the type surfaces as an
+    /// EXISTING Kotlin type — emitters generate no file for it (the FQN is
+    /// used verbatim at reference sites only).
+    pub(crate) fn is_verbatim(&self) -> bool {
+        matches!(self, NameSpec::Verbatim(_))
+    }
+}
+
 impl JniGen {
     /// Set the JVM/Kotlin **base** package (dot-separated, e.g.
     /// `"io.zenoh.jni"`). All derived forms (slash-separated `FindClass`

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -2,7 +2,7 @@
 //! package, name-mangling rules, native-init hook and handle-lock toggle.
 //!
 //! Every setter carries the `set_` prefix: unlike the declaration methods
-//! ([`JniGen::package`], [`JniGen::scalar_type_wrapper`], …) which each add
+//! ([`JniGen::package`], [`JniGen::convert`], …) which each add
 //! one item to the binding surface, a `set_` method changes how *all* other
 //! declarations are interpreted. Setters are **order-independent by
 //! construction**: the builder stores only raw inputs — settings here,

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -97,28 +97,14 @@ macro_rules! fun {
     };
 }
 
-/// Build a [`ConstDecl`] directly from a bare const ident:
-/// `constant!(MAX_LEN)` is `ConstDecl::new(prebindgen::ident!(MAX_LEN))`.
+/// Build a [`ConstDecl`] from a bare ident: `constant!(MAX_LEN)` is
+/// `ConstDecl::new(prebindgen::ident!(MAX_LEN))` — with no source modifier
+/// it declares the same-named `#[prebindgen]` const; `.fun(…)` / `.with(…)`
+/// / `.expr(…)` switch the value source (the ident stays as the `val` name).
 #[macro_export]
 macro_rules! constant {
     ($name:ident) => {
         $crate::lang::ConstDecl::new($crate::ident!($name))
-    };
-}
-
-/// Build a [`ConstExprDecl`] in val-declaration syntax:
-/// `constant_expr!(BANNER: String = format!("{COVER_TAG}:{COVER_MAGIC}"))` is
-/// `ConstExprDecl::new("BANNER", <String>, <the expression>)`. The expression
-/// is evaluated inside the generated getter with a glob import of every
-/// source module in scope.
-#[macro_export]
-macro_rules! constant_expr {
-    ($name:ident : $ty:ty = $expr:expr) => {
-        $crate::lang::ConstExprDecl::new(
-            stringify!($name),
-            ::syn::parse_quote!($ty),
-            ::syn::parse_quote!($expr),
-        )
     };
 }
 
@@ -148,11 +134,21 @@ macro_rules! ty {
 
 /// Build a `syn::Path` from a bare path token: `path!(crate::conv::f)`. The
 /// callable argument of [`ConvertDecl::input_with`] /
-/// [`ConvertDecl::output_with`].
+/// [`ConvertDecl::output_with`] and [`ConstDecl::with`].
 #[macro_export]
 macro_rules! path {
     ($p:path) => {
         $crate::__macro_support::parse_path(stringify!($p))
+    };
+}
+
+/// Build a `syn::Expr` from an expression token: `expr!(format!("{A}:{B}"))`.
+/// The initializer argument of [`ConstDecl::expr`] — allowed only for
+/// constants, where the expression binds no arguments.
+#[macro_export]
+macro_rules! expr {
+    ($e:expr) => {
+        $crate::__macro_support::parse_expr(stringify!($e))
     };
 }
 
@@ -677,19 +673,52 @@ impl FunctionDecl {
     }
 }
 
-/// Declares one `#[prebindgen]` **const** for emission: on the Rust side a
-/// nullary JNI getter extern is generated (the const's type goes through the
-/// ordinary output-converter machinery, exactly like a function return); on
-/// the Kotlin side the const surfaces as an eagerly-initialized top-level
-/// `val` in its package's `.kt` file.
+/// A [`ConstDecl`]'s **value source** — where the constant's value comes
+/// from. Mirrors `convert!`'s source vocabulary at the nullary edge:
+/// prebindgen item (bare) / prebindgen fn (`.fun`) / binding-local named fn
+/// (`.with`) / expression (`.expr` — const-only: an expression binds no
+/// arguments only when there is no value flowing in).
+// Build-time declaration object, a handful per binding — the Expr variant's
+// size is irrelevant, same trade-off as `ConvertSpec`.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum ConstSource {
+    /// The same-named `#[prebindgen]` const (the bare `constant!(X)` form).
+    Item,
+    /// A **nullary** `#[prebindgen]` fn; the value type is read from its
+    /// registry signature and the result flows through the ordinary
+    /// generated wrapper, consumed as an eager `val`.
+    Fun(syn::Ident),
+    /// A binding-defined initializer expression with a **stated** value
+    /// type, evaluated once inside a generated nullary JNI getter (with a
+    /// glob import of every source module in scope). `.with(ty, path)`
+    /// lowers here as `path()`.
+    Expr { ty: syn::Type, expr: syn::Expr },
+}
+
+/// Declares one **constant** for emission: an eagerly-initialized top-level
+/// Kotlin `val` in its package's `.kt` file, initialized through a generated
+/// nullary JNI getter (the value type goes through the ordinary
+/// output-converter machinery, exactly like a function return).
 ///
-/// Build one with [`constant!`](crate::constant) and add it to a
-/// [`PackageDecl`] via [`PackageDecl::constant`]. Opaque-handle-typed consts
-/// are rejected (a shared closeable `val` is semantically wrong) — expose a
-/// factory function instead.
+/// Build one with [`constant!`](crate::constant) — the ident is the `val`
+/// name — and pick the value source:
+///
+/// ```rust,ignore
+/// .constant(constant!(MAX_LEN))                          // #[prebindgen] const MAX_LEN
+/// .constant(constant!(TAG_RUNTIME).fun(fun!(tag_runtime)))  // nullary #[prebindgen] fn
+/// .constant(constant!(VERSION).with(ty!(String), path!(crate::version)))  // binding-local fn
+/// .constant(constant!(BANNER).expr(ty!(String), expr!(format!("{A}:{B}"))))  // expression
+/// ```
+///
+/// For declaration loops build the subject at runtime with
+/// [`ConstDecl::named`]. Opaque-handle-typed (and `Result`-typed) constants
+/// are rejected for every source — expose a factory function instead.
 pub struct ConstDecl {
+    /// Subject ident: the default `val` name; for the [`ConstSource::Item`]
+    /// source also the `#[prebindgen]` const to look up.
     pub(crate) rust_ident: syn::Ident,
     pub(crate) kotlin_name_override: Option<String>,
+    pub(crate) source: ConstSource,
 }
 
 impl ConstDecl {
@@ -697,51 +726,99 @@ impl ConstDecl {
         Self {
             rust_ident,
             kotlin_name_override: None,
+            source: ConstSource::Item,
         }
     }
 
-    /// Set the Kotlin-side name. Default: the Rust const ident verbatim
+    /// Runtime form of [`constant!`](crate::constant) for declaration
+    /// loops: `ConstDecl::named(format!("ENCODING_{n}")).expr(ty, expr)`.
+    /// The name must be a valid identifier (it seeds the extern symbol).
+    pub fn named(name: impl AsRef<str>) -> Self {
+        let name = name.as_ref();
+        let ident: syn::Ident = syn::parse_str(name)
+            .unwrap_or_else(|e| panic!("constant name `{name}` is not a valid identifier: {e}"));
+        Self::new(ident)
+    }
+
+    /// Set the Kotlin-side `val` name. Default: the subject ident verbatim
     /// (`MAX_LEN` → `val MAX_LEN` — SCREAMING_SNAKE is the Kotlin constant
     /// convention too).
     pub fn name(mut self, kotlin_name: impl Into<String>) -> Self {
         self.kotlin_name_override = Some(kotlin_name.into());
         self
     }
+
+    /// The declared `val` name (override, else the subject ident).
+    pub(crate) fn val_name(&self) -> String {
+        self.kotlin_name_override
+            .clone()
+            .unwrap_or_else(|| self.rust_ident.to_string())
+    }
+
+    fn set_source(mut self, source: ConstSource) -> Self {
+        assert!(
+            matches!(self.source, ConstSource::Item),
+            "constant `{}`: value source already set — a constant has exactly one source \
+             (.fun / .with / .expr)",
+            self.rust_ident
+        );
+        self.source = source;
+        self
+    }
+
+    /// Value source: a **nullary** `#[prebindgen]` fn (e.g. a value a Rust
+    /// `const` cannot express — a string only obtainable through a runtime
+    /// `Display`). The value type is read from the fn's signature; the fn
+    /// must take no parameters and must not return `Result`.
+    pub fn fun(self, decl: FunctionDecl) -> Self {
+        assert!(
+            decl.param_expands.is_empty() && decl.return_expand.is_none(),
+            "constant `{}`: expand overrides don't apply to a constant source fn `{}`",
+            self.rust_ident,
+            decl.rust_ident
+        );
+        assert!(
+            decl.kotlin_name_override.is_none(),
+            "constant `{}`: the val name belongs on `constant!(…)` (or its `.name(…)`), \
+             not on the source fn `{}`",
+            self.rust_ident,
+            decl.rust_ident
+        );
+        self.set_source(ConstSource::Fun(decl.rust_ident))
+    }
+
+    /// Value source: a **binding-local nullary fn** named by path —
+    /// `(stated value type, path)`, the const analog of
+    /// [`ConvertDecl::input_with`]. The fn lives in the binding crate
+    /// (callable because the generated file compiles inside it):
+    /// `fn() -> T`.
+    pub fn with(self, ty: syn::Type, path: syn::Path) -> Self {
+        let expr: syn::Expr = syn::parse_quote!(#path());
+        self.set_source(ConstSource::Expr { ty, expr })
+    }
+
+    /// Value source: a binding-defined **expression** with a stated value
+    /// type, evaluated once inside the generated getter with a glob import
+    /// of every source module in scope — so it composes source-crate
+    /// `#[prebindgen]` items freely, e.g.
+    /// `expr!(encoding_to_string(encoding_const_text_plain()))`. This
+    /// source exists only for constants: an expression binds no arguments
+    /// exactly when nothing flows in (a unary conversion source must be a
+    /// named callable — see [`ConvertDecl`]). Fns referenced only inside
+    /// expressions are undeclared to the registry — acknowledge them via
+    /// [`JniGen::ignore_fun`] / [`JniGen::ignore_funs_where`].
+    pub fn expr(self, ty: syn::Type, expr: syn::Expr) -> Self {
+        self.set_source(ConstSource::Expr { ty, expr })
+    }
 }
 
-/// Declares one **expression-backed constant**: an arbitrary binding-defined
-/// Rust expression, evaluated once inside a generated nullary JNI getter and
-/// surfaced as an eagerly-initialized top-level Kotlin `val`. The expression
-/// runs with a glob import of every source module in scope, so it composes the source
-/// crate's `#[prebindgen]` items freely without the source crate having to
-/// export a dedicated accessor per constant — e.g.
-/// `encoding_to_string(encoding_const_text_plain())`.
-///
-/// Build one with [`constant_expr!`](crate::constant_expr) (literal form) or
-/// [`ConstExprDecl::new`] (runtime form, for declaration loops) and add it to
-/// a [`PackageDecl`] via [`PackageDecl::constant_expr`]. The value type is
-/// declared explicitly and flows through the ordinary output-converter
-/// machinery; opaque-handle and `Result` types are rejected like every other
-/// constant kind.
+/// Internal storage form of an expression-backed constant (the lowered
+/// `.with` / `.expr` sources of [`ConstDecl`]).
 #[derive(Clone)]
-pub struct ConstExprDecl {
+pub(crate) struct ConstExprDecl {
     pub(crate) kotlin_name: String,
     pub(crate) ty: syn::Type,
     pub(crate) expr: syn::Expr,
-}
-
-impl ConstExprDecl {
-    /// `kotlin_name` is the top-level `val` name (also the seed of the
-    /// extern symbol, so it must be unique among the binding's constants);
-    /// `ty` is the Rust value type the expression yields; `expr` is the
-    /// initializer expression, resolved against the source module.
-    pub fn new(kotlin_name: impl Into<String>, ty: syn::Type, expr: syn::Expr) -> Self {
-        Self {
-            kotlin_name: kotlin_name.into(),
-            ty,
-            expr,
-        }
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -760,8 +837,6 @@ pub struct PackageDecl {
     pub(crate) classes: Vec<ClassDecl>,
     pub(crate) functions: Vec<FunctionDecl>,
     pub(crate) constants: Vec<ConstDecl>,
-    pub(crate) constant_functions: Vec<FunctionDecl>,
-    pub(crate) constant_exprs: Vec<ConstExprDecl>,
 }
 
 impl PackageDecl {
@@ -777,8 +852,6 @@ impl PackageDecl {
             classes: Vec::new(),
             functions: Vec::new(),
             constants: Vec::new(),
-            constant_functions: Vec::new(),
-            constant_exprs: Vec::new(),
         }
     }
 
@@ -798,46 +871,13 @@ impl PackageDecl {
         self
     }
 
-    /// Add a `#[prebindgen]` const to this package: a top-level Kotlin `val`
-    /// in the package file, initialized through a generated nullary JNI
-    /// getter. Take a bare name via [`constant!`](crate::constant), or a
-    /// customized [`ConstDecl`] when you need `.name(...)`.
+    /// Add a **constant** to this package: a top-level Kotlin `val` in the
+    /// package file, initialized through a generated nullary JNI getter.
+    /// Build the decl with [`constant!`](crate::constant) and pick its
+    /// value source (`#[prebindgen]` const by default, `.fun` / `.with` /
+    /// `.expr` otherwise) — see [`ConstDecl`].
     pub fn constant(mut self, decl: ConstDecl) -> Self {
         self.constants.push(decl);
-        self
-    }
-
-    /// Add a **function-backed constant** to this package: a **nullary**
-    /// `#[prebindgen]` fn whose result surfaces as an eagerly-initialized
-    /// top-level Kotlin `val` (computed once, at package-file class-load,
-    /// through the ordinary generated wrapper) instead of a callable `fun`.
-    /// Use it for constant values a Rust `const` cannot express — e.g. a
-    /// string only obtainable through a runtime `Display`.
-    ///
-    /// `.name(...)` sets the val name; the default is the fn ident verbatim
-    /// (you almost always want an explicit SCREAMING_SNAKE name). The same
-    /// restrictions as [`Self::constant`] apply to the return type
-    /// (opaque-handle results are rejected), the fn must take no parameters,
-    /// and expand overrides are meaningless here — both are hard errors.
-    pub fn constant_fun(mut self, decl: FunctionDecl) -> Self {
-        assert!(
-            decl.param_expands.is_empty() && decl.return_expand.is_none(),
-            "constant_fun `{}`: expand overrides don't apply to a constant — \
-             declare a plain `FunctionDecl` (optionally with `.name(...)`)",
-            decl.rust_ident
-        );
-        self.constant_functions.push(decl);
-        self
-    }
-
-    /// Add an **expression-backed constant** to this package: an arbitrary
-    /// binding-defined Rust expression evaluated once (at package-file
-    /// class-load) inside a generated nullary JNI getter, surfacing as an
-    /// eagerly-initialized top-level Kotlin `val`. See [`ConstExprDecl`];
-    /// build one with [`constant_expr!`](crate::constant_expr) or
-    /// [`ConstExprDecl::new`].
-    pub fn constant_expr(mut self, decl: ConstExprDecl) -> Self {
-        self.constant_exprs.push(decl);
         self
     }
 }
@@ -854,8 +894,8 @@ impl PackageDecl {
 ///
 /// ```rust,ignore
 /// .convert(convert!(Millis)
-///     .input(fun!(millis_from_long))   // fn(u64) -> Millis    (wire → rust)
-///     .output(fun!(millis_value)))     // fn(&Millis) -> u64   (rust → wire)
+///     .input_fun(fun!(millis_from_long))   // fn(u64) -> Millis    (wire → rust)
+///     .output_fun(fun!(millis_value)))     // fn(&Millis) -> u64   (rust → wire)
 /// ```
 ///
 /// The Kotlin surface derives from the conversion functions' other-side type
@@ -924,7 +964,7 @@ impl ConvertDecl {
         assert!(
             self.input.is_none(),
             "convert!({}): the input conversion is already declared — pick ONE of \
-             .input()/.input_from()/.input_try_from()/.input_with()",
+             .input_fun()/.input_from()/.input_try_from()/.input_with()",
             self.key.as_str()
         );
         self.input = Some(spec);
@@ -935,7 +975,7 @@ impl ConvertDecl {
         assert!(
             self.output.is_none(),
             "convert!({}): the output conversion is already declared — pick ONE of \
-             .output()/.output_into()/.output_try_into()/.output_with()",
+             .output_fun()/.output_into()/.output_try_into()/.output_with()",
             self.key.as_str()
         );
         self.output = Some(spec);
@@ -967,8 +1007,8 @@ impl ConvertDecl {
     /// `#[prebindgen]` `fn(U) -> T` or `fn(U) -> Result<T, E>` where `T` is
     /// this decl's type. `U` (taken by value or `&U`) determines the wire and
     /// the Kotlin surface through its own converter chain.
-    pub fn input(self, rust_fun: FunctionDecl) -> Self {
-        let ident = self.plain_fn_ident("input", rust_fun);
+    pub fn input_fun(self, rust_fun: FunctionDecl) -> Self {
+        let ident = self.plain_fn_ident("input_fun", rust_fun);
         self.set_input(ConvertSpec::PrebindgenFn(ident))
     }
 
@@ -1027,9 +1067,9 @@ impl ConvertDecl {
 
     /// The **out-of-Rust** conversion (returns, callback arguments) as a
     /// `#[prebindgen]` `fn(&T) -> U` (or `fn(T) -> U`) where `T` is this
-    /// decl's type — the counterpart of [`input`](Self::input).
-    pub fn output(self, rust_fun: FunctionDecl) -> Self {
-        let ident = self.plain_fn_ident("output", rust_fun);
+    /// decl's type — the counterpart of [`input_fun`](Self::input_fun).
+    pub fn output_fun(self, rust_fun: FunctionDecl) -> Self {
+        let ident = self.plain_fn_ident("output_fun", rust_fun);
         self.set_output(ConvertSpec::PrebindgenFn(ident))
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -109,8 +109,8 @@ macro_rules! constant {
 /// Build a [`ConstExprDecl`] in val-declaration syntax:
 /// `constant_expr!(BANNER: String = format!("{COVER_TAG}:{COVER_MAGIC}"))` is
 /// `ConstExprDecl::new("BANNER", <String>, <the expression>)`. The expression
-/// is evaluated inside the generated getter with `use <source_module>::*;`
-/// in scope.
+/// is evaluated inside the generated getter with a glob import of every
+/// source module in scope.
 #[macro_export]
 macro_rules! constant_expr {
     ($name:ident : $ty:ty = $expr:expr) => {
@@ -691,7 +691,7 @@ impl ConstDecl {
 /// Declares one **expression-backed constant**: an arbitrary binding-defined
 /// Rust expression, evaluated once inside a generated nullary JNI getter and
 /// surfaced as an eagerly-initialized top-level Kotlin `val`. The expression
-/// runs with `use <source_module>::*;` in scope, so it composes the source
+/// runs with a glob import of every source module in scope, so it composes the source
 /// crate's `#[prebindgen]` items freely without the source crate having to
 /// export a dedicated accessor per constant — e.g.
 /// `encoding_to_string(encoding_const_text_plain())`.

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -862,8 +862,9 @@ impl PackageDecl {
 /// (`u64` ⇒ `Long`) — nothing is stated verbatim. An input function may be
 /// fallible (`fn(U) -> Result<T, E>`): an `Err` routes to the caller's error
 /// handler. The functions may live in the flat crate or in a **helper
-/// crate** ingested as an extra source ([`crate::core::Registry::from_sources`]);
-/// generated calls qualify each function with its origin crate.
+/// crate** whose item stream is chained into the same
+/// [`crate::core::Registry::from_items`] call; generated calls qualify each
+/// function with its origin crate.
 ///
 /// Distinct from the [`expand_param!`](crate::expand_param) /
 /// [`expand_return!`](crate::expand_return) boundary decls: those reshape a

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -6,8 +6,8 @@
 //! `Builder`/`Decl` split, no terminal `.build()` call.
 //!
 //! `JniGen` itself only ever *accepts* fully-built values of these types
-//! (`JniGen::package`, `JniGen::scalar_type_wrapper`,
-//! `JniGen::generic_type_wrapper`, in `builder.rs`); none of them reach back
+//! (`JniGen::package`, `JniGen::expand`, `JniGen::convert`, in
+//! `builder.rs`); none of them reach back
 //! into any `JniGen` state while being built.
 
 use super::*;
@@ -135,28 +135,13 @@ macro_rules! package {
     };
 }
 
-/// Build a [`ScalarTypeWrapperDecl`] directly from bare Rust types:
-/// `scalar_type_wrapper!(Millis, jni::sys::jlong, "Long")` is
-/// `ScalarTypeWrapperDecl::new(<Millis as syn::Type>, <jni::sys::jlong as syn::Type>, "Long")`.
+/// Build a [`ConvertDecl`] directly from a bare Rust type:
+/// `convert!(Millis)` is `ConvertDecl::new(<Millis as syn::Type>)`.
+/// See [`ptr_class!`] for the parsing mechanics.
 #[macro_export]
-macro_rules! scalar_type_wrapper {
-    ($pattern:ty, $wire:ty, $kotlin_type:expr) => {
-        $crate::lang::ScalarTypeWrapperDecl::new(
-            $crate::__macro_support::parse_type(stringify!($pattern)),
-            $crate::__macro_support::parse_type(stringify!($wire)),
-            $kotlin_type,
-        )
-    };
-}
-
-/// Build a [`GenericTypeWrapperDecl`] directly from a bare wildcard type
-/// pattern: `generic_type_wrapper!(Result<_, ConcreteErr>)`.
-#[macro_export]
-macro_rules! generic_type_wrapper {
+macro_rules! convert {
     ($t:ty) => {
-        $crate::lang::GenericTypeWrapperDecl::new($crate::__macro_support::parse_type(stringify!(
-            $t
-        )))
+        $crate::lang::ConvertDecl::new($crate::__macro_support::parse_type(stringify!($t)))
     };
 }
 
@@ -837,246 +822,102 @@ impl PackageDecl {
 }
 
 // ──────────────────────────────────────────────────────────────────────
-// Wrapper decls — split by rank (see the module doc for why)
+// Convert decl — the canonical single-value conversion for a type
 // ──────────────────────────────────────────────────────────────────────
 
-/// Rejects a wrapper registration on a Rust **builtin** type: the generated
-/// converter qualifies the pattern with the `source_module`
-/// (`myflat::usize`), which does not compile. Wrap the builtin in a
-/// source-crate newtype (like `Millis(u64)`) instead. Only ever relevant for
-/// rank-0 (a builtin type has no wildcards), so this is called from
-/// [`ScalarTypeWrapperDecl::new`] alone.
-fn reject_builtin_wrapper_pattern(key: &TypeKey) {
+/// Declares a type's **canonical single-value conversion**: how one value of
+/// the type crosses the boundary wherever a single value is needed — as a
+/// parameter or return, inside `Option<_>` / `Vec<_>` / the `Result<T, E>`
+/// success position, as a `data_class` field. The conversion is a pair of
+/// ordinary `#[prebindgen]` functions (no injected Rust expressions):
+///
+/// ```rust,ignore
+/// .convert(convert!(Millis)
+///     .input(fun!(millis_from_long))   // fn(u64) -> Millis    (wire → rust)
+///     .output(fun!(millis_value)))     // fn(&Millis) -> u64   (rust → wire)
+/// ```
+///
+/// The Kotlin surface derives from the conversion functions' other-side type
+/// (`u64` ⇒ `Long`) — nothing is stated verbatim. An input function may be
+/// fallible (`fn(U) -> Result<T, E>`): an `Err` routes to the caller's error
+/// handler. The functions may live in the flat crate or in a **helper
+/// crate** ingested as an extra source ([`crate::core::Registry::from_sources`]);
+/// generated calls qualify each function with its origin crate.
+///
+/// Distinct from the [`expand_param!`](crate::expand_param) /
+/// [`expand_return!`](crate::expand_return) boundary decls: those reshape a
+/// **function boundary** into multiple leaves (variants in / fields out),
+/// while `convert!` defines the type's one-value form used everywhere else.
+/// A type may declare both — expansion wins at the fn boundaries where it is
+/// declared; the conversion serves every other position. The method names
+/// differ deliberately: converters are direction-things ([`input`](Self::input)
+/// also serves callback returns, [`output`](Self::output) also serves
+/// callback arguments), while expansion decls are position-things.
+#[derive(Clone)]
+pub struct ConvertDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) input: Option<syn::Ident>,
+    pub(crate) output: Option<syn::Ident>,
+}
+
+impl ConvertDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        reject_builtin_convert_type(&TypeKey::from_type(&rust_type));
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            input: None,
+            output: None,
+        }
+    }
+
+    /// The **into-Rust** conversion (parameters, callback returns): a
+    /// `#[prebindgen]` `fn(U) -> T` or `fn(U) -> Result<T, E>` where `T` is
+    /// this decl's type. `U` (taken by value or `&U`) determines the wire and
+    /// the Kotlin surface through its own converter chain.
+    pub fn input(mut self, rust_fun: FunctionDecl) -> Self {
+        assert!(
+            rust_fun.kotlin_name_override.is_none()
+                && rust_fun.param_expands.is_empty()
+                && rust_fun.return_expand.is_none(),
+            "convert!({}).input({}): a conversion function is never surfaced in Kotlin — \
+             .name()/expand overrides don't apply",
+            self.key.as_str(),
+            rust_fun.rust_ident
+        );
+        self.input = Some(rust_fun.rust_ident);
+        self
+    }
+
+    /// The **out-of-Rust** conversion (returns, callback arguments): a
+    /// `#[prebindgen]` `fn(&T) -> U` (or `fn(T) -> U`) where `T` is this
+    /// decl's type — the counterpart of [`input`](Self::input).
+    pub fn output(mut self, rust_fun: FunctionDecl) -> Self {
+        assert!(
+            rust_fun.kotlin_name_override.is_none()
+                && rust_fun.param_expands.is_empty()
+                && rust_fun.return_expand.is_none(),
+            "convert!({}).output({}): a conversion function is never surfaced in Kotlin — \
+             .name()/expand overrides don't apply",
+            self.key.as_str(),
+            rust_fun.rust_ident
+        );
+        self.output = Some(rust_fun.rust_ident);
+        self
+    }
+}
+
+/// Rejects a `convert!` declaration on a Rust **builtin** type: builtins
+/// already have their own converters, and the generated calls would try to
+/// qualify the builtin with a crate path. Wrap the builtin in a source-crate
+/// newtype (like `Millis(u64)`) instead.
+fn reject_builtin_convert_type(key: &TypeKey) {
     const BUILTINS: &[&str] = &[
         "usize", "isize", "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128",
-        "f32", "f64", "bool", "char", "str",
+        "f32", "f64", "bool", "char", "str", "String",
     ];
     assert!(
         !BUILTINS.contains(&key.as_str()),
-        "ScalarTypeWrapperDecl on builtin `{}`: the generated converter qualifies the pattern \
-         with the source module, which is invalid for builtins — wrap the builtin in a newtype \
-         instead",
+        "convert!({}): builtins already have converters — wrap the builtin in a newtype instead",
         key.as_str()
     );
-}
-
-/// The fixed identifier every wrapper body sees in scope for "the value being
-/// converted" (`env: &mut JNIEnv` is NOT provided — confirmed zero real
-/// wrapper bodies, built-in or user, ever need it; see the module doc).
-pub(crate) fn wrapper_value_ident() -> syn::Ident {
-    syn::Ident::new("v", Span::call_site())
-}
-
-/// A [`ScalarTypeWrapperDecl`] conversion body: given the in-scope value
-/// ident, produce the conversion expression.
-pub(crate) type ScalarConvFn = Arc<dyn Fn(&syn::Ident) -> syn::Expr + Send + Sync>;
-
-/// Teaches the generator to carry one Rust type across the boundary as a
-/// **plain scalar** — e.g. a `Millis(u64)` newtype that should surface in
-/// Kotlin as a `Long`, converted with your own expressions each way, with no
-/// generated class. The scalar peer of [`ValueClassDecl`] (which carries
-/// `Copy` types as `ByteArray`). Register it with
-/// [`JniGen::scalar_type_wrapper`]; it applies wherever the type appears, in
-/// any package.
-///
-/// Build one with [`scalar_type_wrapper!`](crate::scalar_type_wrapper), then
-/// give it [`on_param`](Self::on_param) / [`on_return`](Self::on_return)
-/// conversions.
-pub struct ScalarTypeWrapperDecl {
-    pub(crate) pattern: syn::Type,
-    // Stored as tokenized source text, not `syn::Type`: this workspace's
-    // proc-macro2 feature resolution makes `syn::Type`/`syn::Expr` `!Send`/
-    // `!Sync` (it unconditionally wraps the compiler's non-Send
-    // `proc_macro::TokenStream` variant even outside a real proc-macro
-    // expansion), so an owned one can't be captured into the `Send + Sync`
-    // `WrapperFn` closure `JniGen::scalar_type_wrapper` builds from this —
-    // re-parsed fresh at lookup time instead.
-    pub(crate) wire: String,
-    pub(crate) kotlin_type: String,
-    pub(crate) input: Option<ScalarConvFn>,
-    pub(crate) output: Option<ScalarConvFn>,
-}
-
-impl ScalarTypeWrapperDecl {
-    /// `pattern` is the Rust type being mapped, `wire` is the primitive it
-    /// travels as (e.g. `jni::sys::jlong`), and `kotlin_type` is how it shows
-    /// up in Kotlin (e.g. `"Long"`). See
-    /// [`scalar_type_wrapper!`](crate::scalar_type_wrapper) for the macro
-    /// shorthand.
-    pub fn new(pattern: syn::Type, wire: syn::Type, kotlin_type: impl Into<String>) -> Self {
-        reject_builtin_wrapper_pattern(&TypeKey::from_type(&pattern));
-        Self {
-            pattern,
-            wire: quote!(#wire).to_string(),
-            kotlin_type: kotlin_type.into(),
-            input: None,
-            output: None,
-        }
-    }
-
-    /// How to turn the incoming **wire value into the Rust value** (used when
-    /// the type is a parameter). `body` gets the wire value's ident and
-    /// returns the Rust expression, e.g.
-    /// `|v| pq!(perftest_flat::Millis(*#v as u64))`.
-    pub fn on_param(
-        mut self,
-        body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static,
-    ) -> Self {
-        self.input = Some(Arc::new(body));
-        self
-    }
-
-    /// How to turn the **Rust value into the wire value** (used when the type
-    /// is returned). `body` gets the Rust value's ident and returns the wire
-    /// expression, e.g. `|v| pq!(#v.0 as jni::sys::jlong)`.
-    pub fn on_return(
-        mut self,
-        body: impl Fn(&syn::Ident) -> syn::Expr + Send + Sync + 'static,
-    ) -> Self {
-        self.output = Some(Arc::new(body));
-        self
-    }
-}
-
-/// What a [`GenericTypeWrapperDecl`] conversion produces: the wire type plus
-/// the expression, and whether the conversion can fail with a **domain
-/// error** the caller should see. Use [`infallible`](Self::infallible) when
-/// it always succeeds, or [`fallible`](Self::fallible) to route an `Err` to
-/// the caller's error handler (as the built-in `Result` unwrap does).
-// large_enum_variant: a transient codegen-time value immediately destructured
-// by `into_tuple`; boxing the `syn` payloads would only complicate the public
-// variant shape.
-#[allow(clippy::large_enum_variant)]
-pub enum WireBody {
-    Infallible(syn::Type, syn::Expr),
-    Fallible(syn::Type, syn::Type, syn::Expr),
-}
-
-impl WireBody {
-    /// The conversion always succeeds. `wire` is the wire type, `expr` the
-    /// conversion expression.
-    pub fn infallible(wire: syn::Type, expr: syn::Expr) -> Self {
-        Self::Infallible(wire, expr)
-    }
-
-    /// The conversion may fail: `expr` evaluates to `Result<wire, error>`,
-    /// and an `Err` is delivered to the caller's error handler.
-    pub fn fallible(wire: syn::Type, error: syn::Type, expr: syn::Expr) -> Self {
-        Self::Fallible(wire, error, expr)
-    }
-
-    pub(crate) fn into_tuple(self) -> (syn::Type, Option<syn::Type>, syn::Expr) {
-        match self {
-            Self::Infallible(wire, expr) => (wire, None, expr),
-            Self::Fallible(wire, err, expr) => (wire, Some(err), expr),
-        }
-    }
-}
-
-/// Trait selecting the arity-appropriate impl of
-/// [`GenericTypeWrapperDecl::input`] / [`GenericTypeWrapperDecl::output`].
-/// The phantom type parameter discriminates closures of arity 1..3 so a
-/// single public method name accepts any of them. Closures take the wildcard
-/// substitutions plus the in-scope value ident, and return a [`WireBody`].
-pub trait WrapperBuilder<Arity>: Send + Sync + 'static {
-    fn into_wrapper_fn(self) -> WrapperFn;
-    fn rank() -> usize;
-}
-
-/// Arity-discriminating marker types. `Arity1`/`2`/`3` carry that many `_`
-/// slots in the registered pattern (e.g. `Result<_, _>` is `Arity2`).
-pub(crate) struct Arity1;
-pub(crate) struct Arity2;
-pub(crate) struct Arity3;
-
-impl<F> WrapperBuilder<Arity1> for F
-where
-    F: Fn(&syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
-{
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(
-            move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                Some(self(&args[0], &wrapper_value_ident()).into_tuple())
-            },
-        )
-    }
-    fn rank() -> usize {
-        1
-    }
-}
-
-impl<F> WrapperBuilder<Arity2> for F
-where
-    F: Fn(&syn::Type, &syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
-{
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(
-            move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                Some(self(&args[0], &args[1], &wrapper_value_ident()).into_tuple())
-            },
-        )
-    }
-    fn rank() -> usize {
-        2
-    }
-}
-
-impl<F> WrapperBuilder<Arity3> for F
-where
-    F: Fn(&syn::Type, &syn::Type, &syn::Type, &syn::Ident) -> WireBody + Send + Sync + 'static,
-{
-    fn into_wrapper_fn(self) -> WrapperFn {
-        Arc::new(
-            move |args: &[syn::Type], _registry: &Registry<KotlinMeta>| {
-                Some(self(&args[0], &args[1], &args[2], &wrapper_value_ident()).into_tuple())
-            },
-        )
-    }
-    fn rank() -> usize {
-        3
-    }
-}
-
-/// An **advanced** override for how a generic wrapper (`Option`/`Result`/
-/// `Vec`/…) is unwrapped for one specific inner type — e.g. handle
-/// `Result<_, MyError>` your own way instead of through the built-in
-/// `Result` support. The `pattern` carries `_` wildcards for the parts that
-/// stay generic. Register it with [`JniGen::generic_type_wrapper`]; it names
-/// no Kotlin type of its own and belongs to no package.
-///
-/// Build one with [`generic_type_wrapper!`](crate::generic_type_wrapper),
-/// then supply [`input`](Self::input) / [`output`](Self::output).
-pub struct GenericTypeWrapperDecl {
-    pub(crate) pattern: syn::Type,
-    pub(crate) input: Option<(usize, WrapperFn)>,
-    pub(crate) output: Option<(usize, WrapperFn)>,
-}
-
-impl GenericTypeWrapperDecl {
-    /// `pattern` contains 1–3 `_` wildcard placeholders (e.g.
-    /// `Result<_, ConcreteErr>`). See [`crate::generic_type_wrapper!`] for the
-    /// equivalent macro form.
-    pub fn new(pattern: syn::Type) -> Self {
-        Self {
-            pattern,
-            input: None,
-            output: None,
-        }
-    }
-
-    /// How to convert **into Rust** (used when the type is a parameter). The
-    /// closure receives one `&syn::Type` per `_` in `pattern` (so its arity
-    /// tells the generator how many wildcards there are), plus the value's
-    /// ident, and returns a [`WireBody`].
-    pub fn input<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
-        self.input = Some((B::rank(), builder.into_wrapper_fn()));
-        self
-    }
-
-    /// How to convert **out of Rust** (used when the type is returned) — the
-    /// counterpart of [`input`](Self::input).
-    pub fn output<A, B: WrapperBuilder<A>>(mut self, builder: B) -> Self {
-        self.output = Some((B::rank(), builder.into_wrapper_fn()));
-        self
-    }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -1053,6 +1053,29 @@ pub(crate) enum ConvertSpec {
     },
 }
 
+impl ConvertSpec {
+    /// One-line human description of the source kind (report use).
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            ConvertSpec::PrebindgenFn(f) => format!("`#[prebindgen]` fn `{f}`"),
+            ConvertSpec::Trait {
+                repr,
+                fallible: false,
+            } => format!("`Into` ⇄ `{}`", repr.to_token_stream()),
+            ConvertSpec::Trait {
+                repr,
+                fallible: true,
+            } => format!("`TryInto` ⇄ `{}`", repr.to_token_stream()),
+            ConvertSpec::LocalFn { repr, path, error } => format!(
+                "binding-local `{}` ⇄ `{}`{}",
+                path.to_token_stream(),
+                repr.to_token_stream(),
+                if error.is_some() { " (fallible)" } else { "" }
+            ),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ConvertDecl {
     pub(crate) key: TypeKey,
@@ -1061,6 +1084,22 @@ pub struct ConvertDecl {
 }
 
 impl ConvertDecl {
+    /// `: input …, output …` suffix for the report's conversions section.
+    pub(crate) fn describe_sources(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(i) = &self.input {
+            parts.push(format!("input {}", i.describe()));
+        }
+        if let Some(o) = &self.output {
+            parts.push(format!("output {}", o.describe()));
+        }
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!(": {}", parts.join(", "))
+        }
+    }
+
     pub fn new(rust_type: syn::Type) -> Self {
         reject_builtin_convert_type(&TypeKey::from_type(&rust_type));
         Self {

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -17,8 +17,7 @@ use super::*;
 // by the accept logic in `builder.rs` once a decl is handed to `JniGen`)
 // ──────────────────────────────────────────────────────────────────────
 
-/// One arm of a `param_expand!` `.variant*` / per-fn `.param_expand*`
-/// build-from list.
+/// One arm of an `expand_param!` `.variant*` list (type-level or per-fn).
 #[derive(Clone)]
 pub(crate) enum LocalVariant {
     /// Build via this declared constructor member / constructor fn.
@@ -27,8 +26,7 @@ pub(crate) enum LocalVariant {
     SelfIdentity,
 }
 
-/// One arm of a `return_expand!` `.field*` / per-fn `.return_expand*` field
-/// list. The name is stored raw (`None` = derive at replay time: for a
+/// One arm of an `expand_return!` `.field*` list (type-level or per-fn). The name is stored raw (`None` = derive at replay time: for a
 /// class-level field, the class member's Kotlin name if the accessor is a
 /// declared member, else `snake_to_camel`; for a per-fn field,
 /// `snake_to_camel`).
@@ -43,7 +41,7 @@ pub(crate) enum LocalField {
 
 // Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
 // not a reduced ident+name record — so the `FunctionDecl`'s per-fn
-// `.param_expand*`/`.return_expand*` overrides survive to `builder.rs`'s
+// `.expand_param`/`.expand_return` overrides survive to `builder.rs`'s
 // `accept_members`, which applies them exactly like `accept_function` does
 // for free package functions.
 
@@ -162,23 +160,23 @@ macro_rules! generic_type_wrapper {
     };
 }
 
-/// Build a [`ParamExpandDecl`] directly from a bare Rust type:
-/// `param_expand!(KeyExpr)` is `ParamExpandDecl::new(<KeyExpr as syn::Type>)`.
+/// Build a [`ExpandParamDecl`] directly from a bare Rust type:
+/// `expand_param!(KeyExpr)` is `ExpandParamDecl::new(<KeyExpr as syn::Type>)`.
 /// See [`ptr_class!`] for the parsing mechanics.
 #[macro_export]
-macro_rules! param_expand {
+macro_rules! expand_param {
     ($t:ty) => {
-        $crate::lang::ParamExpandDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+        $crate::lang::ExpandParamDecl::new($crate::__macro_support::parse_type(stringify!($t)))
     };
 }
 
-/// Build a [`ReturnExpandDecl`] directly from a bare Rust type:
-/// `return_expand!(Sample)` is `ReturnExpandDecl::new(<Sample as syn::Type>)`.
+/// Build a [`ExpandReturnDecl`] directly from a bare Rust type:
+/// `expand_return!(Sample)` is `ExpandReturnDecl::new(<Sample as syn::Type>)`.
 /// See [`ptr_class!`] for the parsing mechanics.
 #[macro_export]
-macro_rules! return_expand {
+macro_rules! expand_return {
     ($t:ty) => {
-        $crate::lang::ReturnExpandDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+        $crate::lang::ExpandReturnDecl::new($crate::__macro_support::parse_type(stringify!($t)))
     };
 }
 
@@ -195,8 +193,8 @@ macro_rules! return_expand {
 /// or small `Copy` values ([`value_class!`](crate::value_class)).
 ///
 /// A type that never materializes in Kotlin needs **no class declaration at
-/// all**: give it boundary decls only ([`param_expand!`](crate::param_expand)
-/// / [`return_expand!`](crate::return_expand)) and it stays rust-side-only —
+/// all**: give it boundary decls only ([`expand_param!`](crate::expand_param)
+/// / [`expand_return!`](crate::expand_return)) and it stays rust-side-only —
 /// built from ingredients on the way in, decomposed into fields on the way
 /// out.
 ///
@@ -208,7 +206,7 @@ macro_rules! return_expand {
 /// companion-object factories ([`constructor`](Self::constructor)). How the
 /// type crosses the FFI boundary by default — accepted as which parameter
 /// variants, returned as which field set — is declared separately with
-/// [`param_expand!`](crate::param_expand) / [`return_expand!`](crate::return_expand)
+/// [`expand_param!`](crate::expand_param) / [`expand_return!`](crate::expand_return)
 /// handed to [`JniGen::expand`]; any single
 /// function can override those defaults locally (see [`FunctionDecl`]).
 ///
@@ -256,7 +254,7 @@ impl PtrClassDecl {
     /// factory** — callers write `Class.name(...)`. `rust_fun` returns `Self`
     /// (or `Result<Self, E>`) and its parameters become the factory's
     /// arguments. A constructor can also serve as a build option in a
-    /// [`param_expand!`](crate::param_expand) variant list.
+    /// [`expand_param!`](crate::expand_param) variant list.
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Constructor));
         self
@@ -277,9 +275,9 @@ impl From<syn::Type> for PtrClassDecl {
 /// may be supplied, as a list of *variants* — "built from this constructor's
 /// ingredients, OR that one's, OR passed as an existing handle". Applies to
 /// every function with a parameter of the type; a single function opts out or
-/// narrows via [`FunctionDecl::param_expand`] / [`FunctionDecl::param_expand_self`].
+/// narrows via [`FunctionDecl::expand_param`].
 ///
-/// Build one with [`param_expand!`](crate::param_expand), add arms with
+/// Build one with [`expand_param!`](crate::expand_param), add arms with
 /// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
 /// it to [`JniGen::expand`]. With more than one arm the generated Kotlin
 /// selects the variant at runtime.
@@ -294,17 +292,17 @@ impl From<syn::Type> for PtrClassDecl {
 /// ```
 /// // A KeyExpr param accepts EITHER a String (built via keyexpr_new_try_from)
 /// // OR an existing KeyExpr handle:
-/// let _ = prebindgen::param_expand!(KeyExpr)
+/// let _ = prebindgen::expand_param!(KeyExpr)
 ///     .variant(prebindgen::fun!(keyexpr_new_try_from))
 ///     .variant_self();
 /// ```
 #[derive(Clone)]
-pub struct ParamExpandDecl {
+pub struct ExpandParamDecl {
     pub(crate) key: TypeKey,
     pub(crate) variants: Vec<LocalVariant>,
 }
 
-impl ParamExpandDecl {
+impl ExpandParamDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
@@ -335,9 +333,9 @@ impl ParamExpandDecl {
 /// *fields*, all delivered in one FFI crossing — instead of an opaque handle
 /// the caller must then query field by field with more JNI calls. Applies to
 /// every function returning the type; a single function opts out or replaces
-/// the set via [`FunctionDecl::return_expand`] / [`FunctionDecl::return_expand_self`].
+/// the set via [`FunctionDecl::expand_return`].
 ///
-/// Build one with [`return_expand!`](crate::return_expand), add fields with
+/// Build one with [`expand_return!`](crate::expand_return), add fields with
 /// [`field`](Self::field) / [`field_self`](Self::field_self), and hand it to
 /// [`JniGen::expand`].
 ///
@@ -353,17 +351,17 @@ impl ParamExpandDecl {
 ///
 /// ```
 /// // A returned Sample crosses as { payload, kind } in one call:
-/// let _ = prebindgen::return_expand!(Sample)
+/// let _ = prebindgen::expand_return!(Sample)
 ///     .field(prebindgen::fun!(sample_get_payload))
 ///     .field(prebindgen::fun!(sample_get_kind));
 /// ```
 #[derive(Clone)]
-pub struct ReturnExpandDecl {
+pub struct ExpandReturnDecl {
     pub(crate) key: TypeKey,
     pub(crate) fields: Vec<LocalField>,
 }
 
-impl ReturnExpandDecl {
+impl ExpandReturnDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
@@ -401,20 +399,20 @@ impl ReturnExpandDecl {
 /// Deliberately **no** `impl From<syn::Type> for ExpandDecl` — a bare
 /// `syn::Type` alone doesn't say which direction it describes, so every
 /// declaration names its direction via the matching constructor macro:
-/// `.expand(prebindgen::param_expand!(Summary)...)`,
-/// `.expand(prebindgen::return_expand!(Sample)...)`.
+/// `.expand(prebindgen::expand_param!(Summary)...)`,
+/// `.expand(prebindgen::expand_return!(Sample)...)`.
 pub enum ExpandDecl {
-    Param(ParamExpandDecl),
-    Return(ReturnExpandDecl),
+    Param(ExpandParamDecl),
+    Return(ExpandReturnDecl),
 }
 
-impl From<ParamExpandDecl> for ExpandDecl {
-    fn from(d: ParamExpandDecl) -> Self {
+impl From<ExpandParamDecl> for ExpandDecl {
+    fn from(d: ExpandParamDecl) -> Self {
         Self::Param(d)
     }
 }
-impl From<ReturnExpandDecl> for ExpandDecl {
-    fn from(d: ReturnExpandDecl) -> Self {
+impl From<ExpandReturnDecl> for ExpandDecl {
+    fn from(d: ExpandReturnDecl) -> Self {
         Self::Return(d)
     }
 }
@@ -599,17 +597,17 @@ impl From<ValueClassDecl> for ClassDecl {
 /// [`PtrClassDecl::fun`] / [`PtrClassDecl::constructor`].
 ///
 /// Build it from a bare Rust name with [`fun!`](crate::fun) and chain
-/// [`name`](Self::name) to set its Kotlin name. The `param_expand*` /
-/// `return_expand*` methods **override, for this one function**, the
-/// boundary defaults its parameter/return types declare via
-/// [`param_expand!`](crate::param_expand) / [`return_expand!`](crate::return_expand)
-/// — most often to opt back out (a lone `_self`) so this function sees the
-/// raw handle rather than the type's default expansion.
+/// [`name`](Self::name) to set its Kotlin name.
+/// [`expand_param`](Self::expand_param) / [`expand_return`](Self::expand_return)
+/// **override, for this one function**, the boundary defaults its
+/// parameter/return types declare at the generator level ([`JniGen::expand`])
+/// — using the very same decl objects, so the complete-set rule is identical
+/// at both scopes.
 pub struct FunctionDecl {
     pub(crate) rust_ident: syn::Ident,
     pub(crate) kotlin_name_override: Option<String>,
-    pub(crate) input_overrides: Vec<(syn::Ident, Vec<LocalVariant>)>,
-    pub(crate) output_override: Option<Vec<LocalField>>,
+    pub(crate) param_expands: Vec<(String, ExpandParamDecl)>,
+    pub(crate) return_expand: Option<ExpandReturnDecl>,
 }
 
 impl FunctionDecl {
@@ -617,8 +615,8 @@ impl FunctionDecl {
         Self {
             rust_ident,
             kotlin_name_override: None,
-            input_overrides: Vec::new(),
-            output_override: None,
+            param_expands: Vec::new(),
+            return_expand: None,
         }
     }
 
@@ -629,63 +627,46 @@ impl FunctionDecl {
         self
     }
 
-    /// Override, for `param` of this function only, how that parameter is
-    /// built — the same idea as a [`ParamExpandDecl`] variant list, but
-    /// scoped here and keyed by which parameter (a function may have several
-    /// handle parameters, each overridden independently). Point at a
-    /// constructor to offer it as a build option; call again (same or a
-    /// different `param`) to add more.
-    pub fn param_expand(mut self, param: syn::Ident, ctor: FunctionDecl) -> Self {
-        self.input_override_entry(param)
-            .push(LocalVariant::Ctor(ctor.rust_ident));
+    /// Override, for the named parameter of this function only, how that
+    /// parameter is supplied — with the same [`ExpandParamDecl`] a type-level
+    /// default uses, so the **complete-set rule** applies here too: the decl
+    /// states the entire variant set for this param (a lone `.variant_self()`
+    /// = "only a ready-made handle", replacing the type's build variants —
+    /// e.g. *un*-declaring a key expression needs the handle, not a string).
+    ///
+    /// `param` is the Rust parameter name; the decl's type is cross-checked
+    /// against that parameter's (peeled) type at generation time — an unknown
+    /// parameter or a type mismatch is a hard error. Call again with a
+    /// different `param` to override several parameters independently;
+    /// declaring the same parameter twice is a hard error.
+    pub fn expand_param(mut self, param: impl AsRef<str>, decl: ExpandParamDecl) -> Self {
+        let param = param.as_ref().to_string();
+        assert!(
+            !self.param_expands.iter().any(|(p, _)| *p == param),
+            "fun!({}).expand_param(\"{}\", ...): parameter already has an expand override — \
+             declare each parameter's complete variant set in ONE decl",
+            self.rust_ident,
+            param
+        );
+        self.param_expands.push((param, decl));
         self
     }
 
-    /// Make `param` of this function accept **only a ready-made handle**,
-    /// ignoring the build variants its type would otherwise apply here. Use
-    /// it when one function needs the real object rather than something built
-    /// from ingredients — e.g. *un*-declaring a key expression needs the
-    /// handle, not a string.
-    pub fn param_expand_self(mut self, param: syn::Ident) -> Self {
-        self.input_override_entry(param)
-            .push(LocalVariant::SelfIdentity);
-        self
-    }
-
-    /// The variant list of `param`'s override, creating it on first use.
-    fn input_override_entry(&mut self, param: syn::Ident) -> &mut Vec<LocalVariant> {
-        let idx = match self.input_overrides.iter().position(|(p, _)| *p == param) {
-            Some(i) => i,
-            None => {
-                self.input_overrides.push((param, Vec::new()));
-                self.input_overrides.len() - 1
-            }
-        };
-        &mut self.input_overrides[idx].1
-    }
-
-    /// Override this function's return decomposition — the same idea as a
-    /// [`ReturnExpandDecl`] field list, but for this function alone. Add one
-    /// field per call; the field name is `field`'s `.name(...)` or the
-    /// camel-cased Rust name.
-    pub fn return_expand(mut self, field: FunctionDecl) -> Self {
-        self.output_override
-            .get_or_insert_with(Vec::new)
-            .push(LocalField::Named(
-                field.rust_ident,
-                field.kotlin_name_override,
-            ));
-        self
-    }
-
-    /// Return this function's result as the **raw handle**, overriding the
-    /// decomposition its return type would otherwise apply. Also the right
-    /// choice for a borrowed return (`&T` / `Option<&T>`), which crosses by
-    /// cloning into a fresh owned handle.
-    pub fn return_expand_self(mut self) -> Self {
-        self.output_override
-            .get_or_insert_with(Vec::new)
-            .push(LocalField::SelfField);
+    /// Override this function's return decomposition — with the same
+    /// [`ExpandReturnDecl`] a type-level default uses, stating the complete
+    /// field set (a lone `.field_self()` = the raw whole value, which for a
+    /// borrowed `&T` / `Option<&T>` return crosses by cloning into a fresh
+    /// owned handle). The decl's type is cross-checked against the function's
+    /// (peeled) return type at generation time — a mismatch is a hard error.
+    /// At most one per function.
+    pub fn expand_return(mut self, decl: ExpandReturnDecl) -> Self {
+        assert!(
+            self.return_expand.is_none(),
+            "fun!({}).expand_return(...): the function already has a return expand override — \
+             declare the complete field set in ONE decl",
+            self.rust_ident
+        );
+        self.return_expand = Some(decl);
         self
     }
 }
@@ -831,11 +812,11 @@ impl PackageDecl {
     /// (you almost always want an explicit SCREAMING_SNAKE name). The same
     /// restrictions as [`Self::constant`] apply to the return type
     /// (opaque-handle results are rejected), the fn must take no parameters,
-    /// and flatten overrides are meaningless here — both are hard errors.
+    /// and expand overrides are meaningless here — both are hard errors.
     pub fn constant_fun(mut self, decl: FunctionDecl) -> Self {
         assert!(
-            decl.input_overrides.is_empty() && decl.output_override.is_none(),
-            "constant_fun `{}`: flatten overrides don't apply to a constant — \
+            decl.param_expands.is_empty() && decl.return_expand.is_none(),
+            "constant_fun `{}`: expand overrides don't apply to a constant — \
              declare a plain `FunctionDecl` (optionally with `.name(...)`)",
             decl.rust_ident
         );

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -194,6 +194,12 @@ macro_rules! return_expand {
 /// as opposed to plain data you copy across ([`data_class!`](crate::data_class))
 /// or small `Copy` values ([`value_class!`](crate::value_class)).
 ///
+/// A type that never materializes in Kotlin needs **no class declaration at
+/// all**: give it boundary decls only ([`param_expand!`](crate::param_expand)
+/// / [`return_expand!`](crate::return_expand)) and it stays rust-side-only —
+/// built from ingredients on the way in, decomposed into fields on the way
+/// out.
+///
 /// Build one with [`ptr_class!`](crate::ptr_class), add it to a
 /// [`PackageDecl`], and hand that to [`JniGen::package`].
 ///
@@ -278,6 +284,13 @@ impl From<syn::Type> for PtrClassDecl {
 /// it to [`JniGen::param_expand`]. With more than one arm the generated Kotlin
 /// selects the variant at runtime.
 ///
+/// The type does **not** have to be declared in any package. A boundary decl
+/// on an undeclared type makes it **rust-side-only**: the value is always
+/// built from its ingredients at the boundary and never materializes in
+/// Kotlin — no class, no handle, nothing to `close()`. The one restriction is
+/// structural: [`variant_self`](Self::variant_self) hard-errors for such a
+/// type, since there is no Kotlin object to pass.
+///
 /// ```
 /// // A KeyExpr param accepts EITHER a String (built via keyexpr_new_try_from)
 /// // OR an existing KeyExpr handle:
@@ -327,6 +340,16 @@ impl ParamExpandDecl {
 /// Build one with [`return_expand!`](crate::return_expand), add fields with
 /// [`field`](Self::field) / [`field_self`](Self::field_self), and hand it to
 /// [`JniGen::return_expand`].
+///
+/// The type does **not** have to be declared in any package. A boundary decl
+/// on an undeclared type makes it **rust-side-only**: every returned /
+/// callback-delivered / `Result`-error value of it is decomposed into these
+/// fields and the value itself never reaches Kotlin. This is the natural
+/// shape for an error type consumed by the `onError` channel — no dead
+/// Kotlin class is emitted. Restrictions for such a type:
+/// [`field_self`](Self::field_self) hard-errors (there is no Kotlin object to
+/// deliver), and field names cannot inherit from class members (there are
+/// none) — use `.name(...)` on each field or accept the camel-cased default.
 ///
 /// ```
 /// // A returned Sample crosses as { payload, kind } in one call:

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -135,6 +135,27 @@ macro_rules! package {
     };
 }
 
+/// Build a `syn::Type` from a bare Rust type token: `ty!(i32)`. The type
+/// argument of decl methods like [`ConvertDecl::input_from`] — always yields
+/// the concrete `syn::Type`, so no inference context is needed (see
+/// [`ident!`](crate::ident) for the E0283 background).
+#[macro_export]
+macro_rules! ty {
+    ($t:ty) => {
+        $crate::__macro_support::parse_type(stringify!($t))
+    };
+}
+
+/// Build a `syn::Path` from a bare path token: `path!(crate::conv::f)`. The
+/// callable argument of [`ConvertDecl::input_with`] /
+/// [`ConvertDecl::output_with`].
+#[macro_export]
+macro_rules! path {
+    ($p:path) => {
+        $crate::__macro_support::parse_path(stringify!($p))
+    };
+}
+
 /// Build a [`ConvertDecl`] directly from a bare Rust type:
 /// `convert!(Millis)` is `ConvertDecl::new(<Millis as syn::Type>)`.
 /// See [`ptr_class!`] for the parsing mechanics.
@@ -853,11 +874,30 @@ impl PackageDecl {
 /// differ deliberately: converters are direction-things ([`input`](Self::input)
 /// also serves callback returns, [`output`](Self::output) also serves
 /// callback arguments), while expansion decls are position-things.
+/// One direction's conversion **source** — where the conversion code comes
+/// from. Four kinds, one per [`ConvertDecl`] method family.
+#[derive(Clone)]
+pub(crate) enum ConvertSpec {
+    /// A `#[prebindgen]` fn (flat or helper crate): the representable type
+    /// and fallibility are read from its registry signature at lookup time.
+    PrebindgenFn(syn::Ident),
+    /// A `core::convert` trait impl; the representable type is stated
+    /// explicitly (there is no signature to read). `fallible` selects
+    /// `TryInto` (the associated `Error` routes to the caller's error
+    /// handler) vs `Into`.
+    Trait { repr: syn::Type, fallible: bool },
+    /// An arbitrary callable path — typically a plain fn in the **binding
+    /// crate itself** (the generated file compiles inside it, so
+    /// `crate::…` paths resolve). Representable type stated explicitly;
+    /// by-value both ways (`fn(Repr) -> T` / `fn(T) -> Repr`), infallible.
+    LocalFn { repr: syn::Type, path: syn::Path },
+}
+
 #[derive(Clone)]
 pub struct ConvertDecl {
     pub(crate) key: TypeKey,
-    pub(crate) input: Option<syn::Ident>,
-    pub(crate) output: Option<syn::Ident>,
+    pub(crate) input: Option<ConvertSpec>,
+    pub(crate) output: Option<ConvertSpec>,
 }
 
 impl ConvertDecl {
@@ -870,39 +910,128 @@ impl ConvertDecl {
         }
     }
 
-    /// The **into-Rust** conversion (parameters, callback returns): a
-    /// `#[prebindgen]` `fn(U) -> T` or `fn(U) -> Result<T, E>` where `T` is
-    /// this decl's type. `U` (taken by value or `&U`) determines the wire and
-    /// the Kotlin surface through its own converter chain.
-    pub fn input(mut self, rust_fun: FunctionDecl) -> Self {
+    fn set_input(mut self, spec: ConvertSpec) -> Self {
         assert!(
-            rust_fun.kotlin_name_override.is_none()
-                && rust_fun.param_expands.is_empty()
-                && rust_fun.return_expand.is_none(),
-            "convert!({}).input({}): a conversion function is never surfaced in Kotlin — \
-             .name()/expand overrides don't apply",
-            self.key.as_str(),
-            rust_fun.rust_ident
+            self.input.is_none(),
+            "convert!({}): the input conversion is already declared — pick ONE of \
+             .input()/.input_from()/.input_try_from()/.input_with()",
+            self.key.as_str()
         );
-        self.input = Some(rust_fun.rust_ident);
+        self.input = Some(spec);
         self
     }
 
-    /// The **out-of-Rust** conversion (returns, callback arguments): a
-    /// `#[prebindgen]` `fn(&T) -> U` (or `fn(T) -> U`) where `T` is this
-    /// decl's type — the counterpart of [`input`](Self::input).
-    pub fn output(mut self, rust_fun: FunctionDecl) -> Self {
+    fn set_output(mut self, spec: ConvertSpec) -> Self {
+        assert!(
+            self.output.is_none(),
+            "convert!({}): the output conversion is already declared — pick ONE of \
+             .output()/.output_into()/.output_try_into()/.output_with()",
+            self.key.as_str()
+        );
+        self.output = Some(spec);
+        self
+    }
+
+    fn plain_fn_ident(&self, dir: &str, rust_fun: FunctionDecl) -> syn::Ident {
         assert!(
             rust_fun.kotlin_name_override.is_none()
                 && rust_fun.param_expands.is_empty()
                 && rust_fun.return_expand.is_none(),
-            "convert!({}).output({}): a conversion function is never surfaced in Kotlin — \
+            "convert!({}).{dir}({}): a conversion function is never surfaced in Kotlin — \
              .name()/expand overrides don't apply",
             self.key.as_str(),
             rust_fun.rust_ident
         );
-        self.output = Some(rust_fun.rust_ident);
-        self
+        rust_fun.rust_ident
+    }
+
+    fn check_repr(&self, method: &str, repr: &syn::Type) {
+        assert!(
+            TypeKey::from_type(repr) != self.key,
+            "convert!({k}).{method}: the representable type must differ from `{k}` itself",
+            k = self.key.as_str()
+        );
+    }
+
+    /// The **into-Rust** conversion (parameters, callback returns) as a
+    /// `#[prebindgen]` `fn(U) -> T` or `fn(U) -> Result<T, E>` where `T` is
+    /// this decl's type. `U` (taken by value or `&U`) determines the wire and
+    /// the Kotlin surface through its own converter chain.
+    pub fn input(self, rust_fun: FunctionDecl) -> Self {
+        let ident = self.plain_fn_ident("input", rust_fun);
+        self.set_input(ConvertSpec::PrebindgenFn(ident))
+    }
+
+    /// The into-Rust conversion via `core::convert`: requires
+    /// `Repr: Into<T>` (satisfied by an `impl From<Repr> for T` through the
+    /// blanket). `repr` — stated explicitly, e.g. `ty!(i32)` — determines
+    /// the wire and Kotlin surface through its own converter chain.
+    pub fn input_from(self, repr: syn::Type) -> Self {
+        self.check_repr("input_from", &repr);
+        self.set_input(ConvertSpec::Trait {
+            repr,
+            fallible: false,
+        })
+    }
+
+    /// The fallible into-Rust conversion via `core::convert`: requires
+    /// `Repr: TryInto<T>` (satisfied by an `impl TryFrom<Repr> for T`). The
+    /// associated `Error` must implement `Display`; an `Err` routes to the
+    /// caller's error handler like any domain error.
+    pub fn input_try_from(self, repr: syn::Type) -> Self {
+        self.check_repr("input_try_from", &repr);
+        self.set_input(ConvertSpec::Trait {
+            repr,
+            fallible: true,
+        })
+    }
+
+    /// The into-Rust conversion as an arbitrary callable — typically a plain
+    /// fn declared **in the binding crate itself** (no `#[prebindgen]`
+    /// needed; the generated file compiles inside the binding crate, so
+    /// `path!(crate::…)` resolves). Shape: `fn(Repr) -> T`, by value,
+    /// infallible — for fallibility use a `TryFrom` impl or a
+    /// `#[prebindgen]` fn returning `Result`.
+    pub fn input_with(self, repr: syn::Type, path: syn::Path) -> Self {
+        self.check_repr("input_with", &repr);
+        self.set_input(ConvertSpec::LocalFn { repr, path })
+    }
+
+    /// The **out-of-Rust** conversion (returns, callback arguments) as a
+    /// `#[prebindgen]` `fn(&T) -> U` (or `fn(T) -> U`) where `T` is this
+    /// decl's type — the counterpart of [`input`](Self::input).
+    pub fn output(self, rust_fun: FunctionDecl) -> Self {
+        let ident = self.plain_fn_ident("output", rust_fun);
+        self.set_output(ConvertSpec::PrebindgenFn(ident))
+    }
+
+    /// The out-of-Rust conversion via `core::convert`: requires
+    /// `T: Into<Repr>` (satisfied by an `impl From<T> for Repr`).
+    pub fn output_into(self, repr: syn::Type) -> Self {
+        self.check_repr("output_into", &repr);
+        self.set_output(ConvertSpec::Trait {
+            repr,
+            fallible: false,
+        })
+    }
+
+    /// The fallible out-of-Rust conversion via `core::convert`: requires
+    /// `T: TryInto<Repr>`; the associated `Error` (must be `Display`) routes
+    /// to the caller's error handler.
+    pub fn output_try_into(self, repr: syn::Type) -> Self {
+        self.check_repr("output_try_into", &repr);
+        self.set_output(ConvertSpec::Trait {
+            repr,
+            fallible: true,
+        })
+    }
+
+    /// The out-of-Rust conversion as an arbitrary callable (see
+    /// [`input_with`](Self::input_with)). Shape: `fn(T) -> Repr`, by value,
+    /// infallible.
+    pub fn output_with(self, repr: syn::Type, path: syn::Path) -> Self {
+        self.check_repr("output_with", &repr);
+        self.set_output(ConvertSpec::LocalFn { repr, path })
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -822,6 +822,77 @@ pub(crate) struct ConstExprDecl {
 }
 
 // ──────────────────────────────────────────────────────────────────────
+// IgnoreDecl — one acceptor for acknowledged-unbound items
+// ──────────────────────────────────────────────────────────────────────
+
+/// Declares a `#[prebindgen]` item this binding deliberately does NOT
+/// bind: nothing is emitted for it and the registry's per-item "skipping
+/// undeclared" warning is suppressed. One acceptor
+/// ([`JniGen::ignore`]), the kind carried by what you built:
+///
+/// ```rust,ignore
+/// .ignore(fun!(string_len))                                // a fn
+/// .ignore(ty!(InternalThing))                              // a struct/enum
+/// .ignore(constant!(INTERNAL_MAGIC))                       // a const
+/// .ignore(matching(|n| n.starts_with("encoding_const_")))  // a naming family
+/// ```
+pub struct IgnoreDecl(pub(crate) IgnoreKind);
+
+pub(crate) enum IgnoreKind {
+    Fun(syn::Ident),
+    Type(TypeKey),
+    Const(syn::Ident),
+    Matching(crate::api::core::prebindgen::NamePredicate),
+}
+
+impl From<FunctionDecl> for IgnoreDecl {
+    fn from(decl: FunctionDecl) -> Self {
+        assert!(
+            decl.kotlin_name_override.is_none()
+                && decl.param_expands.is_empty()
+                && decl.return_expand.is_none(),
+            "ignore(fun!({})): an ignored fn is never surfaced — \
+             .name()/expand overrides don't apply",
+            decl.rust_ident
+        );
+        IgnoreDecl(IgnoreKind::Fun(decl.rust_ident))
+    }
+}
+
+impl From<syn::Type> for IgnoreDecl {
+    fn from(ty: syn::Type) -> Self {
+        IgnoreDecl(IgnoreKind::Type(TypeKey::from_type(&ty)))
+    }
+}
+
+impl From<ConstDecl> for IgnoreDecl {
+    fn from(decl: ConstDecl) -> Self {
+        assert!(
+            matches!(decl.source, ConstSource::Item) && decl.kotlin_name_override.is_none(),
+            "ignore(constant!({})): an ignore names a `#[prebindgen]` const — \
+             value sources/.name() don't apply",
+            decl.rust_ident
+        );
+        IgnoreDecl(IgnoreKind::Const(decl.rust_ident))
+    }
+}
+
+/// Bulk [`IgnoreDecl`]: acknowledge every `#[prebindgen]` item whose NAME
+/// matches the predicate — kind-agnostic (fn, struct/enum, const), since
+/// prebindgen items live in one flat namespace. E.g.
+/// `.ignore(matching(|n| n.starts_with("encoding_const_")))` instead of one
+/// line per member of a naming family. A *declared* item matching the
+/// predicate is unaffected (declaration wins), and unlike an exact-name
+/// ignore, a predicate matching nothing is silent — it is a filter, not a
+/// claim about a specific item (match counts vary across feature configs).
+pub fn matching<F>(f: F) -> IgnoreDecl
+where
+    F: Fn(&str) -> bool + Send + Sync + 'static,
+{
+    IgnoreDecl(IgnoreKind::Matching(std::sync::Arc::new(f)))
+}
+
+// ──────────────────────────────────────────────────────────────────────
 // PackageDecl — aggregates the package-scoped decls
 // ──────────────────────────────────────────────────────────────────────
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -286,8 +286,15 @@ impl From<syn::Type> for PtrClassDecl {
 ///
 /// Build one with [`expand_param!`](crate::expand_param), add arms with
 /// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
-/// it to [`JniGen::expand`]. With more than one arm the generated Kotlin
-/// selects the variant at runtime.
+/// it to [`JniGen::expand`].
+///
+/// **Generated shape** — this is a WIRE-level dispatch, not overloads: with
+/// more than one arm the parameter crosses as a selector `Int` plus one
+/// nullable slot per arm (`keyExprSel: Int, keyExpr0: String?,
+/// keyExpr1: KeyExpr?`), and the call site passes `(0, "key", null)`-style
+/// tuples. Idiomatic overloads / sealed types are a hand-written SDK tier's
+/// job on top; the wrapper's generated KDoc shape-notes document the exact
+/// slots per function.
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
 /// on an undeclared type makes it **rust-side-only**: the value is always
@@ -317,10 +324,12 @@ impl ExpandParamDecl {
         }
     }
 
-    /// Add a **build-from** arm: parameters of this type also accept the
-    /// named `#[prebindgen]` constructor's inputs, and Rust builds the value
-    /// in the same call. E.g. `keyexpr_new_try_from(&str)` lets every
-    /// function taking a `KeyExpr` also accept a plain `String`.
+    /// Add a **build-from** arm: parameters of this type also carry the
+    /// named `#[prebindgen]` constructor's inputs on the wire, and Rust
+    /// builds the value in the same call. E.g. `keyexpr_new_try_from(&str)`
+    /// gives every function taking a `KeyExpr` a String-carrying arm —
+    /// as a selector + nullable slot at the wire tier (see the type-level
+    /// docs for the exact generated shape), not as a Kotlin overload.
     pub fn variant(mut self, ctor: FunctionDecl) -> Self {
         self.variants.push(LocalVariant::Ctor(ctor.rust_ident));
         self
@@ -845,7 +854,7 @@ impl ConstDecl {
     /// exactly when nothing flows in (a unary conversion source must be a
     /// named callable — see [`ConvertDecl`]). Fns referenced only inside
     /// expressions are undeclared to the registry — acknowledge them via
-    /// [`JniGen::ignore_fun`] / [`JniGen::ignore_funs_where`].
+    /// [`JniGen::ignore`] (+ [`matching`](crate::lang::matching)).
     pub fn expr(self, ty: syn::Type, expr: syn::Expr) -> Self {
         self.set_source(ConstSource::Expr { ty, expr })
     }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -876,6 +876,9 @@ impl PackageDecl {
 /// callback arguments), while expansion decls are position-things.
 /// One direction's conversion **source** — where the conversion code comes
 /// from. Four kinds, one per [`ConvertDecl`] method family.
+// large_enum_variant: a handful of these exist per binding, held once in the
+// builder — boxing the syn payloads would only complicate the decl arms.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub(crate) enum ConvertSpec {
     /// A `#[prebindgen]` fn (flat or helper crate): the representable type
@@ -889,8 +892,14 @@ pub(crate) enum ConvertSpec {
     /// An arbitrary callable path — typically a plain fn in the **binding
     /// crate itself** (the generated file compiles inside it, so
     /// `crate::…` paths resolve). Representable type stated explicitly;
-    /// by-value both ways (`fn(Repr) -> T` / `fn(T) -> Repr`), infallible.
-    LocalFn { repr: syn::Type, path: syn::Path },
+    /// by-value both ways. `error: None` = infallible (`fn(Repr) -> T` /
+    /// `fn(T) -> Repr`); `Some(E)` = the fn returns `Result<…, E>` and an
+    /// `Err` routes to the caller's error handler (`E: Display`).
+    LocalFn {
+        repr: syn::Type,
+        path: syn::Path,
+        error: Option<syn::Type>,
+    },
 }
 
 #[derive(Clone)]
@@ -990,11 +999,29 @@ impl ConvertDecl {
     /// fn declared **in the binding crate itself** (no `#[prebindgen]`
     /// needed; the generated file compiles inside the binding crate, so
     /// `path!(crate::…)` resolves). Shape: `fn(Repr) -> T`, by value,
-    /// infallible — for fallibility use a `TryFrom` impl or a
-    /// `#[prebindgen]` fn returning `Result`.
+    /// infallible — see [`input_try_with`](Self::input_try_with) for the
+    /// fallible form.
     pub fn input_with(self, repr: syn::Type, path: syn::Path) -> Self {
         self.check_repr("input_with", &repr);
-        self.set_input(ConvertSpec::LocalFn { repr, path })
+        self.set_input(ConvertSpec::LocalFn {
+            repr,
+            path,
+            error: None,
+        })
+    }
+
+    /// The fallible into-Rust conversion as an arbitrary callable: shape
+    /// `fn(Repr) -> Result<T, Error>`, by value. `error` is stated
+    /// explicitly (a callable path carries no signature to read); it must
+    /// implement `Display`, and an `Err` routes to the caller's error
+    /// handler like any domain error.
+    pub fn input_try_with(self, repr: syn::Type, error: syn::Type, path: syn::Path) -> Self {
+        self.check_repr("input_try_with", &repr);
+        self.set_input(ConvertSpec::LocalFn {
+            repr,
+            path,
+            error: Some(error),
+        })
     }
 
     /// The **out-of-Rust** conversion (returns, callback arguments) as a
@@ -1031,7 +1058,23 @@ impl ConvertDecl {
     /// infallible.
     pub fn output_with(self, repr: syn::Type, path: syn::Path) -> Self {
         self.check_repr("output_with", &repr);
-        self.set_output(ConvertSpec::LocalFn { repr, path })
+        self.set_output(ConvertSpec::LocalFn {
+            repr,
+            path,
+            error: None,
+        })
+    }
+
+    /// The fallible out-of-Rust conversion as an arbitrary callable: shape
+    /// `fn(T) -> Result<Repr, Error>`, by value (see
+    /// [`input_try_with`](Self::input_try_with) for the error conventions).
+    pub fn output_try_with(self, repr: syn::Type, error: syn::Type, path: syn::Path) -> Self {
+        self.check_repr("output_try_with", &repr);
+        self.set_output(ConvertSpec::LocalFn {
+            repr,
+            path,
+            error: Some(error),
+        })
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -17,7 +17,8 @@ use super::*;
 // by the accept logic in `builder.rs` once a decl is handed to `JniGen`)
 // ──────────────────────────────────────────────────────────────────────
 
-/// One arm of a `.default_param_expand*`/`.param_expand*` build-from list.
+/// One arm of a `param_expand!` `.variant*` / per-fn `.param_expand*`
+/// build-from list.
 #[derive(Clone)]
 pub(crate) enum LocalVariant {
     /// Build via this declared constructor member / constructor fn.
@@ -26,11 +27,16 @@ pub(crate) enum LocalVariant {
     SelfIdentity,
 }
 
-/// One arm of a `.default_return_expand*`/`.return_expand*` field list.
+/// One arm of a `return_expand!` `.field*` / per-fn `.return_expand*` field
+/// list. The name is stored raw (`None` = derive at replay time: for a
+/// class-level field, the class member's Kotlin name if the accessor is a
+/// declared member, else `snake_to_camel`; for a per-fn field,
+/// `snake_to_camel`).
 #[derive(Clone)]
 pub(crate) enum LocalField {
-    /// Include the named accessor's value as this leaf/field name.
-    Named(syn::Ident, String),
+    /// Include the named accessor's value as a leaf/field, with an optional
+    /// explicit name override.
+    Named(syn::Ident, Option<String>),
     /// Include the handle itself as a field.
     SelfField,
 }
@@ -156,6 +162,26 @@ macro_rules! generic_type_wrapper {
     };
 }
 
+/// Build a [`ParamExpandDecl`] directly from a bare Rust type:
+/// `param_expand!(KeyExpr)` is `ParamExpandDecl::new(<KeyExpr as syn::Type>)`.
+/// See [`ptr_class!`] for the parsing mechanics.
+#[macro_export]
+macro_rules! param_expand {
+    ($t:ty) => {
+        $crate::lang::ParamExpandDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build a [`ReturnExpandDecl`] directly from a bare Rust type:
+/// `return_expand!(Sample)` is `ReturnExpandDecl::new(<Sample as syn::Type>)`.
+/// See [`ptr_class!`] for the parsing mechanics.
+#[macro_export]
+macro_rules! return_expand {
+    ($t:ty) => {
+        $crate::lang::ReturnExpandDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Class-kind decls
 // ──────────────────────────────────────────────────────────────────────
@@ -171,31 +197,24 @@ macro_rules! generic_type_wrapper {
 /// Build one with [`ptr_class!`](crate::ptr_class), add it to a
 /// [`PackageDecl`], and hand that to [`JniGen::package`].
 ///
-/// A `PtrClassDecl` does two jobs:
-///
-/// 1. **Defines the Kotlin class** — its name ([`name`](Self::name)), its
-///    instance methods ([`fun`](Self::fun)), and its companion-object
-///    factories ([`constructor`](Self::constructor)).
-/// 2. **Sets the type's default behavior at every FFI boundary** — how a
-///    *parameter* of this type is accepted ([`default_param_expand`](Self::default_param_expand))
-///    and how a *returned* or callback-delivered value of it is handed to
-///    Kotlin ([`default_return_expand`](Self::default_return_expand)), for
-///    *every* function that mentions the type. Any single function can
-///    override its own copy of these defaults (see [`FunctionDecl`]).
+/// A `PtrClassDecl` defines the **Kotlin class only** — its name
+/// ([`name`](Self::name)), its instance methods ([`fun`](Self::fun)), and its
+/// companion-object factories ([`constructor`](Self::constructor)). How the
+/// type crosses the FFI boundary by default — accepted as which parameter
+/// variants, returned as which field set — is declared separately with
+/// [`param_expand!`](crate::param_expand) / [`return_expand!`](crate::return_expand)
+/// handed to [`JniGen::param_expand`] / [`JniGen::return_expand`]; any single
+/// function can override those defaults locally (see [`FunctionDecl`]).
 ///
 /// ```
-/// // A KeyExpr handle exposing `str()` as an instance method; by default a
-/// // KeyExpr returned to Kotlin is delivered as just the handle.
+/// // A KeyExpr handle exposing `str()` as an instance method.
 /// let _ = prebindgen::ptr_class!(KeyExpr)
-///     .fun(prebindgen::fun!(keyexpr_get_str).name("str"))
-///     .default_return_expand_self();
+///     .fun(prebindgen::fun!(keyexpr_get_str).name("str"));
 /// ```
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
     pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
-    pub(crate) input_variants: Option<Vec<LocalVariant>>,
-    pub(crate) output_fields: Option<Vec<LocalField>>,
 }
 
 impl PtrClassDecl {
@@ -204,8 +223,6 @@ impl PtrClassDecl {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
             members: Vec::new(),
-            input_variants: None,
-            output_fields: None,
         }
     }
 
@@ -232,82 +249,10 @@ impl PtrClassDecl {
     /// Expose a `#[prebindgen]` factory as a Kotlin **companion-object
     /// factory** — callers write `Class.name(...)`. `rust_fun` returns `Self`
     /// (or `Result<Self, E>`) and its parameters become the factory's
-    /// arguments. A constructor can also serve as a build option in
-    /// [`default_param_expand`](Self::default_param_expand).
+    /// arguments. A constructor can also serve as a build option in a
+    /// [`param_expand!`](crate::param_expand) variant list.
     pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
         self.members.push((rust_fun, MemberKind::Constructor));
-        self
-    }
-
-    /// Let callers pass the **ingredients** of this type wherever a parameter
-    /// of it is expected, instead of having to build the handle first. Point
-    /// this at a `#[prebindgen]` constructor: at every such parameter, the
-    /// Kotlin signature gains that constructor's inputs and Rust builds the
-    /// value in the same call.
-    ///
-    /// For example, giving `KeyExpr` a `keyexpr_from_str(&str)` build option
-    /// lets every function taking a `KeyExpr` also accept a plain `String`.
-    ///
-    /// Call repeatedly to offer several ways to build the value (and add
-    /// [`default_param_expand_self`](Self::default_param_expand_self) to also
-    /// accept a ready-made handle); with more than one option the generated
-    /// Kotlin picks at runtime. Overridable per function via
-    /// [`FunctionDecl::param_expand`].
-    pub fn default_param_expand(mut self, rust_fun: FunctionDecl) -> Self {
-        self.input_variants
-            .get_or_insert_with(Vec::new)
-            .push(LocalVariant::Ctor(rust_fun.rust_ident));
-        self
-    }
-
-    /// Also accept an **already-built handle** at parameters of this type —
-    /// the "…or just pass one you already have" option alongside the
-    /// [`default_param_expand`](Self::default_param_expand) build variants.
-    /// On its own this is simply the default (a bare handle), so declaring it
-    /// alone changes nothing; it earns its place only next to build variants.
-    pub fn default_param_expand_self(mut self) -> Self {
-        self.input_variants
-            .get_or_insert_with(Vec::new)
-            .push(LocalVariant::SelfIdentity);
-        self
-    }
-
-    /// Decompose this type into **named fields delivered in one FFI crossing**
-    /// wherever it is returned or handed to a callback — instead of returning
-    /// an opaque handle the caller must then query field by field with more
-    /// JNI calls.
-    ///
-    /// Point each call at a `#[prebindgen]` reader (`f(&Self) -> Field`); its
-    /// value becomes one field, named via `fun!(reader).name("field")`
-    /// (default: the reader's camel-cased name). For example, decomposing a
-    /// `Sample` into `keyExpr`, `payload`, `timestamp`, … hands a subscriber
-    /// callback the whole sample in a single call with no follow-up accessor
-    /// round-trips.
-    ///
-    /// Call repeatedly to add fields, and add
-    /// [`default_return_expand_self`](Self::default_return_expand_self) to
-    /// also include the live handle. Overridable per function via
-    /// [`FunctionDecl::return_expand`].
-    pub fn default_return_expand(mut self, rust_fun: FunctionDecl) -> Self {
-        let name = rust_fun
-            .kotlin_name_override
-            .unwrap_or_else(|| snake_to_camel(&rust_fun.rust_ident.to_string()));
-        self.output_fields
-            .get_or_insert_with(Vec::new)
-            .push(LocalField::Named(rust_fun.rust_ident, name));
-        self
-    }
-
-    /// Include the **handle itself** among the decomposed fields, so the
-    /// consumer gets a live, closeable object in addition to the read-out
-    /// values (e.g. a `Query` delivered with its fields *and* the handle it
-    /// needs to reply). Declare it **last**, after any field that decomposes
-    /// a nested handle, so the generated Rust moves the value only after
-    /// those borrows.
-    pub fn default_return_expand_self(mut self) -> Self {
-        self.output_fields
-            .get_or_insert_with(Vec::new)
-            .push(LocalField::SelfField);
         self
     }
 }
@@ -315,6 +260,116 @@ impl PtrClassDecl {
 impl From<syn::Type> for PtrClassDecl {
     fn from(rust_type: syn::Type) -> Self {
         Self::new(rust_type)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Boundary decls — how a declared type crosses the FFI boundary by default
+// ──────────────────────────────────────────────────────────────────────
+
+/// Declares a type's **default input boundary**: how a parameter of this type
+/// may be supplied, as a list of *variants* — "built from this constructor's
+/// ingredients, OR that one's, OR passed as an existing handle". Applies to
+/// every function with a parameter of the type; a single function opts out or
+/// narrows via [`FunctionDecl::param_expand`] / [`FunctionDecl::param_expand_self`].
+///
+/// Build one with [`param_expand!`](crate::param_expand), add arms with
+/// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
+/// it to [`JniGen::param_expand`]. With more than one arm the generated Kotlin
+/// selects the variant at runtime.
+///
+/// ```
+/// // A KeyExpr param accepts EITHER a String (built via keyexpr_new_try_from)
+/// // OR an existing KeyExpr handle:
+/// let _ = prebindgen::param_expand!(KeyExpr)
+///     .variant(prebindgen::fun!(keyexpr_new_try_from))
+///     .variant_self();
+/// ```
+#[derive(Clone)]
+pub struct ParamExpandDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) variants: Vec<LocalVariant>,
+}
+
+impl ParamExpandDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            variants: Vec::new(),
+        }
+    }
+
+    /// Add a **build-from** arm: parameters of this type also accept the
+    /// named `#[prebindgen]` constructor's inputs, and Rust builds the value
+    /// in the same call. E.g. `keyexpr_new_try_from(&str)` lets every
+    /// function taking a `KeyExpr` also accept a plain `String`.
+    pub fn variant(mut self, ctor: FunctionDecl) -> Self {
+        self.variants.push(LocalVariant::Ctor(ctor.rust_ident));
+        self
+    }
+
+    /// Add the **existing-handle** arm: also accept an already-built value.
+    /// On its own this is simply the default (a bare handle), so declaring it
+    /// alone changes nothing; it earns its place next to build variants.
+    pub fn variant_self(mut self) -> Self {
+        self.variants.push(LocalVariant::SelfIdentity);
+        self
+    }
+}
+
+/// Declares a type's **default output boundary**: wherever the type is
+/// returned or handed to a callback, it is decomposed into this set of
+/// *fields*, all delivered in one FFI crossing — instead of an opaque handle
+/// the caller must then query field by field with more JNI calls. Applies to
+/// every function returning the type; a single function opts out or replaces
+/// the set via [`FunctionDecl::return_expand`] / [`FunctionDecl::return_expand_self`].
+///
+/// Build one with [`return_expand!`](crate::return_expand), add fields with
+/// [`field`](Self::field) / [`field_self`](Self::field_self), and hand it to
+/// [`JniGen::return_expand`].
+///
+/// ```
+/// // A returned Sample crosses as { payload, kind } in one call:
+/// let _ = prebindgen::return_expand!(Sample)
+///     .field(prebindgen::fun!(sample_get_payload))
+///     .field(prebindgen::fun!(sample_get_kind));
+/// ```
+#[derive(Clone)]
+pub struct ReturnExpandDecl {
+    pub(crate) key: TypeKey,
+    pub(crate) fields: Vec<LocalField>,
+}
+
+impl ReturnExpandDecl {
+    pub fn new(rust_type: syn::Type) -> Self {
+        Self {
+            key: TypeKey::from_type(&rust_type),
+            fields: Vec::new(),
+        }
+    }
+
+    /// Add one field: the named `#[prebindgen]` reader's (`f(&Self) -> Field`)
+    /// value. The Kotlin field name is, in order of precedence: an explicit
+    /// `.name(...)` on `accessor`; the Kotlin name of the class member if the
+    /// same function is declared via [`PtrClassDecl::fun`] on this type (so a
+    /// getter that is both a method and a field is named once); else the
+    /// camel-cased Rust name.
+    pub fn field(mut self, accessor: FunctionDecl) -> Self {
+        self.fields.push(LocalField::Named(
+            accessor.rust_ident,
+            accessor.kotlin_name_override,
+        ));
+        self
+    }
+
+    /// Include the **handle itself** among the fields, so the consumer gets a
+    /// live, closeable object in addition to the read-out values (e.g. a
+    /// `Query` delivered with its fields *and* the handle it needs to reply).
+    /// Declare it **last**, after any field that decomposes a nested handle,
+    /// so the generated Rust moves the value only after those borrows.
+    pub fn field_self(mut self) -> Self {
+        self.fields.push(LocalField::SelfField);
+        self
     }
 }
 
@@ -500,9 +555,10 @@ impl From<ValueClassDecl> for ClassDecl {
 /// Build it from a bare Rust name with [`fun!`](crate::fun) and chain
 /// [`name`](Self::name) to set its Kotlin name. The `param_expand*` /
 /// `return_expand*` methods **override, for this one function**, the
-/// boundary defaults that its parameter/return types set on their
-/// `ptr_class!` — most often to opt back out (a lone `_self`) so this
-/// function sees the raw handle rather than the class's default expansion.
+/// boundary defaults its parameter/return types declare via
+/// [`param_expand!`](crate::param_expand) / [`return_expand!`](crate::return_expand)
+/// — most often to opt back out (a lone `_self`) so this function sees the
+/// raw handle rather than the type's default expansion.
 pub struct FunctionDecl {
     pub(crate) rust_ident: syn::Ident,
     pub(crate) kotlin_name_override: Option<String>,
@@ -528,7 +584,7 @@ impl FunctionDecl {
     }
 
     /// Override, for `param` of this function only, how that parameter is
-    /// built — the same idea as [`PtrClassDecl::default_param_expand`], but
+    /// built — the same idea as a [`ParamExpandDecl`] variant list, but
     /// scoped here and keyed by which parameter (a function may have several
     /// handle parameters, each overridden independently). Point at a
     /// constructor to offer it as a build option; call again (same or a
@@ -562,16 +618,17 @@ impl FunctionDecl {
         &mut self.input_overrides[idx].1
     }
 
-    /// Override this function's return decomposition — the same idea as
-    /// [`PtrClassDecl::default_return_expand`], but for this function alone.
-    /// Add one field per call.
+    /// Override this function's return decomposition — the same idea as a
+    /// [`ReturnExpandDecl`] field list, but for this function alone. Add one
+    /// field per call; the field name is `field`'s `.name(...)` or the
+    /// camel-cased Rust name.
     pub fn return_expand(mut self, field: FunctionDecl) -> Self {
-        let name = field
-            .kotlin_name_override
-            .unwrap_or_else(|| snake_to_camel(&field.rust_ident.to_string()));
         self.output_override
             .get_or_insert_with(Vec::new)
-            .push(LocalField::Named(field.rust_ident, name));
+            .push(LocalField::Named(
+                field.rust_ident,
+                field.kotlin_name_override,
+            ));
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -217,6 +217,11 @@ macro_rules! expand_return {
 /// let _ = prebindgen::ptr_class!(KeyExpr)
 ///     .fun(prebindgen::fun!(keyexpr_get_str).name("str"));
 /// ```
+/// Deliberately has no `.kotlin_type()`: the generated typed-handle class
+/// OWNS a lifecycle contract — the `NativeHandle` base, the `ptr` slot,
+/// `close()`, the lock protocol, and the paired `freePtr` extern — that an
+/// arbitrary existing Kotlin type cannot be assumed to honor. The other
+/// class kinds are pure surface and may be mapped; a handle is not.
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
@@ -425,11 +430,14 @@ impl From<ExpandReturnDecl> for ExpandDecl {
 /// unit-variant only and `#[repr(i32)]`-style with explicit discriminants,
 /// so both sides agree on the numbers.
 ///
-/// Has no `.fun`/`.constructor` — instance members are only meaningful on
-/// handle ([`PtrClassDecl`]) and value ([`ValueClassDecl`]) classes.
+/// Has no `.fun`/`.constructor` by rule, not omission: members belong to
+/// class kinds whose instances can re-enter Rust as an object (handle /
+/// blob / field leaves). An enum value is a bare scalar with no object
+/// identity — a "method" on it is just a free function taking the enum.
 pub struct EnumClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
+    pub(crate) kotlin_type: Option<String>,
 }
 
 impl EnumClassDecl {
@@ -437,12 +445,23 @@ impl EnumClassDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
+            kotlin_type: None,
         }
     }
 
     /// Override the Kotlin **class name** (relative, no dots).
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name_override = Some(name.into());
+        self
+    }
+
+    /// Surface this enum as an **existing** Kotlin type instead of
+    /// generating an `enum class` file (see [`DataClassDecl::kotlin_type`]).
+    /// The named type must expose the generated protocol: a companion
+    /// `fromInt(Int): T` and a `val value: Int` with the Rust
+    /// discriminants — exactly what a generated enum class provides.
+    pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
+        self.kotlin_type = Some(expr.into());
         self
     }
 }
@@ -460,12 +479,14 @@ impl From<syn::Type> for EnumClassDecl {
 /// [`ptr_class!`](crate::ptr_class) handles or
 /// [`value_class!`](crate::value_class) blobs.
 ///
-/// Has no `.fun`/`.constructor` — a data class has no handle to hang an
-/// instance method on.
+/// Members work like every class kind whose instance can re-enter Rust —
+/// here the receiver re-enters as its **field leaves** (the same call-site
+/// destructuring a data-class parameter gets), just rebased to `this`.
 pub struct DataClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
     pub(crate) kotlin_type: Option<String>,
+    pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
 }
 
 impl DataClassDecl {
@@ -474,6 +495,7 @@ impl DataClassDecl {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
             kotlin_type: None,
+            members: Vec::new(),
         }
     }
 
@@ -485,9 +507,26 @@ impl DataClassDecl {
 
     /// Surface this type as a verbatim Kotlin type instead of a generated
     /// class — for when it should map onto an existing or container type,
-    /// e.g. `"List<ByteArray>"`.
+    /// e.g. `"List<ByteArray>"`. Mutually exclusive with members (a mapped
+    /// type has no generated class to hold them).
     pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
         self.kotlin_type = Some(expr.into());
+        self
+    }
+
+    /// Expose a `#[prebindgen]` reader (`f(&Self) -> R`) as an instance
+    /// method on the generated data class (see [`PtrClassDecl::fun`]) — the
+    /// receiver crosses as `this`'s field leaves, exactly like a data-class
+    /// parameter.
+    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
+        self.members.push((rust_fun, MemberKind::Fun));
+        self
+    }
+
+    /// Expose a `#[prebindgen]` factory as a companion-object factory
+    /// (see [`PtrClassDecl::constructor`]).
+    pub fn constructor(mut self, rust_fun: FunctionDecl) -> Self {
+        self.members.push((rust_fun, MemberKind::Constructor));
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -209,7 +209,7 @@ macro_rules! return_expand {
 /// type crosses the FFI boundary by default — accepted as which parameter
 /// variants, returned as which field set — is declared separately with
 /// [`param_expand!`](crate::param_expand) / [`return_expand!`](crate::return_expand)
-/// handed to [`JniGen::param_expand`] / [`JniGen::return_expand`]; any single
+/// handed to [`JniGen::expand`]; any single
 /// function can override those defaults locally (see [`FunctionDecl`]).
 ///
 /// ```
@@ -281,7 +281,7 @@ impl From<syn::Type> for PtrClassDecl {
 ///
 /// Build one with [`param_expand!`](crate::param_expand), add arms with
 /// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
-/// it to [`JniGen::param_expand`]. With more than one arm the generated Kotlin
+/// it to [`JniGen::expand`]. With more than one arm the generated Kotlin
 /// selects the variant at runtime.
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
@@ -339,7 +339,7 @@ impl ParamExpandDecl {
 ///
 /// Build one with [`return_expand!`](crate::return_expand), add fields with
 /// [`field`](Self::field) / [`field_self`](Self::field_self), and hand it to
-/// [`JniGen::return_expand`].
+/// [`JniGen::expand`].
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
 /// on an undeclared type makes it **rust-side-only**: every returned /
@@ -393,6 +393,29 @@ impl ReturnExpandDecl {
     pub fn field_self(mut self) -> Self {
         self.fields.push(LocalField::SelfField);
         self
+    }
+}
+
+/// Unifies the two boundary decls into one type so [`JniGen::expand`] can
+/// expose a single entry point — the boundary-decl peer of [`ClassDecl`].
+/// Deliberately **no** `impl From<syn::Type> for ExpandDecl` — a bare
+/// `syn::Type` alone doesn't say which direction it describes, so every
+/// declaration names its direction via the matching constructor macro:
+/// `.expand(prebindgen::param_expand!(Summary)...)`,
+/// `.expand(prebindgen::return_expand!(Sample)...)`.
+pub enum ExpandDecl {
+    Param(ParamExpandDecl),
+    Return(ReturnExpandDecl),
+}
+
+impl From<ParamExpandDecl> for ExpandDecl {
+    fn from(d: ParamExpandDecl) -> Self {
+        Self::Param(d)
+    }
+}
+impl From<ReturnExpandDecl> for ExpandDecl {
+    fn from(d: ReturnExpandDecl) -> Self {
+        Self::Return(d)
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -314,15 +314,19 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
 /// `v: <ident>` signature — so binding crates can pick whichever
 /// upstream type a bare `<ident>` resolves to in their include-site
 /// `use` statements. Pairs with output body below.
-pub(crate) fn enum_input_body(ext: &JniGen, e: &syn::ItemEnum) -> (syn::Type, syn::Expr) {
+pub(crate) fn enum_input_body(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    e: &syn::ItemEnum,
+) -> (syn::Type, syn::Expr) {
     assert_only_unit_variants(e);
     let ident = &e.ident;
     let ident_name = ident.to_string();
-    // Qualify the variant constructors with `source_module`, exactly as the
-    // type-position pass qualifies the enum's return type — otherwise a bare
-    // `Enum::Variant` fails to resolve when the enum lives in the source crate
-    // (the usual flat-library case).
-    let source_module = &ext.source_module;
+    // Qualify the variant constructors with the enum's origin module,
+    // exactly as the type-position pass qualifies the enum's return type —
+    // otherwise a bare `Enum::Variant` fails to resolve when the enum lives
+    // in a source crate (the usual flat-library case).
+    let source_module = ext.fn_module(registry, ident);
     let arms = crate::api::lang::jnigen::util::enum_discriminant_values(e)
         .into_iter()
         .map(|(variant, value)| {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -409,7 +409,7 @@ pub(crate) fn cast_wire_to_jobject(
 /// a final `Option` step unwraps too.
 #[allow(clippy::too_many_arguments)]
 fn reach_leaf(
-    source_module: &syn::Path,
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
     path: &[syn::Ident],
     returns_option: &dyn Fn(&syn::Ident) -> bool,
     base: TokenStream,
@@ -428,18 +428,21 @@ fn reach_leaf(
         // No (more) `Option` nesting steps: compose the rest plainly.
         None => {
             for a in path {
-                e = quote!(#source_module::#a(#e));
+                let m = qualify(a);
+                e = quote!(#m::#a(#e));
             }
             body(e)
         }
         Some(k) => {
             for a in &path[..k] {
-                e = quote!(#source_module::#a(#e));
+                let m = qualify(a);
+                e = quote!(#m::#a(#e));
             }
             let opt_acc = &path[k];
+            let opt_m = qualify(opt_acc);
             let nested = format_ident!("__n{}", depth);
             let inner = reach_leaf(
-                source_module,
+                qualify,
                 &path[k + 1..],
                 returns_option,
                 quote!(#nested),
@@ -449,7 +452,7 @@ fn reach_leaf(
                 body,
             );
             quote! {
-                match #source_module::#opt_acc(#e) {
+                match #opt_m::#opt_acc(#e) {
                     ::core::option::Option::Some(#nested) => { #inner }
                     ::core::option::Option::None => jni::objects::JObject::null(),
                 }
@@ -478,7 +481,9 @@ pub(crate) fn encode_plan_leaves(
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
-    let source_module = &ext.source_module;
+    // Per-fn origin qualification: each accessor call is prefixed with the
+    // module of the crate that defines it (multi-source bindings).
+    let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
     let by_ref = plan.by_ref;
     let n = plan.leaves.len();
 
@@ -569,7 +574,7 @@ pub(crate) fn encode_plan_leaves(
                         // Reached non-null handle: clone via the converter,
                         // raw jlong (no Option steps on the path).
                         let expr = reach_leaf(
-                            source_module,
+                            &qualify,
                             &leaf.path,
                             &returns_option,
                             value.clone(),
@@ -597,7 +602,7 @@ pub(crate) fn encode_plan_leaves(
                         // JVM null when absent — matching the `Long?` param.
                         let box_fail = fail(quote!(__e.to_string()));
                         let expr = reach_leaf(
-                            source_module,
+                            &qualify,
                             &leaf.path,
                             &returns_option,
                             value.clone(),
@@ -645,7 +650,7 @@ pub(crate) fn encode_plan_leaves(
                         ));
                     } else {
                         let expr = reach_leaf(
-                            source_module,
+                            &qualify,
                             &leaf.path,
                             &returns_option,
                             value.clone(),
@@ -682,7 +687,7 @@ pub(crate) fn encode_plan_leaves(
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
             match leaf.source {
                 LeafSource::Accessor => reach_leaf(
-                    source_module,
+                    &qualify,
                     &leaf.path,
                     &returns_option,
                     value.clone(),

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -9,7 +9,7 @@ pub(crate) fn struct_input_body(
     registry: &Registry<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.ident.to_string();
-    let struct_module = struct_module_path(ext, s);
+    let struct_module = struct_module_path(ext, registry, s);
     let struct_ident = &s.ident;
 
     let syn::Fields::Named(named) = &s.fields else {
@@ -462,7 +462,7 @@ pub(crate) fn build_flat_input_plan(
     };
 
     // 3. Classify every field as a simple leaf, else fall back.
-    let struct_module = struct_module_path(ext, st);
+    let struct_module = struct_module_path(ext, registry, st);
     // `kt_base` is the Kotlin expression for the object at the call site —
     // normally the camelCase param name, or `this` for a promoted instance
     // receiver. The native param idents / extern names stay keyed on

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -38,21 +38,22 @@ pub(crate) fn rust_short_name_opt(key: &TypeKey) -> Option<String> {
 }
 
 /// `VisitMut` that prefixes every bare single-segment `Type::Path` whose
-/// ident lives in `source_names` with `source_module`. Walks the full
-/// AST — function signatures, generic args, type ascriptions, casts,
-/// turbofish — so any emitted item passes through one universal pass
+/// ident is a key of `source_names` with that name's origin module. Walks
+/// the full AST — function signatures, generic args, type ascriptions,
+/// casts, turbofish — so any emitted item passes through one universal pass
 /// instead of each emit site having to remember to qualify.
 pub(crate) struct QualifyEmittedTypes<'a> {
-    pub(crate) source_module: &'a syn::Path,
-    pub(crate) source_names: &'a std::collections::HashSet<String>,
+    /// Bare type name → the module it is reachable under (the item's origin
+    /// crate, or the registry's default module).
+    pub(crate) source_names: &'a std::collections::HashMap<String, syn::Path>,
 }
 
 impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
     fn visit_type_path_mut(&mut self, tp: &mut syn::TypePath) {
         if tp.qself.is_none() && tp.path.leading_colon.is_none() && tp.path.segments.len() == 1 {
             let ident = tp.path.segments[0].ident.to_string();
-            if self.source_names.contains(&ident) {
-                let mut qualified = self.source_module.clone();
+            if let Some(module) = self.source_names.get(&ident) {
+                let mut qualified = module.clone();
                 qualified.segments.push(tp.path.segments[0].clone());
                 tp.path = qualified;
             }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -418,15 +418,14 @@ pub(crate) fn struct_output_body(
     Some((syn::parse_quote!(jni::objects::JObject), body))
 }
 
-pub(crate) fn struct_module_path(ext: &JniGen, s: &syn::ItemStruct) -> syn::Path {
-    // Place the struct under <source_module>::<file_stem>::<Name>. Today's
-    // pipeline derives the module from the source file stem; here we ride
-    // on the same convention by inspecting the SourceLocation. Without a
-    // location handy at this stage we fall back to <source_module>::<Name>.
-    // In practice the actual file stem is added in the compose step at the
-    // call site by the consuming crate when needed.
-    let _ = s;
-    ext.source_module.clone()
+pub(crate) fn struct_module_path(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    s: &syn::ItemStruct,
+) -> syn::Path {
+    // The module the struct is reachable under from the generated file: its
+    // origin crate (multi-source registries) or the default module.
+    ext.fn_module(registry, &s.ident)
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -143,7 +143,6 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
 ) -> TokenStream {
     let original_ident = &f.sig.ident;
     let wrapper_ident = mangle_jni_name(ext, original_ident);
-    let source_module = &ext.source_module;
 
     let mut wire_params: Vec<TokenStream> = Vec::new();
     // Each entry is a per-input decode statement. Fallible decodes are
@@ -205,7 +204,10 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
 
     let raw_call = match &callee {
         Some(e) => quote!(#e),
-        None => quote!(#source_module::#original_ident(#(#call_args),*)),
+        None => {
+            let call_module = ext.fn_module(registry, original_ident);
+            quote!(#call_module::#original_ident(#(#call_args),*))
+        }
     };
     // For `convert_output` (Return), the value the output converter sees is the
     // **deconstructed** single value (the converter's accessor applied to the
@@ -220,7 +222,8 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
             let mut e = if base_is_ref { base } else { quote!(&#base) };
             for a in &leaf.path {
-                e = quote!(#source_module::#a(#e));
+                let m = ext.fn_module(registry, a);
+                e = quote!(#m::#a(#e));
             }
             e
         };
@@ -721,7 +724,6 @@ pub(crate) fn emit_expanded_param(
     orig_param: &syn::Ident,
     on_err: &TokenStream,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
-    let source_module = &ext.source_module;
     let mut wire_params: Vec<TokenStream> = Vec::new();
     let mut prelude: Vec<TokenStream> = Vec::new();
     let mut leaf_locals: Vec<syn::Ident> = Vec::new();
@@ -849,7 +851,10 @@ pub(crate) fn emit_expanded_param(
 
     // The fold itself (language-agnostic). Its `Err(String)` is lifted into
     // `__JniErr` and routed through the same sink as fallible inputs.
-    let qualify = |id: &syn::Ident| -> syn::Path { syn::parse_quote!(#source_module::#id) };
+    let qualify = |id: &syn::Ident| -> syn::Path {
+        let m = ext.fn_module(registry, id);
+        syn::parse_quote!(#m::#id)
+    };
     let fold_expr = crate::api::core::expand::emit_fold(plan, &leaf_locals, &qualify);
     let folded = format_ident!("__folded_{}", orig_param);
     prelude.push(quote!(

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -130,11 +130,11 @@ pub(crate) fn validate_constant_expr(ext: &JniGen, kotlin_name: &str, ty: &syn::
 }
 
 /// [`emit_jni_function_wrapper`] with the raw callee expression overridable:
-/// `None` = the ordinary `<source_module>::<fn ident>(args)` call; `Some(e)`
+/// `None` = the ordinary `<origin module>::<fn ident>(args)` call; `Some(e)`
 /// splices `e` verbatim as the value the output phase converts. Used by the
 /// const getter emission (`JniGen::on_const`), whose synthetic nullary `f`
 /// carries the signature while the value comes from
-/// `<source_module>::<CONST_IDENT>` — a path, not a call.
+/// `<origin module>::<CONST_IDENT>` — a path, not a call.
 pub(crate) fn emit_jni_function_wrapper_with_callee(
     ext: &JniGen,
     f: &syn::ItemFn,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -78,7 +78,7 @@ pub(crate) fn reject_handle_constant_type(ext: &JniGen, ty: &syn::Type, what: &s
     );
 }
 
-/// Validates a [`PackageDecl::constant_fun`] declaration against the real
+/// Validates a [`ConstDecl::fun`] declaration against the real
 /// signature: the fn must be **nullary** (a constant has no inputs), must
 /// not return a `Result` (a domain-fallible value is not a constant — and
 /// the `val` initializer's throwing `JniErrorHandler` only fits the

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -149,6 +149,9 @@ pub(crate) struct IfaceSpec {
     /// twin still takes the leaf `params`; the `asRaw` proxy reassembles. Always
     /// forces a raw twin (see [`Self::needs_raw`]).
     pub typed_groups: Vec<TypedGroup>,
+    /// Interface-level KDoc, rendered on the TYPED declaration (the raw
+    /// twin is internal machinery). `None` = no doc.
+    pub kdoc: Option<String>,
 }
 
 impl IfaceSpec {
@@ -171,6 +174,7 @@ impl IfaceSpec {
             params,
             ret,
             descr,
+            kdoc: None,
             typed_groups: Vec::new(),
         }
     }
@@ -332,6 +336,9 @@ impl IfaceSpec {
         }
         m = m.returns(self.ret.clone());
         let mut i = kt::KtFunInterface::new(&self.name, m).vis(kt::Vis::Public);
+        if let Some(doc) = &self.kdoc {
+            i = i.kdoc(doc.clone());
+        }
         for tp in &self.type_params {
             i = i.type_param(tp);
         }
@@ -1092,13 +1099,22 @@ pub(crate) fn error_handler_iface_spec(
         decon_base_name(&subject_short(&spec.source), Some(decon))
     );
     let package = subject_package(ext, &spec.source);
-    Some(IfaceSpec::assemble(
+    let source_short = subject_short(&spec.source);
+    let mut iface = IfaceSpec::assemble(
         package,
         name,
         vec!["out R".to_string()],
         params,
         kt::KtType::var_r(),
-    ))
+    );
+    iface.kdoc = Some(format!(
+        "Error callback. Contract: `je != null` ⇒ a binding/system-tier failure — `je` is\n\
+         its message and the remaining parameters carry defaults; `je == null` ⇒ a domain\n\
+         error — the remaining parameters carry the decomposed `{source_short}`. The\n\
+         wrapper returns whatever `run` returns; throwing from `run` is safe (it executes\n\
+         after the native call has returned)."
+    ));
+    Some(iface)
 }
 
 /// The shared infallible handler `JniErrorHandler<out R> { run(je: String?): R }`
@@ -1109,13 +1125,21 @@ pub(crate) fn jni_error_handler_iface_spec(ext: &JniGen) -> IfaceSpec {
         "je".to_string(),
         kt::KtType::string().nullable(),
     )];
-    IfaceSpec::assemble(
+    let mut iface = IfaceSpec::assemble(
         ext.package.clone(),
         "JniErrorHandler".to_string(),
         vec!["out R".to_string()],
         params,
         kt::KtType::var_r(),
-    )
+    );
+    iface.kdoc = Some(
+        "Error callback for wrappers without a declared error type. `je` is the\n\
+         binding/system failure message (any converter in the chain may fail). The\n\
+         wrapper returns whatever `run` returns; throwing from `run` is safe (it\n\
+         executes after the native call has returned)."
+            .to_string(),
+    );
+    iface
 }
 
 /// The onError handler spec for a declared function: its error plan's

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -556,7 +556,7 @@ fn method_descr(params: &[IfaceParam], ret: &kt::KtType, type_params: &[String])
 /// The interface base name for a decomposition: the subject type's short
 /// name, extended by the deconstructor declaration's identity. The type's
 /// default declaration keeps the bare short; per-fn inline records
-/// (`.return_expand()`) append the function's UpperCamel ident.
+/// (`.expand_return()`) append the function's UpperCamel ident.
 /// This is what makes interface identity == declaration identity: functions
 /// sharing a declaration share the interface, differently-declared
 /// decompositions of one type get distinct interfaces.

--- a/prebindgen/src/api/lang/jnigen/jni/iface/tests.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface/tests.rs
@@ -21,6 +21,7 @@ fn as_raw_adapter_is_multiline_even_when_short() {
         ret: kt::KtType::unit(),
         descr: "(J)V".to_string(),
         typed_groups: Vec::new(),
+        kdoc: None,
     };
 
     let src = render_as_raw(spec);
@@ -69,6 +70,7 @@ fn as_raw_adapter_breaks_wide_lambda_params_and_run_args() {
         ret: kt::KtType::unit(),
         descr: "([BIZLjava/lang/Long;Ljava/lang/Long;)V".to_string(),
         typed_groups: Vec::new(),
+        kdoc: None,
     };
 
     let src = render_as_raw(spec);

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -261,6 +261,10 @@ impl JniGen {
             if !cfg.value_blob {
                 continue;
             }
+            // `kotlin_type`-mapped: surfaces as an existing type, no file.
+            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
+                continue;
+            }
             let fqn = cfg
                 .name_spec
                 .as_ref()
@@ -404,6 +408,11 @@ impl JniGen {
             if cfg.enum_cfg.is_none() {
                 continue;
             }
+            // `kotlin_type`-mapped: the enum surfaces as an existing Kotlin
+            // type honoring the `fromInt`/`.value` protocol — no file.
+            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
+                continue;
+            }
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
@@ -447,6 +456,10 @@ impl JniGen {
             if cfg.special_decl() {
                 continue;
             }
+            // `kotlin_type`-mapped: surfaces as an existing type, no file.
+            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
+                continue;
+            }
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
@@ -470,7 +483,61 @@ impl JniGen {
             if item_struct.ident != class_name {
                 aliases.push((item_struct.ident.to_string(), class_name.clone()));
             }
-            let (class, imports) = build_data_class(self, &class_name, item_struct, registry);
+            let (mut class, mut imports) =
+                build_data_class(self, &class_name, item_struct, registry);
+            // Members: same shape as the value-blob path — the instance
+            // method's receiver re-enters Rust as `this`'s field leaves
+            // (the data-class param destructuring, rebased to `this`).
+            let members = self
+                .class_members
+                .get(key)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            if !members.is_empty() && !self.package.is_empty() {
+                imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
+            }
+            for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
+                if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
+                    if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
+                        self,
+                        item_fn,
+                        registry,
+                        &mut imports,
+                        Some(m.kotlin_name.as_str()),
+                        Some(key),
+                    ) {
+                        class = class.member(f);
+                    }
+                }
+            }
+            let ctors: Vec<_> = members
+                .iter()
+                .filter(|m| m.kind == MemberKind::Constructor)
+                .collect();
+            if !ctors.is_empty() {
+                // `build_data_class` already installed the `fromParts`
+                // companion — factories join it rather than replacing it.
+                let mut companion = class
+                    .companion
+                    .take()
+                    .map(|c| *c)
+                    .unwrap_or_else(|| KtClass::companion_object().vis(Vis::Public));
+                for m in ctors {
+                    if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
+                        if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
+                            self,
+                            item_fn,
+                            registry,
+                            &mut imports,
+                            Some(m.kotlin_name.as_str()),
+                            None,
+                        ) {
+                            companion = companion.member(f);
+                        }
+                    }
+                }
+                class = class.companion(companion);
+            }
             written.push(kt::KtFile::new(package).decl(class).imports(imports));
         }
 

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -309,7 +309,7 @@ impl JniGen {
                         item_fn,
                         registry,
                         &mut imports,
-                        Some(m.kotlin_name.as_str()),
+                        Some(self.effective_member_name(key, m).as_str()),
                         Some(key),
                     ) {
                         class = class.member(f);
@@ -330,7 +330,7 @@ impl JniGen {
                             item_fn,
                             registry,
                             &mut imports,
-                            Some(m.kotlin_name.as_str()),
+                            Some(self.effective_member_name(key, m).as_str()),
                             None,
                         ) {
                             companion = companion.member(f);
@@ -503,7 +503,7 @@ impl JniGen {
                         item_fn,
                         registry,
                         &mut imports,
-                        Some(m.kotlin_name.as_str()),
+                        Some(self.effective_member_name(key, m).as_str()),
                         Some(key),
                     ) {
                         class = class.member(f);
@@ -529,7 +529,7 @@ impl JniGen {
                             item_fn,
                             registry,
                             &mut imports,
-                            Some(m.kotlin_name.as_str()),
+                            Some(self.effective_member_name(key, m).as_str()),
                             None,
                         ) {
                             companion = companion.member(f);

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -51,15 +51,24 @@ pub(crate) struct TypedHandle<'a> {
     pub key: &'a TypeKey,
 }
 
+impl crate::api::core::Generation<JniGen> {
+    /// Unified Kotlin emission — the JNI adapter's second artifact,
+    /// alongside [`write_rust`](Self::write_rust). Each per-kind emitter
+    /// builds in-memory [`kt::KtFile`] model fragments; they are merged
+    /// into one file per package, rendered, and written under
+    /// `kotlin_root`. Pure emission over the resolved registry —
+    /// order-free with respect to `write_rust`. Returns every path
+    /// written (one per non-empty package).
+    pub fn write_kotlin(&self, kotlin_root: &Path) -> Result<Vec<PathBuf>, WriteKotlinError> {
+        self.adapter().write_kotlin(self.registry(), kotlin_root)
+    }
+}
+
 impl JniGen {
-    /// Unified Kotlin emission — single public entry point. Each per-kind
-    /// emitter builds in-memory [`kt::KtFile`] model fragments; they are then
-    /// merged into one file per package, rendered, and written under
-    /// `kotlin_root`. Reads all
-    /// configuration (typed-handle methods, Kotlin type names) from internal
-    /// state set during the builder phase. Returns every path written (one
-    /// per non-empty package).
-    pub fn write_kotlin(
+    /// Kotlin emission body — the public entry point is
+    /// `Generation::<JniGen>::write_kotlin`, which guarantees the registry
+    /// was resolved first.
+    pub(crate) fn write_kotlin(
         &self,
         registry: &Registry<KotlinMeta>,
         kotlin_root: &Path,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -56,9 +56,12 @@ impl crate::api::core::Generation<JniGen> {
     /// alongside [`write_rust`](Self::write_rust). Each per-kind emitter
     /// builds in-memory [`kt::KtFile`] model fragments; they are merged
     /// into one file per package, rendered, and written under
-    /// `kotlin_root`. Pure emission over the resolved registry —
-    /// order-free with respect to `write_rust`. Returns every path
-    /// written (one per non-empty package).
+    /// `kotlin_root` — which is **generator-owned**: deleted and recreated
+    /// on every run (point it at a dedicated directory like
+    /// `kotlin/generated/`, never at hand-written sources). Pure emission
+    /// over the resolved registry — order-free with respect to
+    /// `write_rust`. Returns every path written (one per non-empty
+    /// package).
     pub fn write_kotlin(&self, kotlin_root: &Path) -> Result<Vec<PathBuf>, WriteKotlinError> {
         self.adapter().write_kotlin(self.registry(), kotlin_root)
     }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -282,13 +282,17 @@ impl JniGen {
                 Some((p, c)) => (p.to_string(), c.to_string()),
                 None => (String::new(), fqn.clone()),
             };
+            let framework_line = format!(
+                "Typed by-value wrapper for the native Rust `{}` (a `Copy` blob carried\n\
+                 as its raw bytes; `@JvmInline`-erased to `ByteArray` at the JNI boundary).",
+                key.as_str()
+            );
+            let class_kdoc = crate::api::lang::jnigen::jni::source_item_doc(registry, key)
+                .map(|d| format!("{d}\n\n{framework_line}"))
+                .unwrap_or(framework_line);
             let mut class = KtClass::new(ClassKind::ValueInline, class_name)
                 .vis(Vis::Public)
-                .kdoc(format!(
-                    "Typed by-value wrapper for the native Rust `{}` (a `Copy` blob carried\n\
-                     as its raw bytes; `@JvmInline`-erased to `ByteArray` at the JNI boundary).",
-                    key.as_str()
-                ))
+                .kdoc(class_kdoc)
                 .ctor_param(
                     KtCtorParam::new("bytes", KtType::byte_array())
                         .val()

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -20,10 +20,10 @@
 //! last segment and lives in the directory of its parent package, holding all
 //! of that package's classes, enums, value-classes and free functions.
 //!
-//! Every `#[prebindgen]` function must be assigned a Kotlin home via
-//! `.method(...)` on either a typed-handle / data-class / enum config
-//! or on `package(...)`. Undeclared functions are skipped (see
-//! `Registry::scan_declared` warnings). There is no "orphan" bucket.
+//! Every `#[prebindgen]` function must be assigned a Kotlin home — as a
+//! class member (`.fun`/`.constructor` on a class decl) or a free function
+//! (`PackageDecl::fun`). Undeclared functions are skipped with a build
+//! warning (`Registry::scan_declared`); there is no "orphan" bucket.
 
 use super::*;
 use crate::api::gen::{

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -279,7 +279,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///             .variant(prebindgen::fun!(keyexpr_new_try_from))
 ///             .variant_self(),
 ///     )
-///     .return_expand(prebindgen::return_expand!(KeyExpr).field(prebindgen::fun!(keyexpr_get_str)));
+///     .expand(prebindgen::return_expand!(KeyExpr).field(prebindgen::fun!(keyexpr_get_str)));
 /// ```
 #[derive(Clone)]
 pub struct JniGen {
@@ -379,12 +379,12 @@ pub struct JniGen {
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
 
     /// Type-level default input boundaries ([`ParamExpandDecl`], accepted by
-    /// [`JniGen::param_expand`]), stored raw — merged into the expansion set
+    /// [`JniGen::expand`]), stored raw — merged into the expansion set
     /// at the point of use so declarations stay order-independent.
     pub(crate) param_expand_decls: Vec<ParamExpandDecl>,
 
     /// Type-level default output boundaries ([`ReturnExpandDecl`], accepted
-    /// by [`JniGen::return_expand`]), stored raw — field names (member
+    /// by [`JniGen::expand`]), stored raw — field names (member
     /// inheritance) resolve at the point of use so declarations stay
     /// order-independent.
     pub(crate) return_expand_decls: Vec<ReturnExpandDecl>,

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -209,12 +209,14 @@ pub(crate) enum MemberKind {
 pub(crate) struct ClassMember {
     /// Rust function ident (`registry.functions[ident]`).
     pub rust_ident: syn::Ident,
-    /// Kotlin-visible name of this instance method / companion factory
-    /// (derived from `FunctionDecl.name()`, defaulting to
-    /// `snake_to_camel(rust_ident)`). A `expand_return!` `.field` referencing
-    /// the same underlying function inherits this name unless it sets its own
-    /// `.name()`; `expand_param!` variants reference the fn by ident only.
-    pub kotlin_name: String,
+    /// Per-member `.name()` override, stored RAW — the effective Kotlin
+    /// name is derived at point of use by [`JniGen::member_kotlin_name`]
+    /// (override, else member-mangle over the namespace-stripped camelCase
+    /// ident), keeping `set_member_name_mangle` order-independent. An
+    /// `expand_return!` `.field` referencing the same underlying function
+    /// inherits the effective name unless it sets its own `.name()`;
+    /// `expand_param!` variants reference the fn by ident only.
+    pub kotlin_name_override: Option<String>,
     /// Member kind (fun / constructor).
     pub kind: MemberKind,
 }
@@ -306,6 +308,10 @@ pub struct JniGen {
     /// Mangler for `EnumClassDecl`-declared C-like enum class
     /// names. Default = identity.
     pub(crate) enum_name_mangle: Option<NameMangle>,
+    /// Member-name mangle hook ([`JniGen::set_member_name_mangle`]) —
+    /// applied to the namespace-stripped camelCase default of every class
+    /// member without a per-member `.name()`.
+    pub(crate) member_name_mangle: Option<NameMangle>,
     /// Mangler for the framework "harness" class name —
     /// `"Native"` (the centralized JNI extern holder). Default when
     /// unset = prepend `"JNI"`, so you get `JNINative`. Override to

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -453,6 +453,7 @@ mod trait_impl;
 mod fold;
 mod kotlin_emit;
 mod render;
+mod report;
 mod struct_plan;
 
 pub(crate) use builder::*;

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -195,7 +195,7 @@ pub(crate) enum MemberKind {
     Fun,
     /// `f(…) -> T` / `Result<T,E>`: a factory emitted as a companion-object
     /// member returning the class; never output-flattened; referenceable by a
-    /// a `param_expand!` `.variant(fun!(...))` arm.
+    /// a `expand_param!` `.variant(fun!(...))` arm.
     Constructor,
 }
 
@@ -211,9 +211,9 @@ pub(crate) struct ClassMember {
     pub rust_ident: syn::Ident,
     /// Kotlin-visible name of this instance method / companion factory
     /// (derived from `FunctionDecl.name()`, defaulting to
-    /// `snake_to_camel(rust_ident)`). A `return_expand!` `.field` referencing
+    /// `snake_to_camel(rust_ident)`). A `expand_return!` `.field` referencing
     /// the same underlying function inherits this name unless it sets its own
-    /// `.name()`; `param_expand!` variants reference the fn by ident only.
+    /// `.name()`; `expand_param!` variants reference the fn by ident only.
     pub kotlin_name: String,
     /// Member kind (fun / constructor).
     pub kind: MemberKind,
@@ -257,7 +257,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 
 /// JNI back-end. Global settings are applied with the order-insensitive
 /// `set_*` methods; declarations are accepted as pre-built objects
-/// (`PackageDecl`, `ParamExpandDecl`, `ReturnExpandDecl`,
+/// (`PackageDecl`, `ExpandParamDecl`, `ExpandReturnDecl`,
 /// `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see `decl.rs`) built
 /// independently of `JniGen` itself; there is no fluent typestate cursor.
 ///
@@ -274,12 +274,12 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///     )
 ///     // A KeyExpr param accepts EITHER a String (built via tryFrom) OR an
 ///     // existing handle; a returned KeyExpr decomposes into its string form.
-///     .param_expand(
-///         prebindgen::param_expand!(KeyExpr)
+///     .expand(
+///         prebindgen::expand_param!(KeyExpr)
 ///             .variant(prebindgen::fun!(keyexpr_new_try_from))
 ///             .variant_self(),
 ///     )
-///     .expand(prebindgen::return_expand!(KeyExpr).field(prebindgen::fun!(keyexpr_get_str)));
+///     .expand(prebindgen::expand_return!(KeyExpr).field(prebindgen::fun!(keyexpr_get_str)));
 /// ```
 #[derive(Clone)]
 pub struct JniGen {
@@ -361,7 +361,7 @@ pub struct JniGen {
     /// init block — loading stays the consumer's responsibility.
     pub(crate) jni_native_init: Option<String>,
 
-    /// Per-fn constructor-expansion overrides (`.param_expand*` on a
+    /// Per-fn constructor-expansion overrides (`.expand_param` on a
     /// [`FunctionDecl`]), replayed eagerly at accept time. The type-level
     /// defaults live raw in [`Self::param_expand_decls`]; the two merge on
     /// demand in [`JniGen::build_expansions`], resolved into
@@ -369,7 +369,7 @@ pub struct JniGen {
     /// `write_rust` and consumed at the parameter-emission site.
     pub(crate) expansions: crate::api::core::expand::Expansions,
 
-    /// Per-fn output-expansion overrides (`.return_expand*` on a
+    /// Per-fn output-expansion overrides (`.expand_return` on a
     /// [`FunctionDecl`]) plus constructor-member skip-defaults, replayed
     /// eagerly at accept time. The type-level defaults live raw in
     /// [`Self::return_expand_decls`]; the two merge on demand in
@@ -378,16 +378,26 @@ pub struct JniGen {
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
 
-    /// Type-level default input boundaries ([`ParamExpandDecl`], accepted by
+    /// Type-level default input boundaries ([`ExpandParamDecl`], accepted by
     /// [`JniGen::expand`]), stored raw — merged into the expansion set
     /// at the point of use so declarations stay order-independent.
-    pub(crate) param_expand_decls: Vec<ParamExpandDecl>,
+    pub(crate) param_expand_decls: Vec<ExpandParamDecl>,
 
-    /// Type-level default output boundaries ([`ReturnExpandDecl`], accepted
+    /// Type-level default output boundaries ([`ExpandReturnDecl`], accepted
     /// by [`JniGen::expand`]), stored raw — field names (member
     /// inheritance) resolve at the point of use so declarations stay
     /// order-independent.
-    pub(crate) return_expand_decls: Vec<ReturnExpandDecl>,
+    pub(crate) return_expand_decls: Vec<ExpandReturnDecl>,
+
+    /// Per-fn input overrides ([`FunctionDecl::expand_param`]): the fn ident,
+    /// the parameter name, and the decl — stored raw like the type-level
+    /// decls; cross-checked and lowered in `core/expand.rs`'s `apply`.
+    pub(crate) fn_param_expands: Vec<(syn::Ident, String, ExpandParamDecl)>,
+
+    /// Per-fn output overrides ([`FunctionDecl::expand_return`]): the fn
+    /// ident and the decl — stored raw; cross-checked and lowered in
+    /// `core/unfold.rs`'s `apply`.
+    pub(crate) fn_return_expands: Vec<(syn::Ident, ExpandReturnDecl)>,
 
     /// Class members (funs / constructors) attached to a declared class via
     /// its decl's `.fun()`/`.constructor()`, keyed by the class's canonical
@@ -410,17 +420,6 @@ pub struct JniGen {
     /// `#[prebindgen]` consts the binding deliberately does NOT declare,
     /// via [`JniGen::ignore_const`]. Backs [`Prebindgen::ignored_consts`].
     pub(crate) ignored_const_idents: std::collections::HashSet<syn::Ident>,
-
-    /// Every function referenced as a named leaf in a per-fn
-    /// `.return_expand(fun!(...))` override — populated as `builder.rs`
-    /// accepts each decl. [`Prebindgen::accessor_functions`] unions this
-    /// with the field fns of [`Self::return_expand_decls`]: `core/unfold.rs`'s
-    /// deconstructor gate requires every named record's function to be in
-    /// that set (`RecordNotAccessor` otherwise), and `core/expand.rs` excludes
-    /// them from parameter composition. Derived from *usage*, not from any
-    /// separate declaration — a function need not also be a `.fun()` class
-    /// member to be referenced this way.
-    pub(crate) accessor_record_fns: std::collections::HashSet<syn::Ident>,
 }
 
 // ── Sibling submodules (carved from the former monolithic file) ─────────

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -416,6 +416,11 @@ pub struct JniGen {
     /// without emitting anything.
     pub(crate) ignored_fns: std::collections::HashSet<syn::Ident>,
 
+    /// Bulk fn-ignore predicates, declared via [`JniGen::ignore_funs_where`].
+    /// Backs [`Prebindgen::ignored_function_predicates`]: every undeclared
+    /// fn whose name matches is an acknowledged skip.
+    pub(crate) ignored_fn_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
+
     /// `#[prebindgen]` types the binding deliberately does NOT declare,
     /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].
     pub(crate) ignored_class_types: std::collections::HashSet<TypeKey>,

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -291,7 +291,9 @@ pub struct JniGen {
     /// (`JniGen::java_class_prefix()`), `_`-mangled for JNI extern idents
     /// (`JniGen::jni_class_path()`), dot-separated for Kotlin `package`
     /// declarations — is computed from this at the point of use.
-    pub package: String,
+    /// `pub(crate)`: consumers go through [`JniGen::set_package_prefix`],
+    /// whose trimming a direct field write would bypass.
+    pub(crate) package: String,
 
     /// Mangler for function names (scanned `#[prebindgen]` free fns and
     /// the synthetic `freePtr` destructor). Default = identity; in

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -416,10 +416,11 @@ pub struct JniGen {
     /// without emitting anything.
     pub(crate) ignored_fns: std::collections::HashSet<syn::Ident>,
 
-    /// Bulk fn-ignore predicates, declared via [`JniGen::ignore_funs_where`].
-    /// Backs [`Prebindgen::ignored_function_predicates`]: every undeclared
-    /// fn whose name matches is an acknowledged skip.
-    pub(crate) ignored_fn_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
+    /// Bulk name-family ignore predicates, declared via [`JniGen::ignore`] +
+    /// [`matching`](crate::lang::matching). Backs
+    /// [`Prebindgen::ignored_name_predicates`]: every undeclared item
+    /// (fn/type/const) whose name matches is an acknowledged skip.
+    pub(crate) ignored_name_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
 
     /// `#[prebindgen]` types the binding deliberately does NOT declare,
     /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -169,14 +169,14 @@ pub(crate) struct PackageConfig {
     /// initialized through a generated nullary JNI getter. `MethodEntry`
     /// is reused as-is (rust ident + Kotlin-name override).
     pub constants: Vec<MethodEntry>,
-    /// Function-backed constants declared via [`PackageDecl::constant_fun`]:
+    /// Fn-sourced constants declared via [`ConstDecl::fun`]:
     /// nullary `#[prebindgen]` fns whose result surfaces as a top-level
     /// Kotlin `val` (eagerly initialized through the fn's ordinary generated
     /// wrapper) instead of a callable `fun`. Rust-side emission and the
     /// `JNINative` extern are the plain declared-function ones.
     pub constant_functions: Vec<MethodEntry>,
     /// Expression-backed constants declared via
-    /// [`PackageDecl::constant_expr`](super::jni::decl::PackageDecl::constant_expr):
+    /// [`ConstDecl::expr`](super::jni::decl::ConstDecl::expr):
     /// binding-defined expressions evaluated once inside a generated nullary
     /// getter (extern symbol seeded from the val name), surfacing as
     /// top-level Kotlin `val`s. Stored as the full decl — there is no Rust
@@ -419,7 +419,7 @@ pub struct JniGen {
     pub(crate) class_members: HashMap<TypeKey, Vec<ClassMember>>,
 
     /// `#[prebindgen]` fns the binding deliberately does NOT wrap, declared
-    /// via [`JniGen::ignore_fun`]. Backs [`Prebindgen::ignored_functions`]:
+    /// via [`JniGen::ignore`]. Backs [`Prebindgen::ignored_functions`]:
     /// suppresses the registry's per-item "skipping undeclared" warning
     /// without emitting anything.
     pub(crate) ignored_fns: std::collections::HashSet<syn::Ident>,
@@ -431,7 +431,7 @@ pub struct JniGen {
     pub(crate) ignored_name_predicates: Vec<crate::api::core::prebindgen::NamePredicate>,
 
     /// `#[prebindgen]` types the binding deliberately does NOT declare,
-    /// via [`JniGen::ignore_class`]. Backs [`Prebindgen::ignored_types`].
+    /// via [`JniGen::ignore`]. Backs [`Prebindgen::ignored_types`].
     pub(crate) ignored_class_types: std::collections::HashSet<TypeKey>,
 
     /// `#[prebindgen]` consts the binding deliberately does NOT declare,

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -195,7 +195,7 @@ pub(crate) enum MemberKind {
     Fun,
     /// `f(…) -> T` / `Result<T,E>`: a factory emitted as a companion-object
     /// member returning the class; never output-flattened; referenceable by a
-    /// `.default_param_expand(fun!(...))`.
+    /// a `param_expand!` `.variant(fun!(...))` arm.
     Constructor,
 }
 
@@ -211,9 +211,9 @@ pub(crate) struct ClassMember {
     pub rust_ident: syn::Ident,
     /// Kotlin-visible name of this instance method / companion factory
     /// (derived from `FunctionDecl.name()`, defaulting to
-    /// `snake_to_camel(rust_ident)`). Independent of any `.default_param_expand`/
-    /// `.default_return_expand` reference to the same underlying function — those
-    /// take a fresh `FunctionDecl` directly and don't consult this list.
+    /// `snake_to_camel(rust_ident)`). A `return_expand!` `.field` referencing
+    /// the same underlying function inherits this name unless it sets its own
+    /// `.name()`; `param_expand!` variants reference the fn by ident only.
     pub kotlin_name: String,
     /// Member kind (fun / constructor).
     pub kind: MemberKind,
@@ -257,9 +257,9 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 
 /// JNI back-end. Global settings are applied with the order-insensitive
 /// `set_*` methods; declarations are accepted as pre-built objects
-/// (`PackageDecl`, `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see
-/// `decl.rs`) built independently of `JniGen` itself; there is no fluent
-/// typestate cursor.
+/// (`PackageDecl`, `ParamExpandDecl`, `ReturnExpandDecl`,
+/// `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see `decl.rs`) built
+/// independently of `JniGen` itself; there is no fluent typestate cursor.
 ///
 /// ```
 /// use prebindgen::lang::JniGen;
@@ -267,11 +267,19 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 /// let jni = JniGen::new()
 ///     .set_package_prefix("io.test.jni")
 ///     .package(
-///         prebindgen::package!("session")
-///             .class(prebindgen::ptr_class!(ZKeyExpr)
-///                 .fun(prebindgen::fun!(z_keyexpr_as_str).name("getStr"))
-///                 .default_return_expand_self()),
-///     );
+///         prebindgen::package!("keyexpr")
+///             .class(prebindgen::ptr_class!(KeyExpr)
+///                 .fun(prebindgen::fun!(keyexpr_get_str).name("getStr"))
+///                 .constructor(prebindgen::fun!(keyexpr_new_try_from).name("tryFrom"))),
+///     )
+///     // A KeyExpr param accepts EITHER a String (built via tryFrom) OR an
+///     // existing handle; a returned KeyExpr decomposes into its string form.
+///     .param_expand(
+///         prebindgen::param_expand!(KeyExpr)
+///             .variant(prebindgen::fun!(keyexpr_new_try_from))
+///             .variant_self(),
+///     )
+///     .return_expand(prebindgen::return_expand!(KeyExpr).field(prebindgen::fun!(keyexpr_get_str)));
 /// ```
 #[derive(Clone)]
 pub struct JniGen {
@@ -353,16 +361,33 @@ pub struct JniGen {
     /// init block — loading stays the consumer's responsibility.
     pub(crate) jni_native_init: Option<String>,
 
-    /// Constructor-expansion declarations (`.default_param_expand()` /    /// `.param_expand()` on a class/function decl). Resolved into
+    /// Per-fn constructor-expansion overrides (`.param_expand*` on a
+    /// [`FunctionDecl`]), replayed eagerly at accept time. The type-level
+    /// defaults live raw in [`Self::param_expand_decls`]; the two merge on
+    /// demand in [`JniGen::build_expansions`], resolved into
     /// [`crate::api::core::expand::FoldPlan`]s on the registry during
     /// `write_rust` and consumed at the parameter-emission site.
     pub(crate) expansions: crate::api::core::expand::Expansions,
 
-    /// Output-expansion declarations (`.default_return_expand()` /
-    /// `.return_expand()` on a class/function decl). Resolved into
+    /// Per-fn output-expansion overrides (`.return_expand*` on a
+    /// [`FunctionDecl`]) plus constructor-member skip-defaults, replayed
+    /// eagerly at accept time. The type-level defaults live raw in
+    /// [`Self::return_expand_decls`]; the two merge on demand in
+    /// [`JniGen::build_deconstructors`], resolved into
     /// [`crate::api::core::unfold::UnfoldPlan`]s on the registry during
     /// `write_rust` and consumed at the return-emission site.
     pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
+
+    /// Type-level default input boundaries ([`ParamExpandDecl`], accepted by
+    /// [`JniGen::param_expand`]), stored raw — merged into the expansion set
+    /// at the point of use so declarations stay order-independent.
+    pub(crate) param_expand_decls: Vec<ParamExpandDecl>,
+
+    /// Type-level default output boundaries ([`ReturnExpandDecl`], accepted
+    /// by [`JniGen::return_expand`]), stored raw — field names (member
+    /// inheritance) resolve at the point of use so declarations stay
+    /// order-independent.
+    pub(crate) return_expand_decls: Vec<ReturnExpandDecl>,
 
     /// Class members (funs / constructors) attached to a declared class via
     /// its decl's `.fun()`/`.constructor()`, keyed by the class's canonical
@@ -386,12 +411,12 @@ pub struct JniGen {
     /// via [`JniGen::ignore_const`]. Backs [`Prebindgen::ignored_consts`].
     pub(crate) ignored_const_idents: std::collections::HashSet<syn::Ident>,
 
-    /// Every function ever referenced as a named leaf in a `.default_return_expand(fun!(...))`/
-    /// `.return_expand(...)` record (class- or
-    /// function-scoped) — populated as `builder.rs` accepts each decl.
-    /// Backs [`Prebindgen::accessor_functions`]: `core/unfold.rs`'s
+    /// Every function referenced as a named leaf in a per-fn
+    /// `.return_expand(fun!(...))` override — populated as `builder.rs`
+    /// accepts each decl. [`Prebindgen::accessor_functions`] unions this
+    /// with the field fns of [`Self::return_expand_decls`]: `core/unfold.rs`'s
     /// deconstructor gate requires every named record's function to be in
-    /// this set (`RecordNotAccessor` otherwise), and `core/expand.rs` excludes
+    /// that set (`RecordNotAccessor` otherwise), and `core/expand.rs` excludes
     /// them from parameter composition. Derived from *usage*, not from any
     /// separate declaration — a function need not also be a `.fun()` class
     /// member to be referenced this way.

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -283,10 +283,6 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 /// ```
 #[derive(Clone)]
 pub struct JniGen {
-    /// Module path the original `#[prebindgen]` fns live under (e.g.
-    /// the host crate of `#[prebindgen]` items). The wrapper body calls
-    /// `<source_module>::<fn>(args)`.
-    pub source_module: syn::Path,
     /// Single source of truth for the JVM/Kotlin namespace this binding
     /// targets, dot-separated (e.g. `io.zenoh.jni`). Empty = no prefix.
     /// Every derived form — slash-separated for `FindClass`

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -258,7 +258,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 /// JNI back-end. Global settings are applied with the order-insensitive
 /// `set_*` methods; declarations are accepted as pre-built objects
 /// (`PackageDecl`, `ExpandParamDecl`, `ExpandReturnDecl`,
-/// `ScalarTypeWrapperDecl`, `GenericTypeWrapperDecl` — see `decl.rs`) built
+/// `ConvertDecl` — see `decl.rs`) built
 /// independently of `JniGen` itself; there is no fluent typestate cursor.
 ///
 /// ```
@@ -318,7 +318,7 @@ pub struct JniGen {
 
     /// Structured per-type configuration keyed by canonical Rust type.
     /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting
-    /// a `ClassDecl` or a `ScalarTypeWrapperDecl`. Holds opaque-handle
+    /// a `ClassDecl`. Holds opaque-handle
     /// config, enum config, and the raw [`NameSpec`] (Kotlin FQNs are
     /// derived from it on read via [`JniGen::kotlin_fqn`] /
     /// [`JniGen::fqn_of`]); the converter bodies themselves live in
@@ -343,6 +343,13 @@ pub struct JniGen {
 
     /// Per-rank output converters. Same shape as [`Self::input_wrappers`].
     pub(crate) output_wrappers: [HashMap<TypeKey, WrapperFn>; 4],
+
+    /// Canonical single-value conversions ([`ConvertDecl`], accepted by
+    /// [`JniGen::convert`]), stored raw — the rank-0 converter bodies derive
+    /// from the conversion fns' registry signatures at lookup time
+    /// ([`JniGen::convert_input_body`] / [`JniGen::convert_output_body`]),
+    /// keeping declarations order-independent and origin-qualified.
+    pub(crate) convert_decls: Vec<ConvertDecl>,
 
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -803,7 +803,7 @@ pub(crate) fn render_const_val(
     render_val_over_helper(ext, helper, val_name, kdoc, imports)
 }
 
-/// Render one function-backed constant (see `PackageDecl::constant_fun`):
+/// Render one fn-sourced constant (see `ConstDecl::fun`):
 /// the declared nullary fn's ordinary wrapper demoted to a **private**
 /// helper, plus the public eagerly-initialized `val` holding its result —
 /// computed once, at package-file class-load, through the ordinary generated
@@ -830,7 +830,7 @@ pub(crate) fn render_constant_fn_val(
     render_val_over_helper(ext, helper, val_name, kdoc, imports)
 }
 
-/// Render one expression-backed constant (see `PackageDecl::constant_expr`):
+/// Render one expression-backed constant (see `ConstDecl::expr`):
 /// a private nullary helper over the synthetic `const_get_*` getter (seeded
 /// from the val name), plus the public eagerly-initialized `val` — the value
 /// is the binding-defined expression, evaluated once at package-file
@@ -852,7 +852,7 @@ pub(crate) fn render_const_expr_val(
 }
 
 /// Shared val-rendering core for both constant kinds (`ConstDecl` /
-/// `PackageDecl::constant_fun`): demote the rendered wrapper to a private
+/// `ConstDecl::fun`): demote the rendered wrapper to a private
 /// helper and emit the public eagerly-initialized `val` that calls it once
 /// with a throwing `JniErrorHandler` (dead code for infallible converts; a
 /// binding-layer failure surfaces as `IllegalStateException` via

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -285,7 +285,7 @@ pub(crate) fn build_typed_handle(
                 item_fn,
                 registry,
                 imports,
-                Some(m.kotlin_name.as_str()),
+                Some(ext.effective_member_name(key, m).as_str()),
                 None,
             ) {
                 companion = companion.member(f);
@@ -340,7 +340,7 @@ pub(crate) fn build_typed_handle(
                 item_fn,
                 registry,
                 imports,
-                Some(m.kotlin_name.as_str()),
+                Some(ext.effective_member_name(key, m).as_str()),
                 Some(key),
             ) {
                 class = class.member(f);

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -660,7 +660,7 @@ struct Opaque {
 /// Peel `&` / `Option<…>` / `Option<&…>` layers and return the inner type's
 /// [`TypeKey`] — used to match an accessor's receiver parameter against its
 /// owning class key in [`render_wrapper_fn`].
-fn peel_receiver_key(ty: &syn::Type) -> TypeKey {
+pub(crate) fn peel_receiver_key(ty: &syn::Type) -> TypeKey {
     let core = match ty {
         syn::Type::Reference(r) => &*r.elem,
         other => other,

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -25,12 +25,16 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
             })
             .collect();
 
+    let framework_line = format!(
+        "JVM-side surface for the native Rust `{}` enum.",
+        item_enum.ident
+    );
+    let enum_kdoc = crate::api::lang::jnigen::util::doc_string(&item_enum.attrs)
+        .map(|d| format!("{d}\n\n{framework_line}"))
+        .unwrap_or(framework_line);
     kt::KtClass::new(kt::ClassKind::Enum(entries), class_name)
         .vis(kt::Vis::Public)
-        .kdoc(format!(
-            "JVM-side surface for the native Rust `{}` enum.",
-            item_enum.ident
-        ))
+        .kdoc(enum_kdoc)
         .ctor_param(
             kt::KtCtorParam::new("value", kt::KtType::int())
                 .val()
@@ -179,6 +183,9 @@ pub(crate) fn build_data_class(
             });
 
     let mut class = kt::KtClass::new(kt::ClassKind::Data, class_name).vis(kt::Vis::Public);
+    if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_struct.attrs) {
+        class = class.kdoc(doc);
+    }
     for p in ctor_params {
         class = class.ctor_param(p);
     }
@@ -293,11 +300,14 @@ pub(crate) fn build_typed_handle(
         }
     }
 
+    // KDoc: the Rust struct's `///` prose first, framework line after.
+    let framework_line = format!("Typed handle for a native Zenoh `{rust_doc_name}`.");
+    let class_kdoc = source_item_doc(registry, key)
+        .map(|d| format!("{d}\n\n{framework_line}"))
+        .unwrap_or(framework_line);
     let mut class = kt::KtClass::new(kt::ClassKind::Plain, class_name)
         .vis(kt::Vis::Public)
-        .kdoc(format!(
-            "Typed handle for a native Zenoh `{rust_doc_name}`."
-        ))
+        .kdoc(class_kdoc)
         .ctor_param(kt::KtCtorParam::new("initialPtr", kt::KtType::long()))
         .supertype(kt::KtType::cls(base_fqn), Some("initialPtr"))
         .member(
@@ -722,6 +732,11 @@ pub(crate) fn render_wrapper_fn(
     let sink = error_sink_parts(ext, f, registry, imports, &r_ty)?;
 
     let mut fun = kt::KtFun::new(&kt_name).vis(kt::Vis::Public);
+    // KDoc: the Rust fn's `///` prose first, then generated notes for every
+    // position an expansion reshaped away from the Rust signature (N1).
+    if let Some(doc) = wrapper_kdoc(ext, f, registry) {
+        fun = fun.kdoc(doc);
+    }
     if let Some(g) = &out.generic {
         fun = fun.generic(g);
     }
@@ -777,11 +792,14 @@ pub(crate) fn render_const_val(
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| c.ident.to_string());
-    let kdoc = format!(
+    let framework_line = format!(
         "Mirrors the Rust `#[prebindgen]` const `{}` (read once through the \
          generated JNI getter).",
         c.ident
     );
+    let kdoc = crate::api::lang::jnigen::util::doc_string(&c.attrs)
+        .map(|d| format!("{d}\n\n{framework_line}"))
+        .unwrap_or(framework_line);
     render_val_over_helper(ext, helper, val_name, kdoc, imports)
 }
 
@@ -801,11 +819,14 @@ pub(crate) fn render_constant_fn_val(
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| f.sig.ident.to_string());
-    let kdoc = format!(
+    let framework_line = format!(
         "Mirrors the Rust `#[prebindgen]` fn `{}()` (evaluated once through the \
          generated JNI wrapper).",
         f.sig.ident
     );
+    let kdoc = crate::api::lang::jnigen::util::doc_string(&f.attrs)
+        .map(|d| format!("{d}\n\n{framework_line}"))
+        .unwrap_or(framework_line);
     render_val_over_helper(ext, helper, val_name, kdoc, imports)
 }
 
@@ -2055,4 +2076,114 @@ pub(crate) fn kt_param_name(rust_ident: &str) -> String {
     } else {
         camel
     }
+}
+
+/// A wrapper's KDoc (N1): the Rust fn's `///` prose, then generated notes
+/// documenting the REAL prototype after all expansions — one note per
+/// position a plan reshaped, phrased for the caller. `None` for an
+/// undocumented, unshaped fn.
+fn wrapper_kdoc(ext: &JniGen, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
+    let prose = crate::api::lang::jnigen::util::doc_string(&f.attrs);
+    let notes = shape_notes(ext, f, registry);
+    match (prose, notes) {
+        (Some(p), Some(n)) => Some(format!("{p}\n\n{n}")),
+        (Some(p), None) => Some(p),
+        (None, Some(n)) => Some(n),
+        (None, None) => None,
+    }
+}
+
+/// Caller-facing notes for every boundary position an expansion reshaped:
+/// expanded params (what to pass instead of the Rust argument), decomposed
+/// returns (what the builder/fold receives), and error decompositions
+/// (what `onError` receives). Reads the same resolved plan maps the C7
+/// report uses.
+fn shape_notes(ext: &JniGen, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
+    let fn_ident = &f.sig.ident;
+    let mut notes: Vec<String> = Vec::new();
+
+    let mut plans: Vec<(&syn::Ident, &crate::api::core::expand::FoldPlan)> = registry
+        .expansion_plans
+        .iter()
+        .filter(|((func, _), _)| func == fn_ident)
+        .map(|((_, param), plan)| (param, plan))
+        .collect();
+    plans.sort_by_key(|(p, _)| p.to_string());
+    for (param, plan) in plans {
+        let target = plan.target.to_token_stream().to_string();
+        let arms: Vec<String> = plan
+            .variants
+            .iter()
+            .map(|v| match &v.ctor {
+                Some(c) => format!("its `{c}` inputs"),
+                None => format!("an existing `{target}`"),
+            })
+            .collect();
+        let leaf_names: Vec<String> = plan
+            .leaves
+            .iter()
+            .map(|l| ext.mangle_member(&snake_to_camel(&l.name.to_string())))
+            .collect();
+        let how = if plan.selector.is_some() {
+            format!(
+                "pass EITHER {} — the selector chooses the arm",
+                arms.join(" OR ")
+            )
+        } else {
+            arms.join(" / ").to_string()
+        };
+        notes.push(format!(
+            "Parameter `{param}` is the Rust `{target}` argument, expanded: {how} \
+             (crosses as `{}`).",
+            leaf_names.join("`, `")
+        ));
+    }
+
+    if let Some(plan) = registry.unfold_plans.get(fn_ident) {
+        let source = plan.source.to_token_stream().to_string();
+        let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+        match plan.delivery {
+            crate::api::core::unfold::Delivery::Callback if !leaves.is_empty() => {
+                notes.push(format!(
+                    "The Rust `{source}` result is delivered decomposed: the builder \
+                     callback receives (`{}`).",
+                    leaves.join("`, `")
+                ));
+            }
+            crate::api::core::unfold::Delivery::Return => {
+                notes.push(format!(
+                    "The Rust `{source}` result is converted and returned as a single value."
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(plan) = registry.error_plans.get(fn_ident) {
+        let source = plan.source.to_token_stream().to_string();
+        let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+        notes.push(format!(
+            "On failure `onError` receives `je` plus the decomposed Rust `{source}` \
+             error (`{}`).",
+            leaves.join("`, `")
+        ));
+    }
+
+    if notes.is_empty() {
+        None
+    } else {
+        Some(notes.join("\n"))
+    }
+}
+
+/// The `///` doc of the `#[prebindgen]` struct/enum behind a declared type
+/// key, when the item is indexed (a re-exported foreign type has none).
+pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Option<String> {
+    let ident = bare_path_ident(&key.to_type())?;
+    let attrs = registry
+        .structs
+        .get(&ident)
+        .map(|(s, _)| s.attrs.as_slice())
+        .or_else(|| registry.enums.get(&ident).map(|(e, _)| e.attrs.as_slice()))?;
+    crate::api::lang::jnigen::util::doc_string(attrs)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -1,0 +1,300 @@
+//! `Generation::<JniGen>::report()` — the resolved binding surface,
+//! explained.
+//!
+//! Declarations act at a distance: one `expand_return!` / `convert!` /
+//! error decl reshapes every function touching its type, and the effect
+//! set is computed inside `resolve`. The report is the missing *explain*
+//! mode: for each declared function its FINAL Kotlin signature (rendered
+//! through the same [`render_wrapper_fn`] the emitters use, so it cannot
+//! drift from the real output) plus the plans that shaped it, and for
+//! each type its kind / Kotlin FQN / wire. Consumers write it next to the
+//! committed regen so a decl's effect is reviewable in a PR without
+//! reading generated Kotlin.
+//!
+//! The report is deliberately an inherent method of `Generation<JniGen>`
+//! (the `write_kotlin` seam): the *pattern* — describe your resolved
+//! surface — is adapter-universal, but the *content* is intrinsically in
+//! the destination language's vocabulary, so each adapter implements its
+//! own.
+
+use super::*;
+
+impl crate::api::core::Generation<JniGen> {
+    /// Render the resolved binding surface as a deterministic markdown
+    /// report: per package / class the final Kotlin signature of every
+    /// wrapper (exactly as generated) with the expand/error plans that
+    /// shaped it, then the type table (kind, Kotlin FQN, wire, conversion
+    /// sources). Pure read over the resolved registry.
+    pub fn report(&self) -> String {
+        let ext = self.adapter();
+        let registry = self.registry();
+        let mut out = String::new();
+        out.push_str("# JniGen binding report\n\n");
+        out.push_str(&format!(
+            "Base package: `{}`\n",
+            if ext.package.is_empty() {
+                "(none)"
+            } else {
+                &ext.package
+            }
+        ));
+
+        // ── Packages: free functions + constants ─────────────────────────
+        for (subpackage, pkg_cfg) in &ext.packages {
+            let has_consts = !pkg_cfg.constants.is_empty()
+                || !pkg_cfg.constant_functions.is_empty()
+                || !pkg_cfg.constant_exprs.is_empty();
+            if pkg_cfg.functions.is_empty() && !has_consts {
+                continue;
+            }
+            let full = if subpackage.is_empty() {
+                ext.package.clone()
+            } else if ext.package.is_empty() {
+                subpackage.clone()
+            } else {
+                format!("{}.{}", ext.package, subpackage)
+            };
+            out.push_str(&format!("\n## package `{full}`\n\n"));
+            let mut entries: Vec<&MethodEntry> = pkg_cfg.functions.iter().collect();
+            entries.sort_by_key(|m| m.rust_ident.to_string());
+            for m in entries {
+                self.report_fn(
+                    &mut out,
+                    &m.rust_ident,
+                    m.kotlin_name_override.as_deref(),
+                    None,
+                );
+            }
+            let mut consts: Vec<String> = pkg_cfg
+                .constants
+                .iter()
+                .map(|c| {
+                    format!(
+                        "- `val {}` — `#[prebindgen]` const `{}`\n",
+                        c.kotlin_name_override
+                            .clone()
+                            .unwrap_or_else(|| c.rust_ident.to_string()),
+                        c.rust_ident
+                    )
+                })
+                .chain(pkg_cfg.constant_functions.iter().map(|c| {
+                    format!(
+                        "- `val {}` — nullary `#[prebindgen]` fn `{}`\n",
+                        c.kotlin_name_override
+                            .clone()
+                            .unwrap_or_else(|| c.rust_ident.to_string()),
+                        c.rust_ident
+                    )
+                }))
+                .chain(pkg_cfg.constant_exprs.iter().map(|e| {
+                    format!(
+                        "- `val {}: {}` — binding expression\n",
+                        e.kotlin_name,
+                        e.ty.to_token_stream()
+                    )
+                }))
+                .collect();
+            consts.sort();
+            for c in consts {
+                out.push_str(&c);
+            }
+        }
+
+        // ── Classes: members ──────────────────────────────────────────────
+        let mut class_keys: Vec<&TypeKey> = ext.class_members.keys().collect();
+        class_keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        for key in class_keys {
+            let members = &ext.class_members[key];
+            if members.is_empty() {
+                continue;
+            }
+            let fqn = ext
+                .kotlin_fqn(key.as_str())
+                .unwrap_or_else(|| key.as_str().to_string());
+            out.push_str(&format!(
+                "\n## class `{fqn}` ({}, Rust `{}`)\n\n",
+                ext.class_kind_name(key),
+                key.as_str()
+            ));
+            let mut ms: Vec<&ClassMember> = members.iter().collect();
+            ms.sort_by_key(|m| m.rust_ident.to_string());
+            for m in ms {
+                let name = ext.effective_member_name(key, m);
+                let receiver = match m.kind {
+                    MemberKind::Fun => Some(key),
+                    MemberKind::Constructor => None,
+                };
+                self.report_fn(&mut out, &m.rust_ident, Some(&name), receiver);
+            }
+        }
+
+        // ── Types ────────────────────────────────────────────────────────
+        out.push_str("\n## types\n\n");
+        let mut type_keys: Vec<&TypeKey> = ext.types.keys().collect();
+        type_keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        for key in type_keys {
+            let cfg = &ext.types[key];
+            if cfg.name_spec.is_none() {
+                continue;
+            }
+            let fqn = ext
+                .kotlin_fqn(key.as_str())
+                .unwrap_or_else(|| key.as_str().to_string());
+            let wire = registry
+                .output_entry(&key.to_type())
+                .map(|e| e.wire_type().to_token_stream().to_string())
+                .unwrap_or_else(|| "?".to_string());
+            out.push_str(&format!(
+                "- `{}`: {} → `{fqn}` (wire `{wire}`)\n",
+                key.as_str(),
+                ext.class_kind_name(key),
+            ));
+        }
+        // Conversion sources (`convert!` decls) — the canonical single-value
+        // aspect, reported once per type rather than per function.
+        let mut convs: Vec<String> = ext
+            .convert_decls
+            .iter()
+            .map(|d| format!("- `convert!({})`{}\n", d.key.as_str(), d.describe_sources()))
+            .collect();
+        convs.sort();
+        if !convs.is_empty() {
+            out.push_str("\n## conversions\n\n");
+            for c in convs {
+                out.push_str(&c);
+            }
+        }
+        // Rust-side-only boundary types (expand decls on undeclared types).
+        let mut boundary: Vec<String> = crate::api::core::Prebindgen::boundary_only_types(ext)
+            .into_iter()
+            .map(|k| format!("- `{}` (never materializes in Kotlin)\n", k.as_str()))
+            .collect();
+        boundary.sort();
+        if !boundary.is_empty() {
+            out.push_str("\n## rust-side-only types\n\n");
+            for b in boundary {
+                out.push_str(&b);
+            }
+        }
+        out
+    }
+
+    /// One function entry: the final Kotlin signature (same render path as
+    /// the emitters) + the plans that shaped it.
+    fn report_fn(
+        &self,
+        out: &mut String,
+        rust_ident: &syn::Ident,
+        kotlin_name: Option<&str>,
+        receiver_key: Option<&TypeKey>,
+    ) {
+        let ext = self.adapter();
+        let registry = self.registry();
+        let Some((item_fn, _)) = registry.functions.get(rust_ident) else {
+            return;
+        };
+        let mut imports = BTreeSet::new();
+        let Some(f) = render_wrapper_fn(
+            ext,
+            item_fn,
+            registry,
+            &mut imports,
+            kotlin_name,
+            receiver_key,
+        ) else {
+            return;
+        };
+        out.push_str(&format!("- `{}` — `{}`\n", rust_ident, signature(&f)));
+
+        // Param expansions.
+        let mut shaped: Vec<String> = Vec::new();
+        let mut plans: Vec<(&syn::Ident, &crate::api::core::expand::FoldPlan)> = registry
+            .expansion_plans
+            .iter()
+            .filter(|((func, _), _)| func == rust_ident)
+            .map(|((_, param), plan)| (param, plan))
+            .collect();
+        plans.sort_by_key(|(p, _)| p.to_string());
+        for (param, plan) in plans {
+            let variants: Vec<String> = plan
+                .variants
+                .iter()
+                .map(|v| match &v.ctor {
+                    Some(c) => c.to_string(),
+                    None => "self".to_string(),
+                })
+                .collect();
+            shaped.push(format!(
+                "param `{param}` expanded from `{}` — variants [{}]",
+                plan.target.to_token_stream(),
+                variants.join(", ")
+            ));
+        }
+        if let Some(plan) = registry.unfold_plans.get(rust_ident) {
+            let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+            shaped.push(format!(
+                "return `{}` decomposed → [{}] ({:?} delivery)",
+                plan.source.to_token_stream(),
+                leaves.join(", "),
+                plan.delivery
+            ));
+        }
+        if let Some(plan) = registry.error_plans.get(rust_ident) {
+            let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+            shaped.push(format!(
+                "error `{}` decomposed → [je, {}]",
+                plan.source.to_token_stream(),
+                leaves.join(", ")
+            ));
+        }
+        for s in shaped {
+            out.push_str(&format!("  - shaped by: {s}\n"));
+        }
+    }
+}
+
+impl JniGen {
+    /// Human-readable class-kind name of a declared type (report use).
+    pub(crate) fn class_kind_name(&self, key: &TypeKey) -> &'static str {
+        let Some(cfg) = self.types.get(key) else {
+            return "undeclared";
+        };
+        if cfg.opaque.is_some() {
+            "ptr_class"
+        } else if cfg.enum_cfg.is_some() {
+            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
+                "enum_class (kotlin_type-mapped)"
+            } else {
+                "enum_class"
+            }
+        } else if cfg.value_blob {
+            "value_class"
+        } else if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
+            "kotlin_type-mapped"
+        } else if cfg.class_decl {
+            "data_class"
+        } else {
+            "wrapper"
+        }
+    }
+}
+
+/// `fun <generics> name(params): ret` off the public [`kt::KtFun`] fields —
+/// the signature only, no body/annotations (they are emission detail).
+fn signature(f: &kt::KtFun) -> String {
+    let generics = if f.generics.is_empty() {
+        String::new()
+    } else {
+        format!("<{}> ", f.generics.join(", "))
+    };
+    let params: Vec<String> = f
+        .params
+        .iter()
+        .map(|p| format!("{}: {}", p.name, p.ty))
+        .collect();
+    let ret = match &f.ret {
+        Some(t) => format!(": {t}"),
+        None => String::new(),
+    };
+    format!("fun {generics}{}({}){ret}", f.name, params.join(", "))
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -48,7 +48,7 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
         // Canonical output: handle (identity) + its string form — a callback
         // arg of ZThing decomposes into these 2 leaves.
         .expand(
-            crate::return_expand!(ZThing)
+            crate::expand_return!(ZThing)
                 .field_self()
                 .field(crate::fun!(z_thing_name)),
         );
@@ -179,7 +179,7 @@ fn callback_snapshot_kotlin_side() {
 
 /// Regression: a callback-delivered type that has BOTH a nested handle identity
 /// (a child `ptr_class` reached by an accessor) AND its own root identity
-/// (`return_expand!` `.field_self()`) must emit the root MOVE after every borrow of
+/// (`expand_return!` `.field_self()`) must emit the root MOVE after every borrow of
 /// the owned value — otherwise the nested child clone (which borrows the root)
 /// follows `Box::into_raw(Box::new(value))` and fails to compile with "use of
 /// moved value". Declaring `.field_self()` LAST guarantees the
@@ -232,13 +232,13 @@ fn callback_root_identity_moved_after_nested_borrow() {
         )
         // Child handle: canonical output = identity (clone) + its name string.
         .expand(
-            crate::return_expand!(ZChild)
+            crate::expand_return!(ZChild)
                 .field_self()
                 .field(crate::fun!(z_child_name)),
         )
         // Parent: a nested child-handle record, then its OWN root identity LAST.
         .expand(
-            crate::return_expand!(ZParent)
+            crate::expand_return!(ZParent)
                 .field(crate::fun!(z_parent_child))
                 .field_self(),
         );
@@ -331,19 +331,19 @@ fn callback_double_option_unwrap_pipeline() {
                 .fun(crate::fun!(z_get)),
         )
         .expand(
-            crate::return_expand!(ZKeyExpr)
+            crate::expand_return!(ZKeyExpr)
                 .field_self()
                 .field(crate::fun!(z_keyexpr_as_str)),
         )
-        .expand(crate::return_expand!(ZTs).field(crate::fun!(z_ts_ntp64)))
+        .expand(crate::expand_return!(ZTs).field(crate::fun!(z_ts_ntp64)))
         .expand(
-            crate::return_expand!(ZSample)
+            crate::expand_return!(ZSample)
                 .field(crate::fun!(z_sample_key_expr))
                 .field(crate::fun!(z_sample_timestamp)),
         )
-        .expand(crate::return_expand!(ZErr).field(crate::fun!(z_err_payload)))
+        .expand(crate::expand_return!(ZErr).field(crate::fun!(z_err_payload)))
         .expand(
-            crate::return_expand!(ZReply)
+            crate::expand_return!(ZReply)
                 .field(crate::fun!(z_reply_zid))
                 .field(crate::fun!(z_reply_is_ok))
                 .field(crate::fun!(z_reply_sample))
@@ -431,7 +431,7 @@ fn callback_double_option_unwrap_pipeline() {
 // ────────────────────────────────────────────────────────────────────────
 // Declaration-keyed interfaces: a type may have several decompositions —
 // the default (unnamed) deconstructor and per-fn inline records
-// (`.return_expand`). Interface identity follows the DECLARATION, so
+// (`.expand_return`). Interface identity follows the DECLARATION, so
 // differently-decomposed functions get distinct interfaces instead of
 // colliding on one type-keyed name.
 // ────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -2,7 +2,7 @@ use super::*;
 
 fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Fn(syn::parse_quote!(
@@ -33,7 +33,6 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -189,7 +188,7 @@ fn callback_snapshot_kotlin_side() {
 #[test]
 fn callback_root_identity_moved_after_nested_borrow() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Fn(syn::parse_quote!(
@@ -220,7 +219,6 @@ fn callback_root_identity_moved_after_nested_borrow() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -278,7 +276,7 @@ fn callback_root_identity_moved_after_nested_borrow() {
 #[test]
 fn callback_double_option_unwrap_pipeline() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_reply_zid(r: &ZReply) -> Option<ZId> { unimplemented!() }",
         "pub fn z_reply_is_ok(r: &ZReply) -> bool { unimplemented!() }",
@@ -306,7 +304,6 @@ fn callback_double_option_unwrap_pipeline() {
         loc.clone(),
     ));
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -32,7 +32,7 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -56,13 +56,12 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let mut kotlin = std::collections::BTreeMap::new();
     for p in &paths {
         let name = p.file_name().unwrap().to_string_lossy().to_string();
@@ -218,7 +217,7 @@ fn callback_root_identity_moved_after_nested_borrow() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -244,9 +243,8 @@ fn callback_root_identity_moved_after_nested_borrow() {
     let dir = unique_test_dir("jnigen_root_id_order");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
@@ -303,7 +301,7 @@ fn callback_double_option_unwrap_pipeline() {
         )),
         loc.clone(),
     ));
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -350,9 +348,8 @@ fn callback_double_option_unwrap_pipeline() {
     let dir = unique_test_dir("jnigen_double_opt");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
@@ -393,7 +390,7 @@ fn callback_double_option_unwrap_pipeline() {
     // the discriminator non-null; the value-blob leaf surfaces as its raw
     // (nullable) ByteArray wire, NOT the value class — the SDK wraps.
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let iface_file = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -33,9 +33,9 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
@@ -220,9 +220,9 @@ fn callback_root_identity_moved_after_nested_borrow() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
@@ -306,9 +306,9 @@ fn callback_double_option_unwrap_pipeline() {
         loc.clone(),
     ));
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("query")

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -47,7 +47,7 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
         )
         // Canonical output: handle (identity) + its string form — a callback
         // arg of ZThing decomposes into these 2 leaves.
-        .return_expand(
+        .expand(
             crate::return_expand!(ZThing)
                 .field_self()
                 .field(crate::fun!(z_thing_name)),
@@ -231,13 +231,13 @@ fn callback_root_identity_moved_after_nested_borrow() {
                 .fun(crate::fun!(z_parent_sub)),
         )
         // Child handle: canonical output = identity (clone) + its name string.
-        .return_expand(
+        .expand(
             crate::return_expand!(ZChild)
                 .field_self()
                 .field(crate::fun!(z_child_name)),
         )
         // Parent: a nested child-handle record, then its OWN root identity LAST.
-        .return_expand(
+        .expand(
             crate::return_expand!(ZParent)
                 .field(crate::fun!(z_parent_child))
                 .field_self(),
@@ -330,19 +330,19 @@ fn callback_double_option_unwrap_pipeline() {
                 )
                 .fun(crate::fun!(z_get)),
         )
-        .return_expand(
+        .expand(
             crate::return_expand!(ZKeyExpr)
                 .field_self()
                 .field(crate::fun!(z_keyexpr_as_str)),
         )
-        .return_expand(crate::return_expand!(ZTs).field(crate::fun!(z_ts_ntp64)))
-        .return_expand(
+        .expand(crate::return_expand!(ZTs).field(crate::fun!(z_ts_ntp64)))
+        .expand(
             crate::return_expand!(ZSample)
                 .field(crate::fun!(z_sample_key_expr))
                 .field(crate::fun!(z_sample_timestamp)),
         )
-        .return_expand(crate::return_expand!(ZErr).field(crate::fun!(z_err_payload)))
-        .return_expand(
+        .expand(crate::return_expand!(ZErr).field(crate::fun!(z_err_payload)))
+        .expand(
             crate::return_expand!(ZReply)
                 .field(crate::fun!(z_reply_zid))
                 .field(crate::fun!(z_reply_is_ok))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -39,18 +39,18 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
-                .class(
-                    crate::ptr_class!(ZThing)
-                        // Canonical output: handle (identity) + its string form — a
-                        // callback arg of ZThing decomposes into these 2 leaves.
-                        .fun(crate::fun!(z_thing_name).name("name"))
-                        .default_return_expand_self()
-                        .default_return_expand(crate::fun!(z_thing_name).name("name")),
-                )
+                .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
                 // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
                 .class(crate::ptr_class!(ZOther))
                 .fun(crate::fun!(z_thing_sub))
                 .fun(crate::fun!(z_other_sub)),
+        )
+        // Canonical output: handle (identity) + its string form — a callback
+        // arg of ZThing decomposes into these 2 leaves.
+        .return_expand(
+            crate::return_expand!(ZThing)
+                .field_self()
+                .field(crate::fun!(z_thing_name)),
         );
 
     let dir = unique_test_dir("jnigen_cb_snap");
@@ -179,10 +179,10 @@ fn callback_snapshot_kotlin_side() {
 
 /// Regression: a callback-delivered type that has BOTH a nested handle identity
 /// (a child `ptr_class` reached by an accessor) AND its own root identity
-/// (`.default_return_expand().field_self()`) must emit the root MOVE after every borrow of
+/// (`return_expand!` `.field_self()`) must emit the root MOVE after every borrow of
 /// the owned value — otherwise the nested child clone (which borrows the root)
 /// follows `Box::into_raw(Box::new(value))` and fails to compile with "use of
-/// moved value". Declaring `.default_return_expand().field_self()` LAST guarantees the
+/// moved value". Declaring `.field_self()` LAST guarantees the
 /// correct order (the emitter emits identity leaves in declaration order, after
 /// all non-identity leaves). This mirrors the zenoh-flat `ZQuery` queryable
 /// callback (handle + decomposed fields, nested `ZKeyExpr` identity).
@@ -226,21 +226,21 @@ fn callback_root_identity_moved_after_nested_borrow() {
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
-                // Child handle: canonical output = identity (clone) + its name string.
-                .class(
-                    crate::ptr_class!(ZChild)
-                        .fun(crate::fun!(z_child_name).name("name"))
-                        .default_return_expand_self()
-                        .default_return_expand(crate::fun!(z_child_name).name("name")),
-                )
-                // Parent: a nested child-handle record, then its OWN root identity LAST.
-                .class(
-                    crate::ptr_class!(ZParent)
-                        .fun(crate::fun!(z_parent_child).name("child"))
-                        .default_return_expand(crate::fun!(z_parent_child).name("child"))
-                        .default_return_expand_self(),
-                )
+                .class(crate::ptr_class!(ZChild).fun(crate::fun!(z_child_name).name("name")))
+                .class(crate::ptr_class!(ZParent).fun(crate::fun!(z_parent_child).name("child")))
                 .fun(crate::fun!(z_parent_sub)),
+        )
+        // Child handle: canonical output = identity (clone) + its name string.
+        .return_expand(
+            crate::return_expand!(ZChild)
+                .field_self()
+                .field(crate::fun!(z_child_name)),
+        )
+        // Parent: a nested child-handle record, then its OWN root identity LAST.
+        .return_expand(
+            crate::return_expand!(ZParent)
+                .field(crate::fun!(z_parent_child))
+                .field_self(),
         );
 
     let dir = unique_test_dir("jnigen_root_id_order");
@@ -313,41 +313,41 @@ fn callback_double_option_unwrap_pipeline() {
         .package(
             crate::package!("query")
                 .class(crate::value_class!(ZId))
-                .class(
-                    crate::ptr_class!(ZKeyExpr)
-                        .fun(crate::fun!(z_keyexpr_as_str).name("asStr"))
-                        .default_return_expand_self()
-                        .default_return_expand(crate::fun!(z_keyexpr_as_str).name("asStr")),
-                )
-                .class(
-                    crate::ptr_class!(ZTs)
-                        .fun(crate::fun!(z_ts_ntp64).name("ntp64"))
-                        .default_return_expand(crate::fun!(z_ts_ntp64).name("ntp64")),
-                )
+                .class(crate::ptr_class!(ZKeyExpr).fun(crate::fun!(z_keyexpr_as_str).name("asStr")))
+                .class(crate::ptr_class!(ZTs).fun(crate::fun!(z_ts_ntp64).name("ntp64")))
                 .class(
                     crate::ptr_class!(ZSample)
                         .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                        .fun(crate::fun!(z_sample_timestamp).name("timestamp"))
-                        .default_return_expand(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                        .default_return_expand(crate::fun!(z_sample_timestamp).name("timestamp")),
+                        .fun(crate::fun!(z_sample_timestamp).name("timestamp")),
                 )
-                .class(
-                    crate::ptr_class!(ZErr)
-                        .fun(crate::fun!(z_err_payload).name("payload"))
-                        .default_return_expand(crate::fun!(z_err_payload).name("payload")),
-                )
+                .class(crate::ptr_class!(ZErr).fun(crate::fun!(z_err_payload).name("payload")))
                 .class(
                     crate::ptr_class!(ZReply)
                         .fun(crate::fun!(z_reply_zid).name("zid"))
                         .fun(crate::fun!(z_reply_is_ok).name("isOk"))
                         .fun(crate::fun!(z_reply_sample).name("sample"))
-                        .fun(crate::fun!(z_reply_err).name("err"))
-                        .default_return_expand(crate::fun!(z_reply_zid).name("zid"))
-                        .default_return_expand(crate::fun!(z_reply_is_ok).name("isOk"))
-                        .default_return_expand(crate::fun!(z_reply_sample).name("sample"))
-                        .default_return_expand(crate::fun!(z_reply_err).name("err")),
+                        .fun(crate::fun!(z_reply_err).name("err")),
                 )
                 .fun(crate::fun!(z_get)),
+        )
+        .return_expand(
+            crate::return_expand!(ZKeyExpr)
+                .field_self()
+                .field(crate::fun!(z_keyexpr_as_str)),
+        )
+        .return_expand(crate::return_expand!(ZTs).field(crate::fun!(z_ts_ntp64)))
+        .return_expand(
+            crate::return_expand!(ZSample)
+                .field(crate::fun!(z_sample_key_expr))
+                .field(crate::fun!(z_sample_timestamp)),
+        )
+        .return_expand(crate::return_expand!(ZErr).field(crate::fun!(z_err_payload)))
+        .return_expand(
+            crate::return_expand!(ZReply)
+                .field(crate::fun!(z_reply_zid))
+                .field(crate::fun!(z_reply_is_ok))
+                .field(crate::fun!(z_reply_sample))
+                .field(crate::fun!(z_reply_err)),
         );
 
     let dir = unique_test_dir("jnigen_double_opt");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -197,3 +197,120 @@ fn generation_writes_are_order_free() {
     assert_eq!(rust1, rust2);
     assert_eq!(kt1, kt2);
 }
+
+/// C1: the default member name is namespace-relative — the class's Rust-name
+/// prefix is stripped from the fn ident (underscore-insensitively), the rest
+/// camel-cases. `.name()` stays verbatim; a no-prefix member falls back to
+/// the full camelCase ident.
+#[test]
+fn member_names_default_to_namespace_relative() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn key_expr_get_str(k: &KeyExpr) -> String { unimplemented!() }",
+        "pub fn keyexpr_intersects(k: &KeyExpr, s: String) -> bool { unimplemented!() }",
+        "pub fn shared_helper(k: &KeyExpr) -> i64 { unimplemented!() }",
+        "pub fn keyexpr_to_string(k: &KeyExpr) -> String { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("ke").class(
+            crate::ptr_class!(KeyExpr)
+                // Underscore-insensitive strip: `key_expr_` and `keyexpr_`
+                // both spell the class namespace.
+                .fun(crate::fun!(key_expr_get_str))
+                .fun(crate::fun!(keyexpr_intersects))
+                // No class prefix → full camelCase fallback.
+                .fun(crate::fun!(shared_helper))
+                // `.name()` is verbatim and wins over the derivation.
+                .fun(crate::fun!(keyexpr_to_string).name("toStr")),
+        ),
+    );
+    let dir = unique_test_dir("jnigen_member_names");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ac: String = all.split_whitespace().collect();
+    assert!(ac.contains("fungetStr("), "{all}");
+    assert!(ac.contains("funintersects("), "{all}");
+    assert!(ac.contains("funsharedHelper("), "{all}");
+    assert!(ac.contains("funtoStr("), "{all}");
+    // The wrapper tier lost the namespace; the extern tier (JNINative)
+    // keeps the full ident — that's the JNI symbol, not a member name.
+    let ke_file: String = paths
+        .iter()
+        .filter(|p| p.ends_with("ke.kt"))
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("")
+        .split_whitespace()
+        .collect();
+    assert!(!ke_file.contains("funkeyExprGetStr("), "{all}");
+    assert!(ac.contains("externalfunkeyExprGetStr("), "{all}");
+}
+
+/// C1: `set_member_name_mangle` — the sixth hook — receives the
+/// namespace-stripped camelCase default, skips `.name()`d members, and is
+/// order-independent (registered AFTER the `.package(...)` declaration).
+#[test]
+fn member_name_mangle_hook_applies_order_independently() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn thing_size(t: &ZThing) -> i64 { unimplemented!() }",
+        "pub fn thing_label(t: &ZThing) -> String { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("t").class(
+                crate::ptr_class!(ZThing)
+                    .name("Thing")
+                    .fun(crate::fun!(thing_size))
+                    .fun(crate::fun!(thing_label).name("label")),
+            ),
+        )
+        // Registered AFTER the declaration — must still apply (settings are
+        // order-independent by construction).
+        .set_member_name_mangle(|n| format!("{n}Native"));
+    let dir = unique_test_dir("jnigen_member_mangle");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ac: String = all.split_whitespace().collect();
+    // Hook over the stripped default (`thing_size` → `size` → `sizeNative`);
+    // note the strip matched the RUST short name ZThing? No — `thing_size`
+    // has no `zthing` prefix, so the fallback full ident applies first:
+    // `thingSize` → `thingSizeNative`.
+    assert!(ac.contains("funthingSizeNative("), "{all}");
+    // `.name("label")` bypasses the hook entirely.
+    assert!(ac.contains("funlabel("), "{all}");
+    assert!(!ac.contains("funlabelNative("), "{all}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -351,3 +351,80 @@ fn write_kotlin_owns_and_resets_the_root() {
     assert_eq!(paths, paths2);
     assert!(paths2.iter().all(|p| p.exists()));
 }
+
+/// C7: `Generation::report()` — the explain mode. The report carries the
+/// FINAL Kotlin signature of each fn (same render path as the emitters),
+/// the plans that shaped it, an unshaped fn with no `shaped by:` lines,
+/// and the type table. Deterministic across calls.
+#[test]
+fn report_explains_the_resolved_surface() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn summary_count(s: &Summary) -> i64 { unimplemented!() }",
+        "pub fn summary_total(s: &Summary) -> i64 { unimplemented!() }",
+        "pub fn storage_summary(v: i64) -> Summary { unimplemented!() }",
+        "pub fn z_plain(v: i64) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(
+                    crate::ptr_class!(Summary)
+                        .fun(crate::fun!(summary_count))
+                        .fun(crate::fun!(summary_total)),
+                )
+                .fun(crate::fun!(storage_summary))
+                .fun(crate::fun!(z_plain)),
+        )
+        .expand(
+            crate::expand_return!(Summary)
+                .field(crate::fun!(summary_count))
+                .field(crate::fun!(summary_total)),
+        );
+    let gen = registry.resolve(jni).expect("resolve");
+    let report = gen.report();
+
+    // The reshaped fn: exact signature (builder callback form) + provenance.
+    assert!(report.contains("`storage_summary`"), "{report}");
+    assert!(
+        report.contains("build: io.test.jni.ops.SummaryBuilder<R>"),
+        "{report}"
+    );
+    assert!(
+        report.contains("return `Summary` decomposed → [count, total] (Callback delivery)"),
+        "{report}"
+    );
+    // The plain fn appears with no `shaped by:` after it.
+    let plain_at = report.find("`z_plain`").expect("plain fn listed");
+    let after_plain = &report[plain_at..];
+    let next_entry = after_plain[1..]
+        .find("- `")
+        .map(|i| i + 1)
+        .unwrap_or(after_plain.len());
+    assert!(
+        !after_plain[..next_entry].contains("shaped by:"),
+        "{report}"
+    );
+    // Class members appear under the class heading with C1-derived names.
+    assert!(
+        report.contains("## class `io.test.jni.ops.Summary` (ptr_class, Rust `Summary`)"),
+        "{report}"
+    );
+    assert!(report.contains("fun count("), "{report}");
+    // Types table with the jlong wire.
+    assert!(
+        report.contains("- `Summary`: ptr_class → `io.test.jni.ops.Summary`"),
+        "{report}"
+    );
+    // Deterministic.
+    assert_eq!(report, gen.report());
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -42,7 +42,7 @@ fn per_class_name_and_base_package_fun() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -58,11 +58,10 @@ fn per_class_name_and_base_package_fun() {
     let dir = unique_test_dir("jnigen_class_name_base_fun");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -116,7 +115,7 @@ fn setters_after_declarations_apply() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     // Declarations first, settings last.
     let jni = JniGen::new()
@@ -131,11 +130,10 @@ fn setters_after_declarations_apply() {
     let dir = unique_test_dir("jnigen_setters_after_decls");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
 
     // The late-set package prefix drives the file layout...
     let things = paths
@@ -151,4 +149,51 @@ fn setters_after_declarations_apply() {
         tc.contains("funthingNew(onError:JniErrorHandler<Thing>):Thing"),
         "{things}"
     );
+}
+
+/// The I3 contract: after `Registry::resolve`, `write_kotlin` and
+/// `write_rust` are pure reads on one receiver — calling Kotlin FIRST
+/// produces byte-identical output to the usual order.
+#[test]
+fn generation_writes_are_order_free() {
+    let build = || {
+        let loc = myflat_loc();
+        let f: syn::ItemFn =
+            syn::parse_str("pub fn z_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
+        let registry =
+            Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(crate::package!("thing").fun(crate::fun!(z_ping)));
+        registry.resolve(jni).expect("resolve")
+    };
+    let read_all = |dir: &std::path::Path, paths: &[std::path::PathBuf]| -> String {
+        let mut out = String::new();
+        let mut sorted: Vec<_> = paths.to_vec();
+        sorted.sort();
+        for p in sorted {
+            out.push_str(&format!("== {}\n", p.strip_prefix(dir).unwrap().display()));
+            out.push_str(&std::fs::read_to_string(&p).unwrap());
+        }
+        out
+    };
+
+    // Usual order: rust, then kotlin.
+    let d1 = unique_test_dir("jnigen_orderfree_a");
+    let _ = std::fs::remove_dir_all(&d1);
+    std::fs::create_dir_all(&d1).unwrap();
+    let gen = build();
+    let rust1 = std::fs::read_to_string(gen.write_rust(d1.join("gen.rs")).unwrap()).unwrap();
+    let kt1 = read_all(&d1, &gen.write_kotlin(&d1.join("kotlin")).unwrap());
+
+    // Flipped order: kotlin FIRST.
+    let d2 = unique_test_dir("jnigen_orderfree_b");
+    let _ = std::fs::remove_dir_all(&d2);
+    std::fs::create_dir_all(&d2).unwrap();
+    let gen = build();
+    let kt2 = read_all(&d2, &gen.write_kotlin(&d2.join("kotlin")).unwrap());
+    let rust2 = std::fs::read_to_string(gen.write_rust(d2.join("gen.rs")).unwrap()).unwrap();
+
+    assert_eq!(rust1, rust2);
+    assert_eq!(kt1, kt2);
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -428,3 +428,121 @@ fn report_explains_the_resolved_surface() {
     // Deterministic.
     assert_eq!(report, gen.report());
 }
+
+/// N1: `///` docs become KDoc, and shaped positions get generated notes
+/// documenting the REAL prototype after expansions.
+#[test]
+fn docs_become_kdoc_with_shape_notes() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                /// A summary of stored payloads.
+                pub struct Summary {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                /// Count of aggregated entries.
+                pub fn summary_count(s: &Summary) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn summary_total(s: &Summary) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                /// Produces the storage summary.
+                pub fn storage_summary(v: i64) -> Summary {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_plain(v: i64) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Const(syn::parse_quote!(
+                /// The magic number.
+                pub const MAGIC: i64 = 7;
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(
+                    crate::ptr_class!(Summary)
+                        .fun(crate::fun!(summary_count))
+                        .fun(crate::fun!(summary_total)),
+                )
+                .fun(crate::fun!(storage_summary))
+                .fun(crate::fun!(z_plain))
+                .constant(crate::constant!(MAGIC)),
+        )
+        .expand(
+            crate::expand_return!(Summary)
+                .field(crate::fun!(summary_count))
+                .field(crate::fun!(summary_total)),
+        );
+    let gen = registry.resolve(jni).expect("resolve");
+    let dir = unique_test_dir("jnigen_kdoc");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Author prose on the wrapper + shape notes for the decomposed return.
+    assert!(all.contains("Produces the storage summary."), "{all}");
+    assert!(
+        all.contains("The Rust `Summary` result is delivered decomposed"),
+        "{all}"
+    );
+    assert!(all.contains("(`count`, `total`)"), "{all}");
+    // Member method carries the fn's doc (name derived by C1).
+    assert!(all.contains("Count of aggregated entries."), "{all}");
+    // Class kdoc: author prose FIRST, framework line after.
+    let class_doc_at = all
+        .find("A summary of stored payloads.")
+        .expect("struct doc present");
+    let framework_at = all
+        .find("Typed handle for a native Zenoh `Summary`.")
+        .expect("framework line kept");
+    assert!(class_doc_at < framework_at, "{all}");
+    // Const doc + framework line.
+    assert!(all.contains("The magic number."), "{all}");
+    assert!(
+        all.contains("Mirrors the Rust `#[prebindgen]` const `MAGIC`"),
+        "{all}"
+    );
+    // Undocumented, unshaped fn: no kdoc block directly above it.
+    let plain_at = all.find("fun zPlain(").expect("plain fn present");
+    let before = &all[..plain_at];
+    let tail = &before[before.len().saturating_sub(120)..];
+    assert!(!tail.contains("*/"), "unexpected kdoc above zPlain: {tail}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -1,12 +1,12 @@
 use super::*;
 
-/// A rank-0 wrapper on a Rust builtin generates a converter qualified with the
-/// `source_module` (`myflat::usize`) — invalid Rust — so the registration is
-/// rejected up front, at construction time.
+/// A `convert!` on a Rust builtin is rejected up front, at construction
+/// time — builtins already have converters, and generated calls would try
+/// to crate-qualify the builtin.
 #[test]
-#[should_panic(expected = "ScalarTypeWrapperDecl on builtin `usize`")]
-fn builtin_wrapper_pattern_panics() {
-    let _ = crate::scalar_type_wrapper!(usize, jni::sys::jlong, "Long");
+#[should_panic(expected = "convert!(usize): builtins already have converters")]
+fn builtin_convert_type_panics() {
+    let _ = crate::convert!(usize);
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -314,3 +314,40 @@ fn member_name_mangle_hook_applies_order_independently() {
     assert!(ac.contains("funlabel("), "{all}");
     assert!(!ac.contains("funlabelNative("), "{all}");
 }
+
+/// C4: the Kotlin root is generator-owned — `write_kotlin` deletes and
+/// recreates it on every run, so stale files from a previous generation
+/// (renamed package, removed declaration) never linger and consumers need
+/// no cleanup boilerplate. Repeat runs are idempotent.
+#[test]
+fn write_kotlin_owns_and_resets_the_root() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("thing").fun(crate::fun!(z_ping)));
+    let gen = registry.resolve(jni).expect("resolve");
+
+    let dir = unique_test_dir("jnigen_owned_root");
+    let _ = std::fs::remove_dir_all(&dir);
+    let root = dir.join("kotlin");
+    // A stale file from a "previous run" at a path this generation won't
+    // write — wiped with the rest of the owned root.
+    let stale_dir = root.join("io/test/jni/old");
+    std::fs::create_dir_all(&stale_dir).unwrap();
+    let stale = stale_dir.join("stale.kt");
+    std::fs::write(&stale, "package io.test.jni.old\n").unwrap();
+
+    let paths = gen.write_kotlin(&root).expect("write_kotlin");
+    assert!(!stale.exists(), "stale file must be wiped with the root");
+    assert!(!stale_dir.exists());
+    assert!(paths.iter().all(|p| p.exists()));
+
+    // Idempotent: a second run rewrites the same set.
+    let paths2 = gen.write_kotlin(&root).expect("write_kotlin again");
+    assert_eq!(paths, paths2);
+    assert!(paths2.iter().all(|p| p.exists()));
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -15,7 +15,7 @@ fn builtin_convert_type_panics() {
 #[test]
 fn per_class_name_and_base_package_fun() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -43,7 +43,6 @@ fn per_class_name_and_base_package_fun() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -98,7 +97,7 @@ fn per_class_name_and_base_package_fun() {
 #[test]
 fn setters_after_declarations_apply() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -118,7 +117,6 @@ fn setters_after_declarations_apply() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     // Declarations first, settings last.
     let jni = JniGen::new()

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -43,9 +43,9 @@ fn per_class_name_and_base_package_fun() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         // Rename the handle class; the mangle closures do NOT apply to it.
         .set_ptr_class_name_mangle(|n| format!("JNI{n}"))
@@ -118,6 +118,7 @@ fn setters_after_declarations_apply() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     // Declarations first, settings last.
     let jni = JniGen::new()
@@ -126,7 +127,6 @@ fn setters_after_declarations_apply() {
                 .class(crate::ptr_class!(ZThing))
                 .fun(crate::fun!(thing_new)),
         )
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.late.jni")
         .set_ptr_class_name_mangle(|n| n.strip_prefix('Z').unwrap_or(n).to_string());
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -5,7 +5,7 @@
 use super::*;
 
 fn const_items() -> Vec<(syn::Item, crate::SourceLocation)> {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     vec![
         (
             syn::Item::Const(syn::parse_quote!(
@@ -29,7 +29,6 @@ fn const_items() -> Vec<(syn::Item, crate::SourceLocation)> {
 #[test]
 fn declared_consts_emit_getter_and_val() {
     let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg")
@@ -102,7 +101,6 @@ fn declared_consts_emit_getter_and_val() {
 #[test]
 fn undeclared_const_not_emitted() {
     let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -135,7 +133,7 @@ fn undeclared_const_not_emitted() {
 /// wrapper are the ordinary declared-function ones (`myflat::tag()` call).
 #[test]
 fn constant_fun_emits_val_over_ordinary_wrapper() {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
         syn::Item::Fn(syn::parse_quote!(
             pub fn tag() -> String {
@@ -145,7 +143,6 @@ fn constant_fun_emits_val_over_ordinary_wrapper() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -189,7 +186,7 @@ fn constant_fun_emits_val_over_ordinary_wrapper() {
 #[test]
 #[should_panic(expected = "must be nullary")]
 fn constant_fun_non_nullary_rejected() {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
         syn::Item::Fn(syn::parse_quote!(
             pub fn scaled(factor: i64) -> i64 {
@@ -199,7 +196,6 @@ fn constant_fun_non_nullary_rejected() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("cfg").constant_fun(crate::fun!(scaled)));
@@ -217,7 +213,7 @@ fn constant_fun_non_nullary_rejected() {
 #[test]
 #[should_panic(expected = "declared opaque handle")]
 fn constant_fun_handle_return_rejected() {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -237,7 +233,6 @@ fn constant_fun_handle_return_rejected() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
@@ -259,7 +254,7 @@ fn constant_fun_handle_return_rejected() {
 /// a private helper + public eagerly-initialized `val`.
 #[test]
 fn constant_expr_emits_getter_and_val() {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     // Only `tag_of` exists in the source crate; the constant composes it.
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
         syn::Item::Fn(syn::parse_quote!(
@@ -270,7 +265,6 @@ fn constant_expr_emits_getter_and_val() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg")
@@ -323,7 +317,7 @@ fn constant_expr_emits_getter_and_val() {
 #[test]
 #[should_panic(expected = "declared opaque handle")]
 fn constant_expr_handle_type_rejected() {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -343,7 +337,6 @@ fn constant_expr_handle_type_rejected() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
@@ -361,7 +354,7 @@ fn constant_expr_handle_type_rejected() {
 #[test]
 #[should_panic(expected = "declared opaque handle")]
 fn handle_const_rejected() {
-    let loc = crate::SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -387,7 +380,6 @@ fn handle_const_rejected() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -29,15 +29,13 @@ fn const_items() -> Vec<(syn::Item, crate::SourceLocation)> {
 #[test]
 fn declared_consts_emit_getter_and_val() {
     let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("cfg")
-                .constant(crate::constant!(MAX_LEN))
-                .constant(crate::constant!(GREETING).name("HELLO")),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("cfg")
+            .constant(crate::constant!(MAX_LEN))
+            .constant(crate::constant!(GREETING).name("HELLO")),
+    );
 
     let dir = unique_test_dir("jnigen_consts_basic");
     let _ = std::fs::remove_dir_all(&dir);
@@ -104,9 +102,9 @@ fn declared_consts_emit_getter_and_val() {
 #[test]
 fn undeclared_const_not_emitted() {
     let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("cfg").constant(crate::constant!(MAX_LEN)))
         .ignore_const(crate::constant!(GREETING));
@@ -147,9 +145,9 @@ fn constant_fun_emits_val_over_ordinary_wrapper() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("cfg").constant_fun(crate::fun!(tag).name("THE_TAG")));
 
@@ -201,8 +199,8 @@ fn constant_fun_non_nullary_rejected() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("cfg").constant_fun(crate::fun!(scaled)));
     let dir = unique_test_dir("jnigen_constant_fun_arity_reject");
@@ -239,14 +237,12 @@ fn constant_fun_handle_return_rejected() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("things")
-                .class(crate::ptr_class!(ZThing))
-                .constant_fun(crate::fun!(default_thing)),
-        );
+    registry.set_default_module("myflat");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("things")
+            .class(crate::ptr_class!(ZThing))
+            .constant_fun(crate::fun!(default_thing)),
+    );
     let dir = unique_test_dir("jnigen_constant_fun_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -258,7 +254,7 @@ fn constant_fun_handle_return_rejected() {
 
 /// End-to-end for expression-backed constants (`PackageDecl::constant_expr`):
 /// the binding-defined expression is evaluated inside a generated nullary
-/// getter (with `use <source_module>::*;` in scope, composing source items
+/// getter (with every source module glob-imported, composing source items
 /// without the source crate exporting a dedicated accessor), and surfaces as
 /// a private helper + public eagerly-initialized `val`.
 #[test]
@@ -274,15 +270,13 @@ fn constant_expr_emits_getter_and_val() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("cfg")
-                .fun(crate::fun!(tag_of))
-                .constant_expr(crate::constant_expr!(DEFAULT_TAG: String = tag_of(7))),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("cfg")
+            .fun(crate::fun!(tag_of))
+            .constant_expr(crate::constant_expr!(DEFAULT_TAG: String = tag_of(7))),
+    );
 
     let dir = unique_test_dir("jnigen_constant_expr_basic");
     let _ = std::fs::remove_dir_all(&dir);
@@ -349,15 +343,13 @@ fn constant_expr_handle_type_rejected() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("things")
-                .class(crate::ptr_class!(ZThing))
-                .fun(crate::fun!(thing_new))
-                .constant_expr(crate::constant_expr!(DEFAULT_THING: ZThing = thing_new())),
-        );
+    registry.set_default_module("myflat");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("things")
+            .class(crate::ptr_class!(ZThing))
+            .fun(crate::fun!(thing_new))
+            .constant_expr(crate::constant_expr!(DEFAULT_THING: ZThing = thing_new())),
+    );
     let dir = unique_test_dir("jnigen_constant_expr_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -395,16 +387,14 @@ fn handle_const_rejected() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("things")
-                .class(crate::ptr_class!(ZThing))
-                .fun(crate::fun!(thing_new))
-                .constant(crate::constant!(DEFAULT_THING)),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("things")
+            .class(crate::ptr_class!(ZThing))
+            .fun(crate::fun!(thing_new))
+            .constant(crate::constant!(DEFAULT_THING)),
+    );
 
     let dir = unique_test_dir("jnigen_consts_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -127,12 +127,12 @@ fn undeclared_const_not_emitted() {
     assert!(!all.contains("GREETING"), "{all}");
 }
 
-/// End-to-end for function-backed constants (`PackageDecl::constant_fun`):
-/// a declared nullary fn surfaces as a private helper + public
-/// eagerly-initialized `val` in the package file; the extern and the Rust
-/// wrapper are the ordinary declared-function ones (`myflat::tag()` call).
+/// End-to-end for fn-sourced constants (`constant!(N).fun(…)`): a declared
+/// nullary fn surfaces as a private helper + public eagerly-initialized
+/// `val` in the package file; the extern and the Rust wrapper are the
+/// ordinary declared-function ones (`myflat::tag()` call).
 #[test]
-fn constant_fun_emits_val_over_ordinary_wrapper() {
+fn constant_fun_source_emits_val_over_ordinary_wrapper() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
         syn::Item::Fn(syn::parse_quote!(
@@ -146,7 +146,7 @@ fn constant_fun_emits_val_over_ordinary_wrapper() {
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .package(crate::package!("cfg").constant_fun(crate::fun!(tag).name("THE_TAG")));
+        .package(crate::package!("cfg").constant(crate::constant!(THE_TAG).fun(crate::fun!(tag))));
 
     let dir = unique_test_dir("jnigen_constant_fun_basic");
     let _ = std::fs::remove_dir_all(&dir);
@@ -185,7 +185,7 @@ fn constant_fun_emits_val_over_ordinary_wrapper() {
 /// A non-nullary fn cannot be a constant.
 #[test]
 #[should_panic(expected = "must be nullary")]
-fn constant_fun_non_nullary_rejected() {
+fn constant_fun_source_non_nullary_rejected() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
         syn::Item::Fn(syn::parse_quote!(
@@ -196,9 +196,9 @@ fn constant_fun_non_nullary_rejected() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_package_prefix("io.test.jni")
-        .package(crate::package!("cfg").constant_fun(crate::fun!(scaled)));
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("cfg").constant(crate::constant!(SCALED).fun(crate::fun!(scaled))),
+    );
     let dir = unique_test_dir("jnigen_constant_fun_arity_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -212,7 +212,7 @@ fn constant_fun_non_nullary_rejected() {
 /// rejection (and guidance) as a handle-typed const.
 #[test]
 #[should_panic(expected = "declared opaque handle")]
-fn constant_fun_handle_return_rejected() {
+fn constant_fun_source_handle_return_rejected() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
         (
@@ -236,7 +236,7 @@ fn constant_fun_handle_return_rejected() {
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
-            .constant_fun(crate::fun!(default_thing)),
+            .constant(crate::constant!(DEFAULT_THING).fun(crate::fun!(default_thing))),
     );
     let dir = unique_test_dir("jnigen_constant_fun_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
@@ -247,7 +247,7 @@ fn constant_fun_handle_return_rejected() {
     let _ = jni.write_kotlin(&registry, &dir.join("kotlin"));
 }
 
-/// End-to-end for expression-backed constants (`PackageDecl::constant_expr`):
+/// End-to-end for expression-sourced constants (`constant!(N).expr(…)`):
 /// the binding-defined expression is evaluated inside a generated nullary
 /// getter (with every source module glob-imported, composing source items
 /// without the source crate exporting a dedicated accessor), and surfaces as
@@ -267,9 +267,9 @@ fn constant_expr_emits_getter_and_val() {
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
-        crate::package!("cfg")
-            .fun(crate::fun!(tag_of))
-            .constant_expr(crate::constant_expr!(DEFAULT_TAG: String = tag_of(7))),
+        crate::package!("cfg").fun(crate::fun!(tag_of)).constant(
+            crate::constant!(DEFAULT_TAG).expr(crate::ty!(String), crate::expr!(tag_of(7))),
+        ),
     );
 
     let dir = unique_test_dir("jnigen_constant_expr_basic");
@@ -341,7 +341,9 @@ fn constant_expr_handle_type_rejected() {
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
             .fun(crate::fun!(thing_new))
-            .constant_expr(crate::constant_expr!(DEFAULT_THING: ZThing = thing_new())),
+            .constant(
+                crate::constant!(DEFAULT_THING).expr(crate::ty!(ZThing), crate::expr!(thing_new())),
+            ),
     );
     let dir = unique_test_dir("jnigen_constant_expr_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
@@ -392,4 +394,84 @@ fn handle_const_rejected() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+}
+
+/// `.with(ty!, path!)` — the binding-local nullary fn source, const analog
+/// of `ConvertDecl::input_with`: lowers to an expression getter that calls
+/// the path verbatim (multi-segment paths bypass source-module
+/// qualification, exactly like convert's `_with`).
+#[test]
+fn constant_with_source_calls_path_verbatim() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn unrelated() -> i64 {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("cfg").fun(crate::fun!(unrelated)).constant(
+            crate::constant!(COVER_VERSION)
+                .with(crate::ty!(String), crate::path!(crate::cover_version)),
+        ),
+    );
+    let dir = unique_test_dir("jnigen_constant_with_basic");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rust.contains("Java_io_test_jni_JNINative_constGetCoverVersion"),
+        "{rust}"
+    );
+    // The path is called verbatim — no `myflat::` qualification.
+    assert!(rc.contains("crate::cover_version()"), "{rust}");
+    assert!(!rc.contains("myflat::cover_version"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let pkg = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni/cfg.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("cfg package file");
+    let pc: String = pkg.split_whitespace().collect();
+    assert!(
+        pc.contains("valCOVER_VERSION:String=constGetCoverVersion("),
+        "{pkg}"
+    );
+}
+
+/// A constant has exactly ONE value source — a second modifier panics.
+#[test]
+#[should_panic(expected = "value source already set")]
+fn constant_second_source_rejected() {
+    let _ = crate::constant!(X)
+        .expr(crate::ty!(i64), crate::expr!(1 + 1))
+        .with(crate::ty!(i64), crate::path!(crate::f));
+}
+
+/// `ConstDecl::named(...)` is the runtime subject form for declaration
+/// loops — equivalent to the `constant!` macro with the same ident.
+#[test]
+fn constant_named_runtime_form_matches_macro() {
+    let a = crate::lang::ConstDecl::named(format!("ENCODING_{}", "ZENOH_BYTES"))
+        .expr(crate::ty!(String), crate::expr!(enc()));
+    let b = crate::constant!(ENCODING_ZENOH_BYTES).expr(crate::ty!(String), crate::expr!(enc()));
+    assert_eq!(a.val_name(), b.val_name());
+    assert_eq!(a.rust_ident, b.rust_ident);
+}
+
+/// A non-identifier runtime name is a decl-time panic (it seeds the extern
+/// symbol).
+#[test]
+#[should_panic(expected = "not a valid identifier")]
+fn constant_named_invalid_ident_rejected() {
+    let _ = crate::lang::ConstDecl::named("NOT AN IDENT");
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -104,7 +104,7 @@ fn undeclared_const_not_emitted() {
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("cfg").constant(crate::constant!(MAX_LEN)))
-        .ignore_const(crate::constant!(GREETING));
+        .ignore(crate::constant!(GREETING));
 
     let dir = unique_test_dir("jnigen_consts_undeclared");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -28,7 +28,7 @@ fn const_items() -> Vec<(syn::Item, crate::SourceLocation)> {
 /// private helpers, and `JNINative` declares the matching `external fun`s.
 #[test]
 fn declared_consts_emit_getter_and_val() {
-    let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg")
@@ -39,9 +39,8 @@ fn declared_consts_emit_getter_and_val() {
     let dir = unique_test_dir("jnigen_consts_basic");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     // Path-alias const re-emission (the initializer tokens are never
     // copied — they may reference source-crate internals) + one extern
@@ -71,7 +70,7 @@ fn declared_consts_emit_getter_and_val() {
     assert!(rust.contains("myflat::MAX_LEN"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let pkg = paths
         .iter()
         .find(|p| p.ends_with("io/test/jni/cfg.kt"))
@@ -100,7 +99,7 @@ fn declared_consts_emit_getter_and_val() {
 /// acknowledges it without emitting.
 #[test]
 fn undeclared_const_not_emitted() {
-    let mut registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -110,16 +109,15 @@ fn undeclared_const_not_emitted() {
     let dir = unique_test_dir("jnigen_consts_undeclared");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     assert!(rust.contains("pub const MAX_LEN"), "{rust}");
     // The ignored const neither re-emits nor gets a getter.
     assert!(!rust.contains("GREETING"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let all: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -142,7 +140,7 @@ fn constant_fun_source_emits_val_over_ordinary_wrapper() {
         )),
         loc.clone(),
     )];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -151,16 +149,15 @@ fn constant_fun_source_emits_val_over_ordinary_wrapper() {
     let dir = unique_test_dir("jnigen_constant_fun_basic");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     // Ordinary declared-function wrapper: an extern calling `myflat::tag()`.
     assert!(rust.contains("Java_io_test_jni_JNINative_tag"), "{rust}");
     assert!(rust.contains("myflat::tag()"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let pkg = paths
         .iter()
         .find(|p| p.ends_with("io/test/jni/cfg.kt"))
@@ -195,17 +192,16 @@ fn constant_fun_source_non_nullary_rejected() {
         )),
         loc.clone(),
     )];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg").constant(crate::constant!(SCALED).fun(crate::fun!(scaled))),
     );
     let dir = unique_test_dir("jnigen_constant_fun_arity_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
-    let _ = jni.write_kotlin(&registry, &dir.join("kotlin"));
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let _ = gen.write_kotlin(&dir.join("kotlin"));
 }
 
 /// A fn returning a declared opaque handle cannot be a constant — same
@@ -232,7 +228,7 @@ fn constant_fun_source_handle_return_rejected() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
@@ -241,10 +237,9 @@ fn constant_fun_source_handle_return_rejected() {
     let dir = unique_test_dir("jnigen_constant_fun_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
-    let _ = jni.write_kotlin(&registry, &dir.join("kotlin"));
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let _ = gen.write_kotlin(&dir.join("kotlin"));
 }
 
 /// End-to-end for expression-sourced constants (`constant!(N).expr(…)`):
@@ -264,7 +259,7 @@ fn constant_expr_emits_getter_and_val() {
         )),
         loc.clone(),
     )];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg").fun(crate::fun!(tag_of)).constant(
@@ -275,9 +270,8 @@ fn constant_expr_emits_getter_and_val() {
     let dir = unique_test_dir("jnigen_constant_expr_basic");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     // The getter extern is seeded from the val name and evaluates the
@@ -290,7 +284,7 @@ fn constant_expr_emits_getter_and_val() {
     assert!(rc.contains("tag_of(7)"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let pkg = paths
         .iter()
         .find(|p| p.ends_with("io/test/jni/cfg.kt"))
@@ -336,7 +330,7 @@ fn constant_expr_handle_type_rejected() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
@@ -348,7 +342,9 @@ fn constant_expr_handle_type_rejected() {
     let dir = unique_test_dir("jnigen_constant_expr_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+    let _ = registry
+        .resolve(jni)
+        .and_then(|gen| gen.write_rust(dir.join("gen.rs")));
 }
 
 /// A const whose type is a declared opaque handle is rejected with guidance
@@ -381,7 +377,7 @@ fn handle_const_rejected() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
@@ -393,7 +389,9 @@ fn handle_const_rejected() {
     let dir = unique_test_dir("jnigen_consts_handle_reject");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+    let _ = registry
+        .resolve(jni)
+        .and_then(|gen| gen.write_rust(dir.join("gen.rs")));
 }
 
 /// `.with(ty!, path!)` — the binding-local nullary fn source, const analog
@@ -411,7 +409,7 @@ fn constant_with_source_calls_path_verbatim() {
         )),
         loc.clone(),
     )];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg").fun(crate::fun!(unrelated)).constant(
             crate::constant!(COVER_VERSION)
@@ -421,9 +419,8 @@ fn constant_with_source_calls_path_verbatim() {
     let dir = unique_test_dir("jnigen_constant_with_basic");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     assert!(
@@ -435,7 +432,7 @@ fn constant_with_source_calls_path_verbatim() {
     assert!(!rc.contains("myflat::cover_version"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let pkg = paths
         .iter()
         .find(|p| p.ends_with("io/test/jni/cfg.kt"))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -5,8 +5,7 @@ use super::*;
 /// inline field list. Each gets its own builder interface.
 #[test]
 fn inline_output_gets_own_builder() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_thing_name(t: &ZThing) -> String { unimplemented!() }",
         "pub fn z_thing_size(t: &ZThing) -> i64 { unimplemented!() }",
@@ -21,7 +20,6 @@ fn inline_output_gets_own_builder() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -104,8 +102,7 @@ fn inline_output_gets_own_builder() {
 /// defaults (closed handle, "", null for nullable).
 #[test]
 fn error_unwrap_universal_records() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_err_message(e: &ZErr) -> String { unimplemented!() }",
         "pub fn z_err_detail(e: &ZErr) -> Option<&ZDetail> { unimplemented!() }",
@@ -120,7 +117,6 @@ fn error_unwrap_universal_records() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -227,8 +223,7 @@ fn error_unwrap_universal_records() {
 /// `.expand_return(...field_self()...)` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_thing_name(t: &ZThing) -> String { unimplemented!() }",
         "pub fn z_thing_rename(t: &ZThing, name: String) -> bool { unimplemented!() }",
@@ -243,7 +238,6 @@ fn method_constructor_and_inline_field_self() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -302,8 +296,7 @@ fn method_constructor_and_inline_field_self() {
 /// is emitted for `ZErr` — the value lives and dies in Rust.
 #[test]
 fn rust_side_only_error_type() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_err_message(e: &ZErr) -> String { unimplemented!() }",
         "pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }",
@@ -316,7 +309,6 @@ fn rust_side_only_error_type() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -373,8 +365,7 @@ fn rust_side_only_error_type() {
 /// (no selector — single variant); the type never surfaces in Kotlin.
 #[test]
 fn rust_side_only_input_type() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_opts_new(retries: i32, verbose: bool) -> ZOpts { unimplemented!() }",
         "pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }",
@@ -387,7 +378,6 @@ fn rust_side_only_input_type() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -428,13 +418,11 @@ fn rust_side_only_input_type() {
 #[test]
 #[should_panic(expected = "has no class declaration")]
 fn rust_side_only_variant_self_rejected() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
         .expand(crate::expand_param!(ZOpts).variant_self());
@@ -449,12 +437,10 @@ fn rust_side_only_variant_self_rejected() {
 #[test]
 #[should_panic(expected = "has no class declaration")]
 fn rust_side_only_field_self_rejected() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let f: syn::ItemFn = syn::parse_str("pub fn z_make() -> ZThing { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .package(crate::package!("ops").fun(crate::fun!(z_make)))
         .expand(crate::expand_return!(ZThing).field_self());
@@ -469,8 +455,7 @@ fn rust_side_only_field_self_rejected() {
 /// both types.
 #[test]
 fn fn_expand_param_type_mismatch_rejected() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_thing_make(name: String) -> ZThing { unimplemented!() }",
         "pub fn z_use(t: ZThing) -> i64 { unimplemented!() }",
@@ -483,7 +468,6 @@ fn fn_expand_param_type_mismatch_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
@@ -508,8 +492,7 @@ fn fn_expand_param_type_mismatch_rejected() {
 /// function's peeled return type — a mismatch is a hard error.
 #[test]
 fn fn_expand_return_type_mismatch_rejected() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_thing_name(t: &ZThing) -> String { unimplemented!() }",
         "pub fn z_make() -> ZThing { unimplemented!() }",
@@ -522,7 +505,6 @@ fn fn_expand_return_type_mismatch_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
@@ -544,8 +526,7 @@ fn fn_expand_return_type_mismatch_rejected() {
 /// error (`UnknownParam`) — the second typo guard.
 #[test]
 fn fn_expand_param_unknown_param_rejected() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_thing_make(name: String) -> ZThing { unimplemented!() }",
         "pub fn z_use(t: ZThing) -> i64 { unimplemented!() }",
@@ -558,7 +539,6 @@ fn fn_expand_param_unknown_param_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
@@ -592,16 +572,12 @@ fn fn_expand_return_duplicate_rejected() {
 /// omission, no stale-ignore warning.
 #[test]
 fn typo_in_expand_decl_is_hard_error() {
-    use crate::{
-        api::core::registry::{ScanError, WriteRustError},
-        SourceLocation,
-    };
-    let loc = SourceLocation::default();
+    use crate::api::core::registry::{ScanError, WriteRustError};
+    let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
@@ -630,8 +606,7 @@ fn typo_in_expand_decl_is_hard_error() {
 /// still succeeds with only the declared surface.
 #[test]
 fn ignore_funs_where_acknowledges_matching_family() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_len(v: i64) -> i64 { unimplemented!() }",
         "pub fn detail_const_a() -> i64 { unimplemented!() }",
@@ -645,7 +620,6 @@ fn ignore_funs_where_acknowledges_matching_family() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_len)))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -292,3 +292,174 @@ fn method_constructor_and_inline_field_self() {
         "{all}"
     );
 }
+
+/// A **rust-side-only** error type: `return_expand!` with NO class
+/// declaration. The `Result<_, ZErr>` error channel decomposes the error into
+/// its fields (here just the message), the `ZErrHandler` interface lands in
+/// the BASE package (no type package exists), and no Kotlin class / `freePtr`
+/// is emitted for `ZErr` — the value lives and dies in Rust.
+#[test]
+fn rust_side_only_error_type() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn z_err_message(e: &ZErr) -> String { unimplemented!() }",
+        "pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
+        // No class declaration for ZErr anywhere — rust-side-only. The field
+        // name is explicit (no class member to inherit from).
+        .return_expand(
+            crate::return_expand!(ZErr).field(crate::fun!(z_err_message).name("message")),
+        );
+
+    let dir = unique_test_dir("jnigen_rust_side_only_err");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+
+    // The error decomposition calls the accessor Rust-side...
+    assert!(rc.contains("myflat::z_err_message(&__de)"), "{rust}");
+    // ...and no freePtr destructor exists for ZErr (no opaque handle).
+    assert!(!rc.contains("ZErr_1freePtr"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .split_whitespace()
+        .collect();
+    // Handler in the BASE package with the decomposed message field; no ZErr
+    // class anywhere.
+    assert!(
+        all.contains("funinterfaceZErrHandler<outR>{publicfunrun(je:String?,message:String):R"),
+        "{all}"
+    );
+    assert!(!all.contains("classZErr("), "{all}");
+    // The handler file belongs to the base package (io/test/jni.kt), not a
+    // type package.
+    let base_file: String = paths
+        .iter()
+        .filter(|p| p.ends_with("io/test/jni.kt"))
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .split_whitespace()
+        .collect();
+    assert!(base_file.contains("funinterfaceZErrHandler"), "{all}");
+}
+
+/// A **rust-side-only** input type: `param_expand!` with NO class
+/// declaration. Every param of the type is built from the ctor's ingredients
+/// (no selector — single variant); the type never surfaces in Kotlin.
+#[test]
+fn rust_side_only_input_type() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn z_opts_new(retries: i32, verbose: bool) -> ZOpts { unimplemented!() }",
+        "pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("ops").fun(crate::fun!(z_run)))
+        .param_expand(crate::param_expand!(ZOpts).variant(crate::fun!(z_opts_new)));
+
+    let dir = unique_test_dir("jnigen_rust_side_only_in");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // The wrapper folds the ctor Rust-side.
+    assert!(rc.contains("myflat::z_opts_new("), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .split_whitespace()
+        .collect();
+    // The Kotlin wrapper takes the ctor's flattened ingredients (prefixed by
+    // the param name), not a ZOpts object; no ZOpts class exists.
+    assert!(
+        all.contains("funzRun(optsRetries:Int,optsVerbose:Boolean"),
+        "{all}"
+    );
+    assert!(!all.contains("classZOpts("), "{all}");
+}
+
+/// `variant_self()` on a type with no class declaration is structurally
+/// impossible (no Kotlin object to pass) — hard error at write time.
+#[test]
+#[should_panic(expected = "has no class declaration")]
+fn rust_side_only_variant_self_rejected() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .package(crate::package!("ops").fun(crate::fun!(z_run)))
+        .param_expand(crate::param_expand!(ZOpts).variant_self());
+    let dir = unique_test_dir("jnigen_rso_self_in");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+}
+
+/// `field_self()` on a type with no class declaration is structurally
+/// impossible (no Kotlin object to deliver) — hard error at write time.
+#[test]
+#[should_panic(expected = "has no class declaration")]
+fn rust_side_only_field_self_rejected() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn = syn::parse_str("pub fn z_make() -> ZThing { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .package(crate::package!("ops").fun(crate::fun!(z_make)))
+        .return_expand(crate::return_expand!(ZThing).field_self());
+    let dir = unique_test_dir("jnigen_rso_self_out");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -593,12 +593,13 @@ fn typo_in_expand_decl_is_hard_error() {
     }
 }
 
-/// `ignore_funs_where` (C2): one predicate acknowledges a whole naming
-/// family — the matching undeclared fns are skipped without per-name
-/// `ignore_fun` lines, no extern is emitted for them, and the generation
-/// still succeeds with only the declared surface.
+/// `.ignore(matching(…))` (C2/I4): one predicate acknowledges a whole
+/// naming family — the matching undeclared items are skipped without
+/// per-name lines, no extern is emitted for them, and the generation still
+/// succeeds with only the declared surface. Also exercises the exact
+/// type-ignore path (`.ignore(ty!(…))`).
 #[test]
-fn ignore_funs_where_acknowledges_matching_family() {
+fn ignore_matching_acknowledges_naming_family() {
     let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_len(v: i64) -> i64 { unimplemented!() }",
@@ -616,13 +617,18 @@ fn ignore_funs_where_acknowledges_matching_family() {
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_len)))
-        .ignore_funs_where(|name| name.starts_with("detail_const_"));
+        .ignore(crate::matching(|name| name.starts_with("detail_const_")))
+        // The previously-untested type-ignore path: acknowledge a type by key.
+        .ignore(crate::ty!(ZUnusedThing));
     // The predicate flows through the Prebindgen hook…
     {
         use crate::api::core::prebindgen::Prebindgen;
-        let preds = jni.ignored_function_predicates();
+        let preds = jni.ignored_name_predicates();
         assert_eq!(preds.len(), 1);
         assert!(preds[0]("detail_const_a") && !preds[0]("z_len"));
+        assert!(jni
+            .ignored_types()
+            .contains(&TypeKey::parse("ZUnusedThing")));
     }
     // …and the full pipeline runs clean, emitting only the declared fn.
     let dir = unique_test_dir("jnigen_ignore_funs_where");
@@ -633,4 +639,22 @@ fn ignore_funs_where_acknowledges_matching_family() {
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     assert!(rust.contains("Java_io_test_jni_JNINative_zLen"), "{rust}");
     assert!(!rust.contains("detailConstA"), "{rust}");
+}
+
+/// An ignore names a bare item — surface overrides are meaningless and
+/// rejected at decl time.
+#[test]
+#[should_panic(expected = "expand overrides don't apply")]
+fn ignore_fun_with_overrides_rejected() {
+    let _ = crate::lang::IgnoreDecl::from(crate::fun!(z_thing).name("thing"));
+}
+
+/// Same for constants: an ignore names a `#[prebindgen]` const, not a
+/// value-sourced val.
+#[test]
+#[should_panic(expected = "value sources/.name() don't apply")]
+fn ignore_const_with_source_rejected() {
+    let _ = crate::lang::IgnoreDecl::from(
+        crate::constant!(X).expr(crate::ty!(i64), crate::expr!(1 + 1)),
+    );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -592,8 +592,10 @@ fn fn_expand_return_duplicate_rejected() {
 /// omission, no stale-ignore warning.
 #[test]
 fn typo_in_expand_decl_is_hard_error() {
-    use crate::api::core::registry::{ScanError, WriteRustError};
-    use crate::SourceLocation;
+    use crate::{
+        api::core::registry::{ScanError, WriteRustError},
+        SourceLocation,
+    };
     let loc = SourceLocation::default();
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }").unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -658,3 +658,67 @@ fn ignore_const_with_source_rejected() {
         crate::constant!(X).expr(crate::ty!(i64), crate::expr!(1 + 1)),
     );
 }
+
+/// N5: a `.fun()` member whose target has no parameter of the class type
+/// is a hard `AdapterInvariant` error at resolve — previously it silently
+/// emitted a method that ignored `this`.
+#[test]
+fn member_fun_without_receiver_rejected() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_thing_free_standing(v: i64) -> i64 { unimplemented!() }",
+        "pub fn z_make() -> ZThing { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("t").class(
+            crate::ptr_class!(ZThing)
+                .fun(crate::fun!(z_thing_free_standing))
+                .constructor(crate::fun!(z_make)),
+        ),
+    );
+    let err = registry.resolve(jni).expect_err("receiver-less member");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("member fun `z_thing_free_standing`") && msg.contains("`ZThing`"),
+        "{msg}"
+    );
+}
+
+/// N5: a `.constructor()` member must return `Self` or `Result<Self, E>`.
+#[test]
+fn constructor_with_wrong_return_rejected() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_thing_len(t: &ZThing) -> i64 { unimplemented!() }",
+        "pub fn z_make_number() -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("t").class(
+            crate::ptr_class!(ZThing)
+                .fun(crate::fun!(z_thing_len))
+                .constructor(crate::fun!(z_make_number)),
+        ),
+    );
+    let err = registry.resolve(jni).expect_err("wrong ctor return");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("constructor `z_make_number`") && msg.contains("it returns `i64`"),
+        "{msg}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 /// Two fns returning the same type under different output decompositions:
-/// the default one and a per-fn `.default_return_expand(...)` inline field list.
-/// Each gets its own builder interface.
+/// the type-level `return_expand!` default and a per-fn `.return_expand(...)`
+/// inline field list. Each gets its own builder interface.
 #[test]
 fn inline_output_gets_own_builder() {
     use crate::SourceLocation;
@@ -30,10 +30,7 @@ fn inline_output_gets_own_builder() {
                 .class(
                     crate::ptr_class!(ZThing)
                         .fun(crate::fun!(z_thing_name).name("name"))
-                        .fun(crate::fun!(z_thing_size).name("size"))
-                        // Default output: name + size (2 leaves ⇒ builder callback).
-                        .default_return_expand(crate::fun!(z_thing_name).name("name"))
-                        .default_return_expand(crate::fun!(z_thing_size).name("size")),
+                        .fun(crate::fun!(z_thing_size).name("size")),
                 )
                 .fun(crate::fun!(z_make_a))
                 // Per-fn inline fields: name + size + name again (different shape). The
@@ -45,6 +42,14 @@ fn inline_output_gets_own_builder() {
                         .return_expand(crate::fun!(z_thing_size).name("size"))
                         .return_expand(crate::fun!(z_thing_name).name("name2")),
                 ),
+        )
+        // Default output: name + size (2 leaves ⇒ builder callback). The
+        // `name` field inherits its Kotlin name from the class member; `size`
+        // sets it explicitly — both paths resolve to the member-equal names.
+        .return_expand(
+            crate::return_expand!(ZThing)
+                .field(crate::fun!(z_thing_name))
+                .field(crate::fun!(z_thing_size).name("size")),
         );
 
     let dir = unique_test_dir("jnigen_inline_out");
@@ -119,22 +124,23 @@ fn error_unwrap_universal_records() {
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("errors")
-                .class(
-                    crate::ptr_class!(ZDetail)
-                        .fun(crate::fun!(z_detail_code).name("code"))
-                        .default_return_expand(crate::fun!(z_detail_code).name("code")),
-                )
+                .class(crate::ptr_class!(ZDetail).fun(crate::fun!(z_detail_code).name("code")))
                 .class(
                     crate::ptr_class!(ZErr)
                         .fun(crate::fun!(z_err_message).name("message"))
-                        .fun(crate::fun!(z_err_detail).name("detail"))
-                        // Canonical error decomposition: the owned error handle itself,
-                        // its message, and the Option-nested detail spliced to its code leaf.
-                        .default_return_expand_self()
-                        .default_return_expand(crate::fun!(z_err_message).name("message"))
-                        .default_return_expand(crate::fun!(z_err_detail).name("detail")),
+                        .fun(crate::fun!(z_err_detail).name("detail")),
                 )
                 .fun(crate::fun!(z_fallible)),
+        )
+        .return_expand(crate::return_expand!(ZDetail).field(crate::fun!(z_detail_code)))
+        // Canonical error decomposition: the owned error handle itself, its
+        // message, and the Option-nested detail spliced to its code leaf.
+        // Field names inherit from the class members.
+        .return_expand(
+            crate::return_expand!(ZErr)
+                .field_self()
+                .field(crate::fun!(z_err_message))
+                .field(crate::fun!(z_err_detail)),
         );
 
     let dir = unique_test_dir("jnigen_err_universal");
@@ -216,7 +222,7 @@ fn error_unwrap_universal_records() {
 /// signature, its handle locked) while keeping the non-receiver params; the
 /// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
 /// companion-object factory returning the class. Per-fn
-/// `.default_return_expand_self()` emits the handle leaf.
+/// `.return_expand_self()` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
     use crate::SourceLocation;

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Two fns returning the same type under different output decompositions:
-/// the type-level `return_expand!` default and a per-fn `.return_expand(...)`
+/// the type-level `expand_return!` default and a per-fn `.return_expand(...)`
 /// inline field list. Each gets its own builder interface.
 #[test]
 fn inline_output_gets_own_builder() {
@@ -37,17 +37,19 @@ fn inline_output_gets_own_builder() {
                 // third field reuses the `z_thing_name` accessor but must carry a
                 // distinct (literal) leaf name — duplicate names are a hard error.
                 .fun(
-                    crate::fun!(z_make_b)
-                        .return_expand(crate::fun!(z_thing_name).name("name"))
-                        .return_expand(crate::fun!(z_thing_size).name("size"))
-                        .return_expand(crate::fun!(z_thing_name).name("name2")),
+                    crate::fun!(z_make_b).expand_return(
+                        crate::expand_return!(ZThing)
+                            .field(crate::fun!(z_thing_name).name("name"))
+                            .field(crate::fun!(z_thing_size).name("size"))
+                            .field(crate::fun!(z_thing_name).name("name2")),
+                    ),
                 ),
         )
         // Default output: name + size (2 leaves ⇒ builder callback). The
         // `name` field inherits its Kotlin name from the class member; `size`
         // sets it explicitly — both paths resolve to the member-equal names.
         .expand(
-            crate::return_expand!(ZThing)
+            crate::expand_return!(ZThing)
                 .field(crate::fun!(z_thing_name))
                 .field(crate::fun!(z_thing_size).name("size")),
         );
@@ -132,12 +134,12 @@ fn error_unwrap_universal_records() {
                 )
                 .fun(crate::fun!(z_fallible)),
         )
-        .expand(crate::return_expand!(ZDetail).field(crate::fun!(z_detail_code)))
+        .expand(crate::expand_return!(ZDetail).field(crate::fun!(z_detail_code)))
         // Canonical error decomposition: the owned error handle itself, its
         // message, and the Option-nested detail spliced to its code leaf.
         // Field names inherit from the class members.
         .expand(
-            crate::return_expand!(ZErr)
+            crate::expand_return!(ZErr)
                 .field_self()
                 .field(crate::fun!(z_err_message))
                 .field(crate::fun!(z_err_detail)),
@@ -222,7 +224,7 @@ fn error_unwrap_universal_records() {
 /// signature, its handle locked) while keeping the non-receiver params; the
 /// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
 /// companion-object factory returning the class. Per-fn
-/// `.return_expand_self()` emits the handle leaf.
+/// `.expand_return(...field_self()...)` emits the handle leaf.
 #[test]
 fn method_constructor_and_inline_field_self() {
     use crate::SourceLocation;
@@ -257,9 +259,11 @@ fn method_constructor_and_inline_field_self() {
                 )
                 // A free fn whose per-fn inline output decomposes to (handle, name).
                 .fun(
-                    crate::fun!(z_get)
-                        .return_expand_self()
-                        .return_expand(crate::fun!(z_thing_name).name("name")),
+                    crate::fun!(z_get).expand_return(
+                        crate::expand_return!(ZThing)
+                            .field_self()
+                            .field(crate::fun!(z_thing_name).name("name")),
+                    ),
                 ),
         );
 
@@ -293,7 +297,7 @@ fn method_constructor_and_inline_field_self() {
     );
 }
 
-/// A **rust-side-only** error type: `return_expand!` with NO class
+/// A **rust-side-only** error type: `expand_return!` with NO class
 /// declaration. The `Result<_, ZErr>` error channel decomposes the error into
 /// its fields (here just the message), the `ZErrHandler` interface lands in
 /// the BASE package (no type package exists), and no Kotlin class / `freePtr`
@@ -321,7 +325,7 @@ fn rust_side_only_error_type() {
         .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
         // No class declaration for ZErr anywhere — rust-side-only. The field
         // name is explicit (no class member to inherit from).
-        .expand(crate::return_expand!(ZErr).field(crate::fun!(z_err_message).name("message")));
+        .expand(crate::expand_return!(ZErr).field(crate::fun!(z_err_message).name("message")));
 
     let dir = unique_test_dir("jnigen_rust_side_only_err");
     let _ = std::fs::remove_dir_all(&dir);
@@ -366,7 +370,7 @@ fn rust_side_only_error_type() {
     assert!(base_file.contains("funinterfaceZErrHandler"), "{all}");
 }
 
-/// A **rust-side-only** input type: `param_expand!` with NO class
+/// A **rust-side-only** input type: `expand_param!` with NO class
 /// declaration. Every param of the type is built from the ctor's ingredients
 /// (no selector — single variant); the type never surfaces in Kotlin.
 #[test]
@@ -390,7 +394,7 @@ fn rust_side_only_input_type() {
         .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
-        .expand(crate::param_expand!(ZOpts).variant(crate::fun!(z_opts_new)));
+        .expand(crate::expand_param!(ZOpts).variant(crate::fun!(z_opts_new)));
 
     let dir = unique_test_dir("jnigen_rust_side_only_in");
     let _ = std::fs::remove_dir_all(&dir);
@@ -435,7 +439,7 @@ fn rust_side_only_variant_self_rejected() {
     let jni = JniGen::new()
         .set_source_module(syn::parse_quote!(myflat))
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
-        .expand(crate::param_expand!(ZOpts).variant_self());
+        .expand(crate::expand_param!(ZOpts).variant_self());
     let dir = unique_test_dir("jnigen_rso_self_in");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -455,9 +459,134 @@ fn rust_side_only_field_self_rejected() {
     let jni = JniGen::new()
         .set_source_module(syn::parse_quote!(myflat))
         .package(crate::package!("ops").fun(crate::fun!(z_make)))
-        .expand(crate::return_expand!(ZThing).field_self());
+        .expand(crate::expand_return!(ZThing).field_self());
     let dir = unique_test_dir("jnigen_rso_self_out");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+}
+
+/// Per-fn `.expand_param(name, expand_param!(T))`: the decl's `T` must match
+/// the named parameter's peeled type — a typo'd type is a hard error naming
+/// both types.
+#[test]
+fn fn_expand_param_type_mismatch_rejected() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn z_thing_make(name: String) -> ZThing { unimplemented!() }",
+        "pub fn z_use(t: ZThing) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
+                .class(crate::ptr_class!(ZOther))
+                // Wrong type: the param `t` is a ZThing, not a ZOther.
+                .fun(crate::fun!(z_use).expand_param(
+                    "t",
+                    crate::expand_param!(ZOther).variant(crate::fun!(z_thing_make)),
+                )),
+        );
+    let dir = unique_test_dir("jnigen_fn_param_mismatch");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let err = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect_err("type mismatch must fail");
+    let msg = format!("{err}");
+    assert!(msg.contains("ZOther") && msg.contains("ZThing"), "{msg}");
+}
+
+/// Per-fn `.expand_return(expand_return!(T))`: the decl's `T` must match the
+/// function's peeled return type — a mismatch is a hard error.
+#[test]
+fn fn_expand_return_type_mismatch_rejected() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn z_thing_name(t: &ZThing) -> String { unimplemented!() }",
+        "pub fn z_make() -> ZThing { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
+                .class(crate::ptr_class!(ZOther))
+                // Wrong type: z_make returns ZThing, not ZOther.
+                .fun(crate::fun!(z_make).expand_return(crate::expand_return!(ZOther).field_self())),
+        );
+    let dir = unique_test_dir("jnigen_fn_return_mismatch");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let err = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect_err("type mismatch must fail");
+    let msg = format!("{err}");
+    assert!(msg.contains("ZOther") && msg.contains("ZThing"), "{msg}");
+}
+
+/// `.expand_param` on a parameter name the function doesn't have is a hard
+/// error (`UnknownParam`) — the second typo guard.
+#[test]
+fn fn_expand_param_unknown_param_rejected() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn z_thing_make(name: String) -> ZThing { unimplemented!() }",
+        "pub fn z_use(t: ZThing) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
+                .fun(crate::fun!(z_use).expand_param(
+                    "typo",
+                    crate::expand_param!(ZThing).variant(crate::fun!(z_thing_make)),
+                )),
+        );
+    let dir = unique_test_dir("jnigen_fn_param_unknown");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let err = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect_err("unknown param must fail");
+    assert!(format!("{err}").contains("typo"), "{err}");
+}
+
+/// Duplicate `.expand_return` on one function is a decl-time hard error —
+/// the complete field set belongs in ONE decl.
+#[test]
+#[should_panic(expected = "already has a return expand override")]
+fn fn_expand_return_duplicate_rejected() {
+    let _ = crate::fun!(z_make)
+        .expand_return(crate::expand_return!(ZThing).field_self())
+        .expand_return(crate::expand_return!(ZThing).field_self());
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -21,9 +21,9 @@ fn inline_output_gets_own_builder() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
@@ -120,9 +120,9 @@ fn error_unwrap_universal_records() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("errors")
@@ -243,29 +243,27 @@ fn method_constructor_and_inline_field_self() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("thing")
-                .class(
-                    crate::ptr_class!(ZThing)
-                        .fun(crate::fun!(z_thing_name).name("name"))
-                        // A fun with extra params: `&ZThing` receiver + a `name: String` param.
-                        .fun(crate::fun!(z_thing_rename).name("rename"))
-                        // A constructor: factory returning ZThing.
-                        .constructor(crate::fun!(z_thing_make).name("make")),
-                )
-                // A free fn whose per-fn inline output decomposes to (handle, name).
-                .fun(
-                    crate::fun!(z_get).expand_return(
-                        crate::expand_return!(ZThing)
-                            .field_self()
-                            .field(crate::fun!(z_thing_name).name("name")),
-                    ),
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .class(
+                crate::ptr_class!(ZThing)
+                    .fun(crate::fun!(z_thing_name).name("name"))
+                    // A fun with extra params: `&ZThing` receiver + a `name: String` param.
+                    .fun(crate::fun!(z_thing_rename).name("rename"))
+                    // A constructor: factory returning ZThing.
+                    .constructor(crate::fun!(z_thing_make).name("make")),
+            )
+            // A free fn whose per-fn inline output decomposes to (handle, name).
+            .fun(
+                crate::fun!(z_get).expand_return(
+                    crate::expand_return!(ZThing)
+                        .field_self()
+                        .field(crate::fun!(z_thing_name).name("name")),
                 ),
-        );
+            ),
+    );
 
     let dir = unique_test_dir("jnigen_method_ctor");
     let _ = std::fs::remove_dir_all(&dir);
@@ -318,9 +316,9 @@ fn rust_side_only_error_type() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
         // No class declaration for ZErr anywhere — rust-side-only. The field
@@ -389,9 +387,9 @@ fn rust_side_only_input_type() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
         .expand(crate::expand_param!(ZOpts).variant(crate::fun!(z_opts_new)));
@@ -436,8 +434,8 @@ fn rust_side_only_variant_self_rejected() {
         syn::parse_str("pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
         .expand(crate::expand_param!(ZOpts).variant_self());
     let dir = unique_test_dir("jnigen_rso_self_in");
@@ -456,8 +454,8 @@ fn rust_side_only_field_self_rejected() {
     let f: syn::ItemFn = syn::parse_str("pub fn z_make() -> ZThing { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .package(crate::package!("ops").fun(crate::fun!(z_make)))
         .expand(crate::expand_return!(ZThing).field_self());
     let dir = unique_test_dir("jnigen_rso_self_out");
@@ -485,18 +483,17 @@ fn fn_expand_param_type_mismatch_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .package(
-            crate::package!("ops")
-                .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
-                .class(crate::ptr_class!(ZOther))
-                // Wrong type: the param `t` is a ZThing, not a ZOther.
-                .fun(crate::fun!(z_use).expand_param(
-                    "t",
-                    crate::expand_param!(ZOther).variant(crate::fun!(z_thing_make)),
-                )),
-        );
+    registry.set_default_module("myflat");
+    let jni = JniGen::new().package(
+        crate::package!("ops")
+            .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
+            .class(crate::ptr_class!(ZOther))
+            // Wrong type: the param `t` is a ZThing, not a ZOther.
+            .fun(crate::fun!(z_use).expand_param(
+                "t",
+                crate::expand_param!(ZOther).variant(crate::fun!(z_thing_make)),
+            )),
+    );
     let dir = unique_test_dir("jnigen_fn_param_mismatch");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -525,15 +522,14 @@ fn fn_expand_return_type_mismatch_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .package(
-            crate::package!("ops")
-                .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
-                .class(crate::ptr_class!(ZOther))
-                // Wrong type: z_make returns ZThing, not ZOther.
-                .fun(crate::fun!(z_make).expand_return(crate::expand_return!(ZOther).field_self())),
-        );
+    registry.set_default_module("myflat");
+    let jni = JniGen::new().package(
+        crate::package!("ops")
+            .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
+            .class(crate::ptr_class!(ZOther))
+            // Wrong type: z_make returns ZThing, not ZOther.
+            .fun(crate::fun!(z_make).expand_return(crate::expand_return!(ZOther).field_self())),
+    );
     let dir = unique_test_dir("jnigen_fn_return_mismatch");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -562,16 +558,15 @@ fn fn_expand_param_unknown_param_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .package(
-            crate::package!("ops")
-                .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
-                .fun(crate::fun!(z_use).expand_param(
-                    "typo",
-                    crate::expand_param!(ZThing).variant(crate::fun!(z_thing_make)),
-                )),
-        );
+    registry.set_default_module("myflat");
+    let jni = JniGen::new().package(
+        crate::package!("ops")
+            .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
+            .fun(crate::fun!(z_use).expand_param(
+                "typo",
+                crate::expand_param!(ZThing).variant(crate::fun!(z_thing_make)),
+            )),
+    );
     let dir = unique_test_dir("jnigen_fn_param_unknown");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -585,3 +585,84 @@ fn fn_expand_return_duplicate_rejected() {
         .expand_return(crate::expand_return!(ZThing).field_self())
         .expand_return(crate::expand_return!(ZThing).field_self());
 }
+
+/// A typo'd `fun!` inside a boundary decl is a HARD scan error (I7):
+/// boundary-referenced fns ride the helper-function channel, and a declared
+/// helper matching no `#[prebindgen]` item fails the scan — no silent
+/// omission, no stale-ignore warning.
+#[test]
+fn typo_in_expand_decl_is_hard_error() {
+    use crate::api::core::registry::{ScanError, WriteRustError};
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
+        // `z_err_mesage` (sic) exists nowhere among the indexed items.
+        .expand(crate::expand_return!(ZErr).field(crate::fun!(z_err_mesage).name("message")));
+    let dir = unique_test_dir("jnigen_expand_typo_hard_error");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let err = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect_err("typo'd expand accessor must fail the scan");
+    match err {
+        WriteRustError::Scan(ScanError::DeclaredNotFound { entries }) => {
+            assert_eq!(
+                entries,
+                vec![("helper function", "z_err_mesage".to_string())]
+            );
+        }
+        other => panic!("expected DeclaredNotFound, got {other:?}"),
+    }
+}
+
+/// `ignore_funs_where` (C2): one predicate acknowledges a whole naming
+/// family — the matching undeclared fns are skipped without per-name
+/// `ignore_fun` lines, no extern is emitted for them, and the generation
+/// still succeeds with only the declared surface.
+#[test]
+fn ignore_funs_where_acknowledges_matching_family() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn z_len(v: i64) -> i64 { unimplemented!() }",
+        "pub fn detail_const_a() -> i64 { unimplemented!() }",
+        "pub fn detail_const_b() -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("ops").fun(crate::fun!(z_len)))
+        .ignore_funs_where(|name| name.starts_with("detail_const_"));
+    // The predicate flows through the Prebindgen hook…
+    {
+        use crate::api::core::prebindgen::Prebindgen;
+        let preds = jni.ignored_function_predicates();
+        assert_eq!(preds.len(), 1);
+        assert!(preds[0]("detail_const_a") && !preds[0]("z_len"));
+    }
+    // …and the full pipeline runs clean, emitting only the declared fn.
+    let dir = unique_test_dir("jnigen_ignore_funs_where");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    assert!(rust.contains("Java_io_test_jni_JNINative_zLen"), "{rust}");
+    assert!(!rust.contains("detailConstA"), "{rust}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -46,7 +46,7 @@ fn inline_output_gets_own_builder() {
         // Default output: name + size (2 leaves ⇒ builder callback). The
         // `name` field inherits its Kotlin name from the class member; `size`
         // sets it explicitly — both paths resolve to the member-equal names.
-        .return_expand(
+        .expand(
             crate::return_expand!(ZThing)
                 .field(crate::fun!(z_thing_name))
                 .field(crate::fun!(z_thing_size).name("size")),
@@ -132,11 +132,11 @@ fn error_unwrap_universal_records() {
                 )
                 .fun(crate::fun!(z_fallible)),
         )
-        .return_expand(crate::return_expand!(ZDetail).field(crate::fun!(z_detail_code)))
+        .expand(crate::return_expand!(ZDetail).field(crate::fun!(z_detail_code)))
         // Canonical error decomposition: the owned error handle itself, its
         // message, and the Option-nested detail spliced to its code leaf.
         // Field names inherit from the class members.
-        .return_expand(
+        .expand(
             crate::return_expand!(ZErr)
                 .field_self()
                 .field(crate::fun!(z_err_message))
@@ -321,9 +321,7 @@ fn rust_side_only_error_type() {
         .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
         // No class declaration for ZErr anywhere — rust-side-only. The field
         // name is explicit (no class member to inherit from).
-        .return_expand(
-            crate::return_expand!(ZErr).field(crate::fun!(z_err_message).name("message")),
-        );
+        .expand(crate::return_expand!(ZErr).field(crate::fun!(z_err_message).name("message")));
 
     let dir = unique_test_dir("jnigen_rust_side_only_err");
     let _ = std::fs::remove_dir_all(&dir);
@@ -392,7 +390,7 @@ fn rust_side_only_input_type() {
         .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
-        .param_expand(crate::param_expand!(ZOpts).variant(crate::fun!(z_opts_new)));
+        .expand(crate::param_expand!(ZOpts).variant(crate::fun!(z_opts_new)));
 
     let dir = unique_test_dir("jnigen_rust_side_only_in");
     let _ = std::fs::remove_dir_all(&dir);
@@ -437,7 +435,7 @@ fn rust_side_only_variant_self_rejected() {
     let jni = JniGen::new()
         .set_source_module(syn::parse_quote!(myflat))
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
-        .param_expand(crate::param_expand!(ZOpts).variant_self());
+        .expand(crate::param_expand!(ZOpts).variant_self());
     let dir = unique_test_dir("jnigen_rso_self_in");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -457,7 +455,7 @@ fn rust_side_only_field_self_rejected() {
     let jni = JniGen::new()
         .set_source_module(syn::parse_quote!(myflat))
         .package(crate::package!("ops").fun(crate::fun!(z_make)))
-        .return_expand(crate::return_expand!(ZThing).field_self());
+        .expand(crate::return_expand!(ZThing).field_self());
     let dir = unique_test_dir("jnigen_rso_self_out");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -19,7 +19,7 @@ fn inline_output_gets_own_builder() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -55,9 +55,8 @@ fn inline_output_gets_own_builder() {
     let dir = unique_test_dir("jnigen_inline_out");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
@@ -70,7 +69,7 @@ fn inline_output_gets_own_builder() {
     );
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let all: String = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())
@@ -116,7 +115,7 @@ fn error_unwrap_universal_records() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -144,9 +143,8 @@ fn error_unwrap_universal_records() {
     let dir = unique_test_dir("jnigen_err_universal");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
@@ -173,7 +171,7 @@ fn error_unwrap_universal_records() {
     assert!(rc.contains("env.new_string(\"\")"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let all: String = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())
@@ -237,7 +235,7 @@ fn method_constructor_and_inline_field_self() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -262,11 +260,10 @@ fn method_constructor_and_inline_field_self() {
     let dir = unique_test_dir("jnigen_method_ctor");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let all: String = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())
@@ -308,7 +305,7 @@ fn rust_side_only_error_type() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -320,9 +317,8 @@ fn rust_side_only_error_type() {
     let dir = unique_test_dir("jnigen_rust_side_only_err");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
@@ -332,7 +328,7 @@ fn rust_side_only_error_type() {
     assert!(!rc.contains("ZErr_1freePtr"), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let all: String = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())
@@ -377,7 +373,7 @@ fn rust_side_only_input_type() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -387,16 +383,15 @@ fn rust_side_only_input_type() {
     let dir = unique_test_dir("jnigen_rust_side_only_in");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     // The wrapper folds the ctor Rust-side.
     assert!(rc.contains("myflat::z_opts_new("), "{rust}");
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let all: String = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())
@@ -421,7 +416,7 @@ fn rust_side_only_variant_self_rejected() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
@@ -429,7 +424,9 @@ fn rust_side_only_variant_self_rejected() {
     let dir = unique_test_dir("jnigen_rso_self_in");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+    let _ = registry
+        .resolve(jni)
+        .and_then(|gen| gen.write_rust(dir.join("gen.rs")));
 }
 
 /// `field_self()` on a type with no class declaration is structurally
@@ -439,7 +436,7 @@ fn rust_side_only_variant_self_rejected() {
 fn rust_side_only_field_self_rejected() {
     let loc = myflat_loc();
     let f: syn::ItemFn = syn::parse_str("pub fn z_make() -> ZThing { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .package(crate::package!("ops").fun(crate::fun!(z_make)))
@@ -447,7 +444,9 @@ fn rust_side_only_field_self_rejected() {
     let dir = unique_test_dir("jnigen_rso_self_out");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+    let _ = registry
+        .resolve(jni)
+        .and_then(|gen| gen.write_rust(dir.join("gen.rs")));
 }
 
 /// Per-fn `.expand_param(name, expand_param!(T))`: the decl's `T` must match
@@ -467,7 +466,7 @@ fn fn_expand_param_type_mismatch_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
@@ -481,9 +480,7 @@ fn fn_expand_param_type_mismatch_rejected() {
     let dir = unique_test_dir("jnigen_fn_param_mismatch");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let err = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect_err("type mismatch must fail");
+    let err = registry.resolve(jni).expect_err("type mismatch must fail");
     let msg = format!("{err}");
     assert!(msg.contains("ZOther") && msg.contains("ZThing"), "{msg}");
 }
@@ -504,7 +501,7 @@ fn fn_expand_return_type_mismatch_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
@@ -515,9 +512,7 @@ fn fn_expand_return_type_mismatch_rejected() {
     let dir = unique_test_dir("jnigen_fn_return_mismatch");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let err = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect_err("type mismatch must fail");
+    let err = registry.resolve(jni).expect_err("type mismatch must fail");
     let msg = format!("{err}");
     assert!(msg.contains("ZOther") && msg.contains("ZThing"), "{msg}");
 }
@@ -538,7 +533,7 @@ fn fn_expand_param_unknown_param_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
@@ -550,9 +545,7 @@ fn fn_expand_param_unknown_param_rejected() {
     let dir = unique_test_dir("jnigen_fn_param_unknown");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let err = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect_err("unknown param must fail");
+    let err = registry.resolve(jni).expect_err("unknown param must fail");
     assert!(format!("{err}").contains("typo"), "{err}");
 }
 
@@ -576,7 +569,7 @@ fn typo_in_expand_decl_is_hard_error() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -587,7 +580,7 @@ fn typo_in_expand_decl_is_hard_error() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let err = registry
-        .write_rust(&jni, dir.join("gen.rs"))
+        .resolve(jni)
         .expect_err("typo'd expand accessor must fail the scan");
     match err {
         WriteRustError::Scan(ScanError::DeclaredNotFound { entries }) => {
@@ -619,7 +612,7 @@ fn ignore_funs_where_acknowledges_matching_family() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_len)))
@@ -635,9 +628,8 @@ fn ignore_funs_where_acknowledges_matching_family() {
     let dir = unique_test_dir("jnigen_ignore_funs_where");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     assert!(rust.contains("Java_io_test_jni_JNINative_zLen"), "{rust}");
     assert!(!rust.contains("detailConstA"), "{rust}");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -1,13 +1,27 @@
 use quote::ToTokens;
 
 use super::*;
-use crate::api::{
-    core::{
-        niches::{NicheSlot, Niches},
-        registry::{Registry, TypeEntry, TypeKey},
+use crate::{
+    api::{
+        core::{
+            niches::{NicheSlot, Niches},
+            registry::{Registry, TypeEntry, TypeKey},
+        },
+        test_util::unique_test_dir,
     },
-    test_util::unique_test_dir,
+    SourceLocation,
 };
+
+/// A test item's `SourceLocation` stamped with the tests' canonical source
+/// crate `myflat` — the production path records origins from stream stamps
+/// (`Source` fills them at parse time), so tests build their items the same
+/// way instead of poking a registry-level override.
+fn myflat_loc() -> crate::SourceLocation {
+    crate::SourceLocation {
+        crate_name: Some("myflat".to_string()),
+        ..Default::default()
+    }
+}
 
 mod callbacks;
 mod config;

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -44,9 +44,9 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!()
@@ -223,16 +223,14 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("payload")
-                .class(crate::data_class!(Payload))
-                .fun(crate::fun!(payload_get))
-                .fun(crate::fun!(payload_put)),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("payload")
+            .class(crate::data_class!(Payload))
+            .fun(crate::fun!(payload_get))
+            .fun(crate::fun!(payload_put)),
+    );
 
     let dir = unique_test_dir("jnigen_boxstr");
     let _ = std::fs::remove_dir_all(&dir);
@@ -304,16 +302,14 @@ fn slice_input_builds_vec_handle() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("foo")
-                .class(crate::data_class!(Foo))
-                .fun(crate::fun!(put_slice))
-                .fun(crate::fun!(put_vec)),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("foo")
+            .class(crate::data_class!(Foo))
+            .fun(crate::fun!(put_slice))
+            .fun(crate::fun!(put_vec)),
+    );
 
     let dir = unique_test_dir("jnigen_slice_vec_handle");
     let _ = std::fs::remove_dir_all(&dir);
@@ -401,9 +397,9 @@ fn jni_native_init_emits_init_block() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .set_jni_native_init("io.test.jni.NativeLibrary.ensureLoaded()")
         .package(crate::package!("thing").fun(crate::fun!(z_ping)));

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -183,6 +183,62 @@ fn snapshot_kotlin_side() {
     );
 }
 
+/// Generated onError handler interfaces carry the `je` contract KDoc: the
+/// typed `<Err>Handler` documents the `je != null` (binding/system, defaults)
+/// vs `je == null` (decomposed domain error) split naming the error type; the
+/// shared `JniErrorHandler` documents `je` as the binding/system message.
+#[test]
+fn handler_interfaces_carry_je_contract_kdoc() {
+    // The snapshot pipeline has no error plan, so it emits the SHARED handler.
+    let (_, kotlin) = snapshot_pipeline();
+    let shared = kotlin
+        .values()
+        .find(|v| v.contains("fun interface JniErrorHandler<"))
+        .cloned()
+        .expect("no generated file declares JniErrorHandler");
+    assert!(
+        shared.contains("binding/system failure message"),
+        "{shared}"
+    );
+    assert!(shared.contains("throwing from `run` is safe"), "{shared}");
+
+    // A `Result<_, ZErr>` fn with a declared error decomposition emits the
+    // TYPED handler; its KDoc states the je-null/non-null contract and names
+    // the decomposed error type.
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_err_message(e: &ZErr) -> String { unimplemented!() }",
+        "pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
+        .expand(crate::expand_return!(ZErr).field(crate::fun!(z_err_message).name("message")));
+
+    let dir = unique_test_dir("jnigen_handler_kdoc");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let typed = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .find(|v| v.contains("fun interface ZErrHandler<"))
+        .expect("no generated file declares ZErrHandler");
+    assert!(typed.contains("`je != null`"), "{typed}");
+    assert!(typed.contains("decomposed `ZErr`"), "{typed}");
+    assert!(typed.contains("throwing from `run` is safe"), "{typed}");
+}
+
 /// A `data_class` struct with an opaque-pointer string field
 /// (`label: Option<Box<String>>`) maps that field to a nullable Kotlin `String?`
 /// (via the `Box<String>` terminal converter + the `Option<_>` wrapper), and the

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -43,7 +43,7 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -63,13 +63,12 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let mut kotlin = std::collections::BTreeMap::new();
     for p in &paths {
         let name = p.file_name().unwrap().to_string_lossy().to_string();
@@ -221,7 +220,7 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("payload")
@@ -233,14 +232,13 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
     let dir = unique_test_dir("jnigen_boxstr");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -299,7 +297,7 @@ fn slice_input_builds_vec_handle() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("foo")
@@ -311,14 +309,13 @@ fn slice_input_builds_vec_handle() {
     let dir = unique_test_dir("jnigen_slice_vec_handle");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -393,7 +390,7 @@ fn jni_native_init_emits_init_block() {
         )),
         loc.clone(),
     )];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -403,12 +400,9 @@ fn jni_native_init_emits_init_block() {
     let dir = unique_test_dir("jnigen_native_init");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
-    let paths = jni
-        .write_kotlin(&registry, &dir.join("kotlin"))
-        .expect("write_kotlin");
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
     let native = paths
         .iter()
         .filter_map(|p| std::fs::read_to_string(p).ok())

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -6,7 +6,7 @@ use super::*;
 /// discriminants), and a throwable data class (`Error`).
 fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -44,7 +44,6 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -194,7 +193,7 @@ fn snapshot_kotlin_side() {
 #[test]
 fn box_string_field_maps_to_nullable_kotlin_string() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -223,7 +222,6 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("payload")
@@ -273,7 +271,7 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
 #[test]
 fn slice_input_builds_vec_handle() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -302,7 +300,6 @@ fn slice_input_builds_vec_handle() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("foo")
@@ -387,7 +384,7 @@ fn slice_input_builds_vec_handle() {
 #[test]
 fn jni_native_init_emits_init_block() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![(
         syn::Item::Fn(syn::parse_quote!(
             pub fn z_ping() {
@@ -397,7 +394,6 @@ fn jni_native_init_emits_init_block() {
         loc.clone(),
     )];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -9,8 +9,7 @@ use super::*;
 /// (`<name>?.value ?: 0` for an enum).
 #[test]
 fn option_scalar_param_crosses_as_present_value_pair() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Enum(syn::parse_quote!(
@@ -31,7 +30,6 @@ fn option_scalar_param_crosses_as_present_value_pair() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -102,8 +100,7 @@ fn option_scalar_param_crosses_as_present_value_pair() {
 /// objects is built (the `reject_vec_of_handle` guard is lifted for outputs).
 #[test]
 fn vec_of_handle_output_folds_kotlin_side() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -131,7 +128,6 @@ fn vec_of_handle_output_folds_kotlin_side() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -189,8 +185,7 @@ fn vec_of_handle_output_folds_kotlin_side() {
 /// leaf pair the Rust side rebuilds with no reflective unbox.
 #[test]
 fn option_scalar_struct_field_flattens() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Struct(syn::parse_quote!(
@@ -212,7 +207,6 @@ fn option_scalar_struct_field_flattens() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
@@ -282,8 +276,7 @@ fn option_scalar_struct_field_flattens() {
 ///    class while the native side returned a boxed `Integer`.
 #[test]
 fn fromparts_fallback_boxes_option_fields() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Enum(syn::parse_quote!(
@@ -331,7 +324,6 @@ fn fromparts_fallback_boxes_option_fields() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -416,8 +408,7 @@ fn fromparts_fallback_boxes_option_fields() {
 /// jlong wire, Kotlin `Long`), no verbatim strings, no injected expressions.
 #[test]
 fn output_only_convert_resolves_without_input_twin() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn len_of(s: &String) -> Len { unimplemented!() }",
         "pub fn len_value(l: &Len) -> i64 { unimplemented!() }",
@@ -430,7 +421,6 @@ fn output_only_convert_resolves_without_input_twin() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output(crate::fun!(len_value)))
@@ -454,7 +444,6 @@ fn output_only_convert_resolves_without_input_twin() {
 /// registry's default module — the helper-crate model behind `convert!`.
 #[test]
 fn convert_fn_qualifies_with_origin_crate() {
-    use crate::SourceLocation;
     // Two chained streams: the flat crate provides `len_of`, a helper crate
     // provides the conversion fn — each item's origin rides its
     // `SourceLocation` stamp, exactly as `Source` streams deliver it.
@@ -499,8 +488,7 @@ fn convert_fn_qualifies_with_origin_crate() {
 #[test]
 #[should_panic(expected = "produces `Other`, not `Len`")]
 fn convert_input_target_mismatch_rejected() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn from_long(v: i64) -> Other { unimplemented!() }",
         "pub fn use_len(l: Len) { unimplemented!() }",
@@ -513,7 +501,6 @@ fn convert_input_target_mismatch_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .convert(crate::convert!(Len).input(crate::fun!(from_long)))
         .package(crate::package!("len").fun(crate::fun!(use_len)));
@@ -528,13 +515,11 @@ fn convert_input_target_mismatch_rejected() {
 /// and Kotlin surface derive from the stated repr's converter chain.
 #[test]
 fn convert_via_trait_impls() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn temp_double(c: Celsius) -> Celsius { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
@@ -566,13 +551,11 @@ fn convert_via_trait_impls() {
 /// `try_into` call.
 #[test]
 fn convert_via_try_from_is_fallible() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn pct_use(p: Percent) -> i32 { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Percent).input_try_from(crate::ty!(i32)))
@@ -600,13 +583,11 @@ fn convert_via_try_from_is_fallible() {
 /// binding-local `crate::…` fns need no `#[prebindgen]` marking.
 #[test]
 fn convert_via_local_fns() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
@@ -641,13 +622,11 @@ fn convert_duplicate_input_rejected() {
 /// verbatim (no `Ok(...)` wrap).
 #[test]
 fn convert_via_local_try_fn_is_fallible() {
-    use crate::SourceLocation;
-    let loc = SourceLocation::default();
+    let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
     let mut registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
-    registry.set_default_module("myflat");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -31,9 +31,9 @@ fn option_scalar_param_crosses_as_present_value_pair() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(crate::package!().class(crate::enum_class!(Mode)))
         .package(crate::package!("cfg").fun(crate::fun!(z_set_timeout)));
@@ -131,16 +131,14 @@ fn vec_of_handle_output_folds_kotlin_side() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("thing")
-                .class(crate::ptr_class!(ZThing))
-                .fun(crate::fun!(thing_list))
-                .fun(crate::fun!(thing_list_opt)),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .class(crate::ptr_class!(ZThing))
+            .fun(crate::fun!(thing_list))
+            .fun(crate::fun!(thing_list_opt)),
+    );
 
     let dir = unique_test_dir("jnigen_vec_handle_out");
     let _ = std::fs::remove_dir_all(&dir);
@@ -214,15 +212,13 @@ fn option_scalar_struct_field_flattens() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
-    let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!()
-                .class(crate::data_class!(Opts))
-                .fun(crate::fun!(opts_put)),
-        );
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::data_class!(Opts))
+            .fun(crate::fun!(opts_put)),
+    );
 
     let dir = unique_test_dir("jnigen_optfield");
     let _ = std::fs::remove_dir_all(&dir);
@@ -335,9 +331,9 @@ fn fromparts_fallback_boxes_option_fields() {
         ),
     ];
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
 
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("model")
@@ -434,8 +430,8 @@ fn output_only_convert_resolves_without_input_twin() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output(crate::fun!(len_value)))
         .package(crate::package!("len").fun(crate::fun!(len_of)));
@@ -455,7 +451,7 @@ fn output_only_convert_resolves_without_input_twin() {
 
 /// Multi-source qualification: a fn with a recorded origin crate is called
 /// with that crate's module prefix, while origin-less fns keep the
-/// configured `source_module` — the helper-crate model behind `convert!`.
+/// registry's default module — the helper-crate model behind `convert!`.
 #[test]
 fn convert_fn_qualifies_with_origin_crate() {
     use crate::SourceLocation;
@@ -472,14 +468,14 @@ fn convert_fn_qualifies_with_origin_crate() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
     // Simulate `from_sources` ingestion: the conversion fn comes from a
     // separate helper crate.
-    registry.fn_origins.insert(
+    registry.item_origins.insert(
         syn::Ident::new("len_value", proc_macro2::Span::call_site()),
         "my-helpers".to_string(),
     );
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output(crate::fun!(len_value)))
         .package(crate::package!("len").fun(crate::fun!(len_of)));
@@ -516,8 +512,8 @@ fn convert_input_target_mismatch_rejected() {
         })
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    registry.set_default_module("myflat");
     let jni = JniGen::new()
-        .set_source_module(syn::parse_quote!(myflat))
         .convert(crate::convert!(Len).input(crate::fun!(from_long)))
         .package(crate::package!("len").fun(crate::fun!(use_len)));
     let dir = unique_test_dir("jnigen_convert_mismatch");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -634,3 +634,41 @@ fn convert_duplicate_input_rejected() {
         .input_from(crate::ty!(i32))
         .input_with(crate::ty!(String), crate::path!(crate::widget_in));
 }
+
+/// `.input_try_with`: the fallible binding-local form — the converter's
+/// error type is the decl-stated one and the fn's `Result` is emitted
+/// verbatim (no `Ok(...)` wrap).
+#[test]
+fn convert_via_local_try_fn_is_fallible() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .convert(
+            crate::convert!(Label)
+                .input_try_with(
+                    crate::ty!(String),
+                    crate::ty!(String),
+                    crate::path!(crate::conv::label_in),
+                )
+                .output_with(crate::ty!(String), crate::path!(crate::conv::label_out)),
+        )
+        .package(crate::package!("m").fun(crate::fun!(label_id)));
+    let dir = unique_test_dir("jnigen_convert_local_try");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // Verbatim body (no Ok-wrap) with the stated error in the signature.
+    assert!(rc.contains("crate::conv::label_in(v)"), "{rust}");
+    assert!(!rc.contains("Ok(crate::conv::label_in(v))"), "{rust}");
+    assert!(rc.contains("Result<myflat::Label,String>"), "{rust}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -646,3 +646,148 @@ fn convert_via_local_try_fn_is_fallible() {
     assert!(!rc.contains("Ok(crate::conv::label_in(v))"), "{rust}");
     assert!(rc.contains("Result<myflat::Label,String>"), "{rust}");
 }
+
+/// I5: `enum_class!(T).kotlin_type("io.other.Mode")` maps the enum onto an
+/// EXISTING Kotlin type — no `enum class` file is generated, and wrappers
+/// speak the `fromInt`/`.value` protocol against the mapped FQN. The jint
+/// wire on the Rust side is unchanged.
+#[test]
+fn enum_kotlin_type_maps_to_existing_type() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Mode {
+                    A = 0,
+                    B = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn flip(m: Mode) -> Mode {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::enum_class!(Mode).kotlin_type("io.other.Mode"))
+            .fun(crate::fun!(flip)),
+    );
+    let dir = unique_test_dir("jnigen_enum_kotlin_type");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    // Rust side: ordinary jint enum wire.
+    assert!(rust.contains("jni::sys::jint"), "{rust}");
+
+    let kdir = dir.join("kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ac: String = all.split_whitespace().collect();
+    // No generated enum class anywhere…
+    assert!(!ac.contains("enumclass"), "{all}");
+    // …and the wrapper references the mapped type's protocol.
+    assert!(ac.contains("io.other.Mode"), "{all}");
+    assert!(ac.contains("Mode.fromInt("), "{all}");
+    assert!(ac.contains("m.value"), "{all}");
+}
+
+/// I5: data-class members — the receiver re-enters Rust as `this`'s field
+/// leaves (the data-class param destructuring rebased to `this`); a
+/// constructor member joins the `fromParts` companion. Extern signatures
+/// are identical to the free-fn form.
+#[test]
+fn data_class_members_reenter_as_field_leaves() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Point {
+                    pub x: i64,
+                    pub y: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn point_norm(p: &Point) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn point_origin() -> Point {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!().class(
+            crate::data_class!(Point)
+                .fun(crate::fun!(point_norm).name("norm"))
+                .constructor(crate::fun!(point_origin).name("origin")),
+        ),
+    );
+    let dir = unique_test_dir("jnigen_data_members");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+
+    let kdir = dir.join("kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ac: String = all.split_whitespace().collect();
+    // The instance method lives INSIDE the data class and destructures
+    // `this` into the flattened leaf args.
+    assert!(ac.contains("dataclassPoint("), "{all}");
+    assert!(ac.contains("funnorm("), "{all}");
+    assert!(ac.contains("this.x,this.y"), "{all}");
+    // The factory joined the fromParts companion: within the Point class
+    // block there is exactly ONE companion object holding both.
+    let point_block = all
+        .split("data class Point")
+        .nth(1)
+        .and_then(|rest| rest.split("fun interface").next())
+        .expect("Point class block");
+    assert_eq!(point_block.matches("companion object").count(), 1, "{all}");
+    let pb: String = point_block.split_whitespace().collect();
+    assert!(pb.contains("funorigin("), "{all}");
+    assert!(pb.contains("funfromParts("), "{all}");
+}
+
+/// I5: `.kotlin_type()` and members are mutually exclusive — a mapped type
+/// has no generated class to hold them.
+#[test]
+#[should_panic(expected = "no generated class to hold members")]
+fn data_class_kotlin_type_with_members_rejected() {
+    let _ = JniGen::new().package(
+        crate::package!().class(
+            crate::data_class!(Point)
+                .kotlin_type("io.other.Point")
+                .fun(crate::fun!(point_norm)),
+        ),
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -29,7 +29,7 @@ fn option_scalar_param_crosses_as_present_value_pair() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -39,14 +39,13 @@ fn option_scalar_param_crosses_as_present_value_pair() {
     let dir = unique_test_dir("jnigen_optscalar");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -127,7 +126,7 @@ fn vec_of_handle_output_folds_kotlin_side() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -139,14 +138,13 @@ fn vec_of_handle_output_folds_kotlin_side() {
     let dir = unique_test_dir("jnigen_vec_handle_out");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -206,7 +204,7 @@ fn option_scalar_struct_field_flattens() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
@@ -217,14 +215,13 @@ fn option_scalar_struct_field_flattens() {
     let dir = unique_test_dir("jnigen_optfield");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -323,7 +320,7 @@ fn fromparts_fallback_boxes_option_fields() {
             loc.clone(),
         ),
     ];
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -342,14 +339,13 @@ fn fromparts_fallback_boxes_option_fields() {
     let dir = unique_test_dir("jnigen_fromparts_optbox");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
     let kdir = dir.join("kotlin");
-    let paths = jni.write_kotlin(&registry, &kdir).expect("write_kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
     let kotlin: String = paths
         .iter()
         .map(|p| std::fs::read_to_string(p).unwrap())
@@ -420,7 +416,7 @@ fn output_only_convert_resolves_without_input_twin() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output_fun(crate::fun!(len_value)))
@@ -428,9 +424,10 @@ fn output_only_convert_resolves_without_input_twin() {
     let dir = unique_test_dir("jnigen_outonly_convert");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
+    let gen = registry
+        .resolve(jni)
         .expect("an output-only convert type must not require an input twin");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     // The return crosses through the conversion fn, composed with i64's own
@@ -463,7 +460,7 @@ fn convert_fn_qualifies_with_origin_crate() {
         "pub fn len_value(l: &Len) -> i64 { unimplemented!() }",
         "my-helpers",
     )];
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(flat.into_iter().chain(helpers)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -472,9 +469,8 @@ fn convert_fn_qualifies_with_origin_crate() {
     let dir = unique_test_dir("jnigen_convert_origin");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     // The conversion fn call carries the origin-crate module (dashes →
@@ -500,14 +496,16 @@ fn convert_input_target_mismatch_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
         .convert(crate::convert!(Len).input_fun(crate::fun!(from_long)))
         .package(crate::package!("len").fun(crate::fun!(use_len)));
     let dir = unique_test_dir("jnigen_convert_mismatch");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
+    let _ = registry
+        .resolve(jni)
+        .and_then(|gen| gen.write_rust(dir.join("gen.rs")));
 }
 
 /// `convert!` via `core::convert` trait impls: `.input_from(ty!(i32))` /
@@ -518,7 +516,7 @@ fn convert_via_trait_impls() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn temp_double(c: Celsius) -> Celsius { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -531,9 +529,8 @@ fn convert_via_trait_impls() {
     let dir = unique_test_dir("jnigen_convert_trait");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     assert!(
@@ -554,7 +551,7 @@ fn convert_via_try_from_is_fallible() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn pct_use(p: Percent) -> i32 { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -563,9 +560,8 @@ fn convert_via_try_from_is_fallible() {
     let dir = unique_test_dir("jnigen_convert_tryfrom");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     assert!(
@@ -586,7 +582,7 @@ fn convert_via_local_fns() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -599,9 +595,8 @@ fn convert_via_local_fns() {
     let dir = unique_test_dir("jnigen_convert_local");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     assert!(rc.contains("crate::conv::label_in(v)"), "{rust}");
@@ -625,7 +620,7 @@ fn convert_via_local_try_fn_is_fallible() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
         syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
-    let mut registry =
+    let registry =
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -642,9 +637,8 @@ fn convert_via_local_try_fn_is_fallible() {
     let dir = unique_test_dir("jnigen_convert_local_try");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-    let rust_path = registry
-        .write_rust(&jni, dir.join("gen.rs"))
-        .expect("write_rust");
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
     // Verbatim body (no Ok-wrap) with the stated error in the signature.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -423,7 +423,7 @@ fn output_only_convert_resolves_without_input_twin() {
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .convert(crate::convert!(Len).output(crate::fun!(len_value)))
+        .convert(crate::convert!(Len).output_fun(crate::fun!(len_value)))
         .package(crate::package!("len").fun(crate::fun!(len_of)));
     let dir = unique_test_dir("jnigen_outonly_convert");
     let _ = std::fs::remove_dir_all(&dir);
@@ -467,7 +467,7 @@ fn convert_fn_qualifies_with_origin_crate() {
         Registry::<KotlinMeta>::from_items(flat.into_iter().chain(helpers)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .convert(crate::convert!(Len).output(crate::fun!(len_value)))
+        .convert(crate::convert!(Len).output_fun(crate::fun!(len_value)))
         .package(crate::package!("len").fun(crate::fun!(len_of)));
     let dir = unique_test_dir("jnigen_convert_origin");
     let _ = std::fs::remove_dir_all(&dir);
@@ -502,7 +502,7 @@ fn convert_input_target_mismatch_rejected() {
         .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
-        .convert(crate::convert!(Len).input(crate::fun!(from_long)))
+        .convert(crate::convert!(Len).input_fun(crate::fun!(from_long)))
         .package(crate::package!("len").fun(crate::fun!(use_len)));
     let dir = unique_test_dir("jnigen_convert_mismatch");
     let _ = std::fs::remove_dir_all(&dir);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -455,26 +455,27 @@ fn output_only_convert_resolves_without_input_twin() {
 #[test]
 fn convert_fn_qualifies_with_origin_crate() {
     use crate::SourceLocation;
-    let loc = SourceLocation::default();
-    let fns: &[&str] = &[
+    // Two chained streams: the flat crate provides `len_of`, a helper crate
+    // provides the conversion fn — each item's origin rides its
+    // `SourceLocation` stamp, exactly as `Source` streams deliver it.
+    let loc = |krate: &str| SourceLocation {
+        crate_name: Some(krate.to_string()),
+        ..SourceLocation::default()
+    };
+    let item = |src: &str, krate: &str| -> (syn::Item, SourceLocation) {
+        let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+        (syn::Item::Fn(f), loc(krate))
+    };
+    let flat = vec![item(
         "pub fn len_of(s: &String) -> Len { unimplemented!() }",
+        "myflat",
+    )];
+    let helpers = vec![item(
         "pub fn len_value(l: &Len) -> i64 { unimplemented!() }",
-    ];
-    let items: Vec<(syn::Item, SourceLocation)> = fns
-        .iter()
-        .map(|src| {
-            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
-            (syn::Item::Fn(f), loc.clone())
-        })
-        .collect();
-    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    registry.set_default_module("myflat");
-    // Simulate `from_sources` ingestion: the conversion fn comes from a
-    // separate helper crate.
-    registry.item_origins.insert(
-        syn::Ident::new("len_value", proc_macro2::Span::call_site()),
-        "my-helpers".to_string(),
-    );
+        "my-helpers",
+    )];
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(flat.into_iter().chain(helpers)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output(crate::fun!(len_value)))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -413,41 +413,115 @@ fn fromparts_fallback_boxes_option_fields() {
     assert!(kc.contains("?.let{Level.fromInt(it)}"), "{kotlin}");
 }
 
-/// An output-only wrapper type must resolve with only its `.on_return()`
-/// registered: wrapper registrations are required per USAGE direction, unlike
-/// the four class declarators (always both). Regression: registering the
-/// wrapper used to add the type to `declared_types`, and the scan blanket-
-/// required both directions.
+/// An output-only `convert!` type must resolve with only its `.output()`
+/// conversion declared: conversions are required per USAGE direction, unlike
+/// the four class declarators (always both). The conversion is an ordinary
+/// `#[prebindgen]` fn — its signature supplies the continue type (`i64` ⇒
+/// jlong wire, Kotlin `Long`), no verbatim strings, no injected expressions.
 #[test]
-fn output_only_wrapper_resolves_without_input_twin() {
+fn output_only_convert_resolves_without_input_twin() {
     use crate::SourceLocation;
     let loc = SourceLocation::default();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![(
-        syn::Item::Fn(syn::parse_quote!(
-            pub fn len_of(s: &String) -> Len {
-                unimplemented!()
-            }
-        )),
-        loc.clone(),
-    )];
+    let fns: &[&str] = &[
+        "pub fn len_of(s: &String) -> Len { unimplemented!() }",
+        "pub fn len_value(l: &Len) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
     let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
         .set_source_module(syn::parse_quote!(myflat))
         .set_package_prefix("io.test.jni")
-        .scalar_type_wrapper(
-            crate::scalar_type_wrapper!(Len, jni::sys::jlong, "Long")
-                .on_return(|v| syn::parse_quote!(#v.0 as jni::sys::jlong)),
-        )
+        .convert(crate::convert!(Len).output(crate::fun!(len_value)))
         .package(crate::package!("len").fun(crate::fun!(len_of)));
-    let dir = unique_test_dir("jnigen_outonly_wrapper");
+    let dir = unique_test_dir("jnigen_outonly_convert");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let rust_path = registry
         .write_rust(&jni, dir.join("gen.rs"))
-        .expect("an output-only wrapper type must not require an input twin");
+        .expect("an output-only convert type must not require an input twin");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
-    // The return crosses through the registered output wrapper (jlong wire).
-    assert!(rc.contains("Len_to_jlong"), "{rust}");
+    // The return crosses through the conversion fn, composed with i64's own
+    // converter chain (jlong wire).
+    assert!(rc.contains("myflat::len_value(&v)"), "{rust}");
     assert!(rc.contains("myflat::len_of(&s)"), "{rust}");
+}
+
+/// Multi-source qualification: a fn with a recorded origin crate is called
+/// with that crate's module prefix, while origin-less fns keep the
+/// configured `source_module` — the helper-crate model behind `convert!`.
+#[test]
+fn convert_fn_qualifies_with_origin_crate() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn len_of(s: &String) -> Len { unimplemented!() }",
+        "pub fn len_value(l: &Len) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    // Simulate `from_sources` ingestion: the conversion fn comes from a
+    // separate helper crate.
+    registry.fn_origins.insert(
+        syn::Ident::new("len_value", proc_macro2::Span::call_site()),
+        "my-helpers".to_string(),
+    );
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .set_package_prefix("io.test.jni")
+        .convert(crate::convert!(Len).output(crate::fun!(len_value)))
+        .package(crate::package!("len").fun(crate::fun!(len_of)));
+    let dir = unique_test_dir("jnigen_convert_origin");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // The conversion fn call carries the origin-crate module (dashes →
+    // underscores); the exported fn keeps the default source module.
+    assert!(rc.contains("my_helpers::len_value(&v)"), "{rust}");
+    assert!(rc.contains("myflat::len_of(&s)"), "{rust}");
+}
+
+/// `convert!` input fn must produce the declared type — a mismatch is a
+/// hard error naming both.
+#[test]
+#[should_panic(expected = "produces `Other`, not `Len`")]
+fn convert_input_target_mismatch_rejected() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let fns: &[&str] = &[
+        "pub fn from_long(v: i64) -> Other { unimplemented!() }",
+        "pub fn use_len(l: Len) { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let mut registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_source_module(syn::parse_quote!(myflat))
+        .convert(crate::convert!(Len).input(crate::fun!(from_long)))
+        .package(crate::package!("len").fun(crate::fun!(use_len)));
+    let dir = unique_test_dir("jnigen_convert_mismatch");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let _ = registry.write_rust(&jni, dir.join("gen.rs"));
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -521,3 +521,116 @@ fn convert_input_target_mismatch_rejected() {
     std::fs::create_dir_all(&dir).unwrap();
     let _ = registry.write_rust(&jni, dir.join("gen.rs"));
 }
+
+/// `convert!` via `core::convert` trait impls: `.input_from(ty!(i32))` /
+/// `.output_into(ty!(i32))` generate fully-qualified `Into` calls; the wire
+/// and Kotlin surface derive from the stated repr's converter chain.
+#[test]
+fn convert_via_trait_impls() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn temp_double(c: Celsius) -> Celsius { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .convert(
+            crate::convert!(Celsius)
+                .input_from(crate::ty!(i32))
+                .output_into(crate::ty!(i32)),
+        )
+        .package(crate::package!("m").fun(crate::fun!(temp_double)));
+    let dir = unique_test_dir("jnigen_convert_trait");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("<i32as::core::convert::Into<myflat::Celsius>>::into(v)"),
+        "{rust}"
+    );
+    assert!(
+        rc.contains("<myflat::Celsiusas::core::convert::Into<i32>>::into(v)"),
+        "{rust}"
+    );
+}
+
+/// `.input_try_from(ty!(i32))`: the generated converter is fallible with the
+/// impl's associated `Error` as its error type; the body is the qualified
+/// `try_into` call.
+#[test]
+fn convert_via_try_from_is_fallible() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn pct_use(p: Percent) -> i32 { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .convert(crate::convert!(Percent).input_try_from(crate::ty!(i32)))
+        .package(crate::package!("m").fun(crate::fun!(pct_use)));
+    let dir = unique_test_dir("jnigen_convert_tryfrom");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("<i32as::core::convert::TryInto<myflat::Percent>>::try_into(v)"),
+        "{rust}"
+    );
+    // The converter's Result error type is the impl's associated Error.
+    assert!(
+        rc.contains("<i32as::core::convert::TryInto<myflat::Percent>>::Error"),
+        "{rust}"
+    );
+}
+
+/// `.input_with`/`.output_with`: the callable path is emitted verbatim —
+/// binding-local `crate::…` fns need no `#[prebindgen]` marking.
+#[test]
+fn convert_via_local_fns() {
+    use crate::SourceLocation;
+    let loc = SourceLocation::default();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
+    let mut registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    registry.set_default_module("myflat");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .convert(
+            crate::convert!(Label)
+                .input_with(crate::ty!(String), crate::path!(crate::conv::label_in))
+                .output_with(crate::ty!(String), crate::path!(crate::conv::label_out)),
+        )
+        .package(crate::package!("m").fun(crate::fun!(label_id)));
+    let dir = unique_test_dir("jnigen_convert_local");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust_path = registry
+        .write_rust(&jni, dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    assert!(rc.contains("crate::conv::label_in(v)"), "{rust}");
+    assert!(rc.contains("crate::conv::label_out(v)"), "{rust}");
+}
+
+/// Two input conversions on one decl are contradictory — decl-time panic.
+#[test]
+#[should_panic(expected = "input conversion is already declared")]
+fn convert_duplicate_input_rejected() {
+    let _ = crate::convert!(Widget)
+        .input_from(crate::ty!(i32))
+        .input_with(crate::ty!(String), crate::path!(crate::widget_in));
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1008,7 +1008,7 @@ impl Prebindgen for JniGen {
     /// and undeclared consts get the skip warning (see
     /// [`Prebindgen::declared_consts`]).
     /// The declared value types of every expression constant
-    /// (`PackageDecl::constant_expr`) — they have no `#[prebindgen]` item to
+    /// (`ConstDecl::expr`) — they have no `#[prebindgen]` item to
     /// scan, so the resolver is told directly to produce their output
     /// converters.
     fn required_output_types(&self) -> Vec<syn::Type> {
@@ -1098,12 +1098,12 @@ impl Prebindgen for JniGen {
         Ok(())
     }
 
-    /// Consts acknowledged-but-unexposed via [`JniGen::ignore_const`].
+    /// Consts acknowledged-but-unexposed via [`JniGen::ignore`].
     fn ignored_consts(&self) -> std::collections::HashSet<syn::Ident> {
         self.ignored_const_idents.clone()
     }
 
-    /// Fns acknowledged-but-unbound via [`JniGen::ignore_fun`] — suppresses
+    /// Fns acknowledged-but-unbound via [`JniGen::ignore`] — suppresses
     /// the registry's "skipping undeclared" warning, emits nothing.
     fn ignored_functions(&self) -> std::collections::HashSet<syn::Ident> {
         self.ignored_fns.clone()
@@ -1121,7 +1121,7 @@ impl Prebindgen for JniGen {
     /// `expand_param!` ctors, called by the generated fold/unfold code).
     /// Routing both through the *helper* channel — not the ignore channel —
     /// makes a typo'd `fun!(…)` inside a decl a hard scan error
-    /// ([`crate::ScanError::DeclaredNotFound`]) instead of a stale-ignore
+    /// (`ScanError::DeclaredNotFound`) instead of a stale-ignore
     /// warning.
     /// Declared functions are subtracted: a fn that is also a real
     /// member/package fn keeps its extern. Type requirements come through
@@ -1158,7 +1158,7 @@ impl Prebindgen for JniGen {
         out
     }
 
-    /// Types acknowledged-but-undeclared via [`JniGen::ignore_class`].
+    /// Types acknowledged-but-undeclared via [`JniGen::ignore`].
     fn ignored_types(&self) -> std::collections::HashSet<TypeKey> {
         self.ignored_class_types.clone()
     }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -804,14 +804,19 @@ impl Prebindgen for JniGen {
 
     /// Hand the registry this back-end's constructor-expansion declarations so
     /// `write_rust` can resolve `.expand`s into fold plans before resolution.
-    fn expansions(&self) -> Option<&crate::api::core::expand::Expansions> {
-        Some(&self.expansions)
+    /// Assembled on demand from the per-fn overrides plus the raw type-level
+    /// [`ParamExpandDecl`]s (see [`JniGen::build_expansions`]).
+    fn expansions(&self) -> Option<crate::api::core::expand::Expansions> {
+        Some(self.build_expansions())
     }
 
     /// Hand the registry this back-end's output-expansion declarations so
     /// `write_rust` can resolve them into unfold plans before resolution.
-    fn deconstructors(&self) -> Option<&crate::api::core::unfold::Deconstructors> {
-        Some(&self.deconstructors)
+    /// Assembled on demand — field names (member inheritance) resolve here,
+    /// against the complete declaration set (see
+    /// [`JniGen::build_deconstructors`]).
+    fn deconstructors(&self) -> Option<crate::api::core::unfold::Deconstructors> {
+        Some(self.build_deconstructors())
     }
 
     /// Synthesize a field-decomposition for every `.data_class` type whose
@@ -936,13 +941,21 @@ impl Prebindgen for JniGen {
         out
     }
 
-    /// Functions ever referenced as a named leaf in a `.default_return_expand(fun!(...))`/
+    /// Functions ever referenced as a named leaf in a `return_expand!` `.field(fun!(...))`/
     /// `.return_expand(...)` record — see
     /// `accessor_record_fns`'s doc (`jni/mod.rs`). Usage-derived, not tied to
     /// `.fun()` class-member declarations: a function need not also be
     /// exposed as an instance method to be referenced this way.
     fn accessor_functions(&self) -> std::collections::HashSet<syn::Ident> {
-        self.accessor_record_fns.clone()
+        let mut set = self.accessor_record_fns.clone();
+        for decl in &self.return_expand_decls {
+            for f in &decl.fields {
+                if let LocalField::Named(func, _) = f {
+                    set.insert(func.clone());
+                }
+            }
+        }
+        set
     }
 
     /// Fun members (`.fun`) — their fn ident mapped to the owning class's

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -813,7 +813,7 @@ impl Prebindgen for JniGen {
     /// Hand the registry this back-end's constructor-expansion declarations so
     /// `write_rust` can resolve `.expand`s into fold plans before resolution.
     /// Assembled on demand from the per-fn overrides plus the raw type-level
-    /// [`ParamExpandDecl`]s (see [`JniGen::build_expansions`]).
+    /// [`ExpandParamDecl`]s (see [`JniGen::build_expansions`]).
     fn expansions(&self) -> Option<crate::api::core::expand::Expansions> {
         Some(self.build_expansions())
     }
@@ -949,21 +949,13 @@ impl Prebindgen for JniGen {
         out
     }
 
-    /// Functions ever referenced as a named leaf in a `return_expand!` `.field(fun!(...))`/
-    /// `.return_expand(...)` record — see
-    /// `accessor_record_fns`'s doc (`jni/mod.rs`). Usage-derived, not tied to
-    /// `.fun()` class-member declarations: a function need not also be
-    /// exposed as an instance method to be referenced this way.
+    /// Functions ever referenced as a named `.field(fun!(...))` in any
+    /// `expand_return!` decl, type-level or per-fn — see
+    /// [`JniGen::field_accessor_fns`]. Usage-derived, not tied to `.fun()`
+    /// class-member declarations: a function need not also be exposed as an
+    /// instance method to be referenced this way.
     fn accessor_functions(&self) -> std::collections::HashSet<syn::Ident> {
-        let mut set = self.accessor_record_fns.clone();
-        for decl in &self.return_expand_decls {
-            for f in &decl.fields {
-                if let LocalField::Named(func, _) = f {
-                    set.insert(func.clone());
-                }
-            }
-        }
-        set
+        self.field_accessor_fns()
     }
 
     /// Fun members (`.fun`) — their fn ident mapped to the owning class's
@@ -1028,7 +1020,7 @@ impl Prebindgen for JniGen {
     /// Fns acknowledged-but-unbound via [`JniGen::ignore_fun`] — suppresses
     /// the registry's "skipping undeclared" warning, emits nothing. Also
     /// includes functions referenced only inside boundary decls
-    /// (`return_expand!` accessors / `param_expand!` ctors that are not
+    /// (`expand_return!` accessors / `expand_param!` ctors that are not
     /// otherwise declared): they are called by the generated fold/unfold code
     /// and need no extern of their own. Declared functions are subtracted —
     /// a fn that is also a real member/package fn keeps its extern, and the
@@ -1048,8 +1040,8 @@ impl Prebindgen for JniGen {
         self.ignored_class_types.clone()
     }
 
-    /// **Rust-side-only** types: boundary decls (`param_expand!` /
-    /// `return_expand!`) whose type has no class declaration. They never
+    /// **Rust-side-only** types: boundary decls (`expand_param!` /
+    /// `expand_return!`) whose type has no class declaration. They never
     /// materialize in Kotlin — only their ingredients (fold) and fields
     /// (unfold / error channel) cross the boundary — so the registry
     /// acknowledges them and drops their direct converter requirements once

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1028,6 +1028,76 @@ impl Prebindgen for JniGen {
         Some(out)
     }
 
+    /// Member-shape invariants (N5), checked against registry signatures —
+    /// the earliest possible moment. Without this, a receiver-less `.fun()`
+    /// member would silently emit a method that ignores `this`, and a
+    /// wrong-return `.constructor()` a factory of the wrong type.
+    fn validate(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
+        for (key, members) in &self.class_members {
+            for m in members {
+                // A registry-absent fn already hard-errored in the scan.
+                let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) else {
+                    continue;
+                };
+                match m.kind {
+                    MemberKind::Fun => {
+                        let has_receiver = item_fn.sig.inputs.iter().any(|input| {
+                            matches!(input, syn::FnArg::Typed(pt)
+                                if &peel_receiver_key(&pt.ty) == key)
+                        });
+                        if !has_receiver {
+                            let took: Vec<String> = item_fn
+                                .sig
+                                .inputs
+                                .iter()
+                                .filter_map(|i| match i {
+                                    syn::FnArg::Typed(pt) => {
+                                        Some(pt.ty.to_token_stream().to_string())
+                                    }
+                                    _ => None,
+                                })
+                                .collect();
+                            return Err(format!(
+                                "class `{}` member fun `{}`: no parameter of type `{}` — an \
+                                 instance method's receiver must appear in the signature \
+                                 (took: {})",
+                                key.as_str(),
+                                m.rust_ident,
+                                key.as_str(),
+                                if took.is_empty() {
+                                    "no parameters".to_string()
+                                } else {
+                                    took.join(", ")
+                                }
+                            ));
+                        }
+                    }
+                    MemberKind::Constructor => {
+                        let ret = match &item_fn.sig.output {
+                            syn::ReturnType::Type(_, ty) => (**ty).clone(),
+                            syn::ReturnType::Default => syn::parse_quote!(()),
+                        };
+                        // Allowed factory shapes: `Self` and `Result<Self, E>`.
+                        let core = crate::api::core::types_util::result_ok_type(&ret)
+                            .unwrap_or_else(|| ret.clone());
+                        if &peel_receiver_key(&core) != key {
+                            return Err(format!(
+                                "class `{}` constructor `{}`: must return `{}` or \
+                                 `Result<{}, E>` — it returns `{}`",
+                                key.as_str(),
+                                m.rust_ident,
+                                key.as_str(),
+                                key.as_str(),
+                                ret.to_token_stream()
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Consts acknowledged-but-unexposed via [`JniGen::ignore_const`].
     fn ignored_consts(&self) -> std::collections::HashSet<syn::Ident> {
         self.ignored_const_idents.clone()

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -286,6 +286,13 @@ impl JniGen {
                 names.insert(short);
             }
         }
+        // `convert!`-declared types likewise have no type-table entry but
+        // appear in emitted converter signatures.
+        for decl in &self.convert_decls {
+            if let Some(short) = rust_short_name_opt(&decl.key) {
+                names.insert(short);
+            }
+        }
         names
     }
 
@@ -1032,6 +1039,41 @@ impl Prebindgen for JniGen {
             self.boundary_referenced_fns()
                 .filter(|f| !declared.contains(f)),
         );
+        out
+    }
+
+    /// `convert!` conversion functions: no extern is emitted for them —
+    /// generated converter bodies call them directly; the registry stops
+    /// warning about them. Their type requirements come through
+    /// [`Self::extra_required_types`], not a signature scan.
+    fn helper_functions(&self) -> std::collections::HashSet<syn::Ident> {
+        let declared = self.declared_functions();
+        self.convert_fns()
+            .filter(|f| !declared.contains(f))
+            .collect()
+    }
+
+    /// The other-side type of every `convert!` conversion, in the
+    /// conversion's direction: an input fn's parameter type (peeled of `&`)
+    /// must have its own **input** converter for the composed rank-0 body to
+    /// chain through; an output fn's return type needs the **output** twin.
+    /// Signatures are read from the registry (missing fns are reported by
+    /// the scan's helper-function warning; the body derivation later
+    /// hard-errors with the precise decl).
+    fn extra_required_types(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> Vec<(crate::api::core::registry::Direction, syn::Type)> {
+        use crate::api::core::registry::Direction;
+        let mut out = Vec::new();
+        for decl in &self.convert_decls {
+            if let Some((ty, _, _)) = self.convert_input_body(&decl.key, registry) {
+                out.push((Direction::Input, ty));
+            }
+            if let Some((ty, _, _)) = self.convert_output_body(&decl.key, registry) {
+                out.push((Direction::Output, ty));
+            }
+        }
         out
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -278,6 +278,14 @@ impl JniGen {
                 names.insert(short);
             }
         }
+        // Rust-side-only boundary types are absent from the type table but
+        // still appear in emitted signatures (e.g. the `E` of a peeled
+        // `Result<T, E>`), so they need the same source-module qualification.
+        for key in self.rust_side_only_types() {
+            if let Some(short) = rust_short_name_opt(&key) {
+                names.insert(short);
+            }
+        }
         names
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1018,14 +1018,36 @@ impl Prebindgen for JniGen {
     }
 
     /// Fns acknowledged-but-unbound via [`JniGen::ignore_fun`] — suppresses
-    /// the registry's "skipping undeclared" warning, emits nothing.
+    /// the registry's "skipping undeclared" warning, emits nothing. Also
+    /// includes functions referenced only inside boundary decls
+    /// (`return_expand!` accessors / `param_expand!` ctors that are not
+    /// otherwise declared): they are called by the generated fold/unfold code
+    /// and need no extern of their own. Declared functions are subtracted —
+    /// a fn that is also a real member/package fn keeps its extern, and the
+    /// registry rejects a declared∩ignored overlap as conflicting intent.
     fn ignored_functions(&self) -> std::collections::HashSet<syn::Ident> {
-        self.ignored_fns.clone()
+        let declared = self.declared_functions();
+        let mut out = self.ignored_fns.clone();
+        out.extend(
+            self.boundary_referenced_fns()
+                .filter(|f| !declared.contains(f)),
+        );
+        out
     }
 
     /// Types acknowledged-but-undeclared via [`JniGen::ignore_class`].
     fn ignored_types(&self) -> std::collections::HashSet<TypeKey> {
         self.ignored_class_types.clone()
+    }
+
+    /// **Rust-side-only** types: boundary decls (`param_expand!` /
+    /// `return_expand!`) whose type has no class declaration. They never
+    /// materialize in Kotlin — only their ingredients (fold) and fields
+    /// (unfold / error channel) cross the boundary — so the registry
+    /// acknowledges them and drops their direct converter requirements once
+    /// the plans are in place.
+    fn boundary_only_types(&self) -> std::collections::HashSet<TypeKey> {
+        self.rust_side_only_types().collect()
     }
 
     /// Emit the `OwnedObject<T>` borrow wrapper used by

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1034,30 +1034,31 @@ impl Prebindgen for JniGen {
     }
 
     /// Fns acknowledged-but-unbound via [`JniGen::ignore_fun`] — suppresses
-    /// the registry's "skipping undeclared" warning, emits nothing. Also
-    /// includes functions referenced only inside boundary decls
-    /// (`expand_return!` accessors / `expand_param!` ctors that are not
-    /// otherwise declared): they are called by the generated fold/unfold code
-    /// and need no extern of their own. Declared functions are subtracted —
-    /// a fn that is also a real member/package fn keeps its extern, and the
-    /// registry rejects a declared∩ignored overlap as conflicting intent.
+    /// the registry's "skipping undeclared" warning, emits nothing.
     fn ignored_functions(&self) -> std::collections::HashSet<syn::Ident> {
-        let declared = self.declared_functions();
-        let mut out = self.ignored_fns.clone();
-        out.extend(
-            self.boundary_referenced_fns()
-                .filter(|f| !declared.contains(f)),
-        );
-        out
+        self.ignored_fns.clone()
     }
 
-    /// `convert!` conversion functions: no extern is emitted for them —
-    /// generated converter bodies call them directly; the registry stops
-    /// warning about them. Their type requirements come through
+    /// Bulk fn ignores from [`JniGen::ignore_funs_where`].
+    fn ignored_function_predicates(&self) -> Vec<crate::api::core::prebindgen::NamePredicate> {
+        self.ignored_fn_predicates.clone()
+    }
+
+    /// Framework-called fns that get no extern of their own: `convert!`
+    /// conversion fns (called by generated converter bodies) and fns
+    /// referenced only inside boundary decls (`expand_return!` accessors /
+    /// `expand_param!` ctors, called by the generated fold/unfold code).
+    /// Routing both through the *helper* channel — not the ignore channel —
+    /// makes a typo'd `fun!(…)` inside a decl a hard scan error
+    /// ([`crate::ScanError::DeclaredNotFound`]) instead of a stale-ignore
+    /// warning.
+    /// Declared functions are subtracted: a fn that is also a real
+    /// member/package fn keeps its extern. Type requirements come through
     /// [`Self::extra_required_types`], not a signature scan.
     fn helper_functions(&self) -> std::collections::HashSet<syn::Ident> {
         let declared = self.declared_functions();
         self.convert_fns()
+            .chain(self.boundary_referenced_fns())
             .filter(|f| !declared.contains(f))
             .collect()
     }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1039,9 +1039,10 @@ impl Prebindgen for JniGen {
         self.ignored_fns.clone()
     }
 
-    /// Bulk fn ignores from [`JniGen::ignore_funs_where`].
-    fn ignored_function_predicates(&self) -> Vec<crate::api::core::prebindgen::NamePredicate> {
-        self.ignored_fn_predicates.clone()
+    /// Bulk name-family ignores from [`JniGen::ignore`] +
+    /// [`matching`](crate::lang::matching).
+    fn ignored_name_predicates(&self) -> Vec<crate::api::core::prebindgen::NamePredicate> {
+        self.ignored_name_predicates.clone()
     }
 
     /// Framework-called fns that get no extern of their own: `convert!`

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -271,44 +271,53 @@ impl JniGen {
         output_name(rust, wire)
     }
 
-    fn emitted_source_type_names(&self) -> std::collections::HashSet<String> {
-        let mut names = std::collections::HashSet::new();
-        for key in self.types.keys() {
+    fn emitted_source_type_names(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> std::collections::HashMap<String, syn::Path> {
+        let mut names = std::collections::HashMap::new();
+        let mut add = |key: &TypeKey| {
             if let Some(short) = rust_short_name_opt(key) {
-                names.insert(short);
+                // Per-item origin when the type has an indexed
+                // `#[prebindgen]` item; else the default module (a declared
+                // type re-exported by the primary source, or a deliberately
+                // unmarked type like a convert!-only newtype).
+                let ident = syn::Ident::new(&short, Span::call_site());
+                let module = registry
+                    .origin_module(&ident)
+                    .unwrap_or_else(|| self.default_module(registry));
+                names.insert(short, module);
             }
+        };
+        for key in self.types.keys() {
+            add(key);
         }
         // Rust-side-only boundary types are absent from the type table but
         // still appear in emitted signatures (e.g. the `E` of a peeled
-        // `Result<T, E>`), so they need the same source-module qualification.
-        for key in self.rust_side_only_types() {
-            if let Some(short) = rust_short_name_opt(&key) {
-                names.insert(short);
-            }
+        // `Result<T, E>`), so they need the same qualification.
+        for key in self.rust_side_only_types().collect::<Vec<_>>() {
+            add(&key);
         }
         // `convert!`-declared types likewise have no type-table entry but
         // appear in emitted converter signatures.
         for decl in &self.convert_decls {
-            if let Some(short) = rust_short_name_opt(&decl.key) {
-                names.insert(short);
-            }
+            add(&decl.key);
         }
         names
     }
 
     /// Walk `item` and prefix every bare single-segment type reference
-    /// matching a [`Self::emitted_source_type_names`] name with
-    /// [`Self::source_module`]. Applied once per emitted item at write
+    /// matching a [`Self::emitted_source_type_names`] name with that name's
+    /// origin module. Applied once per emitted item at write
     /// time via [`Prebindgen::post_process_item`] so converter bodies,
     /// type ascriptions, and casts all stay in sync without each emit
     /// site having to remember to qualify.
-    fn qualify_item(&self, item: &mut syn::Item) {
-        let source_names = self.emitted_source_type_names();
+    fn qualify_item(&self, item: &mut syn::Item, registry: &Registry<KotlinMeta>) {
+        let source_names = self.emitted_source_type_names(registry);
         if source_names.is_empty() {
             return;
         }
         let mut visitor = QualifyEmittedTypes {
-            source_module: &self.source_module,
             source_names: &source_names,
         };
         syn::visit_mut::VisitMut::visit_item_mut(&mut visitor, item);
@@ -1131,7 +1140,7 @@ impl Prebindgen for JniGen {
         // `Copy` types. A mis-declared non-`Copy` type fails to compile here
         // (at the include site) with a clear bound error rather than at a
         // converter use. The bare type name is qualified against
-        // `source_module` by `post_process_item` like every other body.
+        // its origin module by `post_process_item` like every other body.
         for (key, cfg) in &self.types {
             if cfg.value_blob {
                 let ty = key.to_type();
@@ -1145,18 +1154,23 @@ impl Prebindgen for JniGen {
         }
         // Expression constants — one nullary JNI getter extern per
         // `PackageDecl::constant_expr`, its value the binding-defined
-        // expression evaluated with `use <source_module>::*;` in scope (so
+        // expression evaluated with a glob import of every source module (so
         // it composes the source crate's items without qualification). The
         // getter reuses the whole function-wrapper pipeline via the
         // synthetic signature, exactly like a const-backed getter.
-        let source_module = &self.source_module;
+        let mut glob_modules = registry.all_source_modules();
+        if glob_modules.is_empty() {
+            glob_modules.push(self.default_module(registry));
+        }
         for decl in self.packages.values().flat_map(|p| &p.constant_exprs) {
             validate_constant_expr(self, &decl.kotlin_name, &decl.ty);
             let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
             let expr = &decl.expr;
             let callee: syn::Expr = syn::parse_quote!({
-                #[allow(unused_imports)]
-                use #source_module::*;
+                #(
+                    #[allow(unused_imports)]
+                    use #glob_modules::*;
+                )*
                 #expr
             });
             let wrapper =
@@ -1168,8 +1182,8 @@ impl Prebindgen for JniGen {
         items
     }
 
-    fn post_process_item(&self, item: &mut syn::Item) {
-        self.qualify_item(item);
+    fn post_process_item(&self, item: &mut syn::Item, registry: &Registry<KotlinMeta>) {
+        self.qualify_item(item, registry);
     }
 
     // ── Item methods ─────────────────────────────────────────────────
@@ -1189,10 +1203,6 @@ impl Prebindgen for JniGen {
         TokenStream::new()
     }
 
-    fn source_module(&self) -> Option<&syn::Path> {
-        Some(&self.source_module)
-    }
-
     /// Declared consts only reach here (write gating via
     /// [`Prebindgen::declared_consts`]): re-emit the const as a path-alias
     /// to its source-of-truth (initializer tokens are never copied — they
@@ -1210,10 +1220,10 @@ impl Prebindgen for JniGen {
         reject_handle_const(self, c);
         let getter = const_getter_fn(c);
         let const_ident = &c.ident;
-        let source_module = &self.source_module;
+        let source_module = self.fn_module(registry, const_ident);
         let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
         let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
-        let alias = crate::api::core::const_path_alias(c, source_module);
+        let alias = crate::api::core::const_path_alias(c, &source_module);
         quote! {
             #alias
             #wrapper
@@ -1317,7 +1327,7 @@ impl JniGen {
             if cfg.enum_cfg.is_some() {
                 if let Some(name) = bare_path_ident(ty) {
                     if let Some((e, _)) = registry.enums.get(&name) {
-                        let (wire, body) = enum_input_body(self, e);
+                        let (wire, body) = enum_input_body(self, registry, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
                             .name_spec

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,10 +21,9 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, DataClassDecl,
-    EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
-    GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl,
-    ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
+    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, ConvertDecl,
+    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
+    JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -23,7 +23,8 @@ pub use jni::{
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, DataClassDecl,
     EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl,
-    PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
+    ParamExpandDecl, PtrClassDecl, ReturnExpandDecl, ScalarTypeWrapperDecl, ValueClassDecl,
+    WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -22,9 +22,9 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, DataClassDecl,
-    EnumClassDecl, ExpandDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen,
-    PackageDecl, ParamExpandDecl, PtrClassDecl, ReturnExpandDecl, ScalarTypeWrapperDecl,
-    ValueClassDecl, WireBody,
+    EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
+    GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl,
+    ScalarTypeWrapperDecl, ValueClassDecl, WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -22,9 +22,9 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, DataClassDecl,
-    EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, PackageDecl,
-    ParamExpandDecl, PtrClassDecl, ReturnExpandDecl, ScalarTypeWrapperDecl, ValueClassDecl,
-    WireBody,
+    EnumClassDecl, ExpandDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen,
+    PackageDecl, ParamExpandDecl, PtrClassDecl, ReturnExpandDecl, ScalarTypeWrapperDecl,
+    ValueClassDecl, WireBody,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -21,9 +21,9 @@ pub(crate) mod util;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
-    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl, ConvertDecl,
-    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
-    JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
+    null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, DataClassDecl,
+    EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl, JniBindingError,
+    JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -20,10 +20,10 @@ pub(crate) mod util;
 
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
-    decode_byte_array, decode_string, encode_byte_array, encode_string, null_byte_array,
+    decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, DataClassDecl,
-    EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl, JniBindingError,
-    JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
+    EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl, IgnoreDecl,
+    JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -19,6 +19,42 @@ pub(crate) fn snake_to_camel(s: &str) -> String {
     out
 }
 
+/// Strip a type's **namespace prefix** from a flat-crate fn ident: a flat
+/// Rust crate spells the type namespace inside the ident (`storage_len`,
+/// `keyexpr_intersects`) because flat FFI has no method syntax; a class
+/// member already lives in its class's namespace, so its default Kotlin
+/// name removes exactly that prefix — nothing else.
+///
+/// Matching is underscore-insensitive on both sides (class `KeyExpr`
+/// strips `keyexpr_get_str` AND `key_expr_get_str`): leading
+/// `_`-separated segments of `ident` are consumed while their
+/// concatenation (lowercased) is a prefix of the lowercased,
+/// underscore-free `type_short`. Succeeds only when the consumed segments
+/// spell the class name exactly and a non-empty remainder follows.
+pub(crate) fn strip_type_prefix<'a>(ident: &'a str, type_short: &str) -> Option<&'a str> {
+    let class: String = type_short
+        .chars()
+        .filter(|c| *c != '_')
+        .flat_map(|c| c.to_lowercase())
+        .collect();
+    if class.is_empty() {
+        return None;
+    }
+    let mut consumed = String::new();
+    let mut rest = ident;
+    while let Some((seg, tail)) = rest.split_once('_') {
+        consumed.extend(seg.chars().flat_map(|c| c.to_lowercase()));
+        if !class.starts_with(&consumed) {
+            return None;
+        }
+        rest = tail;
+        if consumed == class {
+            return if rest.is_empty() { None } else { Some(rest) };
+        }
+    }
+    None
+}
+
 /// Convert a `CamelCase` Rust identifier to `SCREAMING_SNAKE_CASE`. Used to
 /// project Rust enum variant idents into Kotlin enum constant names.
 pub(crate) fn camel_to_screaming_snake(s: &str) -> String {

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -55,6 +55,37 @@ pub(crate) fn strip_type_prefix<'a>(ident: &'a str, type_short: &str) -> Option<
     None
 }
 
+/// Extract an item's `///` documentation from its captured attributes
+/// (`#[doc = " …"]` lines, in order): one leading space stripped per line,
+/// joined with `\n`; `None` when the item carries no docs. `*/` is
+/// defanged so the text is always safe inside a `/** … */` KDoc block.
+pub(crate) fn doc_string(attrs: &[syn::Attribute]) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        let syn::Meta::NameValue(nv) = &attr.meta else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(s),
+            ..
+        }) = &nv.value
+        else {
+            continue;
+        };
+        let raw = s.value();
+        let line = raw.strip_prefix(' ').unwrap_or(&raw);
+        lines.push(line.replace("*/", "*\u{200B}/"));
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
 /// Convert a `CamelCase` Rust identifier to `SCREAMING_SNAKE_CASE`. Used to
 /// project Rust enum variant idents into Kotlin enum constant names.
 pub(crate) fn camel_to_screaming_snake(s: &str) -> String {

--- a/prebindgen/src/api/lang/jnigen/util/tests.rs
+++ b/prebindgen/src/api/lang/jnigen/util/tests.rs
@@ -97,3 +97,23 @@ fn strip_type_prefix_basics() {
     assert_eq!(strip_type_prefix("storage", "Storage"), None);
     assert_eq!(strip_type_prefix("storage_", "Storage"), None);
 }
+
+#[test]
+fn doc_string_extracts_and_sanitizes() {
+    use super::doc_string;
+    let f: syn::ItemFn = syn::parse_quote! {
+        /// Puts a payload.
+        ///
+        /// Second paragraph with */ inside.
+        fn f() {}
+    };
+    let doc = doc_string(&f.attrs).expect("docs present");
+    assert_eq!(
+        doc,
+        "Puts a payload.\n\nSecond paragraph with *\u{200B}/ inside."
+    );
+    let bare: syn::ItemFn = syn::parse_quote!(
+        fn g() {}
+    );
+    assert_eq!(doc_string(&bare.attrs), None);
+}

--- a/prebindgen/src/api/lang/jnigen/util/tests.rs
+++ b/prebindgen/src/api/lang/jnigen/util/tests.rs
@@ -65,3 +65,35 @@ fn discriminants_non_literal_rejected() {
     };
     let _ = discriminants(e);
 }
+
+#[test]
+fn strip_type_prefix_basics() {
+    use super::strip_type_prefix;
+    // Plain one-segment class namespace.
+    assert_eq!(strip_type_prefix("storage_len", "Storage"), Some("len"));
+    assert_eq!(
+        strip_type_prefix("payload_label_len", "Payload"),
+        Some("label_len")
+    );
+    // Underscore-insensitive on both sides: class KeyExpr vs `keyexpr_` and
+    // `key_expr_` idents.
+    assert_eq!(
+        strip_type_prefix("keyexpr_get_str", "KeyExpr"),
+        Some("get_str")
+    );
+    assert_eq!(
+        strip_type_prefix("key_expr_get_str", "KeyExpr"),
+        Some("get_str")
+    );
+    assert_eq!(
+        strip_type_prefix("zbytes_as_bytes", "ZBytes"),
+        Some("as_bytes")
+    );
+    // No namespace prefix → None (fallback keeps the full ident).
+    assert_eq!(strip_type_prefix("millis_add", "Storage"), None);
+    // Partial overlap that never completes the class name → None.
+    assert_eq!(strip_type_prefix("key_something", "KeyExpr"), None);
+    // The ident IS the class name alone → None (empty remainder).
+    assert_eq!(strip_type_prefix("storage", "Storage"), None);
+    assert_eq!(strip_type_prefix("storage_", "Storage"), None);
+}

--- a/prebindgen/src/api/record.rs
+++ b/prebindgen/src/api/record.rs
@@ -30,6 +30,14 @@ pub struct SourceLocation {
     pub line: usize,
     /// The column number where the item starts (1-based)
     pub column: usize,
+    /// Origin crate of the item. Not part of the captured JSONL (the
+    /// proc-macro writes records from inside the crate, which reaches its
+    /// consumers under a name only they know) — `Source` stamps it while
+    /// parsing records, so every item stream carries its origin and streams
+    /// from different sources can be `chain`ed into one
+    /// `Registry::from_items` call without losing per-item origins.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crate_name: Option<String>,
 }
 
 impl std::fmt::Display for SourceLocation {
@@ -48,6 +56,7 @@ impl SourceLocation {
                     file: span.unwrap().file(),
                     line: span.unwrap().line(),
                     column: span.unwrap().column(),
+                    crate_name: None,
                 }
             }
         } else {
@@ -57,6 +66,7 @@ impl SourceLocation {
                 file: "<unknown>".to_string(),
                 line: 0,
                 column: 0,
+                crate_name: None,
             }
         }}
     }

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -96,6 +96,7 @@ impl Source {
         input_dir: &Path,
         features_constant: Option<String>,
         target_triple: Option<String>,
+        crate_name_override: Option<String>,
     ) -> Self {
         if let Some(source) = DOCTEST_SOURCE.with(|source| (*source.borrow()).clone()) {
             return source;
@@ -106,13 +107,18 @@ impl Source {
                 input_dir.display()
             );
         }
-        let crate_name = read_stored_crate_name(input_dir).unwrap_or_else(|| {
+        // The stored name (CARGO_PKG_NAME at capture time) doubles as the
+        // "directory was initialized" check, so it is read even when
+        // overridden. The override wins: it is the name THIS crate
+        // references the source crate by (a Cargo.toml dependency rename).
+        let stored_crate_name = read_stored_crate_name(input_dir).unwrap_or_else(|| {
             panic!(
                 "The directory {} was not initialized with init_prebindgen_out_dir(). \
                 Please ensure that init_prebindgen_out_dir() is called in the build.rs of the source crate.",
                 input_dir.display()
             )
         });
+        let crate_name = crate_name_override.unwrap_or(stored_crate_name);
 
         let groups = Self::discover_groups(input_dir);
         let mut items = HashMap::new();
@@ -411,6 +417,7 @@ pub struct Builder {
     input_dir: PathBuf,
     features_constant: Option<String>,
     target_triple: Option<String>,
+    crate_name: Option<String>,
 }
 
 impl Builder {
@@ -428,7 +435,28 @@ impl Builder {
             input_dir: input_dir.as_ref().to_path_buf(),
             features_constant: Some("FEATURES".to_string()),
             target_triple,
+            crate_name: None,
         }
+    }
+
+    /// Override the crate name recorded by the source crate's build script
+    /// (`CARGO_PKG_NAME` at capture time) with the name **this** crate
+    /// references the source crate by. Needed when the dependency is
+    /// renamed in Cargo.toml:
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// myflat = { package = "some-flat-crate", version = "..." }
+    /// ```
+    ///
+    /// The name is stamped into every yielded item's `SourceLocation`, so
+    /// it is what generated code qualifies references with
+    /// (`myflat::…`) and what qualifies the features-guard constant. Being
+    /// per-`Source`, it composes with multi-source registries — each
+    /// chained stream carries its own (possibly overridden) origin.
+    pub fn crate_name(mut self, name: impl Into<String>) -> Self {
+        self.crate_name = Some(name.into());
+        self
     }
 
     /// Enables or disables filtering by features when extracting collected data.
@@ -516,6 +544,11 @@ impl Builder {
 
     /// Build the `Source` instance
     pub fn build(self) -> Source {
-        Source::build_internal(&self.input_dir, self.features_constant, self.target_triple)
+        Source::build_internal(
+            &self.input_dir,
+            self.features_constant,
+            self.target_triple,
+            self.crate_name,
+        )
     }
 }

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -118,7 +118,20 @@ impl Source {
         let mut items = HashMap::new();
         for group in groups {
             let records = Self::read_group(input_dir, &group);
-            let group_items = records.iter().map(|r| r.parse()).collect::<Vec<_>>();
+            let group_items = records
+                .iter()
+                .map(|r| {
+                    // Stamp the origin crate into every item's location: the
+                    // captured JSONL doesn't carry it (the proc-macro runs
+                    // inside the crate), but from here on the item streams
+                    // are self-describing — streams from several sources can
+                    // be chained into one `Registry::from_items` call
+                    // without losing per-item origins.
+                    let (item, mut loc) = r.parse();
+                    loc.crate_name = Some(crate_name.clone());
+                    (item, loc)
+                })
+                .collect::<Vec<_>>();
             items.insert(group, group_items);
         }
 
@@ -149,7 +162,10 @@ impl Source {
                                 pub field: i32,
                             }
                         },
-                        SourceLocation::default(),
+                        SourceLocation {
+                            crate_name: Some("source_ffi".to_string()),
+                            ..SourceLocation::default()
+                        },
                     )],
                 ),
                 (
@@ -159,7 +175,10 @@ impl Source {
                             #[prebindgen("functions")]
                             pub fn test_function() -> i32 { 42 }
                         },
-                        SourceLocation::default(),
+                        SourceLocation {
+                            crate_name: Some("source_ffi".to_string()),
+                            ..SourceLocation::default()
+                        },
                     )],
                 ),
             ]),

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -153,6 +153,10 @@ pub mod __macro_support {
     pub fn parse_path(s: &str) -> ::syn::Path {
         ::syn::parse_str(s).unwrap_or_else(|e| panic!("prebindgen: invalid path `{s}`: {e}"))
     }
+
+    pub fn parse_expr(s: &str) -> ::syn::Expr {
+        ::syn::parse_str(s).unwrap_or_else(|e| panic!("prebindgen: invalid expression `{s}`: {e}"))
+    }
 }
 
 /// Build a `syn::Ident` from a bare identifier token. Unlike
@@ -261,10 +265,10 @@ pub mod lang {
         jnigen::{
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
-            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl,
-            ConvertDecl, DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl,
-            ExpandReturnDecl, FunctionDecl, JniBindingError, JniGen, KotlinFile, PackageDecl,
-            PtrClassDecl, ValueClassDecl, WriteKotlinError,
+            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl,
+            DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl,
+            FunctionDecl, JniBindingError, JniGen, KotlinFile, PackageDecl, PtrClassDecl,
+            ValueClassDecl, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -250,7 +250,6 @@ pub mod core {
 /// root because the `extern "C"` converters emitted by [`lang::Cbindgen`]
 /// reference them as `::prebindgen::Transmute` / `::prebindgen::Gravestone`.
 pub use crate::api::core::gravestone::{Gravestone, Transmute};
-
 /// Root re-export of [`lang::matching`] so the ignore-predicate constructor
 /// sits next to the decl macros it composes with
 /// (`.ignore(matching(|n| …))`, like `.ignore(fun!(…))`).

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -258,9 +258,9 @@ pub mod lang {
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl,
-            DataClassDecl, EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError,
-            JniGen, KotlinFile, PackageDecl, ParamExpandDecl, PtrClassDecl, ReturnExpandDecl,
-            ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
+            DataClassDecl, EnumClassDecl, ExpandDecl, FunctionDecl, GenericTypeWrapperDecl,
+            JniBindingError, JniGen, KotlinFile, PackageDecl, ParamExpandDecl, PtrClassDecl,
+            ReturnExpandDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -258,9 +258,9 @@ pub mod lang {
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl,
-            DataClassDecl, EnumClassDecl, ExpandDecl, FunctionDecl, GenericTypeWrapperDecl,
-            JniBindingError, JniGen, KotlinFile, PackageDecl, ParamExpandDecl, PtrClassDecl,
-            ReturnExpandDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
+            DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl,
+            FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, KotlinFile, PackageDecl,
+            PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -251,6 +251,11 @@ pub mod core {
 /// reference them as `::prebindgen::Transmute` / `::prebindgen::Gravestone`.
 pub use crate::api::core::gravestone::{Gravestone, Transmute};
 
+/// Root re-export of [`lang::matching`] so the ignore-predicate constructor
+/// sits next to the decl macros it composes with
+/// (`.ignore(matching(|n| …))`, like `.ignore(fun!(…))`).
+pub use crate::api::lang::jnigen::matching;
+
 /// Destination-language adapters implementing [`core::Prebindgen`].
 ///
 /// [`lang::Cbindgen`] is the C / cbindgen adapter: it turns a flat
@@ -268,10 +273,10 @@ pub mod lang {
         jnigen::{
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
-            null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl,
-            DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl,
-            FunctionDecl, JniBindingError, JniGen, KotlinFile, PackageDecl, PtrClassDecl,
-            ValueClassDecl, WriteKotlinError,
+            matching, null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl,
+            ConvertDecl, DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl,
+            ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen, KotlinFile,
+            PackageDecl, PtrClassDecl, ValueClassDecl, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -259,8 +259,8 @@ pub mod lang {
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl,
             DataClassDecl, EnumClassDecl, FunctionDecl, GenericTypeWrapperDecl, JniBindingError,
-            JniGen, KotlinFile, PackageDecl, PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl,
-            WireBody, WriteKotlinError,
+            JniGen, KotlinFile, PackageDecl, ParamExpandDecl, PtrClassDecl, ReturnExpandDecl,
+            ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -258,9 +258,9 @@ pub mod lang {
             box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConstExprDecl,
-            DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl,
-            FunctionDecl, GenericTypeWrapperDecl, JniBindingError, JniGen, KotlinFile, PackageDecl,
-            PtrClassDecl, ScalarTypeWrapperDecl, ValueClassDecl, WireBody, WriteKotlinError,
+            ConvertDecl, DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl,
+            ExpandReturnDecl, FunctionDecl, JniBindingError, JniGen, KotlinFile, PackageDecl,
+            PtrClassDecl, ValueClassDecl, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -149,6 +149,10 @@ pub mod __macro_support {
     pub fn parse_type(s: &str) -> ::syn::Type {
         ::syn::parse_str(s).unwrap_or_else(|e| panic!("prebindgen: invalid type `{s}`: {e}"))
     }
+
+    pub fn parse_path(s: &str) -> ::syn::Path {
+        ::syn::parse_str(s).unwrap_or_else(|e| panic!("prebindgen: invalid path `{s}`: {e}"))
+    }
 }
 
 /// Build a `syn::Ident` from a bare identifier token. Unlike

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -98,10 +98,12 @@
 //!         .function(pq!(calculator_new))
 //!         .function(pq!(calculator_get_value)).panic();
 //!
-//!     // Resolve types and write the Rust file of `extern "C"` wrappers.
-//!     let mut registry =
-//!         prebindgen::core::Registry::from_items(source.items_all()).unwrap();
-//!     let bindings_file = registry.write_rust(&cbindgen, "example_flat.rs").unwrap();
+//!     // Resolve types, then write the Rust file of `extern "C"` wrappers.
+//!     let generation = prebindgen::core::Registry::from_items(source.items_all())
+//!         .unwrap()
+//!         .resolve(cbindgen)
+//!         .unwrap();
+//!     let bindings_file = generation.write_rust("example_flat.rs").unwrap();
 //!
 //!     // Pass the generated file to cbindgen for C header generation.
 //!     generate_c_headers(&bindings_file);
@@ -215,9 +217,10 @@ macro_rules! ident {
 ///
 /// 1. [`Registry::from_items`](core::Registry::from_items) indexes the
 ///    `(syn::Item, SourceLocation)` stream (typically [`Source::items_all`]).
-/// 2. [`Registry::write_rust`](core::Registry::write_rust) resolves every
-///    required type via your back-end and writes the generated Rust bindings
-///    file.
+/// 2. [`Registry::resolve`](core::Registry::resolve) resolves every required
+///    type via your back-end, yielding a [`Generation`](core::Generation);
+///    its `write_rust` (and adapter-specific `write_*`) methods emit the
+///    artifacts.
 /// 3. The back-end produces any secondary artifacts (C headers, Kotlin sources,
 ///    …) by walking the resolved [`Registry`](core::Registry).
 ///
@@ -237,8 +240,8 @@ macro_rules! ident {
 /// ([`lang::Cbindgen`]) and the JNI / Kotlin back-end ([`lang::JniGen`]).
 pub mod core {
     pub use crate::api::core::{
-        ConverterImpl, Direction, Gravestone, NicheSlot, Niches, Prebindgen, Registry, ScanError,
-        Stage, Transmute, TypeEntry, TypeKey, WriteRustError,
+        ConverterImpl, Direction, Generation, Gravestone, NicheSlot, Niches, Prebindgen, Registry,
+        ScanError, Stage, Transmute, TypeEntry, TypeKey, WriteRustError,
     };
 }
 


### PR DESCRIPTION
Step-by-step cleanup of the `lang::JniGen` declaration API, driven by the findings in [docs/jnigen-api-critique.md](https://github.com/milyin/prebindgen/blob/jnigen-api-cleanup/docs/jnigen-api-critique.md) (committed on this branch). Each checklist item is decided individually — **fix / defer / won't-fix** — and implemented as its own commit on this branch; boxes are ticked as decisions land. IDs link to the full write-up in the doc.

## Misleading

- [x] **M1 — OR/AND hidden behind symmetric names**: ~~repeated `default_param_expand` accumulates *alternatives* (dispatch), repeated `default_return_expand` accumulates *fields* (product)~~ — fixed in d2a50ee: type-level decls are now `param_expand!(T).variant(…)` (OR) / `return_expand!(T).field(…)` (AND).
- [x] **M2 — `_self` means three things**: ~~class-level no-op vs fn-level opt-out vs borrowed-return clone~~ — fixed in 531a37c: per-fn overrides are now `FunctionDecl::expand_param("name", expand_param!(T)…)` / `.expand_return(expand_return!(T)…)`, taking the same decl objects as `JniGen::expand` (macros renamed `expand_param!`/`expand_return!`). One complete-set rule at both scopes: identity-only = the plain form; decl types cross-checked against the fn signature; borrowed-return clone documented on `field_self`.
- [x] **M3 — `default_param_expand` docs oversell**: ~~"also accept a plain String" actually generates a `keyExprSel: Int, keyExpr0: String?, keyExpr1: KeyExpr?` discriminator triple~~ — fixed in eecaea7: `ExpandParamDecl`/`variant()` docs rephrased in wire terms (selector `Int` + one nullable slot per arm; call sites pass `(0, "key", null)`-style tuples); idiomatic overloads/sealed types explicitly an SDK tier's job. Since N1 the wrapper KDoc shape-notes show the real slots per function. No behavior change.
- [x] **M4 — phantom error class**: ~~`Result<T, Error>` support requires `ptr_class!(Error)`~~ — fixed in 01a4f00, generalized: boundary decls (`param_expand!`/`return_expand!`) now work for **rust-side-only types** with no class declaration (built from ingredients in, decomposed into fields out, never materialize in Kotlin; `_self` arms hard-error). Errors are just the E-position case; zenoh-flat's `Error` is one `return_expand!` line, dead class gone.
- [x] **M5 — "wrapper" overloaded**: ~~two wrapper decls with inconsistent direction pairs~~ — fixed in c52e91a: the injected-expression wrapper tier is deleted, replaced by `.convert(convert!(T).input(fun!(f)).output(fun!(g)))` — ordinary `#[prebindgen]` fns, wire/Kotlin derived from signatures. Helper fns may live in a separate source crate (per-fn origin qualification — proven in covertest; a01f766: origins ride each item's `SourceLocation` stamp, so multi-source = `from_items(flat.items_all().chain(helpers.items_all()))` — `from_sources`/`add_source` removed, stream prefiltering preserved; 1e83f56: dependency-rename override moved per-source, `Source::builder(dir).crate_name("cov_helpers")`, `set_default_module` removed — proven in covertest by renaming the helpers dep in Cargo.toml). The dead `GenericTypeWrapperDecl` tier removed (scope cut recorded). Follow-up: four conversion sources — prebindgen fn / `Into` impls (`input_from`/`output_into`) / `TryInto` impls (`input_try_from`, Err→onError) / binding-local fns (`input_with(ty!, path!(crate::…))`), all demonstrated in covertest incl. the JVM TryFrom error path. Follow-up: `set_source_module` removed entirely — the registry owns all origins (per-item from `from_sources`, first source = default module; `set_default_module` for item-level registries).
- [x] **M6 — two "package" concepts**: `.package(package!(..))` = subpackage batch vs `set_package_prefix` = the actual package. *Resolved: intended design, no change — absolute base + relative subpackages is deliberate (one knob relocates the tree, declarations can't land outside it); semantics documented on `package!`/`PackageDecl`/`config.rs`; `subpackage!` rename rejected (method/macro mismatch, breaking).*
- [x] **M7 — stale docs**: ~~`kotlin_emit.rs` references removed `.method(...)`; `JniGen` doc example uses pre-de-prefix `ZKeyExpr`/`z_keyexpr_as_str`~~ — fixed in eecaea7: full sweep — `.method(...)` line rewritten to the current `.fun`/`.constructor`/`PackageDecl::fun` vocabulary (doc example was already de-prefixed); also fixed every stale reference this cleanup's own renames introduced (`constant_expr`/`constant_fun` → `ConstDecl::expr`/`fun`, `ignore_fun`/`ignore_class`/`ignore_const`/`ignore_funs_where` → `ignore`/`matching`, `Registry::write_rust` → `resolve`/`Generation::write_rust`). `cargo doc`: zero unresolved intradoc links.
- [x] **M8 — internals leak into generated API**: ~~public `ErrorHandler.run(je: String?, ...)`, `ze0` fields, `__cap.ze0!!`~~ — fixed in eecaea7: **keep `je`, document the contract** (rename rejected — `je` is load-bearing shorthand across the whole error model, and any name still needs the null-contract explained). Every generated handler `fun interface` now carries a KDoc: `je != null` ⇒ binding/system failure (message + default leaves), `je == null` ⇒ decomposed domain error (typed handler names the type); throwing from `run` is safe (runs after the native call returns). `ze{i}` capture fields were already `internal`. Plumbing: `IfaceSpec.kdoc` → `KtFunInterface.kdoc`; snapshot test; regen = handler KDoc lines only.

## Illogical / inconsistent

- [x] **I1 — same fact declared twice**: ~~every Sample getter appears as both `.fun(...)` and `.default_return_expand(...)` with `.name()` repeated~~ — fixed in d2a50ee: class decls declare only the Kotlin surface; boundary shape moves to generator-level `param_expand!`/`return_expand!` decls, and `.field(fun!(x))` inherits the member's Kotlin name (written once). Follow-up 046d7fa: single acceptor `JniGen::expand(impl Into<ExpandDecl>)`, direction carried by the decl (mirrors `.class(...)`).
- [x] **I2 — declaration order is load-bearing**: correction — the generator already hard-errors on wrong order (`RootIdentityBeforeNested`) with the fix in the message; the invariant IS owned. Decision: keep the hard error (declaration order defines leaf order everywhere else); no code change.
- [x] **I3 — flipped receivers + hidden coupling**: ~~`registry.write_rust(&jni, ..)` vs `jni.write_kotlin(&registry, ..)`~~ — fixed in aebdb72: `Registry::resolve(self, adapter) -> Generation<E>` consumes both; `gen.write_rust(path)` / `gen.write_kotlin(root)` are pure emissions on ONE receiver, order-free (verified by a flipped-order byte-identity test; write phase takes `&Registry`, no interior mutability). Resolve-before-write is unrepresentable to violate; adapter named once; cbindgen consumers chain `.resolve(cb)?.write_rust(..)?`.
- [x] **I4 — inconsistent argument kinds**: ~~`ignore_fun(FunctionDecl)` vs `ignore_class(syn::Type)`~~ — fixed in 1802d17: ONE `.ignore(impl Into<IgnoreDecl>)` acceptor (`fun!` / `ty!` / `constant!` for exact items, `matching(|n| …)` for a name-family predicate over ANY item kind — flat namespace, so no kind needed; supersedes I7's fn-only `ignore_funs_where`, core hook renamed `ignored_name_predicates` and applied to fn/type/const skip filters). Spelling standard: decl macros normal form, `FunctionDecl::new`/`ConstDecl::named` runtime loop forms; `pq!` survives only in the Cbindgen builder (out of scope).
- [x] **I5 — member support varies by class kind for impl reasons**: ~~`data_class` forbids members; `.kotlin_type()` missing on enum/ptr~~ — fixed in b0c43ac, matrix now follows two rules: **members** exist wherever an instance re-enters Rust (ptr=handle, value=blob, data=FIELD LEAVES — new; receiver crosses like a data-class param rebased to `this`, extern unchanged; enum ✗ by rule — bare scalar); **`.kotlin_type()`** exists wherever the class is pure surface (data, value, enum — new, target honors `fromInt`/`.value`; ptr ✗ by rule — owns the NativeHandle lifecycle contract). `.kotlin_type()`+members rejected on both data and value. Covertest: `Payload.labelLen()` instance method.
- [x] **I6 — three overlapping const mechanisms**: ~~`constant` / `constant_fun` / `constant_expr`~~ — fixed in 276c98e: ONE source-kinded decl, aligned with `convert!` (nullary/unary edges of one vocabulary): `constant!(X)` bare = prebindgen const, `.fun(fun!)` = nullary prebindgen fn, `.with(ty!, path!)` = binding-local fn, `.expr(ty!, expr!)` = expression (const-ONLY — an expression binds no arguments exactly when nothing flows in). convert!'s bare `.input`/`.output` renamed `input_fun`/`output_fun` for uniform source naming; `constant_expr!(N: T = e)` DSL arm deleted (decl macros take ONE simple argument); loops use `ConstDecl::named(name).expr(ty, expr)`. All four sources in covertest.
- [x] **I7 — mixed failure modes**: ~~panics vs cargo-warning-plus-silent-omission (typo'd `fun!` name!) vs generated-code compile errors vs runtime~~ — fixed in 7111cb0: declared-but-missing (fns, convert!/boundary helpers, consts) is now a hard scan error (`ScanError::DeclaredNotFound`, all missing names in ONE sorted error); stale *ignores* keep warning (bookkeeping, not claims). Boundary-referenced fns rerouted ignore→helper channel so a typo'd `fun!` inside `expand_*!` hard-errors too. (Scalar-wrapper panic and rank>3 silent None were already gone — M5 / structural resolver.)

## Inconvenient

- [x] **C1 — `.name()` on nearly every member**: ~~default `snake_to_camel(full_rust_ident)`~~ — fixed in b59ddec: member defaults are **namespace-relative** (the class's Rust-name prefix strips from the ident, underscore-insensitively — `storage_len`→`len`, `keyexpr_get_str`→`getStr`; extern tier keeps the full ident). `get_`/`new_` dropping deliberately NOT automatic (style, not structure — zenoh keeps `get` in half its names) → `.name()` or the new SIXTH hook `set_member_name_mangle` (order-independent; effective name derived at point of use; expand `.field` inheritance follows). Validated by byte-identical regen after deleting 10 covertest + 13 zenoh `.name()`s.
- [x] **C2 — no bulk/pattern ignore**: ~~53 hand-enumerated `ignore_fun(ident!(encoding_const_*))` lines~~ — fixed in 7111cb0: `.ignore_funs_where(|n| n.starts_with("encoding_const_"))` closure predicate (core hook `ignored_function_predicates`); predicate = filter not claim (zero-match silent, declaration wins). zenoh-flat-jni's loop is one line now; covertest shows predicate + exact ignores side by side.
- [x] **C3 — advanced wrapper tier demands syn/quote fluency**: ~~token-interpolation closures, arity-as-rank phantom traits~~ — resolved by M5's c52e91a: the whole injected-expression tier is gone; conversions are named `#[prebindgen]` fns checked by rustc.
- [x] **C4 — manual output hygiene**: ~~consumer must `remove_dir_all` the Kotlin root itself~~ — fixed in d53d57a: the Kotlin root is **generator-owned** — `write_kotlin` deletes and recreates it every run (contract documented: dedicated dir like `kotlin/generated/`, never hand-written sources). Boilerplate deleted from all three consumers; a marker-based selective prune was considered and rejected as too complex.
- [x] **C5 — params named by bare ident**: ~~unvalidated against the fn signature~~ — resolved in 0280301 as already-fixed by M2/I7/I3: every bare-ident reference is a hard `Err` out of `Registry::resolve` (the earliest moment signatures exist) — `DeclaredNotFound` (fns/members/consts/helpers), `UnknownParam`+`Param/ReturnTypeMismatch` (per-fn expand), `UnknownConstructor`/`TargetMismatch`/`NoConstructor` (variant ctors), `UnknownAccessor`/`AccessorTargetMismatch`/`RecordNotAccessor` (field accessors), `DuplicateLeafName` (leaves). Exact ignores warn by design. Gap-fill tests added for the three previously untested variants; the example API itself was deleted by M2.
- [x] **C6 — global-only lock toggle**: ~~cannot be traded per class/fn on hot paths~~ — resolved in cd9beb6: the premise ('known per-call lock overhead') was **measured false** — perftest locks-on vs locks-off deltas −3.2%…+3.6% mixed-sign (within noise; ~1 ns bound for the whole uncontended lock pair from `put native.null` at ~33 ns/call, JDK 21/macOS arm64, N=5M). Per-class granularity = knob without payoff, rejected; the global toggle is re-documented as existing solely for independent re-verification of this claim.
- [x] **C7 — no introspection/dry-run**: ~~only way to see a decl's effect is generate + diff~~ — fixed in 36da80a: `Generation::<JniGen>::report()` — per fn the FINAL Kotlin signature (same render path as the emitters, cannot drift) + `shaped by:` provenance (param expansions/variants, return/error decompositions with leaves), type table (kind/FQN/wire), `convert!` sources, rust-side-only types. Deterministic; committed as `kotlin/REPORT.md` next to the regen (covertest + zenoh, 373 lines/106 consts at scale) so decl effects are PR-reviewable. Inherent on `Generation<JniGen>` (the I3 seam) — pattern universal, content per-language; `Generation<Cbindgen>::report()` a natural future twin.

## Incomplete

- [x] **N1 — doc comments dropped**: ~~`///` never reaches generated Kotlin~~ — fixed in 8ad163f: KDoc = **author prose + shape notes**. Every wrapper/member/factory/class/const val carries the Rust `///` verbatim (framework lines follow after author prose); shaped positions additionally get caller-phrased notes documenting the REAL prototype after expansions (expanded params with variant choices, decomposed returns with builder leaves, error decompositions) — same plan maps as C7's report, phrased for the caller. Undocumented+unshaped fn = no KDoc. zenoh regen +551 KDoc lines.
- [x] **N2 — acknowledged coverage holes**: catalogued in [#33](https://github.com/milyin/prebindgen/issues/33) — triaged into deferred gaps (`Vec<handle>` input, `Option<ptr_class>` recursive fold, `&mut` shapes; each with failure mode, workaround, sketch; `&mut`'s cryptic unresolved-type error flagged as the first sub-task) vs by-design exclusions (opaque consts → loaning-factory idiom; output `Option<prim>` boxing → inherent to the return channel). Feature work, not API shape — tracked outside this PR.
- [x] **N3 — API split across branches**: ~~consts only on `const_support`~~ — resolved before this PR; merged to main as #31.
- [x] **N4 — public-surface hygiene**: ~~`pub` fields bypass setter invariants; `pub mod jni` leaks internals~~ — fixed in ea16acc: `JniGen.package` sealed `pub(crate)` (the one live leak — direct writes bypassed `set_package_prefix` trimming). Rest already sealed: `source_module` deleted (M5 follow-up), `WireBody` died with the wrapper tier, module leak structurally closed (`pub(crate) mod api` ⇒ curated `lang` list is the only public path). Sweep of the curated list found no other pub fields.
- [x] **N5 — decl-time validation gaps**: ~~no member-shape checks; no JVM lock test~~ — fixed in 2614111: the gap was WORSE than stated (receiver-less `.fun()` silently emitted a method ignoring `this`; wrong-return ctor a wrong-typed factory). New core hook `Prebindgen::validate(registry) -> Result<(), String>` (runs in `resolve` right after the scan; `Err` = `ScanError::AdapterInvariant` verbatim); jnigen checks every member — `.fun()` needs a param peeling to the class, `.constructor()` must return `Self`/`Result<Self, E>`; errors name class/fn/actual shape. The JVM lock test half was stale — Test.kt's 3-handle + multi-thread smoke (opposite lock orders, writer, join-timeout deadlock check) exists since covertest-hardening, runs in CI.

---

**Process**: items are being decided one by one (starting from the critique's ranked recommendations: I1, I2, M4, I7+C2, C1, M1/M2/M5 renames, N1, then hygiene). Each accepted item lands as a dedicated commit referencing its ID; the corresponding box is ticked and a **Resolution** note is appended to the doc. Deferred / won't-fix decisions are recorded the same way.

**Status: checklist COMPLETE** — all 23 items resolved (fixed, resolved-as-designed, or triaged out to [#33](https://github.com/milyin/prebindgen/issues/33)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


