### PR TITLE
jnigen: one contract for all six name-mangle hooks + the doc table

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -105,13 +105,14 @@ fn main() {
     let jni = JniGen::new()
         .set_package_prefix("io.prebindgen.covertest")
         .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
-        // All five per-kind name-mangle hooks are registered. The harness hook
-        // is a real transform (`Native` → `CovNative`, an internal symbol so it
-        // needs no Kotlin-side coordination); the other four are the identity
+        // All six name-mangle hooks are registered. The harness hook is a
+        // real transform: it receives the derived default `JNINative` and
+        // replaces it wholesale with `CovNative` (an internal symbol, so no
+        // Kotlin-side coordination is needed); the other five are the identity
         // (the domain names are already the desired Kotlin names) — registering
         // them still exercises the customization API and its `Some(closure)`
         // path.
-        .set_harness_name_mangle(|n| format!("Cov{n}"))
+        .set_harness_name_mangle(|_| "CovNative".to_string())
         .set_fun_name_mangle(|n| n.to_string())
         .set_ptr_class_name_mangle(|n| n.to_string())
         .set_data_class_name_mangle(|n| n.to_string())

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -155,20 +155,22 @@ impl JniGen {
             None => name.to_string(),
         }
     }
-    /// Apply the harness mangle closure to `name`. Defaults to
-    /// `|n| format!("JNI{n}")` when unset, so `mangle_harness("Native")`
-    /// yields `"JNINative"`.
+    /// Apply the harness mangle closure to `name`, returning the closure
+    /// result or `name` verbatim when unset — identity default, same
+    /// contract as the other five hooks.
     pub(crate) fn mangle_harness(&self, name: &str) -> String {
         match &self.harness_name_mangle {
             Some(f) => f(name),
-            None => format!("JNI{name}"),
+            None => name.to_string(),
         }
     }
-    /// The mangled name of the centralized Native object that hosts every
-    /// JNI `external fun`. Drives both the Kotlin class emission and the
-    /// JNI extern symbol path on the Rust side.
+    /// The name of the centralized Native object that hosts every JNI
+    /// `external fun`: the explicit default value `"JNINative"` run through
+    /// the harness mangle hook (identity when unset). Drives both the
+    /// Kotlin class emission and the JNI extern symbol path on the Rust
+    /// side.
     pub(crate) fn jni_native_class_name(&self) -> String {
-        self.mangle_harness("Native")
+        self.mangle_harness("JNINative")
     }
 
     /// Resolve a relative class name against [`Self::package`] +

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -10,6 +10,26 @@
 //! setting-derived value (class FQN, `FindClass` path, JNI extern symbol
 //! path) is computed at the point of use, so there is no stored derived
 //! state that could go stale.
+//!
+//! # Name-mangle hooks
+//!
+//! One uniform contract for all six hooks: **the hook receives the derived
+//! default name for its tier** — exactly what the generator would use if no
+//! hook were set — **and returns the final name; every default is the
+//! identity.** The input *domain* differs per tier (a fn name is camelCase,
+//! a class name is a Rust short name); the table states each:
+//!
+//! | hook | names | input (the derived default) | default |
+//! |---|---|---|---|
+//! | [`set_harness_name_mangle`](JniGen::set_harness_name_mangle) | the centralized externs object | `"JNINative"` | identity |
+//! | [`set_fun_name_mangle`](JniGen::set_fun_name_mangle) | JNI extern short names (scanned fns, synthetic `freePtr`) | camelCased Rust fn name (`put_publisher` → `"putPublisher"`) | identity |
+//! | [`set_ptr_class_name_mangle`](JniGen::set_ptr_class_name_mangle) | `ptr_class` Kotlin classes | Rust type short name (`"KeyExpr"`) | identity |
+//! | [`set_data_class_name_mangle`](JniGen::set_data_class_name_mangle) | `data_class` + `value_class` Kotlin classes | Rust type short name | identity |
+//! | [`set_enum_name_mangle`](JniGen::set_enum_name_mangle) | `enum_class` Kotlin classes | Rust type short name | identity |
+//! | [`set_member_name_mangle`](JniGen::set_member_name_mangle) | class members without a per-member `.name()` | namespace-stripped camelCase (`storage_len` on `Storage` → `"len"`) | identity |
+//!
+//! A per-decl `.name()` override is always verbatim and **bypasses** the
+//! hooks entirely.
 
 use super::*;
 
