### PR TITLE
jnigen: generated <Name>Api interface — checked injection hatch on all class kinds (#54)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -254,17 +254,13 @@ fn main() {
                 )
                 .class(
                     ptr_class!(Storage)
-                        // #54: `.overrides()` — the member implements the
-                        // matching CovResource abstract (Kotlin needs the
-                        // `override` modifier on class-body members).
-                        .fun(fun!(storage_len).overrides())
+                        .fun(fun!(storage_len))
                         .fun(fun!(storage_contains))
                         .constructor(fun!(storage_with_payload))
                         // #54 integration hatch: the generated class joins a
-                        // hand-written consumer interface — abstracts satisfied
-                        // by NativeHandle's inherited peek()/isClosed() AND the
-                        // `.overrides()`-marked len() — no hand-editing of
-                        // generated code.
+                        // hand-written consumer interface (satisfied by
+                        // NativeHandle's public peek()/isClosed()) — no
+                        // hand-editing of generated code.
                         .implements("io.prebindgen.covertest.CovResource"),
                 )
                 // The callback-handler handles (single payload / whole batch / owned

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -254,13 +254,17 @@ fn main() {
                 )
                 .class(
                     ptr_class!(Storage)
-                        .fun(fun!(storage_len))
+                        // #54: `.overrides()` — the member implements the
+                        // matching CovResource abstract (Kotlin needs the
+                        // `override` modifier on class-body members).
+                        .fun(fun!(storage_len).overrides())
                         .fun(fun!(storage_contains))
                         .constructor(fun!(storage_with_payload))
                         // #54 integration hatch: the generated class joins a
-                        // hand-written consumer interface (satisfied by
-                        // NativeHandle's public peek()/isClosed()) — no
-                        // hand-editing of generated code.
+                        // hand-written consumer interface — abstracts satisfied
+                        // by NativeHandle's inherited peek()/isClosed() AND the
+                        // `.overrides()`-marked len() — no hand-editing of
+                        // generated code.
                         .implements("io.prebindgen.covertest.CovResource"),
                 )
                 // The callback-handler handles (single payload / whole batch / owned

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -56,7 +56,6 @@
 //! | binding-error channel (`je != null`) | malformed `Stamp` bytes (value-blob length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
 //! | `data_class` instance member          | `Payload.labelLen()` (receiver crosses as `this` field leaves) |
-//! | `enum_class!(T).kotlin_type(…)`       | lib-tested (maps enum onto an existing Kotlin type; no file) |
 //! | `JniGen::ignore` (exact)              | `string_len` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
 //! | `JniGen::ignore` + `matching(…)`      | the `storage_get_into_*` group (one name predicate, any item kind) |
 //!

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -33,6 +33,7 @@
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | namespace-relative member names (C1)  | `storage_len`→`len`, `stamp_secs`→`secs`, … (no `.name()`); `summary_new`→`.name("of")` still overrides |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
+//! | `.implements(…)` integration hatch    | `Storage` implements hand-written `CovResource` (#54) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `constant!` (bare = `#[prebindgen]` const) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
 //! | `constant!(N).fun(fun!(…))`           | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
@@ -255,7 +256,12 @@ fn main() {
                     ptr_class!(Storage)
                         .fun(fun!(storage_len))
                         .fun(fun!(storage_contains))
-                        .constructor(fun!(storage_with_payload)),
+                        .constructor(fun!(storage_with_payload))
+                        // #54 integration hatch: the generated class joins a
+                        // hand-written consumer interface (satisfied by
+                        // NativeHandle's public peek()/isClosed()) — no
+                        // hand-editing of generated code.
+                        .implements("io.prebindgen.covertest.CovResource"),
                 )
                 // The callback-handler handles (single payload / whole batch / owned
                 // storage handle).

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -33,7 +33,8 @@
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | namespace-relative member names (C1)  | `storage_len`→`len`, `stamp_secs`→`secs`, … (no `.name()`); `summary_new`→`.name("of")` still overrides |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
-//! | `.implements(…)` integration hatch    | `Storage` implements hand-written `CovResource` (#54) |
+//! | `.interface()` + `.implements(…)`      | `Storage`/`Payload` emit an Api interface; `CovResource`/`Timestamped` extend it (#54) |
+//! | `.interface_name(…)`                  | `Priority` → generated `PriorityKind` interface (#54) |
 //! | base-package functions               | `string_new` (declared in a `package!()`) |
 //! | `constant!` (bare = `#[prebindgen]` const) | `COVER_MAGIC` (`Long`) + `COVER_TAG` (`String`) → top-level `val`s |
 //! | `constant!(N).fun(fun!(…))`           | `cover_tag_runtime()` → eagerly-initialized `val COVER_TAG_RUNTIME` |
