### PR TITLE
jnigen: tag-bit handle lifecycle — immutable lock-order key + closed-handle guards

### DIFF
--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -11,23 +11,39 @@ import io.prebindgen.covertest.model.Stamp
  * Base class for every typed native handle: owns the raw `Box<T>` pointer
  * slot and its monitor. Subclasses add their type-specific `close()` /
  * `take()` / `freePtr`.
+ *
+ * Lifecycle is a tag bit: `Box` pointers are at least 2-aligned (asserted
+ * on the Rust side), so bit 0 is free — closing/consuming sets `ptr = p or 1`
+ * instead of zeroing. The address bits (`ptr and -2`) are therefore
+ * write-once for the object's whole lifetime, which is what makes them a
+ * sound lock-ordering key (a mutable key could reorder concurrent lock
+ * acquisition and deadlock). All `ptr` writes happen under this handle's
+ * monitor.
  */
 public abstract class NativeHandle(initialPtr: Long) : AutoCloseable {
     @Volatile internal var ptr: Long = initialPtr
 
-    public fun peek(): Long = ptr
+    /** The live pointer, or `0` if this handle is closed. */
+    public fun peek(): Long {
+        val p = ptr
+        return if (p == 0L || (p and 1L) != 0L) 0L else p
+    }
 
-    public fun isClosed(): Boolean = ptr == 0L
+    public fun isClosed(): Boolean = ptr == 0L || (ptr and 1L) != 0L
 }
 
 /**
- * Acquire every handle's monitor in one global order (sorted by raw
- * pointer) so concurrent calls touching the same handles can't deadlock,
- * then run [body]. Closed handles (`ptr == 0`) are still locked; callers
- * re-read and null-check each pointer inside [body]. Scales to any arity.
+ * Acquire every handle's monitor in one global order — sorted by the
+ * immutable address bits (`ptr and -2`; bit 0 is the closed tag and
+ * never participates) — so concurrent calls touching the same handles
+ * can't deadlock, then run [body]. The key never changes after
+ * construction: closing only sets bit 0, so a concurrent `close()`
+ * can't reorder anyone's acquisition. Closed handles are still locked;
+ * their tagged pointers are rejected by the Rust-side converter guard
+ * inside the native call. Scales to any arity.
  */
 internal fun <R> withSortedHandleLocks(handles: List<NativeHandle>, body: () -> R): R {
-    val sorted = handles.sortedBy { it.ptr }
+    val sorted = handles.sortedBy { it.ptr and -2L }
     fun rec(i: Int): R = if (i == sorted.size) body() else synchronized(sorted[i]) { rec(i + 1) }
     return rec(0)
 }
@@ -35,11 +51,11 @@ internal fun <R> withSortedHandleLocks(handles: List<NativeHandle>, body: () -> 
 /** Allocation-free single-handle lock (one monitor, nothing to order). */
 internal inline fun <R> withSortedHandleLocks(a: NativeHandle, body: () -> R): R = synchronized(a) { body() }
 
-/** Allocation-free two-handle lock: order by `ptr` then nest monitors. */
+/** Allocation-free two-handle lock: order by masked address then nest monitors. */
 internal inline fun <R> withSortedHandleLocks(a: NativeHandle, b: NativeHandle, body: () -> R): R {
     val first: NativeHandle
     val second: NativeHandle
-    if (a.ptr <= b.ptr) { first = a; second = b } else { first = b; second = a }
+    if ((a.ptr and -2L) <= (b.ptr and -2L)) { first = a; second = b } else { first = b; second = a }
     return synchronized(first) { synchronized(second) { body() } }
 }
 
@@ -53,9 +69,9 @@ internal inline fun <R> withSortedHandleLocks(
     var x = a
     var y = b
     var z = c
-    if (x.ptr > y.ptr) { val t = x; x = y; y = t }
-    if (y.ptr > z.ptr) { val t = y; y = z; z = t }
-    if (x.ptr > y.ptr) { val t = x; x = y; y = t }
+    if ((x.ptr and -2L) > (y.ptr and -2L)) { val t = x; x = y; y = t }
+    if ((y.ptr and -2L) > (z.ptr and -2L)) { val t = y; y = z; z = t }
+    if ((x.ptr and -2L) > (y.ptr and -2L)) { val t = x; x = y; y = t }
     return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }
 }
 
@@ -102,8 +118,8 @@ public class PayloadHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -111,7 +127,7 @@ public class PayloadHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): PayloadHandler {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return PayloadHandler(p)
     }
 
@@ -126,8 +142,8 @@ public class PayloadVecHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -135,7 +151,7 @@ public class PayloadVecHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): PayloadVecHandler {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return PayloadVecHandler(p)
     }
 
