### PR TITLE
jnigen: idiomatic Kotlin overloads for expanded params — splittability + .split_on_param (#52)

### DIFF
--- a/examples/covertest-helpers/src/lib.rs
+++ b/examples/covertest-helpers/src/lib.rs
@@ -18,7 +18,7 @@
 //! small helper crate like this one, consumed as both a normal and a build
 //! dependency (exactly like the flat crate).
 
-use perftest_flat::Millis;
+use perftest_flat::{summary_total, Millis, Summary};
 use prebindgen_proc_macro::{features, prebindgen};
 
 /// Output directory with the prebindgen data of this crate.
@@ -42,4 +42,19 @@ pub fn millis_from_long(v: i64) -> Millis {
 #[prebindgen]
 pub fn millis_value(m: &Millis) -> i64 {
     m.0 as i64
+}
+
+/// Two-`Summary`-parameter function exercising #52's **cartesian-product**
+/// overloads: covertest declares `.split_on_param("primary")
+/// .split_on_param("fallback")`, so each parameter is independently split into
+/// its (count, total)-build / handle arms and the generator emits the 2×2
+/// product (all four combinations distinct). Returns `1` when `primary` has the
+/// larger total, else `0`.
+#[prebindgen]
+pub fn summary_prefer(primary: Summary, fallback: Summary) -> i64 {
+    if summary_total(&primary) >= summary_total(&fallback) {
+        1
+    } else {
+        0
+    }
 }

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -27,8 +27,8 @@
 //! | `convert!` `.input(try_from!)` (fallible) | `Percent` ⇄ `Int`; out-of-range → `onError` |
 //! | `convert!` sources `.with(path!)`/`.error(ty!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
-//! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
-//! | `expand_param!` `.split()` (#52)      | `Summary` typed overloads — `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); manual same-named overload in `ManualOverloads.kt` |
+//! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
+//! | `FunctionDecl::split_on_param` (#52)  | single: `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); cartesian product: `summaryPrefer` (2 params); manual same-named overload in `ManualOverloads.kt` |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
@@ -231,16 +231,15 @@ fn main() {
                 .class(ptr_class!(Archive).name("SummaryVault")),
         )
         // `Summary` default input: rebuilt from the `of` constructor's
-        // ingredients OR passed as an existing handle (runtime-selected).
-        // `.split()` (#52) also emits idiomatic typed overloads per variant —
-        // `f(count, total, …)` / `f(summary, …)` — delegating to the selector
-        // form. This is the CLASS-DEFAULT split: it fires on every function
-        // taking a `Summary` by the type default (e.g. `archiveStore`).
+        // ingredients OR passed as an existing handle (runtime-selected). This
+        // 2-variant set is verified *splittable* up front (#52): its arms
+        // `(count, total)` vs `Summary` surface as distinct JVM signatures, so
+        // functions may `.split_on_param(...)` it into typed overloads (see
+        // `archive_store` / `storage_matches_summary` / `summary_prefer`).
         .expand(
             expand_param!(Summary)
                 .variant(fun!(summary_new))
-                .variant_self()
-                .split(),
+                .variant_self(),
         )
         // `Summary` default output: decomposed `(count, total)` leaves, names
         // inherited from the class members.
@@ -326,7 +325,9 @@ fn main() {
         .package(
             package!("analytics")
                 .fun(fun!(storage_summary))
-                .fun(fun!(storage_matches_summary))
+                // Single split (#52) on the CLASS-DEFAULT `Summary` variants:
+                // `storageMatchesSummary(count, total, …)` / `(expected, …)`.
+                .fun(fun!(storage_matches_summary).split_on_param("expected"))
                 .fun(
                     fun!(storage_summary_handle)
                         .expand_return(expand_return!(Summary).field_self()),
@@ -343,23 +344,35 @@ fn main() {
                             .field_self(),
                     ),
                 )
-                // Per-fn split (#52): the `expected` param gets typed overloads
-                // `storageExpectSummary(count, total, …)` / `(expected, …)` on
-                // top of the selector form (which Test.kt still calls directly).
+                // Per-fn split (#52): a per-fn `.expand_param` variant override
+                // (demoing the override) whose `expected` param is then split
+                // into typed overloads `storageExpectSummary(count, total, …)` /
+                // `(expected, …)` on top of the selector form (which Test.kt
+                // still calls directly).
                 .fun(
-                    fun!(storage_expect_summary).expand_param(
-                        "expected",
-                        expand_param!(Summary)
-                            .variant(fun!(summary_new))
-                            .variant_self()
-                            .split(),
-                    ),
+                    fun!(storage_expect_summary)
+                        .expand_param(
+                            "expected",
+                            expand_param!(Summary)
+                                .variant(fun!(summary_new))
+                                .variant_self(),
+                        )
+                        .split_on_param("expected"),
+                )
+                // Cartesian-product split (#52): TWO `Summary` params each split
+                // → the 2×2 product of typed overloads (all combinations
+                // distinct: build/build, build/handle, handle/build, handle/handle).
+                .fun(
+                    fun!(summary_prefer)
+                        .split_on_param("primary")
+                        .split_on_param("fallback"),
                 )
                 // The borrowed-accessor trio. `archive_latest` suppresses the default
                 // Summary return-field default so the BORROWED handle path (clone into a
                 // fresh owned handle, null when absent) is what crosses.
                 .fun(fun!(archive_new))
-                .fun(fun!(archive_store))
+                // Single split (#52) on the CLASS-DEFAULT variants, consuming arm.
+                .fun(fun!(archive_store).split_on_param("s"))
                 .fun(fun!(archive_latest).expand_return(expand_return!(Summary).field_self())),
         )
         // storage: the perf surface (handles, callbacks, Vec, Option) plus the

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -28,6 +28,7 @@
 //! | `convert!` sources `.with(path!)`/`.error(ty!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
 //! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input |
+//! | `expand_param!` `.split()` (#52)      | `Summary` typed overloads — `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); manual same-named overload in `ManualOverloads.kt` |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
@@ -231,10 +232,15 @@ fn main() {
         )
         // `Summary` default input: rebuilt from the `of` constructor's
         // ingredients OR passed as an existing handle (runtime-selected).
+        // `.split()` (#52) also emits idiomatic typed overloads per variant —
+        // `f(count, total, …)` / `f(summary, …)` — delegating to the selector
+        // form. This is the CLASS-DEFAULT split: it fires on every function
+        // taking a `Summary` by the type default (e.g. `archiveStore`).
         .expand(
             expand_param!(Summary)
                 .variant(fun!(summary_new))
-                .variant_self(),
+                .variant_self()
+                .split(),
         )
         // `Summary` default output: decomposed `(count, total)` leaves, names
         // inherited from the class members.
@@ -337,12 +343,16 @@ fn main() {
                             .field_self(),
                     ),
                 )
+                // Per-fn split (#52): the `expected` param gets typed overloads
+                // `storageExpectSummary(count, total, …)` / `(expected, …)` on
+                // top of the selector form (which Test.kt still calls directly).
                 .fun(
                     fun!(storage_expect_summary).expand_param(
                         "expected",
                         expand_param!(Summary)
                             .variant(fun!(summary_new))
-                            .variant_self(),
+                            .variant_self()
+                            .split(),
                     ),
                 )
                 // The borrowed-accessor trio. `archive_latest` suppresses the default

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -26,6 +26,9 @@ Base package: `io.prebindgen.covertest`
 - `storage_summary_full` — `fun <R> storageSummaryFull(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryStorageSummaryFullBuilder<R>): R`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
 - `storage_summary_handle` — `fun storageSummaryHandle(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
+- `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+  - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
+  - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
 - `summary_total_raw` — `fun summaryTotalRaw(s: Summary, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
 
 ## package `io.prebindgen.covertest.model`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -642,6 +642,21 @@ internal object CovNative {
     external fun stringNew(s: String, errorSink: Any): String
     external fun summaryCount(s: Long, errorSink: Any): Long
     external fun summaryNew(count: Long, total: Double, errorSink: Any): Long
+    external fun summaryPrefer(
+        primarySel: Int,
+        primary00Present: Boolean,
+        primary00Value: Long,
+        primary01Present: Boolean,
+        primary01Value: Double,
+        primary1: Long,
+        fallbackSel: Int,
+        fallback00Present: Boolean,
+        fallback00Value: Long,
+        fallback01Present: Boolean,
+        fallback01Value: Double,
+        fallback1: Long,
+        errorSink: Any,
+    ): Long
     external fun summaryScaled(s: Long, factor: Double, errorSink: Any): Double
     external fun summaryTotal(s: Long, errorSink: Any): Double
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -145,6 +145,19 @@ public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: Su
     return __ret
 }
 
+public fun storageMatchesSummary(
+    s: Storage,
+    count: Long,
+    total: Double,
+    onError: JniErrorHandler<Boolean>,
+): Boolean = storageMatchesSummary(s, 0, count, total, null, onError)
+
+public fun storageMatchesSummary(
+    s: Storage,
+    expected: Summary,
+    onError: JniErrorHandler<Boolean>,
+): Boolean = storageMatchesSummary(s, 1, null, null, expected, onError)
+
 /**
  * Whether `expected` matches the storage's live summary (takes a `Summary`
  * **parameter**; the binding's **default flatten-input** rebuilds it from
@@ -248,6 +261,19 @@ public fun <R> storageSummaryFull(
     return __ret
 }
 
+public fun storageExpectSummary(
+    s: Storage,
+    count: Long,
+    total: Double,
+    onError: JniErrorHandler<Boolean>,
+): Boolean = storageExpectSummary(s, 0, count, total, null, onError)
+
+public fun storageExpectSummary(
+    s: Storage,
+    expected: Summary,
+    onError: JniErrorHandler<Boolean>,
+): Boolean = storageExpectSummary(s, 1, null, null, expected, onError)
+
 /**
  * Set the storage's "expected" summary, accepting a `Summary` built via an
  * explicit per-fn **flatten-input-with** variant list. Returns whether it
@@ -302,6 +328,10 @@ public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
     if (__cap.failed) return onError.run(__cap.je)
     return __ret
 }
+
+public fun archiveStore(a: SummaryVault, count: Long, total: Double, onError: JniErrorHandler<Unit>) = archiveStore(a, 0, count, total, null, onError)
+
+public fun archiveStore(a: SummaryVault, s: Summary, onError: JniErrorHandler<Unit>) = archiveStore(a, 1, null, null, s, onError)
 
 /**
  * Store a summary, consuming it (owned-handle input).

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -321,6 +321,92 @@ public fun storageExpectSummary(
     return __ret
 }
 
+public fun summaryPrefer(
+    primaryCount: Long,
+    primaryTotal: Double,
+    fallbackCount: Long,
+    fallbackTotal: Double,
+    onError: JniErrorHandler<Long>,
+): Long = summaryPrefer(0, primaryCount, primaryTotal, null, 0, fallbackCount, fallbackTotal, null, onError)
+
+public fun summaryPrefer(
+    primaryCount: Long,
+    primaryTotal: Double,
+    fallback: Summary,
+    onError: JniErrorHandler<Long>,
+): Long = summaryPrefer(0, primaryCount, primaryTotal, null, 1, null, null, fallback, onError)
+
+public fun summaryPrefer(
+    primary: Summary,
+    fallbackCount: Long,
+    fallbackTotal: Double,
+    onError: JniErrorHandler<Long>,
+): Long = summaryPrefer(1, null, null, primary, 0, fallbackCount, fallbackTotal, null, onError)
+
+public fun summaryPrefer(primary: Summary, fallback: Summary, onError: JniErrorHandler<Long>): Long = summaryPrefer(1, null, null, primary, 1, null, null, fallback, onError)
+
+/**
+ * Two-`Summary`-parameter function exercising #52's **cartesian-product**
+ * overloads: covertest declares `.split_on_param("primary")
+ * .split_on_param("fallback")`, so each parameter is independently split into
+ * its (count, total)-build / handle arms and the generator emits the 2×2
+ * product (all four combinations distinct). Returns `1` when `primary` has the
+ * larger total, else `0`.
+ *
+ * Parameter `fallback` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `fallbackSel`, `fallback00`, `fallback01`, `fallback1`).
+ * Parameter `primary` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `primarySel`, `primary00`, `primary01`, `primary1`).
+ */
+public fun summaryPrefer(
+    primarySel: Int,
+    primary00: Long?,
+    primary01: Double?,
+    primary1: Summary?,
+    fallbackSel: Int,
+    fallback00: Long?,
+    fallback01: Double?,
+    fallback1: Summary?,
+    onError: JniErrorHandler<Long>,
+): Long {
+    if (primary1 != null && primary1.isClosed()) return onError.run(
+        "Operation on a closed native handle.",
+    )
+    if (fallback1 != null && fallback1.isClosed()) return onError.run(
+        "Operation on a closed native handle.",
+    )
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        primary1?.let { __locks.add(it) }
+        fallback1?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val primary1_ptr = primary1?.ptr ?: 0L
+            val fallback1_ptr = fallback1?.ptr ?: 0L
+            try {
+                CovNative.summaryPrefer(
+                    primarySel,
+                    primary00 != null,
+                    primary00 ?: 0L,
+                    primary01 != null,
+                    primary01 ?: 0.0,
+                    primary1_ptr,
+                    fallbackSel,
+                    fallback00 != null,
+                    fallback00 ?: 0L,
+                    fallback01 != null,
+                    fallback01 ?: 0.0,
+                    fallback1_ptr,
+                    __cap,
+                )
+            } finally {
+                primary1?.let { it.ptr = it.ptr or 1L }
+                fallback1?.let { it.ptr = it.ptr or 1L }
+            }
+        }
+    }
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
 /** Create an empty archive. */
 public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
     val __cap = JniErrorHandlerCapture.acquire()

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -10,6 +10,7 @@ import io.prebindgen.covertest.analytics.storageMatchesSummary
 import io.prebindgen.covertest.analytics.storageSummary
 import io.prebindgen.covertest.analytics.storageSummaryFull
 import io.prebindgen.covertest.analytics.storageSummaryHandle
+import io.prebindgen.covertest.analytics.summaryPrefer
 import io.prebindgen.covertest.analytics.summaryTotalRaw
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.model.Annotated
@@ -271,8 +272,8 @@ fun main() {
         check(sum.count(boom) == 2L && sum.total(boom) == 40.0 && sum.scaled(0.5, boom) == 20.0)
         sum.close()
 
-        // #52 `.split()` overloads (class-default `expand_param!(Summary)`):
-        // idiomatic typed forms delegating to the selector wrapper.
+        // #52 single-param `.split_on_param("expected")` on the CLASS-DEFAULT
+        // `Summary` variants: idiomatic typed forms delegating to the selector.
         check(storageMatchesSummary(s, 2L, 40.0, boom))       // build-from-leaves arm
         check(!storageMatchesSummary(s, 1L, 40.0, boom))
         val h0 = Summary.of(2L, 40.0, boom)
@@ -280,10 +281,21 @@ fun main() {
         // The selector form stays public underneath (raw arm dispatch).
         check(storageMatchesSummary(s, 0, 2L, 40.0, null, boom))
 
-        // #52 `.split()` overloads (per-fn `.expand_param("expected", …)`).
+        // #52 single-param split via a per-fn `.expand_param` override.
         check(storageExpectSummary(s, 2L, 40.0, boom))        // build-from-leaves arm
         val h1 = Summary.of(2L, 40.0, boom)
         check(storageExpectSummary(s, h1, boom))              // pass-handle arm
+
+        // #52 CARTESIAN PRODUCT: two split params → the 2×2 grid of typed
+        // overloads, all four combinations distinct. Build args are prefixed
+        // with the origin parameter name (`primaryCount`, `fallbackTotal`); the
+        // handle arm consumes its `Summary`, so each is a fresh handle.
+        check(summaryPrefer(2L, 40.0, 1L, 1.0, boom) == 1L)                       // build / build
+        check(summaryPrefer(1L, 1.0, Summary.of(3L, 99.0, boom), boom) == 0L)     // build / handle
+        check(summaryPrefer(Summary.of(3L, 99.0, boom), 1L, 1.0, boom) == 1L)     // handle / build
+        check(
+            summaryPrefer(Summary.of(1L, 1.0, boom), Summary.of(3L, 99.0, boom), boom) == 0L,
+        )                                                                          // handle / handle
 
         // Auto-generated overloads coexist with a HAND-WRITTEN same-named one
         // (issue #52's manual path): `ManualOverloads.kt` adds another

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -271,18 +271,25 @@ fun main() {
         check(sum.count(boom) == 2L && sum.total(boom) == 40.0 && sum.scaled(0.5, boom) == 20.0)
         sum.close()
 
-        // flatten_input DEFAULT, selector 0: rebuild from (count, total) leaves.
-        check(storageMatchesSummary(s, 0, 2L, 40.0, null, boom))
-        check(!storageMatchesSummary(s, 0, 1L, 40.0, null, boom))
-        // flatten_input DEFAULT, selector 1: pass a handle (consumed by the call).
+        // #52 `.split()` overloads (class-default `expand_param!(Summary)`):
+        // idiomatic typed forms delegating to the selector wrapper.
+        check(storageMatchesSummary(s, 2L, 40.0, boom))       // build-from-leaves arm
+        check(!storageMatchesSummary(s, 1L, 40.0, boom))
         val h0 = Summary.of(2L, 40.0, boom)
-        check(storageMatchesSummary(s, 1, null, null, h0, boom))
+        check(storageMatchesSummary(s, h0, boom))             // pass-handle arm
+        // The selector form stays public underneath (raw arm dispatch).
+        check(storageMatchesSummary(s, 0, 2L, 40.0, null, boom))
 
-        // flatten_input_with, selector 0: rebuild from leaves.
-        check(storageExpectSummary(s, 0, 2L, 40.0, null, boom))
-        // flatten_input_with, selector 1: pass a handle (consumed by the call).
+        // #52 `.split()` overloads (per-fn `.expand_param("expected", …)`).
+        check(storageExpectSummary(s, 2L, 40.0, boom))        // build-from-leaves arm
         val h1 = Summary.of(2L, 40.0, boom)
-        check(storageExpectSummary(s, 1, null, null, h1, boom))
+        check(storageExpectSummary(s, h1, boom))              // pass-handle arm
+
+        // Auto-generated overloads coexist with a HAND-WRITTEN same-named one
+        // (issue #52's manual path): `ManualOverloads.kt` adds another
+        // `storageExpectSummary` — an `Int`-typed arm — in the analytics
+        // package; Kotlin resolves it by signature alongside the generated ones.
+        check(storageExpectSummary(s, 2, 40.0, boom))         // manual Int overload
         s.close()
     }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/analytics/ManualOverloads.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/analytics/ManualOverloads.kt
@@ -1,0 +1,21 @@
+package io.prebindgen.covertest.analytics
+
+import io.prebindgen.covertest.JniErrorHandler
+import io.prebindgen.covertest.Storage
+
+/**
+ * Hand-written same-named overload demonstrating issue #52's manual path: the
+ * generator's `.split()` overloads for `storageExpectSummary` do not preclude a
+ * consumer from adding *their own* same-named function. This `Int`-typed arm
+ * lives in the same `analytics` package as the generated top-level overloads
+ * (a separate file — generated code is never hand-edited) and is resolved by
+ * signature, distinct from the generated `(Storage, Long, Double, …)` /
+ * `(Storage, Summary, …)` / selector forms. It simply widens to the generated
+ * `Long` overload.
+ */
+fun storageExpectSummary(
+    s: Storage,
+    count: Int,
+    total: Double,
+    onError: JniErrorHandler<Boolean>,
+): Boolean = storageExpectSummary(s, count.toLong(), total, onError)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/analytics/ManualOverloads.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/analytics/ManualOverloads.kt
@@ -5,8 +5,9 @@ import io.prebindgen.covertest.Storage
 
 /**
  * Hand-written same-named overload demonstrating issue #52's manual path: the
- * generator's `.split()` overloads for `storageExpectSummary` do not preclude a
- * consumer from adding *their own* same-named function. This `Int`-typed arm
+ * generator's `.split_on_param` overloads for `storageExpectSummary` do not
+ * preclude a consumer from adding *their own* same-named function. This
+ * `Int`-typed arm
  * lives in the same `analytics` package as the generated top-level overloads
  * (a separate file — generated code is never hand-edited) and is resolved by
  * signature, distinct from the generated `(Storage, Long, Double, …)` /

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -6335,6 +6335,314 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    primary_sel: jni::sys::jint,
+    primary_0_0_present: jni::sys::jboolean,
+    primary_0_0_value: jni::sys::jlong,
+    primary_0_1_present: jni::sys::jboolean,
+    primary_0_1_value: jni::sys::jdouble,
+    primary_1: jni::sys::jlong,
+    fallback_sel: jni::sys::jint,
+    fallback_0_0_present: jni::sys::jboolean,
+    fallback_0_0_value: jni::sys::jlong,
+    fallback_0_1_present: jni::sys::jboolean,
+    fallback_0_1_value: jni::sys::jdouble,
+    fallback_1: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __exp_primary_sel = match jint_to_i32_a3e3b6ef(&mut env, &primary_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_primary_0_0: Option<i64> = if primary_0_0_present != 0u8 {
+        let __v = match jlong_to_i64_fbf9a9bc(&mut env, &primary_0_0_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_primary_0_1: Option<f64> = if primary_0_1_present != 0u8 {
+        let __v = match jdouble_to_f64_9e4a8f70(&mut env, &primary_0_1_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_primary_1 = match jlong_to_Option_Summary_252ef2ba(&mut env, &primary_1) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __folded_primary = match {
+        match __exp_primary_sel {
+            0i32 => {
+                match (__exp_primary_0_0, __exp_primary_0_1) {
+                    (
+                        ::core::option::Option::Some(__p0),
+                        ::core::option::Option::Some(__p1),
+                    ) => {
+                        ::core::result::Result::Ok(
+                            perftest_flat::summary_new(__p0, __p1),
+                        )
+                    }
+                    _ => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from(
+                                "constructor variant input missing",
+                            ),
+                        )
+                    }
+                }
+            }
+            1i32 => {
+                match __exp_primary_1 {
+                    ::core::option::Option::Some(__v) => ::core::result::Result::Ok(__v),
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from("identity variant value missing"),
+                        )
+                    }
+                }
+            }
+            __sel => {
+                ::core::result::Result::Err(
+                    ::std::format!("invalid constructor selector: {}", __sel),
+                )
+            }
+        }
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__je.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_fallback_sel = match jint_to_i32_a3e3b6ef(&mut env, &fallback_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_fallback_0_0: Option<i64> = if fallback_0_0_present != 0u8 {
+        let __v = match jlong_to_i64_fbf9a9bc(&mut env, &fallback_0_0_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_fallback_0_1: Option<f64> = if fallback_0_1_present != 0u8 {
+        let __v = match jdouble_to_f64_9e4a8f70(&mut env, &fallback_0_1_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_fallback_1 = match jlong_to_Option_Summary_252ef2ba(
+        &mut env,
+        &fallback_1,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __folded_fallback = match {
+        match __exp_fallback_sel {
+            0i32 => {
+                match (__exp_fallback_0_0, __exp_fallback_0_1) {
+                    (
+                        ::core::option::Option::Some(__p0),
+                        ::core::option::Option::Some(__p1),
+                    ) => {
+                        ::core::result::Result::Ok(
+                            perftest_flat::summary_new(__p0, __p1),
+                        )
+                    }
+                    _ => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from(
+                                "constructor variant input missing",
+                            ),
+                        )
+                    }
+                }
+            }
+            1i32 => {
+                match __exp_fallback_1 {
+                    ::core::option::Option::Some(__v) => ::core::result::Result::Ok(__v),
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from("identity variant value missing"),
+                        )
+                    }
+                }
+            }
+            __sel => {
+                ::core::result::Result::Err(
+                    ::std::format!("invalid constructor selector: {}", __sel),
+                )
+            }
+        }
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__je.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = cov_helpers::summary_prefer(__folded_primary, __folded_fallback);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryScaled<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -91,6 +91,7 @@ impl JniGen {
             return_expand_decls: Vec::new(),
             fn_param_expands: Vec::new(),
             fn_return_expands: Vec::new(),
+            fn_split_params: Vec::new(),
             class_members: HashMap::new(),
             ignored_fns: std::collections::HashSet::new(),
             ignored_name_predicates: Vec::new(),
@@ -466,6 +467,7 @@ impl JniGen {
             kotlin_name_override: _,
             param_expands,
             return_expand,
+            split_on_params,
         } = decl;
         for (param, pdecl) in param_expands {
             self.fn_param_expands
@@ -473,6 +475,9 @@ impl JniGen {
         }
         if let Some(rdecl) = return_expand {
             self.fn_return_expands.push((rust_ident.clone(), rdecl));
+        }
+        for param in split_on_params {
+            self.fn_split_params.push((rust_ident.clone(), param));
         }
     }
 }
@@ -568,12 +573,6 @@ impl JniGen {
         let mut exp = self.expansions.clone();
         for decl in &self.param_expand_decls {
             assert!(
-                !decl.split || decl.variants.len() >= 2,
-                "expand_param!({}).split(): needs ≥2 variants — a single arm already \
-                 flattens to an idiomatic signature, so there is nothing to overload",
-                decl.key.as_str()
-            );
-            assert!(
                 self.is_class_declared(&decl.key)
                     || !decl
                         .variants
@@ -603,13 +602,6 @@ impl JniGen {
         // param-name/type cross-check and the identity-only lowering happen
         // in `core/expand.rs`'s `apply` (which sees the fn signatures).
         for (func, param, decl) in &self.fn_param_expands {
-            assert!(
-                !decl.split || decl.variants.len() >= 2,
-                "fun!({func}).expand_param(\"{param}\", expand_param!({k}).split()): needs ≥2 \
-                 variants — a single arm already flattens to an idiomatic signature, so there is \
-                 nothing to overload",
-                k = decl.key.as_str()
-            );
             assert!(
                 self.is_class_declared(&decl.key)
                     || !decl

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -568,6 +568,12 @@ impl JniGen {
         let mut exp = self.expansions.clone();
         for decl in &self.param_expand_decls {
             assert!(
+                !decl.split || decl.variants.len() >= 2,
+                "expand_param!({}).split(): needs ≥2 variants — a single arm already \
+                 flattens to an idiomatic signature, so there is nothing to overload",
+                decl.key.as_str()
+            );
+            assert!(
                 self.is_class_declared(&decl.key)
                     || !decl
                         .variants
@@ -597,6 +603,13 @@ impl JniGen {
         // param-name/type cross-check and the identity-only lowering happen
         // in `core/expand.rs`'s `apply` (which sees the fn signatures).
         for (func, param, decl) in &self.fn_param_expands {
+            assert!(
+                !decl.split || decl.variants.len() >= 2,
+                "fun!({func}).expand_param(\"{param}\", expand_param!({k}).split()): needs ≥2 \
+                 variants — a single arm already flattens to an idiomatic signature, so there is \
+                 nothing to overload",
+                k = decl.key.as_str()
+            );
             assert!(
                 self.is_class_declared(&decl.key)
                     || !decl

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -443,12 +443,19 @@ impl From<syn::Type> for PtrClassDecl {
 /// nullable slot per arm (`keyExprSel: Int, keyExpr0: String?,
 /// keyExpr1: KeyExpr?`), and the raw call site passes `(0, "key", null)`-style
 /// tuples. That selector form is always emitted; the wrapper's generated KDoc
-/// shape-notes document the exact slots per function. To surface the idiomatic
-/// typed **overloads** on top of it (`f(key: String, …)` / `f(key: KeyExpr,
-/// …)`), add [`.split()`](Self::split) — opt-in, one function may split one
-/// parameter. Without it, an idiomatic tier is a hand-written SDK's job (and
-/// remains possible: the selector form is public, so consumers can add their
-/// own same-named overloads).
+/// shape-notes document the exact slots per function.
+///
+/// **Splittability (checked)** — a multi-variant declaration must be
+/// *splittable*: its arms must surface as **distinct JVM signatures**, so a
+/// function can request idiomatic typed **overloads** on top of the selector
+/// form (`f(key: String, …)` / `f(key: KeyExpr, …)`) via
+/// [`FunctionDecl::split_on_param`](crate::fun). This is verified up front —
+/// two arms with the same erased parameter types are a hard build error.
+/// [`.no_split()`](Self::no_split) suppresses that check for a variant set that
+/// will only ever be used as the selector form. The type-level declaration
+/// itself emits no overloads; emission is per-function via `.split_on_param`.
+/// The selector form always stays public, so consumers can also add their own
+/// same-named overloads by hand.
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
 /// on an undeclared type makes it **rust-side-only**: the value is always
@@ -468,10 +475,10 @@ impl From<syn::Type> for PtrClassDecl {
 pub struct ExpandParamDecl {
     pub(crate) key: TypeKey,
     pub(crate) variants: Vec<LocalVariant>,
-    /// `.split()` — emit one idiomatic typed Kotlin overload per variant
-    /// (delegating to the selector form) instead of leaving the selector
-    /// tuple as the only surface. Opt-in; see [`Self::split`].
-    pub(crate) split: bool,
+    /// `.no_split()` — suppress the proactive splittability check for this
+    /// variant set (it will only ever be used as the selector form). See
+    /// [`Self::no_split`].
+    pub(crate) no_split: bool,
 }
 
 impl ExpandParamDecl {
@@ -479,7 +486,7 @@ impl ExpandParamDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             variants: Vec::new(),
-            split: false,
+            no_split: false,
         }
     }
 
@@ -515,30 +522,17 @@ impl ExpandParamDecl {
         self
     }
 
-    /// **Opt in to idiomatic typed overloads.** By default a multi-arm
-    /// expansion crosses only as the selector tuple (see the type-level docs).
-    /// With `.split()` the generator additionally emits, alongside that form,
-    /// one typed Kotlin overload per variant — `f(count: Long, total: Double,
-    /// onError)` for a `summary_new(count, total)` arm, `f(summary: Summary,
-    /// onError)` for `variant_self()` — each delegating to the selector form.
-    /// The selector form stays public (the delegation target, and a base for
-    /// hand-written overloads).
+    /// **Suppress the splittability check.** A multi-variant expansion is
+    /// verified up front to be *splittable* (its arms surface as distinct JVM
+    /// signatures) so that [`FunctionDecl::split_on_param`](crate::fun) can emit
+    /// idiomatic typed overloads. `.no_split()` opts this variant set out of
+    /// that check — declare it when two arms genuinely share a JVM signature and
+    /// you only ever want the selector form (a function that then tries to
+    /// `.split_on_param` such a parameter gets the concrete ambiguity error).
     ///
-    /// Rules, all hard build errors:
-    /// * needs **≥2 variants** (a single arm already flattens idiomatically);
-    /// * the variants must surface as **distinct JVM signatures** (two arms
-    ///   with the same erased parameter types are a platform-declaration clash
-    ///   — disambiguate the constructors or drop `.split()`);
-    /// * a function may have **at most one split parameter** (overloads are the
-    ///   product of every split param's arms; capping at one keeps the surface
-    ///   sound and finite — un-split the others with a per-fn
-    ///   [`expand_param`](crate::fun) override that omits `.split()`).
-    ///
-    /// Only flat, non-optional arms are overloaded; an `Option<T>` / `Vec<T>`
-    /// parameter or a recursively-built arm keeps the selector form for that
-    /// function (the overload has no clean single type).
-    pub fn split(mut self) -> Self {
-        self.split = true;
+    /// A no-op on a single-variant declaration (nothing to check).
+    pub fn no_split(mut self) -> Self {
+        self.no_split = true;
         self
     }
 }
@@ -849,6 +843,7 @@ pub struct FunctionDecl {
     pub(crate) kotlin_name_override: Option<String>,
     pub(crate) param_expands: Vec<(String, ExpandParamDecl)>,
     pub(crate) return_expand: Option<ExpandReturnDecl>,
+    pub(crate) split_on_params: Vec<String>,
 }
 
 impl FunctionDecl {
@@ -858,6 +853,7 @@ impl FunctionDecl {
             kotlin_name_override: None,
             param_expands: Vec::new(),
             return_expand: None,
+            split_on_params: Vec::new(),
         }
     }
 
@@ -890,6 +886,40 @@ impl FunctionDecl {
             param
         );
         self.param_expands.push((param, decl));
+        self
+    }
+
+    /// **Emit idiomatic typed Kotlin overloads for this parameter.** By default
+    /// a multi-variant expanded parameter crosses only as the selector tuple
+    /// (`expectedSel: Int, expected0: …, expected1: …`). `.split_on_param("p")`
+    /// additionally emits, alongside the selector wrapper, one typed overload
+    /// per variant of `p` — `f(count: Long, total: Double, …)` for a
+    /// `summary_new(count, total)` arm, `f(expected: Summary, …)` for
+    /// `variant_self()` — each delegating to the selector form.
+    ///
+    /// The parameter's variant set must be *splittable* (its arms surface as
+    /// distinct JVM signatures) — enforced up front on the
+    /// [`expand_param!`](crate::expand_param) declaration unless it opted out
+    /// with [`.no_split()`](ExpandParamDecl::no_split).
+    ///
+    /// Call again for **several** parameters: the generated overloads are then
+    /// the **cartesian product** of the named parameters' arms. That concrete
+    /// product must have no two combinations sharing a JVM signature — a hard
+    /// build error if it does.
+    ///
+    /// `param` is the Rust parameter name; it must be an expanded,
+    /// multi-variant parameter of this function (unknown / single-variant /
+    /// `Option<T>` / recursively-built ⇒ a hard error). Declaring the same
+    /// parameter twice is a hard error.
+    pub fn split_on_param(mut self, param: impl AsRef<str>) -> Self {
+        let param = param.as_ref().to_string();
+        assert!(
+            !self.split_on_params.contains(&param),
+            "fun!({}).split_on_param(\"{}\"): parameter is already split",
+            self.rust_ident,
+            param
+        );
+        self.split_on_params.push(param);
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -438,13 +438,17 @@ impl From<syn::Type> for PtrClassDecl {
 /// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
 /// it to [`JniGen::expand`].
 ///
-/// **Generated shape** — this is a WIRE-level dispatch, not overloads: with
+/// **Generated shape** — at the wire tier this is a selector dispatch: with
 /// more than one arm the parameter crosses as a selector `Int` plus one
 /// nullable slot per arm (`keyExprSel: Int, keyExpr0: String?,
-/// keyExpr1: KeyExpr?`), and the call site passes `(0, "key", null)`-style
-/// tuples. Idiomatic overloads / sealed types are a hand-written SDK tier's
-/// job on top; the wrapper's generated KDoc shape-notes document the exact
-/// slots per function.
+/// keyExpr1: KeyExpr?`), and the raw call site passes `(0, "key", null)`-style
+/// tuples. That selector form is always emitted; the wrapper's generated KDoc
+/// shape-notes document the exact slots per function. To surface the idiomatic
+/// typed **overloads** on top of it (`f(key: String, …)` / `f(key: KeyExpr,
+/// …)`), add [`.split()`](Self::split) — opt-in, one function may split one
+/// parameter. Without it, an idiomatic tier is a hand-written SDK's job (and
+/// remains possible: the selector form is public, so consumers can add their
+/// own same-named overloads).
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
 /// on an undeclared type makes it **rust-side-only**: the value is always
@@ -464,6 +468,10 @@ impl From<syn::Type> for PtrClassDecl {
 pub struct ExpandParamDecl {
     pub(crate) key: TypeKey,
     pub(crate) variants: Vec<LocalVariant>,
+    /// `.split()` — emit one idiomatic typed Kotlin overload per variant
+    /// (delegating to the selector form) instead of leaving the selector
+    /// tuple as the only surface. Opt-in; see [`Self::split`].
+    pub(crate) split: bool,
 }
 
 impl ExpandParamDecl {
@@ -471,6 +479,7 @@ impl ExpandParamDecl {
         Self {
             key: TypeKey::from_type(&rust_type),
             variants: Vec::new(),
+            split: false,
         }
     }
 
@@ -503,6 +512,33 @@ impl ExpandParamDecl {
     /// alone changes nothing; it earns its place next to build variants.
     pub fn variant_self(mut self) -> Self {
         self.variants.push(LocalVariant::SelfIdentity);
+        self
+    }
+
+    /// **Opt in to idiomatic typed overloads.** By default a multi-arm
+    /// expansion crosses only as the selector tuple (see the type-level docs).
+    /// With `.split()` the generator additionally emits, alongside that form,
+    /// one typed Kotlin overload per variant — `f(count: Long, total: Double,
+    /// onError)` for a `summary_new(count, total)` arm, `f(summary: Summary,
+    /// onError)` for `variant_self()` — each delegating to the selector form.
+    /// The selector form stays public (the delegation target, and a base for
+    /// hand-written overloads).
+    ///
+    /// Rules, all hard build errors:
+    /// * needs **≥2 variants** (a single arm already flattens idiomatically);
+    /// * the variants must surface as **distinct JVM signatures** (two arms
+    ///   with the same erased parameter types are a platform-declaration clash
+    ///   — disambiguate the constructors or drop `.split()`);
+    /// * a function may have **at most one split parameter** (overloads are the
+    ///   product of every split param's arms; capping at one keeps the surface
+    ///   sound and finite — un-split the others with a per-fn
+    ///   [`expand_param`](crate::fun) override that omits `.split()`).
+    ///
+    /// Only flat, non-optional arms are overloaded; an `Option<T>` / `Vec<T>`
+    /// parameter or a recursively-built arm keeps the selector form for that
+    /// function (the overload has no clean single type).
+    pub fn split(mut self) -> Self {
+        self.split = true;
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -333,6 +333,11 @@ impl JniGen {
                         Some(self.effective_member_name(key, m).as_str()),
                         Some(key),
                     ) {
+                        for ov in crate::api::lang::jnigen::jni::render_param_overloads(
+                            self, item_fn, registry, &f,
+                        ) {
+                            class = class.member(ov);
+                        }
                         class = class.member(f);
                     }
                 }
@@ -354,6 +359,11 @@ impl JniGen {
                             Some(self.effective_member_name(key, m).as_str()),
                             None,
                         ) {
+                            for ov in crate::api::lang::jnigen::jni::render_param_overloads(
+                                self, item_fn, registry, &f,
+                            ) {
+                                companion = companion.member(ov);
+                            }
                             companion = companion.member(f);
                         }
                     }
@@ -531,6 +541,11 @@ impl JniGen {
                         Some(self.effective_member_name(key, m).as_str()),
                         Some(key),
                     ) {
+                        for ov in crate::api::lang::jnigen::jni::render_param_overloads(
+                            self, item_fn, registry, &f,
+                        ) {
+                            class = class.member(ov);
+                        }
                         class = class.member(f);
                     }
                 }
@@ -557,6 +572,11 @@ impl JniGen {
                             Some(self.effective_member_name(key, m).as_str()),
                             None,
                         ) {
+                            for ov in crate::api::lang::jnigen::jni::render_param_overloads(
+                                self, item_fn, registry, &f,
+                            ) {
+                                companion = companion.member(ov);
+                            }
                             companion = companion.member(f);
                         }
                     }
@@ -988,6 +1008,11 @@ impl JniGen {
                 entry.kotlin_name_override.as_deref(),
                 None,
             ) {
+                // #52: idiomatic typed overloads for a `.split()` param,
+                // delegating to this selector wrapper.
+                for ov in render_param_overloads(self, item_fn, registry, &f) {
+                    file = file.decl(ov);
+                }
                 file = file.decl(f);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -76,6 +76,9 @@ impl JniGen {
         registry: &Registry<KotlinMeta>,
         kotlin_root: &Path,
     ) -> Result<Vec<PathBuf>, WriteKotlinError> {
+        // #52: verify every multi-variant expand_param! is splittable up front,
+        // before any per-function `.split_on_param` emission.
+        self.validate_split_declarations(registry);
         let mut fragments: Vec<kt::KtFile> = Vec::new();
         fragments.push(self.write_native_handle());
         fragments.extend(self.write_enum_classes(registry)?);
@@ -1008,8 +1011,8 @@ impl JniGen {
                 entry.kotlin_name_override.as_deref(),
                 None,
             ) {
-                // #52: idiomatic typed overloads for a `.split()` param,
-                // delegating to this selector wrapper.
+                // #52: idiomatic typed overloads for `.split_on_param`
+                // parameters, delegating to this selector wrapper.
                 for ov in render_param_overloads(self, item_fn, registry, &f) {
                     file = file.decl(ov);
                 }

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -426,6 +426,11 @@ pub struct JniGen {
     /// `core/unfold.rs`'s `apply`.
     pub(crate) fn_return_expands: Vec<(syn::Ident, ExpandReturnDecl)>,
 
+    /// Per-fn split requests ([`FunctionDecl::split_on_param`]): the fn ident
+    /// and the parameter name whose variants get idiomatic typed overloads
+    /// (#52). Consumed by `overloads::render_param_overloads`.
+    pub(crate) fn_split_params: Vec<(syn::Ident, String)>,
+
     /// Class members (funs / constructors) attached to a declared class via
     /// its decl's `.fun()`/`.constructor()`, keyed by the class's canonical
     /// Rust type. Supplies the instance-method / companion-factory emission

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -470,6 +470,7 @@ mod trait_impl;
 
 mod fold;
 mod kotlin_emit;
+mod overloads;
 mod render;
 mod report;
 mod struct_plan;
@@ -481,6 +482,7 @@ pub use decl::*;
 pub(crate) use emit::*;
 pub(crate) use fold::*;
 pub(crate) use iface::*;
+pub(crate) use overloads::*;
 pub(crate) use prim::*;
 pub(crate) use render::*;
 pub(crate) use struct_plan::*;

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -214,8 +214,8 @@ fn prefixed(origin: &str, name: &str) -> String {
     }
 }
 
-/// Clear nullability (`T?` → `T`): an overload takes each arm's real,
-/// non-nullable constructor parameter type.
+/// Clear selector-dispatch nullability (`T?` → `T`). Genuinely optional
+/// constructor parameters bypass this helper and retain their rendered `T?`.
 fn non_null(mut ty: kt::KtType) -> kt::KtType {
     match &mut ty {
         kt::KtType::Named { nullable, .. } | kt::KtType::Function { nullable, .. } => {
@@ -223,6 +223,15 @@ fn non_null(mut ty: kt::KtType) -> kt::KtType {
         }
     }
     ty
+}
+
+fn is_option(ty: &syn::Type) -> bool {
+    matches!(
+        ty,
+        syn::Type::Path(p)
+            if p.qself.is_none()
+                && p.path.segments.last().is_some_and(|s| s.ident == "Option")
+    )
 }
 
 /// The typed overload params of one variant arm, paired with the leaf index
@@ -237,14 +246,23 @@ fn variant_typed_params(
     multi: bool,
 ) -> Option<Vec<(kt::KtParam, usize)>> {
     let origin_kt = kt_param_name(&origin.to_string());
-    let names: Vec<String> = match &variant.ctor {
+    let (names, optional): (Vec<String>, Vec<bool>) = match &variant.ctor {
         Some(cf) => {
             let (item_fn, _) = registry.functions.get(cf)?;
-            ctor_param_names(item_fn)
+            let optional = item_fn
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|a| match a {
+                    syn::FnArg::Typed(pt) => Some(is_option(&pt.ty)),
+                    _ => None,
+                })
+                .collect();
+            (ctor_param_names(item_fn), optional)
         }
         // Identity arm: one parameter, the value itself, named after the origin
         // parameter (already unique across split params — never prefixed).
-        None => vec![origin_kt.clone()],
+        None => (vec![origin_kt.clone()], vec![false]),
     };
     let mut out = Vec::new();
     for (m, arg) in variant.inputs.iter().enumerate() {
@@ -258,7 +276,12 @@ fn variant_typed_params(
         } else {
             base
         };
-        out.push((kt::KtParam::new(&name, non_null(slot.ty.clone())), *idx));
+        let ty = if optional.get(m).copied().unwrap_or(false) {
+            slot.ty.clone()
+        } else {
+            non_null(slot.ty.clone())
+        };
+        out.push((kt::KtParam::new(&name, ty), *idx));
     }
     Some(out)
 }
@@ -534,4 +557,48 @@ fn combo_label(splits: &[Split], combo: &[usize]) -> String {
         })
         .collect();
     format!("({})", parts.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SourceLocation;
+
+    #[test]
+    fn split_params_preserve_constructor_option_nullability() {
+        let ctor: syn::ItemFn = syn::parse_quote! {
+            pub fn z_summary_optional(count: Option<i64>, total: f64) -> ZSummary {
+                unimplemented!()
+            }
+        };
+        let registry = Registry::<KotlinMeta>::from_items(vec![(
+            syn::Item::Fn(ctor),
+            SourceLocation::default(),
+        )])
+        .expect("index constructor");
+        let variant = crate::api::core::expand::FoldVariant {
+            ctor: Some(syn::parse_quote!(z_summary_optional)),
+            fallible: false,
+            clone: false,
+            inputs: vec![FoldArg::Leaf(0), FoldArg::Leaf(1)],
+        };
+        // Both slots are nullable in the selector wrapper. Only the first is
+        // nullable in the constructor's actual signature.
+        let block = vec![
+            kt::KtParam::new("expected0", kt::KtType::long().nullable()),
+            kt::KtParam::new("expected1", kt::KtType::cls("Double").nullable()),
+        ];
+
+        let params = variant_typed_params(
+            &registry,
+            &variant,
+            &syn::parse_quote!(expected),
+            &block,
+            false,
+        )
+        .expect("flat arm");
+
+        assert_eq!(params[0].0.ty.to_string(), "Long?");
+        assert_eq!(params[1].0.ty.to_string(), "Double");
+    }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -1,0 +1,331 @@
+//! #52: opt-in idiomatic Kotlin overloads for `.split()` expanded params.
+//!
+//! A multi-variant `expand_param!(T)` crosses the wire as a selector tuple
+//! (`expectedSel: Int, expected00: Long?, …`). With `.split()` the generator
+//! emits, alongside that selector form, one **typed overload per variant**
+//! delegating to it — turning `storageExpectSummary(s, 0, count, total, null,
+//! onError)` into `storageExpectSummary(s, count, total, onError)`.
+//!
+//! Validation is folded into emission (in-scope-aware, so it never flags a
+//! case that would not emit an overload):
+//! * **≤1 split parameter per function** — overloads are the product of every
+//!   split param's arms; capping at one keeps the surface finite and reduces
+//!   collision detection to the sound, complete type-level check.
+//! * **distinct JVM-erased arm signatures** — two variants that surface as the
+//!   same erased parameter list are a platform-declaration clash; a hard build
+//!   error names the offending class's variants.
+//!
+//! Only flat, non-optional single-level arms are overloaded; `Option<T>` /
+//! `Vec<T>` params and recursively-built arms keep the selector form for that
+//! function (documented fallback — there is no clean single type to offer).
+
+use super::*;
+use crate::api::core::expand::{FoldArg, FoldPlan};
+
+impl JniGen {
+    /// Whether the expanded parameter `(func, param)` producing `target` is
+    /// marked `.split()`. A per-fn `.expand_param(param, …)` override for this
+    /// exact `(func, param)` wins over the type-level default — the same
+    /// replace semantics [`Self::build_expansions`] applies.
+    pub(crate) fn is_split_param(
+        &self,
+        func: &syn::Ident,
+        param: &syn::Ident,
+        target: &syn::Type,
+    ) -> bool {
+        let param_s = param.to_string();
+        if let Some((_, _, decl)) = self
+            .fn_param_expands
+            .iter()
+            .find(|(f, p, _)| f == func && *p == param_s)
+        {
+            return decl.split;
+        }
+        let key = TypeKey::from_type(target);
+        self.param_expand_decls
+            .iter()
+            .any(|d| d.key == key && d.split)
+    }
+
+    /// `true` if `simple` is the Kotlin simple name of a `value_blob`
+    /// (`@JvmInline value class`) type — which erases to `ByteArray` on the
+    /// JVM, so two distinct such classes share one method descriptor.
+    fn is_value_blob_kotlin(&self, simple: &str) -> bool {
+        self.types.values().any(|c| {
+            c.value_blob
+                && c.name_spec
+                    .as_ref()
+                    .map(|s| self.fqn_of(s))
+                    .and_then(|fqn| fqn.rsplit('.').next().map(str::to_string))
+                    .as_deref()
+                    == Some(simple)
+        })
+    }
+}
+
+/// One resolved split parameter of a function.
+struct SplitParam<'a> {
+    /// The original Rust parameter ident (e.g. `expected`).
+    param: syn::Ident,
+    /// Its resolved expansion plan (multi-variant, non-optional, flat).
+    plan: &'a FoldPlan,
+}
+
+/// Whether `plan` is a multi-variant expansion this feature can turn into
+/// overloads: it has a selector (≥2 arms), a plain (non-`Option`) outer shape,
+/// and no recursively-built arm.
+fn plan_in_scope(plan: &FoldPlan) -> bool {
+    plan.selector.is_some()
+        && !plan.produces_option()
+        && !plan
+            .variants
+            .iter()
+            .any(|v| v.inputs.iter().any(|a| matches!(a, FoldArg::Build(_))))
+}
+
+/// Every in-scope split parameter of `f`, in signature order. Used both to
+/// pick the one to overload and to enforce the ≤1-per-function rule.
+fn split_params<'a>(
+    ext: &JniGen,
+    f: &syn::ItemFn,
+    registry: &'a Registry<KotlinMeta>,
+) -> Vec<SplitParam<'a>> {
+    let mut out = Vec::new();
+    for input in &f.sig.inputs {
+        let syn::FnArg::Typed(pt) = input else {
+            continue;
+        };
+        let syn::Pat::Ident(pid) = &*pt.pat else {
+            continue;
+        };
+        let Some(plan) = registry
+            .expansion_plans
+            .get(&(f.sig.ident.clone(), pid.ident.clone()))
+        else {
+            continue;
+        };
+        if !ext.is_split_param(&f.sig.ident, &pid.ident, &plan.target) {
+            continue;
+        }
+        if !plan_in_scope(plan) {
+            continue;
+        }
+        out.push(SplitParam {
+            param: pid.ident.clone(),
+            plan,
+        });
+    }
+    out
+}
+
+/// Camel-cased Kotlin names of a `#[prebindgen]` constructor's parameters, in
+/// order — the idiomatic overload parameter names for a build arm.
+fn ctor_param_names(f: &syn::ItemFn) -> Vec<String> {
+    f.sig
+        .inputs
+        .iter()
+        .filter_map(|a| match a {
+            syn::FnArg::Typed(pt) => match &*pt.pat {
+                syn::Pat::Ident(pid) => Some(kt_param_name(&pid.ident.to_string())),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+/// A named type with its nullability cleared (`T?` → `T`) — a split overload
+/// takes each arm's real, non-nullable constructor parameter type, unlike the
+/// selector form whose per-arm slots are all nullable.
+fn non_null(mut ty: kt::KtType) -> kt::KtType {
+    match &mut ty {
+        kt::KtType::Named { nullable, .. } | kt::KtType::Function { nullable, .. } => {
+            *nullable = false
+        }
+    }
+    ty
+}
+
+/// The JVM method descriptor fragment one overload parameter erases to —
+/// value classes to `ByteArray`, primitives/`String` to themselves, other
+/// classes to their FQN. Two arms collide iff their fragment lists match.
+fn erased(ext: &JniGen, ty: &kt::KtType) -> String {
+    let simple = ty.simple_name().unwrap_or("");
+    if ext.is_value_blob_kotlin(simple) {
+        return "ByteArray".to_string();
+    }
+    match simple {
+        "Int" | "Long" | "Double" | "Float" | "Boolean" | "Byte" | "Short" | "Char" | "String"
+        | "ByteArray" => simple.to_string(),
+        _ => ty.leaf_name().unwrap_or(simple).to_string(),
+    }
+}
+
+/// The typed overload parameters of one variant arm, paired with the flat leaf
+/// index each fills in the selector form. `block` is the selector wrapper's
+/// contiguous run of leaf params (index `k` = `plan.leaves[k]`). Returns
+/// `None` if any input is not a flat leaf (out of scope).
+fn variant_typed_params(
+    registry: &Registry<KotlinMeta>,
+    variant: &crate::api::core::expand::FoldVariant,
+    base_param: &syn::Ident,
+    block: &[kt::KtParam],
+) -> Option<Vec<(kt::KtParam, usize)>> {
+    let names: Vec<String> = match &variant.ctor {
+        Some(cf) => {
+            let (item_fn, _) = registry.functions.get(cf)?;
+            ctor_param_names(item_fn)
+        }
+        // Identity arm: a single parameter, the target value itself, named
+        // after the original Rust parameter.
+        None => vec![kt_param_name(&base_param.to_string())],
+    };
+    let mut out = Vec::new();
+    for (m, arg) in variant.inputs.iter().enumerate() {
+        let FoldArg::Leaf(idx) = arg else {
+            return None;
+        };
+        let slot = block.get(*idx)?;
+        let name = names.get(m).cloned().unwrap_or_else(|| slot.name.clone());
+        out.push((kt::KtParam::new(&name, non_null(slot.ty.clone())), *idx));
+    }
+    Some(out)
+}
+
+/// Locate the split param's contiguous leaf block in the already-rendered
+/// selector wrapper's parameter list, matching by leaf name in order.
+fn find_block(params: &[kt::KtParam], leaf_names: &[String]) -> Option<usize> {
+    if leaf_names.is_empty() || params.len() < leaf_names.len() {
+        return None;
+    }
+    (0..=params.len() - leaf_names.len()).find(|&s| {
+        params[s..s + leaf_names.len()]
+            .iter()
+            .zip(leaf_names)
+            .all(|(p, n)| &p.name == n)
+    })
+}
+
+/// The overloads for one function, delegating to its already-rendered selector
+/// wrapper `sel_fun` (same Kotlin name). Empty unless the function has one
+/// in-scope split parameter. Panics (a build error) on the ≤1-per-function and
+/// distinct-signature rules.
+pub(crate) fn render_param_overloads(
+    ext: &JniGen,
+    f: &syn::ItemFn,
+    registry: &Registry<KotlinMeta>,
+    sel_fun: &kt::KtFun,
+) -> Vec<kt::KtFun> {
+    let splits = split_params(ext, f, registry);
+    if splits.len() > 1 {
+        let names: Vec<String> = splits.iter().map(|s| s.param.to_string()).collect();
+        panic!(
+            "fn `{}` has {} `.split()` parameters ({}); a function may split at most one — \
+             un-split the others with a per-fn `.expand_param(name, …)` override that omits \
+             `.split()`",
+            f.sig.ident,
+            names.len(),
+            names.join(", ")
+        );
+    }
+    let Some(sp) = splits.first() else {
+        return Vec::new();
+    };
+    let plan = sp.plan;
+
+    let leaf_names: Vec<String> = plan
+        .leaves
+        .iter()
+        .map(|l| kt_param_name(&l.name.to_string()))
+        .collect();
+    let len = leaf_names.len();
+    // Degrade to selector-only if the leaf block can't be located (a shape the
+    // offset assumption doesn't cover) — never emit a malformed overload.
+    let Some(start) = find_block(&sel_fun.params, &leaf_names) else {
+        return Vec::new();
+    };
+    let block = &sel_fun.params[start..start + len];
+    let sel_idx = plan.selector.expect("in-scope ⇒ selector present");
+
+    // Build every arm's typed params first, so the distinct-signature check
+    // runs before any emission.
+    let mut arms: Vec<Vec<(kt::KtParam, usize)>> = Vec::with_capacity(plan.variants.len());
+    for variant in &plan.variants {
+        let Some(tp) = variant_typed_params(registry, variant, &sp.param, block) else {
+            return Vec::new();
+        };
+        arms.push(tp);
+    }
+    // Distinct-signature (JVM erasure) check — class-attributed hard error.
+    for i in 0..arms.len() {
+        for j in (i + 1)..arms.len() {
+            let di: Vec<String> = arms[i].iter().map(|(p, _)| erased(ext, &p.ty)).collect();
+            let dj: Vec<String> = arms[j].iter().map(|(p, _)| erased(ext, &p.ty)).collect();
+            if di == dj {
+                panic!(
+                    "expand_param!({}).split(): variants {} and {} both surface as `({})` — \
+                     two overloads with the same JVM signature are a platform-declaration \
+                     clash; disambiguate the constructors or drop `.split()`",
+                    plan.target.to_token_stream(),
+                    variant_label(&plan.variants[i]),
+                    variant_label(&plan.variants[j]),
+                    di.join(", "),
+                );
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(arms.len());
+    for (i, typed) in arms.iter().enumerate() {
+        // Overload signature: fixed params, the arm's typed params in place of
+        // the leaf block, then the trailing fixed/onError params.
+        let mut params: Vec<kt::KtParam> = Vec::new();
+        params.extend_from_slice(&sel_fun.params[..start]);
+        params.extend(typed.iter().map(|(p, _)| p.clone()));
+        params.extend_from_slice(&sel_fun.params[start + len..]);
+
+        // Delegation args: leaf slots get the selector value, this arm's typed
+        // params, or `null`; every other param passes through by name.
+        let mut leaf_arg: Vec<String> = vec!["null".to_string(); len];
+        leaf_arg[sel_idx] = i.to_string();
+        for (p, lidx) in typed {
+            leaf_arg[*lidx] = p.name.clone();
+        }
+        let call_args: Vec<String> = sel_fun
+            .params
+            .iter()
+            .enumerate()
+            .map(|(j, p)| {
+                if j >= start && j < start + len {
+                    leaf_arg[j - start].clone()
+                } else {
+                    p.name.clone()
+                }
+            })
+            .collect();
+
+        let mut ov = kt::KtFun::new(&sel_fun.name).vis(kt::Vis::Public);
+        for p in params {
+            ov = ov.param(p);
+        }
+        if let Some(rt) = &sel_fun.ret {
+            ov = ov.returns(rt.clone());
+        }
+        ov = ov.expr_body(kt::Code::new().line(format!(
+            "{}({})",
+            sel_fun.name,
+            call_args.join(", ")
+        )));
+        out.push(ov);
+    }
+    out
+}
+
+/// A short label for a variant in error messages: the constructor ident, or
+/// `variant_self()` for the identity arm.
+fn variant_label(v: &crate::api::core::expand::FoldVariant) -> String {
+    match &v.ctor {
+        Some(c) => c.to_string(),
+        None => "variant_self()".to_string(),
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -1,52 +1,28 @@
-//! #52: opt-in idiomatic Kotlin overloads for `.split()` expanded params.
+//! #52: idiomatic Kotlin overloads for expanded params.
 //!
 //! A multi-variant `expand_param!(T)` crosses the wire as a selector tuple
-//! (`expectedSel: Int, expected00: Long?, …`). With `.split()` the generator
-//! emits, alongside that selector form, one **typed overload per variant**
-//! delegating to it — turning `storageExpectSummary(s, 0, count, total, null,
-//! onError)` into `storageExpectSummary(s, count, total, onError)`.
+//! (`expectedSel: Int, expected00: Long?, …`); the raw call site passes magic
+//! ints and null-padding. Two mechanisms turn that into idiomatic Kotlin:
 //!
-//! Validation is folded into emission (in-scope-aware, so it never flags a
-//! case that would not emit an overload):
-//! * **≤1 split parameter per function** — overloads are the product of every
-//!   split param's arms; capping at one keeps the surface finite and reduces
-//!   collision detection to the sound, complete type-level check.
-//! * **distinct JVM-erased arm signatures** — two variants that surface as the
-//!   same erased parameter list are a platform-declaration clash; a hard build
-//!   error names the offending class's variants.
+//! * **Proactive splittability check** ([`JniGen::validate_split_declarations`]):
+//!   every multi-variant `expand_param!` declaration (type-level or per-fn) is
+//!   verified up front to be *splittable* — its arms surface as pairwise-distinct
+//!   JVM signatures — so a function can safely request overloads. A collision is
+//!   a hard build error attributed to the declaration; `.no_split()` opts out.
+//! * **Per-function emission** ([`render_param_overloads`], driven by
+//!   [`FunctionDecl::split_on_param`](crate::fun)): for the named split params the
+//!   generator emits, alongside the selector wrapper, the **cartesian product** of
+//!   their arms as typed overloads, each delegating to the selector form. The
+//!   concrete product must have no two combinations sharing a JVM signature.
 //!
-//! Only flat, non-optional single-level arms are overloaded; `Option<T>` /
-//! `Vec<T>` params and recursively-built arms keep the selector form for that
-//! function (documented fallback — there is no clean single type to offer).
+//! Only flat, non-optional arms are splittable; an explicit `.split_on_param` on
+//! an `Option<T>` / recursively-built / single-variant / unknown parameter is a
+//! hard error.
 
 use super::*;
 use crate::api::core::expand::{FoldArg, FoldPlan};
 
 impl JniGen {
-    /// Whether the expanded parameter `(func, param)` producing `target` is
-    /// marked `.split()`. A per-fn `.expand_param(param, …)` override for this
-    /// exact `(func, param)` wins over the type-level default — the same
-    /// replace semantics [`Self::build_expansions`] applies.
-    pub(crate) fn is_split_param(
-        &self,
-        func: &syn::Ident,
-        param: &syn::Ident,
-        target: &syn::Type,
-    ) -> bool {
-        let param_s = param.to_string();
-        if let Some((_, _, decl)) = self
-            .fn_param_expands
-            .iter()
-            .find(|(f, p, _)| f == func && *p == param_s)
-        {
-            return decl.split;
-        }
-        let key = TypeKey::from_type(target);
-        self.param_expand_decls
-            .iter()
-            .any(|d| d.key == key && d.split)
-    }
-
     /// `true` if `simple` is the Kotlin simple name of a `value_blob`
     /// (`@JvmInline value class`) type — which erases to `ByteArray` on the
     /// JVM, so two distinct such classes share one method descriptor.
@@ -61,19 +37,134 @@ impl JniGen {
                     == Some(simple)
         })
     }
+
+    /// Proactively verify every multi-variant `expand_param!` declaration is
+    /// splittable (its arms have pairwise-distinct JVM-erased signatures), so
+    /// [`FunctionDecl::split_on_param`](crate::fun) can emit unambiguous
+    /// overloads. Runs regardless of whether any function actually splits the
+    /// type, so authorship errors surface early. `.no_split()` opts a decl out.
+    /// A collision panics with a message attributed to the declaration.
+    pub(crate) fn validate_split_declarations(&self, registry: &Registry<KotlinMeta>) {
+        let type_level = self
+            .param_expand_decls
+            .iter()
+            .map(|d| (d.key.as_str().to_string(), d));
+        let per_fn = self
+            .fn_param_expands
+            .iter()
+            .map(|(func, param, d)| (format!("fun `{func}` param `{param}`"), d));
+        for (site, decl) in type_level.chain(per_fn) {
+            if decl.no_split || decl.variants.len() < 2 {
+                continue;
+            }
+            let target = decl.key.to_type();
+            let sigs: Vec<(String, Vec<String>)> = decl
+                .variants
+                .iter()
+                .map(|v| {
+                    let ctor = match v {
+                        LocalVariant::Ctor(c) => Some(c),
+                        LocalVariant::SelfIdentity => None,
+                    };
+                    (
+                        ctor.map(|c| c.to_string())
+                            .unwrap_or_else(|| "variant_self()".to_string()),
+                        arm_erased_sig(self, registry, &target, ctor),
+                    )
+                })
+                .collect();
+            for i in 0..sigs.len() {
+                for j in (i + 1)..sigs.len() {
+                    if sigs[i].1 == sigs[j].1 {
+                        panic!(
+                            "expand_param!({t}) [{site}]: variants {a} and {b} both surface as \
+                             `({sig})` — a split would emit two overloads with the same JVM \
+                             signature; disambiguate the constructors or add .no_split()",
+                            t = decl.key.as_str(),
+                            a = sigs[i].0,
+                            b = sigs[j].0,
+                            sig = sigs[i].1.join(", "),
+                        );
+                    }
+                }
+            }
+        }
+    }
 }
 
-/// One resolved split parameter of a function.
-struct SplitParam<'a> {
-    /// The original Rust parameter ident (e.g. `expected`).
-    param: syn::Ident,
-    /// Its resolved expansion plan (multi-variant, non-optional, flat).
-    plan: &'a FoldPlan,
+/// The JVM-erased type list of one arm: the constructor's parameter types
+/// (build arm), or the single target type (`variant_self`, `ctor == None`).
+fn arm_erased_sig(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    target: &syn::Type,
+    ctor: Option<&syn::Ident>,
+) -> Vec<String> {
+    match ctor {
+        Some(cf) => match registry.functions.get(cf) {
+            Some((item_fn, _)) => item_fn
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|a| match a {
+                    syn::FnArg::Typed(pt) => Some(rust_type_erased(ext, registry, &pt.ty)),
+                    _ => None,
+                })
+                .collect(),
+            None => Vec::new(),
+        },
+        None => vec![rust_type_erased(ext, registry, target)],
+    }
 }
 
-/// Whether `plan` is a multi-variant expansion this feature can turn into
-/// overloads: it has a selector (≥2 arms), a plain (non-`Option`) outer shape,
-/// and no recursively-built arm.
+/// The JVM-erased descriptor fragment a Rust type surfaces as: a declared
+/// value-blob class erases to `ByteArray`, another declared class to its simple
+/// Kotlin name, a primitive/`String` to its Kotlin builtin, everything else to
+/// its token string (structural fallback). References are peeled first (a `&T`
+/// handle erases like `T`).
+fn rust_type_erased(ext: &JniGen, registry: &Registry<KotlinMeta>, ty: &syn::Type) -> String {
+    let peeled = match ty {
+        syn::Type::Reference(r) => &*r.elem,
+        other => other,
+    };
+    let key = TypeKey::from_type(peeled);
+    if let Some(cfg) = ext.types.get(&key) {
+        if cfg.name_spec.is_some() {
+            if cfg.value_blob {
+                return "ByteArray".to_string();
+            }
+            if let Some(fqn) = ext.kotlin_fqn(key.as_str()) {
+                return fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
+            }
+        }
+    }
+    if let Some(kt) = registry
+        .input_entry(peeled)
+        .and_then(|e| e.metadata.kotlin_name.clone())
+    {
+        return erased(ext, &kt);
+    }
+    peeled.to_token_stream().to_string()
+}
+
+/// The JVM-erased descriptor fragment of an already-rendered [`kt::KtType`] —
+/// value classes to `ByteArray`, primitives/`String` to themselves, other
+/// classes to their simple name.
+fn erased(ext: &JniGen, ty: &kt::KtType) -> String {
+    let simple = ty.simple_name().unwrap_or("");
+    if ext.is_value_blob_kotlin(simple) {
+        return "ByteArray".to_string();
+    }
+    match simple {
+        "Int" | "Long" | "Double" | "Float" | "Boolean" | "Byte" | "Short" | "Char" | "String"
+        | "ByteArray" => simple.to_string(),
+        _ => simple.to_string(),
+    }
+}
+
+/// Whether `plan` is a multi-variant expansion that can be turned into
+/// overloads: a selector (≥2 arms), a plain (non-`Option`) outer shape, and no
+/// recursively-built arm.
 fn plan_in_scope(plan: &FoldPlan) -> bool {
     plan.selector.is_some()
         && !plan.produces_option()
@@ -83,43 +174,23 @@ fn plan_in_scope(plan: &FoldPlan) -> bool {
             .any(|v| v.inputs.iter().any(|a| matches!(a, FoldArg::Build(_))))
 }
 
-/// Every in-scope split parameter of `f`, in signature order. Used both to
-/// pick the one to overload and to enforce the ≤1-per-function rule.
-fn split_params<'a>(
-    ext: &JniGen,
-    f: &syn::ItemFn,
-    registry: &'a Registry<KotlinMeta>,
-) -> Vec<SplitParam<'a>> {
-    let mut out = Vec::new();
-    for input in &f.sig.inputs {
-        let syn::FnArg::Typed(pt) = input else {
-            continue;
-        };
-        let syn::Pat::Ident(pid) = &*pt.pat else {
-            continue;
-        };
-        let Some(plan) = registry
-            .expansion_plans
-            .get(&(f.sig.ident.clone(), pid.ident.clone()))
-        else {
-            continue;
-        };
-        if !ext.is_split_param(&f.sig.ident, &pid.ident, &plan.target) {
-            continue;
-        }
-        if !plan_in_scope(plan) {
-            continue;
-        }
-        out.push(SplitParam {
-            param: pid.ident.clone(),
-            plan,
-        });
-    }
-    out
+/// One resolved split parameter of a function, positioned against the rendered
+/// selector wrapper.
+struct Split<'a> {
+    /// The original Rust parameter ident (e.g. `expected`).
+    param: syn::Ident,
+    plan: &'a FoldPlan,
+    /// Start of this param's contiguous leaf block in `sel_fun.params`.
+    start: usize,
+    /// Block length (`plan.leaves.len()`).
+    len: usize,
+    /// Selector-leaf index within the block.
+    sel_idx: usize,
+    /// Per-variant typed params: `(param, leaf-index-within-block)`.
+    arms: Vec<Vec<(kt::KtParam, usize)>>,
 }
 
-/// Camel-cased Kotlin names of a `#[prebindgen]` constructor's parameters, in
-/// order — the idiomatic overload parameter names for a build arm.
+/// Camel-cased Kotlin names of a `#[prebindgen]` constructor's parameters.
 fn ctor_param_names(f: &syn::ItemFn) -> Vec<String> {
     f.sig
         .inputs
@@ -134,9 +205,17 @@ fn ctor_param_names(f: &syn::ItemFn) -> Vec<String> {
         .collect()
 }
 
-/// A named type with its nullability cleared (`T?` → `T`) — a split overload
-/// takes each arm's real, non-nullable constructor parameter type, unlike the
-/// selector form whose per-arm slots are all nullable.
+/// `origin` + Capitalized `name` (`primary` + `count` → `primaryCount`).
+fn prefixed(origin: &str, name: &str) -> String {
+    let mut c = name.chars();
+    match c.next() {
+        Some(first) => format!("{origin}{}{}", first.to_uppercase(), c.as_str()),
+        None => origin.to_string(),
+    }
+}
+
+/// Clear nullability (`T?` → `T`): an overload takes each arm's real,
+/// non-nullable constructor parameter type.
 fn non_null(mut ty: kt::KtType) -> kt::KtType {
     match &mut ty {
         kt::KtType::Named { nullable, .. } | kt::KtType::Function { nullable, .. } => {
@@ -146,39 +225,26 @@ fn non_null(mut ty: kt::KtType) -> kt::KtType {
     ty
 }
 
-/// The JVM method descriptor fragment one overload parameter erases to —
-/// value classes to `ByteArray`, primitives/`String` to themselves, other
-/// classes to their FQN. Two arms collide iff their fragment lists match.
-fn erased(ext: &JniGen, ty: &kt::KtType) -> String {
-    let simple = ty.simple_name().unwrap_or("");
-    if ext.is_value_blob_kotlin(simple) {
-        return "ByteArray".to_string();
-    }
-    match simple {
-        "Int" | "Long" | "Double" | "Float" | "Boolean" | "Byte" | "Short" | "Char" | "String"
-        | "ByteArray" => simple.to_string(),
-        _ => ty.leaf_name().unwrap_or(simple).to_string(),
-    }
-}
-
-/// The typed overload parameters of one variant arm, paired with the flat leaf
-/// index each fills in the selector form. `block` is the selector wrapper's
-/// contiguous run of leaf params (index `k` = `plan.leaves[k]`). Returns
-/// `None` if any input is not a flat leaf (out of scope).
+/// The typed overload params of one variant arm, paired with the leaf index
+/// each fills. `origin`/`multi` drive name disambiguation (build-arm params are
+/// prefixed with the origin parameter name when the function splits more than
+/// one parameter). Returns `None` if any input is not a flat leaf.
 fn variant_typed_params(
     registry: &Registry<KotlinMeta>,
     variant: &crate::api::core::expand::FoldVariant,
-    base_param: &syn::Ident,
+    origin: &syn::Ident,
     block: &[kt::KtParam],
+    multi: bool,
 ) -> Option<Vec<(kt::KtParam, usize)>> {
+    let origin_kt = kt_param_name(&origin.to_string());
     let names: Vec<String> = match &variant.ctor {
         Some(cf) => {
             let (item_fn, _) = registry.functions.get(cf)?;
             ctor_param_names(item_fn)
         }
-        // Identity arm: a single parameter, the target value itself, named
-        // after the original Rust parameter.
-        None => vec![kt_param_name(&base_param.to_string())],
+        // Identity arm: one parameter, the value itself, named after the origin
+        // parameter (already unique across split params — never prefixed).
+        None => vec![origin_kt.clone()],
     };
     let mut out = Vec::new();
     for (m, arg) in variant.inputs.iter().enumerate() {
@@ -186,14 +252,19 @@ fn variant_typed_params(
             return None;
         };
         let slot = block.get(*idx)?;
-        let name = names.get(m).cloned().unwrap_or_else(|| slot.name.clone());
+        let base = names.get(m).cloned().unwrap_or_else(|| slot.name.clone());
+        let name = if multi && variant.ctor.is_some() {
+            prefixed(&origin_kt, &base)
+        } else {
+            base
+        };
         out.push((kt::KtParam::new(&name, non_null(slot.ty.clone())), *idx));
     }
     Some(out)
 }
 
-/// Locate the split param's contiguous leaf block in the already-rendered
-/// selector wrapper's parameter list, matching by leaf name in order.
+/// Locate a param's contiguous leaf block in the selector wrapper's parameter
+/// list, matching by leaf name in order.
 fn find_block(params: &[kt::KtParam], leaf_names: &[String]) -> Option<usize> {
     if leaf_names.is_empty() || params.len() < leaf_names.len() {
         return None;
@@ -206,103 +277,212 @@ fn find_block(params: &[kt::KtParam], leaf_names: &[String]) -> Option<usize> {
     })
 }
 
-/// The overloads for one function, delegating to its already-rendered selector
-/// wrapper `sel_fun` (same Kotlin name). Empty unless the function has one
-/// in-scope split parameter. Panics (a build error) on the ≤1-per-function and
-/// distinct-signature rules.
-pub(crate) fn render_param_overloads(
-    ext: &JniGen,
+/// Resolve one `.split_on_param` request against the rendered selector wrapper,
+/// validating the parameter is expandable, multi-variant, and in-scope (all
+/// hard errors — the user explicitly asked to split it).
+fn resolve_split<'a>(
+    registry: &'a Registry<KotlinMeta>,
     f: &syn::ItemFn,
-    registry: &Registry<KotlinMeta>,
     sel_fun: &kt::KtFun,
-) -> Vec<kt::KtFun> {
-    let splits = split_params(ext, f, registry);
-    if splits.len() > 1 {
-        let names: Vec<String> = splits.iter().map(|s| s.param.to_string()).collect();
-        panic!(
-            "fn `{}` has {} `.split()` parameters ({}); a function may split at most one — \
-             un-split the others with a per-fn `.expand_param(name, …)` override that omits \
-             `.split()`",
-            f.sig.ident,
-            names.len(),
-            names.join(", ")
-        );
-    }
-    let Some(sp) = splits.first() else {
-        return Vec::new();
-    };
-    let plan = sp.plan;
-
+    param_name: &str,
+    multi: bool,
+) -> Split<'a> {
+    let param = syn::Ident::new(param_name, Span::call_site());
+    let plan = registry
+        .expansion_plans
+        .get(&(f.sig.ident.clone(), param.clone()))
+        .unwrap_or_else(|| {
+            panic!(
+                "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` is not an expandable \
+                 parameter (it has no `expand_param!` variants)",
+                f.sig.ident
+            )
+        });
+    assert!(
+        plan.selector.is_some(),
+        "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` has a single variant — there \
+         is nothing to split (it already flattens to one signature)",
+        f.sig.ident
+    );
+    assert!(
+        !plan.produces_option(),
+        "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` is an `Option<_>` / `Vec<_>` \
+         parameter — its overload has no clean single type; keep the selector form",
+        f.sig.ident
+    );
+    assert!(
+        plan_in_scope(plan),
+        "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` has a recursively-built arm — \
+         it cannot be overloaded; keep the selector form",
+        f.sig.ident
+    );
     let leaf_names: Vec<String> = plan
         .leaves
         .iter()
         .map(|l| kt_param_name(&l.name.to_string()))
         .collect();
     let len = leaf_names.len();
-    // Degrade to selector-only if the leaf block can't be located (a shape the
-    // offset assumption doesn't cover) — never emit a malformed overload.
-    let Some(start) = find_block(&sel_fun.params, &leaf_names) else {
-        return Vec::new();
-    };
+    let start = find_block(&sel_fun.params, &leaf_names).unwrap_or_else(|| {
+        panic!(
+            "fun!({}).split_on_param(\"{param_name}\"): could not locate the parameter's leaf \
+             block in the generated wrapper",
+            f.sig.ident
+        )
+    });
     let block = &sel_fun.params[start..start + len];
-    let sel_idx = plan.selector.expect("in-scope ⇒ selector present");
-
-    // Build every arm's typed params first, so the distinct-signature check
-    // runs before any emission.
-    let mut arms: Vec<Vec<(kt::KtParam, usize)>> = Vec::with_capacity(plan.variants.len());
-    for variant in &plan.variants {
-        let Some(tp) = variant_typed_params(registry, variant, &sp.param, block) else {
-            return Vec::new();
-        };
-        arms.push(tp);
-    }
-    // Distinct-signature (JVM erasure) check — class-attributed hard error.
-    for i in 0..arms.len() {
-        for j in (i + 1)..arms.len() {
-            let di: Vec<String> = arms[i].iter().map(|(p, _)| erased(ext, &p.ty)).collect();
-            let dj: Vec<String> = arms[j].iter().map(|(p, _)| erased(ext, &p.ty)).collect();
-            if di == dj {
+    let sel_idx = plan.selector.expect("selector present");
+    let arms: Vec<Vec<(kt::KtParam, usize)>> = plan
+        .variants
+        .iter()
+        .map(|v| {
+            variant_typed_params(registry, v, &param, block, multi).unwrap_or_else(|| {
                 panic!(
-                    "expand_param!({}).split(): variants {} and {} both surface as `({})` — \
-                     two overloads with the same JVM signature are a platform-declaration \
-                     clash; disambiguate the constructors or drop `.split()`",
-                    plan.target.to_token_stream(),
-                    variant_label(&plan.variants[i]),
-                    variant_label(&plan.variants[j]),
-                    di.join(", "),
+                    "fun!({}).split_on_param(\"{param_name}\"): an arm has a non-flat input; \
+                     it cannot be overloaded",
+                    f.sig.ident
+                )
+            })
+        })
+        .collect();
+    Split {
+        param,
+        plan,
+        start,
+        len,
+        sel_idx,
+        arms,
+    }
+}
+
+/// The overloads for one function, delegating to its already-rendered selector
+/// wrapper `sel_fun`. Empty unless the function has `.split_on_param` requests.
+/// Emits the cartesian product of the named params' arms; panics (a build
+/// error) if the product has two combinations with the same JVM signature.
+pub(crate) fn render_param_overloads(
+    ext: &JniGen,
+    f: &syn::ItemFn,
+    registry: &Registry<KotlinMeta>,
+    sel_fun: &kt::KtFun,
+) -> Vec<kt::KtFun> {
+    // Requested split params for this function, in signature order.
+    let requested: Vec<String> = {
+        let want: std::collections::HashSet<&str> = ext
+            .fn_split_params
+            .iter()
+            .filter(|(func, _)| func == &f.sig.ident)
+            .map(|(_, p)| p.as_str())
+            .collect();
+        if want.is_empty() {
+            return Vec::new();
+        }
+        f.sig
+            .inputs
+            .iter()
+            .filter_map(|a| match a {
+                syn::FnArg::Typed(pt) => match &*pt.pat {
+                    syn::Pat::Ident(pid) if want.contains(pid.ident.to_string().as_str()) => {
+                        Some(pid.ident.to_string())
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect()
+    };
+    // Any requested name that didn't match a real parameter is a typo — surface
+    // it rather than silently dropping.
+    for (func, p) in &ext.fn_split_params {
+        if func == &f.sig.ident && !requested.iter().any(|r| r == p) {
+            panic!(
+                "fun!({}).split_on_param(\"{p}\"): no parameter named `{p}` on this function",
+                f.sig.ident
+            );
+        }
+    }
+
+    let multi = requested.len() > 1;
+    let splits: Vec<Split> = requested
+        .iter()
+        .map(|name| resolve_split(registry, f, sel_fun, name, multi))
+        .collect();
+
+    // Cartesian product of arm indices across all split params.
+    let combos = cartesian(&splits.iter().map(|s| s.arms.len()).collect::<Vec<_>>());
+
+    // Product-global JVM-signature collision check (fixed params are identical
+    // across every overload, so only the split-arm lists can collide).
+    let sigs: Vec<Vec<String>> = combos
+        .iter()
+        .map(|combo| {
+            splits
+                .iter()
+                .zip(combo)
+                .flat_map(|(s, &ai)| {
+                    let ctor = s.plan.variants[ai].ctor.as_ref();
+                    arm_erased_sig(ext, registry, &s.plan.target, ctor)
+                })
+                .collect()
+        })
+        .collect();
+    for i in 0..sigs.len() {
+        for j in (i + 1)..sigs.len() {
+            if sigs[i] == sigs[j] {
+                panic!(
+                    "fun!({}): split_on_param product is ambiguous — combinations {} and {} both \
+                     surface as `({})`; add .no_split() intent is not enough here, disambiguate \
+                     the constructors or drop one .split_on_param",
+                    f.sig.ident,
+                    combo_label(&splits, &combos[i]),
+                    combo_label(&splits, &combos[j]),
+                    sigs[i].join(", "),
                 );
             }
         }
     }
 
-    let mut out = Vec::with_capacity(arms.len());
-    for (i, typed) in arms.iter().enumerate() {
-        // Overload signature: fixed params, the arm's typed params in place of
-        // the leaf block, then the trailing fixed/onError params.
+    // Emit one overload per product combination.
+    let n = sel_fun.params.len();
+    let mut out = Vec::with_capacity(combos.len());
+    for combo in &combos {
+        // Per-split delegation slots, keyed by block start.
         let mut params: Vec<kt::KtParam> = Vec::new();
-        params.extend_from_slice(&sel_fun.params[..start]);
-        params.extend(typed.iter().map(|(p, _)| p.clone()));
-        params.extend_from_slice(&sel_fun.params[start + len..]);
-
-        // Delegation args: leaf slots get the selector value, this arm's typed
-        // params, or `null`; every other param passes through by name.
-        let mut leaf_arg: Vec<String> = vec!["null".to_string(); len];
-        leaf_arg[sel_idx] = i.to_string();
-        for (p, lidx) in typed {
-            leaf_arg[*lidx] = p.name.clone();
-        }
-        let call_args: Vec<String> = sel_fun
-            .params
-            .iter()
-            .enumerate()
-            .map(|(j, p)| {
-                if j >= start && j < start + len {
-                    leaf_arg[j - start].clone()
-                } else {
-                    p.name.clone()
+        let mut call_args: Vec<String> = Vec::new();
+        let mut pos = 0usize;
+        while pos < n {
+            if let Some((si, s)) = splits.iter().enumerate().find(|(_, s)| s.start == pos) {
+                // Replace this param's whole leaf block with the chosen arm's
+                // typed params; fill the block's delegation slots.
+                let ai = combo[si];
+                let typed = &s.arms[ai];
+                let mut leaf_arg: Vec<String> = vec!["null".to_string(); s.len];
+                leaf_arg[s.sel_idx] = ai.to_string();
+                for (p, lidx) in typed {
+                    params.push(p.clone());
+                    leaf_arg[*lidx] = p.name.clone();
                 }
-            })
-            .collect();
+                call_args.extend(leaf_arg);
+                pos += s.len;
+            } else {
+                // A fixed (or non-split expanded) param — passes through.
+                let p = &sel_fun.params[pos];
+                params.push(p.clone());
+                call_args.push(p.name.clone());
+                pos += 1;
+            }
+        }
+
+        // Guard against a param-name clash (e.g. an arm name colliding with a
+        // fixed param) rather than emitting uncompilable Kotlin.
+        let mut seen = std::collections::HashSet::new();
+        for p in &params {
+            assert!(
+                seen.insert(p.name.clone()),
+                "fun!({}): split overload has a duplicate parameter name `{}` — rename the \
+                 constructor parameter",
+                f.sig.ident,
+                p.name
+            );
+        }
 
         let mut ov = kt::KtFun::new(&sel_fun.name).vis(kt::Vis::Public);
         for p in params {
@@ -321,11 +501,37 @@ pub(crate) fn render_param_overloads(
     out
 }
 
-/// A short label for a variant in error messages: the constructor ident, or
-/// `variant_self()` for the identity arm.
-fn variant_label(v: &crate::api::core::expand::FoldVariant) -> String {
-    match &v.ctor {
-        Some(c) => c.to_string(),
-        None => "variant_self()".to_string(),
+/// Cartesian product of index ranges `0..counts[k]`, as a list of index
+/// tuples. `[2, 2]` → `[[0,0],[0,1],[1,0],[1,1]]`.
+fn cartesian(counts: &[usize]) -> Vec<Vec<usize>> {
+    let mut acc = vec![Vec::new()];
+    for &c in counts {
+        acc = acc
+            .into_iter()
+            .flat_map(|prefix| {
+                (0..c).map(move |i| {
+                    let mut next = prefix.clone();
+                    next.push(i);
+                    next
+                })
+            })
+            .collect();
     }
+    acc
+}
+
+/// A `param=variant` label for one product combination, for error messages.
+fn combo_label(splits: &[Split], combo: &[usize]) -> String {
+    let parts: Vec<String> = splits
+        .iter()
+        .zip(combo)
+        .map(|(s, &ai)| {
+            let v = match &s.plan.variants[ai].ctor {
+                Some(c) => c.to_string(),
+                None => "variant_self()".to_string(),
+            };
+            format!("{}={v}", s.param)
+        })
+        .collect();
+    format!("({})", parts.join(", "))
 }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -295,6 +295,9 @@ pub(crate) fn build_typed_handle(
                 Some(ext.effective_member_name(key, m).as_str()),
                 None,
             ) {
+                for ov in render_param_overloads(ext, item_fn, registry, &f) {
+                    companion = companion.member(ov);
+                }
                 companion = companion.member(f);
             }
         }
@@ -356,6 +359,9 @@ pub(crate) fn build_typed_handle(
                 Some(ext.effective_member_name(key, m).as_str()),
                 Some(key),
             ) {
+                for ov in render_param_overloads(ext, item_fn, registry, &f) {
+                    class = class.member(ov);
+                }
                 class = class.member(f);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -757,120 +757,234 @@ fn constructor_with_wrong_return_rejected() {
     );
 }
 
-/// #52: a `.split()` multi-variant expansion emits, alongside the selector
+/// #52 shared fixture: a `ZSummary` ptr class, its `(count, total)` builder, a
+/// splittable 2-variant type-level `expand_param!`, and functions taking one or
+/// two `ZSummary` params. `extra` fns are appended before indexing.
+fn split_fixture(extra: &[&str]) -> Registry<KotlinMeta> {
+    let loc = myflat_loc();
+    let base: &[&str] = &[
+        "pub fn z_summary_new(count: i64, total: f64) -> ZSummary { unimplemented!() }",
+        "pub fn z_store_expect(expected: ZSummary) -> bool { unimplemented!() }",
+        "pub fn z_prefer(primary: ZSummary, fallback: ZSummary) -> i64 { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZSummary {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for src in base.iter().chain(extra) {
+        items.push((
+            syn::Item::Fn(syn::parse_str(src).expect("parse fn")),
+            loc.clone(),
+        ));
+    }
+    Registry::<KotlinMeta>::from_items(items).expect("index items")
+}
+
+fn write_all(gen: crate::api::core::Generation<JniGen>, tag: &str) -> String {
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// #52: `FunctionDecl::split_on_param` emits, alongside the retained selector
 /// form, one idiomatic typed overload per variant — the build arm named after
 /// the constructor's parameters, the `variant_self()` arm typed as the class —
 /// each delegating to the selector wrapper.
 #[test]
-fn split_param_emits_typed_overloads() {
-    let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![
-        (
-            syn::Item::Struct(syn::parse_quote!(
-                pub struct ZSummary {
-                    _p: u8,
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_summary_new(count: i64, total: f64) -> ZSummary {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_store_expect(expected: ZSummary) -> bool {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-    ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+fn split_on_param_emits_typed_overloads() {
+    let registry = split_fixture(&[]);
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("ops")
                 .class(crate::ptr_class!(ZSummary))
-                .fun(crate::fun!(z_store_expect)),
+                .fun(crate::fun!(z_store_expect).split_on_param("expected")),
         )
         .expand(
             crate::expand_param!(ZSummary)
                 .variant(crate::fun!(z_summary_new))
-                .variant_self()
-                .split(),
+                .variant_self(),
         );
-    let dir = unique_test_dir("jnigen_split_overloads");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let gen = registry.resolve(jni).expect("resolve");
-    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
-    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
-    let raw = paths
-        .iter()
-        .filter_map(|p| std::fs::read_to_string(p).ok())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let raw = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_one");
     let all: String = raw.split_whitespace().collect();
-    // The selector form is retained (the delegation target).
-    assert!(all.contains("expectedSel:Int"), "{raw}");
-    // Build-arm overload: named after the constructor's own parameters.
+    assert!(all.contains("expectedSel:Int"), "{raw}"); // selector retained
     assert!(
         all.contains("funzStoreExpect(count:Long,total:Double,"),
         "{raw}"
     );
-    // Identity-arm overload: typed as the class, named after the parameter.
     assert!(all.contains("funzStoreExpect(expected:ZSummary,"), "{raw}");
-    // Each overload delegates to the selector form with its arm index.
     assert!(all.contains("zStoreExpect(0,count,total,null,"), "{raw}");
     assert!(all.contains("zStoreExpect(1,null,null,expected,"), "{raw}");
 }
 
-/// #52: two `.split()` variants that surface as the same JVM-erased signature
-/// are a platform-declaration clash — a hard, class-attributed build error.
+/// #52: two `.split_on_param` on one function emit the **cartesian product** of
+/// the params' arms (2×2 = four overloads); build-arm params are prefixed with
+/// their origin parameter name to stay unique.
+#[test]
+fn split_on_param_cartesian_product() {
+    let registry = split_fixture(&[]);
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZSummary))
+                .fun(
+                    crate::fun!(z_prefer)
+                        .split_on_param("primary")
+                        .split_on_param("fallback"),
+                ),
+        )
+        .expand(
+            crate::expand_param!(ZSummary)
+                .variant(crate::fun!(z_summary_new))
+                .variant_self(),
+        );
+    let raw = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_prod");
+    let all: String = raw.split_whitespace().collect();
+    // build / build
+    assert!(
+        all.contains(
+            "funzPrefer(primaryCount:Long,primaryTotal:Double,fallbackCount:Long,fallbackTotal:Double,"
+        ),
+        "{raw}"
+    );
+    // build / handle, handle / build, handle / handle
+    assert!(
+        all.contains("funzPrefer(primaryCount:Long,primaryTotal:Double,fallback:ZSummary,"),
+        "{raw}"
+    );
+    assert!(
+        all.contains("funzPrefer(primary:ZSummary,fallbackCount:Long,fallbackTotal:Double,"),
+        "{raw}"
+    );
+    assert!(
+        all.contains("funzPrefer(primary:ZSummary,fallback:ZSummary,"),
+        "{raw}"
+    );
+    // A product delegation fills BOTH selector blocks.
+    assert!(
+        all.contains(
+            "zPrefer(0,primaryCount,primaryTotal,null,0,fallbackCount,fallbackTotal,null,"
+        ),
+        "{raw}"
+    );
+}
+
+/// #52: a `.split_on_param` product whose two combinations erase to the same
+/// JVM signature is a hard, per-function error. `from_one(Long)` /
+/// `from_two(Long,Long)` on two params collide at (one,two) vs (two,one).
+#[test]
+#[should_panic(expected = "ambiguous")]
+fn split_on_param_product_ambiguous_rejected() {
+    let loc = myflat_loc();
+    let srcs: &[&str] = &[
+        "pub fn z_thing_one(a: i64) -> ZThing { unimplemented!() }",
+        "pub fn z_thing_two(a: i64, b: i64) -> ZThing { unimplemented!() }",
+        "pub fn z_combine(primary: ZThing, fallback: ZThing) -> bool { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZThing {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for s in srcs {
+        items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops").class(crate::ptr_class!(ZThing)).fun(
+                crate::fun!(z_combine)
+                    .split_on_param("primary")
+                    .split_on_param("fallback"),
+            ),
+        )
+        .expand(
+            crate::expand_param!(ZThing)
+                .variant(crate::fun!(z_thing_one))
+                .variant(crate::fun!(z_thing_two)),
+        );
+    let _ = write_all(
+        registry.resolve(jni).expect("resolve"),
+        "jnigen_split_ambig",
+    );
+}
+
+/// #52 proactive: a multi-variant `expand_param!` whose arms share a JVM
+/// signature is a hard error at the DECLARATION — no function need split it.
 #[test]
 #[should_panic(expected = "same JVM signature")]
-fn split_param_colliding_variants_rejected() {
+fn split_declaration_colliding_variants_rejected() {
     let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![
-        (
-            syn::Item::Struct(syn::parse_quote!(
-                pub struct ZName {
-                    _p: u8,
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_name_from_text(text: String) -> ZName {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_name_from_label(label: String) -> ZName {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_use_name(name: ZName) -> bool {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
+    let srcs: &[&str] = &[
+        "pub fn z_name_from_text(text: String) -> ZName { unimplemented!() }",
+        "pub fn z_name_from_label(label: String) -> ZName { unimplemented!() }",
+        "pub fn z_use_name(name: ZName) -> bool { unimplemented!() }",
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZName {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for s in srcs {
+        items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZName))
+                .fun(crate::fun!(z_use_name)), // NOT split — still errors
+        )
+        .expand(
+            crate::expand_param!(ZName)
+                .variant(crate::fun!(z_name_from_text))
+                .variant(crate::fun!(z_name_from_label)),
+        );
+    let _ = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_decl");
+}
+
+/// #52: `.no_split()` suppresses the proactive splittability check for a
+/// genuinely non-splittable variant set (used only as the selector form).
+#[test]
+fn split_no_split_suppresses_check() {
+    let loc = myflat_loc();
+    let srcs: &[&str] = &[
+        "pub fn z_name_from_text(text: String) -> ZName { unimplemented!() }",
+        "pub fn z_name_from_label(label: String) -> ZName { unimplemented!() }",
+        "pub fn z_use_name(name: ZName) -> bool { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZName {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for s in srcs {
+        items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -882,117 +996,53 @@ fn split_param_colliding_variants_rejected() {
             crate::expand_param!(ZName)
                 .variant(crate::fun!(z_name_from_text))
                 .variant(crate::fun!(z_name_from_label))
-                .split(),
+                .no_split(),
         );
-    let dir = unique_test_dir("jnigen_split_collision");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let gen = registry.resolve(jni).expect("resolve");
-    // Collision is detected during Kotlin emission (in-scope-aware).
-    let _ = gen.write_kotlin(&dir.join("kotlin"));
+    // No panic: the colliding variants are tolerated as selector-only.
+    let raw = write_all(registry.resolve(jni).expect("resolve"), "jnigen_no_split");
+    let all: String = raw.split_whitespace().collect();
+    assert!(all.contains("nameSel:Int"), "{raw}"); // selector form emitted
 }
 
-/// #52: `.split()` on a single-variant expansion is meaningless (one arm
-/// already flattens idiomatically) — a hard error at declaration time.
+/// #52: `.split_on_param` naming a parameter that does not exist on the
+/// function is a hard error (typo guard).
 #[test]
-#[should_panic(expected = "needs ≥2 variants")]
-fn split_single_variant_rejected() {
-    let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![
-        (
-            syn::Item::Struct(syn::parse_quote!(
-                pub struct ZOne {
-                    _p: u8,
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_one_new(x: i64) -> ZOne {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_use_one(o: ZOne) -> bool {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-    ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("ops")
-                .class(crate::ptr_class!(ZOne))
-                .fun(crate::fun!(z_use_one)),
-        )
-        .expand(
-            crate::expand_param!(ZOne)
-                .variant(crate::fun!(z_one_new))
-                .split(),
-        );
-    let dir = unique_test_dir("jnigen_split_single");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    // Panics during resolve (build_expansions runs the ≥2-variant assert).
-    let _ = registry.resolve(jni);
-}
-
-/// #52: a function may split at most one parameter — two split params would
-/// need the cartesian product of their arms. A hard error names both.
-#[test]
-#[should_panic(expected = "split at most one")]
-fn split_two_params_on_one_fn_rejected() {
-    let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![
-        (
-            syn::Item::Struct(syn::parse_quote!(
-                pub struct ZSummary {
-                    _p: u8,
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_summary_new(count: i64, total: f64) -> ZSummary {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn z_combine(a: ZSummary, b: ZSummary) -> bool {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-    ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+#[should_panic(expected = "no parameter named")]
+fn split_on_unknown_param_rejected() {
+    let registry = split_fixture(&[]);
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("ops")
                 .class(crate::ptr_class!(ZSummary))
-                .fun(crate::fun!(z_combine)),
+                .fun(crate::fun!(z_store_expect).split_on_param("nope")),
         )
         .expand(
             crate::expand_param!(ZSummary)
                 .variant(crate::fun!(z_summary_new))
-                .variant_self()
-                .split(),
+                .variant_self(),
         );
-    let dir = unique_test_dir("jnigen_split_two_params");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let gen = registry.resolve(jni).expect("resolve");
-    let _ = gen.write_kotlin(&dir.join("kotlin"));
+    let _ = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_typo");
+}
+
+/// #52: `.split_on_param` on an `Option<T>` parameter is a hard error — the
+/// overload has no clean single type; the selector form must be kept.
+#[test]
+#[should_panic(expected = "Option")]
+fn split_on_option_param_rejected() {
+    let registry =
+        split_fixture(&["pub fn z_maybe(opt: Option<ZSummary>) -> bool { unimplemented!() }"]);
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZSummary))
+                .fun(crate::fun!(z_maybe).split_on_param("opt")),
+        )
+        .expand(
+            crate::expand_param!(ZSummary)
+                .variant(crate::fun!(z_summary_new))
+                .variant_self(),
+        );
+    let _ = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_opt");
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -756,3 +756,243 @@ fn constructor_with_wrong_return_rejected() {
         "{msg}"
     );
 }
+
+/// #52: a `.split()` multi-variant expansion emits, alongside the selector
+/// form, one idiomatic typed overload per variant — the build arm named after
+/// the constructor's parameters, the `variant_self()` arm typed as the class —
+/// each delegating to the selector wrapper.
+#[test]
+fn split_param_emits_typed_overloads() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZSummary {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_summary_new(count: i64, total: f64) -> ZSummary {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_store_expect(expected: ZSummary) -> bool {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZSummary))
+                .fun(crate::fun!(z_store_expect)),
+        )
+        .expand(
+            crate::expand_param!(ZSummary)
+                .variant(crate::fun!(z_summary_new))
+                .variant_self()
+                .split(),
+        );
+    let dir = unique_test_dir("jnigen_split_overloads");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let raw = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let all: String = raw.split_whitespace().collect();
+    // The selector form is retained (the delegation target).
+    assert!(all.contains("expectedSel:Int"), "{raw}");
+    // Build-arm overload: named after the constructor's own parameters.
+    assert!(
+        all.contains("funzStoreExpect(count:Long,total:Double,"),
+        "{raw}"
+    );
+    // Identity-arm overload: typed as the class, named after the parameter.
+    assert!(all.contains("funzStoreExpect(expected:ZSummary,"), "{raw}");
+    // Each overload delegates to the selector form with its arm index.
+    assert!(all.contains("zStoreExpect(0,count,total,null,"), "{raw}");
+    assert!(all.contains("zStoreExpect(1,null,null,expected,"), "{raw}");
+}
+
+/// #52: two `.split()` variants that surface as the same JVM-erased signature
+/// are a platform-declaration clash — a hard, class-attributed build error.
+#[test]
+#[should_panic(expected = "same JVM signature")]
+fn split_param_colliding_variants_rejected() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZName {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_name_from_text(text: String) -> ZName {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_name_from_label(label: String) -> ZName {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_use_name(name: ZName) -> bool {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZName))
+                .fun(crate::fun!(z_use_name)),
+        )
+        .expand(
+            crate::expand_param!(ZName)
+                .variant(crate::fun!(z_name_from_text))
+                .variant(crate::fun!(z_name_from_label))
+                .split(),
+        );
+    let dir = unique_test_dir("jnigen_split_collision");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    // Collision is detected during Kotlin emission (in-scope-aware).
+    let _ = gen.write_kotlin(&dir.join("kotlin"));
+}
+
+/// #52: `.split()` on a single-variant expansion is meaningless (one arm
+/// already flattens idiomatically) — a hard error at declaration time.
+#[test]
+#[should_panic(expected = "needs ≥2 variants")]
+fn split_single_variant_rejected() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOne {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_new(x: i64) -> ZOne {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_use_one(o: ZOne) -> bool {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZOne))
+                .fun(crate::fun!(z_use_one)),
+        )
+        .expand(
+            crate::expand_param!(ZOne)
+                .variant(crate::fun!(z_one_new))
+                .split(),
+        );
+    let dir = unique_test_dir("jnigen_split_single");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    // Panics during resolve (build_expansions runs the ≥2-variant assert).
+    let _ = registry.resolve(jni);
+}
+
+/// #52: a function may split at most one parameter — two split params would
+/// need the cartesian product of their arms. A hard error names both.
+#[test]
+#[should_panic(expected = "split at most one")]
+fn split_two_params_on_one_fn_rejected() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZSummary {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_summary_new(count: i64, total: f64) -> ZSummary {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_combine(a: ZSummary, b: ZSummary) -> bool {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZSummary))
+                .fun(crate::fun!(z_combine)),
+        )
+        .expand(
+            crate::expand_param!(ZSummary)
+                .variant(crate::fun!(z_summary_new))
+                .variant_self()
+                .split(),
+        );
+    let dir = unique_test_dir("jnigen_split_two_params");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let _ = gen.write_kotlin(&dir.join("kotlin"));
+}


### PR DESCRIPTION
Fixes #52 (P2 from the 2026-07-14 JniGen API review).

## Problem

A multi-variant `expand_param!(T)` (`.variant(fun!(ctor)).variant_self()`) crosses the wire as a **selector tuple**, and that is the only public Kotlin surface — callers pass magic ints + null-padding (`storageExpectSummary(s, 0, 2L, 40.0, null, boom)`).

## Model: proactive splittability + per-function `.split_on_param`

Two independent mechanisms, one at each scope:

**Type declaration — splittability is checked, not opted into.** A multi-variant `expand_param!(T)` is proactively verified *splittable*: its arms must surface as pairwise-distinct JVM-erased signatures, so a function can safely request overloads. A collision is a hard build error attributed to the declaration — whether or not any function splits it. `.no_split()` opts a variant set out (it will only ever be used as the selector form).

**Function — `FunctionDecl::split_on_param("p")` is the sole emission trigger.** Overloads are emitted iff a function names the parameter:

```rust
fun!(storage_expect_summary).split_on_param("expected")
```

```kotlin
// generated, alongside the retained selector wrapper
public fun storageExpectSummary(s: Storage, count: Long, total: Double, onError): Boolean =
    storageExpectSummary(s, 0, count, total, null, onError)
public fun storageExpectSummary(s: Storage, expected: Summary, onError): Boolean =
    storageExpectSummary(s, 1, null, null, expected, onError)
```

**Multiple splits → cartesian product.** Several `.split_on_param(...)` on one function emit the product of the named params' arms; a per-function concrete check hard-errors if two combinations share a JVM signature. Build-arm params are prefixed with the origin parameter name (`primaryCount`, `fallbackTotal`) to stay unique:

```rust
fun!(summary_prefer).split_on_param("primary").split_on_param("fallback")  // 2×2 = 4 overloads
```

## Why this decomposition is sound

Single-param distinctness is a property of the variant set → checked once, early, at the declaration. Cross-param collisions only exist for a concrete combination of split params → checked per function over the product. Two products can erase to the same JVM signature even when neither param collides internally (e.g. `a`∈{`(Long)`,`(Long,Long)`}, `b`∈{`(Long,Long)`,`(Long)`} → `(a=one,b=two)` and `(a=two,b=one)` both `(Long,Long,Long)`); the product check catches exactly that. JVM **erasure** is respected throughout (`@JvmInline` value classes erase to their underlying type).

`Option<T>` / `Vec<T>` / recursively-built / single-variant / unknown parameters are hard errors when explicitly `.split_on_param`'d (no clean single type).

## Manual path preserved (owner's ask)

The selector form stays public, so consumers can add their own same-named overloads. covertest's `ManualOverloads.kt` adds an `Int`-typed `storageExpectSummary` resolved by signature alongside the generated ones.

## Acceptance

- covertest exercises single splits (`archiveStore` / `storageMatchesSummary` class-default, `storageExpectSummary` per-fn), the **cartesian product** (`summaryPrefer`, two params → 2×2), the retained selector form, and the manual overload. **`./gradlew run`: PASS, 26 sections.**
- Lib tests: single-param overloads (golden); product overloads (golden, 4 distinct); product ambiguity ⇒ hard error; **proactive** declaration collision with no function ⇒ hard error; `.no_split()` suppresses it; `.split_on_param` on unknown / `Option<T>` param ⇒ hard error. `cargo test -p prebindgen --lib`: **261 passed.**
- `regen-check`: wire form (Rust side) unchanged for existing functions (the only new extern is the demo `summary_prefer`); perftest-kotlin / perftest-c / example-cbindgen byte-identical.
- CI pre-flight clean (fmt CI config, clippy `--deny warnings`, example-cbindgen goldens restored).
- No consumer needs `.no_split()` — the only multi-variant expand_params (covertest `Summary`, zenoh-flat-jni `KeyExpr`) are already splittable.

## Review follow-up

- Preserve Kotlin nullability for flat `Option<T>` constructor parameters in generated split overloads, so callers can pass `null` to construct `None`.
- Continue stripping only selector-dispatch nullability from genuinely required constructor parameters.
- Added a focused regression test covering optional and required constructor inputs in the same arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