@@ -155,12 +156,30 @@ fn main() {
         // reassembled via a generated `fromParts`). A data class can carry
         // members like any re-enterable kind: the instance method's receiver
         // crosses as `this`'s field leaves (I5).
-        .package(package!().class(data_class!(Payload).fun(fun!(payload_label_len))))
+        // `Payload` also demos the `.interface()` hatch on a DATA class:
+        // `PayloadApi` exposes its fields + `labelLen()`, and the
+        // hand-written `Timestamped` interface extends it (#54).
+        .package(
+            package!().class(
+                data_class!(Payload)
+                    .interface()
+                    .implements("io.prebindgen.covertest.Timestamped")
+                    .fun(fun!(payload_label_len)),
+            ),
+        )
         // ── Subpackage `model`: enum + value class + nested data class ──────
         .package(
             package!("model")
-                // `Priority` as a Kotlin `enum class` (jint wire, `fromInt` companion).
-                .class(enum_class!(Priority))
+                // `Priority` as a Kotlin `enum class` (jint wire, `fromInt`
+                // companion); `.interface_name("PriorityKind")` demos the
+                // generated interface on an ENUM with a per-decl name, and the
+                // hand-written `Ranked` (which extends `PriorityKind`) is
+                // attached via `.implements` (#54).
+                .class(
+                    enum_class!(Priority)
+                        .interface_name("PriorityKind")
+                        .implements("io.prebindgen.covertest.Ranked"),
+                )
                 // `Annotated` exercises a NESTED data-class field (`payload`,
                 // recursive fromParts / recursive leaf decode) plus Option<prim> and
                 // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
@@ -254,14 +273,17 @@ fn main() {
                 )
                 .class(
                     ptr_class!(Storage)
+                        // #54: emit the generated `StorageApi` interface (the
+                        // class implements it, members get `override`) AND
+                        // attach the hand-written `CovResource` which EXTENDS
+                        // `StorageApi` — so its defaults call `len()`/`peek()`
+                        // with full compiler checking, no hand-editing of
+                        // generated code.
+                        .interface()
+                        .implements("io.prebindgen.covertest.CovResource")
                         .fun(fun!(storage_len))
                         .fun(fun!(storage_contains))
-                        .constructor(fun!(storage_with_payload))
-                        // #54 integration hatch: the generated class joins a
-                        // hand-written consumer interface (satisfied by
-                        // NativeHandle's public peek()/isClosed()) — no
-                        // hand-editing of generated code.
-                        .implements("io.prebindgen.covertest.CovResource"),
+                        .constructor(fun!(storage_with_payload)),
                 )
                 // The callback-handler handles (single payload / whole batch / owned
                 // storage handle).

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -180,7 +180,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), CovResource {
     }
 
     /** Number of stored payloads (an **accessor** on `Storage`). */
-    public override fun len(onError: JniErrorHandler<Long>): Long {
+    public fun len(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -180,7 +180,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), CovResource {
     }
 
     /** Number of stored payloads (an **accessor** on `Storage`). */
-    public fun len(onError: JniErrorHandler<Long>): Long {
+    public override fun len(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -75,19 +75,33 @@ internal inline fun <R> withSortedHandleLocks(
     return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }
 }
 
+public interface PayloadApi {
+    val id: Long
+
+    val seq: Int
+
+    val value: Double
+
+    val flag: Boolean
+
+    val label: String?
+
+    fun labelLen(onError: JniErrorHandler<Long?>): Long?
+}
+
 /**
  * A by-value, FFI-safe payload. Scalars cross the C ABI as themselves; the
  * `label` string crosses as an opaque pointer (`Option<Box<String>>` ⇒ a nullable
  * `string_t *`). Being `#[repr(C)]`, the whole struct is passed by direct
  * reinterpret (zero-copy) — see `perftest-c`'s `.repr_c_struct(Payload)`.
  */
-public data class Payload(val id: Long, val seq: Int, val value: Double, val flag: Boolean, val label: String?) {
+public data class Payload(override val id: Long, override val seq: Int, override val value: Double, override val flag: Boolean, override val label: String?) : PayloadApi, Timestamped {
     /**
      * Length of a payload's label, or `None` when it is unlabeled. Exercises an
      * `Option<i64>` (nullable primitive) return, distinct from the `Option<handle>`
      * / `Option<data-class>` shapes elsewhere.
      */
-    public fun labelLen(onError: JniErrorHandler<Long?>): Long? {
+    public override fun labelLen(onError: JniErrorHandler<Long?>): Long? {
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = CovNative.payloadLabelLen(
             this.id,
@@ -161,8 +175,20 @@ public class PayloadVecHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     }
 }
 
+public interface StorageApi : AutoCloseable {
+    fun peek(): Long
+
+    fun isClosed(): Boolean
+
+    fun take(): Storage
+
+    fun len(onError: JniErrorHandler<Long>): Long
+
+    fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean
+}
+
 /** Typed handle for a native Zenoh `Storage`. */
-public class Storage(initialPtr: Long) : NativeHandle(initialPtr), CovResource {
+public class Storage(initialPtr: Long) : NativeHandle(initialPtr), StorageApi, CovResource {
     @Synchronized
     override fun close() {
         val p = ptr
@@ -173,14 +199,14 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), CovResource {
     }
 
     @Synchronized
-    public fun take(): Storage {
+    public override fun take(): Storage {
         val p = ptr
         ptr = p or 1L
         return Storage(p)
     }
 
     /** Number of stored payloads (an **accessor** on `Storage`). */
-    public fun len(onError: JniErrorHandler<Long>): Long {
+    public override fun len(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
@@ -192,7 +218,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), CovResource {
     }
 
     /** Whether any stored payload has the given id (a **method** on `Storage`). */
-    public fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean {
+    public override fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __cap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -162,7 +162,7 @@ public class PayloadVecHandler(initialPtr: Long) : NativeHandle(initialPtr) {
 }
 
 /** Typed handle for a native Zenoh `Storage`. */
-public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
+public class Storage(initialPtr: Long) : NativeHandle(initialPtr), CovResource {
     @Synchronized
     override fun close() {
         val p = ptr

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -5,6 +5,11 @@ import io.prebindgen.covertest.CovNative
 import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.Payload
+import io.prebindgen.covertest.Ranked
+
+public interface PriorityKind {
+    val value: Int
+}
 
 /**
  * Coarse importance bucket derived from a payload's `value`. A C-like
@@ -13,7 +18,7 @@ import io.prebindgen.covertest.Payload
  *
  * JVM-side surface for the native Rust `Priority` enum.
  */
-public enum class Priority(public val value: Int) {
+public enum class Priority(public override val value: Int) : PriorityKind, Ranked {
     LOW(0),
     NORMAL(1),
     HIGH(2);

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
@@ -4,14 +4,23 @@ package io.prebindgen.covertest
  * Hand-written consumer interface for the `.implements(...)` acceptance test
  * (prebindgen#54): a generated handle class joins an existing SDK hierarchy
  * without hand-editing generated code. Its abstract members are satisfied by
- * the generated surface (`NativeHandle`'s public `peek()`/`isClosed()`), and
- * the default member shows interface-injected behavior on top of it.
+ * the generated surface two ways — `peek()`/`isClosed()` by `NativeHandle`'s
+ * inherited public members (no marker needed), `len(...)` by the class-body
+ * method generated from `.fun(fun!(storage_len).overrides())` (Kotlin
+ * requires the `override` modifier on class-body members, which the marker
+ * emits). The default members show interface-injected behavior over both.
  */
 interface CovResource {
     fun peek(): Long
 
     fun isClosed(): Boolean
 
-    /** Interface-provided behavior over the generated members. */
+    /** Satisfied by the generated class-body method (`.overrides()`). */
+    fun len(onError: JniErrorHandler<Long>): Long
+
+    /** Interface-provided behavior over the inherited members. */
     fun isLive(): Boolean = !isClosed() && peek() != 0L
+
+    /** Interface-provided behavior over a generated class-specific method. */
+    fun isEmpty(): Boolean = len(JniErrorHandler { je -> error(je ?: "len failed") }) == 0L
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
@@ -1,17 +1,36 @@
 package io.prebindgen.covertest
 
+import io.prebindgen.covertest.model.Priority
+
 /**
- * Hand-written consumer interface for the `.implements(...)` acceptance test
- * (prebindgen#54): a generated handle class joins an existing SDK hierarchy
- * without hand-editing generated code. Its abstract members are satisfied by
- * the generated surface (`NativeHandle`'s public `peek()`/`isClosed()`), and
- * the default member shows interface-injected behavior on top of it.
+ * Hand-written SDK interfaces demonstrating the `.interface()` hatch
+ * (prebindgen#54): each EXTENDS the generated `<Name>Api` interface, so its
+ * default members call the class's real generated members with full compiler
+ * checking — no hand-replicated signatures, no editing of generated code.
  */
-interface CovResource {
-    fun peek(): Long
 
-    fun isClosed(): Boolean
+/** Extends the generated `StorageApi` (a ptr class). */
+interface CovResource : StorageApi {
+    /** Default member over the class-specific generated `len(...)`. */
+    fun isEmpty(): Boolean = len(JniErrorHandler { je -> error(je ?: "len failed") }) == 0L
 
-    /** Interface-provided behavior over the generated members. */
-    fun isLive(): Boolean = !isClosed() && peek() != 0L
+    /** Default member over the inherited `NativeHandle` surface. */
+    val live: Boolean
+        get() = !isClosed() && peek() != 0L
+}
+
+/** Extends the generated `PayloadApi` (a data class) — uses its `seq` field. */
+interface Timestamped : io.prebindgen.covertest.PayloadApi {
+    /** Whether this payload carries a positive sequence number. */
+    val fresh: Boolean
+        get() = seq > 0
+}
+
+/**
+ * The enum's generated interface is named `PriorityKind` (via
+ * `.interface_name(...)`); this SDK extension adds ranking behavior over its
+ * `value` property.
+ */
+interface Ranked : io.prebindgen.covertest.model.PriorityKind {
+    fun outranks(other: Priority): Boolean = value > other.value
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
@@ -4,23 +4,14 @@ package io.prebindgen.covertest
  * Hand-written consumer interface for the `.implements(...)` acceptance test
  * (prebindgen#54): a generated handle class joins an existing SDK hierarchy
  * without hand-editing generated code. Its abstract members are satisfied by
- * the generated surface two ways — `peek()`/`isClosed()` by `NativeHandle`'s
- * inherited public members (no marker needed), `len(...)` by the class-body
- * method generated from `.fun(fun!(storage_len).overrides())` (Kotlin
- * requires the `override` modifier on class-body members, which the marker
- * emits). The default members show interface-injected behavior over both.
+ * the generated surface (`NativeHandle`'s public `peek()`/`isClosed()`), and
+ * the default member shows interface-injected behavior on top of it.
  */
 interface CovResource {
     fun peek(): Long
 
     fun isClosed(): Boolean
 
-    /** Satisfied by the generated class-body method (`.overrides()`). */
-    fun len(onError: JniErrorHandler<Long>): Long
-
-    /** Interface-provided behavior over the inherited members. */
+    /** Interface-provided behavior over the generated members. */
     fun isLive(): Boolean = !isClosed() && peek() != 0L
-
-    /** Interface-provided behavior over a generated class-specific method. */
-    fun isEmpty(): Boolean = len(JniErrorHandler { je -> error(je ?: "len failed") }) == 0L
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/CovResource.kt
@@ -1,0 +1,17 @@
+package io.prebindgen.covertest
+
+/**
+ * Hand-written consumer interface for the `.implements(...)` acceptance test
+ * (prebindgen#54): a generated handle class joins an existing SDK hierarchy
+ * without hand-editing generated code. Its abstract members are satisfied by
+ * the generated surface (`NativeHandle`'s public `peek()`/`isClosed()`), and
+ * the default member shows interface-injected behavior on top of it.
+ */
+interface CovResource {
+    fun peek(): Long
+
+    fun isClosed(): Boolean
+
+    /** Interface-provided behavior over the generated members. */
+    fun isLive(): Boolean = !isClosed() && peek() != 0L
+}

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -172,6 +172,20 @@ fun main() {
         s.close()
     }
 
+    // ── .implements(...) integration hatch (#54): the generated Storage class
+    // implements the HAND-WRITTEN CovResource interface — used here through a
+    // polymorphic interface reference, including an interface-default member
+    // built on the generated peek()/isClosed() surface ────────────────────────
+    section(".implements() hatch (Storage as CovResource)") {
+        val s = storageNew(boom)
+        val r: CovResource = s
+        check(r.isLive())                 // default member over generated surface
+        check(!r.isClosed() && r.peek() != 0L)
+        s.close()
+        check(!r.isLive())
+        check(r.isClosed() && r.peek() == 0L)
+    }
+
     // ── impl Fn callbacks: single-payload + whole-batch ──────────────────────
     section("callbacks (impl Fn single + slice)") {
         val s = storageNew(boom)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -174,13 +174,20 @@ fun main() {
 
     // ── .implements(...) integration hatch (#54): the generated Storage class
     // implements the HAND-WRITTEN CovResource interface — used here through a
-    // polymorphic interface reference, including an interface-default member
-    // built on the generated peek()/isClosed() surface ────────────────────────
-    section(".implements() hatch (Storage as CovResource)") {
+    // polymorphic interface reference. Abstracts are satisfied both by the
+    // inherited NativeHandle surface (peek/isClosed) and by the
+    // `.overrides()`-marked class-body method (len); the default members build
+    // interface-injected behavior over each ───────────────────────────────────
+    section(".implements() hatch (Storage as CovResource, .overrides() len)") {
         val s = storageNew(boom)
         val r: CovResource = s
-        check(r.isLive())                 // default member over generated surface
+        check(r.isLive())                 // default member over inherited surface
         check(!r.isClosed() && r.peek() != 0L)
+        check(r.isEmpty())                // default member over generated len()
+        check(r.len(boom) == 0L)          // class-specific method via the interface
+        storagePutByTake(s, payload(7L, 0, 0.0, false, null), boom)
+        check(!r.isEmpty())
+        check(r.len(boom) == 1L)
         s.close()
         check(!r.isLive())
         check(r.isClosed() && r.peek() == 0L)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -174,20 +174,13 @@ fun main() {
 
     // ── .implements(...) integration hatch (#54): the generated Storage class
     // implements the HAND-WRITTEN CovResource interface — used here through a
-    // polymorphic interface reference. Abstracts are satisfied both by the
-    // inherited NativeHandle surface (peek/isClosed) and by the
-    // `.overrides()`-marked class-body method (len); the default members build
-    // interface-injected behavior over each ───────────────────────────────────
-    section(".implements() hatch (Storage as CovResource, .overrides() len)") {
+    // polymorphic interface reference, including an interface-default member
+    // built on the generated peek()/isClosed() surface ────────────────────────
+    section(".implements() hatch (Storage as CovResource)") {
         val s = storageNew(boom)
         val r: CovResource = s
-        check(r.isLive())                 // default member over inherited surface
+        check(r.isLive())                 // default member over generated surface
         check(!r.isClosed() && r.peek() != 0L)
-        check(r.isEmpty())                // default member over generated len()
-        check(r.len(boom) == 0L)          // class-specific method via the interface
-        storagePutByTake(s, payload(7L, 0, 0.0, false, null), boom)
-        check(!r.isEmpty())
-        check(r.len(boom) == 1L)
         s.close()
         check(!r.isLive())
         check(r.isClosed() && r.peek() == 0L)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -172,18 +172,34 @@ fun main() {
         s.close()
     }
 
-    // ── .implements(...) integration hatch (#54): the generated Storage class
-    // implements the HAND-WRITTEN CovResource interface — used here through a
-    // polymorphic interface reference, including an interface-default member
-    // built on the generated peek()/isClosed() surface ────────────────────────
-    section(".implements() hatch (Storage as CovResource)") {
+    // ── .interface() hatch (#54): each generated class emits a `<Name>Api`
+    // interface; the HAND-WRITTEN CovResource/Timestamped/Ranked interfaces
+    // EXTEND those and add default members that call the class's real
+    // generated members — used here polymorphically, no generated-code edits ──
+    section(".interface() hatch (Api interfaces extended by SDK interfaces)") {
+        // ptr class: Storage implements StorageApi; CovResource : StorageApi.
         val s = storageNew(boom)
         val r: CovResource = s
-        check(r.isLive())                 // default member over generated surface
-        check(!r.isClosed() && r.peek() != 0L)
+        check(r.live)                     // default over inherited peek()/isClosed()
+        check(r.isEmpty())                // default over class-specific len()
+        check(r.len(boom) == 0L)          // generated member through the interface
+        storagePutByTake(s, payload(7L, 0, 0.0, false, null), boom)
+        check(!r.isEmpty())
+        check(r.len(boom) == 1L)
         s.close()
-        check(!r.isLive())
+        check(!r.live)
         check(r.isClosed() && r.peek() == 0L)
+
+        // data class: Payload implements PayloadApi; Timestamped : PayloadApi.
+        val fresh: Timestamped = payload(1L, 5, 0.0, false, null)
+        val stale: Timestamped = payload(1L, 0, 0.0, false, null)
+        check(fresh.fresh && !stale.fresh)
+        check(fresh.seq == 5)             // generated field through the interface
+
+        // enum class: Priority implements PriorityKind + Ranked.
+        val hi: Ranked = Priority.HIGH
+        check(hi.outranks(Priority.LOW))  // default over generated `value`
+        check(!Priority.LOW.outranks(Priority.HIGH))
     }
 
     // ── impl Fn callbacks: single-payload + whole-batch ──────────────────────

--- a/prebindgen/src/api/gen/kotlin/model.rs
+++ b/prebindgen/src/api/gen/kotlin/model.rs
@@ -175,6 +175,9 @@ pub enum ClassKind {
     Object,
     /// `companion object` (only valid as [`KtClass::companion`]).
     Companion,
+    /// A plain `interface` — members with no body render as abstract
+    /// signatures; no ctor params.
+    Interface,
 }
 
 #[derive(Clone, Debug)]
@@ -191,6 +194,9 @@ pub struct KtCtorParam {
     pub ty: KtType,
     /// `None` = plain ctor param; `Some(false)` = `val`, `Some(true)` = `var`.
     pub prop: Option<bool>,
+    /// Render the `override` modifier (`override val id: Long`) — the
+    /// property implements an abstract of a supertype interface.
+    pub overrides: bool,
     pub vis: Vis,
     pub default: Option<String>,
     pub annotations: Vec<String>,
@@ -202,6 +208,7 @@ impl KtCtorParam {
             name: name.into(),
             ty,
             prop: None,
+            overrides: false,
             vis: Vis::Default,
             default: None,
             annotations: Vec::new(),
@@ -209,6 +216,11 @@ impl KtCtorParam {
     }
     pub fn val(mut self) -> Self {
         self.prop = Some(false);
+        self
+    }
+    /// Mark the property as overriding a supertype-interface abstract.
+    pub fn overrides(mut self) -> Self {
+        self.overrides = true;
         self
     }
     pub fn var(mut self) -> Self {

--- a/prebindgen/src/api/gen/kotlin/render.rs
+++ b/prebindgen/src/api/gen/kotlin/render.rs
@@ -148,6 +148,7 @@ fn class_keyword(kind: &ClassKind) -> &'static str {
         ClassKind::ValueInline => "value class",
         ClassKind::Object => "object",
         ClassKind::Companion => "companion object",
+        ClassKind::Interface => "interface",
     }
 }
 
@@ -157,6 +158,9 @@ fn render_ctor_param(p: &KtCtorParam, imports: &mut ImportSet) -> String {
         s.push_str(&format!("@{a} "));
     }
     s.push_str(p.vis.prefix());
+    if p.overrides {
+        s.push_str("override ");
+    }
     match p.prop {
         Some(false) => s.push_str("val "),
         Some(true) => s.push_str("var "),

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -336,7 +336,7 @@ impl JniGen {
                 opaque.interfaces.push(iface);
             }
         }
-        self.accept_members_impl(&key, decl.members, true);
+        self.accept_members(&key, decl.members);
     }
 
     fn accept_enum_class(&mut self, subpackage: &str, decl: EnumClassDecl) {
@@ -427,27 +427,9 @@ impl JniGen {
     /// constructor member's return is additionally never output-flattened
     /// (it's a factory); then the members join the class's registered set.
     fn accept_members(&mut self, key: &TypeKey, members: Vec<(FunctionDecl, MemberKind)>) {
-        self.accept_members_impl(key, members, false)
-    }
-
-    /// `overrides_allowed`: only `ptr_class` instance methods may carry
-    /// `.overrides()` — the marker pairs with `PtrClassDecl::implements`,
-    /// which the other class kinds don't have.
-    fn accept_members_impl(
-        &mut self,
-        key: &TypeKey,
-        members: Vec<(FunctionDecl, MemberKind)>,
-        overrides_allowed: bool,
-    ) {
         for (decl, kind) in members {
             let rust_ident = decl.rust_ident.clone();
             let kotlin_name_override = decl.kotlin_name_override.clone();
-            let overrides = decl.overrides;
-            assert!(
-                !overrides || (overrides_allowed && kind == MemberKind::Fun),
-                "fun!({rust_ident}).overrides(): the `override` modifier applies only to a \
-                 ptr_class instance method (the marker pairs with `.implements(...)`)"
-            );
             self.accept_fn_expands(decl);
             if kind == MemberKind::Constructor {
                 self.deconstructors
@@ -460,18 +442,11 @@ impl JniGen {
                     rust_ident,
                     kotlin_name_override,
                     kind,
-                    overrides,
                 });
         }
     }
 
     fn accept_function(&mut self, subpackage: &str, decl: FunctionDecl) {
-        assert!(
-            !decl.overrides,
-            "fun!({}).overrides(): a free package function overrides nothing — the marker \
-             applies only to a ptr_class instance method",
-            decl.rust_ident
-        );
         let mut entry = MethodEntry::new(decl.rust_ident.clone());
         entry.kotlin_name_override = decl.kotlin_name_override.clone();
         self.packages
@@ -496,7 +471,6 @@ impl JniGen {
             kotlin_name_override: _,
             param_expands,
             return_expand,
-            overrides: _,
         } = decl;
         for (param, pdecl) in param_expands {
             self.fn_param_expands

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -336,7 +336,7 @@ impl JniGen {
                 opaque.interfaces.push(iface);
             }
         }
-        self.accept_members(&key, decl.members);
+        self.accept_members_impl(&key, decl.members, true);
     }
 
     fn accept_enum_class(&mut self, subpackage: &str, decl: EnumClassDecl) {
@@ -427,9 +427,27 @@ impl JniGen {
     /// constructor member's return is additionally never output-flattened
     /// (it's a factory); then the members join the class's registered set.
     fn accept_members(&mut self, key: &TypeKey, members: Vec<(FunctionDecl, MemberKind)>) {
+        self.accept_members_impl(key, members, false)
+    }
+
+    /// `overrides_allowed`: only `ptr_class` instance methods may carry
+    /// `.overrides()` — the marker pairs with `PtrClassDecl::implements`,
+    /// which the other class kinds don't have.
+    fn accept_members_impl(
+        &mut self,
+        key: &TypeKey,
+        members: Vec<(FunctionDecl, MemberKind)>,
+        overrides_allowed: bool,
+    ) {
         for (decl, kind) in members {
             let rust_ident = decl.rust_ident.clone();
             let kotlin_name_override = decl.kotlin_name_override.clone();
+            let overrides = decl.overrides;
+            assert!(
+                !overrides || (overrides_allowed && kind == MemberKind::Fun),
+                "fun!({rust_ident}).overrides(): the `override` modifier applies only to a \
+                 ptr_class instance method (the marker pairs with `.implements(...)`)"
+            );
             self.accept_fn_expands(decl);
             if kind == MemberKind::Constructor {
                 self.deconstructors
@@ -442,11 +460,18 @@ impl JniGen {
                     rust_ident,
                     kotlin_name_override,
                     kind,
+                    overrides,
                 });
         }
     }
 
     fn accept_function(&mut self, subpackage: &str, decl: FunctionDecl) {
+        assert!(
+            !decl.overrides,
+            "fun!({}).overrides(): a free package function overrides nothing — the marker \
+             applies only to a ptr_class instance method",
+            decl.rust_ident
+        );
         let mut entry = MethodEntry::new(decl.rust_ident.clone());
         entry.kotlin_name_override = decl.kotlin_name_override.clone();
         self.packages
@@ -471,6 +496,7 @@ impl JniGen {
             kotlin_name_override: _,
             param_expands,
             return_expand,
+            overrides: _,
         } = decl;
         for (param, pdecl) in param_expands {
             self.fn_param_expands

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -67,6 +67,7 @@ impl JniGen {
             enum_name_mangle: None,
             member_name_mangle: None,
             harness_name_mangle: None,
+            interface_name_mangle: None,
             types: HashMap::new(),
             packages: BTreeMap::new(),
             input_wrappers: [
@@ -295,7 +296,7 @@ impl JniGen {
         // derived at write time, but a dotted relative name is a declaration
         // mistake and should surface in the declaring call (the same check
         // `resolve_class_fqn` repeats at derivation time).
-        if let NameSpec::Class {
+        if let NameSpec {
             name_override: Some(n),
             ..
         } = &spec
@@ -312,30 +313,44 @@ impl JniGen {
         entry.name_spec = Some(spec);
     }
 
+    /// Merge a decl's interface options into the type's [`TypeConfig`]
+    /// (reopened decls merge; the `.interface()` switch and name override are
+    /// sticky-OR / last-wins, a repeated `.implements` interface is
+    /// idempotent).
+    fn store_iface_opts(&mut self, key: &TypeKey, iface: IfaceOpts) {
+        let cfg = self
+            .types
+            .get_mut(key)
+            .expect("register_class_name created the entry");
+        cfg.interface_enabled |= iface.enabled;
+        if iface.name_override.is_some() {
+            cfg.interface_name_override = iface.name_override;
+        }
+        for i in iface.implements {
+            if !cfg.interfaces.contains(&i) {
+                cfg.interfaces.push(i);
+            }
+        }
+    }
+
     fn accept_ptr_class(&mut self, subpackage: &str, decl: PtrClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
         self.register_class_name(
             &key,
-            NameSpec::Class {
+            NameSpec {
                 subpackage: subpackage.to_string(),
                 short,
                 name_override: decl.name_override,
                 kind: NameKind::Ptr,
             },
         );
-        let opaque = self
-            .types
+        self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
             .opaque
             .get_or_insert_with(OpaqueConfig::default);
-        // Reopened decls merge; a repeated interface is idempotent.
-        for iface in decl.interfaces {
-            if !opaque.interfaces.contains(&iface) {
-                opaque.interfaces.push(iface);
-            }
-        }
+        self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
     }
 
@@ -350,74 +365,54 @@ impl JniGen {
              a type can be one or the other, not both",
             short
         );
-        // An explicit `kotlin_type` maps the enum onto an existing Kotlin
-        // type (verbatim FQN, no file generated); the jint wire and the
-        // `fromInt`/`.value` call protocol are identical either way.
-        let spec = match decl.kotlin_type {
-            Some(expr) => NameSpec::Verbatim(expr),
-            None => NameSpec::Class {
+        self.register_class_name(
+            &key,
+            NameSpec {
                 subpackage: subpackage.to_string(),
                 short,
                 name_override: decl.name_override,
                 kind: NameKind::Enum,
             },
-        };
-        self.register_class_name(&key, spec);
+        );
         self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
             .enum_cfg = Some(EnumConfig::default());
+        self.store_iface_opts(&key, decl.iface);
     }
 
-    /// A data/value class's explicit `kotlin_type` expression is a verbatim
-    /// Kotlin type and wins over everything; otherwise the name derives from
-    /// settings at read time like any other declared class.
     fn data_value_name_spec(
         subpackage: &str,
         short: String,
         name_override: Option<String>,
-        kotlin_type: Option<String>,
     ) -> NameSpec {
-        match kotlin_type {
-            Some(expr) => NameSpec::Verbatim(expr),
-            None => NameSpec::Class {
-                subpackage: subpackage.to_string(),
-                short,
-                name_override,
-                kind: NameKind::DataOrValue,
-            },
+        NameSpec {
+            subpackage: subpackage.to_string(),
+            short,
+            name_override,
+            kind: NameKind::DataOrValue,
         }
     }
 
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        assert!(
-            decl.kotlin_type.is_none() || decl.members.is_empty(),
-            "data_class `{short}`: .kotlin_type() maps onto an EXISTING type — there is no \
-             generated class to hold members"
-        );
-        let spec =
-            Self::data_value_name_spec(subpackage, short, decl.name_override, decl.kotlin_type);
+        let spec = Self::data_value_name_spec(subpackage, short, decl.name_override);
         self.register_class_name(&key, spec);
+        self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
     }
 
     fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        assert!(
-            decl.kotlin_type.is_none() || decl.members.is_empty(),
-            "value_class `{short}`: .kotlin_type() maps onto an EXISTING type — there is no \
-             generated class to hold members"
-        );
-        let spec =
-            Self::data_value_name_spec(subpackage, short, decl.name_override, decl.kotlin_type);
+        let spec = Self::data_value_name_spec(subpackage, short, decl.name_override);
         self.register_class_name(&key, spec);
         self.types
             .get_mut(&key)
             .expect("register_class_name created the entry")
             .value_blob = true;
+        self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -324,10 +324,18 @@ impl JniGen {
                 kind: NameKind::Ptr,
             },
         );
-        self.types
+        let opaque = self
+            .types
             .get_mut(&key)
             .expect("register_class_name created the entry")
-            .opaque = Some(OpaqueConfig::default());
+            .opaque
+            .get_or_insert_with(OpaqueConfig::default);
+        // Reopened decls merge; a repeated interface is idempotent.
+        for iface in decl.interfaces {
+            if !opaque.interfaces.contains(&iface) {
+                opaque.interfaces.push(iface);
+            }
+        }
         self.accept_members(&key, decl.members);
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -13,9 +13,9 @@
 //!
 //! # Name-mangle hooks
 //!
-//! One uniform contract for all six hooks: **the hook receives the derived
-//! default name for its tier** — exactly what the generator would use if no
-//! hook were set — **and returns the final name; every default is the
+//! One uniform contract for the six name hooks: **the hook receives the
+//! derived default name for its tier** — exactly what the generator would use
+//! if no hook were set — **and returns the final name; every default is the
 //! identity.** The input *domain* differs per tier (a fn name is camelCase,
 //! a class name is a Rust short name); the table states each:
 //!
@@ -28,8 +28,15 @@
 //! | [`set_enum_name_mangle`](JniGen::set_enum_name_mangle) | `enum_class` Kotlin classes | Rust type short name | identity |
 //! | [`set_member_name_mangle`](JniGen::set_member_name_mangle) | class members without a per-member `.name()` | namespace-stripped camelCase (`storage_len` on `Storage` → `"len"`) | identity |
 //!
-//! A per-decl `.name()` override is always verbatim and **bypasses** the
-//! hooks entirely.
+//! One further hook does NOT follow the identity rule, because its input and
+//! output are two names that must differ:
+//!
+//! | hook | names | input | default |
+//! |---|---|---|---|
+//! | [`set_interface_name_mangle`](JniGen::set_interface_name_mangle) | the generated `.interface()` interface | the final **class** name (`"Storage"`) | append `"Api"` (`"StorageApi"`); identity is a hard error |
+//!
+//! A per-decl `.name()` / `.interface_name()` override is always verbatim and
+//! **bypasses** the hooks entirely.
 
 use super::*;
 
@@ -42,33 +49,18 @@ pub(crate) enum NameKind {
     DataOrValue,
 }
 
-/// Raw naming spec of one type, stored in [`TypeConfig`] as declared and
-/// turned into a concrete Kotlin FQN only when read ([`JniGen::fqn_of`]),
-/// against whatever the settings are at that moment.
+/// Raw naming spec of one declared class type, stored in [`TypeConfig`] as
+/// declared and turned into a concrete Kotlin FQN only when read
+/// ([`JniGen::fqn_of`]), against whatever the settings are at that moment.
 #[derive(Clone)]
-pub(crate) enum NameSpec {
-    /// Verbatim Kotlin type/FQN — a scalar wrapper's `kotlin_type`, or a
-    /// data/value class's `kotlin_type` expression. Settings-independent.
-    Verbatim(String),
-    /// A declared class whose FQN derives from the current settings.
-    Class {
-        subpackage: String,
-        /// `rust_short_name(&key)` — the mangle hook's input.
-        short: String,
-        /// Per-decl `.name()` — resolved against package + subpackage,
-        /// bypasses the mangle hook.
-        name_override: Option<String>,
-        kind: NameKind,
-    },
-}
-
-impl NameSpec {
-    /// True for a `kotlin_type`-mapped declaration: the type surfaces as an
-    /// EXISTING Kotlin type — emitters generate no file for it (the FQN is
-    /// used verbatim at reference sites only).
-    pub(crate) fn is_verbatim(&self) -> bool {
-        matches!(self, NameSpec::Verbatim(_))
-    }
+pub(crate) struct NameSpec {
+    pub(crate) subpackage: String,
+    /// `rust_short_name(&key)` — the mangle hook's input.
+    pub(crate) short: String,
+    /// Per-decl `.name()` — resolved against package + subpackage,
+    /// bypasses the mangle hook.
+    pub(crate) name_override: Option<String>,
+    pub(crate) kind: NameKind,
 }
 
 impl JniGen {
@@ -120,6 +112,22 @@ impl JniGen {
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.fun_name_mangle = Some(Arc::new(f));
+        self
+    }
+
+    /// Set the closure that turns a class name into the name of its generated
+    /// `.interface()` interface. Receives the **final class name** and must
+    /// return a DIFFERENT name — identity is a hard error (a class and its
+    /// interface cannot share a name in one package), the one deviation from
+    /// the uniform hook contract in the module-level table. Default when
+    /// unset = append `"Api"` (`Storage` → `StorageApi`). A per-decl
+    /// [`interface_name`](crate::lang::PtrClassDecl::interface_name) wins over
+    /// the hook.
+    pub fn set_interface_name_mangle<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.interface_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -196,25 +204,21 @@ impl JniGen {
     /// `name_override` (package-resolved, mangle-bypassed), then the mangle
     /// hook for the class kind + package resolution.
     pub(crate) fn fqn_of(&self, spec: &NameSpec) -> String {
-        match spec {
-            NameSpec::Verbatim(fqn) => fqn.clone(),
-            NameSpec::Class {
-                subpackage,
-                short,
-                name_override,
-                kind,
-            } => {
-                if let Some(n) = name_override {
-                    return self.resolve_class_fqn(subpackage, n);
-                }
-                let mangled = match kind {
-                    NameKind::Ptr => self.mangle_ptr_class(short),
-                    NameKind::Enum => self.mangle_enum(short),
-                    NameKind::DataOrValue => self.mangle_data_class(short),
-                };
-                self.resolve_class_fqn(subpackage, &mangled)
-            }
+        let NameSpec {
+            subpackage,
+            short,
+            name_override,
+            kind,
+        } = spec;
+        if let Some(n) = name_override {
+            return self.resolve_class_fqn(subpackage, n);
         }
+        let mangled = match kind {
+            NameKind::Ptr => self.mangle_ptr_class(short),
+            NameKind::Enum => self.mangle_enum(short),
+            NameKind::DataOrValue => self.mangle_data_class(short),
+        };
+        self.resolve_class_fqn(subpackage, &mangled)
     }
 
     /// The registered Kotlin FQN for a canonical Rust type key, derived on

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -429,7 +429,8 @@ impl ExpandParamDecl {
         assert!(
             ctor.kotlin_name_override.is_none()
                 && ctor.param_expands.is_empty()
-                && ctor.return_expand.is_none(),
+                && ctor.return_expand.is_none()
+                && !ctor.overrides,
             "expand_param!({}).variant(fun!({})): a variant arm only names the \
              `#[prebindgen]` constructor — .name()/expand overrides don't apply",
             self.key.as_str(),
@@ -502,7 +503,9 @@ impl ExpandReturnDecl {
     /// accessor).
     pub fn field(mut self, accessor: FunctionDecl) -> Self {
         assert!(
-            accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
+            accessor.param_expands.is_empty()
+                && accessor.return_expand.is_none()
+                && !accessor.overrides,
             "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
              field accessor — only .name() is honored",
             self.key.as_str(),
@@ -774,6 +777,7 @@ pub struct FunctionDecl {
     pub(crate) kotlin_name_override: Option<String>,
     pub(crate) param_expands: Vec<(String, ExpandParamDecl)>,
     pub(crate) return_expand: Option<ExpandReturnDecl>,
+    pub(crate) overrides: bool,
 }
 
 impl FunctionDecl {
@@ -783,7 +787,19 @@ impl FunctionDecl {
             kotlin_name_override: None,
             param_expands: Vec::new(),
             return_expand: None,
+            overrides: false,
         }
+    }
+
+    /// Emit the Kotlin `override` modifier on the generated member — required
+    /// when a [`PtrClassDecl::implements`] interface declares a matching
+    /// abstract member (Kotlin demands `override` on a class-body member that
+    /// implements an interface member; inherited `NativeHandle` members need
+    /// no marker). Valid only on a `ptr_class` instance method
+    /// ([`PtrClassDecl::fun`]) — everywhere else it is a hard error.
+    pub fn overrides(mut self) -> Self {
+        self.overrides = true;
+        self
     }
 
     /// Set the Kotlin-side name. Default: the Rust name camel-cased
@@ -943,7 +959,7 @@ impl ConstDecl {
     /// must take no parameters and must not return `Result`.
     pub fn fun(self, decl: FunctionDecl) -> Self {
         assert!(
-            decl.param_expands.is_empty() && decl.return_expand.is_none(),
+            decl.param_expands.is_empty() && decl.return_expand.is_none() && !decl.overrides,
             "constant `{}`: expand overrides don't apply to a constant source fn `{}`",
             self.rust_ident,
             decl.rust_ident
@@ -1021,7 +1037,8 @@ impl From<FunctionDecl> for IgnoreDecl {
         assert!(
             decl.kotlin_name_override.is_none()
                 && decl.param_expands.is_empty()
-                && decl.return_expand.is_none(),
+                && decl.return_expand.is_none()
+                && !decl.overrides,
             "ignore(fun!({})): an ignored fn is never surfaced — \
              .name()/expand overrides don't apply",
             decl.rust_ident
@@ -1359,7 +1376,8 @@ impl From<FunctionDecl> for ConvertSourceDecl {
         assert!(
             decl.kotlin_name_override.is_none()
                 && decl.param_expands.is_empty()
-                && decl.return_expand.is_none(),
+                && decl.return_expand.is_none()
+                && !decl.overrides,
             "fun!({}) as a conversion source: a conversion fn is never surfaced in \
              Kotlin — .name()/expand overrides don't apply",
             decl.rust_ident

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -429,8 +429,7 @@ impl ExpandParamDecl {
         assert!(
             ctor.kotlin_name_override.is_none()
                 && ctor.param_expands.is_empty()
-                && ctor.return_expand.is_none()
-                && !ctor.overrides,
+                && ctor.return_expand.is_none(),
             "expand_param!({}).variant(fun!({})): a variant arm only names the \
              `#[prebindgen]` constructor — .name()/expand overrides don't apply",
             self.key.as_str(),
@@ -503,9 +502,7 @@ impl ExpandReturnDecl {
     /// accessor).
     pub fn field(mut self, accessor: FunctionDecl) -> Self {
         assert!(
-            accessor.param_expands.is_empty()
-                && accessor.return_expand.is_none()
-                && !accessor.overrides,
+            accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
             "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
              field accessor — only .name() is honored",
             self.key.as_str(),
@@ -777,7 +774,6 @@ pub struct FunctionDecl {
     pub(crate) kotlin_name_override: Option<String>,
     pub(crate) param_expands: Vec<(String, ExpandParamDecl)>,
     pub(crate) return_expand: Option<ExpandReturnDecl>,
-    pub(crate) overrides: bool,
 }
 
 impl FunctionDecl {
@@ -787,19 +783,7 @@ impl FunctionDecl {
             kotlin_name_override: None,
             param_expands: Vec::new(),
             return_expand: None,
-            overrides: false,
         }
-    }
-
-    /// Emit the Kotlin `override` modifier on the generated member — required
-    /// when a [`PtrClassDecl::implements`] interface declares a matching
-    /// abstract member (Kotlin demands `override` on a class-body member that
-    /// implements an interface member; inherited `NativeHandle` members need
-    /// no marker). Valid only on a `ptr_class` instance method
-    /// ([`PtrClassDecl::fun`]) — everywhere else it is a hard error.
-    pub fn overrides(mut self) -> Self {
-        self.overrides = true;
-        self
     }
 
     /// Set the Kotlin-side name. Default: the Rust name camel-cased
@@ -959,7 +943,7 @@ impl ConstDecl {
     /// must take no parameters and must not return `Result`.
     pub fn fun(self, decl: FunctionDecl) -> Self {
         assert!(
-            decl.param_expands.is_empty() && decl.return_expand.is_none() && !decl.overrides,
+            decl.param_expands.is_empty() && decl.return_expand.is_none(),
             "constant `{}`: expand overrides don't apply to a constant source fn `{}`",
             self.rust_ident,
             decl.rust_ident
@@ -1037,8 +1021,7 @@ impl From<FunctionDecl> for IgnoreDecl {
         assert!(
             decl.kotlin_name_override.is_none()
                 && decl.param_expands.is_empty()
-                && decl.return_expand.is_none()
-                && !decl.overrides,
+                && decl.return_expand.is_none(),
             "ignore(fun!({})): an ignored fn is never surfaced — \
              .name()/expand overrides don't apply",
             decl.rust_ident
@@ -1376,8 +1359,7 @@ impl From<FunctionDecl> for ConvertSourceDecl {
         assert!(
             decl.kotlin_name_override.is_none()
                 && decl.param_expands.is_empty()
-                && decl.return_expand.is_none()
-                && !decl.overrides,
+                && decl.return_expand.is_none(),
             "fun!({}) as a conversion source: a conversion fn is never surfaced in \
              Kotlin — .name()/expand overrides don't apply",
             decl.rust_ident

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -287,6 +287,7 @@ pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
     pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
+    pub(crate) interfaces: Vec<String>,
 }
 
 impl PtrClassDecl {
@@ -295,6 +296,7 @@ impl PtrClassDecl {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
             members: Vec::new(),
+            interfaces: Vec::new(),
         }
     }
 
@@ -304,6 +306,34 @@ impl PtrClassDecl {
     /// from the enclosing [`PackageDecl`].
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name_override = Some(name.into());
+        self
+    }
+
+    /// Add a Kotlin **interface** to the generated class's supertype list —
+    /// the bounded integration hatch for plugging generated handles into an
+    /// existing SDK hierarchy (a `ptr_class` has no `.kotlin_type()`: the
+    /// generated class owns the lifecycle contract, and an interface adds
+    /// obligations without overriding `close()`/`take()`/`ptr` behavior).
+    ///
+    /// `iface` is a Kotlin interface FQN (dotted names are imported and
+    /// shortened) or a same-package name. The interface is implemented
+    /// *nominally*: its abstract members must be satisfied by the generated
+    /// surface — `NativeHandle`'s public `peek()`/`isClosed()`, `close()`
+    /// (via `AutoCloseable`), and the class's declared members — or carry
+    /// default implementations. Call again to add several interfaces.
+    pub fn implements(mut self, iface: impl Into<String>) -> Self {
+        let iface = iface.into();
+        assert!(
+            !iface.trim().is_empty(),
+            "ptr_class!({}).implements(...): the interface name is empty",
+            self.key.as_str()
+        );
+        assert!(
+            !self.interfaces.contains(&iface),
+            "ptr_class!({}).implements(\"{iface}\"): the interface is already declared",
+            self.key.as_str()
+        );
+        self.interfaces.push(iface);
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -278,16 +278,101 @@ macro_rules! expand_return {
 /// let _ = prebindgen::ptr_class!(KeyExpr)
 ///     .fun(prebindgen::fun!(keyexpr_get_str).name("str"));
 /// ```
-/// Deliberately has no `.kotlin_type()`: the generated typed-handle class
-/// OWNS a lifecycle contract — the `NativeHandle` base, the `ptr` slot,
-/// `close()`, the lock protocol, and the paired `freePtr` extern — that an
-/// arbitrary existing Kotlin type cannot be assumed to honor. The other
-/// class kinds are pure surface and may be mapped; a handle is not.
+/// Deliberately has no verbatim type mapping: the generated typed-handle
+/// class OWNS a lifecycle contract — the `NativeHandle` base, the `ptr`
+/// slot, `close()`, the lock protocol, and the paired `freePtr` extern —
+/// that an arbitrary existing Kotlin type cannot be assumed to honor.
+/// Customize it from above instead: [`interface`](Self::interface) /
+/// [`implements`](Self::implements).
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
     pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
-    pub(crate) interfaces: Vec<String>,
+    pub(crate) iface: IfaceOpts,
+}
+
+/// The interface-related options every class decl carries (see
+/// [`class_interface_methods!`]): the generated-interface switch + name
+/// override, and the `.implements(...)` list. The two features are
+/// orthogonal; used together, a user interface extends the generated one.
+#[derive(Clone, Default)]
+pub(crate) struct IfaceOpts {
+    pub(crate) enabled: bool,
+    pub(crate) name_override: Option<String>,
+    pub(crate) implements: Vec<String>,
+}
+
+/// The three interface methods shared verbatim by all four class decls —
+/// generated per decl so the panic messages name the right decl macro.
+macro_rules! class_interface_methods {
+    ($decl_macro:literal) => {
+        /// Emit a generated Kotlin **interface** mirroring this class's
+        /// public instance surface, and make the class implement it (every
+        /// class-body member gains the `override` modifier). The interface
+        /// is named by [`interface_name`](Self::interface_name), else the
+        /// [`JniGen::set_interface_name_mangle`] hook over the final class
+        /// name (default: append `"Api"`).
+        ///
+        /// This is the compiler-checked half of the integration hatch: a
+        /// hand-written interface that *extends* the generated one can build
+        /// default members over the class's real signatures — no
+        /// hand-replication. Pair it with [`implements`](Self::implements)
+        /// to attach that hand-written interface to the class. (For
+        /// behavior-only injection, a Kotlin extension function needs no
+        /// declaration at all.)
+        pub fn interface(mut self) -> Self {
+            self.iface.enabled = true;
+            self
+        }
+
+        /// Name the generated interface literally (relative, no dots),
+        /// bypassing the [`JniGen::set_interface_name_mangle`] hook.
+        /// Implies [`interface`](Self::interface).
+        pub fn interface_name(mut self, name: impl Into<String>) -> Self {
+            let name = name.into();
+            assert!(
+                !name.trim().is_empty(),
+                concat!($decl_macro, "!({}).interface_name(...): the name is empty"),
+                self.key.as_str()
+            );
+            self.iface.enabled = true;
+            self.iface.name_override = Some(name);
+            self
+        }
+
+        /// Add a Kotlin **interface** to the generated class's supertype
+        /// list — the class implements it *nominally*: its abstract members
+        /// must be satisfied by the generated surface or carry default
+        /// implementations. `iface` is an FQN (dotted names are imported and
+        /// shortened) or a same-package name; call again to add several.
+        ///
+        /// Orthogonal to [`interface`](Self::interface) — but to abstract
+        /// over the class's own members from your interface, enable the
+        /// generated interface and make yours extend it (that is what turns
+        /// mismatches into compile errors in YOUR file).
+        pub fn implements(mut self, iface: impl Into<String>) -> Self {
+            let iface = iface.into();
+            assert!(
+                !iface.trim().is_empty(),
+                concat!(
+                    $decl_macro,
+                    "!({}).implements(...): the interface name is empty"
+                ),
+                self.key.as_str()
+            );
+            assert!(
+                !self.iface.implements.contains(&iface),
+                concat!(
+                    $decl_macro,
+                    "!({}).implements(\"{}\"): the interface is already declared"
+                ),
+                self.key.as_str(),
+                iface
+            );
+            self.iface.implements.push(iface);
+            self
+        }
+    };
 }
 
 impl PtrClassDecl {
@@ -296,7 +381,7 @@ impl PtrClassDecl {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
             members: Vec::new(),
-            interfaces: Vec::new(),
+            iface: IfaceOpts::default(),
         }
     }
 
@@ -309,33 +394,7 @@ impl PtrClassDecl {
         self
     }
 
-    /// Add a Kotlin **interface** to the generated class's supertype list —
-    /// the bounded integration hatch for plugging generated handles into an
-    /// existing SDK hierarchy (a `ptr_class` has no `.kotlin_type()`: the
-    /// generated class owns the lifecycle contract, and an interface adds
-    /// obligations without overriding `close()`/`take()`/`ptr` behavior).
-    ///
-    /// `iface` is a Kotlin interface FQN (dotted names are imported and
-    /// shortened) or a same-package name. The interface is implemented
-    /// *nominally*: its abstract members must be satisfied by the generated
-    /// surface — `NativeHandle`'s public `peek()`/`isClosed()`, `close()`
-    /// (via `AutoCloseable`), and the class's declared members — or carry
-    /// default implementations. Call again to add several interfaces.
-    pub fn implements(mut self, iface: impl Into<String>) -> Self {
-        let iface = iface.into();
-        assert!(
-            !iface.trim().is_empty(),
-            "ptr_class!({}).implements(...): the interface name is empty",
-            self.key.as_str()
-        );
-        assert!(
-            !self.interfaces.contains(&iface),
-            "ptr_class!({}).implements(\"{iface}\"): the interface is already declared",
-            self.key.as_str()
-        );
-        self.interfaces.push(iface);
-        self
-    }
+    class_interface_methods!("ptr_class");
 
     /// Expose a `#[prebindgen]` method as a Kotlin **instance method** of this
     /// class. `rust_fun` must take `&Self` first — that receiver becomes
@@ -562,7 +621,7 @@ impl From<ExpandReturnDecl> for ExpandDecl {
 pub struct EnumClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
-    pub(crate) kotlin_type: Option<String>,
+    pub(crate) iface: IfaceOpts,
 }
 
 impl EnumClassDecl {
@@ -570,7 +629,7 @@ impl EnumClassDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
-            kotlin_type: None,
+            iface: IfaceOpts::default(),
         }
     }
 
@@ -580,15 +639,7 @@ impl EnumClassDecl {
         self
     }
 
-    /// Surface this enum as an **existing** Kotlin type instead of
-    /// generating an `enum class` file (see [`DataClassDecl::kotlin_type`]).
-    /// The named type must expose the generated protocol: a companion
-    /// `fromInt(Int): T` and a `val value: Int` with the Rust
-    /// discriminants — exactly what a generated enum class provides.
-    pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
-        self.kotlin_type = Some(expr.into());
-        self
-    }
+    class_interface_methods!("enum_class");
 }
 
 impl From<syn::Type> for EnumClassDecl {
@@ -610,7 +661,7 @@ impl From<syn::Type> for EnumClassDecl {
 pub struct DataClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
-    pub(crate) kotlin_type: Option<String>,
+    pub(crate) iface: IfaceOpts,
     pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
 }
 
@@ -619,7 +670,7 @@ impl DataClassDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
-            kotlin_type: None,
+            iface: IfaceOpts::default(),
             members: Vec::new(),
         }
     }
@@ -630,14 +681,7 @@ impl DataClassDecl {
         self
     }
 
-    /// Surface this type as a verbatim Kotlin type instead of a generated
-    /// class — for when it should map onto an existing or container type,
-    /// e.g. `"List<ByteArray>"`. Mutually exclusive with members (a mapped
-    /// type has no generated class to hold them).
-    pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
-        self.kotlin_type = Some(expr.into());
-        self
-    }
+    class_interface_methods!("data_class");
 
     /// Expose a `#[prebindgen]` reader (`f(&Self) -> R`) as an instance
     /// method on the generated data class (see [`PtrClassDecl::fun`]) — the
@@ -671,7 +715,7 @@ impl From<syn::Type> for DataClassDecl {
 pub struct ValueClassDecl {
     pub(crate) key: TypeKey,
     pub(crate) name_override: Option<String>,
-    pub(crate) kotlin_type: Option<String>,
+    pub(crate) iface: IfaceOpts,
     pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
 }
 
@@ -680,7 +724,7 @@ impl ValueClassDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             name_override: None,
-            kotlin_type: None,
+            iface: IfaceOpts::default(),
             members: Vec::new(),
         }
     }
@@ -691,12 +735,7 @@ impl ValueClassDecl {
         self
     }
 
-    /// Surface this type as a verbatim Kotlin type instead of a generated
-    /// value class (see [`DataClassDecl::kotlin_type`]).
-    pub fn kotlin_type(mut self, expr: impl Into<String>) -> Self {
-        self.kotlin_type = Some(expr.into());
-        self
-    }
+    class_interface_methods!("value_class");
 
     /// Expose a `#[prebindgen]` reader (`f(&Self) -> R`) as an instance
     /// method on the Kotlin value class (see [`PtrClassDecl::fun`]).

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -9,14 +9,13 @@ use super::*;
 /// [`JniGen::data_class`]) to derive a default Kotlin class name from
 /// the Rust type-key. Panics for non-path types (e.g. closures, references) —
 /// the per-kind `*_name_mangle` closures see only path-shaped
-/// shorts. For verbatim Kotlin expressions on non-path types, chain
-/// [`JniGen::kotlin_type`] after the structured builder.
+/// shorts. For verbatim Kotlin expressions on non-path types, use a
+/// scalar / generic type wrapper.
 pub(crate) fn rust_short_name(key: &TypeKey) -> String {
     rust_short_name_opt(key).unwrap_or_else(|| {
         panic!(
             "rust_short_name: cannot derive Kotlin name from type-key `{}` — \
-             only path-shaped types are supported here; use \
-             `kotlin_type(\"<verbatim>\")` to set the name explicitly",
+             only path-shaped types are supported here",
             key.as_str()
         )
     })

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -282,10 +282,6 @@ impl JniGen {
             if !cfg.value_blob {
                 continue;
             }
-            // `kotlin_type`-mapped: surfaces as an existing type, no file.
-            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
-                continue;
-            }
             let fqn = cfg
                 .name_spec
                 .as_ref()
@@ -308,7 +304,7 @@ impl JniGen {
             let class_kdoc = crate::api::lang::jnigen::jni::source_item_doc(registry, key)
                 .map(|d| format!("{d}\n\n{framework_line}"))
                 .unwrap_or(framework_line);
-            let mut class = KtClass::new(ClassKind::ValueInline, class_name)
+            let mut class = KtClass::new(ClassKind::ValueInline, &class_name)
                 .vis(Vis::Public)
                 .kdoc(class_kdoc)
                 .ctor_param(
@@ -364,7 +360,13 @@ impl JniGen {
                 }
                 class = class.companion(companion);
             }
-            written.push(kt::KtFile::new(package).decl(class).imports(imports));
+            let mut file = kt::KtFile::new(package);
+            if let Some(iface) =
+                self.apply_class_interface(key, &mut class, &class_name, &[], Vec::new(), true)
+            {
+                file = file.decl(iface);
+            }
+            written.push(file.decl(class).imports(imports));
         }
         Ok(written)
     }
@@ -433,11 +435,6 @@ impl JniGen {
             if cfg.enum_cfg.is_none() {
                 continue;
             }
-            // `kotlin_type`-mapped: the enum surfaces as an existing Kotlin
-            // type honoring the `fromInt`/`.value` protocol — no file.
-            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
-                continue;
-            }
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
@@ -457,7 +454,14 @@ impl JniGen {
                 Some((p, c)) => (p.to_string(), c.to_string()),
                 None => (String::new(), kotlin_fqn.clone()),
             };
-            written.push(kt::KtFile::new(package).decl(build_enum_class(&class_name, item_enum)));
+            let mut class = build_enum_class(&class_name, item_enum);
+            let mut file = kt::KtFile::new(package);
+            if let Some(iface) =
+                self.apply_class_interface(key, &mut class, &class_name, &[], Vec::new(), true)
+            {
+                file = file.decl(iface);
+            }
+            written.push(file.decl(class));
         }
         Ok(written)
     }
@@ -479,10 +483,6 @@ impl JniGen {
             // types each have their own emitter; only plain structs become
             // data classes here.
             if cfg.special_decl() {
-                continue;
-            }
-            // `kotlin_type`-mapped: surfaces as an existing type, no file.
-            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
                 continue;
             }
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
@@ -563,7 +563,13 @@ impl JniGen {
                 }
                 class = class.companion(companion);
             }
-            written.push(kt::KtFile::new(package).decl(class).imports(imports));
+            let mut file = kt::KtFile::new(package);
+            if let Some(iface) =
+                self.apply_class_interface(key, &mut class, &class_name, &[], Vec::new(), true)
+            {
+                file = file.decl(iface);
+            }
+            written.push(file.decl(class).imports(imports));
         }
 
         if !aliases.is_empty() {
@@ -590,7 +596,7 @@ impl JniGen {
     /// [`Self::write_jni_native`]). Opaque-handle parameters become
     /// `NativeHandle`; the wrapper body nests `withPtr` / `consume` per
     /// the type-conversion rule. Non-opaque parameters pass through with
-    /// the Kotlin type from `kotlin_types`. Opaque-handle return values
+    /// their mapped Kotlin type. Opaque-handle return values
     /// are wrapped in `NativeHandle(...)` before return.
     /// Emit every typed callback `fun interface` the declared functions
     /// reference — impl-`Fn` delivery callbacks, output-expansion builders
@@ -1183,7 +1189,7 @@ impl JniGen {
     /// same `handles` slice to both methods.
     ///
     /// Each handle's `kotlin_fqn` must be registered via
-    /// [`Self::kotlin_type_fqn`] so the generator can map it back to its
+    /// [`JniGen::kotlin_fqn`] so the generator can map it back to its
     /// Rust type-key (which identifies the first param to drop in each
     /// promoted method's signature).
     pub(crate) fn write_typed_handles(
@@ -1198,7 +1204,7 @@ impl JniGen {
                 None => (String::new(), handle.kotlin_fqn.to_string()),
             };
             let mut imports: BTreeSet<String> = BTreeSet::new();
-            let class = build_typed_handle(
+            let mut class = build_typed_handle(
                 self,
                 registry,
                 &class_name,
@@ -1206,8 +1212,147 @@ impl JniGen {
                 handle.key,
                 &mut imports,
             );
-            written.push(kt::KtFile::new(package).decl(class).imports(imports));
+            // A ptr class's own surface for the generated interface: peek() /
+            // isClosed() are inherited from NativeHandle (declared abstract in
+            // the interface, satisfied without an `override`); take() and the
+            // declared members are class-body (marked override by the helper);
+            // close() is covered by AutoCloseable. The interface extends
+            // AutoCloseable so consumers get `close()` too.
+            let base = vec![
+                kt::KtFun::new("peek")
+                    .vis(kt::Vis::Default)
+                    .returns(kt::KtType::long()),
+                kt::KtFun::new("isClosed")
+                    .vis(kt::Vis::Default)
+                    .returns(kt::KtType::boolean()),
+            ];
+            let mut file = kt::KtFile::new(package);
+            if let Some(iface) = self.apply_class_interface(
+                handle.key,
+                &mut class,
+                &class_name,
+                &["AutoCloseable"],
+                base,
+                false,
+            ) {
+                file = file.decl(iface);
+            }
+            written.push(file.decl(class).imports(imports));
         }
         written
     }
+
+    /// The generated-interface short name for a class whose final Kotlin name
+    /// is `class_short`: the per-decl `.interface_name(...)` override, else
+    /// the `set_interface_name_mangle` hook over the class name (unset
+    /// default: append `"Api"`). Asserted to differ from the class name.
+    pub(crate) fn interface_short_name(
+        &self,
+        class_short: &str,
+        override_: Option<&str>,
+    ) -> String {
+        let name = match override_ {
+            Some(n) => n.to_string(),
+            None => match &self.interface_name_mangle {
+                Some(f) => f(class_short),
+                None => format!("{class_short}Api"),
+            },
+        };
+        assert!(
+            name != class_short,
+            "the generated interface name `{name}` must differ from the class name \
+             `{class_short}` (a class and its interface cannot share a name in one package)"
+        );
+        name
+    }
+
+    /// Attach interface information to a just-built class. The `.implements`
+    /// list is added to the class supertypes unconditionally (nominal
+    /// implementation). When `.interface()` is enabled, ALSO build the
+    /// generated `<Name>Api` interface mirroring the class's public surface,
+    /// add it as a supertype, mark every class-body member (and, when
+    /// `include_ctor_props`, every ctor `val`) `override`, and return the
+    /// interface decl to emit alongside. `base_abstracts` are signatures the
+    /// interface declares that are satisfied by an inherited base member (no
+    /// `override` on the class — e.g. a ptr class's `peek()`/`isClosed()`).
+    pub(crate) fn apply_class_interface(
+        &self,
+        key: &TypeKey,
+        class: &mut kt::KtClass,
+        class_short: &str,
+        extra_supers: &[&str],
+        base_abstracts: Vec<kt::KtFun>,
+        include_ctor_props: bool,
+    ) -> Option<kt::KtClass> {
+        let cfg = self.types.get(key)?;
+        let interfaces = cfg.interfaces.clone();
+        let enabled = cfg.interface_enabled;
+        let name_override = cfg.interface_name_override.clone();
+
+        if !enabled {
+            for iface in &interfaces {
+                class.supertypes.push((kt::KtType::cls(iface), None));
+            }
+            return None;
+        }
+
+        let iface_name = self.interface_short_name(class_short, name_override.as_deref());
+        let mut iface =
+            kt::KtClass::new(kt::ClassKind::Interface, &iface_name).vis(kt::Vis::Public);
+        for s in extra_supers {
+            iface = iface.supertype(kt::KtType::cls(*s), None);
+        }
+        // Signatures satisfied by an inherited base member.
+        for f in base_abstracts {
+            iface = iface.member(f);
+        }
+        // Ctor `val`s become interface properties (data/value/enum).
+        if include_ctor_props {
+            for p in &mut class.ctor_params {
+                if p.prop.is_some() {
+                    iface = iface.member(
+                        kt::KtProperty::val(&p.name)
+                            .ty(p.ty.clone())
+                            .vis(kt::Vis::Default),
+                    );
+                    p.overrides = true;
+                }
+            }
+        }
+        // Class-body instance methods become interface abstracts + `override`
+        // on the class. A member already marked `override` (a ptr class's
+        // `close()`, via AutoCloseable) is skipped — already covered.
+        for m in &mut class.members {
+            if let kt::KtDecl::Fun(f) = m {
+                if f.modifiers.iter().any(|s| s == "override") {
+                    continue;
+                }
+                iface = iface.member(abstract_fun_sig(f));
+                f.modifiers.push("override".to_string());
+            }
+        }
+        // The generated interface first, then the user `.implements` list.
+        class.supertypes.push((kt::KtType::cls(&iface_name), None));
+        for iface_fqn in &interfaces {
+            class.supertypes.push((kt::KtType::cls(iface_fqn), None));
+        }
+        Some(iface)
+    }
+}
+
+/// A concrete class member's signature as an abstract interface member:
+/// same name / generics / params / return, no body, no modifiers, no vis
+/// keyword (interface members are public-abstract by default).
+fn abstract_fun_sig(f: &kt::KtFun) -> kt::KtFun {
+    let mut a = kt::KtFun::new(&f.name).vis(kt::Vis::Default);
+    for g in &f.generics {
+        a = a.generic(g.clone());
+    }
+    for p in &f.params {
+        a = a.param(p.clone());
+    }
+    if let Some(r) = &f.ret {
+        a = a.returns(r.clone());
+    }
+    a
 }

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -80,12 +80,7 @@ pub(crate) use crate::api::{
 /// Kotlin emitter writes a typed-handle `.kt` file (and the Rust side its
 /// `freePtr` destructor) for every opaque type.
 #[derive(Clone, Default)]
-pub(crate) struct OpaqueConfig {
-    /// Kotlin interfaces added to the generated class's supertype list
-    /// (`PtrClassDecl::implements`) — the bounded integration hatch; the
-    /// class body and lifecycle members are unaffected.
-    pub(crate) interfaces: Vec<String>,
-}
+pub(crate) struct OpaqueConfig {}
 
 /// Per-enum configuration (driven by `JniGen::enum_class`).
 ///
@@ -159,6 +154,18 @@ pub(crate) struct TypeConfig {
     /// always resolve both ways); a wrapper-only entry is required per
     /// **usage** direction, so an output-only wrapper needs no input twin.
     pub class_decl: bool,
+    /// Emit the generated interface mirroring the class's public instance
+    /// surface, and make the class implement it with `override` on every
+    /// class-body member (`.interface()` / implied by `.interface_name()`).
+    pub interface_enabled: bool,
+    /// Per-decl literal interface name (`.interface_name(...)`, relative, no
+    /// dots) — bypasses the `set_interface_name_mangle` hook.
+    pub interface_name_override: Option<String>,
+    /// Kotlin interfaces added to the generated class's supertype list
+    /// (`.implements(...)`, any class kind) — the class implements them
+    /// nominally; the class body and lifecycle members are unaffected.
+    /// Orthogonal to [`Self::interface_enabled`].
+    pub interfaces: Vec<String>,
 }
 
 /// Free-standing functions emitted into a synthetic package-level wrapper
@@ -324,6 +331,10 @@ pub struct JniGen {
     /// unset = prepend `"JNI"`, so you get `JNINative`. Override to
     /// plug in a different convention.
     pub(crate) harness_name_mangle: Option<NameMangle>,
+    /// Mangler turning a class name into its generated `.interface()` name.
+    /// Receives the final class name; identity is forbidden (a class and its
+    /// interface can't share a name). Default when unset = append `"Api"`.
+    pub(crate) interface_name_mangle: Option<NameMangle>,
 
     /// Structured per-type configuration keyed by canonical Rust type.
     /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -224,6 +224,10 @@ pub(crate) struct ClassMember {
     pub kotlin_name_override: Option<String>,
     /// Member kind (fun / constructor).
     pub kind: MemberKind,
+    /// Emit the Kotlin `override` modifier ([`FunctionDecl::overrides`]) —
+    /// the member implements a matching abstract of a
+    /// [`PtrClassDecl::implements`] interface.
+    pub overrides: bool,
 }
 
 /// Boxed closure that builds a converter when applied to the wildcard

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -80,7 +80,12 @@ pub(crate) use crate::api::{
 /// Kotlin emitter writes a typed-handle `.kt` file (and the Rust side its
 /// `freePtr` destructor) for every opaque type.
 #[derive(Clone, Default)]
-pub(crate) struct OpaqueConfig {}
+pub(crate) struct OpaqueConfig {
+    /// Kotlin interfaces added to the generated class's supertype list
+    /// (`PtrClassDecl::implements`) — the bounded integration hatch; the
+    /// class body and lifecycle members are unaffected.
+    pub(crate) interfaces: Vec<String>,
+}
 
 /// Per-enum configuration (driven by `JniGen::enum_class`).
 ///

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -224,10 +224,6 @@ pub(crate) struct ClassMember {
     pub kotlin_name_override: Option<String>,
     /// Member kind (fun / constructor).
     pub kind: MemberKind,
-    /// Emit the Kotlin `override` modifier ([`FunctionDecl::overrides`]) —
-    /// the member implements a matching abstract of a
-    /// [`PtrClassDecl::implements`] interface.
-    pub overrides: bool,
 }
 
 /// Boxed closure that builds a converter when applied to the wildcard

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -355,10 +355,13 @@ pub(crate) fn build_typed_handle(
 
     // Promoted instance methods: each `.fun(f)` becomes an instance method
     // (receiver bound to `this`), delegating to the same centralized
-    // `JNINative` extern as a free wrapper would.
+    // `JNINative` extern as a free wrapper would. `.overrides()` marks the
+    // member as implementing a matching abstract of a declared
+    // `.implements(...)` interface (Kotlin requires the modifier on
+    // class-body members).
     for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
         if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
-            if let Some(f) = render_wrapper_fn(
+            if let Some(mut f) = render_wrapper_fn(
                 ext,
                 item_fn,
                 registry,
@@ -366,6 +369,9 @@ pub(crate) fn build_typed_handle(
                 Some(ext.effective_member_name(key, m).as_str()),
                 Some(key),
             ) {
+                if m.overrides {
+                    f = f.modifier("override");
+                }
                 class = class.member(f);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -309,7 +309,20 @@ pub(crate) fn build_typed_handle(
         .vis(kt::Vis::Public)
         .kdoc(class_kdoc)
         .ctor_param(kt::KtCtorParam::new("initialPtr", kt::KtType::long()))
-        .supertype(kt::KtType::cls(base_fqn), Some("initialPtr"))
+        .supertype(kt::KtType::cls(base_fqn), Some("initialPtr"));
+    // Declared consumer interfaces (`PtrClassDecl::implements`) join the
+    // supertype list after the lifecycle base — nominal only, the class
+    // body is unaffected.
+    for iface in ext
+        .types
+        .get(key)
+        .and_then(|c| c.opaque.as_ref())
+        .map(|o| o.interfaces.as_slice())
+        .unwrap_or(&[])
+    {
+        class = class.supertype(kt::KtType::cls(iface), None);
+    }
+    class = class
         .member(
             kt::KtFun::new("close")
                 .annotation("Synchronized")

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -305,24 +305,14 @@ pub(crate) fn build_typed_handle(
     let class_kdoc = source_item_doc(registry, key)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
+    // Consumer interfaces (`.implements`) and the generated `<Name>Api`
+    // interface (`.interface()`) are attached by `apply_class_interface` in
+    // `write_typed_handles` after the class body is built.
     let mut class = kt::KtClass::new(kt::ClassKind::Plain, class_name)
         .vis(kt::Vis::Public)
         .kdoc(class_kdoc)
         .ctor_param(kt::KtCtorParam::new("initialPtr", kt::KtType::long()))
-        .supertype(kt::KtType::cls(base_fqn), Some("initialPtr"));
-    // Declared consumer interfaces (`PtrClassDecl::implements`) join the
-    // supertype list after the lifecycle base — nominal only, the class
-    // body is unaffected.
-    for iface in ext
-        .types
-        .get(key)
-        .and_then(|c| c.opaque.as_ref())
-        .map(|o| o.interfaces.as_slice())
-        .unwrap_or(&[])
-    {
-        class = class.supertype(kt::KtType::cls(iface), None);
-    }
-    class = class
+        .supertype(kt::KtType::cls(base_fqn), Some("initialPtr"))
         .member(
             kt::KtFun::new("close")
                 .annotation("Synchronized")

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -355,13 +355,10 @@ pub(crate) fn build_typed_handle(
 
     // Promoted instance methods: each `.fun(f)` becomes an instance method
     // (receiver bound to `this`), delegating to the same centralized
-    // `JNINative` extern as a free wrapper would. `.overrides()` marks the
-    // member as implementing a matching abstract of a declared
-    // `.implements(...)` interface (Kotlin requires the modifier on
-    // class-body members).
+    // `JNINative` extern as a free wrapper would.
     for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
         if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
-            if let Some(mut f) = render_wrapper_fn(
+            if let Some(f) = render_wrapper_fn(
                 ext,
                 item_fn,
                 registry,
@@ -369,9 +366,6 @@ pub(crate) fn build_typed_handle(
                 Some(ext.effective_member_name(key, m).as_str()),
                 Some(key),
             ) {
-                if m.overrides {
-                    f = f.modifier("override");
-                }
                 class = class.member(f);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -262,15 +262,9 @@ impl JniGen {
         if cfg.opaque.is_some() {
             "ptr_class"
         } else if cfg.enum_cfg.is_some() {
-            if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
-                "enum_class (kotlin_type-mapped)"
-            } else {
-                "enum_class"
-            }
+            "enum_class"
         } else if cfg.value_blob {
             "value_class"
-        } else if cfg.name_spec.as_ref().is_some_and(|s| s.is_verbatim()) {
-            "kotlin_type-mapped"
         } else if cfg.class_decl {
             "data_class"
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -12,20 +12,30 @@ fn builtin_convert_type_panics() {
 /// #54: `.implements(...)` — the ptr_class integration hatch. Declared
 /// interfaces join the generated class's supertype list after the lifecycle
 /// base; dotted FQNs are imported and shortened; the class body (close/take/
-/// freePtr) is unchanged.
+/// freePtr) is unchanged. `.overrides()` on a member emits the Kotlin
+/// `override` modifier so the interface can abstract over generated methods.
 #[test]
 fn ptr_class_implements_adds_interface_supertypes() {
     let loc = myflat_loc();
-    let f: syn::ItemFn =
-        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
-    let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let fns: &[&str] = &[
+        "pub fn z_thing_new() -> ZThing { unimplemented!() }",
+        "pub fn z_thing_size(t: &ZThing) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
                     .implements("io.other.Resource")
-                    .implements("LocalIface"),
+                    .implements("LocalIface")
+                    .fun(crate::fun!(z_thing_size).overrides()),
             )
             .fun(crate::fun!(z_thing_new)),
     );
@@ -50,6 +60,9 @@ fn ptr_class_implements_adds_interface_supertypes() {
     // The lifecycle members are untouched by the hatch.
     assert!(thing.contains("override fun close()"), "{thing}");
     assert!(thing.contains("fun take(): ZThing"), "{thing}");
+    // The marked member carries the modifier (namespace-stripped name:
+    // `z_thing_size` on `ZThing` → `size`); the wrapper body is unchanged.
+    assert!(thing.contains("override fun size("), "{thing}");
 }
 
 /// A duplicate interface on one decl is a decl-time hard error.
@@ -59,6 +72,39 @@ fn ptr_class_duplicate_implements_rejected() {
     let _ = crate::ptr_class!(ZThing)
         .implements("io.other.Resource")
         .implements("io.other.Resource");
+}
+
+/// `.overrides()` pairs with `.implements(...)` — a free package function
+/// overrides nothing.
+#[test]
+#[should_panic(expected = "a free package function overrides nothing")]
+fn overrides_on_free_function_rejected() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn = syn::parse_str("pub fn z_ping() -> i64 { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("t").fun(crate::fun!(z_ping).overrides()));
+    let _ = registry.resolve(jni);
+}
+
+/// Same for companion factories: only instance methods can override.
+#[test]
+#[should_panic(expected = "applies only to a ptr_class instance method")]
+fn overrides_on_constructor_rejected() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni =
+        JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(crate::package!("t").class(
+                crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_new).overrides()),
+            ));
+    let _ = registry.resolve(jni);
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -9,23 +9,29 @@ fn builtin_convert_type_panics() {
     let _ = crate::convert!(usize);
 }
 
-/// #54: `.implements(...)` — the ptr_class integration hatch. Declared
-/// interfaces join the generated class's supertype list after the lifecycle
-/// base; dotted FQNs are imported and shortened; the class body (close/take/
-/// freePtr) is unchanged.
+/// #54: `.implements(...)` WITHOUT `.interface()` — declared interfaces join
+/// the class's supertype list (nominal); dotted FQNs are imported and
+/// shortened; the class body is untouched and NO generated interface is
+/// emitted (members stay non-`override`).
 #[test]
 fn ptr_class_implements_adds_interface_supertypes() {
     let loc = myflat_loc();
-    let f: syn::ItemFn =
-        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
-    let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let fns: &[&str] = &[
+        "pub fn z_thing_new() -> ZThing { unimplemented!() }",
+        "pub fn z_thing_size(t: &ZThing) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| (syn::Item::Fn(syn::parse_str(src).unwrap()), loc.clone()))
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
                     .implements("io.other.Resource")
-                    .implements("LocalIface"),
+                    .implements("LocalIface")
+                    .fun(crate::fun!(z_thing_size)),
             )
             .fun(crate::fun!(z_thing_new)),
     );
@@ -47,9 +53,63 @@ fn ptr_class_implements_adds_interface_supertypes() {
         "{thing}"
     );
     assert!(thing.contains("import io.other.Resource"), "{thing}");
-    // The lifecycle members are untouched by the hatch.
-    assert!(thing.contains("override fun close()"), "{thing}");
-    assert!(thing.contains("fun take(): ZThing"), "{thing}");
+    // No generated interface, no `override` on the declared member.
+    assert!(!thing.contains("interface ZThingApi"), "{thing}");
+    assert!(thing.contains("public fun size("), "{thing}");
+    assert!(!thing.contains("override fun size("), "{thing}");
+}
+
+/// #54: `.interface()` — the generated `<Name>Api` interface mirrors the
+/// class's public surface, the class implements it with `override` on
+/// class-body members (peek/isClosed inherited from NativeHandle need none),
+/// and a user `.implements` interface can extend it.
+#[test]
+fn ptr_class_interface_emits_generated_api() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_thing_new() -> ZThing { unimplemented!() }",
+        "pub fn z_thing_size(t: &ZThing) -> i64 { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| (syn::Item::Fn(syn::parse_str(src).unwrap()), loc.clone()))
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .class(
+                crate::ptr_class!(ZThing)
+                    .interface()
+                    .implements("io.other.Resource")
+                    .fun(crate::fun!(z_thing_size)),
+            )
+            .fun(crate::fun!(z_thing_new)),
+    );
+    let dir = unique_test_dir("jnigen_interface");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let thing = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni/thing.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("thing package file");
+    let tc: String = thing.split_whitespace().collect();
+    // Generated interface with the inherited-surface abstracts + the member,
+    // extending AutoCloseable.
+    assert!(tc.contains("interfaceZThingApi:AutoCloseable{"), "{thing}");
+    assert!(tc.contains("funpeek():Long"), "{thing}");
+    assert!(tc.contains("funisClosed():Boolean"), "{thing}");
+    assert!(tc.contains("funsize("), "{thing}");
+    // Class implements the generated interface + the user one; members override.
+    assert!(
+        tc.contains("classZThing(initialPtr:Long):NativeHandle(initialPtr),ZThingApi,Resource{"),
+        "{thing}"
+    );
+    assert!(tc.contains("publicoverridefuntake():ZThing"), "{thing}");
+    assert!(tc.contains("publicoverridefunsize("), "{thing}");
 }
 
 /// A duplicate interface on one decl is a decl-time hard error.
@@ -59,6 +119,146 @@ fn ptr_class_duplicate_implements_rejected() {
     let _ = crate::ptr_class!(ZThing)
         .implements("io.other.Resource")
         .implements("io.other.Resource");
+}
+
+/// The `set_interface_name_mangle` hook receives the final class name and
+/// its result must differ (identity is a hard error).
+#[test]
+#[should_panic(expected = "must differ from the class name")]
+fn interface_name_mangle_identity_rejected() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_interface_name_mangle(|n| n.to_string())
+        .package(
+            crate::package!("thing")
+                .class(crate::ptr_class!(ZThing).interface())
+                .fun(crate::fun!(z_thing_new)),
+        );
+    let dir = unique_test_dir("jnigen_iface_identity");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let _ = gen.write_kotlin(&dir.join("kotlin"));
+}
+
+/// A per-decl `.interface_name(...)` pins the interface name (and implies
+/// `.interface()`); `set_interface_name_mangle` receives the class name.
+#[test]
+fn interface_name_override_and_hook() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Mode {
+                    A = 0,
+                    B = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn flip(m: Mode) -> Mode {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_interface_name_mangle(|n| {
+            assert_eq!(n, "Mode", "hook receives the class name");
+            format!("{n}Contract")
+        })
+        .package(
+            crate::package!("m")
+                .class(crate::enum_class!(Mode).interface_name("ModeIface"))
+                .fun(crate::fun!(flip)),
+        );
+    let dir = unique_test_dir("jnigen_iface_name");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ac: String = all.split_whitespace().collect();
+    // The per-decl override wins over the hook.
+    assert!(ac.contains("interfaceModeIface{"), "{all}");
+    assert!(ac.contains("valvalue:Int"), "{all}");
+    assert!(
+        ac.contains("enumclassMode(overridepublicvalvalue:Int):ModeIface{")
+            || ac.contains("enumclassMode(publicoverridevalvalue:Int):ModeIface{"),
+        "{all}"
+    );
+}
+
+/// #54: `.interface()` on a `value_class!` — the generated `<Name>Api`
+/// interface carries the `bytes` property and the accessors, and the
+/// `@JvmInline value class` implements it with `override val bytes`
+/// (the ctor-prop path, shared with data/enum classes).
+#[test]
+fn value_class_interface_emits_generated_api() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                #[derive(Clone, Copy)]
+                pub struct ZStamp {
+                    pub secs: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_stamp_secs(s: &ZStamp) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("t").class(
+            crate::value_class!(ZStamp)
+                .interface()
+                .fun(crate::fun!(z_stamp_secs).name("secs")),
+        ),
+    );
+    let dir = unique_test_dir("jnigen_value_iface");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let ac: String = all.split_whitespace().collect();
+    assert!(ac.contains("interfaceZStampApi{"), "{all}");
+    assert!(ac.contains("valbytes:ByteArray"), "{all}");
+    assert!(ac.contains("funsecs("), "{all}");
+    assert!(
+        ac.contains("valueclassZStamp(overridepublicvalbytes:ByteArray):ZStampApi{")
+            || ac.contains("valueclassZStamp(publicoverridevalbytes:ByteArray):ZStampApi{"),
+        "{all}"
+    );
+    assert!(ac.contains("publicoverridefunsecs("), "{all}");
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -12,30 +12,20 @@ fn builtin_convert_type_panics() {
 /// #54: `.implements(...)` — the ptr_class integration hatch. Declared
 /// interfaces join the generated class's supertype list after the lifecycle
 /// base; dotted FQNs are imported and shortened; the class body (close/take/
-/// freePtr) is unchanged. `.overrides()` on a member emits the Kotlin
-/// `override` modifier so the interface can abstract over generated methods.
+/// freePtr) is unchanged.
 #[test]
 fn ptr_class_implements_adds_interface_supertypes() {
     let loc = myflat_loc();
-    let fns: &[&str] = &[
-        "pub fn z_thing_new() -> ZThing { unimplemented!() }",
-        "pub fn z_thing_size(t: &ZThing) -> i64 { unimplemented!() }",
-    ];
-    let items: Vec<(syn::Item, SourceLocation)> = fns
-        .iter()
-        .map(|src| {
-            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
-            (syn::Item::Fn(f), loc.clone())
-        })
-        .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
                     .implements("io.other.Resource")
-                    .implements("LocalIface")
-                    .fun(crate::fun!(z_thing_size).overrides()),
+                    .implements("LocalIface"),
             )
             .fun(crate::fun!(z_thing_new)),
     );
@@ -60,9 +50,6 @@ fn ptr_class_implements_adds_interface_supertypes() {
     // The lifecycle members are untouched by the hatch.
     assert!(thing.contains("override fun close()"), "{thing}");
     assert!(thing.contains("fun take(): ZThing"), "{thing}");
-    // The marked member carries the modifier (namespace-stripped name:
-    // `z_thing_size` on `ZThing` → `size`); the wrapper body is unchanged.
-    assert!(thing.contains("override fun size("), "{thing}");
 }
 
 /// A duplicate interface on one decl is a decl-time hard error.
@@ -72,39 +59,6 @@ fn ptr_class_duplicate_implements_rejected() {
     let _ = crate::ptr_class!(ZThing)
         .implements("io.other.Resource")
         .implements("io.other.Resource");
-}
-
-/// `.overrides()` pairs with `.implements(...)` — a free package function
-/// overrides nothing.
-#[test]
-#[should_panic(expected = "a free package function overrides nothing")]
-fn overrides_on_free_function_rejected() {
-    let loc = myflat_loc();
-    let f: syn::ItemFn = syn::parse_str("pub fn z_ping() -> i64 { unimplemented!() }").unwrap();
-    let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
-    let jni = JniGen::new()
-        .set_package_prefix("io.test.jni")
-        .package(crate::package!("t").fun(crate::fun!(z_ping).overrides()));
-    let _ = registry.resolve(jni);
-}
-
-/// Same for companion factories: only instance methods can override.
-#[test]
-#[should_panic(expected = "applies only to a ptr_class instance method")]
-fn overrides_on_constructor_rejected() {
-    let loc = myflat_loc();
-    let f: syn::ItemFn =
-        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
-    let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
-    let jni =
-        JniGen::new()
-            .set_package_prefix("io.test.jni")
-            .package(crate::package!("t").class(
-                crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_new).overrides()),
-            ));
-    let _ = registry.resolve(jni);
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -9,6 +9,58 @@ fn builtin_convert_type_panics() {
     let _ = crate::convert!(usize);
 }
 
+/// #54: `.implements(...)` — the ptr_class integration hatch. Declared
+/// interfaces join the generated class's supertype list after the lifecycle
+/// base; dotted FQNs are imported and shortened; the class body (close/take/
+/// freePtr) is unchanged.
+#[test]
+fn ptr_class_implements_adds_interface_supertypes() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .class(
+                crate::ptr_class!(ZThing)
+                    .implements("io.other.Resource")
+                    .implements("LocalIface"),
+            )
+            .fun(crate::fun!(z_thing_new)),
+    );
+    let dir = unique_test_dir("jnigen_implements");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let thing = paths
+        .iter()
+        .find(|p| p.ends_with("io/test/jni/thing.kt"))
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .expect("thing package file");
+    assert!(
+        thing.contains(
+            "class ZThing(initialPtr: Long) : NativeHandle(initialPtr), Resource, LocalIface {"
+        ),
+        "{thing}"
+    );
+    assert!(thing.contains("import io.other.Resource"), "{thing}");
+    // The lifecycle members are untouched by the hatch.
+    assert!(thing.contains("override fun close()"), "{thing}");
+    assert!(thing.contains("fun take(): ZThing"), "{thing}");
+}
+
+/// A duplicate interface on one decl is a decl-time hard error.
+#[test]
+#[should_panic(expected = "the interface is already declared")]
+fn ptr_class_duplicate_implements_rejected() {
+    let _ = crate::ptr_class!(ZThing)
+        .implements("io.other.Resource")
+        .implements("io.other.Resource");
+}
+
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn
 /// override) and base-package functions (`.fun` with the empty subpackage —
 /// mirroring class declarations, which could always live in the base package).

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -694,63 +694,6 @@ fn convert_via_local_try_fn_is_fallible() {
     assert!(rc.contains("Result<myflat::Label,String>"), "{rust}");
 }
 
-/// I5: `enum_class!(T).kotlin_type("io.other.Mode")` maps the enum onto an
-/// EXISTING Kotlin type — no `enum class` file is generated, and wrappers
-/// speak the `fromInt`/`.value` protocol against the mapped FQN. The jint
-/// wire on the Rust side is unchanged.
-#[test]
-fn enum_kotlin_type_maps_to_existing_type() {
-    let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![
-        (
-            syn::Item::Enum(syn::parse_quote!(
-                pub enum Mode {
-                    A = 0,
-                    B = 1,
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn flip(m: Mode) -> Mode {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-    ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
-        crate::package!()
-            .class(crate::enum_class!(Mode).kotlin_type("io.other.Mode"))
-            .fun(crate::fun!(flip)),
-    );
-    let dir = unique_test_dir("jnigen_enum_kotlin_type");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let gen = registry.resolve(jni).expect("resolve");
-    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
-    let rust = std::fs::read_to_string(&rust_path).unwrap();
-    // Rust side: ordinary jint enum wire.
-    assert!(rust.contains("jni::sys::jint"), "{rust}");
-
-    let kdir = dir.join("kotlin");
-    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
-    let all: String = paths
-        .iter()
-        .filter_map(|p| std::fs::read_to_string(p).ok())
-        .collect::<Vec<_>>()
-        .join("\n");
-    let ac: String = all.split_whitespace().collect();
-    // No generated enum class anywhere…
-    assert!(!ac.contains("enumclass"), "{all}");
-    // …and the wrapper references the mapped type's protocol.
-    assert!(ac.contains("io.other.Mode"), "{all}");
-    assert!(ac.contains("Mode.fromInt("), "{all}");
-    assert!(ac.contains("m.value"), "{all}");
-}
-
 /// I5: data-class members — the receiver re-enters Rust as `this`'s field
 /// leaves (the data-class param destructuring rebased to `this`); a
 /// constructor member joins the `fromParts` companion. Extern signatures
@@ -823,18 +766,4 @@ fn data_class_members_reenter_as_field_leaves() {
     let pb: String = point_block.split_whitespace().collect();
     assert!(pb.contains("funorigin("), "{all}");
     assert!(pb.contains("funfromParts("), "{all}");
-}
-
-/// I5: `.kotlin_type()` and members are mutually exclusive — a mapped type
-/// has no generated class to hold them.
-#[test]
-#[should_panic(expected = "no generated class to hold members")]
-fn data_class_kotlin_type_with_members_rejected() {
-    let _ = JniGen::new().package(
-        crate::package!().class(
-            crate::data_class!(Point)
-                .kotlin_type("io.other.Point")
-                .fun(crate::fun!(point_norm)),
-        ),
-    );
 }


### PR DESCRIPTION
Fixes #54 (P2 from the 2026-07-14 JniGen API review).

## The mechanism: a generated `<Name>Api` interface + orthogonal `.implements`

Every class decl — `ptr_class!` / `data_class!` / `value_class!` / `enum_class!` — gets two independent switches:

- **`.interface()`** emits a generated `<Name>Api` interface mirroring the class's public surface (inherited `NativeHandle` members, ctor properties, and declared `.fun` members) and makes the class implement it, applying `override` automatically to class-body members. Implied by `.interface_name(...)`.
- **`.implements(x)`** makes the class nominally implement the user interface `x` (dotted FQNs imported + shortened; same-package names work bare). It does **not** enable `.interface()` — technically orthogonal.

Used together they form the **checked-injection** story: the user's interface *extends* the generated one, so its default members call the class's real generated members under full compiler checking — no guessed prototypes, no hand-replicated signatures, no editing of generated code.

```rust
ptr_class!(Storage).interface().implements("io.prebindgen.covertest.CovResource")
data_class!(Payload).interface().implements("io.prebindgen.covertest.Timestamped")
enum_class!(Priority).interface_name("PriorityKind").implements("io.prebindgen.covertest.Ranked")
```

```kotlin
// generated
public interface StorageApi : AutoCloseable { fun peek(): Long; fun isClosed(): Boolean; fun take(): Storage; fun len(…): Long; … }
public class Storage(initialPtr: Long) : NativeHandle(initialPtr), StorageApi, CovResource { public override fun len(…) … }

// hand-written SDK — extends the generated interface, defaults over real members
interface CovResource : StorageApi {
    fun isEmpty(): Boolean = len(boom) == 0L      // class-specific generated member
    val live: Boolean get() = !isClosed() && peek() != 0L
}
```

## Interface naming

Per-decl `.interface_name("StorageContract")` (relative, mangle-bypass, like `.name()`), or the global `set_interface_name_mangle(|class_name| …)` hook (receives the **final class name**; **identity is a hard error** — a class and its interface can't share a name in one package; unset default appends `"Api"`).

## Design changes vs the interim sketch

- **`.overrides()` member marker reverted** — it forced consumers to guess generated prototypes and inverted the hierarchy. The generated-interface approach makes the class the source of truth and the compiler the checker.
- **`.kotlin_type()` removed entirely** (all four decls) — its replace-the-class hatch is subsumed by augment-only `.interface()`. No consumer used it. With its only producer gone, `NameSpec` collapses from an enum to a struct (the `Verbatim` arm had no other caller). `NameSpec::Verbatim` for scalar/generic wrappers as mentioned in docs did not actually exist in code.
- The issue's other option — a configurable base *between* `NativeHandle` and the generated class — remains deliberately NOT added: it threads consumer code into the lifecycle chain. Interface defaults cover the need without that risk.

## Acceptance

- covertest exercises the hatch on **three kinds** on the JVM: `Storage` (ptr) via `CovResource : StorageApi`, `Payload` (data) via `Timestamped : PayloadApi`, `Priority` (enum) via `Ranked : PriorityKind` — each SDK interface extends the generated `<Name>Api`, defaults call class-specific generated members, used polymorphically. **`./gradlew run`: PASS, 26 sections.**
- The fourth path (value_class interface) is covered by a generator unit test (`value_class_interface_emits_generated_api`).
- Generator unit tests: implements-only supertypes (no generated interface, no `override`); `.interface()` generated-interface emission + auto-`override`; per-decl `.interface_name` + `set_interface_name_mangle` hook (asserts input = class name); identity-result rejection; duplicate-implements rejection.
- `cargo test -p prebindgen --lib`: **253 passed.** CI pre-flight clean (fmt CI config, clippy `--deny warnings`, example-cbindgen goldens restored). `regen-check.sh`: participating classes changed as designed, non-participating byte-identical, Rust side unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)