@@ -150,8 +166,8 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -159,13 +175,13 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): Storage {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return Storage(p)
     }
 
     /** Number of stored payloads (an **accessor** on `Storage`). */
     public fun len(onError: JniErrorHandler<Long>): Long {
-        if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
@@ -177,7 +193,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
 
     /** Whether any stored payload has the given id (a **method** on `Storage`). */
     public fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean {
-        if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
@@ -218,8 +234,8 @@ public class StorageHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -227,7 +243,7 @@ public class StorageHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): StorageHandler {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return StorageHandler(p)
     }
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -13,8 +13,8 @@ public class SummaryVault(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -22,7 +22,7 @@ public class SummaryVault(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): SummaryVault {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return SummaryVault(p)
     }
 
@@ -37,8 +37,8 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -46,13 +46,13 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): Summary {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return Summary(p)
     }
 
     /** Number of payloads (flatten-output **field** / **accessor**). */
     public fun count(onError: JniErrorHandler<Long>): Long {
-        if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
@@ -64,7 +64,7 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
 
     /** Sum of payload values (flatten-output **field** / **accessor**). */
     public fun total(onError: JniErrorHandler<Double>): Double {
-        if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
@@ -76,7 +76,7 @@ public class Summary(initialPtr: Long) : NativeHandle(initialPtr) {
 
     /** Total scaled by a factor (an instance **method**: `&Self` receiver + arg). */
     public fun scaled(factor: Double, onError: JniErrorHandler<Double>): Double {
-        if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
@@ -135,7 +135,7 @@ public fun <R> SummaryStorageSummaryFullBuilder<R>.asRaw(): SummaryStorageSummar
  */
 @Suppress("UNCHECKED_CAST")
 public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: SummaryBuilder<R>): R {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -160,8 +160,8 @@ public fun storageMatchesSummary(
     expected1: Summary?,
     onError: JniErrorHandler<Boolean>,
 ): Boolean {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
-    if (expected1 != null && expected1.ptr == 0L) return onError.run(
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
+    if (expected1 != null && expected1.isClosed()) return onError.run(
         "Operation on a closed native handle.",
     )
     val __cap = JniErrorHandlerCapture.acquire()
@@ -184,7 +184,7 @@ public fun storageMatchesSummary(
                     __cap,
                 )
             } finally {
-                expected1?.let { it.ptr = 0L }
+                expected1?.let { it.ptr = it.ptr or 1L }
             }
         }
     }
@@ -197,7 +197,7 @@ public fun storageMatchesSummary(
  * handle (per-fn **flatten-output-suppress**).
  */
 public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): Summary {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -212,14 +212,14 @@ public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): 
  * on the `Summary` parameter).
  */
 public fun summaryTotalRaw(s: Summary, onError: JniErrorHandler<Double>): Double {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         try {
             CovNative.summaryTotalRaw(s_ptr, __cap)
         } finally {
-            s.ptr = 0L
+            s.ptr = s.ptr or 1L
         }
     }
     if (__cap.failed) return onError.run(__cap.je)
@@ -238,7 +238,7 @@ public fun <R> storageSummaryFull(
     onError: JniErrorHandler<R>,
     build: SummaryStorageSummaryFullBuilder<R>,
 ): R {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -263,8 +263,8 @@ public fun storageExpectSummary(
     expected1: Summary?,
     onError: JniErrorHandler<Boolean>,
 ): Boolean {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
-    if (expected1 != null && expected1.ptr == 0L) return onError.run(
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
+    if (expected1 != null && expected1.isClosed()) return onError.run(
         "Operation on a closed native handle.",
     )
     val __cap = JniErrorHandlerCapture.acquire()
@@ -287,7 +287,7 @@ public fun storageExpectSummary(
                     __cap,
                 )
             } finally {
-                expected1?.let { it.ptr = 0L }
+                expected1?.let { it.ptr = it.ptr or 1L }
             }
         }
     }
@@ -316,8 +316,8 @@ public fun archiveStore(
     s1: Summary?,
     onError: JniErrorHandler<Unit>,
 ) {
-    if (a.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
-    if (s1 != null && s1.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (a.isClosed()) { onError.run("Operation on a closed native handle."); return }
+    if (s1 != null && s1.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     run {
         val __locks = ArrayList<NativeHandle>()
@@ -338,7 +338,7 @@ public fun archiveStore(
                     __cap,
                 )
             } finally {
-                s1?.let { it.ptr = 0L }
+                s1?.let { it.ptr = it.ptr or 1L }
             }
         }
     }
@@ -350,7 +350,7 @@ public fun archiveStore(
  * empty, otherwise cloned into a fresh owned handle by the JVM binding).
  */
 public fun archiveLatest(a: SummaryVault, onError: JniErrorHandler<Summary?>): Summary? {
-    if (a.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (a.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(a) {
         val a_ptr = a.ptr

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
@@ -12,8 +12,8 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -21,7 +21,7 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): StorageError {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return StorageError(p)
     }
 
@@ -30,7 +30,7 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
      * **accessor**, fed to `onError`).
      */
     public fun message(onError: JniErrorHandler<String>): String {
-        if (this.ptr == 0L) return onError.run("Operation on a closed native handle.")
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
@@ -40,7 +40,7 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -57,7 +57,7 @@ public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? 
  * (see `perftest-c`'s `.repr_c_struct(Payload)` — owned-ness is inferred from `label`).
  */
 public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -79,7 +79,7 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
  * The caller's payload is left untouched.
  */
 public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -101,7 +101,7 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
  * are the array-of-one case of this.
  */
 public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     val __vec_payloads = CovNative.payloadVecNew(payloads.size)
     try {
@@ -136,7 +136,7 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -174,8 +174,8 @@ public fun payloadHandlerNew(
  * reassembled on the Kotlin side — see `prebindgen::lang::JniGen`).
  */
 public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
-    if (handler.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
+    if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
@@ -212,8 +212,8 @@ public fun storageCallbackVec(
     handler: PayloadVecHandler,
     onError: JniErrorHandler<Unit>,
 ) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
-    if (handler.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
+    if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
@@ -283,7 +283,7 @@ public fun storageHandlerNew(
  * the handler's callback.
  */
 public fun storageEmit(n: Long, h: StorageHandler, onError: JniErrorHandler<Unit>) {
-    if (h.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (h.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(h) {
         val h_ptr = h.ptr
@@ -297,9 +297,9 @@ public fun storageEmit(n: Long, h: StorageHandler, onError: JniErrorHandler<Unit
  * generated wrapper must sort-lock all three).
  */
 public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniErrorHandler<Long>): Long {
-    if (a.ptr == 0L) return onError.run("Operation on a closed native handle.")
-    if (b.ptr == 0L) return onError.run("Operation on a closed native handle.")
-    if (c.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (a.isClosed()) return onError.run("Operation on a closed native handle.")
+    if (b.isClosed()) return onError.run("Operation on a closed native handle.")
+    if (c.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(a, b, c) {
         val a_ptr = a.ptr
@@ -316,7 +316,7 @@ public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniError
  * single-leaf string fold).
  */
 public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): List<String> {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -328,7 +328,7 @@ public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): Li
 
 /** Push `p` if present; whether it was pushed (`Option<data-class>` **input**). */
 public fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boolean>): Boolean {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -472,6 +472,66 @@ fun main() {
         listOf(s1, s2, s3, s4).forEach { it.close() }
     }
 
+    // ── close/take storm vs N-ary locking: lock-order stability + closed-race ─
+    // Regression test for prebindgen#35 (lock ordering keyed by a MUTABLE ptr:
+    // a concurrent close() moved a handle across the sort order, letting two
+    // threads acquire the same pair of monitors in opposite orders — AB/BA
+    // deadlock) and prebindgen#34 (a close between the wrapper's pre-lock guard
+    // and the native call passed a dead pointer into Rust — UB/SIGSEGV).
+    // Readers hammer the 3-handle storageTotalLen over a shared pool while
+    // stormers close()/take() the same handles and swap in fresh ones. With the
+    // tag-bit lifecycle the sort key (ptr and -2) is immutable, so no deadlock
+    // (watchdog); a closed handle racing a call must surface via onError as
+    // "closed native handle" — never a crash, never any other error.
+    section("close/take storm (lock-order stability + closed-handle race)") {
+        val slots = 4
+        val pool = java.util.concurrent.atomic.AtomicReferenceArray<Storage>(slots)
+        for (i in 0 until slots) pool.set(i, storageNew(boom))
+        val stop = java.util.concurrent.atomic.AtomicBoolean(false)
+        val closedRaces = AtomicInteger()
+        val unexpected = java.util.concurrent.atomic.AtomicReference<String?>(null)
+        val tolerant = JniErrorHandler<Long> { je ->
+            if (je != null && je.contains("closed native handle")) closedRaces.incrementAndGet()
+            else unexpected.compareAndSet(null, je ?: "je == null")
+            -1L
+        }
+        val readers = List(4) {
+            thread {
+                val rnd = java.util.concurrent.ThreadLocalRandom.current()
+                while (!stop.get()) {
+                    val a = pool.get(rnd.nextInt(slots))
+                    val b = pool.get(rnd.nextInt(slots))
+                    val c = pool.get(rnd.nextInt(slots))
+                    storageTotalLen(a, b, c, tolerant)
+                }
+            }
+        }
+        val stormers = List(2) {
+            thread {
+                val rnd = java.util.concurrent.ThreadLocalRandom.current()
+                repeat(3_000) { n ->
+                    val i = rnd.nextInt(slots)
+                    val old = pool.getAndSet(i, storageNew(boom))
+                    when (n % 3) {
+                        0 -> old.close()
+                        // take(): the twin shares the old handle's masked
+                        // address (an intentional sort-key tie) — the old
+                        // object is closed before the twin exists.
+                        1 -> old.take().close()
+                        else -> { old.close(); old.close() }   // idempotent
+                    }
+                }
+            }
+        }
+        stormers.forEach { it.join(60_000) }
+        stop.set(true)
+        readers.forEach { it.join(60_000) }
+        check((stormers + readers).none { it.isAlive }) { "deadlock: storm threads still alive" }
+        check(unexpected.get() == null) { "unexpected native error: ${unexpected.get()}" }
+        check(closedRaces.get() > 0) { "storm never observed a closed handle — test is not racing" }
+        for (i in 0 until slots) pool.get(i).close()
+    }
+
     // ── high-volume callback: per-upcall local-frame hygiene ─────────────────
     // 20k upcalls, half carrying a fresh String local each — leaked JNI local
     // refs (the historical daemon-thread OOM) would accumulate here.

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -81,10 +81,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_PayloadHandler_free
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::PayloadHandler));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::PayloadHandler>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_PayloadVecHandler_freePtr(
@@ -92,10 +97,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_PayloadVecHandler_f
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::PayloadVecHandler));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::PayloadVecHandler>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_StorageHandler_freePtr(
@@ -103,10 +113,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_StorageHandler_free
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::StorageHandler));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::StorageHandler>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_Storage_freePtr(
@@ -114,10 +129,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_Storage_freePtr(
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::Storage));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Storage>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_analytics_SummaryVault_freePtr(
@@ -125,10 +145,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_analytics_SummaryVa
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::Archive));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Archive>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_analytics_Summary_freePtr(
@@ -136,10 +161,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_analytics_Summary_f
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::Summary));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Summary>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_errors_StorageError_freePtr(
@@ -147,10 +177,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_errors_StorageError
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::StorageError));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::StorageError>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecFree(
@@ -1616,6 +1651,13 @@ pub(crate) unsafe fn jlong_to_Archive_cd73502c<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::Archive>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Archive) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1626,6 +1668,12 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     Ok({
         if *v == 0 {
             None
+        } else if (*v & 1) == 1 {
+            return ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from("Operation on a closed native handle.".to_string()),
+            );
         } else {
             Some(*std::boxed::Box::from_raw(*v as *mut perftest_flat::Summary))
         }
@@ -1636,6 +1684,13 @@ pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::PayloadHandler>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadHandler) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1643,6 +1698,13 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::PayloadVecHandler>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1650,6 +1712,13 @@ pub(crate) unsafe fn jlong_to_StorageError_26b2d298<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::StorageError>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::StorageError) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1657,6 +1726,13 @@ pub(crate) unsafe fn jlong_to_StorageHandler_3b4d3ed3<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::StorageHandler>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::StorageHandler) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1664,6 +1740,13 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::Storage>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Storage) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1671,6 +1754,13 @@ pub(crate) unsafe fn jlong_to_Summary_3cb103b9<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::Summary>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Summary) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -6376,6 +6466,19 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    if s == 0 || (s & 1) == 1 {
+        let __zd = __ze_defaults(&mut env);
+        signal_error(
+            &mut env,
+            &__error_sink,
+            &__SINK_MID,
+            __SINK_FQN,
+            __SINK_DESCR,
+            ::core::option::Option::Some("Operation on a closed native handle."),
+            &__zd,
+        );
+        return 0.0 as jni::sys::jdouble;
+    }
     let s: perftest_flat::Summary = unsafe {
         *std::boxed::Box::from_raw(s as *mut perftest_flat::Summary)
     };

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -5,23 +5,39 @@ package io.prebindgen.perftest
  * Base class for every typed native handle: owns the raw `Box<T>` pointer
  * slot and its monitor. Subclasses add their type-specific `close()` /
  * `take()` / `freePtr`.
+ *
+ * Lifecycle is a tag bit: `Box` pointers are at least 2-aligned (asserted
+ * on the Rust side), so bit 0 is free — closing/consuming sets `ptr = p or 1`
+ * instead of zeroing. The address bits (`ptr and -2`) are therefore
+ * write-once for the object's whole lifetime, which is what makes them a
+ * sound lock-ordering key (a mutable key could reorder concurrent lock
+ * acquisition and deadlock). All `ptr` writes happen under this handle's
+ * monitor.
  */
 public abstract class NativeHandle(initialPtr: Long) : AutoCloseable {
     @Volatile internal var ptr: Long = initialPtr
 
-    public fun peek(): Long = ptr
+    /** The live pointer, or `0` if this handle is closed. */
+    public fun peek(): Long {
+        val p = ptr
+        return if (p == 0L || (p and 1L) != 0L) 0L else p
+    }
 
-    public fun isClosed(): Boolean = ptr == 0L
+    public fun isClosed(): Boolean = ptr == 0L || (ptr and 1L) != 0L
 }
 
 /**
- * Acquire every handle's monitor in one global order (sorted by raw
- * pointer) so concurrent calls touching the same handles can't deadlock,
- * then run [body]. Closed handles (`ptr == 0`) are still locked; callers
- * re-read and null-check each pointer inside [body]. Scales to any arity.
+ * Acquire every handle's monitor in one global order — sorted by the
+ * immutable address bits (`ptr and -2`; bit 0 is the closed tag and
+ * never participates) — so concurrent calls touching the same handles
+ * can't deadlock, then run [body]. The key never changes after
+ * construction: closing only sets bit 0, so a concurrent `close()`
+ * can't reorder anyone's acquisition. Closed handles are still locked;
+ * their tagged pointers are rejected by the Rust-side converter guard
+ * inside the native call. Scales to any arity.
  */
 internal fun <R> withSortedHandleLocks(handles: List<NativeHandle>, body: () -> R): R {
-    val sorted = handles.sortedBy { it.ptr }
+    val sorted = handles.sortedBy { it.ptr and -2L }
     fun rec(i: Int): R = if (i == sorted.size) body() else synchronized(sorted[i]) { rec(i + 1) }
     return rec(0)
 }
@@ -29,11 +45,11 @@ internal fun <R> withSortedHandleLocks(handles: List<NativeHandle>, body: () -> 
 /** Allocation-free single-handle lock (one monitor, nothing to order). */
 internal inline fun <R> withSortedHandleLocks(a: NativeHandle, body: () -> R): R = synchronized(a) { body() }
 
-/** Allocation-free two-handle lock: order by `ptr` then nest monitors. */
+/** Allocation-free two-handle lock: order by masked address then nest monitors. */
 internal inline fun <R> withSortedHandleLocks(a: NativeHandle, b: NativeHandle, body: () -> R): R {
     val first: NativeHandle
     val second: NativeHandle
-    if (a.ptr <= b.ptr) { first = a; second = b } else { first = b; second = a }
+    if ((a.ptr and -2L) <= (b.ptr and -2L)) { first = a; second = b } else { first = b; second = a }
     return synchronized(first) { synchronized(second) { body() } }
 }
 
@@ -47,9 +63,9 @@ internal inline fun <R> withSortedHandleLocks(
     var x = a
     var y = b
     var z = c
-    if (x.ptr > y.ptr) { val t = x; x = y; y = t }
-    if (y.ptr > z.ptr) { val t = y; y = z; z = t }
-    if (x.ptr > y.ptr) { val t = x; x = y; y = t }
+    if ((x.ptr and -2L) > (y.ptr and -2L)) { val t = x; x = y; y = t }
+    if ((y.ptr and -2L) > (z.ptr and -2L)) { val t = y; y = z; z = t }
+    if ((x.ptr and -2L) > (y.ptr and -2L)) { val t = x; x = y; y = t }
     return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }
 }
 
@@ -77,8 +93,8 @@ public class PayloadHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -86,7 +102,7 @@ public class PayloadHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): PayloadHandler {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return PayloadHandler(p)
     }
 
@@ -101,8 +117,8 @@ public class PayloadVecHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -110,7 +126,7 @@ public class PayloadVecHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): PayloadVecHandler {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return PayloadVecHandler(p)
     }
 
@@ -125,8 +141,8 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     override fun close() {
         val p = ptr
-        if (p != 0L) {
-            ptr = 0L
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
             freePtr(p)
         }
     }
@@ -134,7 +150,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
     public fun take(): Storage {
         val p = ptr
-        ptr = 0L
+        ptr = p or 1L
         return Storage(p)
     }
 

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
@@ -33,7 +33,7 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -50,7 +50,7 @@ public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? 
  * (see `perftest-c`'s `.repr_c_struct(Payload)` — owned-ness is inferred from `label`).
  */
 public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -72,7 +72,7 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
  * The caller's payload is left untouched.
  */
 public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -117,8 +117,8 @@ public fun payloadHandlerNew(
  * reassembled on the Kotlin side — see `prebindgen::lang::JniGen`).
  */
 public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
-    if (handler.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
+    if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
@@ -133,7 +133,7 @@ public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErro
  * are the array-of-one case of this.
  */
 public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     val __vec_payloads = JNINative.payloadVecNew(payloads.size)
     try {
@@ -168,7 +168,7 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
-    if (s.ptr == 0L) return onError.run("Operation on a closed native handle.")
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __cap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
@@ -205,8 +205,8 @@ public fun storageCallbackVec(
     handler: PayloadVecHandler,
     onError: JniErrorHandler<Unit>,
 ) {
-    if (s.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
-    if (handler.ptr == 0L) { onError.run("Operation on a closed native handle."); return }
+    if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
+    if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
     val __cap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -81,10 +81,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_PayloadHandler_freeP
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::PayloadHandler));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::PayloadHandler>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_PayloadVecHandler_freePtr(
@@ -92,10 +97,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_PayloadVecHandler_fr
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::PayloadVecHandler));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::PayloadVecHandler>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_Storage_freePtr(
@@ -103,10 +113,15 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_Storage_freePtr(
     _class: jni::objects::JClass,
     ptr: jni::sys::jlong,
 ) {
-    if ptr != 0 {
+    if ptr != 0 && (ptr & 1) == 0 {
         drop(Box::from_raw(ptr as *mut perftest_flat::Storage));
     }
 }
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Storage>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadVecFree(
@@ -968,6 +983,13 @@ pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::PayloadHandler>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadHandler) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -975,6 +997,13 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::PayloadVecHandler>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -982,6 +1011,13 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<OwnedObject<perftest_flat::Storage>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Storage) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -141,7 +141,7 @@ fn typed_handle_subclass_with_ctor_args_supertype() {
                 .annotation("Synchronized")
                 .modifier("override")
                 .body(Code::new().blk("if (ptr != 0L) {", |c| {
-                    c.line("freePtr(ptr)").line("ptr = 0L")
+                    c.line("freePtr(ptr)").line("ptr = ptr or 1L")
                 })),
         )
         .companion(
@@ -161,7 +161,7 @@ public class ZThing(initialPtr: Long) : NativeHandle(initialPtr) {
     override fun close() {
         if (ptr != 0L) {
             freePtr(ptr)
-            ptr = 0L
+            ptr = ptr or 1L
         }
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -64,6 +64,16 @@ pub(crate) fn struct_input_body(
                         quote! { let #fname_ident = #field_conv(env, &#raw_ident)?; }
                     } else {
                         quote! {
+                            // Null or closed handle in a required field —
+                            // reject before any dereference (`peek()`
+                            // normalizes closed handles to 0).
+                            if #raw_ident == 0 || (#raw_ident & 1) == 1 {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<String>>::from(
+                                        "Operation on a closed native handle.".to_string(),
+                                    ),
+                                );
+                            }
                             let #fname_ident: #field_ty = unsafe {
                                 *std::boxed::Box::from_raw(#raw_ident as *mut #field_ty)
                             };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -595,20 +595,25 @@ fn emit_input_param(
 
     // By-value `T` opaque-handle parameter: emit the consume
     // converter inline, bypassing `OwnedObject`. The Java side
-    // takes the pointer out of its `NativeHandle.consume` under
-    // the write lock and passes it here; `Box::from_raw`
-    // reconstructs the unique owner and `*box` moves `T` out,
-    // dropping the heap allocation. The unique-ownership
-    // invariant is upheld by `NativeHandle.consume` (write-lock
-    // + atomic pointer take), which drains all in-flight borrows
-    // and ensures no live borrow can outlive this point. No
-    // `T: Clone` bound, so non-Clone handles (e.g. `Publisher<'a>`)
-    // work too. This decode is infallible — no `match` needed.
+    // holds the handle's monitor and passes the pointer here;
+    // `Box::from_raw` reconstructs the unique owner and `*box`
+    // moves `T` out, dropping the heap allocation. The
+    // unique-ownership invariant is upheld by the Kotlin wrapper
+    // (monitor + tag-bit close in `finally`), which ensures the
+    // same live pointer cannot be passed twice. No `T: Clone`
+    // bound, so non-Clone handles (e.g. `Publisher<'a>`) work too.
+    // A null or tagged (closed) pointer — a close that raced past
+    // the pre-lock guard — is rejected before any dereference.
     let is_consume =
         !matches!(arg_ty, syn::Type::Reference(_)) && entry.metadata.is_direct_handle();
     if is_consume {
         wire_params.push(quote!(#wire_ident: jni::sys::jlong));
         prelude.push(quote!(
+            if #wire_ident == 0 || (#wire_ident & 1) == 1 {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some("Operation on a closed native handle."), &__zd);
+                return #on_err;
+            }
             let #arg_ident: #arg_ty = unsafe {
                 *std::boxed::Box::from_raw(#wire_ident as *mut #arg_ty)
             };
@@ -774,13 +779,19 @@ pub(crate) fn emit_expanded_param(
         }
 
         // Direct owned-handle leaf (e.g. an identity-variant `T`): consume the
-        // jlong handle inline, mirroring the normal by-value-handle path.
+        // jlong handle inline, mirroring the normal by-value-handle path —
+        // including its null/tagged (closed) pointer guard.
         let is_consume =
             !matches!(leaf_ty, syn::Type::Reference(_)) && entry.metadata.is_direct_handle();
         if is_consume {
             let wire_ident = format_ident!("{}_ptr", leaf.name);
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
             prelude.push(quote!(
+                if #wire_ident == 0 || (#wire_ident & 1) == 1 {
+                    let __zd = __ze_defaults(&mut env);
+                    signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some("Operation on a closed native handle."), &__zd);
+                    return #on_err;
+                }
                 let #local: #leaf_ty = unsafe {
                     *std::boxed::Box::from_raw(#wire_ident as *mut #leaf_ty)
                 };

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -124,7 +124,15 @@ impl JniGen {
                 .kdoc(
                     "Base class for every typed native handle: owns the raw `Box<T>` pointer\n\
                      slot and its monitor. Subclasses add their type-specific `close()` /\n\
-                     `take()` / `freePtr`.",
+                     `take()` / `freePtr`.\n\
+                     \n\
+                     Lifecycle is a tag bit: `Box` pointers are at least 2-aligned (asserted\n\
+                     on the Rust side), so bit 0 is free — closing/consuming sets `ptr = p or 1`\n\
+                     instead of zeroing. The address bits (`ptr and -2`) are therefore\n\
+                     write-once for the object's whole lifetime, which is what makes them a\n\
+                     sound lock-ordering key (a mutable key could reorder concurrent lock\n\
+                     acquisition and deadlock). All `ptr` writes happen under this handle's\n\
+                     monitor.",
                 )
                 .ctor_param(KtCtorParam::new("initialPtr", KtType::long()))
                 .supertype(KtType::cls("AutoCloseable"), None)
@@ -138,14 +146,19 @@ impl JniGen {
                 .member(
                     KtFun::new("peek")
                         .vis(Vis::Public)
+                        .kdoc("The live pointer, or `0` if this handle is closed.")
                         .returns(KtType::long())
-                        .expr_body(Code::new().line("ptr")),
+                        .body(
+                            Code::new()
+                                .line("val p = ptr")
+                                .line("return if (p == 0L || (p and 1L) != 0L) 0L else p"),
+                        ),
                 )
                 .member(
                     KtFun::new("isClosed")
                         .vis(Vis::Public)
                         .returns(KtType::boolean())
-                        .expr_body(Code::new().line("ptr == 0L")),
+                        .expr_body(Code::new().line("ptr == 0L || (ptr and 1L) != 0L")),
                 ),
         );
 
@@ -157,10 +170,14 @@ impl JniGen {
                 KtFun::new("withSortedHandleLocks")
                     .vis(Vis::Internal)
                     .kdoc(
-                        "Acquire every handle's monitor in one global order (sorted by raw\n\
-                         pointer) so concurrent calls touching the same handles can't deadlock,\n\
-                         then run [body]. Closed handles (`ptr == 0`) are still locked; callers\n\
-                         re-read and null-check each pointer inside [body]. Scales to any arity.",
+                        "Acquire every handle's monitor in one global order — sorted by the\n\
+                         immutable address bits (`ptr and -2`; bit 0 is the closed tag and\n\
+                         never participates) — so concurrent calls touching the same handles\n\
+                         can't deadlock, then run [body]. The key never changes after\n\
+                         construction: closing only sets bit 0, so a concurrent `close()`\n\
+                         can't reorder anyone's acquisition. Closed handles are still locked;\n\
+                         their tagged pointers are rejected by the Rust-side converter guard\n\
+                         inside the native call. Scales to any arity.",
                     )
                     .generic("R")
                     .param(KtParam::new(
@@ -171,7 +188,7 @@ impl JniGen {
                     .returns(KtType::var_r())
                     .body(
                         Code::new()
-                            .line("val sorted = handles.sortedBy { it.ptr }")
+                            .line("val sorted = handles.sortedBy { it.ptr and -2L }")
                             .line("fun rec(i: Int): R = if (i == sorted.size) body() else synchronized(sorted[i]) { rec(i + 1) }")
                             .line("return rec(0)"),
                     ),
@@ -180,9 +197,10 @@ impl JniGen {
             // statically-known, non-null handles). `inline` folds both the
             // helper and [body] into the call site — no `ArrayList`, no
             // `sortedBy`, no recursion, no lambda object. The ordering key is
-            // `ptr` ascending, IDENTICAL to the `List` overload above, so the
-            // global lock order is consistent whichever overload a wrapper
-            // uses — deadlock-freedom is preserved even across paths.
+            // the masked address bits (`ptr and -2L`) ascending, IDENTICAL to
+            // the `List` overload above, so the global lock order is
+            // consistent whichever overload a wrapper uses — deadlock-freedom
+            // is preserved even across paths.
             file = file
                 .decl(
                     KtFun::new("withSortedHandleLocks")
@@ -199,7 +217,7 @@ impl JniGen {
                     KtFun::new("withSortedHandleLocks")
                         .vis(Vis::Internal)
                         .modifier("inline")
-                        .kdoc("Allocation-free two-handle lock: order by `ptr` then nest monitors.")
+                        .kdoc("Allocation-free two-handle lock: order by masked address then nest monitors.")
                         .generic("R")
                         .param(KtParam::new("a", handle_ty.clone()))
                         .param(KtParam::new("b", handle_ty.clone()))
@@ -209,7 +227,7 @@ impl JniGen {
                             Code::new()
                                 .line("val first: NativeHandle")
                                 .line("val second: NativeHandle")
-                                .line("if (a.ptr <= b.ptr) { first = a; second = b } else { first = b; second = a }")
+                                .line("if ((a.ptr and -2L) <= (b.ptr and -2L)) { first = a; second = b } else { first = b; second = a }")
                                 .line("return synchronized(first) { synchronized(second) { body() } }"),
                         ),
                 )
@@ -229,9 +247,9 @@ impl JniGen {
                                 .line("var x = a")
                                 .line("var y = b")
                                 .line("var z = c")
-                                .line("if (x.ptr > y.ptr) { val t = x; x = y; y = t }")
-                                .line("if (y.ptr > z.ptr) { val t = y; y = z; z = t }")
-                                .line("if (x.ptr > y.ptr) { val t = x; x = y; y = t }")
+                                .line("if ((x.ptr and -2L) > (y.ptr and -2L)) { val t = x; x = y; y = t }")
+                                .line("if ((y.ptr and -2L) > (z.ptr and -2L)) { val t = y; y = z; z = t }")
+                                .line("if ((x.ptr and -2L) > (y.ptr and -2L)) { val t = x; x = y; y = t }")
                                 .line("return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }"),
                         ),
                 );

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -317,8 +317,8 @@ pub(crate) fn build_typed_handle(
                 .body(
                     kt::Code::new()
                         .line("val p = ptr")
-                        .blk("if (p != 0L) {", |c| {
-                            c.line("ptr = 0L").line(format!("{free_extern}(p)"))
+                        .blk("if (p != 0L && (p and 1L) == 0L) {", |c| {
+                            c.line("ptr = p or 1L").line(format!("{free_extern}(p)"))
                         }),
                 ),
         )
@@ -334,7 +334,7 @@ pub(crate) fn build_typed_handle(
                 .body(
                     kt::Code::new()
                         .line("val p = ptr")
-                        .line("ptr = 0L")
+                        .line("ptr = p or 1L")
                         .line(format!("return {class_name}(p)")),
                 ),
         )
@@ -650,8 +650,10 @@ struct Opaque {
     name: String,
     /// Object to synchronize on and read the pointer from (`<name>`).
     target: String,
-    /// Statement that nulls the pointer slot after consume (`"<target>.ptr =
-    /// 0L"`), or `None` for borrow modes.
+    /// Statement that marks the pointer slot closed after consume by setting
+    /// the tag bit (`"<target>.ptr = <target>.ptr or 1L"` — the address bits
+    /// stay put so the lock-ordering key never changes), or `None` for
+    /// borrow modes.
     consume_null: Option<String>,
     /// `true` for `Option<&T>` — nullable param, branches before lock.
     nullable: bool,
@@ -1457,14 +1459,14 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
                 ParamMode::Borrow => (p.kt_name.clone(), None, false),
                 ParamMode::Consume => (
                     p.kt_name.clone(),
-                    Some(format!("{}.ptr = 0L", p.kt_name)),
+                    Some(format!("{n}.ptr = {n}.ptr or 1L", n = p.kt_name)),
                     false,
                 ),
                 ParamMode::BorrowNullable => (p.kt_name.clone(), None, true),
-                // Nullable consume: null the slot only when present (null-safe).
+                // Nullable consume: tag the slot only when present (null-safe).
                 ParamMode::ConsumeNullable => (
                     p.kt_name.clone(),
-                    Some(format!("{n}?.let {{ it.ptr = 0L }}", n = p.kt_name)),
+                    Some(format!("{n}?.let {{ it.ptr = it.ptr or 1L }}", n = p.kt_name)),
                     true,
                 ),
                 _ => return None,
@@ -1561,15 +1563,18 @@ fn error_sink_parts(
     })
 }
 
-/// Pre-lock closed-handle guards: a racy-but-safe `ptr == 0L` check before the
-/// lock, returning `onError.run(...)` (function-level return; no throw).
+/// Pre-lock closed-handle guards: a racy-but-safe `isClosed()` check before
+/// the lock, returning `onError.run(...)` (function-level return; no throw).
+/// Racy: a close between this check and the native call is caught by the
+/// Rust-side converter guard (the tag bit survives the race), which routes
+/// through the same error channel.
 fn render_prelock_guards(opaques: &[Opaque], guard_args: &str, is_unit: bool) -> kt::Code {
     let mut guards = kt::Code::new();
     for o in opaques {
         let cond = if o.nullable {
-            format!("{n} != null && {t}.ptr == 0L", n = o.name, t = o.target)
+            format!("{n} != null && {t}.isClosed()", n = o.name, t = o.target)
         } else {
-            format!("{t}.ptr == 0L", t = o.target)
+            format!("{t}.isClosed()", t = o.target)
         };
         guards = if is_unit {
             guards.wline(format!(
@@ -1614,7 +1619,10 @@ fn render_core_stmt(
     bind: &str,
 ) -> kt::Code {
     // Under-lock pointer reads. The closed-handle check is done pre-lock
-    // (`prelock_guards`, → `onError`); these just bind the ptr the call passes.
+    // (`prelock_guards`, → `onError`); these just bind the ptr the call
+    // passes. A handle closed after the guard carries the tag bit (odd
+    // value), which the Rust-side converter guard rejects — never
+    // dereferenced.
     let mut ptr_binds = kt::Code::new();
     for o in opaques {
         ptr_binds = if o.nullable {

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1466,7 +1466,10 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
                 // Nullable consume: tag the slot only when present (null-safe).
                 ParamMode::ConsumeNullable => (
                     p.kt_name.clone(),
-                    Some(format!("{n}?.let {{ it.ptr = it.ptr or 1L }}", n = p.kt_name)),
+                    Some(format!(
+                        "{n}?.let {{ it.ptr = it.ptr or 1L }}",
+                        n = p.kt_name
+                    )),
                     true,
                 ),
                 _ => return None,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -87,6 +87,15 @@ fn snapshot_rust_side() {
     // Opaque handle round-trips as a boxed pointer of the source type.
     assert!(rc.contains("myflat::ZThing"), "{rust}");
     assert!(rc.contains("Box::from_raw"), "{rust}");
+    // Handle-input converters reject null AND tag-bit-set (closed) pointers
+    // before any dereference — the #34 guard; bit 0 is the Kotlin closed tag.
+    assert!(rc.contains("if*v==0||(*v&1)==1"), "{rust}");
+    // Every opaque type carries the compile-time alignment floor that keeps
+    // bit 0 free for the closed tag (source-module-qualified: the check is
+    // real AST, so it rides the `qualify_item` pass).
+    assert!(rc.contains("align_of::<myflat::ZThing>()<2"), "{rust}");
+    // The freePtr destructor ignores tagged (already-closed) pointers.
+    assert!(rc.contains("ifptr!=0&&(ptr&1)==0"), "{rust}");
     // Errors funnel to the single `signal_error` channel fn (no JVM throw); it
     // now invokes the error callback with `(je, ze…)`.
     assert!(rc.contains("fnsignal_error"), "{rust}");
@@ -133,6 +142,14 @@ fn snapshot_kotlin_side() {
     assert!(!nhc.contains("funinterfaceErrorSink"), "{nh}");
     assert!(!nhc.contains("ZException"), "{nh}");
 
+    // Tag-bit lifecycle: closed = bit 0 set (or the 0 sentinel); the lock
+    // ordering key is the immutable masked address, never the live `ptr`
+    // (a mutable key could invert concurrent lock order → deadlock, #35).
+    assert!(nhc.contains("ptr==0L||(ptrand1L)!=0L"), "{nh}");
+    assert!(nhc.contains("sortedBy{it.ptrand-2L}"), "{nh}");
+    assert!(nhc.contains("(a.ptrand-2L)<=(b.ptrand-2L)"), "{nh}");
+    assert!(!nhc.contains("sortedBy{it.ptr}"), "{nh}");
+
     let nativec: String = native.split_whitespace().collect();
     assert!(nativec.contains("externalfun"), "{native}");
     // Each extern declares the trailing `errorSink: Any` param.
@@ -149,13 +166,12 @@ fn snapshot_kotlin_side() {
 
     // Typed handle subclass of NativeHandle.
     let thing = find("class ZThing(");
-    assert!(
-        thing
-            .split_whitespace()
-            .collect::<String>()
-            .contains(":NativeHandle"),
-        "{thing}"
-    );
+    let thingc: String = thing.split_whitespace().collect();
+    assert!(thingc.contains(":NativeHandle"), "{thing}");
+    // close()/take() mark the handle closed by setting the tag bit — the
+    // address bits (= the lock-ordering key) are never rewritten.
+    assert!(thingc.contains("ptr=por1L"), "{thing}");
+    assert!(!thingc.contains("ptr=0L"), "{thing}");
 
     // The free-function wrappers live in the namespace package object, take a
     // trailing `onError` callback, and call it on failure (no throw).
@@ -175,6 +191,9 @@ fn snapshot_kotlin_side() {
         pc.contains("if(__cap.failed)returnonError.run("),
         "package wrappers: {pkg}"
     );
+    // Pre-lock closed guards go through `isClosed()` (tag-bit aware), not a
+    // raw `ptr == 0L` compare.
+    assert!(pc.contains(".isClosed())returnonError.run("), "{pkg}");
     // `onError` is a **required** parameter (no default) and the wrappers
     // never throw — error surfacing is entirely the caller's business.
     assert!(

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -182,10 +182,15 @@ impl JniGen {
     /// * Output: `Box::into_raw(Box::new(v)) as i64` — leak the heap
     ///   allocation to Java; sole owner is whoever later calls
     ///   `Box::from_raw` on the same pointer.
-    /// * Input: `OwnedObject::from_raw(*v as *const T)` (borrow only).
+    /// * Input: `OwnedObject::from_raw(*v as *const T)` (borrow only),
+    ///   after rejecting null and tag-bit-set values — bit 0 is the
+    ///   Kotlin-side closed tag (see `NativeHandle`), so an odd `jlong`
+    ///   is a handle that was closed after the wrapper's pre-lock guard;
+    ///   it must never be dereferenced.
     /// * Niche: `0i64` / `*v == 0` — `Box::into_raw` never returns 0,
     ///   so `Option<T>` automatically synthesises `0` = `None`,
     ///   matching the legacy "null pointer" ABI for nullable handles.
+    ///   A *tagged* (closed-but-present) value is an error, not `None`.
     pub fn opaque_handle_input(&self, ty: &syn::Type) -> ConverterImpl<KotlinMeta> {
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
         let name = input_name(ty, &wire);
@@ -195,6 +200,15 @@ impl JniGen {
                 env: &mut jni::JNIEnv<'env>,
                 v: &jni::sys::jlong,
             ) -> ::core::result::Result<OwnedObject<#ty>, __JniErr> {
+                // Null or tag-bit-set (closed handle raced past the Kotlin
+                // pre-lock guard) — reject before any dereference.
+                if *v == 0 || (*v & 1) == 1 {
+                    return ::core::result::Result::Err(
+                        <__JniErr as ::core::convert::From<String>>::from(
+                            "Operation on a closed native handle.".to_string(),
+                        ),
+                    );
+                }
                 Ok(unsafe { OwnedObject::from_raw(*v as *const #ty) })
             }
         );
@@ -484,6 +498,21 @@ pub(crate) fn build_handle_destructor_items(
             format!("Java_{class_pkg}_{class_short}_{free_ptr}")
         };
         let ident = syn::Ident::new(&symbol, Span::call_site());
+        // Bit 0 of the jlong is the Kotlin-side closed tag, so every handle
+        // type must leave it free: `Box` pointers to `T` are `align_of::<T>()`
+        // aligned, hence the compile-time floor of 2. Spelled as an `if` +
+        // `panic!` (not `assert!`) so the type reference is real AST — the
+        // `qualify_item` pass does not descend into macro token streams.
+        let item: syn::Item = syn::parse_quote!(
+            const _: () = {
+                if ::core::mem::align_of::<#ty>() < 2 {
+                    panic!(
+                        "opaque handle types must have alignment >= 2 (bit 0 is the closed tag)"
+                    );
+                }
+            };
+        );
+        named.push((format!("{symbol}__align_assert"), item));
         let item: syn::Item = syn::parse_quote!(
             #[no_mangle]
             #[allow(non_snake_case, unused_variables)]
@@ -492,7 +521,7 @@ pub(crate) fn build_handle_destructor_items(
                 _class: jni::objects::JClass,
                 ptr: jni::sys::jlong,
             ) {
-                if ptr != 0 {
+                if ptr != 0 && (ptr & 1) == 0 {
                     drop(Box::from_raw(ptr as *mut #ty));
                 }
             }
@@ -700,6 +729,15 @@ impl JniGen {
                         Ok({
                             if *v == 0 {
                                 None
+                            } else if (*v & 1) == 1 {
+                                // Tagged (closed) handle raced past the Kotlin
+                                // pre-lock guard — present-but-closed is an
+                                // error, absent is None.
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<String>>::from(
+                                        "Operation on a closed native handle.".to_string(),
+                                    ),
+                                );
                             } else {
                                 Some(*std::boxed::Box::from_raw(*v as *mut #t1))
                             }


### PR DESCRIPTION
Fixes #34, #35 — the two P0s from the 2026-07-14 JniGen API review, as one lifecycle redesign.

## Design: tag-bit closed state

Closed state moves into **bit 0 of `NativeHandle.ptr`**: `close()`, `take()`, and every consuming wrapper's `finally` set `ptr = p or 1L` instead of zeroing. The address bits are therefore **write-once** for the object's lifetime:

- **#35 (lock-order inversion)**: the N-ary lock ordering key becomes the masked address `ptr and -2L` — immutable per object, in all three lock paths (list `sortedBy`, 2-arity, 3-arity network). A concurrent `close()` only sets bit 0 and can't move any handle across the sort order. (The original issue's premise needed one correction: the flaw was the key's *mutability*, not pointer-ness — and the mutation fired on **every consuming call** via `ParamMode::Consume`, not just close/take. Pointer-derived ordering survives once the key is frozen.)
- **#34 (closed-race UB)**: a handle closed between the pre-lock guard and the native call now carries an *odd* pointer instead of a 0 that the nullable niche can't distinguish from "absent". Every Rust path that dereferenced a raw `jlong` — required borrow converter, by-value consume prelude, owned-handle expansion leaves, required data-class handle fields (the last one also fixes a pre-existing `Box::from_raw(0)` null-deref) — rejects `*v == 0 || (*v & 1) == 1` and routes `"Operation on a closed native handle."` through the normal `onError` channel. `Option`-consume keeps `0` = `None` but treats tagged as present-but-closed = error. `freePtr` ignores tagged pointers.

Bit 0 is guaranteed free by a generated per-opaque compile-time check `align_of::<T>() >= 2`, spelled as `const _: () = { if … { panic!() } }` rather than `assert!` — the `qualify_item` pass doesn't descend into macro token streams, so a type inside `assert!` would stay unqualified.

Kotlin surface: `isClosed()` = `ptr == 0L || (ptr and 1L) != 0L`; `peek()` normalizes closed → `0` (single volatile read); pre-lock guards use `isClosed()`; kdocs state the real contract (the "callers re-read and null-check inside body" claim from #34's evidence is gone).

Documented residual caveat (in the `NativeHandle` kdoc): sort-key ties exist only between same-address twins (`take()`, allocator address reuse); the older twin is durably closed before the newer exists, so tied pairs can't be locked together in correctly synchronized programs. A construction-counter id would make ties structurally impossible at the cost of an extra field per handle; rejected in favor of zero-cost pointer semantics.

## Tests

- **covertest-kotlin storm section** (acceptance for both issues): 4 reader threads hammering the 3-handle `storageTotalLen` over a shared `AtomicReferenceArray` pool while 2 stormers `close()` / `take().close()` / double-`close()` and swap in fresh handles, 60 s watchdog. No deadlock, no crash; closed-during-call races observed (asserted > 0) and all surfaced via `onError`. `take().close()` deliberately manufactures masked-key ties.
- Generator snapshot tests pin the tagged close/take, masked comparators, `isClosed()` guards, Rust converter guards (`if*v==0||(*v&1)==1`), the align check, and tagged-aware `freePtr`.
- `cargo test --all --all-features` green (237 lib tests); regeneration byte-deterministic; committed goldens regenerated (covertest + perftest; cbindgen output untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
