### PR TITLE
perftest: twin-handle lifecycle benchmark — plain vs .gc_managed()

### DIFF
--- a/examples/perftest-flat/src/lib.rs
+++ b/examples/perftest-flat/src/lib.rs
@@ -273,6 +273,45 @@ pub fn string_len(s: &String) -> usize {
     s.len()
 }
 
+/// Minimal opaque handle for LIFECYCLE benchmarking: the plain variant of a
+/// twin pair whose only difference is the Kotlin-side `.gc_managed()` flag —
+/// benchmarked head-to-head to price the GC-cleanup machinery (atomic cell,
+/// Cleaner registration, CAS release ticket) per handle. A boxed handle like
+/// [`Storage`] (not `#[prebindgen]`, not `#[repr(C)]`).
+pub struct Token {
+    value: i64,
+}
+
+/// Create a plain benchmark token.
+#[prebindgen]
+pub fn token_new(value: i64) -> Token {
+    Token { value }
+}
+
+/// Read a plain benchmark token.
+#[prebindgen]
+pub fn token_value(t: &Token) -> i64 {
+    t.value
+}
+
+/// GC-managed twin of [`Token`] — identical shape and cost on the Rust side;
+/// the Kotlin binding declares this one `.gc_managed()`.
+pub struct TokenGc {
+    value: i64,
+}
+
+/// Create a gc-managed benchmark token.
+#[prebindgen]
+pub fn token_gc_new(value: i64) -> TokenGc {
+    TokenGc { value }
+}
+
+/// Read a gc-managed benchmark token.
+#[prebindgen]
+pub fn token_gc_value(t: &TokenGc) -> i64 {
+    t.value
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -47,7 +47,22 @@ fn main() {
                 // `List` is assembled by a **fold**: the trampoline allocates the list and
                 // folds each element's raw leaves through the hoisted folder (Kotlin does
                 // `fromParts` + `add`) — no per-element Java object is built on the Rust side.
-                .class(ptr_class!(PayloadVecHandler)),
+                .class(ptr_class!(PayloadVecHandler))
+                // Twin minimal handles for the LIFECYCLE benchmark: identical Rust
+                // shape, one plain, one `.gc_managed()` — head-to-head rows in
+                // `Bench.kt` price the GC-cleanup machinery (atomic cell, Cleaner
+                // registration, CAS release ticket) per handle create/close/call.
+                .class(
+                    ptr_class!(Token)
+                        .constructor(fun!(token_new))
+                        .method(fun!(token_value)),
+                )
+                .class(
+                    ptr_class!(TokenGc)
+                        .gc_managed()
+                        .constructor(fun!(token_gc_new))
+                        .method(fun!(token_gc_value)),
+                ),
         )
         // Only the value/ref-input put forms map to JNI: `storage_put_by_take`
         // (by-value `Payload`) and `storage_put_by_read` (`&Payload`). The

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -236,6 +236,94 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr) {
     }
 }
 
+/** Typed handle for a native Zenoh `Token`. */
+public class Token(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): Token {
+        val p = ptr
+        ptr = p or 1L
+        return Token(p)
+    }
+
+    /** Read a plain benchmark token. */
+    public fun tokenValue(onError: JniErrorHandler<Long>): Long {
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
+        val __cap = JniErrorHandlerCapture.acquire()
+        val __ret = withSortedHandleLocks(this) {
+            val this_ptr = this.ptr
+            JNINative.tokenValue(this_ptr, __cap)
+        }
+        if (__cap.failed) return onError.run(__cap.je)
+        return __ret
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+
+        /** Create a plain benchmark token. */
+        public fun tokenNew(value: Long, onError: JniErrorHandler<Token>): Token {
+            val __cap = JniErrorHandlerCapture.acquire()
+            val __ret = Token(JNINative.tokenNew(value, __cap))
+            if (__cap.failed) return onError.run(__cap.je)
+            return __ret
+        }
+    }
+}
+
+/** Typed handle for a native Zenoh `TokenGc`. */
+public class TokenGc(initialPtr: Long) : GcNativeHandle(initialPtr) {
+    private val __cleanable = registerGcHandle(this) { freePtr(it) }
+
+    @Synchronized
+    override fun close() {
+        val p = releaseCell(cell)
+        if (p != 0L) freePtr(p)
+        __cleanable?.clean()
+    }
+
+    @Synchronized
+    public fun take(): TokenGc {
+        val p = releaseCell(cell)
+        __cleanable?.clean()
+        return TokenGc(if (p != 0L) p else cell.get())
+    }
+
+    /** Read a gc-managed benchmark token. */
+    public fun tokenGcValue(onError: JniErrorHandler<Long>): Long {
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
+        val __cap = JniErrorHandlerCapture.acquire()
+        val __ret = withSortedHandleLocks(this) {
+            val this_ptr = this.ptr
+            JNINative.tokenGcValue(this_ptr, __cap)
+        }
+        if (__cap.failed) return onError.run(__cap.je)
+        return __ret
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+
+        /** Create a gc-managed benchmark token. */
+        public fun tokenGcNew(value: Long, onError: JniErrorHandler<TokenGc>): TokenGc {
+            val __cap = JniErrorHandlerCapture.acquire()
+            val __ret = TokenGc(JNINative.tokenGcNew(value, __cap))
+            if (__cap.failed) return onError.run(__cap.je)
+            return __ret
+        }
+    }
+}
+
 public fun interface PayloadCallback {
     public fun run(payload: Payload)
 }
