### PR TITLE
core: Optional selector-dispatched expansion — the selector encodes absence

### DIFF
--- a/examples/covertest-helpers/src/lib.rs
+++ b/examples/covertest-helpers/src/lib.rs
@@ -44,6 +44,16 @@ pub fn millis_value(m: &Millis) -> i64 {
     m.0 as i64
 }
 
+/// Optionally-supplied summary total — exercises the **Optional
+/// combined-selector expansion**: `Summary`'s dual-arm type default (build
+/// from `(count, total)` OR pass a handle) applies to this `Option<&Summary>`
+/// parameter, so the selector also encodes absence (`-1` = `None`). Returns
+/// `-1.0` when absent.
+#[prebindgen]
+pub fn summary_total_opt(s: Option<&Summary>) -> f64 {
+    s.map(summary_total).unwrap_or(-1.0)
+}
+
 /// Two-`Summary`-parameter function exercising #52's **cartesian-product**
 /// overloads: covertest declares `.split_on_param("primary")
 /// .split_on_param("fallback")`, so each parameter is independently split into

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -28,6 +28,7 @@
 //! | `convert!` sources `.with(path!)`/`.error(ty!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
+//! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones |
 //! | `FunctionDecl::split_on_param` (#52)  | single: `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); cartesian product: `summaryPrefer` (2 params); manual same-named overload in `ManualOverloads.kt` |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
@@ -381,6 +382,11 @@ fn main() {
                         .split_on_param("primary")
                         .split_on_param("fallback"),
                 )
