### PR TITLE
Make JniGen name mangling placement-aware

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -128,7 +128,7 @@ fn main() {
         // (the domain names are already the desired Kotlin names) — registering
         // closures, and the method hook strips the flat class prefix. The
         // generated-interface hook deliberately keeps its `ClassApi` default.
-        .set_harness_name_mangle(|_, _| "CovNative".to_string())
+        .set_harness_name_mangle(|_| "CovNative".to_string())
         .set_fun_name_mangle(|_, n| n.to_string())
         .set_ptr_class_name_mangle(|_, n| n.to_string())
         .set_data_class_name_mangle(|_, n| n.to_string())

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -16,7 +16,7 @@
 //! | `JniGen::set_package_prefix`       | `io.prebindgen.covertest` |
 //! | `JniGen::package` (subpackages)      | `model` / `errors` / `analytics` / `storage` |
 //! | `JniGen::set_jni_native_init`      | `NativeLibrary.ensureLoaded()` |
-//! | 5 name-mangle closures               | harness (`Cov*`) + the four per-kind hooks |
+//! | contextual name-mangle closures      | package-aware class/function hooks + package/class-aware method hook |
 //! | `DataClassDecl`                      | `Payload`; `Annotated` (NESTED field + `Option<prim>`/`Option<enum>` fields) |
 //! | `PtrClassDecl`                       | `Storage` / `Summary` / `StorageError` / `Archive` / handlers |
 //! | `EnumClassDecl`                      | `Priority` |
@@ -26,13 +26,13 @@
 //! | `convert!` `.input(from!)`/`.output(into!)` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | `convert!` `.input(try_from!)` (fallible) | `Percent` ⇄ `Int`; out-of-range → `onError` |
 //! | `convert!` sources `.with(path!)`/`.error(ty!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
-//! | `.fun()` / `.constructor()`          | `Storage` + `Summary` + `Stamp` members |
+//! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
 //! | `FunctionDecl::split_on_param` (#52)  | single: `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); cartesian product: `summaryPrefer` (2 params); manual same-named overload in `ManualOverloads.kt` |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
-//! | namespace-relative member names (C1)  | `storage_len`→`len`, `stamp_secs`→`secs`, … (no `.name()`); `summary_new`→`.name("of")` still overrides |
+//! | contextual method names               | method hook strips `storage`/`stamp` class prefixes; `summary_new`→`.name("of")` still overrides |
 //! | per-class `.name()`                  | `Archive` → Kotlin `SummaryVault` (literal, bypasses mangles) |
 //! | `.interface()` + `.implements(…)`      | `Storage`/`Payload` emit an Api interface; `CovResource`/`Timestamped` extend it (#54) |
 //! | `.interface_name(…)`                  | `Priority` → generated `PriorityKind` interface (#54) |
@@ -89,6 +89,20 @@ use prebindgen::{
     from, fun, into, lang::JniGen, matching, package, path, ptr_class, try_from, ty, value_class,
 };
 
+fn strip_flat_class_prefix(class: &str, name: &str) -> String {
+    if name
+        .get(..class.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(class))
+    {
+        let rest = &name[class.len()..];
+        let mut chars = rest.chars();
+        if let Some(first) = chars.next() {
+            return first.to_lowercase().chain(chars).collect();
+        }
+    }
+    name.to_string()
+}
+
 fn main() {
     // Two prebindgen sources: the flat crate plus the binding-side helper
     // crate (conversion fns for `convert!`). The registry records each fn's
@@ -107,19 +121,19 @@ fn main() {
     let jni = JniGen::new()
         .set_package_prefix("io.prebindgen.covertest")
         .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
-        // All six name-mangle hooks are registered. The harness hook is a
+        // Every naming tier used here is configured. The harness hook is a
         // real transform: it receives the derived default `JNINative` and
         // replaces it wholesale with `CovNative` (an internal symbol, so no
-        // Kotlin-side coordination is needed); the other five are the identity
+        // Kotlin-side coordination is needed); four hooks are identity
         // (the domain names are already the desired Kotlin names) — registering
-        // them still exercises the customization API and its `Some(closure)`
-        // path.
-        .set_harness_name_mangle(|_| "CovNative".to_string())
-        .set_fun_name_mangle(|n| n.to_string())
-        .set_ptr_class_name_mangle(|n| n.to_string())
-        .set_data_class_name_mangle(|n| n.to_string())
-        .set_enum_name_mangle(|n| n.to_string())
-        .set_member_name_mangle(|n| n.to_string())
+        // closures, and the method hook strips the flat class prefix. The
+        // generated-interface hook deliberately keeps its `ClassApi` default.
+        .set_harness_name_mangle(|_, _| "CovNative".to_string())
+        .set_fun_name_mangle(|_, n| n.to_string())
+        .set_ptr_class_name_mangle(|_, n| n.to_string())
+        .set_data_class_name_mangle(|_, n| n.to_string())
+        .set_enum_name_mangle(|_, n| n.to_string())
+        .set_method_name_mangle(|_, class, n| strip_flat_class_prefix(class, n))
         // `Millis` newtype: a canonical single-value conversion to a bare
         // `Long` (no generated class) via two ordinary `#[prebindgen]` fns —
         // defined in the SEPARATE `covertest-helpers` source crate, proving
@@ -164,7 +178,7 @@ fn main() {
                 data_class!(Payload)
                     .interface()
                     .implements("io.prebindgen.covertest.Timestamped")
-                    .fun(fun!(payload_label_len)),
+                    .method(fun!(payload_label_len)),
             ),
         )
         // ── Subpackage `model`: enum + value class + nested data class ──────
@@ -189,15 +203,15 @@ fn main() {
                 // surfaces as `List<ByteArray>`.
                 .class(
                     value_class!(Stamp)
-                        .fun(fun!(stamp_secs))
-                        .fun(fun!(stamp_nanos)),
+                        .method(fun!(stamp_secs))
+                        .method(fun!(stamp_nanos)),
                 ),
         )
         // ── Subpackage `errors`: the Result error channel ───────────────────
         .package(package!("errors").class(
             // `StorageError` is the `E` of a fallible `Result`; its
             // boundary shape is declared with `expand_return!` below.
-            ptr_class!(StorageError).fun(fun!(storage_error_message)),
+            ptr_class!(StorageError).method(fun!(storage_error_message)),
         ))
         // `StorageError`'s default return fields make the generated `onError`
         // handler receive the decomposed error: the `message` string (name
@@ -219,9 +233,9 @@ fn main() {
                 .class(
                     ptr_class!(Summary)
                         .constructor(fun!(summary_new).name("of"))
-                        .fun(fun!(summary_count))
-                        .fun(fun!(summary_total))
-                        .fun(fun!(summary_scaled)),
+                        .method(fun!(summary_count))
+                        .method(fun!(summary_total))
+                        .method(fun!(summary_scaled)),
                 )
                 // `Archive` holds the latest `Summary` and returns it BORROWED
                 // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -285,8 +299,8 @@ fn main() {
                         // generated code.
                         .interface()
                         .implements("io.prebindgen.covertest.CovResource")
-                        .fun(fun!(storage_len))
-                        .fun(fun!(storage_contains))
+                        .method(fun!(storage_len))
+                        .method(fun!(storage_contains))
                         .constructor(fun!(storage_with_payload)),
                 )
                 // The callback-handler handles (single payload / whole batch / owned

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -153,11 +153,10 @@ impl JniGen {
         }
     }
     /// Apply the harness mangle closure to `name`, returning the closure
-    /// result or `name` verbatim when unset — identity default, same
-    /// contract as the other package-aware name hooks.
-    pub(crate) fn mangle_harness(&self, package: &str, name: &str) -> String {
+    /// result or `name` verbatim when unset.
+    pub(crate) fn mangle_harness(&self, name: &str) -> String {
         match &self.harness_name_mangle {
-            Some(f) => f(package, name),
+            Some(f) => f(name),
             None => name.to_string(),
         }
     }
@@ -167,7 +166,7 @@ impl JniGen {
     /// Kotlin class emission and the JNI extern symbol path on the Rust
     /// side.
     pub(crate) fn jni_native_class_name(&self) -> String {
-        self.mangle_harness(&self.package, "JNINative")
+        self.mangle_harness("JNINative")
     }
 
     /// Mangle a method emitted on the centralized JNI extern harness.

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -65,7 +65,7 @@ impl JniGen {
             ptr_class_name_mangle: None,
             data_class_name_mangle: None,
             enum_name_mangle: None,
-            member_name_mangle: None,
+            method_name_mangle: None,
             harness_name_mangle: None,
             interface_name_mangle: None,
             types: HashMap::new(),
@@ -113,56 +113,51 @@ impl JniGen {
         jni
     }
 
-    /// Apply the fun-name mangle closure to `name`, returning the closure
-    /// result or `name` verbatim when unset. Called everywhere the framework
-    /// derives a function-shaped Kotlin/JNI short name — scanned
-    /// `#[prebindgen]` extern symbols, the synthetic `freePtr` destructor,
-    /// and the Kotlin-side `external fun` that pairs with each.
-    pub(crate) fn mangle_fun(&self, name: &str) -> String {
+    /// Apply the package-level function-name mangle closure to `name`.
+    pub(crate) fn mangle_fun(&self, package: &str, name: &str) -> String {
         match &self.fun_name_mangle {
-            Some(f) => f(name),
+            Some(f) => f(package, name),
+            None => name.to_string(),
+        }
+    }
+    /// Apply the method-name mangle closure to `name`, providing the package
+    /// and final class name that contain the method.
+    pub(crate) fn mangle_method(&self, package: &str, class: &str, name: &str) -> String {
+        match &self.method_name_mangle {
+            Some(f) => f(package, class, name),
             None => name.to_string(),
         }
     }
     /// Apply the ptr-class mangle closure to `name`, returning the closure
     /// result or `name` verbatim when unset.
-    pub(crate) fn mangle_ptr_class(&self, name: &str) -> String {
+    pub(crate) fn mangle_ptr_class(&self, package: &str, name: &str) -> String {
         match &self.ptr_class_name_mangle {
-            Some(f) => f(name),
+            Some(f) => f(package, name),
             None => name.to_string(),
         }
     }
     /// Apply the data-class mangle closure to `name`, returning the closure
     /// result or `name` verbatim when unset.
-    pub(crate) fn mangle_data_class(&self, name: &str) -> String {
+    pub(crate) fn mangle_data_class(&self, package: &str, name: &str) -> String {
         match &self.data_class_name_mangle {
-            Some(f) => f(name),
+            Some(f) => f(package, name),
             None => name.to_string(),
         }
     }
     /// Apply the enum mangle closure to `name`, returning the closure result
     /// or `name` verbatim when unset.
-    pub(crate) fn mangle_enum(&self, name: &str) -> String {
+    pub(crate) fn mangle_enum(&self, package: &str, name: &str) -> String {
         match &self.enum_name_mangle {
-            Some(f) => f(name),
-            None => name.to_string(),
-        }
-    }
-    /// Apply the member mangle closure to `name` (the namespace-stripped
-    /// camelCase default), returning the closure result or `name` verbatim
-    /// when unset.
-    pub(crate) fn mangle_member(&self, name: &str) -> String {
-        match &self.member_name_mangle {
-            Some(f) => f(name),
+            Some(f) => f(package, name),
             None => name.to_string(),
         }
     }
     /// Apply the harness mangle closure to `name`, returning the closure
     /// result or `name` verbatim when unset — identity default, same
-    /// contract as the other five hooks.
-    pub(crate) fn mangle_harness(&self, name: &str) -> String {
+    /// contract as the other package-aware name hooks.
+    pub(crate) fn mangle_harness(&self, package: &str, name: &str) -> String {
         match &self.harness_name_mangle {
-            Some(f) => f(name),
+            Some(f) => f(package, name),
             None => name.to_string(),
         }
     }
@@ -172,7 +167,21 @@ impl JniGen {
     /// Kotlin class emission and the JNI extern symbol path on the Rust
     /// side.
     pub(crate) fn jni_native_class_name(&self) -> String {
-        self.mangle_harness("JNINative")
+        self.mangle_harness(&self.package, "JNINative")
+    }
+
+    /// Mangle a method emitted on the centralized JNI extern harness.
+    pub(crate) fn mangle_jni_method(&self, name: &str) -> String {
+        self.mangle_method(&self.package, &self.jni_native_class_name(), name)
+    }
+
+    /// Resolve a relative subpackage against the configured base package.
+    pub(crate) fn package_name(&self, subpackage: &str) -> String {
+        match (&self.package, subpackage) {
+            (p, sub) if !sub.is_empty() && !p.is_empty() => format!("{p}.{sub}"),
+            (_, sub) if !sub.is_empty() => sub.to_string(),
+            (p, _) => p.clone(),
+        }
     }
 
     /// Resolve a relative class name against [`Self::package`] +
@@ -187,11 +196,7 @@ impl JniGen {
              package + subpackage",
             name
         );
-        let base: String = match (&self.package, subpackage) {
-            (p, sub) if !sub.is_empty() && !p.is_empty() => format!("{}.{}", p, sub),
-            (p, sub) if !sub.is_empty() && p.is_empty() => sub.to_string(),
-            (p, _) => p.clone(),
-        };
+        let base = self.package_name(subpackage);
         if base.is_empty() {
             name.to_string()
         } else {
@@ -234,12 +239,12 @@ impl JniGen {
             let pkg = self.packages.entry(name.clone()).or_default();
             match c.source {
                 super::decl::ConstSource::Item => {
-                    let mut entry = MethodEntry::new(c.rust_ident);
+                    let mut entry = FunctionEntry::new(c.rust_ident);
                     entry.kotlin_name_override = c.kotlin_name_override;
                     pkg.constants.push(entry);
                 }
                 super::decl::ConstSource::Fun(ref fn_ident) => {
-                    let mut entry = MethodEntry::new(fn_ident.clone());
+                    let mut entry = FunctionEntry::new(fn_ident.clone());
                     entry.kotlin_name_override = Some(c.val_name());
                     pkg.constant_functions.push(entry);
                 }
@@ -443,7 +448,7 @@ impl JniGen {
     }
 
     fn accept_function(&mut self, subpackage: &str, decl: FunctionDecl) {
-        let mut entry = MethodEntry::new(decl.rust_ident.clone());
+        let mut entry = FunctionEntry::new(decl.rust_ident.clone());
         entry.kotlin_name_override = decl.kotlin_name_override.clone();
         self.packages
             .entry(subpackage.to_string())
@@ -523,34 +528,50 @@ impl JniGen {
         self
     }
 
-    /// The Kotlin name of `func` as a declared member (`.fun`/`.constructor`)
+    /// The Kotlin name of `func` as a declared member (`.method`/`.constructor`)
     /// of the class keyed by `key`, if it is one — the name-inheritance
     /// source for [`ExpandReturnDecl::field`].
-    fn member_kotlin_name(&self, key: &TypeKey, func: &syn::Ident) -> Option<String> {
+    fn class_method_kotlin_name(&self, key: &TypeKey, func: &syn::Ident) -> Option<String> {
         self.class_members
             .get(key)?
             .iter()
             .find(|m| &m.rust_ident == func)
-            .map(|m| self.effective_member_name(key, m))
+            .map(|m| self.effective_method_name(key, m))
     }
 
-    /// The effective Kotlin name of a class member, derived at point of
-    /// use (order-independent w.r.t. `set_member_name_mangle`): the
-    /// per-member `.name()` override verbatim, else the member-mangle hook
-    /// over the **namespace-relative** camelCase default — the class's
-    /// Rust-name prefix is stripped from the fn ident first
-    /// ([`strip_type_prefix`]), because a flat crate spells the type
-    /// namespace inside the ident while a Kotlin member already lives in
-    /// its class. No prefix match ⇒ the full ident camel-cases as before.
-    pub(crate) fn effective_member_name(&self, key: &TypeKey, m: &ClassMember) -> String {
+    /// The effective Kotlin name of a class method/factory, derived at point
+    /// of use: a per-method `.name()` override verbatim, else the method
+    /// hook over the full camelCase Rust identifier with its final package
+    /// and class context. Consumers can therefore remove flat namespace
+    /// prefixes without the generator guessing their source convention.
+    pub(crate) fn effective_method_name(&self, key: &TypeKey, m: &ClassMember) -> String {
         if let Some(name) = &m.kotlin_name_override {
             return name.clone();
         }
-        let ident = m.rust_ident.to_string();
-        let short = rust_short_name(key);
-        let base = crate::api::lang::jnigen::util::strip_type_prefix(&ident, &short)
-            .unwrap_or(ident.as_str());
-        self.mangle_member(&snake_to_camel(base))
+        let spec = self
+            .types
+            .get(key)
+            .and_then(|cfg| cfg.name_spec.as_ref())
+            .unwrap_or_else(|| panic!("class member `{}` has no class name", m.rust_ident));
+        let fqn = self.fqn_of(spec);
+        let (package, class) = fqn.rsplit_once('.').unwrap_or(("", fqn.as_str()));
+        self.mangle_method(package, class, &snake_to_camel(&m.rust_ident.to_string()))
+    }
+
+    /// The effective Kotlin name of a package-level function. Explicit
+    /// `.name()` wins; otherwise the package-aware function hook receives
+    /// the full camelCase Rust identifier.
+    pub(crate) fn effective_function_name(
+        &self,
+        subpackage: &str,
+        entry: &FunctionEntry,
+    ) -> String {
+        entry.kotlin_name_override.clone().unwrap_or_else(|| {
+            self.mangle_fun(
+                &self.package_name(subpackage),
+                &snake_to_camel(&entry.rust_ident.to_string()),
+            )
+        })
     }
 
     /// Whether `key` was declared as a class in some package (any of the four
@@ -651,7 +672,7 @@ impl JniGen {
                     LocalField::Named(func, name_override) => {
                         let name = name_override
                             .clone()
-                            .or_else(|| self.member_kotlin_name(&decl.key, func))
+                            .or_else(|| self.class_method_kotlin_name(&decl.key, func))
                             .unwrap_or_else(|| snake_to_camel(&func.to_string()));
                         dec.add_deconstructor_record(func.clone(), name);
                     }
@@ -680,7 +701,7 @@ impl JniGen {
                     LocalField::Named(afunc, name_override) => {
                         let name = name_override
                             .clone()
-                            .or_else(|| self.member_kotlin_name(&decl.key, afunc))
+                            .or_else(|| self.class_method_kotlin_name(&decl.key, afunc))
                             .unwrap_or_else(|| snake_to_camel(&afunc.to_string()));
                         dec.push_inline_field(afunc.clone(), name);
                     }
@@ -743,7 +764,7 @@ impl JniGen {
     /// gate requires every named record's function to be in this set
     /// (`RecordNotAccessor` otherwise), and `core/expand.rs` excludes them
     /// from parameter composition. Derived from *usage* — a function need not
-    /// also be a `.fun()` class member to be referenced this way.
+    /// also be a `.method()` class member to be referenced this way.
     pub(crate) fn field_accessor_fns(&self) -> std::collections::HashSet<syn::Ident> {
         self.return_expand_decls
             .iter()

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -13,27 +13,26 @@
 //!
 //! # Name-mangle hooks
 //!
-//! One uniform contract for the six name hooks: **the hook receives the
-//! derived default name for its tier** — exactly what the generator would use
-//! if no hook were set — **and returns the final name; every default is the
-//! identity.** The input *domain* differs per tier (a fn name is camelCase,
-//! a class name is a Rust short name); the table states each:
+//! Every name hook receives the fully-qualified Kotlin **package where the
+//! named object is emitted**, followed by the derived default name for its
+//! tier. The method hook additionally receives the final containing class
+//! short name. Hooks return the final short name; unset hooks are identity.
 //!
 //! | hook | names | input (the derived default) | default |
 //! |---|---|---|---|
-//! | [`set_harness_name_mangle`](JniGen::set_harness_name_mangle) | the centralized externs object | `"JNINative"` | identity |
-//! | [`set_fun_name_mangle`](JniGen::set_fun_name_mangle) | JNI extern short names (scanned fns, synthetic `freePtr`) | camelCased Rust fn name (`put_publisher` → `"putPublisher"`) | identity |
-//! | [`set_ptr_class_name_mangle`](JniGen::set_ptr_class_name_mangle) | `ptr_class` Kotlin classes | Rust type short name (`"KeyExpr"`) | identity |
-//! | [`set_data_class_name_mangle`](JniGen::set_data_class_name_mangle) | `data_class` + `value_class` Kotlin classes | Rust type short name | identity |
-//! | [`set_enum_name_mangle`](JniGen::set_enum_name_mangle) | `enum_class` Kotlin classes | Rust type short name | identity |
-//! | [`set_member_name_mangle`](JniGen::set_member_name_mangle) | class members without a per-member `.name()` | namespace-stripped camelCase (`storage_len` on `Storage` → `"len"`) | identity |
+//! | [`set_harness_name_mangle`](JniGen::set_harness_name_mangle) | the centralized externs object | package, `"JNINative"` | identity |
+//! | [`set_fun_name_mangle`](JniGen::set_fun_name_mangle) | top-level package functions | package, camelCased Rust fn name (`put_publisher` → `"putPublisher"`) | identity |
+//! | [`set_ptr_class_name_mangle`](JniGen::set_ptr_class_name_mangle) | `ptr_class` Kotlin classes | package, Rust type short name (`"KeyExpr"`) | identity |
+//! | [`set_data_class_name_mangle`](JniGen::set_data_class_name_mangle) | `data_class` + `value_class` Kotlin classes | package, Rust type short name | identity |
+//! | [`set_enum_name_mangle`](JniGen::set_enum_name_mangle) | `enum_class` Kotlin classes | package, Rust type short name | identity |
+//! | [`set_method_name_mangle`](JniGen::set_method_name_mangle) | class methods/factories and JNI extern methods | package, final class name, full camelCase Rust fn name | identity |
 //!
 //! One further hook does NOT follow the identity rule, because its input and
 //! output are two names that must differ:
 //!
 //! | hook | names | input | default |
 //! |---|---|---|---|
-//! | [`set_interface_name_mangle`](JniGen::set_interface_name_mangle) | the generated `.interface()` interface | the final **class** name (`"Storage"`) | append `"Api"` (`"StorageApi"`); identity is a hard error |
+//! | [`set_interface_name_mangle`](JniGen::set_interface_name_mangle) | the generated `.interface()` interface | package, final **class** name (`"Storage"`) | append `"Api"` (`"StorageApi"`); identity is a hard error |
 //!
 //! A per-decl `.name()` / `.interface_name()` override is always verbatim and
 //! **bypasses** the hooks entirely.
@@ -55,7 +54,8 @@ pub(crate) enum NameKind {
 #[derive(Clone)]
 pub(crate) struct NameSpec {
     pub(crate) subpackage: String,
-    /// `rust_short_name(&key)` — the mangle hook's input.
+    /// `rust_short_name(&key)` — the name part of the mangle hook's input;
+    /// `subpackage` supplies its package part.
     pub(crate) short: String,
     /// Per-decl `.name()` — resolved against package + subpackage,
     /// bypasses the mangle hook.
@@ -89,35 +89,34 @@ impl JniGen {
     }
 
     /// Set the closure that renames the framework "harness" class (the
-    /// centralized extern holder). Receives the derived default
+    /// centralized extern holder). Receives its package and the derived default
     /// `"JNINative"` and replaces it wholesale
-    /// (`|_| "MyNative".to_string()`); default = identity (see the
+    /// (`|_, _| "MyNative".to_string()`); default = identity (see the
     /// module-level table). Affects the generated Kotlin class name and
     /// the derived JNI extern symbol path on the Rust side.
     pub fn set_harness_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
         self.harness_name_mangle = Some(Arc::new(f));
         self
     }
 
-    /// Set the closure that mangles function names. Called for every scanned
-    /// `#[prebindgen]` free function and the synthetic `freePtr` destructor;
-    /// receives the camelCased Kotlin-side name and returns the final form
-    /// (e.g. `"putPublisher"` → `"putPublisherViaJNI"`). Default = identity
-    /// (see the module-level table).
+    /// Set the closure that mangles top-level package function names. It
+    /// receives the fully-qualified target package and camelCased Rust name.
+    /// JNI externs are methods of the generated harness and therefore use
+    /// [`set_method_name_mangle`](Self::set_method_name_mangle) instead.
     pub fn set_fun_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
         self.fun_name_mangle = Some(Arc::new(f));
         self
     }
 
     /// Set the closure that turns a class name into the name of its generated
-    /// `.interface()` interface. Receives the **final class name** and must
-    /// return a DIFFERENT name — identity is a hard error (a class and its
+    /// `.interface()` interface. Receives its package and the **final class
+    /// name**, and must return a DIFFERENT name — identity is a hard error (a class and its
     /// interface cannot share a name in one package), the one deviation from
     /// the uniform hook contract in the module-level table. Default when
     /// unset = append `"Api"` (`Storage` → `StorageApi`). A per-decl
@@ -125,18 +124,18 @@ impl JniGen {
     /// the hook.
     pub fn set_interface_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
         self.interface_name_mangle = Some(Arc::new(f));
         self
     }
 
     /// Set the closure that mangles Kotlin ptr-class names declared via a
-    /// `PtrClassDecl`. Receives the Rust short name. Default = identity
-    /// (see the module-level table).
+    /// `PtrClassDecl`. Receives the target package and Rust short name.
+    /// Default = identity (see the module-level table).
     pub fn set_ptr_class_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
         self.ptr_class_name_mangle = Some(Arc::new(f));
         self
@@ -144,39 +143,37 @@ impl JniGen {
 
     /// Set the closure that mangles Kotlin data-class names declared via a
     /// `DataClassDecl` (and value classes, which reuse this hook). Receives
-    /// the Rust short name. Default = identity (see the module-level table).
+    /// the target package and Rust short name. Default = identity (see the
+    /// module-level table).
     pub fn set_data_class_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
         self.data_class_name_mangle = Some(Arc::new(f));
         self
     }
 
     /// Set the closure that mangles enum-class names declared via an
-    /// `EnumClassDecl`. Receives the Rust short name. Default = identity
-    /// (see the module-level table).
+    /// `EnumClassDecl`. Receives the target package and Rust short name.
+    /// Default = identity (see the module-level table).
     pub fn set_enum_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
         self.enum_name_mangle = Some(Arc::new(f));
         self
     }
 
-    /// Set the closure that mangles **class member** names (instance
-    /// methods and companion factories). Receives the derived camelCase
-    /// name AFTER the class-namespace prefix was stripped from the fn
-    /// ident (`storage_len` on class `Storage` arrives as `"len"`); runs
-    /// only for members without a per-member `.name()` (which is always
-    /// verbatim). Default = identity (see the module-level table). The
-    /// sixth hook of the name-mangle family, covering the one name tier
-    /// the other five don't.
-    pub fn set_member_name_mangle<F>(mut self, f: F) -> Self
+    /// Set the closure that mangles methods and companion factories. Receives
+    /// the fully-qualified target package, final containing class short name,
+    /// and the full camelCase Rust function name. It is also used for methods
+    /// of generated infrastructure classes (`JNINative`, handle `freePtr`,
+    /// vector helpers). Per-method `.name()` remains verbatim.
+    pub fn set_method_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> String + Send + Sync + 'static,
+        F: Fn(&str, &str, &str) -> String + Send + Sync + 'static,
     {
-        self.member_name_mangle = Some(Arc::new(f));
+        self.method_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -213,10 +210,11 @@ impl JniGen {
         if let Some(n) = name_override {
             return self.resolve_class_fqn(subpackage, n);
         }
+        let package = self.package_name(subpackage);
         let mangled = match kind {
-            NameKind::Ptr => self.mangle_ptr_class(short),
-            NameKind::Enum => self.mangle_enum(short),
-            NameKind::DataOrValue => self.mangle_data_class(short),
+            NameKind::Ptr => self.mangle_ptr_class(&package, short),
+            NameKind::Enum => self.mangle_enum(&package, short),
+            NameKind::DataOrValue => self.mangle_data_class(&package, short),
         };
         self.resolve_class_fqn(subpackage, &mangled)
     }

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -13,14 +13,16 @@
 //!
 //! # Name-mangle hooks
 //!
-//! Every name hook receives the fully-qualified Kotlin **package where the
-//! named object is emitted**, followed by the derived default name for its
+//! Placement-aware hooks receive the fully-qualified Kotlin **package where
+//! the named object is emitted**, followed by the derived default name for its
 //! tier. The method hook additionally receives the final containing class
-//! short name. Hooks return the final short name; unset hooks are identity.
+//! short name. The harness is the exception: it has one fixed placement and
+//! receives only its default short name. Hooks return the final short name;
+//! unset hooks are identity.
 //!
 //! | hook | names | input (the derived default) | default |
 //! |---|---|---|---|
-//! | [`set_harness_name_mangle`](JniGen::set_harness_name_mangle) | the centralized externs object | package, `"JNINative"` | identity |
+//! | [`set_harness_name_mangle`](JniGen::set_harness_name_mangle) | the centralized externs object | `"JNINative"` | identity |
 //! | [`set_fun_name_mangle`](JniGen::set_fun_name_mangle) | top-level package functions | package, camelCased Rust fn name (`put_publisher` → `"putPublisher"`) | identity |
 //! | [`set_ptr_class_name_mangle`](JniGen::set_ptr_class_name_mangle) | `ptr_class` Kotlin classes | package, Rust type short name (`"KeyExpr"`) | identity |
 //! | [`set_data_class_name_mangle`](JniGen::set_data_class_name_mangle) | `data_class` + `value_class` Kotlin classes | package, Rust type short name | identity |
@@ -89,14 +91,13 @@ impl JniGen {
     }
 
     /// Set the closure that renames the framework "harness" class (the
-    /// centralized extern holder). Receives its package and the derived default
-    /// `"JNINative"` and replaces it wholesale
-    /// (`|_, _| "MyNative".to_string()`); default = identity (see the
+    /// centralized extern holder). Receives the derived default `"JNINative"`
+    /// and replaces it wholesale (`|_| "MyNative".to_string()`); default = identity (see the
     /// module-level table). Affects the generated Kotlin class name and
     /// the derived JNI extern symbol path on the Rust side.
     pub fn set_harness_name_mangle<F>(mut self, f: F) -> Self
     where
-        F: Fn(&str, &str) -> String + Send + Sync + 'static,
+        F: Fn(&str) -> String + Send + Sync + 'static,
     {
         self.harness_name_mangle = Some(Arc::new(f));
         self

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -265,7 +265,7 @@ macro_rules! expand_return {
 /// [`PackageDecl`], and hand that to [`JniGen::package`].
 ///
 /// A `PtrClassDecl` defines the **Kotlin class only** — its name
-/// ([`name`](Self::name)), its instance methods ([`fun`](Self::fun)), and its
+/// ([`name`](Self::name)), its instance methods ([`method`](Self::method)), and its
 /// companion-object factories ([`constructor`](Self::constructor)). How the
 /// type crosses the FFI boundary by default — accepted as which parameter
 /// variants, returned as which field set — is declared separately with
@@ -276,7 +276,7 @@ macro_rules! expand_return {
 /// ```
 /// // A KeyExpr handle exposing `str()` as an instance method.
 /// let _ = prebindgen::ptr_class!(KeyExpr)
-///     .fun(prebindgen::fun!(keyexpr_get_str).name("str"));
+///     .method(prebindgen::fun!(keyexpr_get_str).name("str"));
 /// ```
 /// Deliberately has no verbatim type mapping: the generated typed-handle
 /// class OWNS a lifecycle contract — the `NativeHandle` base, the `ptr`
@@ -402,8 +402,8 @@ impl PtrClassDecl {
     /// become the method's arguments. Name it with
     /// `fun!(rust_name).name("kotlinName")` (default: the Rust name
     /// camel-cased).
-    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        self.members.push((rust_fun, MemberKind::Fun));
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        self.members.push((rust_fun, MemberKind::Method));
         self
     }
 
@@ -581,7 +581,7 @@ impl ExpandReturnDecl {
     /// Add one field: the named `#[prebindgen]` reader's (`f(&Self) -> Field`)
     /// value. The Kotlin field name is, in order of precedence: an explicit
     /// `.name(...)` on `accessor`; the Kotlin name of the class member if the
-    /// same function is declared via [`PtrClassDecl::fun`] on this type (so a
+    /// same function is declared via [`PtrClassDecl::method`] on this type (so a
     /// getter that is both a method and a field is named once); else the
     /// camel-cased Rust name.
     ///
@@ -644,7 +644,7 @@ impl From<ExpandReturnDecl> for ExpandDecl {
 /// unit-variant only and `#[repr(i32)]`-style with explicit discriminants,
 /// so both sides agree on the numbers.
 ///
-/// Has no `.fun`/`.constructor` by rule, not omission: members belong to
+/// Has no `.method`/`.constructor` by rule, not omission: members belong to
 /// class kinds whose instances can re-enter Rust as an object (handle /
 /// blob / field leaves). An enum value is a bare scalar with no object
 /// identity — a "method" on it is just a free function taking the enum.
@@ -714,11 +714,11 @@ impl DataClassDecl {
     class_interface_methods!("data_class");
 
     /// Expose a `#[prebindgen]` reader (`f(&Self) -> R`) as an instance
-    /// method on the generated data class (see [`PtrClassDecl::fun`]) — the
+    /// method on the generated data class (see [`PtrClassDecl::method`]) — the
     /// receiver crosses as `this`'s field leaves, exactly like a data-class
     /// parameter.
-    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        self.members.push((rust_fun, MemberKind::Fun));
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        self.members.push((rust_fun, MemberKind::Method));
         self
     }
 
@@ -740,7 +740,7 @@ impl From<syn::Type> for DataClassDecl {
 /// raw bytes in a `ByteArray` — rather than as a heap handle. The
 /// lightweight peer of [`PtrClassDecl`] for things like ids and timestamps
 /// that have no lifecycle to manage. The type must be `Copy` (the generator
-/// asserts it at compile time). Readers added with [`fun`](Self::fun) become
+/// asserts it at compile time). Readers added with [`method`](Self::method) become
 /// instance methods on the Kotlin value class.
 pub struct ValueClassDecl {
     pub(crate) key: TypeKey,
@@ -768,9 +768,9 @@ impl ValueClassDecl {
     class_interface_methods!("value_class");
 
     /// Expose a `#[prebindgen]` reader (`f(&Self) -> R`) as an instance
-    /// method on the Kotlin value class (see [`PtrClassDecl::fun`]).
-    pub fn fun(mut self, rust_fun: FunctionDecl) -> Self {
-        self.members.push((rust_fun, MemberKind::Fun));
+    /// method on the Kotlin value class (see [`PtrClassDecl::method`]).
+    pub fn method(mut self, rust_fun: FunctionDecl) -> Self {
+        self.members.push((rust_fun, MemberKind::Method));
         self
     }
 
@@ -829,7 +829,7 @@ impl From<ValueClassDecl> for ClassDecl {
 
 /// Declares one `#[prebindgen]` function to export. Add it to a package with
 /// [`PackageDecl::fun`], or attach it to a class as a method/factory with
-/// [`PtrClassDecl::fun`] / [`PtrClassDecl::constructor`].
+/// [`PtrClassDecl::method`] / [`PtrClassDecl::constructor`].
 ///
 /// Build it from a bare Rust name with [`fun!`](crate::fun) and chain
 /// [`name`](Self::name) to set its Kotlin name.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -63,7 +63,7 @@ impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
 
 pub(crate) fn mangle_jni_name(ext: &JniGen, ident: &syn::Ident) -> syn::Ident {
     let camel = snake_to_camel(&ident.to_string());
-    let mangled = ext.mangle_fun(&camel);
+    let mangled = ext.mangle_jni_method(&camel);
     let mut name = ext.jni_class_path();
     name.push('_');
     name.push_str(&mangled);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -105,11 +105,11 @@ pub(crate) fn vec_build_helpers(
 }
 
 /// Kotlin `external fun` short name for a vec helper (`payloadVecNew`), routed
-/// through [`JniGen::mangle_fun`] like every other extern. The Rust JNI symbol
+/// through the method mangler like every other `JNINative` extern. The Rust JNI symbol
 /// (see [`vec_helper_symbol`]) and the Kotlin call site both use this, so they
 /// agree.
 pub(crate) fn vec_helper_method_name(ext: &JniGen, base: &str, suffix: &str) -> String {
-    ext.mangle_fun(&format!("{base}{suffix}"))
+    ext.mangle_jni_method(&format!("{base}{suffix}"))
 }
 
 /// Full Rust JNI symbol for a vec helper — `<jni_class_path>_<method>` (the same

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -21,7 +21,7 @@
 //! of that package's classes, enums, value-classes and free functions.
 //!
 //! Every `#[prebindgen]` function must be assigned a Kotlin home — as a
-//! class member (`.fun`/`.constructor` on a class decl) or a free function
+//! class member (`.method`/`.constructor` on a class decl) or a free function
 //! (`PackageDecl::fun`). Undeclared functions are skipped with a build
 //! warning (`Registry::scan_declared`); there is no "orphan" bucket.
 
@@ -324,16 +324,16 @@ impl JniGen {
             if !members.is_empty() && !self.package.is_empty() {
                 imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
             }
-            // Promoted instance methods (`.fun`): receiver bound to `this`,
+            // Promoted instance methods (`.method`): receiver bound to `this`,
             // passing `this.bytes` to the extern.
-            for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
+            for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
                 if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                         self,
                         item_fn,
                         registry,
                         &mut imports,
-                        Some(self.effective_member_name(key, m).as_str()),
+                        Some(self.effective_method_name(key, m).as_str()),
                         Some(key),
                     ) {
                         for ov in crate::api::lang::jnigen::jni::render_param_overloads(
@@ -359,7 +359,7 @@ impl JniGen {
                             item_fn,
                             registry,
                             &mut imports,
-                            Some(self.effective_member_name(key, m).as_str()),
+                            Some(self.effective_method_name(key, m).as_str()),
                             None,
                         ) {
                             for ov in crate::api::lang::jnigen::jni::render_param_overloads(
@@ -534,14 +534,14 @@ impl JniGen {
             if !members.is_empty() && !self.package.is_empty() {
                 imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
             }
-            for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
+            for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
                 if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                         self,
                         item_fn,
                         registry,
                         &mut imports,
-                        Some(self.effective_member_name(key, m).as_str()),
+                        Some(self.effective_method_name(key, m).as_str()),
                         Some(key),
                     ) {
                         for ov in crate::api::lang::jnigen::jni::render_param_overloads(
@@ -572,7 +572,7 @@ impl JniGen {
                             item_fn,
                             registry,
                             &mut imports,
-                            Some(self.effective_member_name(key, m).as_str()),
+                            Some(self.effective_method_name(key, m).as_str()),
                             None,
                         ) {
                             for ov in crate::api::lang::jnigen::jni::render_param_overloads(
@@ -614,7 +614,7 @@ impl JniGen {
     }
 
     /// Build the package-level wrapper fragment for the given subpackage.
-    /// One top-level safe wrapper per `MethodEntry` in `pkg_cfg.functions`.
+    /// One top-level safe wrapper per `FunctionEntry` in `pkg_cfg.functions`.
     /// Wrappers delegate to the centralized Native object (see
     /// [`Self::write_jni_native`]). Opaque-handle parameters become
     /// `NativeHandle`; the wrapper body nests `withPtr` / `consume` per
@@ -685,7 +685,7 @@ impl JniGen {
             .map(|el| TypeKey::from_type(el).to_string())
             .collect();
 
-        // Walk every declared function — free `.fun`s AND class members
+        // Walk every declared function — free `.fun`s AND class methods/factories
         // (`.method`/`.accessor`/`.constructor`): a method can also need a
         // generated interface (e.g. a `Vec<T>` whole-element folder). The `uses`
         // map dedups, so an identity shared across positions emits once.
@@ -982,13 +982,7 @@ impl JniGen {
         subpackage: &str,
         pkg_cfg: &crate::api::lang::jnigen::jni::PackageConfig,
     ) -> kt::KtFile {
-        let package = if self.package.is_empty() {
-            subpackage.to_string()
-        } else if subpackage.is_empty() {
-            self.package.clone()
-        } else {
-            format!("{}.{}", self.package, subpackage)
-        };
+        let package = self.package_name(subpackage);
         let mut file = kt::KtFile::new(&package);
         let mut imports: BTreeSet<String> = BTreeSet::new();
         for entry in &pkg_cfg.functions {
@@ -1003,12 +997,13 @@ impl JniGen {
                         entry.rust_ident,
                     )
                 });
+            let kotlin_name = self.effective_function_name(subpackage, entry);
             if let Some(f) = render_wrapper_fn(
                 self,
                 item_fn,
                 registry,
                 &mut imports,
-                entry.kotlin_name_override.as_deref(),
+                Some(&kotlin_name),
                 None,
             ) {
                 // #52: idiomatic typed overloads for `.split_on_param`
@@ -1033,6 +1028,7 @@ impl JniGen {
             reject_handle_const(self, item_const);
             if let Some((helper, prop)) = render_const_val(
                 self,
+                &package,
                 item_const,
                 registry,
                 &mut imports,
@@ -1060,6 +1056,7 @@ impl JniGen {
             validate_constant_fn(self, item_fn);
             if let Some((helper, prop)) = render_constant_fn_val(
                 self,
+                &package,
                 item_fn,
                 registry,
                 &mut imports,
@@ -1074,7 +1071,8 @@ impl JniGen {
         // evaluated Rust-side (`prerequisites`).
         for decl in &pkg_cfg.constant_exprs {
             validate_constant_expr(self, &decl.kotlin_name, &decl.ty);
-            if let Some((helper, prop)) = render_const_expr_val(self, decl, registry, &mut imports)
+            if let Some((helper, prop)) =
+                render_const_expr_val(self, &package, decl, registry, &mut imports)
             {
                 file = file.decl(helper).decl(prop);
             }
@@ -1088,8 +1086,8 @@ impl JniGen {
 
     /// Emit the centralized Native-object Kotlin file under `output_dir`
     /// (class name from [`JniGen::jni_native_class_name`]). Holds one
-    /// `external fun` per `#[prebindgen]` function — names mangled via
-    /// [`JniGen::set_fun_name_mangle`], parameter and return types rendered at
+    /// `external fun` per `#[prebindgen]` function — names mangled as methods
+    /// via [`JniGen::set_method_name_mangle`], parameter and return types rendered at
     /// the JNI **wire** level so the declarations match the Rust extern
     /// symbols generated under
     /// `Java_<package>_<jni_native_class>_<name>`. Every generated native
@@ -1201,7 +1199,8 @@ impl JniGen {
 
     /// Emit one Kotlin file per entry in `handles` — each becomes a
     /// `public class <ClassName>(initialPtr: Long) : NativeHandle(initialPtr)`
-    /// with the standard `free()` + `private external fun <mangle_fun("freePtr")>(ptr: Long)`
+    /// with the standard `free()` + package/class-aware mangled
+    /// `private external fun freePtr(ptr: Long)`
     /// destructor pair, plus one instance method per `#[prebindgen]` fn
     /// listed in [`TypedHandle::functions`]. The promoted method's first
     /// opaque parameter matching the handle's Rust type is dropped — the
@@ -1276,13 +1275,14 @@ impl JniGen {
     /// default: append `"Api"`). Asserted to differ from the class name.
     pub(crate) fn interface_short_name(
         &self,
+        package: &str,
         class_short: &str,
         override_: Option<&str>,
     ) -> String {
         let name = match override_ {
             Some(n) => n.to_string(),
             None => match &self.interface_name_mangle {
-                Some(f) => f(class_short),
+                Some(f) => f(package, class_short),
                 None => format!("{class_short}Api"),
             },
         };
@@ -1324,7 +1324,11 @@ impl JniGen {
             return None;
         }
 
-        let iface_name = self.interface_short_name(class_short, name_override.as_deref());
+        let class_fqn = self
+            .kotlin_fqn(key.as_str())
+            .unwrap_or_else(|| class_short.to_string());
+        let package = class_fqn.rsplit_once('.').map(|(p, _)| p).unwrap_or("");
+        let iface_name = self.interface_short_name(package, class_short, name_override.as_deref());
         let mut iface =
             kt::KtClass::new(kt::ClassKind::Interface, &iface_name).vis(kt::Vis::Public);
         for s in extra_supers {

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -268,6 +268,11 @@ pub(crate) type WrapperFn = Arc<
 /// per-kind `set_*_name_mangle` setters. Closure-unset = identity.
 pub(crate) type NameMangle = Arc<dyn Fn(&str, &str) -> String + Send + Sync>;
 
+/// Closure that transforms the centralized JNI harness class short name.
+/// The harness always lives in the configured base package, so no placement
+/// context is needed. Closure-unset = identity.
+pub(crate) type HarnessNameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
+
 /// Closure that transforms a Kotlin method name with both its containing
 /// package and final class short name. This is distinct from [`NameMangle`]
 /// because flat Rust APIs conventionally encode the class namespace in the
@@ -329,9 +334,9 @@ pub struct JniGen {
     /// to the camelCase Rust function name of every class method/factory
     /// without a per-method `.name()`, with package and class context.
     pub(crate) method_name_mangle: Option<MethodNameMangle>,
-    /// Mangler for the framework `JNINative` harness class name. Receives the
-    /// base package and default class name; unset = identity.
-    pub(crate) harness_name_mangle: Option<NameMangle>,
+    /// Mangler for the framework `JNINative` harness class name. Receives its
+    /// default class name; unset = identity.
+    pub(crate) harness_name_mangle: Option<HarnessNameMangle>,
     /// Mangler turning a class name into its generated `.interface()` name.
     /// Receives the target package and final class name; identity is forbidden
     /// (a class and its interface can't share a name). Default when unset =

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -96,23 +96,23 @@ pub(crate) struct OpaqueConfig {}
 #[derive(Clone, Default)]
 pub(crate) struct EnumConfig {}
 
-/// One registered `.fun(...)` entry. The Rust identifier is captured
+/// One registered package-level `.fun(...)` entry. The Rust identifier is captured
 /// at build-script time via `syn::parse_quote` (i.e. `pq!(rust_fn_name)`); the
 /// optional override sets the Kotlin-side name when the default
 /// `snake_to_camel(rust_ident)` derivation isn't what the user wants.
 #[derive(Clone, Debug)]
-pub struct MethodEntry {
+pub struct FunctionEntry {
     /// Rust function ident — must match a `#[prebindgen]`-marked free
     /// function in the registered source module. Looked up by
     /// `registry.functions[ident]`.
     pub rust_ident: syn::Ident,
     /// Kotlin-side name override, set by chaining `.name("...")` after
     /// the entry's registration. `None` = derive from `rust_ident` via
-    /// `snake_to_camel`.
+    /// `snake_to_camel`, then apply the target package's function hook.
     pub kotlin_name_override: Option<String>,
 }
 
-impl MethodEntry {
+impl FunctionEntry {
     pub fn new(rust_ident: syn::Ident) -> Self {
         Self {
             rust_ident,
@@ -175,18 +175,18 @@ pub(crate) struct TypeConfig {
 pub(crate) struct PackageConfig {
     /// `#[prebindgen]` fns declared as free-standing wrappers under this
     /// subpackage via [`JniGen::fun`].
-    pub functions: Vec<MethodEntry>,
+    pub functions: Vec<FunctionEntry>,
     /// `#[prebindgen]` consts declared under this subpackage via
     /// [`PackageDecl::constant`] — each surfaces as a top-level Kotlin `val`
-    /// initialized through a generated nullary JNI getter. `MethodEntry`
+    /// initialized through a generated nullary JNI getter. `FunctionEntry`
     /// is reused as-is (rust ident + Kotlin-name override).
-    pub constants: Vec<MethodEntry>,
+    pub constants: Vec<FunctionEntry>,
     /// Fn-sourced constants declared via [`ConstDecl::fun`]:
     /// nullary `#[prebindgen]` fns whose result surfaces as a top-level
     /// Kotlin `val` (eagerly initialized through the fn's ordinary generated
     /// wrapper) instead of a callable `fun`. Rust-side emission and the
     /// `JNINative` extern are the plain declared-function ones.
-    pub constant_functions: Vec<MethodEntry>,
+    pub constant_functions: Vec<FunctionEntry>,
     /// Expression-backed constants declared via
     /// [`ConstDecl::expr`](super::jni::decl::ConstDecl::expr):
     /// binding-defined expressions evaluated once inside a generated nullary
@@ -204,7 +204,7 @@ pub(crate) enum MemberKind {
     /// normally (a zero-extra-param fn is just the receiver-only case — no
     /// separate arity tracking needed, since there's nothing left to
     /// compose once the receiver is skipped).
-    Fun,
+    Method,
     /// `f(…) -> T` / `Result<T,E>`: a factory emitted as a companion-object
     /// member returning the class; never output-flattened; referenceable by a
     /// a `expand_param!` `.variant(fun!(...))` arm.
@@ -212,9 +212,9 @@ pub(crate) enum MemberKind {
 }
 
 /// One `#[prebindgen]` function attached to a declared class (`ptr_class` /
-/// `enum_class` / `value_class` / `data_class`) via [`JniGen::fun`] /
-/// [`JniGen::constructor`]. Funs become **instance methods** (receiver
-/// dropped→`this`); constructors become **companion factory** members. Each
+/// `value_class` / `data_class`) via a declaration's `.method(...)` /
+/// `.constructor(...)`. Methods become **instance methods** (receiver
+/// dropped→`this`); constructors become **companion factory** methods. Each
 /// is also a real `#[prebindgen]` wrapper (Rust extern + `JNINative` extern +
 /// JSONL).
 #[derive(Clone, Debug)]
@@ -222,14 +222,14 @@ pub(crate) struct ClassMember {
     /// Rust function ident (`registry.functions[ident]`).
     pub rust_ident: syn::Ident,
     /// Per-member `.name()` override, stored RAW — the effective Kotlin
-    /// name is derived at point of use by [`JniGen::member_kotlin_name`]
-    /// (override, else member-mangle over the namespace-stripped camelCase
-    /// ident), keeping `set_member_name_mangle` order-independent. An
+    /// name is derived at point of use by [`JniGen::class_method_kotlin_name`]
+    /// (override, else the package/class-aware method hook over the full
+    /// camelCase ident), keeping `set_method_name_mangle` order-independent. An
     /// `expand_return!` `.field` referencing the same underlying function
     /// inherits the effective name unless it sets its own `.name()`;
     /// `expand_param!` variants reference the fn by ident only.
     pub kotlin_name_override: Option<String>,
-    /// Member kind (fun / constructor).
+    /// Member kind (method / constructor).
     pub kind: MemberKind,
 }
 
@@ -263,11 +263,17 @@ pub(crate) type WrapperFn = Arc<
         + Sync,
 >;
 
-/// Closure that transforms a Kotlin short name. Installed via [`JniGen`]'s
-/// per-kind `set_*_name_mangle` setters; the framework calls the matching
-/// closure wherever it needs to derive a Kotlin/JNI short name for a
-/// generated element. Closure-unset = identity.
-pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
+/// Closure that transforms a Kotlin short name with the fully-qualified
+/// package in which the named object is emitted. Installed via [`JniGen`]'s
+/// per-kind `set_*_name_mangle` setters. Closure-unset = identity.
+pub(crate) type NameMangle = Arc<dyn Fn(&str, &str) -> String + Send + Sync>;
+
+/// Closure that transforms a Kotlin method name with both its containing
+/// package and final class short name. This is distinct from [`NameMangle`]
+/// because flat Rust APIs conventionally encode the class namespace in the
+/// function identifier (`z_session_put`), while a Kotlin method already lives
+/// inside that class.
+pub(crate) type MethodNameMangle = Arc<dyn Fn(&str, &str, &str) -> String + Send + Sync>;
 
 /// JNI back-end. Global settings are applied with the order-insensitive
 /// `set_*` methods; declarations are accepted as pre-built objects
@@ -283,7 +289,7 @@ pub(crate) type NameMangle = Arc<dyn Fn(&str) -> String + Send + Sync>;
 ///     .package(
 ///         prebindgen::package!("keyexpr")
 ///             .class(prebindgen::ptr_class!(KeyExpr)
-///                 .fun(prebindgen::fun!(keyexpr_get_str).name("getStr"))
+///                 .method(prebindgen::fun!(keyexpr_get_str).name("getStr"))
 ///                 .constructor(prebindgen::fun!(keyexpr_new_try_from).name("tryFrom"))),
 ///     )
 ///     // A KeyExpr param accepts EITHER a String (built via tryFrom) OR an
@@ -307,11 +313,8 @@ pub struct JniGen {
     /// whose trimming a direct field write would bypass.
     pub(crate) package: String,
 
-    /// Mangler for function names (scanned `#[prebindgen]` free fns and
-    /// the synthetic `freePtr` destructor). Default = identity; in
-    /// zenoh-jni the closure returns `format!("{name}ViaJNI")` so the
-    /// generated JNI extern symbols and matching Kotlin `external fun`s
-    /// both pick up the `ViaJNI` suffix.
+    /// Mangler for top-level package function names. Receives the destination
+    /// package and camelCase Rust function name; default = identity.
     pub(crate) fun_name_mangle: Option<NameMangle>,
     /// Mangler for Kotlin ptr-class names declared via a
     /// `PtrClassDecl`. Default = identity.
@@ -322,18 +325,17 @@ pub struct JniGen {
     /// Mangler for `EnumClassDecl`-declared C-like enum class
     /// names. Default = identity.
     pub(crate) enum_name_mangle: Option<NameMangle>,
-    /// Member-name mangle hook ([`JniGen::set_member_name_mangle`]) —
-    /// applied to the namespace-stripped camelCase default of every class
-    /// member without a per-member `.name()`.
-    pub(crate) member_name_mangle: Option<NameMangle>,
-    /// Mangler for the framework "harness" class name —
-    /// `"Native"` (the centralized JNI extern holder). Default when
-    /// unset = prepend `"JNI"`, so you get `JNINative`. Override to
-    /// plug in a different convention.
+    /// Method-name mangle hook ([`JniGen::set_method_name_mangle`]) — applied
+    /// to the camelCase Rust function name of every class method/factory
+    /// without a per-method `.name()`, with package and class context.
+    pub(crate) method_name_mangle: Option<MethodNameMangle>,
+    /// Mangler for the framework `JNINative` harness class name. Receives the
+    /// base package and default class name; unset = identity.
     pub(crate) harness_name_mangle: Option<NameMangle>,
     /// Mangler turning a class name into its generated `.interface()` name.
-    /// Receives the final class name; identity is forbidden (a class and its
-    /// interface can't share a name). Default when unset = append `"Api"`.
+    /// Receives the target package and final class name; identity is forbidden
+    /// (a class and its interface can't share a name). Default when unset =
+    /// append `"Api"`.
     pub(crate) interface_name_mangle: Option<NameMangle>,
 
     /// Structured per-type configuration keyed by canonical Rust type.
@@ -432,7 +434,7 @@ pub struct JniGen {
     pub(crate) fn_split_params: Vec<(syn::Ident, String)>,
 
     /// Class members (funs / constructors) attached to a declared class via
-    /// its decl's `.fun()`/`.constructor()`, keyed by the class's canonical
+    /// its decl's `.method()`/`.constructor()`, keyed by the class's canonical
     /// Rust type. Supplies the instance-method / companion-factory emission
     /// and the receiver-skip set for input-flattening (see [`ClassMember`]).
     /// Insertion order within a class is preserved (the Vec); class emission

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -227,9 +227,8 @@ pub(crate) fn build_data_class(
     (class, imports)
 }
 
-/// Render one typed-handle Kotlin source file. Pure-shell form (with
-/// the closure `|n| format!("{n}ViaJNI")` installed via
-/// [`JniGen::set_fun_name_mangle`]):
+/// Render one typed-handle Kotlin source file. Pure-shell form (with a
+/// method hook that appends `ViaJNI` to methods of the handle class):
 ///
 /// ```kotlin
 /// public class JNIFoo(initialPtr: Long) : NativeHandle(initialPtr) {
@@ -245,8 +244,8 @@ pub(crate) fn build_data_class(
 /// inherited [`NativeHandle`] scope.
 ///
 /// The free-pointer extern name is built as
-/// `<mangle_fun("freePtr")>`. Kotlin/JVM's JNI name mangler binds it
-/// to the matching `Java_<pkg>_<class>_<mangle_fun("freePtr")>`
+/// `<mangle_method(package, class, "freePtr")>`. Kotlin/JVM's JNI name mangler binds it
+/// to the matching `Java_<pkg>_<class>_<mangled-freePtr>`
 /// extern on the Rust side (the auto-generated destructor).
 pub(crate) fn build_typed_handle(
     ext: &JniGen,
@@ -265,7 +264,16 @@ pub(crate) fn build_typed_handle(
     // supertype is what lets `render_wrapper_fn` collect a `List<NativeHandle>`
     // and lock it in one pointer-sorted, deadlock-safe pass. The subclass keeps
     // its own type-specific `close()`/`take()`/`freePtr`.
-    let free_extern = ext.mangle_fun("freePtr");
+    let class_fqn = ext
+        .types
+        .get(key)
+        .and_then(|cfg| cfg.name_spec.as_ref())
+        .map(|spec| ext.fqn_of(spec))
+        .unwrap_or_else(|| class_name.to_string());
+    let (class_package, final_class_name) = class_fqn
+        .rsplit_once('.')
+        .unwrap_or(("", class_fqn.as_str()));
+    let free_extern = ext.mangle_method(class_package, final_class_name, "freePtr");
     let base_fqn = if ext.package.is_empty() {
         "NativeHandle".to_string()
     } else {
@@ -292,7 +300,7 @@ pub(crate) fn build_typed_handle(
                 item_fn,
                 registry,
                 imports,
-                Some(ext.effective_member_name(key, m).as_str()),
+                Some(ext.effective_method_name(key, m).as_str()),
                 None,
             ) {
                 for ov in render_param_overloads(ext, item_fn, registry, &f) {
@@ -346,17 +354,17 @@ pub(crate) fn build_typed_handle(
         )
         .companion(companion);
 
-    // Promoted instance methods: each `.fun(f)` becomes an instance method
+    // Promoted instance methods: each `.method(f)` becomes an instance method
     // (receiver bound to `this`), delegating to the same centralized
     // `JNINative` extern as a free wrapper would.
-    for m in members.iter().filter(|m| m.kind == MemberKind::Fun) {
+    for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
         if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
             if let Some(f) = render_wrapper_fn(
                 ext,
                 item_fn,
                 registry,
                 imports,
-                Some(ext.effective_member_name(key, m).as_str()),
+                Some(ext.effective_method_name(key, m).as_str()),
                 Some(key),
             ) {
                 for ov in render_param_overloads(ext, item_fn, registry, &f) {
@@ -369,7 +377,7 @@ pub(crate) fn build_typed_handle(
     class
 }
 
-/// Render one `external fun <mangle_fun(name)>(…): <wire-return>` line
+/// Render one `external fun <mangle_method(package, JNINative, name)>(…): <wire-return>` line
 /// at the JNI **wire** level (matches what the Rust extern receives):
 ///   * opaque-handle (Borrow/Consume) → jlong → `Long`
 ///   * `enum_class`                  → jint  → `Int` (call passes `.value`)
@@ -429,7 +437,7 @@ pub(crate) fn render_extern_decl(
 ) -> Option<kt::Code> {
     let rust_name = f.sig.ident.to_string();
     let kt_name = kt_snake_to_camel(&rust_name);
-    let jni_call = ext.mangle_fun(&kt_name);
+    let jni_call = ext.mangle_jni_method(&kt_name);
 
     let mut params: Vec<(String, String)> = Vec::new();
     for (eff_ident, eff_ty) in effective_inputs(registry, f) {
@@ -720,7 +728,7 @@ pub(crate) fn render_wrapper_fn(
 ) -> Option<kt::KtFun> {
     let rust_name = f.sig.ident.to_string();
     // The Kotlin extern in `JNINative` is keyed on the Rust ident
-    // (`kt_snake_to_camel(rust_name)` → `ext.mangle_fun`). The per-entry
+    // (`kt_snake_to_camel(rust_name)` → the `JNINative` method mangler). The per-entry
     // `.name("...")` override only changes the *user-facing* Kotlin
     // wrapper name; the JNI call still has to hit the one extern that
     // the Rust extern actually emits.
@@ -729,7 +737,7 @@ pub(crate) fn render_wrapper_fn(
         Some(n) => n.to_string(),
         None => default_kt_name.clone(),
     };
-    let jni_call = ext.mangle_fun(&default_kt_name);
+    let jni_call = ext.mangle_jni_method(&default_kt_name);
 
     let (params, receiver_idx) = classify_params(ext, f, registry, imports, receiver_key)?;
     let out = classify_output(ext, f, registry, imports)?;
@@ -745,7 +753,7 @@ pub(crate) fn render_wrapper_fn(
     let mut fun = kt::KtFun::new(&kt_name).vis(kt::Vis::Public);
     // KDoc: the Rust fn's `///` prose first, then generated notes for every
     // position an expansion reshaped away from the Rust signature (N1).
-    if let Some(doc) = wrapper_kdoc(ext, f, registry) {
+    if let Some(doc) = wrapper_kdoc(f, registry) {
         fun = fun.kdoc(doc);
     }
     if let Some(g) = &out.generic {
@@ -791,13 +799,16 @@ pub(crate) fn render_wrapper_fn(
 /// that calls it once, on first use (see [`render_val_over_helper`]).
 pub(crate) fn render_const_val(
     ext: &JniGen,
+    package: &str,
     c: &syn::ItemConst,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
     let getter = const_getter_fn(c);
-    let helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
+    let default = kt_snake_to_camel(&getter.sig.ident.to_string());
+    let helper_name = ext.mangle_fun(package, &default);
+    let helper = render_wrapper_fn(ext, &getter, registry, imports, Some(&helper_name), None)?;
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| c.ident.to_string());
@@ -819,12 +830,15 @@ pub(crate) fn render_const_val(
 /// (one JNI call, exactly like a const getter).
 pub(crate) fn render_constant_fn_val(
     ext: &JniGen,
+    package: &str,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
-    let helper = render_wrapper_fn(ext, f, registry, imports, None, None)?;
+    let default = kt_snake_to_camel(&f.sig.ident.to_string());
+    let helper_name = ext.mangle_fun(package, &default);
+    let helper = render_wrapper_fn(ext, f, registry, imports, Some(&helper_name), None)?;
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| f.sig.ident.to_string());
@@ -846,12 +860,15 @@ pub(crate) fn render_constant_fn_val(
 /// the generated getter.
 pub(crate) fn render_const_expr_val(
     ext: &JniGen,
+    package: &str,
     decl: &crate::api::lang::jnigen::jni::decl::ConstExprDecl,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
     let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
-    let helper = render_wrapper_fn(ext, &getter, registry, imports, None, None)?;
+    let default = kt_snake_to_camel(&getter.sig.ident.to_string());
+    let helper_name = ext.mangle_fun(package, &default);
+    let helper = render_wrapper_fn(ext, &getter, registry, imports, Some(&helper_name), None)?;
     let expr = decl.expr.to_token_stream();
     let kdoc = format!(
         "Binding-defined constant: `{expr}` (evaluated lazily, once, through \
@@ -2101,9 +2118,9 @@ pub(crate) fn kt_param_name(rust_ident: &str) -> String {
 /// documenting the REAL prototype after all expansions — one note per
 /// position a plan reshaped, phrased for the caller. `None` for an
 /// undocumented, unshaped fn.
-fn wrapper_kdoc(ext: &JniGen, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
+fn wrapper_kdoc(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
     let prose = crate::api::lang::jnigen::util::doc_string(&f.attrs);
-    let notes = shape_notes(ext, f, registry);
+    let notes = shape_notes(f, registry);
     match (prose, notes) {
         (Some(p), Some(n)) => Some(format!("{p}\n\n{n}")),
         (Some(p), None) => Some(p),
@@ -2117,7 +2134,7 @@ fn wrapper_kdoc(ext: &JniGen, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) 
 /// returns (what the builder/fold receives), and error decompositions
 /// (what `onError` receives). Reads the same resolved plan maps the C7
 /// report uses.
-fn shape_notes(ext: &JniGen, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
+fn shape_notes(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
     let fn_ident = &f.sig.ident;
     let mut notes: Vec<String> = Vec::new();
 
@@ -2141,7 +2158,7 @@ fn shape_notes(ext: &JniGen, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -
         let leaf_names: Vec<String> = plan
             .leaves
             .iter()
-            .map(|l| ext.mangle_member(&snake_to_camel(&l.name.to_string())))
+            .map(|l| snake_to_camel(&l.name.to_string()))
             .collect();
         let how = if plan.selector.is_some() {
             format!(

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -47,23 +47,13 @@ impl crate::api::core::Generation<JniGen> {
             if pkg_cfg.functions.is_empty() && !has_consts {
                 continue;
             }
-            let full = if subpackage.is_empty() {
-                ext.package.clone()
-            } else if ext.package.is_empty() {
-                subpackage.clone()
-            } else {
-                format!("{}.{}", ext.package, subpackage)
-            };
+            let full = ext.package_name(subpackage);
             out.push_str(&format!("\n## package `{full}`\n\n"));
-            let mut entries: Vec<&MethodEntry> = pkg_cfg.functions.iter().collect();
+            let mut entries: Vec<&FunctionEntry> = pkg_cfg.functions.iter().collect();
             entries.sort_by_key(|m| m.rust_ident.to_string());
             for m in entries {
-                self.report_fn(
-                    &mut out,
-                    &m.rust_ident,
-                    m.kotlin_name_override.as_deref(),
-                    None,
-                );
+                let name = ext.effective_function_name(subpackage, m);
+                self.report_fn(&mut out, &m.rust_ident, Some(&name), None);
             }
             let mut consts: Vec<String> = pkg_cfg
                 .constants
@@ -119,9 +109,9 @@ impl crate::api::core::Generation<JniGen> {
             let mut ms: Vec<&ClassMember> = members.iter().collect();
             ms.sort_by_key(|m| m.rust_ident.to_string());
             for m in ms {
-                let name = ext.effective_member_name(key, m);
+                let name = ext.effective_method_name(key, m);
                 let receiver = match m.kind {
-                    MemberKind::Fun => Some(key),
+                    MemberKind::Method => Some(key),
                     MemberKind::Constructor => None,
                 };
                 self.report_fn(&mut out, &m.rust_ident, Some(&name), receiver);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -38,7 +38,7 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
-                .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
+                .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))
                 // ZOther: plain ptr_class, no canonical output ⇒ whole-handle fallback.
                 .class(crate::ptr_class!(ZOther))
                 .fun(crate::fun!(z_thing_sub))
@@ -223,8 +223,8 @@ fn callback_root_identity_moved_after_nested_borrow() {
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("thing")
-                .class(crate::ptr_class!(ZChild).fun(crate::fun!(z_child_name).name("name")))
-                .class(crate::ptr_class!(ZParent).fun(crate::fun!(z_parent_child).name("child")))
+                .class(crate::ptr_class!(ZChild).method(crate::fun!(z_child_name).name("name")))
+                .class(crate::ptr_class!(ZParent).method(crate::fun!(z_parent_child).name("child")))
                 .fun(crate::fun!(z_parent_sub)),
         )
         // Child handle: canonical output = identity (clone) + its name string.
@@ -308,20 +308,22 @@ fn callback_double_option_unwrap_pipeline() {
         .package(
             crate::package!("query")
                 .class(crate::value_class!(ZId))
-                .class(crate::ptr_class!(ZKeyExpr).fun(crate::fun!(z_keyexpr_as_str).name("asStr")))
-                .class(crate::ptr_class!(ZTs).fun(crate::fun!(z_ts_ntp64).name("ntp64")))
+                .class(
+                    crate::ptr_class!(ZKeyExpr).method(crate::fun!(z_keyexpr_as_str).name("asStr")),
+                )
+                .class(crate::ptr_class!(ZTs).method(crate::fun!(z_ts_ntp64).name("ntp64")))
                 .class(
                     crate::ptr_class!(ZSample)
-                        .fun(crate::fun!(z_sample_key_expr).name("keyExpr"))
-                        .fun(crate::fun!(z_sample_timestamp).name("timestamp")),
+                        .method(crate::fun!(z_sample_key_expr).name("keyExpr"))
+                        .method(crate::fun!(z_sample_timestamp).name("timestamp")),
                 )
-                .class(crate::ptr_class!(ZErr).fun(crate::fun!(z_err_payload).name("payload")))
+                .class(crate::ptr_class!(ZErr).method(crate::fun!(z_err_payload).name("payload")))
                 .class(
                     crate::ptr_class!(ZReply)
-                        .fun(crate::fun!(z_reply_zid).name("zid"))
-                        .fun(crate::fun!(z_reply_is_ok).name("isOk"))
-                        .fun(crate::fun!(z_reply_sample).name("sample"))
-                        .fun(crate::fun!(z_reply_err).name("err")),
+                        .method(crate::fun!(z_reply_zid).name("zid"))
+                        .method(crate::fun!(z_reply_is_ok).name("isOk"))
+                        .method(crate::fun!(z_reply_sample).name("sample"))
+                        .method(crate::fun!(z_reply_err).name("err")),
                 )
                 .fun(crate::fun!(z_get)),
         )

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -31,7 +31,7 @@ fn ptr_class_implements_adds_interface_supertypes() {
                 crate::ptr_class!(ZThing)
                     .implements("io.other.Resource")
                     .implements("LocalIface")
-                    .fun(crate::fun!(z_thing_size)),
+                    .method(crate::fun!(z_thing_size)),
             )
             .fun(crate::fun!(z_thing_new)),
     );
@@ -55,8 +55,8 @@ fn ptr_class_implements_adds_interface_supertypes() {
     assert!(thing.contains("import io.other.Resource"), "{thing}");
     // No generated interface, no `override` on the declared member.
     assert!(!thing.contains("interface ZThingApi"), "{thing}");
-    assert!(thing.contains("public fun size("), "{thing}");
-    assert!(!thing.contains("override fun size("), "{thing}");
+    assert!(thing.contains("public fun zThingSize("), "{thing}");
+    assert!(!thing.contains("override fun zThingSize("), "{thing}");
 }
 
 /// #54: `.interface()` — the generated `<Name>Api` interface mirrors the
@@ -81,7 +81,7 @@ fn ptr_class_interface_emits_generated_api() {
                 crate::ptr_class!(ZThing)
                     .interface()
                     .implements("io.other.Resource")
-                    .fun(crate::fun!(z_thing_size)),
+                    .method(crate::fun!(z_thing_size)),
             )
             .fun(crate::fun!(z_thing_new)),
     );
@@ -102,14 +102,14 @@ fn ptr_class_interface_emits_generated_api() {
     assert!(tc.contains("interfaceZThingApi:AutoCloseable{"), "{thing}");
     assert!(tc.contains("funpeek():Long"), "{thing}");
     assert!(tc.contains("funisClosed():Boolean"), "{thing}");
-    assert!(tc.contains("funsize("), "{thing}");
+    assert!(tc.contains("funzThingSize("), "{thing}");
     // Class implements the generated interface + the user one; members override.
     assert!(
         tc.contains("classZThing(initialPtr:Long):NativeHandle(initialPtr),ZThingApi,Resource{"),
         "{thing}"
     );
     assert!(tc.contains("publicoverridefuntake():ZThing"), "{thing}");
-    assert!(tc.contains("publicoverridefunsize("), "{thing}");
+    assert!(tc.contains("publicoverridefunzThingSize("), "{thing}");
 }
 
 /// A duplicate interface on one decl is a decl-time hard error.
@@ -121,7 +121,7 @@ fn ptr_class_duplicate_implements_rejected() {
         .implements("io.other.Resource");
 }
 
-/// The `set_interface_name_mangle` hook receives the final class name and
+/// The `set_interface_name_mangle` hook receives the class package and final name and
 /// its result must differ (identity is a hard error).
 #[test]
 #[should_panic(expected = "must differ from the class name")]
@@ -133,7 +133,10 @@ fn interface_name_mangle_identity_rejected() {
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .set_interface_name_mangle(|n| n.to_string())
+        .set_interface_name_mangle(|package, n| {
+            assert_eq!(package, "io.test.jni.thing");
+            n.to_string()
+        })
         .package(
             crate::package!("thing")
                 .class(crate::ptr_class!(ZThing).interface())
@@ -147,7 +150,7 @@ fn interface_name_mangle_identity_rejected() {
 }
 
 /// A per-decl `.interface_name(...)` pins the interface name (and implies
-/// `.interface()`); `set_interface_name_mangle` receives the class name.
+/// `.interface()`); `set_interface_name_mangle` receives package + class name.
 #[test]
 fn interface_name_override_and_hook() {
     let loc = myflat_loc();
@@ -173,7 +176,8 @@ fn interface_name_override_and_hook() {
     let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .set_interface_name_mangle(|n| {
+        .set_interface_name_mangle(|package, n| {
+            assert_eq!(package, "io.test.jni.m", "hook receives the target package");
             assert_eq!(n, "Mode", "hook receives the class name");
             format!("{n}Contract")
         })
@@ -235,7 +239,7 @@ fn value_class_interface_emits_generated_api() {
         crate::package!("t").class(
             crate::value_class!(ZStamp)
                 .interface()
-                .fun(crate::fun!(z_stamp_secs).name("secs")),
+                .method(crate::fun!(z_stamp_secs).name("secs")),
         ),
     );
     let dir = unique_test_dir("jnigen_value_iface");
@@ -299,7 +303,10 @@ fn per_class_name_and_base_package_fun() {
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         // Rename the handle class; the mangle closures do NOT apply to it.
-        .set_ptr_class_name_mangle(|n| format!("JNI{n}"))
+        .set_ptr_class_name_mangle(|package, n| {
+            assert_eq!(package, "io.test.jni");
+            format!("JNI{n}")
+        })
         .package(
             crate::package!()
                 .class(crate::ptr_class!(ZThing).name("Gadget"))
@@ -377,7 +384,10 @@ fn setters_after_declarations_apply() {
                 .fun(crate::fun!(thing_new)),
         )
         .set_package_prefix("io.late.jni")
-        .set_ptr_class_name_mangle(|n| n.strip_prefix('Z').unwrap_or(n).to_string());
+        .set_ptr_class_name_mangle(|package, n| {
+            assert_eq!(package, "io.late.jni.things");
+            n.strip_prefix('Z').unwrap_or(n).to_string()
+        });
 
     let dir = unique_test_dir("jnigen_setters_after_decls");
     let _ = std::fs::remove_dir_all(&dir);
@@ -450,12 +460,11 @@ fn generation_writes_are_order_free() {
     assert_eq!(kt1, kt2);
 }
 
-/// C1: the default member name is namespace-relative — the class's Rust-name
-/// prefix is stripped from the fn ident (underscore-insensitively), the rest
-/// camel-cases. `.name()` stays verbatim; a no-prefix member falls back to
-/// the full camelCase ident.
+/// The method hook can use package + class context to strip a flat API's
+/// encoded class namespace. `.name()` stays verbatim; an unmatched method
+/// keeps its full camelCase ident.
 #[test]
-fn member_names_default_to_namespace_relative() {
+fn method_hook_can_strip_flat_class_prefix() {
     let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn key_expr_get_str(k: &KeyExpr) -> String { unimplemented!() }",
@@ -471,19 +480,36 @@ fn member_names_default_to_namespace_relative() {
         })
         .collect();
     let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
-        crate::package!("ke").class(
-            crate::ptr_class!(KeyExpr)
-                // Underscore-insensitive strip: `key_expr_` and `keyexpr_`
-                // both spell the class namespace.
-                .fun(crate::fun!(key_expr_get_str))
-                .fun(crate::fun!(keyexpr_intersects))
-                // No class prefix → full camelCase fallback.
-                .fun(crate::fun!(shared_helper))
-                // `.name()` is verbatim and wins over the derivation.
-                .fun(crate::fun!(keyexpr_to_string).name("toStr")),
-        ),
-    );
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_method_name_mangle(|package, class, name| {
+            if class == "JNINative" {
+                return name.to_string();
+            }
+            assert_eq!(package, "io.test.jni.ke");
+            assert_eq!(class, "KeyExpr");
+            if name
+                .get(..class.len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(class))
+            {
+                let rest = &name[class.len()..];
+                let mut chars = rest.chars();
+                if let Some(first) = chars.next() {
+                    return first.to_lowercase().chain(chars).collect();
+                }
+            }
+            name.to_string()
+        })
+        .package(
+            crate::package!("ke").class(
+                crate::ptr_class!(KeyExpr)
+                    .method(crate::fun!(key_expr_get_str))
+                    .method(crate::fun!(keyexpr_intersects))
+                    .method(crate::fun!(shared_helper))
+                    // `.name()` is verbatim and wins over the hook.
+                    .method(crate::fun!(keyexpr_to_string).name("toStr")),
+            ),
+        );
     let dir = unique_test_dir("jnigen_member_names");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -514,11 +540,11 @@ fn member_names_default_to_namespace_relative() {
     assert!(ac.contains("externalfunkeyExprGetStr("), "{all}");
 }
 
-/// C1: `set_member_name_mangle` — the sixth hook — receives the
-/// namespace-stripped camelCase default, skips `.name()`d members, and is
+/// The method hook receives package, final class, and the full camelCase Rust
+/// name, skips `.name()`d methods, and is
 /// order-independent (registered AFTER the `.package(...)` declaration).
 #[test]
-fn member_name_mangle_hook_applies_order_independently() {
+fn method_name_mangle_hook_applies_order_independently() {
     let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn thing_size(t: &ZThing) -> i64 { unimplemented!() }",
@@ -538,14 +564,21 @@ fn member_name_mangle_hook_applies_order_independently() {
             crate::package!("t").class(
                 crate::ptr_class!(ZThing)
                     .name("Thing")
-                    .fun(crate::fun!(thing_size))
-                    .fun(crate::fun!(thing_label).name("label")),
+                    .method(crate::fun!(thing_size))
+                    .method(crate::fun!(thing_label).name("label")),
             ),
         )
         // Registered AFTER the declaration — must still apply (settings are
         // order-independent by construction).
-        .set_member_name_mangle(|n| format!("{n}Native"));
-    let dir = unique_test_dir("jnigen_member_mangle");
+        .set_method_name_mangle(|package, class, n| {
+            if class == "JNINative" {
+                return n.to_string();
+            }
+            assert_eq!(package, "io.test.jni.t");
+            assert_eq!(class, "Thing");
+            format!("{n}Native")
+        });
+    let dir = unique_test_dir("jnigen_method_mangle");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let gen = registry.resolve(jni).expect("resolve");
@@ -557,18 +590,15 @@ fn member_name_mangle_hook_applies_order_independently() {
         .collect::<Vec<_>>()
         .join("\n");
     let ac: String = all.split_whitespace().collect();
-    // Hook over the stripped default (`thing_size` → `size` → `sizeNative`);
-    // note the strip matched the RUST short name ZThing? No — `thing_size`
-    // has no `zthing` prefix, so the fallback full ident applies first:
-    // `thingSize` → `thingSizeNative`.
+    // The hook receives the full default (`thing_size` → `thingSize`).
     assert!(ac.contains("funthingSizeNative("), "{all}");
     // `.name("label")` bypasses the hook entirely.
     assert!(ac.contains("funlabel("), "{all}");
     assert!(!ac.contains("funlabelNative("), "{all}");
 }
 
-/// #56: the harness hook follows the same contract as the other five —
-/// it receives the DERIVED DEFAULT for its tier (`"JNINative"`, an explicit
+/// #56: the harness hook receives the package and DERIVED DEFAULT for its tier
+/// (`"JNINative"`, an explicit
 /// default value, not a hidden `JNI`-prepend) and replaces it wholesale;
 /// the unset default is identity.
 #[test]
@@ -580,7 +610,8 @@ fn harness_hook_receives_derived_default() {
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .set_harness_name_mangle(|n| {
+        .set_harness_name_mangle(|package, n| {
+            assert_eq!(package, "io.test.jni");
             assert_eq!(n, "JNINative", "hook must receive the derived default");
             "MyNative".to_string()
         })
@@ -602,6 +633,49 @@ fn harness_hook_receives_derived_default() {
         .join("\n");
     assert!(all.contains("object MyNative"), "{all}");
     assert!(!all.contains("JNINative"), "{all}");
+}
+
+/// Top-level functions and class methods are separate naming tiers. The
+/// former sees its destination subpackage; the JNI extern sees the base
+/// package plus its generated harness class.
+#[test]
+fn function_and_native_method_hooks_receive_placement() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn =
+        syn::parse_str("pub fn z_session_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_fun_name_mangle(|package, name| {
+            assert_eq!(package, "io.test.jni.session");
+            assert_eq!(name, "zSessionPing");
+            "ping".to_string()
+        })
+        .set_method_name_mangle(|package, class, name| {
+            assert_eq!(package, "io.test.jni");
+            assert_eq!(class, "JNINative");
+            assert_eq!(name, "zSessionPing");
+            format!("{name}Native")
+        })
+        .package(crate::package!("session").fun(crate::fun!(z_session_ping)));
+    let dir = unique_test_dir("jnigen_placement_mangles");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(all.contains("public fun ping("), "{all}");
+    assert!(all.contains("external fun zSessionPingNative("), "{all}");
+    assert!(
+        rust.contains("Java_io_test_jni_JNINative_zSessionPingNative"),
+        "{rust}"
+    );
 }
 
 /// C4: the Kotlin root is generator-owned — `write_kotlin` deletes and
@@ -668,8 +742,8 @@ fn report_explains_the_resolved_surface() {
             crate::package!("ops")
                 .class(
                     crate::ptr_class!(Summary)
-                        .fun(crate::fun!(summary_count))
-                        .fun(crate::fun!(summary_total)),
+                        .method(crate::fun!(summary_count))
+                        .method(crate::fun!(summary_total)),
                 )
                 .fun(crate::fun!(storage_summary))
                 .fun(crate::fun!(z_plain)),
@@ -689,7 +763,9 @@ fn report_explains_the_resolved_surface() {
         "{report}"
     );
     assert!(
-        report.contains("return `Summary` decomposed → [count, total] (Callback delivery)"),
+        report.contains(
+            "return `Summary` decomposed → [summaryCount, summaryTotal] (Callback delivery)"
+        ),
         "{report}"
     );
     // The plain fn appears with no `shaped by:` after it.
@@ -703,12 +779,12 @@ fn report_explains_the_resolved_surface() {
         !after_plain[..next_entry].contains("shaped by:"),
         "{report}"
     );
-    // Class members appear under the class heading with C1-derived names.
+    // Class methods appear under the class heading with their effective names.
     assert!(
         report.contains("## class `io.test.jni.ops.Summary` (ptr_class, Rust `Summary`)"),
         "{report}"
     );
-    assert!(report.contains("fun count("), "{report}");
+    assert!(report.contains("fun summaryCount("), "{report}");
     // Types table with the jlong wire.
     assert!(
         report.contains("- `Summary`: ptr_class → `io.test.jni.ops.Summary`"),
@@ -782,8 +858,8 @@ fn docs_become_kdoc_with_shape_notes() {
             crate::package!("ops")
                 .class(
                     crate::ptr_class!(Summary)
-                        .fun(crate::fun!(summary_count))
-                        .fun(crate::fun!(summary_total)),
+                        .method(crate::fun!(summary_count))
+                        .method(crate::fun!(summary_total)),
                 )
                 .fun(crate::fun!(storage_summary))
                 .fun(crate::fun!(z_plain))
@@ -812,7 +888,7 @@ fn docs_become_kdoc_with_shape_notes() {
         all.contains("The Rust `Summary` result is delivered decomposed"),
         "{all}"
     );
-    assert!(all.contains("(`count`, `total`)"), "{all}");
+    assert!(all.contains("(`summaryCount`, `summaryTotal`)"), "{all}");
     // Member method carries the fn's doc (name derived by C1).
     assert!(all.contains("Count of aggregated entries."), "{all}");
     // Class kdoc: author prose FIRST, framework line after.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -597,7 +597,7 @@ fn method_name_mangle_hook_applies_order_independently() {
     assert!(!ac.contains("funlabelNative("), "{all}");
 }
 
-/// #56: the harness hook receives the package and DERIVED DEFAULT for its tier
+/// #56: the harness hook receives the DERIVED DEFAULT for its tier
 /// (`"JNINative"`, an explicit
 /// default value, not a hidden `JNI`-prepend) and replaces it wholesale;
 /// the unset default is identity.
@@ -610,8 +610,7 @@ fn harness_hook_receives_derived_default() {
         Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
-        .set_harness_name_mangle(|package, n| {
-            assert_eq!(package, "io.test.jni");
+        .set_harness_name_mangle(|n| {
             assert_eq!(n, "JNINative", "hook must receive the derived default");
             "MyNative".to_string()
         })

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -27,8 +27,8 @@ fn inline_output_gets_own_builder() {
             crate::package!("thing")
                 .class(
                     crate::ptr_class!(ZThing)
-                        .fun(crate::fun!(z_thing_name).name("name"))
-                        .fun(crate::fun!(z_thing_size).name("size")),
+                        .method(crate::fun!(z_thing_name).name("name"))
+                        .method(crate::fun!(z_thing_size).name("size")),
                 )
                 .fun(crate::fun!(z_make_a))
                 // Per-fn inline fields: name + size + name again (different shape). The
@@ -121,11 +121,11 @@ fn error_unwrap_universal_records() {
         .set_package_prefix("io.test.jni")
         .package(
             crate::package!("errors")
-                .class(crate::ptr_class!(ZDetail).fun(crate::fun!(z_detail_code).name("code")))
+                .class(crate::ptr_class!(ZDetail).method(crate::fun!(z_detail_code).name("code")))
                 .class(
                     crate::ptr_class!(ZErr)
-                        .fun(crate::fun!(z_err_message).name("message"))
-                        .fun(crate::fun!(z_err_detail).name("detail")),
+                        .method(crate::fun!(z_err_message).name("message"))
+                        .method(crate::fun!(z_err_detail).name("detail")),
                 )
                 .fun(crate::fun!(z_fallible)),
         )
@@ -214,7 +214,7 @@ fn error_unwrap_universal_records() {
     assert!(!all.contains("?:\"\""), "{all}");
 }
 
-/// `.fun(f)` binds the `&Class` receiver to `this` (dropped from the
+/// `.method(f)` binds the `&Class` receiver to `this` (dropped from the
 /// signature, its handle locked) while keeping the non-receiver params; the
 /// fn delegates to the same `JNINative` extern. `.constructor(f)` emits a
 /// companion-object factory returning the class. Per-fn
@@ -241,9 +241,9 @@ fn method_constructor_and_inline_field_self() {
         crate::package!("thing")
             .class(
                 crate::ptr_class!(ZThing)
-                    .fun(crate::fun!(z_thing_name).name("name"))
-                    // A fun with extra params: `&ZThing` receiver + a `name: String` param.
-                    .fun(crate::fun!(z_thing_rename).name("rename"))
+                    .method(crate::fun!(z_thing_name).name("name"))
+                    // A method with extra params: `&ZThing` receiver + a `name: String` param.
+                    .method(crate::fun!(z_thing_rename).name("rename"))
                     // A constructor: factory returning ZThing.
                     .constructor(crate::fun!(z_thing_make).name("make")),
             )
@@ -504,7 +504,7 @@ fn fn_expand_return_type_mismatch_rejected() {
     let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
-            .class(crate::ptr_class!(ZThing).fun(crate::fun!(z_thing_name).name("name")))
+            .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))
             .class(crate::ptr_class!(ZOther))
             // Wrong type: z_make returns ZThing, not ZOther.
             .fun(crate::fun!(z_make).expand_return(crate::expand_return!(ZOther).field_self())),
@@ -693,11 +693,11 @@ fn expand_return_field_with_name_accepted() {
     let _ = crate::expand_return!(ZThing).field(crate::fun!(z_thing_name).name("label"));
 }
 
-/// N5: a `.fun()` member whose target has no parameter of the class type
+/// N5: a `.method()` whose target has no parameter of the class type
 /// is a hard `AdapterInvariant` error at resolve — previously it silently
 /// emitted a method that ignored `this`.
 #[test]
-fn member_fun_without_receiver_rejected() {
+fn method_without_receiver_rejected() {
     let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_thing_free_standing(v: i64) -> i64 { unimplemented!() }",
@@ -714,14 +714,14 @@ fn member_fun_without_receiver_rejected() {
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t").class(
             crate::ptr_class!(ZThing)
-                .fun(crate::fun!(z_thing_free_standing))
+                .method(crate::fun!(z_thing_free_standing))
                 .constructor(crate::fun!(z_make)),
         ),
     );
     let err = registry.resolve(jni).expect_err("receiver-less member");
     let msg = format!("{err}");
     assert!(
-        msg.contains("member fun `z_thing_free_standing`") && msg.contains("`ZThing`"),
+        msg.contains("method `z_thing_free_standing`") && msg.contains("`ZThing`"),
         "{msg}"
     );
 }
@@ -745,7 +745,7 @@ fn constructor_with_wrong_return_rejected() {
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t").class(
             crate::ptr_class!(ZThing)
-                .fun(crate::fun!(z_thing_len))
+                .method(crate::fun!(z_thing_len))
                 .constructor(crate::fun!(z_make_number)),
         ),
     );

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -732,7 +732,7 @@ fn data_class_members_reenter_as_field_leaves() {
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!().class(
             crate::data_class!(Point)
-                .fun(crate::fun!(point_norm).name("norm"))
+                .method(crate::fun!(point_norm).name("norm"))
                 .constructor(crate::fun!(point_origin).name("origin")),
         ),
     );

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -445,11 +445,11 @@ pub(crate) fn build_signal_error_item() -> syn::Item {
 /// runs (e.g. `Publisher` network-undeclare) with no special casing.
 ///
 /// The symbol follows the documented scheme
-/// `Java_<package_underscores>_<class_short>_<mangle_fun("freePtr")>`,
+/// `Java_<package_underscores>_<class_short>_<mangled-freePtr>`,
 /// where `class_short` is the last segment of the typed-handle FQN
 /// (`TypeConfig::kotlin_name`) and the `freePtr` name passes through
-/// [`JniGen::mangle_fun`] — exact symmetry with the Kotlin
-/// `external fun <mangle_fun("freePtr")>` declaration in
+/// the package/class-aware method hook — exact symmetry with the Kotlin
+/// `external fun <mangled-freePtr>` declaration in
 /// [`render_typed_handle_source`]. `ext.types` is a `HashMap`, so the
 /// items are sorted by symbol to keep generated output deterministic.
 ///
@@ -463,7 +463,6 @@ pub(crate) fn build_handle_destructor_items(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
-    let free_ptr = ext.mangle_fun("freePtr");
     let mut named: Vec<(String, syn::Item)> = Vec::new();
     for (key, cfg) in &ext.types {
         if cfg.opaque.is_none() {
@@ -487,11 +486,9 @@ pub(crate) fn build_handle_destructor_items(
                 )
             });
         let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
-        let class_pkg = class_fqn
-            .rsplit_once('.')
-            .map(|(pkg, _)| pkg)
-            .unwrap_or("")
-            .replace('.', "_");
+        let class_package = class_fqn.rsplit_once('.').map(|(pkg, _)| pkg).unwrap_or("");
+        let free_ptr = ext.mangle_method(class_package, class_short, "freePtr");
+        let class_pkg = class_package.replace('.', "_");
         let symbol = if class_pkg.is_empty() {
             format!("Java_{class_short}_{free_ptr}")
         } else {
@@ -1005,21 +1002,21 @@ impl Prebindgen for JniGen {
 
     /// Functions ever referenced as a named `.field(fun!(...))` in any
     /// `expand_return!` decl, type-level or per-fn — see
-    /// [`JniGen::field_accessor_fns`]. Usage-derived, not tied to `.fun()`
+    /// [`JniGen::field_accessor_fns`]. Usage-derived, not tied to `.method()`
     /// class-member declarations: a function need not also be exposed as an
     /// instance method to be referenced this way.
     fn accessor_functions(&self) -> std::collections::HashSet<syn::Ident> {
         self.field_accessor_fns()
     }
 
-    /// Fun members (`.fun`) — their fn ident mapped to the owning class's
+    /// Methods (`.method`) — their fn ident mapped to the owning class's
     /// `TypeKey`, so input-flattening can skip the receiver parameter.
     fn method_receivers(&self) -> std::collections::HashMap<syn::Ident, TypeKey> {
         self.class_members
             .iter()
             .flat_map(|(key, ms)| {
                 ms.iter()
-                    .filter(|m| m.kind == MemberKind::Fun)
+                    .filter(|m| m.kind == MemberKind::Method)
                     .map(move |m| (m.rust_ident.clone(), key.clone()))
             })
             .collect()
@@ -1067,7 +1064,7 @@ impl Prebindgen for JniGen {
     }
 
     /// Member-shape invariants (N5), checked against registry signatures —
-    /// the earliest possible moment. Without this, a receiver-less `.fun()`
+    /// the earliest possible moment. Without this, a receiver-less `.method()`
     /// member would silently emit a method that ignores `this`, and a
     /// wrong-return `.constructor()` a factory of the wrong type.
     fn validate(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
@@ -1078,7 +1075,7 @@ impl Prebindgen for JniGen {
                     continue;
                 };
                 match m.kind {
-                    MemberKind::Fun => {
+                    MemberKind::Method => {
                         let has_receiver = item_fn.sig.inputs.iter().any(|input| {
                             matches!(input, syn::FnArg::Typed(pt)
                                 if &peel_receiver_key(&pt.ty) == key)
@@ -1096,7 +1093,7 @@ impl Prebindgen for JniGen {
                                 })
                                 .collect();
                             return Err(format!(
-                                "class `{}` member fun `{}`: no parameter of type `{}` — an \
+                                "class `{}` method `{}`: no parameter of type `{}` — an \
                                  instance method's receiver must appear in the signature \
                                  (took: {})",
                                 key.as_str(),

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -19,42 +19,6 @@ pub(crate) fn snake_to_camel(s: &str) -> String {
     out
 }
 
-/// Strip a type's **namespace prefix** from a flat-crate fn ident: a flat
-/// Rust crate spells the type namespace inside the ident (`storage_len`,
-/// `keyexpr_intersects`) because flat FFI has no method syntax; a class
-/// member already lives in its class's namespace, so its default Kotlin
-/// name removes exactly that prefix — nothing else.
-///
-/// Matching is underscore-insensitive on both sides (class `KeyExpr`
-/// strips `keyexpr_get_str` AND `key_expr_get_str`): leading
-/// `_`-separated segments of `ident` are consumed while their
-/// concatenation (lowercased) is a prefix of the lowercased,
-/// underscore-free `type_short`. Succeeds only when the consumed segments
-/// spell the class name exactly and a non-empty remainder follows.
-pub(crate) fn strip_type_prefix<'a>(ident: &'a str, type_short: &str) -> Option<&'a str> {
-    let class: String = type_short
-        .chars()
-        .filter(|c| *c != '_')
-        .flat_map(|c| c.to_lowercase())
-        .collect();
-    if class.is_empty() {
-        return None;
-    }
-    let mut consumed = String::new();
-    let mut rest = ident;
-    while let Some((seg, tail)) = rest.split_once('_') {
-        consumed.extend(seg.chars().flat_map(|c| c.to_lowercase()));
-        if !class.starts_with(&consumed) {
-            return None;
-        }
-        rest = tail;
-        if consumed == class {
-            return if rest.is_empty() { None } else { Some(rest) };
-        }
-    }
-    None
-}
-
 /// Extract an item's `///` documentation from its captured attributes
 /// (`#[doc = " …"]` lines, in order): one leading space stripped per line,
 /// joined with `\n`; `None` when the item carries no docs. `*/` is

--- a/prebindgen/src/api/lang/jnigen/util/tests.rs
+++ b/prebindgen/src/api/lang/jnigen/util/tests.rs
@@ -67,38 +67,6 @@ fn discriminants_non_literal_rejected() {
 }
 
 #[test]
-fn strip_type_prefix_basics() {
-    use super::strip_type_prefix;
-    // Plain one-segment class namespace.
-    assert_eq!(strip_type_prefix("storage_len", "Storage"), Some("len"));
-    assert_eq!(
-        strip_type_prefix("payload_label_len", "Payload"),
-        Some("label_len")
-    );
-    // Underscore-insensitive on both sides: class KeyExpr vs `keyexpr_` and
-    // `key_expr_` idents.
-    assert_eq!(
-        strip_type_prefix("keyexpr_get_str", "KeyExpr"),
-        Some("get_str")
-    );
-    assert_eq!(
-        strip_type_prefix("key_expr_get_str", "KeyExpr"),
-        Some("get_str")
-    );
-    assert_eq!(
-        strip_type_prefix("zbytes_as_bytes", "ZBytes"),
-        Some("as_bytes")
-    );
-    // No namespace prefix → None (fallback keeps the full ident).
-    assert_eq!(strip_type_prefix("millis_add", "Storage"), None);
-    // Partial overlap that never completes the class name → None.
-    assert_eq!(strip_type_prefix("key_something", "KeyExpr"), None);
-    // The ident IS the class name alone → None (empty remainder).
-    assert_eq!(strip_type_prefix("storage", "Storage"), None);
-    assert_eq!(strip_type_prefix("storage_", "Storage"), None);
-}
-
-#[test]
 fn doc_string_extracts_and_sanitizes() {
     use super::doc_string;
     let f: syn::ItemFn = syn::parse_quote! {


### PR DESCRIPTION
## Summary

- pass the fully qualified destination package to placement-aware JniGen name-mangling hooks; keep the fixed-placement harness hook name-only
- separate package function naming from class method naming with set_method_name_mangle(package, class, name)
- rename class declaration .fun(...) to .method(...) and remove implicit generator-specific class-prefix stripping
- route JNINative externs, handle destructors, vector helpers, class methods, and factories through the contextual method hook
- keep explicit .name(...) overrides verbatim and order-independent

This enables binding consumers such as zenoh-flat-jni to systematize flat Rust names like z_session_put into Session.put without teaching prebindgen a Zenoh-specific convention.

Linked downstream PRs:
- https://github.com/ZettaScaleLabs/zenoh-flat-jni/pull/2
- https://github.com/eclipse-zenoh/zenoh-java/pull/481

## Verification

- cargo clippy --all-targets --no-default-features --all-features -- --deny warnings
- cargo test --all --all-features
- bash examples/regen-check.sh
- examples/covertest-kotlin: ./gradlew run (26 sections pass)