@@ -350,6 +438,10 @@ internal object JNINative {
         errorSink: Any,
     )
     external fun storagePutSlice(s: Long, payloads: Long, errorSink: Any)
+    external fun tokenGcNew(value: Long, errorSink: Any): Long
+    external fun tokenGcValue(t: Long, errorSink: Any): Long
+    external fun tokenNew(value: Long, errorSink: Any): Long
+    external fun tokenValue(t: Long, errorSink: Any): Long
     external fun payloadVecNew(cap: Int): Long
     external fun payloadVecPush(handle: Long, eId: Long, eSeq: Int, eValue: Double, eFlag: Boolean, eLabel: String?)
     external fun payloadVecFree(handle: Long)

--- a/examples/perftest-kotlin/kotlin/io/prebindgen/perftest/Bench.kt
+++ b/examples/perftest-kotlin/kotlin/io/prebindgen/perftest/Bench.kt
@@ -153,11 +153,54 @@ fun main() {
         }
     }
 
+    // Handle-lifecycle rows: twin minimal ptr classes — `Token` (plain) vs
+    // `TokenGc` (`.gc_managed()`) — pricing the GC-cleanup machinery per
+    // handle. Capped iterations bound the plain-drop native leak (that row
+    // deliberately never frees — it measures allocation alone, today's
+    // leak-on-drop behavior) and the Cleaner backlog.
+    val HN = minOf(N, 2_000_000L)
+    fun runHandleLifecycle() {
+        // create + explicit close: plain = tag write + freePtr; gc adds the
+        // cell alloc, Cleaner registration, CAS ticket, clean() deregistration.
+        bench("handle_close", "plain", HN) {
+            Token.tokenNew(1L, onError).close()
+        }
+        bench("handle_close", "gc", HN) {
+            TokenGc.tokenGcNew(1L, onError).close()
+        }
+        // create + drop (no close): plain leaks natively; gc is freed by the
+        // Cleaner as the JVM collects the wrappers.
+        bench("handle_drop", "plain", HN) {
+            Token.tokenNew(1L, onError)
+        }
+        bench("handle_drop", "gc", HN) {
+            TokenGc.tokenGcNew(1L, onError)
+        }
+        // Let the Cleaner backlog settle before the call rows.
+        System.gc()
+        Thread.sleep(200)
+        // method call on a live handle: prices the open `ptr` property
+        // (field-backed vs atomic-cell getter) on the call path.
+        val tp = Token.tokenNew(7L, onError)
+        val tg = TokenGc.tokenGcNew(7L, onError)
+        bench("handle_call", "plain", HN) {
+            sink += tp.tokenValue(onError)
+        }
+        bench("handle_call", "gc", HN) {
+            sink += tg.tokenGcValue(onError)
+        }
+        tp.close()
+        tg.close()
+    }
+
     // Warm up the JIT on all paths so steady-state numbers are fair (capped for a small
-    // `N` smoke run).
+    // `N` smoke run). The token warmup also loads BOTH NativeHandle subtypes up front,
+    // so `ptr` call-site profiles reflect the steady state a mixed app sees.
     val warm = makeBatch("hello, payload")
     storagePutSlice(s, warm, onError)
     val warmN = minOf(VEC_ITERS, 50_000L)