@@ -76,10 +96,16 @@ impl JniGen {
         self
     }
 
-    /// Set the closure that mangles the framework "harness" class name
-    /// `"Native"` (the centralized extern holder). Default = prepend
-    /// `"JNI"` (yielding `JNINative`). Affects the generated Kotlin class
-    /// name and the derived JNI extern symbol path on the Rust side.
+    /// Set the closure that renames the framework "harness" class (the
+    /// centralized extern holder). Receives the derived default
+    /// `"JNINative"`; default = identity (see the module-level table).
+    /// Affects the generated Kotlin class name and the derived JNI extern
+    /// symbol path on the Rust side.
+    ///
+    /// **Breaking change vs pre-0.6**: the hook used to receive the bare
+    /// stem `"Native"` with a hidden `JNI`-prepending default; it now
+    /// receives the full derived default `"JNINative"` and replaces it
+    /// wholesale (`|_| "MyNative".to_string()`).
     pub fn set_harness_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
@@ -91,7 +117,8 @@ impl JniGen {
     /// Set the closure that mangles function names. Called for every scanned
     /// `#[prebindgen]` free function and the synthetic `freePtr` destructor;
     /// receives the camelCased Kotlin-side name and returns the final form
-    /// (e.g. `"putPublisher"` → `"putPublisherViaJNI"`). Default = identity.
+    /// (e.g. `"putPublisher"` → `"putPublisherViaJNI"`). Default = identity
+    /// (see the module-level table).
     pub fn set_fun_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
@@ -101,7 +128,8 @@ impl JniGen {
     }
 
     /// Set the closure that mangles Kotlin ptr-class names declared via a
-    /// `PtrClassDecl`. Receives the Rust short name. Default = identity.
+    /// `PtrClassDecl`. Receives the Rust short name. Default = identity
+    /// (see the module-level table).
     pub fn set_ptr_class_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
@@ -112,7 +140,7 @@ impl JniGen {
 
     /// Set the closure that mangles Kotlin data-class names declared via a
     /// `DataClassDecl` (and value classes, which reuse this hook). Receives
-    /// the Rust short name. Default = identity.
+    /// the Rust short name. Default = identity (see the module-level table).
     pub fn set_data_class_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
@@ -122,7 +150,8 @@ impl JniGen {
     }
 
     /// Set the closure that mangles enum-class names declared via an
-    /// `EnumClassDecl`. Receives the Rust short name. Default = identity.
+    /// `EnumClassDecl`. Receives the Rust short name. Default = identity
+    /// (see the module-level table).
     pub fn set_enum_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
@@ -136,8 +165,9 @@ impl JniGen {
     /// name AFTER the class-namespace prefix was stripped from the fn
     /// ident (`storage_len` on class `Storage` arrives as `"len"`); runs
     /// only for members without a per-member `.name()` (which is always
-    /// verbatim). Default = identity. The sixth hook of the name-mangle
-    /// family, covering the one name tier the other five don't.
+    /// verbatim). Default = identity (see the module-level table). The
+    /// sixth hook of the name-mangle family, covering the one name tier
+    /// the other five don't.
     pub fn set_member_name_mangle<F>(mut self, f: F) -> Self
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
@@ -208,10 +238,10 @@ impl JniGen {
     }
 
     /// Derived on demand: `"Java_" + package.replace('.', "_") + "_" +
-    /// mangle_harness("Native")` — the JNI extern symbol path of the
+    /// jni_native_class_name()` — the JNI extern symbol path of the
     /// centralized Native object every emitted wrapper hangs off.
     pub(crate) fn jni_class_path(&self) -> String {
-        let native_class = self.mangle_harness("Native");
+        let native_class = self.jni_native_class_name();
         if self.package.is_empty() {
             format!("Java_{}", native_class)
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -315,6 +315,43 @@ fn member_name_mangle_hook_applies_order_independently() {
     assert!(!ac.contains("funlabelNative("), "{all}");
 }
 
+/// #56: the harness hook follows the same contract as the other five —
+/// it receives the DERIVED DEFAULT for its tier (`"JNINative"`, an explicit
+/// default value, not a hidden `JNI`-prepend) and replaces it wholesale;
+/// the unset default is identity.
+#[test]
+fn harness_hook_receives_derived_default() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_harness_name_mangle(|n| {
+            assert_eq!(n, "JNINative", "hook must receive the derived default");
+            "MyNative".to_string()
+        })
+        .package(crate::package!("thing").fun(crate::fun!(z_ping)));
+    let dir = unique_test_dir("jnigen_harness_mangle");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    // The extern symbol path carries the replaced harness name.
+    assert!(rust.contains("Java_io_test_jni_MyNative_zPing"), "{rust}");
+    assert!(!rust.contains("JNINative"), "{rust}");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(all.contains("object MyNative"), "{all}");
+    assert!(!all.contains("JNINative"), "{all}");
+}
+
 /// C4: the Kotlin root is generator-owned — `write_kotlin` deletes and
 /// recreates it on every run, so stale files from a previous generation
 /// (renamed package, removed declaration) never linger and consumers need


### PR DESCRIPTION
Fixes #56 (P2 from the 2026-07-14 JniGen API review).

## One contract for all six hooks

New uniform rule, stated once in the settings module doc (`jni/config.rs`) together with the acceptance table: **every hook receives the derived default name for its tier — exactly what the generator would use if no hook were set — and returns the final name; every default is identity.** The per-tier input *domains* legitimately differ (fn names are camelCase, class names are Rust short names); the table makes each explicit:

| hook | names | input (the derived default) | default |
|---|---|---|---|
| `set_harness_name_mangle` | the centralized externs object | `"JNINative"` | identity |
| `set_fun_name_mangle` | JNI extern short names (scanned fns, synthetic `freePtr`) | camelCased Rust fn name (`put_publisher` → `"putPublisher"`) | identity |
| `set_ptr_class_name_mangle` | `ptr_class` Kotlin classes | Rust type short name (`"KeyExpr"`) | identity |
| `set_data_class_name_mangle` | `data_class` + `value_class` Kotlin classes | Rust type short name | identity |
| `set_enum_name_mangle` | `enum_class` Kotlin classes | Rust type short name | identity |
| `set_member_name_mangle` | class members without a per-member `.name()` | namespace-stripped camelCase (`storage_len` on `Storage` → `"len"`) | identity |

Per-decl `.name()` overrides remain verbatim and bypass the hooks entirely (also stated under the table; each setter doc cross-links to it).

## The harness fix

Five hooks already conformed; the harness hook was the outlier on both axes — it received the bare stem `"Native"` and its unset default silently prepended `JNI`. Now `"JNINative"` is an **explicit default value** (`jni_native_class_name()` = harness hook applied to `"JNINative"`, single seam — `jni_class_path()` reuses it), the hook receives it and replaces it wholesale, and the unset default is identity like everywhere else.

**Breaking change** (accepted by the issue; pre-crates.io): an existing `set_harness_name_mangle` closure now receives `"JNINative"` instead of `"Native"` — noted prominently in the setter rustdoc. Consumers that don't set the harness hook see byte-identical output (identity on `"JNINative"` = the old prepend on `"Native"`). The one known user, covertest-kotlin's own build.rs, is updated (`|_| "CovNative".to_string()`) and its goldens are unchanged.

## Tests

- New `harness_hook_receives_derived_default` (in `jni/tests/config.rs`, alongside the existing ptr-class/member hook tests): asserts the hook input is exactly `"JNINative"`, and that the replacement name lands in both the Kotlin `object` and the Rust `Java_…_MyNative_…` extern symbols with no `JNINative` remaining.
- Every existing `JNINative` assertion passes unchanged — the default derivation is behavior-preserving. `cargo test -p prebindgen --lib`: 243 passed.
- Goldens byte-identical after regeneration (covertest still `CovNative`, perftest still `JNINative`); `cargo doc` clean for the new table links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