+                // Optional combined-selector expansion: `Option<&Summary>` under
+                // the dual-arm type default — the selector also encodes absence
+                // (`-1` = `None`); the borrow-identity arm clones, so the
+                // caller's handle survives the call.
+                .fun(fun!(summary_total_opt))
                 // The borrowed-accessor trio. `archive_latest` suppresses the default
                 // Summary return-field default so the BORROWED handle path (clone into a
                 // fresh owned handle, null when absent) is what crosses.

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -29,6 +29,8 @@ Base package: `io.prebindgen.covertest`
 - `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
+- `summary_total_opt` — `fun summaryTotalOpt(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
+  - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
 - `summary_total_raw` — `fun summaryTotalRaw(s: Summary, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
 
 ## package `io.prebindgen.covertest.model`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -659,6 +659,15 @@ internal object CovNative {
     ): Long
     external fun summaryScaled(s: Long, factor: Double, errorSink: Any): Double
     external fun summaryTotal(s: Long, errorSink: Any): Double
+    external fun summaryTotalOpt(
+        sSel: Int,
+        s00Present: Boolean,
+        s00Value: Long,
+        s01Present: Boolean,
+        s01Value: Double,
+        s1: Long,
+        errorSink: Any,
+    ): Double
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double
     external fun constGetCoverMagic(errorSink: Any): Long
     external fun constGetCoverTag(errorSink: Any): String

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -407,6 +407,44 @@ public fun summaryPrefer(
     return __ret
 }
 
+/**
+ * Optionally-supplied summary total — exercises the **Optional
+ * combined-selector expansion**: `Summary`'s dual-arm type default (build
+ * from `(count, total)` OR pass a handle) applies to this `Option<&Summary>`
+ * parameter, so the selector also encodes absence (`-1` = `None`). Returns
+ * `-1.0` when absent.
+ *
+ * Parameter `s` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm, `-1` = absent (crosses as `sSel`, `s00`, `s01`, `s1`).
+ */
+public fun summaryTotalOpt(
+    sSel: Int,
+    s00: Long?,
+    s01: Double?,
+    s1: Summary?,
+    onError: JniErrorHandler<Double>,
+): Double {
+    if (s1 != null && s1.isClosed()) return onError.run("Operation on a closed native handle.")
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        s1?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val s1_ptr = s1?.ptr ?: 0L
+            CovNative.summaryTotalOpt(
+                sSel,
+                s00 != null,
+                s00 ?: 0L,
+                s01 != null,
+                s01 ?: 0.0,
+                s1_ptr,
+                __cap,
+            )
+        }
+    }
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
 /** Create an empty archive. */
 public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
     val __cap = JniErrorHandlerCapture.acquire()

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -11,6 +11,7 @@ import io.prebindgen.covertest.analytics.storageSummary
 import io.prebindgen.covertest.analytics.storageSummaryFull
 import io.prebindgen.covertest.analytics.storageSummaryHandle
 import io.prebindgen.covertest.analytics.summaryPrefer
+import io.prebindgen.covertest.analytics.summaryTotalOpt
 import io.prebindgen.covertest.analytics.summaryTotalRaw
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.model.Annotated
@@ -296,6 +297,16 @@ fun main() {
         check(
             summaryPrefer(Summary.of(1L, 1.0, boom), Summary.of(3L, 99.0, boom), boom) == 0L,
         )                                                                          // handle / handle
+
+        // Optional combined-selector expansion: `Option<&Summary>` under the
+        // dual-arm type default. The selector also encodes absence (-1 = None);
+        // the borrow-identity arm CLONES, so the handle survives the call.
+        check(summaryTotalOpt(-1, null, null, null, boom) == -1.0)     // absent
+        check(summaryTotalOpt(0, 2L, 40.0, null, boom) == 40.0)        // build arm
+        val hOpt = Summary.of(3L, 99.0, boom)
+        check(summaryTotalOpt(1, null, null, hOpt, boom) == 99.0)      // borrow-identity arm
+        check(hOpt.total(boom) == 99.0)                                // handle still live
+        hOpt.close()
 
         // Auto-generated overloads coexist with a HAND-WRITTEN same-named one
         // (issue #52's manual path): `ManualOverloads.kt` adds another

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1680,6 +1680,13 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jlong_to_Option_Summary_828826f3<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<Option<OwnedObject<perftest_flat::Summary>>, __JniErr> {
+    Ok({ if *v == 0 { None } else { Some(jlong_to_Summary_3cb103b9(env, v)?) } })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -6741,6 +6748,186 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotal<'a>
         }
     };
     let __out = perftest_flat::summary_total(&s);
+    match f64_to_jdouble_9e4a8f70(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0.0 as jni::sys::jdouble
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    s_sel: jni::sys::jint,
+    s_0_0_present: jni::sys::jboolean,
+    s_0_0_value: jni::sys::jlong,
+    s_0_1_present: jni::sys::jboolean,
+    s_0_1_value: jni::sys::jdouble,
+    s_1: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jdouble {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __exp_s_sel = match jint_to_i32_a3e3b6ef(&mut env, &s_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0.0 as jni::sys::jdouble;
+        }
+    };
+    let __exp_s_0_0: Option<i64> = if s_0_0_present != 0u8 {
+        let __v = match jlong_to_i64_fbf9a9bc(&mut env, &s_0_0_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return 0.0 as jni::sys::jdouble;
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_s_0_1: Option<f64> = if s_0_1_present != 0u8 {
+        let __v = match jdouble_to_f64_9e4a8f70(&mut env, &s_0_1_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return 0.0 as jni::sys::jdouble;
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_s_1 = match jlong_to_Option_Summary_828826f3(&mut env, &s_1) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0.0 as jni::sys::jdouble;
+        }
+    };
+    let __folded_s = match if __exp_s_sel < 0 {
+        ::core::result::Result::Ok(::core::option::Option::None)
+    } else {
+        ({
+            match __exp_s_sel {
+                0i32 => {
+                    match (__exp_s_0_0, __exp_s_0_1) {
+                        (
+                            ::core::option::Option::Some(__p0),
+                            ::core::option::Option::Some(__p1),
+                        ) => {
+                            ::core::result::Result::Ok(
+                                perftest_flat::summary_new(__p0, __p1),
+                            )
+                        }
+                        _ => {
+                            ::core::result::Result::Err(
+                                ::std::string::String::from(
+                                    "constructor variant input missing",
+                                ),
+                            )
+                        }
+                    }
+                }
+                1i32 => {
+                    match __exp_s_1 {
+                        ::core::option::Option::Some(__v) => {
+                            ::core::result::Result::Ok(
+                                ::core::clone::Clone::clone(&*__v),
+                            )
+                        }
+                        ::core::option::Option::None => {
+                            ::core::result::Result::Err(
+                                ::std::string::String::from(
+                                    "identity variant value missing",
+                                ),
+                            )
+                        }
+                    }
+                }
+                __sel => {
+                    ::core::result::Result::Err(
+                        ::std::format!("invalid constructor selector: {}", __sel),
+                    )
+                }
+            }
+        })
+            .map(::core::option::Option::Some)
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__je.to_string()),
+                &__zd,
+            );
+            return 0.0 as jni::sys::jdouble;
+        }
+    };
+    let __out = cov_helpers::summary_total_opt(__folded_s.as_ref());
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -466,18 +466,41 @@ fn build_plan<M>(
     let param = &ed.param;
     let mut leaves: Vec<FoldLeaf> = Vec::new();
 
-    // Optional (`Option<T>`/`Option<&T>`) param: a single (never
-    // selector-dispatched) constructor. No recursion under `Optional`.
-    //  * single-arg ctor → one nullable leaf (`Option<arg>`) decides presence.
-    //  * multi-arg ctor  → an explicit leading `present: bool` flag + one plain
-    //    (non-`Option`) leaf per arg. The flag keeps nullable primitive args
-    //    (e.g. an `Option<i32>` id) from boxing on the wire.
+    // Optional (`Option<T>`/`Option<&T>`) param. No recursion under `Optional`.
+    //  * single single-arg ctor → one nullable leaf (`Option<arg>`) decides
+    //    presence.
+    //  * single multi-arg ctor  → an explicit leading `present: bool` flag +
+    //    one plain (non-`Option`) leaf per arg. The flag keeps nullable
+    //    primitive args (e.g. an `Option<i32>` id) from boxing on the wire.
+    //  * combined (≥2 variants) → the same selector dispatch as a non-optional
+    //    param, with the selector ALSO encoding absence: `-1` = `None`,
+    //    `0..n-1` = the taken arm (no separate present flag — not-taken arms'
+    //    leaves are null exactly as in the non-optional selector case).
     if optional {
         let [Variant::Ctor(func)] = variants else {
-            return Err(ExpandError::UnsupportedOptional {
-                func: ed.func.clone(),
-                param: ed.param.clone(),
-                reason: "selector-dispatched constructors cannot be optional",
+            // Combined-selector dispatch under `Optional`.
+            visited.insert(TypeKey::from_type(target));
+            let prefix = param.to_string();
+            let (selector, fold_variants) = build_core(
+                exp,
+                registry,
+                ed,
+                target,
+                variants,
+                by_ref,
+                &prefix,
+                &mut leaves,
+                visited,
+            )?;
+            visited.remove(&TypeKey::from_type(target));
+            return Ok(FoldPlan {
+                target: target.clone(),
+                by_ref,
+                shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
+                leaves,
+                selector,
+                present: None,
+                variants: fold_variants,
             });
         };
         let sig = ctor_signature(registry, func)?;
@@ -499,7 +522,7 @@ fn build_plan<M>(
                     ctor: Some(func.clone()),
                     fallible: sig.fallible,
                     clone: false,
-                    inputs: vec![FoldArg::Leaf(0)],
+                    inputs: vec![FoldArg::Leaf(0, false)],
                 }],
             });
         }
@@ -666,7 +689,7 @@ fn build_core<M>(
                         ctor: None,
                         fallible: false,
                         clone: by_ref,
-                        inputs: vec![FoldArg::Leaf(idx)],
+                        inputs: vec![FoldArg::Leaf(idx, false)],
                     });
                 }
             }
@@ -743,11 +766,21 @@ fn build_arg<M>(
         })))
     } else {
         let idx = leaves.len();
+        // A dispatched (selector-presence) arm `Option`-wraps its leaves — but
+        // an argument that is itself `Option<…>` passes through with its own
+        // type: `None` is a legitimate value for the taken arm, and the wire
+        // cannot represent the double `Option` anyway. Marked `passthrough` so
+        // the emit side skips the selector-presence unwrap.
+        let passthrough = dispatched && popt;
         leaves.push(FoldLeaf {
             name,
-            ty: if dispatched { opt(pty) } else { pty.clone() },
+            ty: if dispatched && !passthrough {
+                opt(pty)
+            } else {
+                pty.clone()
+            },
         });
-        Ok(FoldArg::Leaf(idx))
+        Ok(FoldArg::Leaf(idx, passthrough))
     }
 }
 
@@ -802,7 +835,19 @@ fn fold_shape(
     match shape {
         FoldShape::Base => emit_core_construct(plan, leaf_locals, bound, qualify),
         FoldShape::Optional((), inner) => {
-            if let Some(pidx) = plan.present {
+            if let Some(sidx) = plan.selector {
+                // Combined-selector dispatch under `Optional`: the selector
+                // ALSO encodes absence — `-1` = `None`, `0..n-1` = the taken
+                // arm (dispatched by the shared construct core; an out-of-range
+                // selector still hits its `Err` default arm).
+                let sel_local = &leaf_locals[sidx];
+                let inner_expr = emit_core_construct(plan, leaf_locals, None, qualify);
+                syn::parse_quote!(if #sel_local < 0 {
+                    ::core::result::Result::Ok(::core::option::Option::None)
+                } else {
+                    (#inner_expr).map(::core::option::Option::Some)
+                })
+            } else if let Some(pidx) = plan.present {
                 // Multi-arg: an explicit `present: bool` flag decides presence;
                 // the construct reads its plain arg leaves directly (`bound =
                 // None`), the flag leaf is consumed only by this `if`.
@@ -937,7 +982,7 @@ fn variant_result_expr(
     // constructor — `build_arg` rejects nesting under a dispatched variant).
     let leaf = |a: &FoldArg| -> &syn::Ident {
         match a {
-            FoldArg::Leaf(i) => &leaf_locals[*i],
+            FoldArg::Leaf(i, _) => &leaf_locals[*i],
             FoldArg::Build(_) => {
                 unreachable!("recursive Build arg only in a non-dispatched single constructor")
             }
@@ -976,36 +1021,54 @@ fn variant_result_expr(
         Some(func) => {
             let path = qualify(func);
             if dispatched {
-                // Combined arm — Leaf-only inputs, `Option`-wrapped (selector
-                // presence); unwrap or yield `Err`.
-                let input_locals: Vec<&syn::Ident> = v.inputs.iter().map(&leaf).collect();
-                let bind: Vec<syn::Ident> = (0..input_locals.len())
-                    .map(|i| ident(&format!("__p{}", i)))
-                    .collect();
-                let call = ctor_call_result(&path, &bind, v.fallible);
+                // Combined arm — Leaf-only inputs. Selector-presence-wrapped
+                // inputs are unwrapped (missing ⇒ `Err`); **passthrough**
+                // inputs (constructor args that are themselves `Option<…>`)
+                // pass their decoded local directly — `None` is a legitimate
+                // value for the taken arm.
+                let mut wrapped_locals: Vec<&syn::Ident> = Vec::new();
+                let mut wrapped_binds: Vec<syn::Ident> = Vec::new();
+                let mut call_args: Vec<syn::Expr> = Vec::new();
+                for (i, a) in v.inputs.iter().enumerate() {
+                    let loc = leaf(a);
+                    if matches!(a, FoldArg::Leaf(_, true)) {
+                        call_args.push(syn::parse_quote!(#loc));
+                    } else {
+                        let b = ident(&format!("__p{}", i));
+                        wrapped_locals.push(loc);
+                        wrapped_binds.push(b.clone());
+                        call_args.push(syn::parse_quote!(#b));
+                    }
+                }
+                let call = ctor_call_result(&path, &call_args, v.fallible);
                 let missing = quote!(::core::result::Result::Err(::std::string::String::from(
                     "constructor variant input missing"
                 )));
-                if input_locals.len() == 1 {
-                    // `match a { Some(p0) => <call>, None => Err }`
-                    let loc = input_locals[0];
-                    let p0 = &bind[0];
-                    syn::parse_quote!(match #loc {
-                        ::core::option::Option::Some(#p0) => #call,
-                        ::core::option::Option::None => #missing,
-                    })
-                } else {
-                    // `match (a, b, …) { (Some(p0), Some(p1), …) => <call>, _ => Err }`
-                    let some_pats: Vec<TokenStream> = bind
-                        .iter()
-                        .map(|b| quote!(::core::option::Option::Some(#b)))
-                        .collect();
-                    syn::parse_quote!(match ( #(#input_locals),* ) {
-                        ( #(#some_pats),* ) => #call,
-                        _ => #missing,
-                    })
+                match wrapped_locals.len() {
+                    // All-passthrough arm: the selector alone decides; call directly.
+                    0 => call,
+                    1 => {
+                        // `match a { Some(p0) => <call>, None => Err }`
+                        let loc = wrapped_locals[0];
+                        let p0 = &wrapped_binds[0];
+                        syn::parse_quote!(match #loc {
+                            ::core::option::Option::Some(#p0) => #call,
+                            ::core::option::Option::None => #missing,
+                        })
+                    }
+                    _ => {
+                        // `match (a, b, …) { (Some(p0), Some(p1), …) => <call>, _ => Err }`
+                        let some_pats: Vec<TokenStream> = wrapped_binds
+                            .iter()
+                            .map(|b| quote!(::core::option::Option::Some(#b)))
+                            .collect();
+                        syn::parse_quote!(match ( #(#wrapped_locals),* ) {
+                            ( #(#some_pats),* ) => #call,
+                            _ => #missing,
+                        })
+                    }
                 }
-            } else if v.inputs.iter().all(|a| matches!(a, FoldArg::Leaf(_))) {
+            } else if v.inputs.iter().all(|a| matches!(a, FoldArg::Leaf(..))) {
                 // Non-dispatched, flat (no recursion): call directly — identical
                 // to the pre-recursion form.
                 let args: Vec<&syn::Ident> = v.inputs.iter().map(&leaf).collect();
@@ -1019,7 +1082,7 @@ fn variant_result_expr(
                 for (i, a) in v.inputs.iter().enumerate() {
                     let ai = ident(&format!("__a{}", i));
                     match a {
-                        FoldArg::Leaf(li) => {
+                        FoldArg::Leaf(li, _) => {
                             let loc = &leaf_locals[*li];
                             stmts.push(quote!(let #ai = #loc;));
                             args.push(quote!(#ai));

--- a/prebindgen/src/api/core/expand/plan.rs
+++ b/prebindgen/src/api/core/expand/plan.rs
@@ -30,7 +30,9 @@ pub struct FoldPlan {
     /// Flattened wire leaves, in foreign-signature order.
     pub leaves: Vec<FoldLeaf>,
     /// Index into [`Self::leaves`] of the selector leaf; `None` for a single
-    /// constructor (the sole variant is applied unconditionally).
+    /// constructor (the sole variant is applied unconditionally). Under an
+    /// [`Optional`](FoldShape::Optional) shape the selector also encodes
+    /// **absence**: `-1` = `None`, `0..n-1` = the taken arm.
     pub selector: Option<usize>,
     /// Index into [`Self::leaves`] of the explicit presence-flag (`bool`) leaf
     /// for a **multi-argument** `Optional` shape (`Option<T>` built from a
@@ -87,7 +89,15 @@ pub struct FoldVariant {
 #[derive(Clone)]
 pub enum FoldArg {
     /// Decode the flat wire leaf at this index into [`FoldPlan::leaves`].
-    Leaf(usize),
+    ///
+    /// The `bool` is the **passthrough** marker for selector-dispatched arms:
+    /// `false` = the leaf is `Option`-wrapped by selector presence and is
+    /// unwrapped before the constructor call (a missing input is an error);
+    /// `true` = the constructor argument is itself an `Option<…>`, so the leaf
+    /// keeps the argument's own type and passes through unwrapped (`None` is a
+    /// legitimate value for the taken arm — arm-taken-ness is decided by the
+    /// selector alone). Always `false` outside dispatched arms.
+    Leaf(usize, bool),
     /// Build this parameter by recursively folding its own default
     /// constructor (the parameter's type is itself a ptr_class with a default
     /// input). Its leaves live in the shared flat [`FoldPlan::leaves`].

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -263,30 +263,87 @@ fn optional_byref_multi_arg_ctor() {
 }
 
 #[test]
-fn optional_combined_rejected() {
+fn optional_combined_selector_encodes_absence() {
+    // `encoding: Option<&ZEncoding>` with TWO variants — build-from
+    // `z_encoding_from_id(i32, Option<String>)` OR identity — composes the
+    // selector dispatch under `Optional`: the selector leaf also encodes
+    // absence (`-1` = `None`). The ctor's own `Option<String>` arg is a
+    // PASSTHROUGH leaf (kept as `Option<String>`, not double-wrapped —
+    // `None` is a legitimate value for the taken arm).
     let mut reg = reg_with(&[
-        "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
-        "fn z_session_get(s: &ZSession, ke: Option<ZKeyExpr>) -> bool { todo!() }",
+        "fn z_encoding_from_id(id: i32, schema: Option<String>) -> ZEncoding { todo!() }",
+        "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
     exp.begin_subset(
-        ident("z_session_get"),
-        ident("ke"),
-        syn::parse_quote!(ZKeyExpr),
+        ident("z_session_put"),
+        ident("encoding"),
+        syn::parse_quote!(ZEncoding),
     );
-    exp.push_subset_variant(ident("z_keyexpr_try_from"));
+    exp.push_subset_variant(ident("z_encoding_from_id"));
     exp.push_subset_self();
 
-    match apply(
+    apply(
         &mut reg,
         &exp,
         &Default::default(),
         &Default::default(),
         &Default::default(),
-    ) {
-        Err(ExpandError::UnsupportedOptional { .. }) => {}
-        other => panic!("expected UnsupportedOptional, got {:?}", other.err()),
-    }
+    )
+    .expect("apply optional combined");
+    let plan = reg
+        .expansion_plans
+        .get(&(ident("z_session_put"), ident("encoding")))
+        .unwrap();
+    assert!(matches!(plan.shape, FoldShape::Optional((), _)));
+    assert!(plan.produces_option());
+    assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
+    assert_eq!(plan.selector, Some(0), "selector at leaf 0");
+    assert_eq!(plan.present, None, "absence rides the selector, no flag");
+    // leaves: sel:i32, id:Option<i32> (wrapped), schema:Option<String>
+    // (passthrough), identity:Option<&ZEncoding>.
+    assert_eq!(plan.leaves.len(), 4);
+    assert_eq!(plan.leaves[0].name.to_string(), "encoding_sel");
+    assert_eq!(plan.leaves[0].ty.to_token_stream().to_string(), "i32");
+    assert_eq!(
+        plan.leaves[1].ty.to_token_stream().to_string(),
+        "Option < i32 >"
+    );
+    assert_eq!(
+        plan.leaves[2].ty.to_token_stream().to_string(),
+        "Option < String >",
+        "already-Option ctor arg is NOT double-wrapped"
+    );
+    assert_eq!(
+        plan.leaves[3].ty.to_token_stream().to_string(),
+        "Option < & ZEncoding >"
+    );
+    assert!(
+        matches!(plan.variants[0].inputs[1], FoldArg::Leaf(2, true)),
+        "schema input marked passthrough"
+    );
+    assert!(plan.variants[1].clone, "borrowed identity arm clones");
+
+    let locals = vec![ident("sel"), ident("id"), ident("schema"), ident("enc")];
+    let s = emit_fold(plan, &locals, &src_qualify)
+        .to_token_stream()
+        .to_string();
+    assert!(s.contains("if sel < 0"), "selector absence gate: {}", s);
+    assert!(
+        s.contains("z_encoding_from_id (__p0 , schema)"),
+        "wrapped id unwrapped, passthrough schema passed directly: {}",
+        s
+    );
+    assert!(
+        s.contains("Clone :: clone"),
+        "identity arm clones the borrow: {}",
+        s
+    );
+    assert!(
+        s.contains("Some") && s.contains("None"),
+        "maps Option: {}",
+        s
+    );
 }
 
 #[test]
@@ -309,7 +366,7 @@ fn iterable_emit_shape() {
             ctor: Some(ident("z_keyexpr_try_from")),
             fallible: true,
             clone: false,
-            inputs: vec![FoldArg::Leaf(0)],
+            inputs: vec![FoldArg::Leaf(0, false)],
         }],
     };
     let locals = vec![ident("kes")];

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -266,7 +266,7 @@ fn variant_typed_params(
     };
     let mut out = Vec::new();
     for (m, arg) in variant.inputs.iter().enumerate() {
-        let FoldArg::Leaf(idx) = arg else {
+        let FoldArg::Leaf(idx, _) = arg else {
             return None;
         };
         let slot = block.get(*idx)?;
@@ -580,7 +580,7 @@ mod tests {
             ctor: Some(syn::parse_quote!(z_summary_optional)),
             fallible: false,
             clone: false,
-            inputs: vec![FoldArg::Leaf(0), FoldArg::Leaf(1)],
+            inputs: vec![FoldArg::Leaf(0, false), FoldArg::Leaf(1, false)],
         };
         // Both slots are nullable in the selector wrapper. Only the first is
         // nullable in the constructor's actual signature.

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -2161,10 +2161,17 @@ fn shape_notes(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<Strin
             .map(|l| snake_to_camel(&l.name.to_string()))
             .collect();
         let how = if plan.selector.is_some() {
-            format!(
-                "pass EITHER {} — the selector chooses the arm",
-                arms.join(" OR ")
-            )
+            if plan.produces_option() {
+                format!(
+                    "pass EITHER {} — the selector chooses the arm, `-1` = absent",
+                    arms.join(" OR ")
+                )
+            } else {
+                format!(
+                    "pass EITHER {} — the selector chooses the arm",
+                    arms.join(" OR ")
+                )
+            }
         } else {
             arms.join(" / ").to_string()
         };

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1046,3 +1046,77 @@ fn split_on_option_param_rejected() {
         );
     let _ = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_opt");
 }
+
+/// Optional combined-selector expansion: an `Option<&T>` param with a
+/// build-from arm AND an identity arm crosses as a selector tuple whose
+/// selector also encodes absence (`-1` = `None`). The ctor's own
+/// `Option<String>` arg passes through un-double-wrapped, and the identity
+/// arm is a nullable typed handle.
+#[test]
+fn optional_selector_dispatch_end_to_end() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZEnc {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_enc_from_id(id: i32, schema: Option<String>) -> ZEnc {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_put(encoding: Option<&ZEnc>) -> bool {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZEnc).constructor(crate::fun!(z_enc_from_id)))
+                .fun(crate::fun!(z_put)),
+        )
+        .expand(
+            crate::expand_param!(ZEnc)
+                .variant(crate::fun!(z_enc_from_id))
+                .variant_self(),
+        );
+    let dir = unique_test_dir("jnigen_opt_selector");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // Rust side: the selector gates absence before the dispatch.
+    assert!(rc.contains("<0"), "{rust}");
+    assert!(rc.contains("Option::None"), "{rust}");
+    assert!(rc.contains("z_enc_from_id"), "{rust}");
+
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let raw = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let all: String = raw.split_whitespace().collect();
+    // Selector Int + nullable build-arm leaves + nullable identity handle.
+    assert!(all.contains("encodingSel:Int"), "{raw}");
+    assert!(all.contains("encoding1:ZEnc?"), "{raw}");
+    // The already-Option schema arg stays a single-level String?.
+    assert!(all.contains("encoding01:String?"), "{raw}");
+    assert!(!all.contains("String??"), "{raw}");
+}


### PR DESCRIPTION
An `Option<T>` / `Option<&T>` parameter could previously only expand through a **single** constructor (`ExpandError::UnsupportedOptional`: "selector-dispatched constructors cannot be optional"). This lifts that: a combined (≥2-variant) expansion under `Optional` builds the same selector dispatch as a non-optional param, with the selector **also encoding absence** — `-1` = `None`, `0..n-1` = the taken arm. No separate present flag; not-taken arms' leaves are null exactly as in the non-optional selector case.

## Correctness detail: passthrough leaves

A dispatched arm `Option`-wraps its input leaves by selector presence — but a constructor argument that is **itself `Option<…>`** (e.g. `encoding_new_from_id(id: i32, schema: Option<String>)`) must not be double-wrapped: `None` is a legitimate value for the *taken* arm, and the wire cannot represent `Option<Option<String>>` anyway. Such args are now **passthrough** leaves (`FoldArg::Leaf` gains the marker): they keep their own type and skip the selector-presence unwrap; arm-taken-ness is decided by the selector alone.

## Motivating case (zenoh stack)

`session_put(.., encoding: Option<&Encoding>)` where the encoding should cross EITHER as its `(id, schema)` value OR as a **preallocated native handle** (`variant_self`) — the handle arm borrows + clones (Arc bump), so a pinned encoding survives a put loop with zero string traffic, and `None` keeps meaning "use the publisher's default".

## Changes

- `core/expand.rs::build_plan`: Optional + multi-variant routes through the shared `build_core` (selector + arms), shape `Optional(Base)`; existing single-ctor Optional paths byte-identical.
- `core/expand.rs::fold_shape`: new selector-first Optional branch — `if sel < 0 { Ok(None) } else { dispatch.map(Some) }`.
- `core/expand.rs::variant_result_expr`: dispatched arms unwrap only the wrapped inputs; passthrough locals pass directly (all-passthrough arm calls directly, selector decides).
- `FoldArg::Leaf(usize)` → `Leaf(usize, passthrough: bool)`; KDoc on `FoldPlan::selector` documents the `-1` rule; jnigen shape-notes mention it.

## Tests

- Core: `optional_combined_selector_encodes_absence` (plan shape, passthrough leaf typing, emitted fold: absence gate + direct-passthrough call + identity clone) — replaces the old rejection test.
- jnigen golden: `optional_selector_dispatch_end_to_end` (selector Int, nullable arm leaves, nullable typed handle, no `String??`).
- covertest: new `summary_total_opt(Option<&Summary>)` under the dual-arm type default; JVM runtime exercises absent / build-arm / borrow-identity (caller's handle survives). **26 sections PASS.**
- 262 lib tests; regen-check: non-participating outputs byte-identical; CI pre-flight clean.