+    val warmTp = Token.tokenNew(3L, onError)
+    val warmTg = TokenGc.tokenGcNew(3L, onError)
     repeat(warmN.toInt()) {
         storagePutByTake(s, warm[0], onError)
         storageGet(s, onError)
@@ -165,13 +208,20 @@ fun main() {
         storagePutSlice(s, warm, onError)
         storageGetVec(s, onError)
         storageCallbackVec(s, vcb, onError)
+        Token.tokenNew(1L, onError).close()
+        TokenGc.tokenGcNew(1L, onError).close()
+        sink += warmTp.tokenValue(onError)
+        sink += warmTg.tokenGcValue(onError)
     }
+    warmTp.close()
+    warmTg.close()
 
     println("BEGIN_PERFTEST lang=kotlin n=$N")
     runCategory("hello, payload", "str")
     runCategory(null, "null")
     runVecCategory("hello, payload", "str")
     runVecCategory(null, "null")
+    runHandleLifecycle()
     println("END_PERFTEST")
 
     cb.close()

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -124,6 +124,38 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_TokenGc_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::TokenGc));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::TokenGc>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_Token_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::Token));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Token>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadVecFree(
     _env: jni::JNIEnv,
     _class: jni::objects::JClass,
@@ -903,6 +935,20 @@ pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn TokenGc_to_jlong_5e58352a<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::TokenGc,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Token_to_jlong_4f7adafa<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Token,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<perftest_flat::Payload>,
@@ -1019,6 +1065,34 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Storage) })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jlong_to_TokenGc_5e58352a<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::TokenGc>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::TokenGc) })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jlong_to_Token_4f7adafa<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::Token>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Token) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn jlong_to_i64_fbf9a9bc<'env, 'v>(
@@ -2040,6 +2114,206 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutSlice<'
                 &__zd,
             );
             ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match jlong_to_i64_fbf9a9bc(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::token_gc_new(value);
+    match TokenGc_to_jlong_5e58352a(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcValue<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    t: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let t = match jlong_to_TokenGc_5e58352a(&mut env, &t) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::token_gc_value(&t);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match jlong_to_i64_fbf9a9bc(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::token_new(value);
+    match Token_to_jlong_4f7adafa(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenValue<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    t: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let t = match jlong_to_Token_4f7adafa(&mut env, &t) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::token_value(&t);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
         }
     }
 }


### PR DESCRIPTION
## What

Measures the real cost of the `.gc_managed()` machinery (#82) with a twin minimal handle pair — `Token` (plain) vs `TokenGc` (`.gc_managed()`), identical Rust shape — plus six new perftest rows.

## Results (medians of 3 runs, N=5M classic / 2M handle rows, Apple Silicon)

| row | plain | gc | delta |
|---|---|---|---|
| `handle_close` — create + explicit close | 34 ns | 119 ns | **+85 ns** |
| `handle_drop` — create + drop, no close | 20 ns* | 171 ns | **+151 ns** |
| `handle_call` — method on a live handle | 18.9 ns | 18.9 ns | **0** |

\* plain drop leaks natively (allocation cost only — today's leak-on-drop behavior); the gc number includes the Cleaner-driven free and PhantomRef/GC churn.

**Existing hot paths are unaffected**: pre-#82 (`598f740`) vs this branch, medians of the untouched `put`/`get`/`callback`(+`_vec`) rows differ only within noise (±3%, mixed signs) — the `NativeHandle.ptr` open-property change costs nothing for plain classes, and the atomic-cell getter matches the plain field on the call path.

## Interpretation for the zenoh hot path

A received zenoh sample materializes 2 handles (KeyExpr + payload ZBytes). GC-managing them would add roughly 85–150 ns × 2 ≈ **0.2–0.3 µs per message** of allocation/registration/cleanup work against the ~1 µs/msg subscriber floor — i.e. a potential double-digit percentage throughput cost, to be confirmed end-to-end with `run_thr_java.sh` (follow-up measurement). The per-class opt-out for KeyExpr/ZBytes in zenoh-flat-jni stays justified; the zero call-path cost confirms the backstop classes (Session, Publisher, …) pay only at create/close time.

265 lib tests green; fmt + clippy clean; covertest untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)