### PR TITLE
jnigen: constants become lazy vals — zero JNI calls at class-load

### DIFF
--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -410,9 +410,9 @@ private fun constGetCoverMagic(onError: JniErrorHandler<Long>): Long {
 /**
  * The storage capacity limit advertised to bindings (a primitive const).
  *
- * Mirrors the Rust `#[prebindgen]` const `COVER_MAGIC` (read once through the generated JNI getter).
+ * Mirrors the Rust `#[prebindgen]` const `COVER_MAGIC` (read lazily, once, through the generated JNI getter on first use).
  */
-public val COVER_MAGIC: Long = constGetCoverMagic(JniErrorHandler { je -> error(je ?: "const COVER_MAGIC: JNI getter failed") })
+public val COVER_MAGIC: Long by lazy { constGetCoverMagic(JniErrorHandler { je -> error(je ?: "const COVER_MAGIC: JNI getter failed") }) }
 
 private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
@@ -424,15 +424,15 @@ private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
 /**
  * The coverage surface's tag string (a string const).
  *
- * Mirrors the Rust `#[prebindgen]` const `COVER_TAG` (read once through the generated JNI getter).
+ * Mirrors the Rust `#[prebindgen]` const `COVER_TAG` (read lazily, once, through the generated JNI getter on first use).
  */
-public val COVER_TAG: String = constGetCoverTag(JniErrorHandler { je -> error(je ?: "const COVER_TAG: JNI getter failed") })
+public val COVER_TAG: String by lazy { constGetCoverTag(JniErrorHandler { je -> error(je ?: "const COVER_TAG: JNI getter failed") }) }
 
 /**
  * The tag with a runtime-computed suffix — a constant value no Rust `const`
  * can express (built through `format!`). Exercises
- * `PackageDecl::constant_fun`: a nullary fn surfaced as an
- * eagerly-initialized Kotlin top-level `val`.
+ * `PackageDecl::constant_fun`: a nullary fn surfaced as a
+ * lazily-initialized Kotlin top-level `val`.
  */
 private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
@@ -444,12 +444,12 @@ private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
 /**
  * The tag with a runtime-computed suffix — a constant value no Rust `const`
  * can express (built through `format!`). Exercises
- * `PackageDecl::constant_fun`: a nullary fn surfaced as an
- * eagerly-initialized Kotlin top-level `val`.
+ * `PackageDecl::constant_fun`: a nullary fn surfaced as a
+ * lazily-initialized Kotlin top-level `val`.
  *
- * Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated once through the generated JNI wrapper).
+ * Mirrors the Rust `#[prebindgen]` fn `cover_tag_runtime()` (evaluated lazily, once, through the generated JNI wrapper on first use).
  */
-public val COVER_TAG_RUNTIME: String = coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") })
+public val COVER_TAG_RUNTIME: String by lazy { coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") }) }
 
 private fun constGetCoverVersion(onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
@@ -458,8 +458,8 @@ private fun constGetCoverVersion(onError: JniErrorHandler<String>): String {
     return __ret
 }
 
-/** Binding-defined constant: `crate :: cover_version ()` (evaluated once through the generated JNI getter). */
-public val COVER_VERSION: String = constGetCoverVersion(JniErrorHandler { je -> error(je ?: "const COVER_VERSION: JNI getter failed") })
+/** Binding-defined constant: `crate :: cover_version ()` (evaluated lazily, once, through the generated JNI getter on first use). */
+public val COVER_VERSION: String by lazy { constGetCoverVersion(JniErrorHandler { je -> error(je ?: "const COVER_VERSION: JNI getter failed") }) }
 
 private fun constGetCoverBanner(onError: JniErrorHandler<String>): String {
     val __cap = JniErrorHandlerCapture.acquire()
@@ -468,8 +468,8 @@ private fun constGetCoverBanner(onError: JniErrorHandler<String>): String {
     return __ret
 }
 
-/** Binding-defined constant: `format ! ("{COVER_TAG}:{COVER_MAGIC:#x}")` (evaluated once through the generated JNI getter). */
-public val COVER_BANNER: String = constGetCoverBanner(JniErrorHandler { je -> error(je ?: "const COVER_BANNER: JNI getter failed") })
+/** Binding-defined constant: `format ! ("{COVER_TAG}:{COVER_MAGIC:#x}")` (evaluated lazily, once, through the generated JNI getter on first use). */
+public val COVER_BANNER: String by lazy { constGetCoverBanner(JniErrorHandler { je -> error(je ?: "const COVER_BANNER: JNI getter failed") }) }
 
 internal object CovNative {
     init {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -547,7 +547,7 @@ pub fn storage_put_opt(s: &mut Storage, p: Option<Payload>) -> bool {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Consts — declared via `PackageDecl::constant`, surfacing as generated JNI
-// getters + eagerly-initialized Kotlin top-level `val`s.
+// getters + lazily-initialized Kotlin top-level `val`s.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// The storage capacity limit advertised to bindings (a primitive const).
@@ -560,8 +560,8 @@ pub const COVER_TAG: &str = "covertest";
 
 /// The tag with a runtime-computed suffix — a constant value no Rust `const`
 /// can express (built through `format!`). Exercises
-/// `PackageDecl::constant_fun`: a nullary fn surfaced as an
-/// eagerly-initialized Kotlin top-level `val`.
+/// `PackageDecl::constant_fun`: a nullary fn surfaced as a
+/// lazily-initialized Kotlin top-level `val`.
 #[prebindgen]
 pub fn cover_tag_runtime() -> String {
     format!("{COVER_TAG}-runtime")

--- a/prebindgen/src/api/gen/kotlin/model.rs
+++ b/prebindgen/src/api/gen/kotlin/model.rs
@@ -409,6 +409,9 @@ pub struct KtProperty {
     pub ty: Option<KtType>,
     /// Raw initializer expression text.
     pub initializer: Option<String>,
+    /// Raw delegate expression text (`val x by <delegate>`, e.g.
+    /// `lazy { … }`). Mutually exclusive with `initializer`.
+    pub delegate: Option<String>,
     pub mutable: bool,
     pub vis: Vis,
     /// Inline annotations rendered before the keyword: `@Volatile internal var …`.
@@ -425,6 +428,7 @@ impl KtProperty {
             name: name.into(),
             ty: None,
             initializer: None,
+            delegate: None,
             mutable: false,
             vis: Vis::Default,
             annotations: Vec::new(),
@@ -444,6 +448,10 @@ impl KtProperty {
     }
     pub fn initializer(mut self, i: impl Into<String>) -> Self {
         self.initializer = Some(i.into());
+        self
+    }
+    pub fn delegate(mut self, d: impl Into<String>) -> Self {
+        self.delegate = Some(d.into());
         self
     }
     pub fn vis(mut self, v: Vis) -> Self {

--- a/prebindgen/src/api/gen/kotlin/render.rs
+++ b/prebindgen/src/api/gen/kotlin/render.rs
@@ -457,6 +457,14 @@ fn render_property(p: &KtProperty, level: usize, imports: &mut ImportSet, out: &
     if let Some(ty) = &p.ty {
         out.push_str(&format!(": {}", ty.render(imports)));
     }
+    debug_assert!(
+        p.delegate.is_none() || p.initializer.is_none(),
+        "property `{}`: delegate and initializer are mutually exclusive",
+        p.name
+    );
+    if let Some(delegate) = &p.delegate {
+        out.push_str(&format!(" by {delegate}"));
+    }
     if let Some(init) = &p.initializer {
         out.push_str(&format!(" = {init}"));
     }

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -560,3 +560,16 @@ fn multiline_kdoc() {
         "{src}"
     );
 }
+
+#[test]
+fn delegated_property_renders_by_clause() {
+    let p = KtProperty::val("MAGIC")
+        .ty(KtType::long())
+        .vis(Vis::Public)
+        .delegate("lazy { constGetMagic(handler) }");
+    let src = render::render_one(&p.into(), "p");
+    assert!(
+        src.contains("public val MAGIC: Long by lazy { constGetMagic(handler) }"),
+        "{src}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -743,10 +743,11 @@ pub(crate) enum ConstSource {
     Expr { ty: syn::Type, expr: syn::Expr },
 }
 
-/// Declares one **constant** for emission: an eagerly-initialized top-level
-/// Kotlin `val` in its package's `.kt` file, initialized through a generated
-/// nullary JNI getter (the value type goes through the ordinary
-/// output-converter machinery, exactly like a function return).
+/// Declares one **constant** for emission: a lazily-initialized top-level
+/// Kotlin `val` (`by lazy`) in its package's `.kt` file, initialized on
+/// first use through a generated nullary JNI getter (the value type goes
+/// through the ordinary output-converter machinery, exactly like a function
+/// return; zero JNI calls at class-load).
 ///
 /// Build one with [`constant!`](crate::constant) — the ident is the `val`
 /// name — and pick the value source:

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -34,10 +34,10 @@ pub(crate) fn const_getter_fn(c: &syn::ItemConst) -> syn::ItemFn {
     }
 }
 
-/// A const whose (peeled) type is a declared opaque handle is rejected: an
-/// eagerly-initialized shared closeable `val` is semantically wrong (whose
-/// `close()` is it?). Expose a factory function instead — the established
-/// idiom (e.g. zenoh's `encoding_const_*` companion factories).
+/// A const whose (peeled) type is a declared opaque handle is rejected: a
+/// shared closeable `val` is semantically wrong (whose `close()` is it?).
+/// Expose a factory function instead — the established idiom (e.g. zenoh's
+/// `encoding_const_*` companion factories).
 pub(crate) fn reject_handle_const(ext: &JniGen, c: &syn::ItemConst) {
     reject_handle_constant_type(ext, &c.ty, "const", &c.ident.to_string());
 }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -986,7 +986,7 @@ impl JniGen {
             }
         }
         // Declared consts: a private nullary helper + the public
-        // eagerly-initialized `val` (see `render_const_val`).
+        // lazily-initialized `val` (see `render_const_val`).
         for entry in &pkg_cfg.constants {
             let (item_const, _loc) = registry.consts.get(&entry.rust_ident).unwrap_or_else(|| {
                 panic!(
@@ -1008,7 +1008,7 @@ impl JniGen {
             }
         }
         // Function-backed constants: the declared nullary fn's ordinary
-        // wrapper demoted to a private helper + the public eagerly-initialized
+        // wrapper demoted to a private helper + the public lazily-initialized
         // `val` (see `render_constant_fn_val`). The JNINative extern and the
         // Rust wrapper are the plain declared-function ones.
         for entry in &pkg_cfg.constant_functions {
@@ -1035,7 +1035,7 @@ impl JniGen {
             }
         }
         // Expression constants: a private nullary helper over the synthetic
-        // getter + the public eagerly-initialized `val` (see
+        // getter + the public lazily-initialized `val` (see
         // `render_const_expr_val`). The value is a binding-defined expression
         // evaluated Rust-side (`prerequisites`).
         for decl in &pkg_cfg.constant_exprs {

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -778,10 +778,8 @@ pub(crate) fn render_wrapper_fn(
 /// Render one declared const (see `ConstDecl`): a **private** nullary helper
 /// — the standard wrapper fn over the synthetic getter signature
 /// ([`const_getter_fn`]), reused verbatim so the const's type crosses through
-/// the ordinary output machinery — plus the public eagerly-initialized `val`
-/// that calls it once with a throwing `JniErrorHandler` (dead code for
-/// infallible converts; a binding-layer failure surfaces as
-/// `IllegalStateException` via `error(...)`).
+/// the ordinary output machinery — plus the public lazily-initialized `val`
+/// that calls it once, on first use (see [`render_val_over_helper`]).
 pub(crate) fn render_const_val(
     ext: &JniGen,
     c: &syn::ItemConst,
@@ -795,8 +793,8 @@ pub(crate) fn render_const_val(
         .map(str::to_string)
         .unwrap_or_else(|| c.ident.to_string());
     let framework_line = format!(
-        "Mirrors the Rust `#[prebindgen]` const `{}` (read once through the \
-         generated JNI getter).",
+        "Mirrors the Rust `#[prebindgen]` const `{}` (read lazily, once, through \
+         the generated JNI getter on first use).",
         c.ident
     );
     let kdoc = crate::api::lang::jnigen::util::doc_string(&c.attrs)
@@ -807,9 +805,9 @@ pub(crate) fn render_const_val(
 
 /// Render one fn-sourced constant (see `ConstDecl::fun`):
 /// the declared nullary fn's ordinary wrapper demoted to a **private**
-/// helper, plus the public eagerly-initialized `val` holding its result —
-/// computed once, at package-file class-load, through the ordinary generated
-/// wrapper (one JNI call, exactly like a const getter).
+/// helper, plus the public lazily-initialized `val` holding its result —
+/// computed once, on first use, through the ordinary generated wrapper
+/// (one JNI call, exactly like a const getter).
 pub(crate) fn render_constant_fn_val(
     ext: &JniGen,
     f: &syn::ItemFn,
@@ -822,8 +820,8 @@ pub(crate) fn render_constant_fn_val(
         .map(str::to_string)
         .unwrap_or_else(|| f.sig.ident.to_string());
     let framework_line = format!(
-        "Mirrors the Rust `#[prebindgen]` fn `{}()` (evaluated once through the \
-         generated JNI wrapper).",
+        "Mirrors the Rust `#[prebindgen]` fn `{}()` (evaluated lazily, once, \
+         through the generated JNI wrapper on first use).",
         f.sig.ident
     );
     let kdoc = crate::api::lang::jnigen::util::doc_string(&f.attrs)
@@ -834,9 +832,9 @@ pub(crate) fn render_constant_fn_val(
 
 /// Render one expression-backed constant (see `ConstDecl::expr`):
 /// a private nullary helper over the synthetic `const_get_*` getter (seeded
-/// from the val name), plus the public eagerly-initialized `val` — the value
-/// is the binding-defined expression, evaluated once at package-file
-/// class-load through the generated getter.
+/// from the val name), plus the public lazily-initialized `val` — the value
+/// is the binding-defined expression, evaluated once, on first use, through
+/// the generated getter.
 pub(crate) fn render_const_expr_val(
     ext: &JniGen,
     decl: &crate::api::lang::jnigen::jni::decl::ConstExprDecl,
@@ -847,18 +845,19 @@ pub(crate) fn render_const_expr_val(
     let helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
     let expr = decl.expr.to_token_stream();
     let kdoc = format!(
-        "Binding-defined constant: `{expr}` (evaluated once through the \
-         generated JNI getter)."
+        "Binding-defined constant: `{expr}` (evaluated lazily, once, through \
+         the generated JNI getter on first use)."
     );
     render_val_over_helper(ext, helper, decl.kotlin_name.clone(), kdoc, imports)
 }
 
 /// Shared val-rendering core for both constant kinds (`ConstDecl` /
 /// `ConstDecl::fun`): demote the rendered wrapper to a private
-/// helper and emit the public eagerly-initialized `val` that calls it once
-/// with a throwing `JniErrorHandler` (dead code for infallible converts; a
-/// binding-layer failure surfaces as `IllegalStateException` via
-/// `error(...)`).
+/// helper and emit the public `val X: T by lazy { … }` that calls it once,
+/// on first use, with a throwing `JniErrorHandler` (dead code for infallible
+/// converts; a binding-layer failure surfaces as `IllegalStateException` via
+/// `error(...)` at first use). Lazy, not eager: a consts-heavy package must
+/// not fire one JNI call per `val` at class-load (issue #58).
 fn render_val_over_helper(
     ext: &JniGen,
     mut helper: kt::KtFun,
@@ -879,7 +878,7 @@ fn render_val_over_helper(
     let prop = kt::KtProperty::val(&val_name)
         .ty(val_ty)
         .vis(kt::Vis::Public)
-        .initializer(init)
+        .delegate(format!("lazy {{ {init} }}"))
         .kdoc(kdoc);
     Some((helper, prop))
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -1,6 +1,7 @@
 //! Declared-const emission: a `#[prebindgen] const` declared via
 //! `package!().constant(constant!(X))` surfaces as a Rust nullary JNI
-//! getter extern plus a Kotlin top-level eagerly-initialized `val`.
+//! getter extern plus a Kotlin top-level lazily-initialized `val`
+//! (`by lazy` — zero JNI calls at class-load, #58).
 
 use super::*;
 
@@ -77,10 +78,13 @@ fn declared_consts_emit_getter_and_val() {
         .map(|p| std::fs::read_to_string(p).unwrap())
         .expect("cfg package file");
     let pc: String = pkg.split_whitespace().collect();
-    // Public eagerly-initialized vals, typed from the output converters;
-    // the `.name()` override applies to the val, not the extern.
-    assert!(pc.contains("valMAX_LEN:Long=constGetMaxLen("), "{pkg}");
-    assert!(pc.contains("valHELLO:String=constGetGreeting("), "{pkg}");
+    // Public lazily-initialized vals (`by lazy` — zero JNI calls at
+    // class-load, #58), typed from the output converters; the `.name()`
+    // override applies to the val, not the extern.
+    assert!(pc.contains("valMAX_LEN:Longbylazy{constGetMaxLen("), "{pkg}");
+    assert!(pc.contains("valHELLO:Stringbylazy{constGetGreeting("), "{pkg}");
+    // No eager form anywhere in the package file.
+    assert!(!pc.contains("=constGet"), "{pkg}");
     // The helpers are private wrapper functions.
     assert!(pc.contains("privatefunconstGetMaxLen("), "{pkg}");
     // JNINative declares the extern halves.
@@ -126,7 +130,7 @@ fn undeclared_const_not_emitted() {
 }
 
 /// End-to-end for fn-sourced constants (`constant!(N).fun(…)`): a declared
-/// nullary fn surfaces as a private helper + public eagerly-initialized
+/// nullary fn surfaces as a private helper + public lazily-initialized
 /// `val` in the package file; the extern and the Rust wrapper are the
 /// ordinary declared-function ones (`myflat::tag()` call).
 #[test]
@@ -164,9 +168,9 @@ fn constant_fun_source_emits_val_over_ordinary_wrapper() {
         .map(|p| std::fs::read_to_string(p).unwrap())
         .expect("cfg package file");
     let pc: String = pkg.split_whitespace().collect();
-    // Public eagerly-initialized val named by `.name()`, over a PRIVATE
+    // Public lazily-initialized val named by `.name()`, over a PRIVATE
     // helper — no public callable fun.
-    assert!(pc.contains("valTHE_TAG:String=tag("), "{pkg}");
+    assert!(pc.contains("valTHE_TAG:Stringbylazy{tag("), "{pkg}");
     assert!(pc.contains("privatefuntag("), "{pkg}");
     assert!(!pc.contains("publicfuntag("), "{pkg}");
     // JNINative declares the ordinary extern.
@@ -292,7 +296,7 @@ fn constant_expr_emits_getter_and_val() {
         .expect("cfg package file");
     let pc: String = pkg.split_whitespace().collect();
     assert!(
-        pc.contains("valDEFAULT_TAG:String=constGetDefaultTag("),
+        pc.contains("valDEFAULT_TAG:Stringbylazy{constGetDefaultTag("),
         "{pkg}"
     );
     assert!(pc.contains("privatefunconstGetDefaultTag("), "{pkg}");
@@ -440,7 +444,7 @@ fn constant_with_source_calls_path_verbatim() {
         .expect("cfg package file");
     let pc: String = pkg.split_whitespace().collect();
     assert!(
-        pc.contains("valCOVER_VERSION:String=constGetCoverVersion("),
+        pc.contains("valCOVER_VERSION:Stringbylazy{constGetCoverVersion("),
         "{pkg}"
     );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -81,8 +81,14 @@ fn declared_consts_emit_getter_and_val() {
     // Public lazily-initialized vals (`by lazy` — zero JNI calls at
     // class-load, #58), typed from the output converters; the `.name()`
     // override applies to the val, not the extern.
-    assert!(pc.contains("valMAX_LEN:Longbylazy{constGetMaxLen("), "{pkg}");
-    assert!(pc.contains("valHELLO:Stringbylazy{constGetGreeting("), "{pkg}");
+    assert!(
+        pc.contains("valMAX_LEN:Longbylazy{constGetMaxLen("),
+        "{pkg}"
+    );
+    assert!(
+        pc.contains("valHELLO:Stringbylazy{constGetGreeting("),
+        "{pkg}"
+    );
     // No eager form anywhere in the package file.
     assert!(!pc.contains("=constGet"), "{pkg}");
     // The helpers are private wrapper functions.


### PR DESCRIPTION
Fixes #58 (P2 from the 2026-07-14 JniGen API review).

## Constants are now `by lazy` — zero JNI calls at class-load

Every generated constant was a top-level `val` initialized eagerly through its own nullary JNI getter, so loading a consts-heavy package file (zenoh-flat-jni's `bytes`: 106 vals) fired 106 JNI round trips at class-load. The generated `val` is now:

```kotlin
public val COVER_MAGIC: Long by lazy { constGetCoverMagic(JniErrorHandler { je -> error(je ?: "…") }) }
```

- **One seam**: all three constant kinds (item const / fn-backed / expression) funnel through `render_val_over_helper`, so a single change covers them uniformly — the acceptance criterion ("zero JNI calls until first const use") holds for every value source, not just expression consts.
- Default `lazy` mode is `SYNCHRONIZED`: still exactly one evaluation, thread-safe, deferred to first use. The documented semantic delta (inherent to lazy, per the issue): a binding-layer getter failure (`IllegalStateException` via `error(...)`) surfaces at first const use instead of at class-load.
- Rust-side getters and `JNINative` externs are untouched; opaque-handle-typed consts were already rejected at decl time, so lazy values are scalars/strings/blobs with no lifecycle interaction.
- The Kotlin model gains general property-delegate support: `KtProperty.delegate`, rendered as `val x: T by <expr>`, debug-asserted mutually exclusive with `initializer`.

## Tests

- New golden-string render test for the delegate clause (`api/gen/kotlin/tests.rs`).
- Consts end-to-end tests updated to pin the `by lazy {` form for all value sources, plus a negative pin that no eager `= constGet…` form remains in a generated package file. `cargo test -p prebindgen --lib`: 238 passed.
- covertest JVM harness: PASS (25 sections) — the const section now exercises first-use initialization of all four value sources.
- Committed goldens regenerated (diff is exactly the const `val` lines + kdoc wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
