### PR TITLE
jnigen: hard-error on FunctionDecl decorations that .variant()/.field() can't honor

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -330,7 +330,20 @@ impl ExpandParamDecl {
     /// gives every function taking a `KeyExpr` a String-carrying arm —
     /// as a selector + nullable slot at the wire tier (see the type-level
     /// docs for the exact generated shape), not as a Kotlin overload.
+    ///
+    /// A variant arm only *names* the constructor: no Kotlin surface of its
+    /// own, so a decorated `fun!` (`.name()` / expand overrides) is a hard
+    /// error rather than a silent discard.
     pub fn variant(mut self, ctor: FunctionDecl) -> Self {
+        assert!(
+            ctor.kotlin_name_override.is_none()
+                && ctor.param_expands.is_empty()
+                && ctor.return_expand.is_none(),
+            "expand_param!({}).variant(fun!({})): a variant arm only names the \
+             `#[prebindgen]` constructor — .name()/expand overrides don't apply",
+            self.key.as_str(),
+            ctor.rust_ident
+        );
         self.variants.push(LocalVariant::Ctor(ctor.rust_ident));
         self
     }
@@ -391,7 +404,19 @@ impl ExpandReturnDecl {
     /// same function is declared via [`PtrClassDecl::fun`] on this type (so a
     /// getter that is both a method and a field is named once); else the
     /// camel-cased Rust name.
+    ///
+    /// Only the accessor's name is used here: expand overrides on the `fun!`
+    /// are a hard error rather than a silent discard (the field's own
+    /// decomposition comes from ITS type's boundary decl, not from the
+    /// accessor).
     pub fn field(mut self, accessor: FunctionDecl) -> Self {
+        assert!(
+            accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
+            "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
+             field accessor — only .name() is honored",
+            self.key.as_str(),
+            accessor.rust_ident
+        );
         self.fields.push(LocalField::Named(
             accessor.rust_ident,
             accessor.kotlin_name_override,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -659,6 +659,41 @@ fn ignore_const_with_source_rejected() {
     );
 }
 
+/// A `.variant()` arm only names its constructor — a `.name()` decoration
+/// has no surface to land on and is rejected at decl time (was a silent
+/// discard).
+#[test]
+#[should_panic(expected = ".name()/expand overrides don't apply")]
+fn expand_param_variant_with_name_rejected() {
+    let _ = crate::expand_param!(ZThing).variant(crate::fun!(z_thing_new).name("thing"));
+}
+
+/// Same for expand overrides on a variant constructor.
+#[test]
+#[should_panic(expected = ".name()/expand overrides don't apply")]
+fn expand_param_variant_with_expand_override_rejected() {
+    let _ = crate::expand_param!(ZThing).variant(
+        crate::fun!(z_thing_new).expand_return(crate::expand_return!(ZName).field_self()),
+    );
+}
+
+/// A `.field()` accessor honors `.name()` but nothing else — expand
+/// overrides are rejected at decl time (was a silent discard).
+#[test]
+#[should_panic(expected = "only .name() is honored")]
+fn expand_return_field_with_expand_override_rejected() {
+    let _ = crate::expand_return!(ZThing).field(
+        crate::fun!(z_thing_name).expand_param("v", crate::expand_param!(ZName).variant_self()),
+    );
+}
+
+/// Positive pin for the asymmetry: `.name()` on a `.field()` accessor is
+/// the documented way to name the field — still accepted.
+#[test]
+fn expand_return_field_with_name_accepted() {
+    let _ = crate::expand_return!(ZThing).field(crate::fun!(z_thing_name).name("label"));
+}
+
 /// N5: a `.fun()` member whose target has no parameter of the class type
 /// is a hard `AdapterInvariant` error at resolve — previously it silently
 /// emitted a method that ignored `this`.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -672,9 +672,8 @@ fn expand_param_variant_with_name_rejected() {
 #[test]
 #[should_panic(expected = ".name()/expand overrides don't apply")]
 fn expand_param_variant_with_expand_override_rejected() {
-    let _ = crate::expand_param!(ZThing).variant(
-        crate::fun!(z_thing_new).expand_return(crate::expand_return!(ZName).field_self()),
-    );
+    let _ = crate::expand_param!(ZThing)
+        .variant(crate::fun!(z_thing_new).expand_return(crate::expand_return!(ZName).field_self()));
 }
 
 /// A `.field()` accessor honors `.name()` but nothing else — expand


### PR DESCRIPTION
Fixes #36 (P1 from the 2026-07-14 JniGen API review).

## One policy for decorated `fun!` in non-honoring positions

The builder had three policies when a decorated `FunctionDecl` reached a position that can't honor the decoration: silent full discard (`ExpandParamDecl::variant` kept only `rust_ident`), silent partial discard (`ExpandReturnDecl::field` used `.name()`, dropped expand overrides), and hard error (`ConstDecl::fun`, `ConvertDecl::plain_fn_ident`, `IgnoreDecl`). This PR unifies on the hard-error policy, at decl-construction time, in the established message style:

- `expand_param!(T).variant(fun!(c).name("x"))` / `…expand_*` overrides → panic: *"a variant arm only names the `#[prebindgen]` constructor — .name()/expand overrides don't apply"*. A variant arm has no Kotlin surface of its own (wire slots are named from the parameter), so nothing could honor the decoration.
- `expand_return!(T).field(fun!(a).expand_*…)` → panic: *"expand overrides don't apply to a field accessor — only .name() is honored"*. `.name()` remains the documented way to name the field (unchanged).

Asserting in `variant()`/`field()` covers both scopes with one implementation: the type-level `JniGen::expand(...)` defaults and the per-function `FunctionDecl::expand_param`/`expand_return` overrides consume the same decl objects.

## Tests / safety

- Per the issue's acceptance: one `should_panic` unit test per rejected decoration shape (variant+name, variant+expand, field+expand), each message naming the decl and the unusable decoration, plus a positive pin that `field(fun!(...).name(...))` stays accepted.
- `cargo test -p prebindgen --lib`: 241 passed.
- `examples/regen-check.sh`: byte-identical — the change only rejects previously-silent misuse. All committed consumers (examples + zenoh-flat-jni) use bare variant ctors and name-only field accessors, so nothing downstream trips the new asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
