### PR TITLE
jnigen: binding-local functions — one vocabulary for custom locally-defined members

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -46,7 +46,9 @@
 //! | per-fn `.expand_return(…)` identity-only | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.expand_param(name, …)` variants | `storage_expect_summary` |
 //! | per-fn `.expand_return(…)` fields+self | `storage_summary_full` |
-//! | binding-local field `field!` `.with(ty!, path!)` | `storage_summary_probe` — conditional handle via `crate::summary_if_nonempty` |
+//! | binding-local field `field!` `.with(ty!, path!)` | `storage_summary_probe` — custom field, here a conditional handle via `crate::summary_if_nonempty` |
+//! | binding-local fn `fun!(crate::…)` `.sig(sig!)` as free fn | `describeSummary` ← `crate::summary_describe` |
+//! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean`; `Summary.fromMean` ← `crate::summary_from_mean` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -88,7 +90,7 @@
 
 use prebindgen::{
     constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
-    field, from, fun, into, lang::JniGen, matching, package, path, ptr_class, try_from, ty,
+    field, from, fun, into, lang::JniGen, matching, package, path, ptr_class, sig, try_from, ty,
     value_class,
 };
 
@@ -242,7 +244,21 @@ fn main() {
                         .constructor(fun!(summary_new).name("of"))
                         .method(fun!(summary_count))
                         .method(fun!(summary_total))
-                        .method(fun!(summary_scaled)),
+                        .method(fun!(summary_scaled))
+                        // Binding-local INSTANCE METHOD and COMPANION
+                        // CONSTRUCTOR (`fun!(crate::…).sig(sig!(…))`): fns
+                        // defined in THIS crate (src/lib.rs), no source-crate
+                        // item — same member machinery as registry fns.
+                        .method(
+                            fun!(crate::summary_mean)
+                                .sig(sig!((s: &Summary) -> f64))
+                                .name("mean"),
+                        )
+                        .constructor(
+                            fun!(crate::summary_from_mean)
+                                .sig(sig!((count: i64, mean: f64) -> Summary))
+                                .name("fromMean"),
+                        ),
                 )
                 // `Archive` holds the latest `Summary` and returns it BORROWED
                 // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
@@ -346,6 +362,15 @@ fn main() {
         .package(
             package!("analytics")
                 .fun(fun!(storage_summary))
+                // Binding-local FREE FUNCTION: exported like any package fn;
+                // its `&Summary` param resolves through the ordinary borrow
+                // converter, its String return through the ordinary output
+                // converter.
+                .fun(
+                    fun!(crate::summary_describe)
+                        .sig(sig!((s: &Summary, verbose: bool) -> String))
+                        .name("describeSummary"),
+                )
                 // Single split (#52) on the CLASS-DEFAULT `Summary` variants:
                 // `storageMatchesSummary(count, total, …)` / `(expected, …)`.
                 .fun(fun!(storage_matches_summary).split_on_param("expected"))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -46,6 +46,7 @@
 //! | per-fn `.expand_return(…)` identity-only | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.expand_param(name, …)` variants | `storage_expect_summary` |
 //! | per-fn `.expand_return(…)` fields+self | `storage_summary_full` |
+//! | binding-local field `field!` `.with(ty!, path!)` | `storage_summary_probe` — conditional handle via `crate::summary_if_nonempty` |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -87,7 +88,8 @@
 
 use prebindgen::{
     constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
-    from, fun, into, lang::JniGen, matching, package, path, ptr_class, try_from, ty, value_class,
+    field, from, fun, into, lang::JniGen, matching, package, path, ptr_class, try_from, ty,
+    value_class,
 };
 
 fn strip_flat_class_prefix(class: &str, name: &str) -> String {
@@ -361,6 +363,23 @@ fn main() {
                             .field(fun!(summary_count).name("count"))
                             .field(fun!(summary_total).name("total"))
                             .field_self(),
+                    ),
+                )
+                // Binding-local CONDITIONAL field (`field!` + `.with(ty, path)`):
+                // the handle leaf is delivered only when the binding-side
+                // predicate (`crate::summary_if_nonempty`, src/lib.rs) says
+                // re-using the value is worth it — nullable identity leaf,
+                // null when the condition fails. The condition is binding
+                // policy, so it lives in THIS crate, not the source crate.
+                .fun(
+                    fun!(storage_summary_probe).expand_return(
+                        expand_return!(Summary)
+                            .field(fun!(summary_count).name("count"))
+                            .field(fun!(summary_total).name("total"))
+                            .field(
+                                field!("handle")
+                                    .with(ty!(Option<&Summary>), path!(crate::summary_if_nonempty)),
+                            ),
                     ),
                 )
                 // Per-fn split (#52): a per-fn `.expand_param` variant override

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -46,9 +46,9 @@
 //! | per-fn `.expand_return(…)` identity-only | `storage_summary_handle` / `archive_latest` (raw handle return) |
 //! | per-fn `.expand_param(name, …)` variants | `storage_expect_summary` |
 //! | per-fn `.expand_return(…)` fields+self | `storage_summary_full` |
-//! | binding-local field `field!` `.with(ty!, path!)` | `storage_summary_probe` — custom field, here a conditional handle via `crate::summary_if_nonempty` |
+//! | binding-local field `fun!(crate::…).sig(sig!).name(…)` | `storage_summary_probe` — custom field, here a conditional handle via `crate::summary_if_nonempty` |
 //! | binding-local fn `fun!(crate::…)` `.sig(sig!)` as free fn | `describeSummary` ← `crate::summary_describe` |
-//! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean`; `Summary.fromMean` ← `crate::summary_from_mean` (FALLIBLE — sig `Result` → `onError`) |
+//! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean` (NO `.name` — derived by the strip hook); `Summary.fromMean` ← `crate::summary_from_mean` (FALLIBLE — sig `Result` → `onError`) |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -90,7 +90,7 @@
 
 use prebindgen::{
     constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
-    field, from, fun, into, lang::JniGen, matching, package, path, ptr_class, sig, try_from, ty,
+    from, fun, into, lang::JniGen, matching, package, path, ptr_class, sig, try_from, ty,
     value_class,
 };
 
@@ -245,19 +245,18 @@ fn main() {
                         // CONSTRUCTOR (`fun!(crate::…).sig(sig!(…))`): fns
                         // defined in THIS crate (src/lib.rs), no source-crate
                         // item — same member machinery as registry fns.
-                        .method(
-                            fun!(crate::summary_mean)
-                                .sig(sig!((s: &Summary) -> f64))
-                                .name("mean"),
-                        )
+                        // NO .name(): the strip-class-prefix method hook
+                        // derives `mean` from the path's LAST segment
+                        // (`summary_mean` on `Summary` → strip → `mean`) —
+                        // automatic mangling covers binding-local fns too.
+                        .method(fun!(crate::summary_mean).sig(sig!((s: &Summary) -> f64)))
                         // FALLIBLE binding-local constructor: the sig's
                         // `Result<Summary, String>` return is the error
                         // channel — a negative count routes the Err message
                         // to onError, exactly like a registry fn's Result.
                         .constructor(
                             fun!(crate::summary_from_mean)
-                                .sig(sig!((count: i64, mean: f64) -> Result<Summary, String>))
-                                .name("fromMean"),
+                                .sig(sig!((count: i64, mean: f64) -> Result<Summary, String>)),
                         ),
                 )
                 // `Archive` holds the latest `Summary` and returns it BORROWED
@@ -402,8 +401,9 @@ fn main() {
                             .field(fun!(summary_count).name("count"))
                             .field(fun!(summary_total).name("total"))
                             .field(
-                                field!("handle")
-                                    .with(ty!(Option<&Summary>), path!(crate::summary_if_nonempty)),
+                                fun!(crate::summary_if_nonempty)
+                                    .sig(sig!((s: &Summary) -> Option<&Summary>))
+                                    .name("handle"),
                             ),
                     ),
                 )

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -25,7 +25,7 @@
 //! | `Source::builder().crate_name()`      | the helpers dep is RENAMED to `cov_helpers` in Cargo.toml |
 //! | `convert!` `.input(from!)`/`.output(into!)` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | `convert!` `.input(try_from!)` (fallible) | `Percent` ⇄ `Int`; out-of-range → `onError` |
-//! | `convert!` sources `.with(path!)`/`.error(ty!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); empty label → `onError` |
+//! | `convert!` sources `fun!(crate::…).sig(sig!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); the sig's `Result` = error channel, empty label → `onError` |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
 //! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones |
@@ -48,7 +48,7 @@
 //! | per-fn `.expand_return(…)` fields+self | `storage_summary_full` |
 //! | binding-local field `field!` `.with(ty!, path!)` | `storage_summary_probe` — custom field, here a conditional handle via `crate::summary_if_nonempty` |
 //! | binding-local fn `fun!(crate::…)` `.sig(sig!)` as free fn | `describeSummary` ← `crate::summary_describe` |
-//! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean`; `Summary.fromMean` ← `crate::summary_from_mean` |
+//! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean`; `Summary.fromMean` ← `crate::summary_from_mean` (FALLIBLE — sig `Result` → `onError`) |
 //! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -157,18 +157,14 @@ fn main() {
         // from the JVM route the impl's Error to onError); infallible output.
         .convert(convert!(Percent).input(try_from!(i32)).output(into!(i32)))
         // `Label`: conversions are plain fns in THIS binding crate (see
-        // src/lib.rs) — no #[prebindgen], no helper crate. The input is
-        // FALLIBLE (`fn(String) -> Result<Label, String>`; the error type is
-        // stated — a bare path carries no signature to read); empty labels
-        // route the Err to onError.
+        // src/lib.rs) — no #[prebindgen], no helper crate — declared with
+        // the ONE binding-local vocabulary, `fun!(crate::…).sig(sig!(…))`.
+        // The input is FALLIBLE: the sig's `Result<Label, String>` return IS
+        // the error channel (empty labels route the Err to onError).
         .convert(
             convert!(Label)
-                .input(
-                    try_from!(String)
-                        .with(path!(crate::label_in))
-                        .error(ty!(String)),
-                )
-                .output(into!(String).with(path!(crate::label_out))),
+                .input(fun!(crate::label_in).sig(sig!((s: String) -> Result<Label, String>)))
+                .output(fun!(crate::label_out).sig(sig!((l: Label) -> String))),
         )
         // ── Base-package types ──────────────────────────────────────────────
         // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
@@ -254,9 +250,13 @@ fn main() {
                                 .sig(sig!((s: &Summary) -> f64))
                                 .name("mean"),
                         )
+                        // FALLIBLE binding-local constructor: the sig's
+                        // `Result<Summary, String>` return is the error
+                        // channel — a negative count routes the Err message
+                        // to onError, exactly like a registry fn's Result.
                         .constructor(
                             fun!(crate::summary_from_mean)
-                                .sig(sig!((count: i64, mean: f64) -> Summary))
+                                .sig(sig!((count: i64, mean: f64) -> Result<Summary, String>))
                                 .name("fromMean"),
                         ),
                 )

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -126,6 +126,6 @@ Base package: `io.prebindgen.covertest`
 ## conversions
 
 - `convert!(Celsius)`: input `Into` ⇄ `i32`, output `Into` ⇄ `i32`
-- `convert!(Label)`: input binding-local `crate :: label_in` ⇄ `String` (fallible), output binding-local `crate :: label_out` ⇄ `String`
+- `convert!(Label)`: input `#[prebindgen]` fn `label_in`, output `#[prebindgen]` fn `label_out`
 - `convert!(Millis)`: input `#[prebindgen]` fn `millis_from_long`, output `#[prebindgen]` fn `millis_value`
 - `convert!(Percent)`: input `TryInto` ⇄ `i32`, output `Into` ⇄ `i32`

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -26,6 +26,8 @@ Base package: `io.prebindgen.covertest`
 - `storage_summary_full` — `fun <R> storageSummaryFull(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryStorageSummaryFullBuilder<R>): R`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
 - `storage_summary_handle` — `fun storageSummaryHandle(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
+- `storage_summary_probe` — `fun <R> storageSummaryProbe(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryStorageSummaryProbeBuilder<R>): R`
+  - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
 - `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -28,6 +28,8 @@ Base package: `io.prebindgen.covertest`
 - `storage_summary_handle` — `fun storageSummaryHandle(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
 - `storage_summary_probe` — `fun <R> storageSummaryProbe(s: Storage, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryStorageSummaryProbeBuilder<R>): R`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
+- `summary_describe` — `fun describeSummary(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, verbose: Boolean, onError: io.prebindgen.covertest.JniErrorHandler<String>): String`
+  - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
 - `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
@@ -101,6 +103,8 @@ Base package: `io.prebindgen.covertest`
 ## class `io.prebindgen.covertest.analytics.Summary` (ptr_class, Rust `Summary`)
 
 - `summary_count` — `fun count(onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
+- `summary_from_mean` — `fun fromMean(count: Long, mean: Double, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
+- `summary_mean` — `fun mean(onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
 - `summary_new` — `fun of(count: Long, total: Double, onError: io.prebindgen.covertest.JniErrorHandler<Summary>): Summary`
 - `summary_scaled` — `fun scaled(factor: Double, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
 - `summary_total` — `fun total(onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -717,6 +717,18 @@ internal object CovNative {
     ): Long
     external fun stringNew(s: String, errorSink: Any): String
     external fun summaryCount(s: Long, errorSink: Any): Long
+    external fun summaryDescribe(
+        sSel: Int,
+        s00Present: Boolean,
+        s00Value: Long,
+        s01Present: Boolean,
+        s01Value: Double,
+        s1: Long,
+        verbose: Boolean,
+        errorSink: Any,
+    ): String
+    external fun summaryFromMean(count: Long, mean: Double, errorSink: Any): Long
+    external fun summaryMean(s: Long, errorSink: Any): Double
     external fun summaryNew(count: Long, total: Double, errorSink: Any): Long
     external fun summaryPrefer(
         primarySel: Int,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -704,6 +704,7 @@ internal object CovNative {
     external fun storageSummary(s: Long, build: Any, errorSink: Any): Any?
     external fun storageSummaryFull(s: Long, build: Any, errorSink: Any): Any?
     external fun storageSummaryHandle(s: Long, errorSink: Any): Long
+    external fun storageSummaryProbe(s: Long, build: Any, errorSink: Any): Any?
     external fun storageTotalLen(a: Long, b: Long, c: Long, errorSink: Any): Long
     external fun storageTryWithLabel(label: String, errorSink: Any): Long
     external fun storageWithPayload(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -89,6 +89,17 @@ public class Summary(initialPtr: Long) : GcNativeHandle(initialPtr) {
         return __ret
     }
 
+    public fun mean(onError: JniErrorHandler<Double>): Double {
+        if (this.isClosed()) return onError.run("Operation on a closed native handle.")
+        val __cap = JniErrorHandlerCapture.acquire()
+        val __ret = withSortedHandleLocks(this) {
+            val this_ptr = this.ptr
+            CovNative.summaryMean(this_ptr, __cap)
+        }
+        if (__cap.failed) return onError.run(__cap.je)
+        return __ret
+    }
+
     public companion object {
         @JvmStatic
         external fun freePtr(ptr: Long)
@@ -100,6 +111,13 @@ public class Summary(initialPtr: Long) : GcNativeHandle(initialPtr) {
         public fun of(count: Long, total: Double, onError: JniErrorHandler<Summary>): Summary {
             val __cap = JniErrorHandlerCapture.acquire()
             val __ret = Summary(CovNative.summaryNew(count, total, __cap))
+            if (__cap.failed) return onError.run(__cap.je)
+            return __ret
+        }
+
+        public fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary>): Summary {
+            val __cap = JniErrorHandlerCapture.acquire()
+            val __ret = Summary(CovNative.summaryFromMean(count, mean, __cap))
             if (__cap.failed) return onError.run(__cap.je)
             return __ret
         }
@@ -163,6 +181,38 @@ public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: Su
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         (CovNative.storageSummary(s_ptr, build, __cap) as R)
+    }
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/** Parameter `s` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `sSel`, `s00`, `s01`, `s1`). */
+public fun describeSummary(
+    sSel: Int,
+    s00: Long?,
+    s01: Double?,
+    s1: Summary?,
+    verbose: Boolean,
+    onError: JniErrorHandler<String>,
+): String {
+    if (s1 != null && s1.isClosed()) return onError.run("Operation on a closed native handle.")
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        s1?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val s1_ptr = s1?.ptr ?: 0L
+            CovNative.summaryDescribe(
+                sSel,
+                s00 != null,
+                s00 ?: 0L,
+                s01 != null,
+                s01 ?: 0.0,
+                s1_ptr,
+                verbose,
+                __cap,
+            )
+        }
     }
     if (__cap.failed) return onError.run(__cap.je)
     return __ret

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -130,6 +130,26 @@ public fun <R> SummaryStorageSummaryFullBuilder<R>.asRaw(): SummaryStorageSummar
         )
     }
 
+public fun interface SummaryStorageSummaryProbeBuilder<out R> {
+    public fun run(count: Long, total: Double, handle: Summary?): R
+}
+
+public fun interface SummaryStorageSummaryProbeBuilderRaw<out R> {
+    public fun run(count: Long, total: Double, handle: Long?): R
+}
+
+public fun <R> SummaryStorageSummaryProbeBuilder<R>.asRaw(): SummaryStorageSummaryProbeBuilderRaw<R> =
+    SummaryStorageSummaryProbeBuilderRaw<R> {
+        count,
+        total,
+        handle ->
+        run(
+            count,
+            total,
+            handle?.let { Summary(it) }
+        )
+    }
+
 /**
  * Summarize a storage (returns a `Summary`; the binding's **default
  * flatten-output** turns it into `(count, total)` leaves).
@@ -259,6 +279,30 @@ public fun <R> storageSummaryFull(
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         (CovNative.storageSummaryFull(s_ptr, build.asRaw(), __cap) as R)
+    }
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/**
+ * Like [`storage_summary`] but the binding's per-fn field set carries a
+ * **binding-local conditional field** (`field!("handle").with(ty!, path!)`):
+ * the handle leaf is delivered only when the binding-side predicate says
+ * re-using the value is worth it (the zenoh conditional-Encoding idiom).
+ *
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`, `handle`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <R> storageSummaryProbe(
+    s: Storage,
+    onError: JniErrorHandler<R>,
+    build: SummaryStorageSummaryProbeBuilder<R>,
+): R {
+    if (s.isClosed()) return onError.run("Operation on a closed native handle.")
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = withSortedHandleLocks(s) {
+        val s_ptr = s.ptr
+        (CovNative.storageSummaryProbe(s_ptr, build.asRaw(), __cap) as R)
     }
     if (__cap.failed) return onError.run(__cap.je)
     return __ret

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -8,6 +8,7 @@ import io.prebindgen.covertest.analytics.archiveStore
 import io.prebindgen.covertest.analytics.storageExpectSummary
 import io.prebindgen.covertest.analytics.storageMatchesSummary
 import io.prebindgen.covertest.analytics.storageSummary
+import io.prebindgen.covertest.analytics.storageSummaryProbe
 import io.prebindgen.covertest.analytics.storageSummaryFull
 import io.prebindgen.covertest.analytics.storageSummaryHandle
 import io.prebindgen.covertest.analytics.summaryPrefer
@@ -260,6 +261,34 @@ fun main() {
         check(full.first == 2L && full.second == 40.0)
         check(fullHandle!!.total(boom) == 40.0)
         fullHandle!!.close()
+        s.close()
+    }
+
+    // ── binding-local conditional field: field!("handle").with(ty!, path!) ──
+    // storageSummaryProbe's per-fn field set delivers (count, total) plus a
+    // handle leaf gated by the BINDING-side predicate crate::summary_if_nonempty
+    // (covertest-kotlin/src/lib.rs) — the zenoh "Encoding handle only when
+    // schema-carrying" idiom. Condition fails ⇒ the leaf is null (no native
+    // clone, no wrapper); holds ⇒ a live owned handle arrives with the values.
+    section("binding-local conditional field (field! + .with)") {
+        val s = storageNew(boom)
+
+        // Empty storage: count == 0 ⇒ the predicate fails ⇒ null handle.
+        val emptyProbe = storageSummaryProbe(s, boom) { count, total, handle ->
+            Triple(count, total, handle)
+        }
+        check(emptyProbe.first == 0L && emptyProbe.second == 0.0)
+        check(emptyProbe.third == null) { "empty summary must arrive value-only" }
+
+        // Non-empty: the handle arrives live alongside the decomposed values.
+        storagePutSlice(s, listOf(payload(1L, 0, 10.0, false, null), payload(2L, 0, 30.0, false, null)), boom)
+        val probe = storageSummaryProbe(s, boom) { count, total, handle ->
+            Triple(count, total, handle)
+        }
+        check(probe.first == 2L && probe.second == 40.0)
+        val h = probe.third ?: error("non-empty summary must deliver its handle")
+        check(h.count(boom) == 2L && h.total(boom) == 40.0)
+        h.close()
         s.close()
     }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -303,11 +303,20 @@ fun main() {
     // param carries the Summary selector form), members and naming all apply
     // exactly as for #[prebindgen] fns.
     section("binding-local functions (fun!(crate::…) + sig!)") {
-        // Companion constructor: Summary.fromMean(4, 2.5) == of(4, 10.0).
+        // FALLIBLE companion constructor: the sig's `Result<Summary, String>`
+        // return is the error channel — happy path first…
         val m = Summary.fromMean(4L, 2.5, boom)
         check(m.count(boom) == 4L && m.total(boom) == 10.0)
         // Instance method.
         check(m.mean(boom) == 2.5)
+        // …then the Err arm: a negative count routes the Err's Display to
+        // onError (a String error has no domain decomposition, so it arrives
+        // as the je message), exactly like a #[prebindgen] fn's Result.
+        var fromMeanErr: String? = null
+        Summary.fromMean(-1L, 2.5) { je -> fromMeanErr = je; m }
+        check(fromMeanErr == "summary count must be non-negative, got -1") {
+            "unexpected fromMean error: $fromMeanErr"
+        }
         // Free fn, selector form: build-arm (0) and handle-arm (1) both reach
         // the same binding-local Rust fn.
         check(describeSummary(0, 2L, 8.0, null, false, boom) == "2/8")

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -265,15 +265,16 @@ fun main() {
         s.close()
     }
 
-    // ── binding-local field: field!("handle").with(ty!, path!) ──────────────
+    // ── binding-local field: fun!(crate::…).sig(sig!).name("handle") ────────
     // A CUSTOM field computed by a fn defined in THIS binding crate
     // (crate::summary_if_nonempty, src/lib.rs) — no source-crate item behind
-    // it. This exercise uses it for CONDITIONAL delivery (one use among
+    // it, declared with the same fun!+sig! vocabulary as every binding-local
+    // fn. This exercise uses it for CONDITIONAL delivery (one use among
     // many): the handle leaf is gated by the binding-side predicate — the
     // zenoh "Encoding handle only when schema-carrying" idiom. Condition
     // fails ⇒ the leaf is null (no native clone, no wrapper); holds ⇒ a live
     // owned handle arrives with the values.
-    section("binding-local field (field! + .with)") {
+    section("binding-local field (fun! + sig!)") {
         val s = storageNew(boom)
 
         // Empty storage: count == 0 ⇒ the predicate fails ⇒ null handle.
@@ -303,6 +304,9 @@ fun main() {
     // param carries the Summary selector form), members and naming all apply
     // exactly as for #[prebindgen] fns.
     section("binding-local functions (fun!(crate::…) + sig!)") {
+        // `mean` and `fromMean` carry NO .name(): the strip-class-prefix
+        // method hook derives them from each path's LAST segment — automatic
+        // mangling covers binding-local fns exactly like registry fns.
         // FALLIBLE companion constructor: the sig's `Result<Summary, String>`
         // return is the error channel — happy path first…
         val m = Summary.fromMean(4L, 2.5, boom)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -9,6 +9,7 @@ import io.prebindgen.covertest.analytics.storageExpectSummary
 import io.prebindgen.covertest.analytics.storageMatchesSummary
 import io.prebindgen.covertest.analytics.storageSummary
 import io.prebindgen.covertest.analytics.storageSummaryProbe
+import io.prebindgen.covertest.analytics.describeSummary
 import io.prebindgen.covertest.analytics.storageSummaryFull
 import io.prebindgen.covertest.analytics.storageSummaryHandle
 import io.prebindgen.covertest.analytics.summaryPrefer
@@ -264,13 +265,15 @@ fun main() {
         s.close()
     }
 
-    // ── binding-local conditional field: field!("handle").with(ty!, path!) ──
-    // storageSummaryProbe's per-fn field set delivers (count, total) plus a
-    // handle leaf gated by the BINDING-side predicate crate::summary_if_nonempty
-    // (covertest-kotlin/src/lib.rs) — the zenoh "Encoding handle only when
-    // schema-carrying" idiom. Condition fails ⇒ the leaf is null (no native
-    // clone, no wrapper); holds ⇒ a live owned handle arrives with the values.
-    section("binding-local conditional field (field! + .with)") {
+    // ── binding-local field: field!("handle").with(ty!, path!) ──────────────
+    // A CUSTOM field computed by a fn defined in THIS binding crate
+    // (crate::summary_if_nonempty, src/lib.rs) — no source-crate item behind
+    // it. This exercise uses it for CONDITIONAL delivery (one use among
+    // many): the handle leaf is gated by the binding-side predicate — the
+    // zenoh "Encoding handle only when schema-carrying" idiom. Condition
+    // fails ⇒ the leaf is null (no native clone, no wrapper); holds ⇒ a live
+    // owned handle arrives with the values.
+    section("binding-local field (field! + .with)") {
         val s = storageNew(boom)
 
         // Empty storage: count == 0 ⇒ the predicate fails ⇒ null handle.
@@ -290,6 +293,26 @@ fun main() {
         check(h.count(boom) == 2L && h.total(boom) == 40.0)
         h.close()
         s.close()
+    }
+
+    // ── binding-local FUNCTIONS: fun!(crate::…).sig(sig!(…)) ─────────────────
+    // Full fns defined in the BINDING crate (covertest-kotlin/src/lib.rs),
+    // exported through the ordinary FunctionDecl surface — free package fn,
+    // instance method, companion constructor. No source-crate item exists for
+    // any of them, yet converters, expansion defaults (describeSummary's `s`
+    // param carries the Summary selector form), members and naming all apply
+    // exactly as for #[prebindgen] fns.
+    section("binding-local functions (fun!(crate::…) + sig!)") {
+        // Companion constructor: Summary.fromMean(4, 2.5) == of(4, 10.0).
+        val m = Summary.fromMean(4L, 2.5, boom)
+        check(m.count(boom) == 4L && m.total(boom) == 10.0)
+        // Instance method.
+        check(m.mean(boom) == 2.5)
+        // Free fn, selector form: build-arm (0) and handle-arm (1) both reach
+        // the same binding-local Rust fn.
+        check(describeSummary(0, 2L, 8.0, null, false, boom) == "2/8")
+        check(describeSummary(1, null, null, m, true, boom) == "summary of 4 payloads totalling 10")
+        m.close()
     }
 
     // ── flatten input on Summary: default + with, both selectors ─────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -5864,6 +5864,161 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryHa
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryProbe<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    s: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/analytics/SummaryStorageSummaryProbeBuilderRaw";
+    const __CB_DESCR: &str = "(JDLjava/lang/Long;)Ljava/lang/Object;";
+    let __out = perftest_flat::storage_summary_probe(&s);
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match i64_to_jlong_fbf9a9bc(
+            &mut env,
+            perftest_flat::summary_count(&__out),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    let __obj1: jni::sys::jvalue = {
+        let __enc1 = match f64_to_jdouble_9e4a8f70(
+            &mut env,
+            perftest_flat::summary_total(&__out),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { d: __enc1 }
+    };
+    let __obj2: jni::objects::JObject = match crate::summary_if_nonempty(&__out) {
+        ::core::option::Option::Some(__n0) => {
+            let __h2: jni::sys::jlong = match Summary_to_jlong_ccacdeac(&mut env, __n0) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    let __zd = __ze_defaults(&mut env);
+                    signal_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        ::core::option::Option::Some(&__e.to_string()),
+                        &__zd,
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            match ::prebindgen::lang::box_jlong(&mut env, __h2) {
+                ::core::result::Result::Ok(__o) => __o,
+                ::core::result::Result::Err(__e) => {
+                    let __zd = __ze_defaults(&mut env);
+                    signal_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        ::core::option::Option::Some(&__e.to_string()),
+                        &__zd,
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            }
+        }
+        ::core::option::Option::None => jni::objects::JObject::null(),
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                jni::sys::jvalue {
+                    l: __obj2.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e2.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTotalLen<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -6430,6 +6430,311 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryCount<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    s_sel: jni::sys::jint,
+    s_0_0_present: jni::sys::jboolean,
+    s_0_0_value: jni::sys::jlong,
+    s_0_1_present: jni::sys::jboolean,
+    s_0_1_value: jni::sys::jdouble,
+    s_1: jni::sys::jlong,
+    verbose: jni::sys::jboolean,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __exp_s_sel = match jint_to_i32_a3e3b6ef(&mut env, &s_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __exp_s_0_0: Option<i64> = if s_0_0_present != 0u8 {
+        let __v = match jlong_to_i64_fbf9a9bc(&mut env, &s_0_0_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_s_0_1: Option<f64> = if s_0_1_present != 0u8 {
+        let __v = match jdouble_to_f64_9e4a8f70(&mut env, &s_0_1_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_s_1 = match jlong_to_Option_Summary_828826f3(&mut env, &s_1) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __folded_s = match {
+        match __exp_s_sel {
+            0i32 => {
+                match (__exp_s_0_0, __exp_s_0_1) {
+                    (
+                        ::core::option::Option::Some(__p0),
+                        ::core::option::Option::Some(__p1),
+                    ) => {
+                        ::core::result::Result::Ok(
+                            perftest_flat::summary_new(__p0, __p1),
+                        )
+                    }
+                    _ => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from(
+                                "constructor variant input missing",
+                            ),
+                        )
+                    }
+                }
+            }
+            1i32 => {
+                match __exp_s_1 {
+                    ::core::option::Option::Some(__v) => {
+                        ::core::result::Result::Ok(::core::clone::Clone::clone(&*__v))
+                    }
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from("identity variant value missing"),
+                        )
+                    }
+                }
+            }
+            __sel => {
+                ::core::result::Result::Err(
+                    ::std::format!("invalid constructor selector: {}", __sel),
+                )
+            }
+        }
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__je.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let verbose = match jboolean_to_bool_31306d98(&mut env, &verbose) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = crate::summary_describe(&__folded_s, verbose);
+    match String_to_JString_c7f3ca43(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    count: jni::sys::jlong,
+    mean: jni::sys::jdouble,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let mean = match jdouble_to_f64_9e4a8f70(&mut env, &mean) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = crate::summary_from_mean(count, mean);
+    match Summary_to_jlong_3cb103b9(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMean<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    s: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jdouble {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let s = match jlong_to_Summary_3cb103b9(&mut env, &s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0.0 as jni::sys::jdouble;
+        }
+    };
+    let __out = crate::summary_mean(&s);
+    match f64_to_jdouble_9e4a8f70(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            0.0 as jni::sys::jdouble
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1397,6 +1397,13 @@ pub(crate) unsafe fn Result_Storage_StorageError_to_Storage_7ccce404<'a>(
     v
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Result_Summary_String_to_Summary_dfdf7f9e<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Result<perftest_flat::Summary, String>,
+) -> ::core::result::Result<perftest_flat::Summary, String> {
+    v
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Stamp_to_JByteArray_2fc9bd18<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Stamp,
@@ -6666,7 +6673,23 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<
         }
     };
     let __out = crate::summary_from_mean(count, mean);
-    match Summary_to_jlong_3cb103b9(&mut env, __out) {
+    let __out_s0 = match Result_Summary_String_to_Summary_dfdf7f9e(&mut env, __out) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    match Summary_to_jlong_3cb103b9(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             let __zd = __ze_defaults(&mut env);

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -2,12 +2,12 @@
 // belong to the generator, not to this file.
 #![allow(clippy::all)]
 
-// Binding-local conversion fns for `Label` — referenced by build.rs as
-// `.convert(convert!(Label).input_try_with(…, path!(crate::label_in))…)`.
-// NOT `#[prebindgen]`-marked: the generated file compiles inside this crate,
-// so plain `crate::` paths resolve; no helper crate needed. The input is the
-// FALLIBLE local form (`fn(Repr) -> Result<T, E>`, E stated in the decl);
-// the output is the infallible one.
+// Binding-local conversion fns for `Label` — declared in build.rs via the
+// one binding-local vocabulary, `.convert(convert!(Label).input(fun!(crate::
+// label_in).sig(…))…)`. NOT `#[prebindgen]`-marked: the generated file
+// compiles inside this crate, so plain `crate::` paths resolve; no helper
+// crate needed. The input is FALLIBLE — the sig's `Result<Label, String>`
+// return is the error channel.
 pub fn label_in(s: String) -> Result<perftest_flat::Label, String> {
     if s.is_empty() {
         Err("label must not be empty".to_string())
@@ -19,12 +19,11 @@ pub fn label_out(l: perftest_flat::Label) -> String {
     l.0
 }
 
-// Binding-local nullary fn backing the `.with`-sourced constant
-// `COVER_VERSION` (build.rs: `constant!(COVER_VERSION).with(ty!(String),
 // Binding-local FUNCTIONS (`fun!(crate::…).sig(sig!(…))`): full fns defined
 // in THIS crate and exported through the ordinary FunctionDecl surface —
 // free package fn, instance method, companion constructor. No source-crate
-// item exists for any of them.
+// item exists for any of them. `summary_from_mean` is FALLIBLE: the sig's
+// `Result<Summary, String>` return routes the Err to onError.
 pub(crate) fn summary_describe(s: &perftest_flat::Summary, verbose: bool) -> String {
     let count = perftest_flat::summary_count(s);
     let total = perftest_flat::summary_total(s);
@@ -44,8 +43,12 @@ pub(crate) fn summary_mean(s: &perftest_flat::Summary) -> f64 {
     }
 }
 
-pub(crate) fn summary_from_mean(count: i64, mean: f64) -> perftest_flat::Summary {
-    perftest_flat::summary_new(count, mean * count as f64)
+pub(crate) fn summary_from_mean(count: i64, mean: f64) -> Result<perftest_flat::Summary, String> {
+    if count < 0 {
+        Err(format!("summary count must be non-negative, got {count}"))
+    } else {
+        Ok(perftest_flat::summary_new(count, mean * count as f64))
+    }
 }
 
 // Binding-local CONDITIONAL output field (`expand_return!(Summary)` per-fn
@@ -57,7 +60,9 @@ pub(crate) fn summary_if_nonempty(s: &perftest_flat::Summary) -> Option<&perftes
     (perftest_flat::summary_count(s) > 0).then_some(s)
 }
 
-// path!(crate::cover_version))`) — the const analog of convert!'s `_with`.
+// Binding-local nullary fn backing the `.with`-sourced constant
+// `COVER_VERSION` (build.rs: `constant!(COVER_VERSION).with(ty!(String),
+// path!(crate::cover_version))`).
 pub fn cover_version() -> String {
     format!("cover-{}", env!("CARGO_PKG_VERSION"))
 }

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -21,6 +21,33 @@ pub fn label_out(l: perftest_flat::Label) -> String {
 
 // Binding-local nullary fn backing the `.with`-sourced constant
 // `COVER_VERSION` (build.rs: `constant!(COVER_VERSION).with(ty!(String),
+// Binding-local FUNCTIONS (`fun!(crate::…).sig(sig!(…))`): full fns defined
+// in THIS crate and exported through the ordinary FunctionDecl surface —
+// free package fn, instance method, companion constructor. No source-crate
+// item exists for any of them.
+pub(crate) fn summary_describe(s: &perftest_flat::Summary, verbose: bool) -> String {
+    let count = perftest_flat::summary_count(s);
+    let total = perftest_flat::summary_total(s);
+    if verbose {
+        format!("summary of {count} payloads totalling {total}")
+    } else {
+        format!("{count}/{total}")
+    }
+}
+
+pub(crate) fn summary_mean(s: &perftest_flat::Summary) -> f64 {
+    let count = perftest_flat::summary_count(s);
+    if count == 0 {
+        0.0
+    } else {
+        perftest_flat::summary_total(s) / count as f64
+    }
+}
+
+pub(crate) fn summary_from_mean(count: i64, mean: f64) -> perftest_flat::Summary {
+    perftest_flat::summary_new(count, mean * count as f64)
+}
+
 // Binding-local CONDITIONAL output field (`expand_return!(Summary)` per-fn
 // set of `storage_summary_probe`: `.field(field!("handle").with(ty!(Option<&
 // Summary>), path!(crate::summary_if_nonempty)))`): deliver the handle leaf

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -21,6 +21,15 @@ pub fn label_out(l: perftest_flat::Label) -> String {
 
 // Binding-local nullary fn backing the `.with`-sourced constant
 // `COVER_VERSION` (build.rs: `constant!(COVER_VERSION).with(ty!(String),
+// Binding-local CONDITIONAL output field (`expand_return!(Summary)` per-fn
+// set of `storage_summary_probe`: `.field(field!("handle").with(ty!(Option<&
+// Summary>), path!(crate::summary_if_nonempty)))`): deliver the handle leaf
+// only when the summary is non-empty — binding policy with no place in the
+// source crate (the zenoh "Encoding handle only when schema-carrying" idiom).
+pub(crate) fn summary_if_nonempty(s: &perftest_flat::Summary) -> Option<&perftest_flat::Summary> {
+    (perftest_flat::summary_count(s) > 0).then_some(s)
+}
+
 // path!(crate::cover_version))`) — the const analog of convert!'s `_with`.
 pub fn cover_version() -> String {
     format!("cover-{}", env!("CARGO_PKG_VERSION"))

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct foo_t {
     pub id: u64,
     pub aarch64_field: u64,
-    pub stable_field: u64,
+    pub unstable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -97,7 +97,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         aarch64_field: v.aarch64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -208,7 +208,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         aarch64_field: v.aarch64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -429,6 +429,17 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
+    let c = match __cbg_in___mut_Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    example_flat::calculator_reset(c);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -480,7 +491,7 @@ pub unsafe extern "C" fn inside_foo_value(x: inside_foo_t) -> i32 {
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "",
+        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -37,7 +37,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t aarch64_field;
-  uint64_t stable_field;
+  uint64_t unstable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -69,6 +69,8 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
+
+void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -230,6 +230,15 @@ pub fn storage_summary_full(s: &Storage) -> Summary {
     storage_summary(s)
 }
 
+/// Like [`storage_summary`] but the binding's per-fn field set carries a
+/// **binding-local conditional field** (`field!("handle").with(ty!, path!)`):
+/// the handle leaf is delivered only when the binding-side predicate says
+/// re-using the value is worth it (the zenoh conditional-Encoding idiom).
+#[prebindgen]
+pub fn storage_summary_probe(s: &Storage) -> Summary {
+    storage_summary(s)
+}
+
 /// Set the storage's "expected" summary, accepting a `Summary` built via an
 /// explicit per-fn **flatten-input-with** variant list. Returns whether it
 /// matched the live summary before being consumed.

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -261,6 +261,20 @@ pub trait Prebindgen {
         HashSet::new()
     }
 
+    /// **Binding-local functions** to synthesize into the registry before
+    /// scanning: `(item, origin module path)` pairs built from
+    /// adapter-declared signatures (there is no `#[prebindgen]` item behind
+    /// them — the fn lives in the binding crate and the generated code calls
+    /// it qualified by `origin`). The item's body is never emitted; only its
+    /// signature is read. A synthesized ident colliding with a real
+    /// `#[prebindgen]` item is a hard resolve error. Adapters without the
+    /// concept return empty.
+    ///
+    /// Default: empty.
+    fn local_functions(&self) -> Vec<(syn::ItemFn, String)> {
+        Vec::new()
+    }
+
     /// `#[prebindgen]` functions declared as **methods** of a class, mapping the
     /// fn ident to its class's canonical [`TypeKey`]. A method's first parameter
     /// of that class type is the receiver and is excluded from input-flattening

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1158,6 +1158,26 @@ impl<M> Registry<M> {
         E: Prebindgen<Metadata = M>,
         M: Clone + Default,
     {
+        // Synthesis pre-pass: adapter-declared BINDING-LOCAL fns become
+        // ordinary registry entries (signature read from the synthesized
+        // item, calls qualified by the recorded origin), so every downstream
+        // stage treats them exactly like `#[prebindgen]` fns.
+        for (item_fn, origin) in adapter.local_functions() {
+            let ident = item_fn.sig.ident.clone();
+            if self.functions.contains_key(&ident) {
+                return Err(ScanError::AdapterInvariant {
+                    message: format!(
+                        "binding-local fn `{ident}` collides with a `#[prebindgen]` item — \
+                         the generated call would resolve the wrong fn; rename the \
+                         binding-local fn"
+                    ),
+                }
+                .into());
+            }
+            self.functions
+                .insert(ident.clone(), (item_fn, crate::SourceLocation::default()));
+            self.item_origins.insert(ident, origin);
+        }
         let declared = DeclaredItems::from_adapter(&adapter)?;
         self.scan_declared_items(&declared)?;
         adapter

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -1357,13 +1357,40 @@ fn flatten<M>(
                     visited.remove(&child_key);
                 } else {
                     // Leaf: the return value as written (`&str`, enum, `i64`, …).
+                    // One exception: a binding-local field returning an
+                    // OPTIONAL BORROW (`Option<&T>`) is the conditional
+                    // HANDLE-delivery idiom — structurally a spliced identity
+                    // behind an `Option`-returning step (cf. an
+                    // `Option`-returning nesting accessor + the child's
+                    // `field_self`), so it contributes a nullable IDENTITY
+                    // leaf of the borrowed type: the reach path unwraps the
+                    // final `Option` (the synthesized signature keeps the
+                    // full return) and the value clones through its handle
+                    // projection, `None` delivering null. It shares the
+                    // one-identity-per-deconstructor budget with
+                    // `.field_self()` — two handle deliveries of one value
+                    // make no sense.
+                    let cond_handle = local && opt && matches!(core, syn::Type::Reference(_));
+                    if cond_handle {
+                        if seen_identity {
+                            return Err(UnfoldError::MultipleIdentity {
+                                target: source_key.to_string(),
+                            });
+                        }
+                        seen_identity = true;
+                    }
+                    let (out_ty, nullable, identity) = if cond_handle {
+                        (core.clone(), true, true)
+                    } else {
+                        (ret, nullable, false)
+                    };
                     let mut path = path_prefix.to_vec();
                     path.push(func.clone());
                     leaves.push(UnfoldLeaf {
                         name: seg_name(name).join("__"),
                         path,
-                        out_ty: ret,
-                        identity: false,
+                        out_ty,
+                        identity,
                         nullable,
                         source: LeafSource::Accessor,
                     });

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -46,6 +46,10 @@ pub use self::{
 
 /// One record (field) of a deconstructor. A deconstructor is a product: every
 /// record contributes a leaf.
+// large_enum_variant: a handful of records exist per binding, held while
+// declarations replay — boxing the syn payloads would only complicate the
+// arms (same trade-off as `ConvertSourceKind`).
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 enum DeconRecord {
     /// Read this field by calling the accessor function `f(&T) -> &F`. `name`
@@ -54,10 +58,54 @@ enum DeconRecord {
     /// An accessor whose return type has its own deconstructor splices that
     /// child's records with the leaf names prefixed `name__<child>`.
     Acc { func: syn::Ident, name: String },
+    /// Read this field by calling a **binding-local** accessor: a callable in
+    /// the binding crate (`path`, e.g. `crate::encoding_if_schema`) with a
+    /// STATED return type (`ty`) — there is no `#[prebindgen]` item behind
+    /// it, so the signature cannot be looked up. [`apply`] synthesizes a
+    /// registry entry from the stated signature (so call qualification and
+    /// `Option`-nesting checks work unchanged); splicing follows [`Self::Acc`]
+    /// rules except that a self-referential field (its type already being
+    /// decomposed) degrades to a plain converter leaf instead of a cycle
+    /// error — the very point of such a field is to re-deliver (part of) the
+    /// value under a binding-defined condition.
+    LocalAcc {
+        path: syn::Path,
+        ty: syn::Type,
+        name: String,
+    },
     /// The value itself — the handle/identity leaf (cloned for a `&T` return,
     /// moved for an owned `T`, copied for a `Copy` value_blob). At most one per
     /// deconstructor.
     Identity,
+}
+
+impl DeconRecord {
+    /// The fn ident of a [`Self::LocalAcc`] — its path's last segment (the
+    /// name the emitted call resolves to under the path-prefix origin).
+    fn local_ident(path: &syn::Path) -> syn::Ident {
+        path.segments
+            .last()
+            .expect("field!(...).with(...): empty accessor path")
+            .ident
+            .clone()
+    }
+
+    /// The origin-module prefix of a [`Self::LocalAcc`] path (`crate::sub::f`
+    /// → `"crate::sub"`); a single-segment path has no prefix and resolves
+    /// bare — reject it instead (a binding-local callable is qualified from
+    /// the generated file, so at least `crate::` is required).
+    fn local_prefix(path: &syn::Path) -> Option<String> {
+        if path.segments.len() < 2 {
+            return None;
+        }
+        let segs: Vec<String> = path
+            .segments
+            .iter()
+            .take(path.segments.len() - 1)
+            .map(|s| s.ident.to_string())
+            .collect();
+        Some(segs.join("::"))
+    }
 }
 
 #[derive(Clone)]
@@ -193,6 +241,24 @@ impl Deconstructors {
         self.deconstructors[i].records.push(DeconRecord::Identity);
     }
 
+    /// `expand_return!` `.field(field!(name).with(ty, path))` — add a
+    /// **binding-local** accessor record (stated return type + callable).
+    pub fn add_deconstructor_record_local(
+        &mut self,
+        path: syn::Path,
+        ty: syn::Type,
+        name: impl Into<String>,
+    ) {
+        let i = self
+            .cur_deconstructor
+            .expect(".field called without a current deconstructor");
+        self.deconstructors[i].records.push(DeconRecord::LocalAcc {
+            path,
+            ty,
+            name: name.into(),
+        });
+    }
+
     /// Begin a per-fn inline output override (`.expand_return(expand_return!(T)…)`):
     /// decompose `func`'s return via an incrementally-built record list
     /// (accessor fields via [`Self::push_inline_field`] and/or the identity/self
@@ -237,6 +303,26 @@ impl Deconstructors {
             records.push(DeconRecord::Identity);
         }
     }
+
+    /// `.expand_return` `.field(field!(name).with(ty, path))` — append a
+    /// **binding-local** accessor field to the current per-fn inline output.
+    pub fn push_inline_field_local(
+        &mut self,
+        path: syn::Path,
+        ty: syn::Type,
+        name: impl Into<String>,
+    ) {
+        let i = self
+            .cur_output
+            .expect(".field called without a current deconstructor");
+        if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
+            records.push(DeconRecord::LocalAcc {
+                path,
+                ty,
+                name: name.into(),
+            });
+        }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -261,12 +347,22 @@ pub fn apply<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
+    // Materialize binding-local accessors: each `LocalAcc` record synthesizes
+    // a registry fn entry from its STATED signature (`fn <ident>(v: &Target)
+    // -> Ty`) with the path prefix as its origin module — downstream
+    // (splicing, call qualification, `Option`-nesting checks, converter
+    // resolution) then reads it exactly like a `#[prebindgen]` accessor's.
+    synthesize_local_accessors(registry, acc)?;
+
     // Gate: every accessor-function record of every declared deconstructor must
     // be a `.fun_accessor` (the single source of truth for "accessor").
+    // Binding-local records skip the gate — there is no `#[prebindgen]` item
+    // behind them — but keep the reserved-separator name check.
     for d in &acc.deconstructors {
         for rec in &d.records {
             let (func, name) = match rec {
-                DeconRecord::Acc { func, name } => (func, name),
+                DeconRecord::Acc { func, name } => (Some(func), name),
+                DeconRecord::LocalAcc { name, .. } => (None, name),
                 DeconRecord::Identity => continue,
             };
             // `"__"` is the reserved nesting/chain separator — author leaf names
@@ -274,8 +370,10 @@ pub fn apply<M>(
             if name.contains("__") {
                 return Err(UnfoldError::ReservedSeparator { name: name.clone() });
             }
-            if !accessor_fns.contains(func) {
-                return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
+            if let Some(func) = func {
+                if !accessor_fns.contains(func) {
+                    return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
+                }
             }
         }
     }
@@ -919,6 +1017,67 @@ fn decl_id(type_key: &TypeKey, _decl: &DeconstructorDecl) -> DeconId {
     DeconId::Default(type_key.to_string())
 }
 
+/// Insert a synthetic registry entry for every [`DeconRecord::LocalAcc`]:
+/// signature `fn <path-last-segment>(v: &Target) -> Ty` keyed by the fn
+/// ident, origin = the path's module prefix (`crate::sub::f` → `crate::sub`),
+/// so [`Registry::origin_module`]-driven call qualification emits the exact
+/// declared path. The same fn may back fields of several types ONLY with an
+/// identical stated signature; colliding with a real `#[prebindgen]` item is
+/// a hard error (the emitted call would resolve the wrong fn).
+fn synthesize_local_accessors<M>(
+    registry: &mut Registry<M>,
+    acc: &Deconstructors,
+) -> Result<(), UnfoldError> {
+    let mut synthesized: std::collections::HashMap<syn::Ident, String> = Default::default();
+    let mut synth = |registry: &mut Registry<M>,
+                     records: &[DeconRecord],
+                     target: &syn::Type|
+     -> Result<(), UnfoldError> {
+        for rec in records {
+            let DeconRecord::LocalAcc { path, ty, .. } = rec else {
+                continue;
+            };
+            let ident = DeconRecord::local_ident(path);
+            let Some(prefix) = DeconRecord::local_prefix(path) else {
+                return Err(UnfoldError::LocalAccessorBarePath {
+                    path: quote::quote!(#path).to_string(),
+                });
+            };
+            let sig = format!("{prefix}::{ident}({}) -> {}", quote::quote!(&#target), {
+                quote::quote!(#ty)
+            });
+            match synthesized.get(&ident) {
+                Some(prev) if *prev == sig => continue, // same fn, same shape — fine
+                Some(_) => return Err(UnfoldError::LocalAccessorCollision { name: ident }),
+                None => {}
+            }
+            if registry.functions.contains_key(&ident) {
+                return Err(UnfoldError::LocalAccessorCollision { name: ident });
+            }
+            let item_fn: syn::ItemFn = syn::parse_quote! {
+                fn #ident(v: &#target) -> #ty {
+                    unimplemented!()
+                }
+            };
+            registry
+                .functions
+                .insert(ident.clone(), (item_fn, crate::SourceLocation::default()));
+            registry.item_origins.insert(ident.clone(), prefix);
+            synthesized.insert(ident, sig);
+        }
+        Ok(())
+    };
+    for d in &acc.deconstructors {
+        synth(registry, &d.records, &d.target)?;
+    }
+    for ed in &acc.outputs {
+        if let (DeconSel::Inline(records), Some(target)) = (&ed.sel, &ed.declared_source) {
+            synth(registry, records, target)?;
+        }
+    }
+    Ok(())
+}
+
 /// Register the declaration-default [`DeconSpec`] for `decon` (no-op when
 /// already present): re-flatten the records with normalized inputs —
 /// borrowed identity, no outer shape — so the stored spec is independent of
@@ -1139,9 +1298,18 @@ fn flatten<M>(
                     source: LeafSource::Accessor,
                 });
             }
-            DeconRecord::Acc { func, name } => {
-                let (takes, ret) = accessor_signature(registry, func)?;
-                check_takes(func, &takes, source)?;
+            DeconRecord::Acc { name, .. } | DeconRecord::LocalAcc { name, .. } => {
+                // A binding-local record resolves through its synthesized
+                // registry entry (see `synthesize_local_accessors`), so both
+                // kinds read one signature source; only the cycle rule below
+                // differs.
+                let (func, local) = match rec {
+                    DeconRecord::Acc { func, .. } => (func.clone(), false),
+                    DeconRecord::LocalAcc { path, .. } => (DeconRecord::local_ident(path), true),
+                    DeconRecord::Identity => unreachable!(),
+                };
+                let (takes, ret) = accessor_signature(registry, &func)?;
+                check_takes(&func, &takes, source)?;
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
@@ -1154,12 +1322,23 @@ fn flatten<M>(
                     other => other.clone(),
                 };
                 let child_key = TypeKey::from_type(&child_ty);
-                if let Some(child_decl) = find_deconstructor_by_type(acc, &child_key) {
-                    if !visited.insert(child_key.clone()) {
+                // A child already on the nesting chain: for a `#[prebindgen]`
+                // accessor that is an authoring cycle (hard error); a
+                // binding-local field re-delivering (part of) its own type
+                // under a binding-defined condition is the POINT — degrade to
+                // a plain converter leaf instead of splicing.
+                let splice = match find_deconstructor_by_type(acc, &child_key) {
+                    Some(child_decl) if !visited.contains(&child_key) => Some(child_decl),
+                    Some(_) if local => None,
+                    Some(_) => {
                         return Err(UnfoldError::Cycle {
                             target: child_key.to_string(),
                         });
                     }
+                    None => None,
+                };
+                if let Some(child_decl) = splice {
+                    visited.insert(child_key.clone());
                     let child_records = child_decl.records.clone();
                     let mut child_path = path_prefix.to_vec();
                     child_path.push(func.clone());

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -58,21 +58,17 @@ enum DeconRecord {
     /// An accessor whose return type has its own deconstructor splices that
     /// child's records with the leaf names prefixed `name__<child>`.
     Acc { func: syn::Ident, name: String },
-    /// Read this field by calling a **binding-local** accessor: a callable in
-    /// the binding crate (`path`, e.g. `crate::encoding_if_schema`) with a
-    /// STATED return type (`ty`) — there is no `#[prebindgen]` item behind
-    /// it, so the signature cannot be looked up. [`apply`] synthesizes a
-    /// registry entry from the stated signature (so call qualification and
-    /// `Option`-nesting checks work unchanged); splicing follows [`Self::Acc`]
-    /// rules except that a self-referential field (its type already being
-    /// decomposed) degrades to a plain converter leaf instead of a cycle
-    /// error — the very point of such a field is to re-deliver (part of) the
-    /// value under a binding-defined condition.
-    LocalAcc {
-        path: syn::Path,
-        ty: syn::Type,
-        name: String,
-    },
+    /// Read this field by calling a **custom, locally-defined** accessor: any
+    /// callable in the binding crate (`path`) with a STATED return type
+    /// (`ty`) — there is no `#[prebindgen]` item behind it, so the signature
+    /// cannot be looked up. The adapter's `local_functions()` pre-pass
+    /// synthesizes a registry entry from the stated signature (so call
+    /// qualification and `Option`-nesting checks work unchanged); splicing
+    /// follows [`Self::Acc`] rules except that a self-referential field (its
+    /// type already being decomposed) degrades to a plain converter leaf
+    /// instead of a cycle error — that is what lets such a field re-deliver
+    /// (part of) the value itself, e.g. under a binding-defined condition.
+    LocalAcc { path: syn::Path, name: String },
     /// The value itself — the handle/identity leaf (cloned for a `&T` return,
     /// moved for an owned `T`, copied for a `Copy` value_blob). At most one per
     /// deconstructor.
@@ -88,23 +84,6 @@ impl DeconRecord {
             .expect("field!(...).with(...): empty accessor path")
             .ident
             .clone()
-    }
-
-    /// The origin-module prefix of a [`Self::LocalAcc`] path (`crate::sub::f`
-    /// → `"crate::sub"`); a single-segment path has no prefix and resolves
-    /// bare — reject it instead (a binding-local callable is qualified from
-    /// the generated file, so at least `crate::` is required).
-    fn local_prefix(path: &syn::Path) -> Option<String> {
-        if path.segments.len() < 2 {
-            return None;
-        }
-        let segs: Vec<String> = path
-            .segments
-            .iter()
-            .take(path.segments.len() - 1)
-            .map(|s| s.ident.to_string())
-            .collect();
-        Some(segs.join("::"))
     }
 }
 
@@ -243,18 +222,12 @@ impl Deconstructors {
 
     /// `expand_return!` `.field(field!(name).with(ty, path))` — add a
     /// **binding-local** accessor record (stated return type + callable).
-    pub fn add_deconstructor_record_local(
-        &mut self,
-        path: syn::Path,
-        ty: syn::Type,
-        name: impl Into<String>,
-    ) {
+    pub fn add_deconstructor_record_local(&mut self, path: syn::Path, name: impl Into<String>) {
         let i = self
             .cur_deconstructor
             .expect(".field called without a current deconstructor");
         self.deconstructors[i].records.push(DeconRecord::LocalAcc {
             path,
-            ty,
             name: name.into(),
         });
     }
@@ -306,19 +279,13 @@ impl Deconstructors {
 
     /// `.expand_return` `.field(field!(name).with(ty, path))` — append a
     /// **binding-local** accessor field to the current per-fn inline output.
-    pub fn push_inline_field_local(
-        &mut self,
-        path: syn::Path,
-        ty: syn::Type,
-        name: impl Into<String>,
-    ) {
+    pub fn push_inline_field_local(&mut self, path: syn::Path, name: impl Into<String>) {
         let i = self
             .cur_output
             .expect(".field called without a current deconstructor");
         if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
             records.push(DeconRecord::LocalAcc {
                 path,
-                ty,
                 name: name.into(),
             });
         }
@@ -347,12 +314,10 @@ pub fn apply<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
-    // Materialize binding-local accessors: each `LocalAcc` record synthesizes
-    // a registry fn entry from its STATED signature (`fn <ident>(v: &Target)
-    // -> Ty`) with the path prefix as its origin module — downstream
-    // (splicing, call qualification, `Option`-nesting checks, converter
-    // resolution) then reads it exactly like a `#[prebindgen]` accessor's.
-    synthesize_local_accessors(registry, acc)?;
+    // Binding-local accessors (`LocalAcc` records) resolve through registry
+    // entries synthesized by the adapter's `local_functions()` pre-pass in
+    // `Registry::resolve` — by this point they read exactly like
+    // `#[prebindgen]` accessors.
 
     // Gate: every accessor-function record of every declared deconstructor must
     // be a `.fun_accessor` (the single source of truth for "accessor").
@@ -1015,67 +980,6 @@ fn process_decl<M>(
 /// The identity of a found declaration — the type's default deconstructor.
 fn decl_id(type_key: &TypeKey, _decl: &DeconstructorDecl) -> DeconId {
     DeconId::Default(type_key.to_string())
-}
-
-/// Insert a synthetic registry entry for every [`DeconRecord::LocalAcc`]:
-/// signature `fn <path-last-segment>(v: &Target) -> Ty` keyed by the fn
-/// ident, origin = the path's module prefix (`crate::sub::f` → `crate::sub`),
-/// so [`Registry::origin_module`]-driven call qualification emits the exact
-/// declared path. The same fn may back fields of several types ONLY with an
-/// identical stated signature; colliding with a real `#[prebindgen]` item is
-/// a hard error (the emitted call would resolve the wrong fn).
-fn synthesize_local_accessors<M>(
-    registry: &mut Registry<M>,
-    acc: &Deconstructors,
-) -> Result<(), UnfoldError> {
-    let mut synthesized: std::collections::HashMap<syn::Ident, String> = Default::default();
-    let mut synth = |registry: &mut Registry<M>,
-                     records: &[DeconRecord],
-                     target: &syn::Type|
-     -> Result<(), UnfoldError> {
-        for rec in records {
-            let DeconRecord::LocalAcc { path, ty, .. } = rec else {
-                continue;
-            };
-            let ident = DeconRecord::local_ident(path);
-            let Some(prefix) = DeconRecord::local_prefix(path) else {
-                return Err(UnfoldError::LocalAccessorBarePath {
-                    path: quote::quote!(#path).to_string(),
-                });
-            };
-            let sig = format!("{prefix}::{ident}({}) -> {}", quote::quote!(&#target), {
-                quote::quote!(#ty)
-            });
-            match synthesized.get(&ident) {
-                Some(prev) if *prev == sig => continue, // same fn, same shape — fine
-                Some(_) => return Err(UnfoldError::LocalAccessorCollision { name: ident }),
-                None => {}
-            }
-            if registry.functions.contains_key(&ident) {
-                return Err(UnfoldError::LocalAccessorCollision { name: ident });
-            }
-            let item_fn: syn::ItemFn = syn::parse_quote! {
-                fn #ident(v: &#target) -> #ty {
-                    unimplemented!()
-                }
-            };
-            registry
-                .functions
-                .insert(ident.clone(), (item_fn, crate::SourceLocation::default()));
-            registry.item_origins.insert(ident.clone(), prefix);
-            synthesized.insert(ident, sig);
-        }
-        Ok(())
-    };
-    for d in &acc.deconstructors {
-        synth(registry, &d.records, &d.target)?;
-    }
-    for ed in &acc.outputs {
-        if let (DeconSel::Inline(records), Some(target)) = (&ed.sel, &ed.declared_source) {
-            synth(registry, records, target)?;
-        }
-    }
-    Ok(())
 }
 
 /// Register the declaration-default [`DeconSpec`] for `decon` (no-op when

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -64,17 +64,6 @@ pub enum UnfoldError {
         declared: String,
         actual: String,
     },
-    /// A binding-local field's callable path has a single segment — the
-    /// generated file calls it qualified, so at least `crate::` is required.
-    LocalAccessorBarePath {
-        path: String,
-    },
-    /// A binding-local field's fn name collides with a `#[prebindgen]` item
-    /// (or another binding-local field with a different signature) — the
-    /// emitted call is `<prefix>::<name>`, so the name must be unambiguous.
-    LocalAccessorCollision {
-        name: syn::Ident,
-    },
 }
 
 impl std::fmt::Display for UnfoldError {
@@ -105,18 +94,6 @@ impl std::fmt::Display for UnfoldError {
                 f,
                 "output expansion: no deconstructor registered for `{}` (return of `{}`)",
                 target, func
-            ),
-            UnfoldError::LocalAccessorBarePath { path } => write!(
-                f,
-                "field!(...).with(..., path!({path})): a binding-local accessor is called \
-                 QUALIFIED from the generated file — give at least a `crate::`-rooted path",
-            ),
-            UnfoldError::LocalAccessorCollision { name } => write!(
-                f,
-                "field!(...).with(...): the binding-local fn name `{name}` collides with a \
-                 `#[prebindgen]` item (or another binding-local field with a different \
-                 signature) — the emitted call is `<prefix>::{name}`, so rename the \
-                 binding-local fn",
             ),
             UnfoldError::AccessorTargetMismatch {
                 accessor,

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -64,6 +64,17 @@ pub enum UnfoldError {
         declared: String,
         actual: String,
     },
+    /// A binding-local field's callable path has a single segment — the
+    /// generated file calls it qualified, so at least `crate::` is required.
+    LocalAccessorBarePath {
+        path: String,
+    },
+    /// A binding-local field's fn name collides with a `#[prebindgen]` item
+    /// (or another binding-local field with a different signature) — the
+    /// emitted call is `<prefix>::<name>`, so the name must be unambiguous.
+    LocalAccessorCollision {
+        name: syn::Ident,
+    },
 }
 
 impl std::fmt::Display for UnfoldError {
@@ -94,6 +105,18 @@ impl std::fmt::Display for UnfoldError {
                 f,
                 "output expansion: no deconstructor registered for `{}` (return of `{}`)",
                 target, func
+            ),
+            UnfoldError::LocalAccessorBarePath { path } => write!(
+                f,
+                "field!(...).with(..., path!({path})): a binding-local accessor is called \
+                 QUALIFIED from the generated file — give at least a `crate::`-rooted path",
+            ),
+            UnfoldError::LocalAccessorCollision { name } => write!(
+                f,
+                "field!(...).with(...): the binding-local fn name `{name}` collides with a \
+                 `#[prebindgen]` item (or another binding-local field with a different \
+                 signature) — the emitted call is `<prefix>::{name}`, so rename the \
+                 binding-local fn",
             ),
             UnfoldError::AccessorTargetMismatch {
                 accessor,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -814,7 +814,7 @@ impl JniGen {
     /// pass through unchecked.
     fn check_local_field_ty(&self, decl_key: &TypeKey, name: &str, ty: &syn::Type) {
         let syn::Type::Path(p) = ty else { return };
-        if !p.path.segments.last().is_some_and(|s| s.ident == "Option") {
+        if p.path.segments.last().is_none_or(|s| s.ident != "Option") {
             return;
         }
         let Some(syn::PathArguments::AngleBracketed(args)) =

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -880,9 +880,24 @@ impl JniGen {
             .flatten()
             .filter_map(|f| match f {
                 LocalField::Named(func, _) => Some(func.clone()),
-                LocalField::SelfField | LocalField::Local { .. } => None,
+                // A binding-local field's synthesized fn is helper-only too:
+                // called by the generated code, never externed, and its
+                // synthesized registry entry must not trip the warning.
+                LocalField::Local { path, .. } => Some(
+                    path.segments
+                        .last()
+                        .expect("validated non-empty at decl time")
+                        .ident
+                        .clone(),
+                ),
+                LocalField::SelfField => None,
             });
-        ctors.chain(accessors)
+        // Synthesized binding-local fns from every entry form (path-built
+        // fun! at fun/method/constructor/convert sites): their registry
+        // entries exist only for signature reads — helper-only unless also
+        // declared (the declared set is subtracted by the caller).
+        let locals = self.local_fns.iter().map(|(ident, _, _)| ident.clone());
+        ctors.chain(accessors).chain(locals)
     }
 
     /// Every function referenced as a named field in any `expand_return!`
@@ -900,7 +915,17 @@ impl JniGen {
             .flatten()
             .filter_map(|f| match f {
                 LocalField::Named(func, _) => Some(func.clone()),
-                LocalField::SelfField | LocalField::Local { .. } => None,
+                // A binding-local field's synthesized fn IS an accessor —
+                // excluded from parameter composition, and acknowledged so
+                // the registry's "skipping undeclared" warning stays quiet.
+                LocalField::Local { path, .. } => Some(
+                    path.segments
+                        .last()
+                        .expect("validated non-empty at decl time")
+                        .ident
+                        .clone(),
+                ),
+                LocalField::SelfField => None,
             })
             .collect()
     }
@@ -917,13 +942,17 @@ impl JniGen {
     /// `data_class` fields). Applies wherever the type appears; not tied to
     /// any package. See [`ConvertDecl`] for the relation to the
     /// [`expand`](Self::expand) boundary decls.
-    pub fn convert(mut self, decl: ConvertDecl) -> Self {
+    pub fn convert(mut self, mut decl: ConvertDecl) -> Self {
         assert!(
             decl.input.is_some() || decl.output.is_some(),
             "convert!({}) declares no conversions — add .input(fun!(...)) and/or \
              .output(fun!(...))",
             decl.key.as_str()
         );
+        // Binding-local fn sources (`fun!(crate::f).sig(…)`) join the same
+        // synthesis list as fun/method/constructor sites — after the
+        // pre-pass they lower exactly like `#[prebindgen]` fn sources.
+        self.local_fns.append(&mut decl.locals);
         self.convert_decls.push(decl);
         self
     }
@@ -997,15 +1026,10 @@ impl JniGen {
                     );
                     Some((repr.clone(), None, body))
                 }
-            }
-            // Binding-local callable: emitted verbatim (multi-segment paths
-            // pass the qualification visitor untouched). With a declared
-            // error type the fn returns `Result<T, E>` — emitted as-is, `E`
-            // riding the standard exc slot.
-            ConvertSpec::LocalFn { repr, path, error } => {
-                let body: syn::Expr = syn::parse_quote!(#path(v));
-                Some((repr.clone(), error.clone(), body))
-            }
+            } // Binding-local callable: emitted verbatim (multi-segment paths
+              // pass the qualification visitor untouched). With a declared
+              // error type the fn returns `Result<T, E>` — emitted as-is, `E`
+              // riding the standard exc slot.
         }
     }
 
@@ -1063,10 +1087,6 @@ impl JniGen {
                     );
                     Some((repr.clone(), None, body))
                 }
-            }
-            ConvertSpec::LocalFn { repr, path, error } => {
-                let body: syn::Expr = syn::parse_quote!(#path(v));
-                Some((repr.clone(), error.clone(), body))
             }
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -694,9 +694,14 @@ impl JniGen {
                         dec.add_deconstructor_record(func.clone(), name);
                     }
                     LocalField::SelfField => dec.add_deconstructor_record_id(),
-                    LocalField::Local { name, ty, path } => {
-                        self.check_local_field_ty(&decl.key, name, ty);
-                        dec.add_deconstructor_record_local(path.clone(), name.clone());
+                    LocalField::Local {
+                        path,
+                        sig,
+                        name_override,
+                    } => {
+                        let name = self.local_field_name(&decl.key, path, name_override);
+                        self.check_local_field_ty(&decl.key, &name, sig);
+                        dec.add_deconstructor_record_local(path.clone(), name);
                     }
                 }
             }
@@ -727,14 +732,36 @@ impl JniGen {
                         dec.push_inline_field(afunc.clone(), name);
                     }
                     LocalField::SelfField => dec.push_inline_field_self(),
-                    LocalField::Local { name, ty, path } => {
-                        self.check_local_field_ty(&decl.key, name, ty);
-                        dec.push_inline_field_local(path.clone(), name.clone());
+                    LocalField::Local {
+                        path,
+                        sig,
+                        name_override,
+                    } => {
+                        let name = self.local_field_name(&decl.key, path, name_override);
+                        self.check_local_field_ty(&decl.key, &name, sig);
+                        dec.push_inline_field_local(path.clone(), name);
                     }
                 }
             }
         }
         dec
+    }
+
+    /// The resolved Kotlin name of a binding-local field — the UNIFORM
+    /// field-name precedence over the path's LAST segment: explicit
+    /// `.name()`; else the class member's Kotlin name if the same fn is a
+    /// `.method()` of the type; else the camel-cased fn ident.
+    fn local_field_name(
+        &self,
+        key: &TypeKey,
+        path: &syn::Path,
+        name_override: &Option<String>,
+    ) -> String {
+        let ident = &path.segments.last().expect("non-empty path").ident;
+        name_override
+            .clone()
+            .or_else(|| self.class_method_kotlin_name(key, ident))
+            .unwrap_or_else(|| snake_to_camel(&ident.to_string()))
     }
 
     /// Synthesize the registry items for every binding-local fn declared on
@@ -787,16 +814,17 @@ impl JniGen {
             .fn_return_expands
             .iter()
             .map(|(_, d)| (d.key.clone(), &d.fields));
-        for (key, fields) in type_level.chain(per_fn) {
+        for (_key, fields) in type_level.chain(per_fn) {
             for f in fields {
-                let LocalField::Local { ty, path, .. } = f else {
+                let LocalField::Local { path, sig, .. } = f else {
                     continue;
                 };
                 let origin = local_path_prefix(path);
                 let ident = path.segments.last().expect("non-empty path").ident.clone();
-                let target = key.to_type();
+                let mut sig = sig.clone();
+                sig.ident = ident;
                 let item_fn: syn::ItemFn = syn::parse_quote! {
-                    fn #ident(v: &#target) -> #ty {
+                    #sig {
                         unimplemented!()
                     }
                 };
@@ -812,8 +840,11 @@ impl JniGen {
     /// must be a declared `ptr_class`. Owned returns — `Option<String>`,
     /// scalars, handles — carry their nullability in their own converters and
     /// pass through unchecked.
-    fn check_local_field_ty(&self, decl_key: &TypeKey, name: &str, ty: &syn::Type) {
-        let syn::Type::Path(p) = ty else { return };
+    fn check_local_field_ty(&self, decl_key: &TypeKey, name: &str, sig: &syn::Signature) {
+        let syn::ReturnType::Type(_, ty) = &sig.output else {
+            return;
+        };
+        let syn::Type::Path(p) = &**ty else { return };
         if p.path.segments.last().is_none_or(|s| s.ident != "Option") {
             return;
         }
@@ -830,7 +861,7 @@ impl JniGen {
             self.types
                 .get(&inner_key)
                 .is_some_and(|c| c.opaque.is_some()),
-            "expand_return!({}).field(field!(\"{name}\")): an `Option<&T>` binding-local field \
+            "expand_return!({}).field(… .name(\"{name}\")): an `Option<&T>` binding-local field \
              delivers a nullable typed HANDLE, so `T` must be a declared ptr_class — `{}` is \
              not; return an owned `Option<{}>` instead",
             decl_key.as_str(),

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -678,6 +678,9 @@ impl JniGen {
                         dec.add_deconstructor_record(func.clone(), name);
                     }
                     LocalField::SelfField => dec.add_deconstructor_record_id(),
+                    LocalField::Local { name, ty, path } => {
+                        dec.add_deconstructor_record_local(path.clone(), ty.clone(), name.clone());
+                    }
                 }
             }
         }
@@ -707,6 +710,9 @@ impl JniGen {
                         dec.push_inline_field(afunc.clone(), name);
                     }
                     LocalField::SelfField => dec.push_inline_field_self(),
+                    LocalField::Local { name, ty, path } => {
+                        dec.push_inline_field_local(path.clone(), ty.clone(), name.clone());
+                    }
                 }
             }
         }
@@ -754,7 +760,7 @@ impl JniGen {
             .flatten()
             .filter_map(|f| match f {
                 LocalField::Named(func, _) => Some(func.clone()),
-                LocalField::SelfField => None,
+                LocalField::SelfField | LocalField::Local { .. } => None,
             });
         ctors.chain(accessors)
     }
@@ -774,7 +780,7 @@ impl JniGen {
             .flatten()
             .filter_map(|f| match f {
                 LocalField::Named(func, _) => Some(func.clone()),
-                LocalField::SelfField => None,
+                LocalField::SelfField | LocalField::Local { .. } => None,
             })
             .collect()
     }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -679,6 +679,7 @@ impl JniGen {
                     }
                     LocalField::SelfField => dec.add_deconstructor_record_id(),
                     LocalField::Local { name, ty, path } => {
+                        self.check_local_field_ty(&decl.key, name, ty);
                         dec.add_deconstructor_record_local(path.clone(), ty.clone(), name.clone());
                     }
                 }
@@ -711,12 +712,46 @@ impl JniGen {
                     }
                     LocalField::SelfField => dec.push_inline_field_self(),
                     LocalField::Local { name, ty, path } => {
+                        self.check_local_field_ty(&decl.key, name, ty);
                         dec.push_inline_field_local(path.clone(), ty.clone(), name.clone());
                     }
                 }
             }
         }
         dec
+    }
+
+    /// Guard for binding-local fields returning an OPTIONAL BORROW: the
+    /// `Option<&T>` conditional-delivery leaf rides the opaque-handle
+    /// projection (nullable typed handle / boxed `Long?` on the wire), so `T`
+    /// must be a declared `ptr_class`. Owned returns — `Option<String>`,
+    /// scalars, handles — carry their nullability in their own converters and
+    /// pass through unchecked.
+    fn check_local_field_ty(&self, decl_key: &TypeKey, name: &str, ty: &syn::Type) {
+        let syn::Type::Path(p) = ty else { return };
+        if !p.path.segments.last().is_some_and(|s| s.ident == "Option") {
+            return;
+        }
+        let Some(syn::PathArguments::AngleBracketed(args)) =
+            p.path.segments.last().map(|s| &s.arguments)
+        else {
+            return;
+        };
+        let Some(syn::GenericArgument::Type(syn::Type::Reference(r))) = args.args.first() else {
+            return;
+        };
+        let inner_key = TypeKey::from_type(&r.elem);
+        assert!(
+            self.types
+                .get(&inner_key)
+                .is_some_and(|c| c.opaque.is_some()),
+            "expand_return!({}).field(field!(\"{name}\")): an `Option<&T>` binding-local field \
+             delivers a nullable typed HANDLE, so `T` must be a declared ptr_class — `{}` is \
+             not; return an owned `Option<{}>` instead",
+            decl_key.as_str(),
+            inner_key.as_str(),
+            inner_key.as_str(),
+        );
     }
 
     /// Type keys of boundary decls (`expand_param!` / `expand_return!`,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -97,6 +97,7 @@ impl JniGen {
             ignored_name_predicates: Vec::new(),
             ignored_class_types: std::collections::HashSet::new(),
             ignored_const_idents: std::collections::HashSet::new(),
+            local_fns: Vec::new(),
         };
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
         // as T and routes E to the error-sink on Err. The rank tables are
@@ -474,7 +475,22 @@ impl JniGen {
             param_expands,
             return_expand,
             split_on_params,
+            local,
         } = decl;
+        // A path-built decl (`fun!(crate::f)`) declares a BINDING-LOCAL fn:
+        // record its stated signature for the synthesis pre-pass
+        // ([`Self::local_functions`]). The signature is mandatory — a path
+        // carries nothing to read.
+        if let Some((path, sig)) = local {
+            let Some(sig) = sig else {
+                panic!(
+                    "fun!({p}): a binding-local fn states its signature — chain \
+                     .sig(sig!((params) -> Ret))",
+                    p = quote::quote!(#path)
+                );
+            };
+            self.local_fns.push((rust_ident.clone(), path, sig));
+        }
         for (param, pdecl) in param_expands {
             self.fn_param_expands
                 .push((rust_ident.clone(), param, pdecl));
@@ -680,7 +696,7 @@ impl JniGen {
                     LocalField::SelfField => dec.add_deconstructor_record_id(),
                     LocalField::Local { name, ty, path } => {
                         self.check_local_field_ty(&decl.key, name, ty);
-                        dec.add_deconstructor_record_local(path.clone(), ty.clone(), name.clone());
+                        dec.add_deconstructor_record_local(path.clone(), name.clone());
                     }
                 }
             }
@@ -713,12 +729,81 @@ impl JniGen {
                     LocalField::SelfField => dec.push_inline_field_self(),
                     LocalField::Local { name, ty, path } => {
                         self.check_local_field_ty(&decl.key, name, ty);
-                        dec.push_inline_field_local(path.clone(), ty.clone(), name.clone());
+                        dec.push_inline_field_local(path.clone(), name.clone());
                     }
                 }
             }
         }
         dec
+    }
+
+    /// Synthesize the registry items for every binding-local fn declared on
+    /// this generator (see [`Prebindgen::local_functions`]): path-built
+    /// `fun!(crate::f).sig(…)` decls contribute their full stated signature;
+    /// `field!("name").with(ty, path)` output fields contribute
+    /// `fn <ident>(v: &Target) -> Ty`. The item body is `unimplemented!()`
+    /// — never emitted, only the signature is read; the origin is the path's
+    /// module prefix, so generated calls qualify exactly as declared. One fn
+    /// ident may back several declarations only with an IDENTICAL
+    /// synthesized signature (panic otherwise — the emitted call could not
+    /// distinguish them).
+    pub(crate) fn collect_local_functions(&self) -> Vec<(syn::ItemFn, String)> {
+        use quote::ToTokens;
+        let mut out: Vec<(syn::ItemFn, String)> = Vec::new();
+        let mut seen: HashMap<syn::Ident, String> = HashMap::new();
+        let mut push = |item_fn: syn::ItemFn, origin: String, out: &mut Vec<_>| {
+            let ident = item_fn.sig.ident.clone();
+            let sig_str = format!("{origin}::{}", item_fn.sig.to_token_stream());
+            match seen.get(&ident) {
+                Some(prev) if *prev == sig_str => {} // same fn, same shape
+                Some(_) => panic!(
+                    "binding-local fn `{ident}` is declared with two different signatures — \
+                     the emitted call is `<origin>::{ident}`, so one fn = one signature"
+                ),
+                None => {
+                    seen.insert(ident, sig_str);
+                    out.push((item_fn, origin));
+                }
+            }
+        };
+        // Path-built fun! decls: the stated signature, renamed to the ident.
+        for (ident, path, sig) in &self.local_fns {
+            let origin = local_path_prefix(path);
+            let mut sig = sig.clone();
+            sig.ident = ident.clone();
+            let item_fn: syn::ItemFn = syn::parse_quote! {
+                #sig {
+                    unimplemented!()
+                }
+            };
+            push(item_fn, origin, &mut out);
+        }
+        // field! output fields: `fn <ident>(v: &Target) -> Ty`.
+        let type_level = self
+            .return_expand_decls
+            .iter()
+            .map(|d| (d.key.clone(), &d.fields));
+        let per_fn = self
+            .fn_return_expands
+            .iter()
+            .map(|(_, d)| (d.key.clone(), &d.fields));
+        for (key, fields) in type_level.chain(per_fn) {
+            for f in fields {
+                let LocalField::Local { ty, path, .. } = f else {
+                    continue;
+                };
+                let origin = local_path_prefix(path);
+                let ident = path.segments.last().expect("non-empty path").ident.clone();
+                let target = key.to_type();
+                let item_fn: syn::ItemFn = syn::parse_quote! {
+                    fn #ident(v: &#target) -> #ty {
+                        unimplemented!()
+                    }
+                };
+                push(item_fn, origin, &mut out);
+            }
+        }
+        out
     }
 
     /// Guard for binding-local fields returning an OPTIONAL BORROW: the
@@ -1395,6 +1480,19 @@ pub(crate) fn is_wire_type(ty: &syn::Type) -> bool {
 /// `Result<T, E>` return instead binds its own raw `E` (see
 /// [`JniGen::lookup_output`]); the extern's `Err` arm funnels both to the
 /// per-call `signal_error` sink via `E: Display`.
+/// The origin-module prefix of a binding-local fn's declared path
+/// (`crate::sub::f` → `"crate::sub"`). Paths are validated ≥2 segments at
+/// decl time (`fun!` path arm / `FieldDecl::with`), so the prefix is
+/// always non-empty.
+pub(crate) fn local_path_prefix(path: &syn::Path) -> String {
+    path.segments
+        .iter()
+        .take(path.segments.len() - 1)
+        .map(|s| s.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
 pub(crate) fn default_err_type() -> syn::Type {
     syn::parse_quote!(__JniErr)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -41,14 +41,15 @@ pub(crate) enum LocalField {
     Named(syn::Ident, Option<String>),
     /// Include the handle itself as a field.
     SelfField,
-    /// Include a **binding-local** accessor's value: a callable in the
-    /// binding crate (`path`) with a stated return type (`ty`) — no
-    /// `#[prebindgen]` registry entry behind it. Built via
-    /// [`field!`](crate::field) + [`FieldDecl::with`].
+    /// Include a **custom, locally-defined** accessor's value: any fn the
+    /// binding crate defines, declared with the one binding-local vocabulary
+    /// (`fun!(crate::f).sig(sig!((v: &Self) -> Ret))`) — no `#[prebindgen]`
+    /// item behind it, so the full signature (receiver explicit) is stated.
+    /// `name_override` follows the uniform field-name precedence.
     Local {
-        name: String,
-        ty: syn::Type,
         path: syn::Path,
+        sig: syn::Signature,
+        name_override: Option<String>,
     },
 }
 
@@ -197,20 +198,6 @@ macro_rules! expr {
     };
 }
 
-/// Build a [`FieldDecl`] for a **custom, locally-defined** `expand_return!`
-/// field: a field computed by any fn the binding crate defines, rather than
-/// by a `#[prebindgen]` accessor. `field!("handle")` names the leaf
-/// LITERALLY (there is no item to inherit a name from), then
-/// [`FieldDecl::with`] states the accessor's return type and callable.
-///
-/// The function-position peer is a path-built [`fun!`](crate::fun) +
-/// [`.sig(…)`](crate::lang::FunctionDecl::sig).
-#[macro_export]
-macro_rules! field {
-    ($name:literal) => {
-        $crate::lang::FieldDecl::named($name)
-    };
-}
 
 /// Build a [`ConvertDecl`] directly from a bare Rust type:
 /// `convert!(Millis)` is `ConvertDecl::new(<Millis as syn::Type>)`.
@@ -650,106 +637,6 @@ impl ExpandParamDecl {
 ///     .field(prebindgen::fun!(sample_get_payload))
 ///     .field(prebindgen::fun!(sample_get_kind));
 /// ```
-/// One field source for [`ExpandReturnDecl::field`]: a `#[prebindgen]`
-/// accessor (`fun!`, converted implicitly) or a **custom, locally-defined**
-/// accessor ([`field!`](crate::field) + [`with`](Self::with)) — any fn the
-/// binding crate defines, computing whatever field the binding surface needs
-/// without touching the source crate.
-///
-/// A binding-local field is the output-field peer of [`ConvertSourceDecl::with`]
-/// and [`ConstDecl::with`] (and of the function-position path-built
-/// [`fun!`](crate::fun) + [`sig`](FunctionDecl::sig)): the callable lives in
-/// the binding crate (the generated file compiles inside it, so
-/// `path!(crate::…)` resolves), and — a path carrying no signature — its
-/// exact Rust return type is stated with `ty!`. Shape: `fn(&T) -> Ret` for a
-/// field of `expand_return!(T)`.
-///
-/// One use among many — a *conditional* handle, delivered only when a
-/// binding-side predicate holds (`Option<&T>` return ⇒ nullable leaf):
-///
-/// ```
-/// // Deliver the Encoding handle only when a schema makes it worth having:
-/// let _ = prebindgen::expand_return!(Encoding)
-///     .field(prebindgen::fun!(encoding_get_id))
-///     .field(prebindgen::field!("handle").with(
-///         prebindgen::ty!(Option<&Encoding>),
-///         prebindgen::path!(crate::encoding_if_schema),
-///     ));
-/// ```
-pub struct FieldDecl {
-    pub(crate) kind: FieldSourceKind,
-}
-
-pub(crate) enum FieldSourceKind {
-    /// `fun!(f)` — a `#[prebindgen]` accessor; signature read from the
-    /// registry, name derivable from class members.
-    Fun(FunctionDecl),
-    /// `field!("name")` — binding-local; `ty`/`path` filled by
-    /// [`FieldDecl::with`], both required by acceptance time.
-    Local {
-        name: String,
-        ty: Option<syn::Type>,
-        path: Option<syn::Path>,
-    },
-}
-
-impl FieldDecl {
-    pub fn named(name: impl Into<String>) -> Self {
-        let name = name.into();
-        assert!(
-            !name.trim().is_empty(),
-            "field!(...): the field name is empty"
-        );
-        Self {
-            kind: FieldSourceKind::Local {
-                name,
-                ty: None,
-                path: None,
-            },
-        }
-    }
-
-    /// State the binding-local accessor: its exact Rust return type and the
-    /// callable path. The callable takes the expanded type by reference
-    /// (`fn(&T) -> Ret`); a `Ret` of `Option<&T>`/`&F`/owned `F` follows the
-    /// same output rules as a `#[prebindgen]` accessor's return.
-    pub fn with(mut self, ty: syn::Type, path: syn::Path) -> Self {
-        assert!(
-            path.segments.len() >= 2,
-            "field!(...).with(..., path!({p})): a binding-local accessor is called QUALIFIED \
-             from the generated file — give at least a `crate::`-rooted path",
-            p = quote::quote!(#path)
-        );
-        match &mut self.kind {
-            FieldSourceKind::Fun(f) => panic!(
-                "fun!({}).with(...): a `#[prebindgen]` accessor's signature is read from \
-                 the registry — .with() applies to field!(\"name\") sources",
-                f.rust_ident
-            ),
-            FieldSourceKind::Local {
-                ty: t,
-                path: p,
-                name,
-            } => {
-                assert!(
-                    t.is_none() && p.is_none(),
-                    "field!(\"{name}\").with(...): the accessor is already stated"
-                );
-                *t = Some(ty);
-                *p = Some(path);
-            }
-        }
-        self
-    }
-}
-
-impl From<FunctionDecl> for FieldDecl {
-    fn from(f: FunctionDecl) -> Self {
-        Self {
-            kind: FieldSourceKind::Fun(f),
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct ExpandReturnDecl {
@@ -765,56 +652,52 @@ impl ExpandReturnDecl {
         }
     }
 
-    /// Add one field, from either source:
+    /// Add one field — a reader whose value crosses as this leaf:
     ///
-    /// * `fun!(f)` — the named `#[prebindgen]` reader's (`f(&Self) -> Field`)
-    ///   value. The Kotlin field name is, in order of precedence: an explicit
-    ///   `.name(...)` on the `fun!`; the Kotlin name of the class member if
-    ///   the same function is declared via [`PtrClassDecl::method`] on this
-    ///   type (so a getter that is both a method and a field is named once);
-    ///   else the camel-cased Rust name.
-    /// * [`field!("name")`](crate::field)[`.with(ty, path)`](FieldDecl::with)
-    ///   — a **binding-local** accessor: a callable in the binding crate with
-    ///   a stated return type, for boundary policy that has no place in the
-    ///   `#[prebindgen]` source crate (e.g. "deliver the handle only when
-    ///   re-sending needs it").
+    /// * `fun!(f)` — a `#[prebindgen]` reader (`f(&Self) -> Field`), its
+    ///   signature read from the registry.
+    /// * `fun!(crate::f).sig(sig!((v: &Self) -> Field))` — a **custom,
+    ///   locally-defined** reader: any fn the binding crate defines, its
+    ///   signature stated (the receiver explicit — it must take `&Self`).
+    ///   One use among many: conditional delivery, an `Option<&Self>` return
+    ///   becoming a nullable handle leaf that is null when the binding-side
+    ///   predicate declines.
     ///
-    /// Only the accessor's name is used from a `fun!`: expand overrides on it
+    /// The Kotlin field name is uniform for both: an explicit `.name(...)`
+    /// on the `fun!`; else the Kotlin name of the class member if the same
+    /// fn is declared via [`PtrClassDecl::method`] on this type (so a getter
+    /// that is both a method and a field is named once); else the
+    /// camel-cased fn ident (a path's LAST segment).
+    ///
+    /// Only the accessor's name is used here: expand overrides on the `fun!`
     /// are a hard error rather than a silent discard (the field's own
     /// decomposition comes from ITS type's boundary decl, not from the
     /// accessor).
-    pub fn field(mut self, source: impl Into<FieldDecl>) -> Self {
-        let decl = source.into();
-        self.fields.push(match decl.kind {
-            FieldSourceKind::Fun(accessor) => {
-                assert!(
-                    accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
-                    "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
-                     field accessor — only .name() is honored",
-                    self.key.as_str(),
-                    accessor.rust_ident
-                );
-                assert!(
-                    accessor.local.is_none(),
-                    "expand_return!({}).field(fun!(…::{f})): a fun! field only NAMES an \
-                     accessor — use field!(\"name\").with(ty, path) for a binding-local \
-                     field, or declare the fn via .fun/.method/.constructor first and \
-                     reference it here by ident: fun!({f})",
-                    self.key.as_str(),
-                    f = accessor.rust_ident
-                );
-                LocalField::Named(accessor.rust_ident, accessor.kotlin_name_override)
-            }
-            FieldSourceKind::Local { name, ty, path } => {
-                let (Some(ty), Some(path)) = (ty, path) else {
+    pub fn field(mut self, accessor: FunctionDecl) -> Self {
+        assert!(
+            accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
+            "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
+             field accessor — only .name() is honored",
+            self.key.as_str(),
+            accessor.rust_ident
+        );
+        self.fields.push(match accessor.local {
+            None => LocalField::Named(accessor.rust_ident, accessor.kotlin_name_override),
+            Some((path, sig)) => {
+                let Some(sig) = sig else {
                     panic!(
-                        "expand_return!({}).field(field!(\"{name}\")): a binding-local field \
-                         states its accessor with .with(ty!(RetTy), path!(crate::f)) — a bare \
-                         name carries no signature",
-                        self.key.as_str()
+                        "expand_return!({}).field(fun!({p})): a binding-local field states \
+                         its accessor's signature — chain .sig(sig!((v: &{k}) -> Ret))",
+                        self.key.as_str(),
+                        p = quote::quote!(#path),
+                        k = self.key.as_str()
                     );
                 };
-                LocalField::Local { name, ty, path }
+                LocalField::Local {
+                    path,
+                    sig,
+                    name_override: accessor.kotlin_name_override,
+                }
             }
         });
         self

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -198,7 +198,6 @@ macro_rules! expr {
     };
 }
 
-
 /// Build a [`ConvertDecl`] directly from a bare Rust type:
 /// `convert!(Millis)` is `ConvertDecl::new(<Millis as syn::Type>)`.
 /// See [`ptr_class!`] for the parsing mechanics.

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -30,6 +30,10 @@ pub(crate) enum LocalVariant {
 /// class-level field, the class member's Kotlin name if the accessor is a
 /// declared member, else `snake_to_camel`; for a per-fn field,
 /// `snake_to_camel`).
+// large_enum_variant: a handful of fields exist per binding, held while
+// declarations replay — boxing the syn payloads would only complicate the
+// arms (same trade-off as `ConvertSourceKind`).
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub(crate) enum LocalField {
     /// Include the named accessor's value as a leaf/field, with an optional
@@ -37,6 +41,15 @@ pub(crate) enum LocalField {
     Named(syn::Ident, Option<String>),
     /// Include the handle itself as a field.
     SelfField,
+    /// Include a **binding-local** accessor's value: a callable in the
+    /// binding crate (`path`) with a stated return type (`ty`) — no
+    /// `#[prebindgen]` registry entry behind it. Built via
+    /// [`field!`](crate::field) + [`FieldDecl::with`].
+    Local {
+        name: String,
+        ty: syn::Type,
+        path: syn::Path,
+    },
 }
 
 // Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
@@ -156,6 +169,17 @@ macro_rules! path {
 macro_rules! expr {
     ($e:expr) => {
         $crate::__macro_support::parse_expr(stringify!($e))
+    };
+}
+
+/// Build a [`FieldDecl`] for a **binding-local** `expand_return!` field:
+/// `field!("handle")` names the leaf LITERALLY (it cannot inherit from a
+/// class member — there is no `#[prebindgen]` item behind it), then
+/// [`FieldDecl::with`] states the accessor's return type and callable.
+#[macro_export]
+macro_rules! field {
+    ($name:literal) => {
+        $crate::lang::FieldDecl::named($name)
     };
 }
 
@@ -589,6 +613,94 @@ impl ExpandParamDecl {
 ///     .field(prebindgen::fun!(sample_get_payload))
 ///     .field(prebindgen::fun!(sample_get_kind));
 /// ```
+/// One field source for [`ExpandReturnDecl::field`]: a `#[prebindgen]`
+/// accessor (`fun!`, converted implicitly) or a **binding-local** accessor
+/// ([`field!`](crate::field) + [`with`](Self::with)).
+///
+/// A binding-local field is the output-field peer of [`ConvertSourceDecl::with`]
+/// and [`ConstDecl::with`]: the callable lives in the binding crate (the
+/// generated file compiles inside it, so `path!(crate::…)` resolves), and —
+/// a path carrying no signature — its exact Rust return type is stated with
+/// `ty!`. Shape: `fn(&T) -> Ret` for a field of `expand_return!(T)`.
+///
+/// ```
+/// // Deliver the Encoding handle only when a schema makes it worth having:
+/// let _ = prebindgen::expand_return!(Encoding)
+///     .field(prebindgen::fun!(encoding_get_id))
+///     .field(prebindgen::field!("handle").with(
+///         prebindgen::ty!(Option<&Encoding>),
+///         prebindgen::path!(crate::encoding_if_schema),
+///     ));
+/// ```
+pub struct FieldDecl {
+    pub(crate) kind: FieldSourceKind,
+}
+
+pub(crate) enum FieldSourceKind {
+    /// `fun!(f)` — a `#[prebindgen]` accessor; signature read from the
+    /// registry, name derivable from class members.
+    Fun(FunctionDecl),
+    /// `field!("name")` — binding-local; `ty`/`path` filled by
+    /// [`FieldDecl::with`], both required by acceptance time.
+    Local {
+        name: String,
+        ty: Option<syn::Type>,
+        path: Option<syn::Path>,
+    },
+}
+
+impl FieldDecl {
+    pub fn named(name: impl Into<String>) -> Self {
+        let name = name.into();
+        assert!(
+            !name.trim().is_empty(),
+            "field!(...): the field name is empty"
+        );
+        Self {
+            kind: FieldSourceKind::Local {
+                name,
+                ty: None,
+                path: None,
+            },
+        }
+    }
+
+    /// State the binding-local accessor: its exact Rust return type and the
+    /// callable path. The callable takes the expanded type by reference
+    /// (`fn(&T) -> Ret`); a `Ret` of `Option<&T>`/`&F`/owned `F` follows the
+    /// same output rules as a `#[prebindgen]` accessor's return.
+    pub fn with(mut self, ty: syn::Type, path: syn::Path) -> Self {
+        match &mut self.kind {
+            FieldSourceKind::Fun(f) => panic!(
+                "fun!({}).with(...): a `#[prebindgen]` accessor's signature is read from \
+                 the registry — .with() applies to field!(\"name\") sources",
+                f.rust_ident
+            ),
+            FieldSourceKind::Local {
+                ty: t,
+                path: p,
+                name,
+            } => {
+                assert!(
+                    t.is_none() && p.is_none(),
+                    "field!(\"{name}\").with(...): the accessor is already stated"
+                );
+                *t = Some(ty);
+                *p = Some(path);
+            }
+        }
+        self
+    }
+}
+
+impl From<FunctionDecl> for FieldDecl {
+    fn from(f: FunctionDecl) -> Self {
+        Self {
+            kind: FieldSourceKind::Fun(f),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ExpandReturnDecl {
     pub(crate) key: TypeKey,
@@ -603,29 +715,49 @@ impl ExpandReturnDecl {
         }
     }
 
-    /// Add one field: the named `#[prebindgen]` reader's (`f(&Self) -> Field`)
-    /// value. The Kotlin field name is, in order of precedence: an explicit
-    /// `.name(...)` on `accessor`; the Kotlin name of the class member if the
-    /// same function is declared via [`PtrClassDecl::method`] on this type (so a
-    /// getter that is both a method and a field is named once); else the
-    /// camel-cased Rust name.
+    /// Add one field, from either source:
     ///
-    /// Only the accessor's name is used here: expand overrides on the `fun!`
+    /// * `fun!(f)` — the named `#[prebindgen]` reader's (`f(&Self) -> Field`)
+    ///   value. The Kotlin field name is, in order of precedence: an explicit
+    ///   `.name(...)` on the `fun!`; the Kotlin name of the class member if
+    ///   the same function is declared via [`PtrClassDecl::method`] on this
+    ///   type (so a getter that is both a method and a field is named once);
+    ///   else the camel-cased Rust name.
+    /// * [`field!("name")`](crate::field)[`.with(ty, path)`](FieldDecl::with)
+    ///   — a **binding-local** accessor: a callable in the binding crate with
+    ///   a stated return type, for boundary policy that has no place in the
+    ///   `#[prebindgen]` source crate (e.g. "deliver the handle only when
+    ///   re-sending needs it").
+    ///
+    /// Only the accessor's name is used from a `fun!`: expand overrides on it
     /// are a hard error rather than a silent discard (the field's own
     /// decomposition comes from ITS type's boundary decl, not from the
     /// accessor).
-    pub fn field(mut self, accessor: FunctionDecl) -> Self {
-        assert!(
-            accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
-            "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
-             field accessor — only .name() is honored",
-            self.key.as_str(),
-            accessor.rust_ident
-        );
-        self.fields.push(LocalField::Named(
-            accessor.rust_ident,
-            accessor.kotlin_name_override,
-        ));
+    pub fn field(mut self, source: impl Into<FieldDecl>) -> Self {
+        let decl = source.into();
+        self.fields.push(match decl.kind {
+            FieldSourceKind::Fun(accessor) => {
+                assert!(
+                    accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
+                    "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
+                     field accessor — only .name() is honored",
+                    self.key.as_str(),
+                    accessor.rust_ident
+                );
+                LocalField::Named(accessor.rust_ident, accessor.kotlin_name_override)
+            }
+            FieldSourceKind::Local { name, ty, path } => {
+                let (Some(ty), Some(path)) = (ty, path) else {
+                    panic!(
+                        "expand_return!({}).field(field!(\"{name}\")): a binding-local field \
+                         states its accessor with .with(ty!(RetTy), path!(crate::f)) — a bare \
+                         name carries no signature",
+                        self.key.as_str()
+                    );
+                };
+                LocalField::Local { name, ty, path }
+            }
+        });
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -588,6 +588,14 @@ impl ExpandParamDecl {
             self.key.as_str(),
             ctor.rust_ident
         );
+        assert!(
+            ctor.local.is_none(),
+            "expand_param!({}).variant(fun!(…::{f})): a variant arm only NAMES a fn — \
+             declare the binding-local fn via .fun/.method/.constructor/convert! first, \
+             then reference it here by ident: fun!({f})",
+            self.key.as_str(),
+            f = ctor.rust_ident
+        );
         self.variants.push(LocalVariant::Ctor(ctor.rust_ident));
         self
     }
@@ -785,6 +793,15 @@ impl ExpandReturnDecl {
                      field accessor — only .name() is honored",
                     self.key.as_str(),
                     accessor.rust_ident
+                );
+                assert!(
+                    accessor.local.is_none(),
+                    "expand_return!({}).field(fun!(…::{f})): a fun! field only NAMES an \
+                     accessor — use field!(\"name\").with(ty, path) for a binding-local \
+                     field, or declare the fn via .fun/.method/.constructor first and \
+                     reference it here by ident: fun!({f})",
+                    self.key.as_str(),
+                    f = accessor.rust_ident
                 );
                 LocalField::Named(accessor.rust_ident, accessor.kotlin_name_override)
             }
@@ -1530,17 +1547,6 @@ pub(crate) enum ConvertSpec {
     /// `TryInto` (the associated `Error` routes to the caller's error
     /// handler) vs `Into`.
     Trait { repr: syn::Type, fallible: bool },
-    /// An arbitrary callable path — typically a plain fn in the **binding
-    /// crate itself** (the generated file compiles inside it, so
-    /// `crate::…` paths resolve). Representable type stated explicitly;
-    /// by-value both ways. `error: None` = infallible (`fn(Repr) -> T` /
-    /// `fn(T) -> Repr`); `Some(E)` = the fn returns `Result<…, E>` and an
-    /// `Err` routes to the caller's error handler (`E: Display`).
-    LocalFn {
-        repr: syn::Type,
-        path: syn::Path,
-        error: Option<syn::Type>,
-    },
 }
 
 impl ConvertSpec {
@@ -1556,12 +1562,6 @@ impl ConvertSpec {
                 repr,
                 fallible: true,
             } => format!("`TryInto` ⇄ `{}`", repr.to_token_stream()),
-            ConvertSpec::LocalFn { repr, path, error } => format!(
-                "binding-local `{}` ⇄ `{}`{}",
-                path.to_token_stream(),
-                repr.to_token_stream(),
-                if error.is_some() { " (fallible)" } else { "" }
-            ),
         }
     }
 }
@@ -1586,14 +1586,15 @@ impl ConvertDirection {
 }
 
 /// One conversion source, accepted by [`ConvertDecl::input`] /
-/// [`ConvertDecl::output`]. Built by [`fun!`](crate::fun) (a
-/// `#[prebindgen]` conversion fn — signature read from the registry) or by
-/// the direction-stating macros [`from!`](crate::from) /
+/// [`ConvertDecl::output`]. Built by [`fun!`](crate::fun) — a
+/// `#[prebindgen]` conversion fn (bare ident, signature read from the
+/// registry) or a **binding-local** one (`fun!(crate::f)` +
+/// [`.sig(sig!(…))`](FunctionDecl::sig), the one vocabulary for locally
+/// defined callables; a `Result<_, E>` return states the error channel) —
+/// or by the direction-stating macros [`from!`](crate::from) /
 /// [`try_from!`](crate::try_from) / [`into!`](crate::into) /
-/// [`try_into!`](crate::try_into) (a `core::convert` trait conversion with a
-/// stated representation type), refined by [`with`](Self::with) (use a
-/// binding-local callable instead of the trait) and [`error`](Self::error)
-/// (the stated `Err` type of a fallible callable).
+/// [`try_into!`](crate::try_into) (a `core::convert` **trait** conversion
+/// with a stated representation type).
 #[derive(Clone)]
 pub struct ConvertSourceDecl {
     pub(crate) kind: ConvertSourceKind,
@@ -1605,18 +1606,19 @@ pub struct ConvertSourceDecl {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub(crate) enum ConvertSourceKind {
-    /// `fun!(f)` — a `#[prebindgen]` conversion fn; representable type and
-    /// fallibility are read from its registry signature.
-    Fun(syn::Ident),
+    /// `fun!(f)` / `fun!(crate::f).sig(…)` — a conversion fn; representable
+    /// type and fallibility are read from its signature (registry, or the
+    /// stated one carried in `local` and synthesized before scanning).
+    Fun {
+        ident: syn::Ident,
+        local: Option<(syn::Path, syn::Signature)>,
+    },
     /// `from!`/`try_from!`/`into!`/`try_into!` — a stated representation
-    /// type, converted via `core::convert` (bare) or a binding-local
-    /// callable (`.with(path)`).
+    /// type, converted via the `core::convert` trait.
     Repr {
         direction: ConvertDirection,
         fallible: bool,
         ty: syn::Type,
-        with: Option<syn::Path>,
-        error: Option<syn::Type>,
     },
 }
 
@@ -1627,8 +1629,6 @@ impl ConvertSourceDecl {
                 direction,
                 fallible,
                 ty,
-                with: None,
-                error: None,
             },
         }
     }
@@ -1648,65 +1648,6 @@ impl ConvertSourceDecl {
     pub fn try_into_type(ty: syn::Type) -> Self {
         Self::repr(ConvertDirection::Output, true, ty)
     }
-
-    /// Convert through a **binding-local callable** instead of the
-    /// `core::convert` trait — typically a plain fn in the binding crate
-    /// (the generated file compiles inside it, so `path!(crate::…)`
-    /// resolves). Shape: `fn(Repr) -> T` for `from!`, `fn(T) -> Repr` for
-    /// `into!`; the `try_` variants return `Result` and must state their
-    /// error type via [`error`](Self::error).
-    pub fn with(mut self, path: syn::Path) -> Self {
-        match &mut self.kind {
-            ConvertSourceKind::Fun(f) => panic!(
-                "fun!({f}).with(...): a `#[prebindgen]` conversion fn is already a \
-                 callable — .with() applies to from!/try_from!/into!/try_into! sources"
-            ),
-            ConvertSourceKind::Repr { with, .. } => {
-                assert!(
-                    with.is_none(),
-                    "a conversion source has exactly one callable — .with() already set"
-                );
-                *with = Some(path);
-            }
-        }
-        self
-    }
-
-    /// State the `Err` type of a fallible binding-local callable
-    /// (`try_from!(…).with(…)` / `try_into!(…).with(…)` — a path carries no
-    /// signature to read). The type must implement `Display`; an `Err`
-    /// routes to the caller's error handler like any domain error.
-    pub fn error(mut self, error_ty: syn::Type) -> Self {
-        match &mut self.kind {
-            ConvertSourceKind::Fun(f) => panic!(
-                "fun!({f}).error(...): a `#[prebindgen]` fn's error type is read from \
-                 its signature — .error() applies to try_from!/try_into! .with() sources"
-            ),
-            ConvertSourceKind::Repr {
-                fallible,
-                with,
-                error,
-                ..
-            } => {
-                assert!(
-                    *fallible,
-                    ".error(...): an infallible source has no error channel — \
-                     use try_from!/try_into!"
-                );
-                assert!(
-                    with.is_some(),
-                    ".error(...): the trait conversion's error is its associated type — \
-                     .error() states the Err type of a .with(...) callable; chain .with first"
-                );
-                assert!(
-                    error.is_none(),
-                    "a conversion source has exactly one error type — .error() already set"
-                );
-                *error = Some(error_ty);
-            }
-        }
-        self
-    }
 }
 
 impl From<FunctionDecl> for ConvertSourceDecl {
@@ -1719,8 +1660,21 @@ impl From<FunctionDecl> for ConvertSourceDecl {
              Kotlin — .name()/expand overrides don't apply",
             decl.rust_ident
         );
+        let local = decl.local.map(|(path, sig)| {
+            let Some(sig) = sig else {
+                panic!(
+                    "fun!({p}) as a conversion source: a binding-local fn states its \
+                     signature — chain .sig(sig!((params) -> Ret))",
+                    p = quote::quote!(#path)
+                );
+            };
+            (path, sig)
+        });
         Self {
-            kind: ConvertSourceKind::Fun(decl.rust_ident),
+            kind: ConvertSourceKind::Fun {
+                ident: decl.rust_ident,
+                local,
+            },
         }
     }
 }
@@ -1730,6 +1684,10 @@ pub struct ConvertDecl {
     pub(crate) key: TypeKey,
     pub(crate) input: Option<ConvertSpec>,
     pub(crate) output: Option<ConvertSpec>,
+    /// Binding-local fn sources declared on this convert (`fun!(crate::f)
+    /// .sig(…)`): drained into [`JniGen::local_fns`] at acceptance so the
+    /// synthesis pre-pass covers them.
+    pub(crate) locals: Vec<(syn::Ident, syn::Path, syn::Signature)>,
 }
 
 impl ConvertDecl {
@@ -1755,6 +1713,7 @@ impl ConvertDecl {
             key: TypeKey::from_type(&rust_type),
             input: None,
             output: None,
+            locals: Vec::new(),
         }
     }
 
@@ -1789,21 +1748,27 @@ impl ConvertDecl {
     }
 
     /// Lower an accepted [`ConvertSourceDecl`] to the internal spec,
-    /// cross-checking the source's stated direction against the acceptor.
+    /// cross-checking the source's stated direction against the acceptor. A
+    /// binding-local fn source records its `(ident, path, sig)` in
+    /// [`Self::locals`] for the synthesis pre-pass — after which it lowers
+    /// exactly like a `#[prebindgen]` fn source.
     fn spec_of(
-        &self,
+        &mut self,
         direction: ConvertDirection,
         method: &str,
         src: ConvertSourceDecl,
     ) -> ConvertSpec {
         match src.kind {
-            ConvertSourceKind::Fun(ident) => ConvertSpec::PrebindgenFn(ident),
+            ConvertSourceKind::Fun { ident, local } => {
+                if let Some((path, sig)) = local {
+                    self.locals.push((ident.clone(), path, sig));
+                }
+                ConvertSpec::PrebindgenFn(ident)
+            }
             ConvertSourceKind::Repr {
                 direction: stated,
                 fallible,
                 ty,
-                with,
-                error,
             } => {
                 assert!(
                     stated == direction,
@@ -1814,22 +1779,7 @@ impl ConvertDecl {
                     want = direction.macros(),
                 );
                 self.check_repr(method, &ty);
-                match with {
-                    None => ConvertSpec::Trait { repr: ty, fallible },
-                    Some(path) => {
-                        assert!(
-                            !fallible || error.is_some(),
-                            "convert!({k}).{method}(...): a fallible .with(...) callable \
-                             carries no signature to read — state its Err type via .error(...)",
-                            k = self.key.as_str(),
-                        );
-                        ConvertSpec::LocalFn {
-                            repr: ty,
-                            path,
-                            error,
-                        }
-                    }
-                }
+                ConvertSpec::Trait { repr: ty, fallible }
             }
         }
     }
@@ -1840,7 +1790,7 @@ impl ConvertDecl {
     /// `fn(U) -> Result<T, E>`) or [`from!`](crate::from) /
     /// [`try_from!`](crate::try_from) (`Repr: Into<T>` / `TryInto`, or a
     /// binding-local callable via `.with(...)`).
-    pub fn input(self, src: impl Into<ConvertSourceDecl>) -> Self {
+    pub fn input(mut self, src: impl Into<ConvertSourceDecl>) -> Self {
         let spec = self.spec_of(ConvertDirection::Input, "input", src.into());
         self.set_input(spec)
     }
@@ -1851,7 +1801,7 @@ impl ConvertDecl {
     /// or [`into!`](crate::into) / [`try_into!`](crate::try_into)
     /// (`T: Into<Repr>` / `TryInto`, or a binding-local callable via
     /// `.with(...)`).
-    pub fn output(self, src: impl Into<ConvertSourceDecl>) -> Self {
+    pub fn output(mut self, src: impl Into<ConvertSourceDecl>) -> Self {
         let spec = self.spec_of(ConvertDirection::Output, "output", src.into());
         self.set_output(spec)
     }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -101,12 +101,37 @@ macro_rules! value_class {
     };
 }
 
-/// Build a [`FunctionDecl`] directly from a bare function ident: `fun!(foo)`
-/// is `FunctionDecl::new(prebindgen::ident!(foo))`.
+/// Build a [`FunctionDecl`] from a bare function ident or a path:
+///
+/// * `fun!(foo)` — a `#[prebindgen]` fn; its signature is read from the
+///   registry.
+/// * `fun!(crate::foo)` — a **binding-local** fn: any fn the binding crate
+///   defines, exported through the same machinery as a `#[prebindgen]` one.
+///   A path carries no signature to read, so chain
+///   [`.sig(sig!(…))`](crate::lang::FunctionDecl::sig). The generated file
+///   calls it by the declared path (it compiles inside the binding crate,
+///   so `crate::`-rooted paths resolve).
 #[macro_export]
 macro_rules! fun {
     ($name:ident) => {
         $crate::lang::FunctionDecl::new($crate::ident!($name))
+    };
+    ($path:path) => {
+        $crate::lang::FunctionDecl::new_local($crate::__macro_support::parse_path(stringify!(
+            $path
+        )))
+    };
+}
+
+/// State a binding-local fn's exact Rust signature, with **named parameters**
+/// (they become the foreign-side parameter names): `sig!((s: &Summary,
+/// verbose: bool) -> String)`; the `-> Ret` tail is optional (unit). The
+/// signature argument of [`FunctionDecl::sig`](crate::lang::FunctionDecl::sig)
+/// for a path-built [`fun!`](crate::fun).
+#[macro_export]
+macro_rules! sig {
+    (($($params:tt)*) $(-> $ret:ty)?) => {
+        $crate::__macro_support::parse_signature(stringify!(($($params)*) $(-> $ret)?))
     };
 }
 
@@ -172,10 +197,14 @@ macro_rules! expr {
     };
 }
 
-/// Build a [`FieldDecl`] for a **binding-local** `expand_return!` field:
-/// `field!("handle")` names the leaf LITERALLY (it cannot inherit from a
-/// class member — there is no `#[prebindgen]` item behind it), then
+/// Build a [`FieldDecl`] for a **custom, locally-defined** `expand_return!`
+/// field: a field computed by any fn the binding crate defines, rather than
+/// by a `#[prebindgen]` accessor. `field!("handle")` names the leaf
+/// LITERALLY (there is no item to inherit a name from), then
 /// [`FieldDecl::with`] states the accessor's return type and callable.
+///
+/// The function-position peer is a path-built [`fun!`](crate::fun) +
+/// [`.sig(…)`](crate::lang::FunctionDecl::sig).
 #[macro_export]
 macro_rules! field {
     ($name:literal) => {
@@ -614,14 +643,21 @@ impl ExpandParamDecl {
 ///     .field(prebindgen::fun!(sample_get_kind));
 /// ```
 /// One field source for [`ExpandReturnDecl::field`]: a `#[prebindgen]`
-/// accessor (`fun!`, converted implicitly) or a **binding-local** accessor
-/// ([`field!`](crate::field) + [`with`](Self::with)).
+/// accessor (`fun!`, converted implicitly) or a **custom, locally-defined**
+/// accessor ([`field!`](crate::field) + [`with`](Self::with)) — any fn the
+/// binding crate defines, computing whatever field the binding surface needs
+/// without touching the source crate.
 ///
 /// A binding-local field is the output-field peer of [`ConvertSourceDecl::with`]
-/// and [`ConstDecl::with`]: the callable lives in the binding crate (the
-/// generated file compiles inside it, so `path!(crate::…)` resolves), and —
-/// a path carrying no signature — its exact Rust return type is stated with
-/// `ty!`. Shape: `fn(&T) -> Ret` for a field of `expand_return!(T)`.
+/// and [`ConstDecl::with`] (and of the function-position path-built
+/// [`fun!`](crate::fun) + [`sig`](FunctionDecl::sig)): the callable lives in
+/// the binding crate (the generated file compiles inside it, so
+/// `path!(crate::…)` resolves), and — a path carrying no signature — its
+/// exact Rust return type is stated with `ty!`. Shape: `fn(&T) -> Ret` for a
+/// field of `expand_return!(T)`.
+///
+/// One use among many — a *conditional* handle, delivered only when a
+/// binding-side predicate holds (`Option<&T>` return ⇒ nullable leaf):
 ///
 /// ```
 /// // Deliver the Encoding handle only when a schema makes it worth having:
@@ -670,6 +706,12 @@ impl FieldDecl {
     /// (`fn(&T) -> Ret`); a `Ret` of `Option<&T>`/`&F`/owned `F` follows the
     /// same output rules as a `#[prebindgen]` accessor's return.
     pub fn with(mut self, ty: syn::Type, path: syn::Path) -> Self {
+        assert!(
+            path.segments.len() >= 2,
+            "field!(...).with(..., path!({p})): a binding-local accessor is called QUALIFIED \
+             from the generated file — give at least a `crate::`-rooted path",
+            p = quote::quote!(#path)
+        );
         match &mut self.kind {
             FieldSourceKind::Fun(f) => panic!(
                 "fun!({}).with(...): a `#[prebindgen]` accessor's signature is read from \
@@ -1001,6 +1043,10 @@ pub struct FunctionDecl {
     pub(crate) param_expands: Vec<(String, ExpandParamDecl)>,
     pub(crate) return_expand: Option<ExpandReturnDecl>,
     pub(crate) split_on_params: Vec<String>,
+    /// `fun!(crate::f)` — a **binding-local** fn: the declared path plus the
+    /// stated signature ([`sig`](Self::sig), required by acceptance time).
+    /// `None` = an ordinary `#[prebindgen]` registry fn.
+    pub(crate) local: Option<(syn::Path, Option<syn::Signature>)>,
 }
 
 impl FunctionDecl {
@@ -1011,7 +1057,47 @@ impl FunctionDecl {
             param_expands: Vec::new(),
             return_expand: None,
             split_on_params: Vec::new(),
+            local: None,
         }
+    }
+
+    /// `fun!(crate::f)` — declare a **binding-local** fn by path. The fn
+    /// ident (the path's last segment) names it everywhere a registry fn's
+    /// ident would; chain [`sig`](Self::sig) to state its signature.
+    pub fn new_local(path: syn::Path) -> Self {
+        assert!(
+            path.segments.len() >= 2,
+            "fun!({}): a binding-local fn is called QUALIFIED from the generated file — \
+             give at least a `crate::`-rooted path (a bare ident declares a `#[prebindgen]` fn)",
+            quote::quote!(#path)
+        );
+        let ident = path.segments.last().expect("non-empty path").ident.clone();
+        Self {
+            local: Some((path, None)),
+            ..Self::new(ident)
+        }
+    }
+
+    /// State a binding-local fn's exact Rust signature (build it with
+    /// [`sig!`](crate::sig)) — a path carries no signature to read. The
+    /// parameter names become the foreign-side parameter names. Required for
+    /// a path-built [`fun!`](crate::fun); a hard error on a registry fn
+    /// (its signature is read from the registry).
+    pub fn sig(mut self, signature: syn::Signature) -> Self {
+        let Some((_, slot)) = &mut self.local else {
+            panic!(
+                "fun!({}).sig(...): a `#[prebindgen]` fn's signature is read from the \
+                 registry — .sig() applies to path-built binding-local fns (fun!(crate::f))",
+                self.rust_ident
+            );
+        };
+        assert!(
+            slot.is_none(),
+            "fun!({}).sig(...): the signature is already stated",
+            self.rust_ident
+        );
+        *slot = Some(signature);
+        self
     }
 
     /// Set the Kotlin-side name. Default: the Rust name camel-cased

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -471,6 +471,11 @@ pub struct JniGen {
     /// `#[prebindgen]` consts the binding deliberately does NOT declare,
     /// via [`JniGen::ignore_const`]. Backs [`Prebindgen::ignored_consts`].
     pub(crate) ignored_const_idents: std::collections::HashSet<syn::Ident>,
+    /// Binding-local fns declared via path-built [`fun!`](crate::fun) +
+    /// [`FunctionDecl::sig`]: `(fn ident = path last segment, declared path,
+    /// stated signature)`. Synthesized into registry entries by the
+    /// [`Prebindgen::local_functions`] pre-pass.
+    pub(crate) local_fns: Vec<(syn::Ident, syn::Path, syn::Signature)>,
 }
 
 // ── Sibling submodules (carved from the former monolithic file) ─────────

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -757,11 +757,12 @@ fn constructor_with_wrong_return_rejected() {
     );
 }
 
-/// Binding-local output field (`field!("name").with(ty, path)`): the accessor
-/// lives in the BINDING crate — the generated Rust calls it by its declared
-/// path — and a self-typed `Option<&T>` return degrades to a nullable typed
-/// handle leaf instead of a splice cycle: the conditional-handle idiom
-/// ("deliver the handle only when the binding says it's worth having").
+/// Binding-local output field (`fun!(crate::…).sig(sig!(…)).name(…)`): the
+/// accessor lives in the BINDING crate — the generated Rust calls it by its
+/// declared path — and a self-typed `Option<&T>` return degrades to a
+/// nullable typed handle leaf instead of a splice cycle: the
+/// conditional-handle idiom ("deliver the handle only when the binding says
+/// it's worth having").
 #[test]
 fn binding_local_field_conditional_handle() {
     let loc = myflat_loc();
@@ -794,10 +795,11 @@ fn binding_local_field_conditional_handle() {
         .expand(
             crate::expand_return!(ZEnc)
                 .field(crate::fun!(z_enc_get_id))
-                .field(crate::field!("handle").with(
-                    crate::ty!(Option<&ZEnc>),
-                    crate::path!(crate::enc_if_custom),
-                )),
+                .field(
+                    crate::fun!(crate::enc_if_custom)
+                        .sig(crate::sig!((e: &ZEnc) -> Option<&ZEnc>))
+                        .name("handle"),
+                ),
         );
     let dir = unique_test_dir("jnigen_local_field");
     let _ = std::fs::remove_dir_all(&dir);
@@ -833,37 +835,13 @@ fn binding_local_field_conditional_handle() {
     assert!(all.contains("zEncGetId:Int,handle:ZEnc?"), "{raw}");
 }
 
-/// A binding-local field's callable must be crate-qualified: the generated
-/// file calls it by path, so a bare single-segment name is a hard error —
-/// at DECLARATION time (`FieldDecl::with`), like every other decl typo.
+/// A binding-local callable must be crate-qualified: `fun!`'s ident arm
+/// catches single segments (declaring a registry fn), and `new_local`
+/// rejects a degenerate single-segment path outright.
 #[test]
 #[should_panic(expected = "crate::")]
 fn binding_local_field_bare_path_rejected() {
-    let loc = myflat_loc();
-    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
-        syn::Item::Struct(syn::parse_quote!(
-            pub struct ZEnc {
-                _p: u8,
-            }
-        )),
-        loc.clone(),
-    )];
-    items.push((
-        syn::Item::Fn(syn::parse_str("pub fn z_enc_make() -> ZEnc { unimplemented!() }").unwrap()),
-        loc.clone(),
-    ));
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
-    let jni = JniGen::new()
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!("enc")
-                .class(crate::ptr_class!(ZEnc))
-                .fun(crate::fun!(z_enc_make)),
-        )
-        .expand(crate::expand_return!(ZEnc).field(
-            crate::field!("handle").with(crate::ty!(Option<&ZEnc>), crate::path!(enc_if_custom)),
-        ));
-    let _ = registry.resolve(jni);
+    let _ = crate::lang::FunctionDecl::new_local(syn::parse_quote!(enc_if_custom));
 }
 
 /// A binding-local fn name colliding with a `#[prebindgen]` item is a hard
@@ -902,7 +880,9 @@ fn binding_local_field_name_collision_rejected() {
             // `z_enc_get_id` names a real #[prebindgen] fn — a binding-local
             // field may not shadow it.
             crate::expand_return!(ZEnc).field(
-                crate::field!("id").with(crate::ty!(i32), crate::path!(crate::z_enc_get_id)),
+                crate::fun!(crate::z_enc_get_id)
+                    .sig(crate::sig!((e: &ZEnc) -> i32))
+                    .name("id"),
             ),
         );
     let err = registry
@@ -961,10 +941,11 @@ fn binding_local_field_splices_through_parent() {
         .expand(
             crate::expand_return!(ZEnc)
                 .field(crate::fun!(z_enc_get_id))
-                .field(crate::field!("handle").with(
-                    crate::ty!(Option<&ZEnc>),
-                    crate::path!(crate::enc_if_custom),
-                )),
+                .field(
+                    crate::fun!(crate::enc_if_custom)
+                        .sig(crate::sig!((e: &ZEnc) -> Option<&ZEnc>))
+                        .name("handle"),
+                ),
         )
         .expand(
             crate::expand_return!(ZMsg)
@@ -1091,6 +1072,88 @@ fn binding_local_functions_all_positions() {
     // The variant arm built from the local ctor: selector slot named after
     // its single param.
     assert!(all.contains("primarySel:Int"), "{raw}");
+}
+
+/// Naming rule for binding-local fns: `.name()` is NEVER obligatory — the
+/// default derivation feeds the manglers the camel-cased LAST PATH SEGMENT
+/// (`crate::sub::z_thing_ratio` → hook sees `zThingRatio`), with the same
+/// package/class context as a registry fn, and the hook's output names the
+/// Kotlin member. A local field without `.name()` defaults the same way.
+#[test]
+fn binding_local_fn_names_flow_through_manglers() {
+    let loc = myflat_loc();
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZThing {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for src in [
+        "pub fn z_thing_make() -> ZThing { unimplemented!() }",
+        // A PLAIN fn returning ZThing — the field decomposition applies here
+        // (constructors are excluded from output decomposition by design).
+        "pub fn z_thing_query() -> ZThing { unimplemented!() }",
+    ] {
+        items.push((
+            syn::Item::Fn(syn::parse_str(src).unwrap()),
+            loc.clone(),
+        ));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        // Custom hooks: prefix every derived name — proof the hook RAN and
+        // received the camel-cased last segment with its context.
+        .set_fun_name_mangle(|pkg, name| {
+            assert!(pkg.ends_with("t"), "fun hook package: {pkg}");
+            format!("pkg_{name}")
+        })
+        .set_method_name_mangle(|_pkg, class, name| {
+            if class == "ZThing" {
+                format!("cls_{name}")
+            } else {
+                name.to_string()
+            }
+        })
+        .package(
+            crate::package!("t")
+                .class(
+                    crate::ptr_class!(ZThing)
+                        .constructor(crate::fun!(z_thing_make))
+                        // local METHOD, no .name(): hook sees `zThingRatio`.
+                        .method(
+                            crate::fun!(crate::sub::z_thing_ratio)
+                                .sig(crate::sig!((t: &ZThing, scale: f64) -> f64)),
+                        ),
+                )
+                // local FREE FN, no .name(): fun hook sees `zThingTag`.
+                .fun(
+                    crate::fun!(crate::sub::z_thing_tag)
+                        .sig(crate::sig!((t: &ZThing) -> i64)),
+                )
+                .fun(crate::fun!(z_thing_query)),
+        )
+        // local FIELD, no .name(): defaults to camel(last segment). A second
+        // field (the handle) keeps the decomposition on the builder path —
+        // a single leaf would deliver by direct return, hiding the name.
+        .expand(
+            crate::expand_return!(ZThing)
+                .field(
+                    crate::fun!(crate::sub::z_thing_len)
+                        .sig(crate::sig!((t: &ZThing) -> i64)),
+                )
+                .field_self(),
+        );
+    let raw = write_all(registry.resolve(jni).expect("resolve"), "jnigen_local_mangle");
+    let all: String = raw.split_whitespace().collect();
+    // Method named by the class hook over the camel-cased last segment.
+    assert!(all.contains("funcls_zThingRatio(scale:Double,"), "{raw}");
+    // Free fn named by the package hook.
+    assert!(all.contains("funpkg_zThingTag("), "{raw}");
+    // Field leaf defaulted to camel(last segment) — builder param name.
+    assert!(all.contains("zThingLen:Long"), "{raw}");
 }
 
 /// A path-built `fun!` without `.sig(…)` is a hard error at acceptance —

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -757,6 +757,237 @@ fn constructor_with_wrong_return_rejected() {
     );
 }
 
+/// Binding-local output field (`field!("name").with(ty, path)`): the accessor
+/// lives in the BINDING crate — the generated Rust calls it by its declared
+/// path — and a self-typed `Option<&T>` return degrades to a nullable typed
+/// handle leaf instead of a splice cycle: the conditional-handle idiom
+/// ("deliver the handle only when the binding says it's worth having").
+#[test]
+fn binding_local_field_conditional_handle() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_enc_get_id(e: &ZEnc) -> i32 { unimplemented!() }",
+        "pub fn z_enc_make() -> ZEnc { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZEnc {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for src in fns {
+        items.push((
+            syn::Item::Fn(syn::parse_str(src).expect("parse fn")),
+            loc.clone(),
+        ));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("enc")
+                .class(crate::ptr_class!(ZEnc).method(crate::fun!(z_enc_get_id)))
+                .fun(crate::fun!(z_enc_make)),
+        )
+        .expand(
+            crate::expand_return!(ZEnc)
+                .field(crate::fun!(z_enc_get_id))
+                .field(crate::field!("handle").with(
+                    crate::ty!(Option<&ZEnc>),
+                    crate::path!(crate::enc_if_custom),
+                )),
+        );
+    let dir = unique_test_dir("jnigen_local_field");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // The generated Rust calls the binding-local accessor by its DECLARED
+    // path (the generated file compiles inside the binding crate).
+    assert!(rc.contains("crate::enc_if_custom("), "{rust}");
+    // The registry accessor stays source-qualified.
+    assert!(rc.contains("myflat::z_enc_get_id("), "{rust}");
+
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let raw = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let all: String = raw.split_whitespace().collect();
+    // Builder callback: the id leaf + the NULLABLE conditional handle leaf
+    // (self-splice degraded to a plain converter leaf).
+    assert!(all.contains("zEncGetId:Int,handle:ZEnc?"), "{raw}");
+}
+
+/// A binding-local field's callable must be crate-qualified: the generated
+/// file calls it by path, so a bare single-segment name is a hard error.
+#[test]
+fn binding_local_field_bare_path_rejected() {
+    let loc = myflat_loc();
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZEnc {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    items.push((
+        syn::Item::Fn(syn::parse_str("pub fn z_enc_make() -> ZEnc { unimplemented!() }").unwrap()),
+        loc.clone(),
+    ));
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("enc")
+                .class(crate::ptr_class!(ZEnc))
+                .fun(crate::fun!(z_enc_make)),
+        )
+        .expand(crate::expand_return!(ZEnc).field(
+            crate::field!("handle").with(crate::ty!(Option<&ZEnc>), crate::path!(enc_if_custom)),
+        ));
+    let err = registry
+        .resolve(jni)
+        .expect_err("bare path must be rejected");
+    let msg = format!("{err}");
+    assert!(msg.contains("crate::"), "{msg}");
+}
+
+/// A binding-local fn name colliding with a `#[prebindgen]` item is a hard
+/// error — the emitted call is `<prefix>::<name>`, so the name must denote
+/// exactly the binding-local fn.
+#[test]
+fn binding_local_field_name_collision_rejected() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_enc_get_id(e: &ZEnc) -> i32 { unimplemented!() }",
+        "pub fn z_enc_make() -> ZEnc { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZEnc {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for src in fns {
+        items.push((
+            syn::Item::Fn(syn::parse_str(src).expect("parse fn")),
+            loc.clone(),
+        ));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("enc")
+                .class(crate::ptr_class!(ZEnc))
+                .fun(crate::fun!(z_enc_make)),
+        )
+        .expand(
+            // `z_enc_get_id` names a real #[prebindgen] fn — a binding-local
+            // field may not shadow it.
+            crate::expand_return!(ZEnc).field(
+                crate::field!("id").with(crate::ty!(i32), crate::path!(crate::z_enc_get_id)),
+            ),
+        );
+    let err = registry
+        .resolve(jni)
+        .expect_err("collision must be rejected");
+    let msg = format!("{err}");
+    assert!(msg.contains("collides"), "{msg}");
+}
+
+/// A binding-local field spliced through a PARENT decomposition: the child's
+/// conditional-handle leaf arrives prefixed (`enc__handle`) and nullable, and
+/// the generated Rust composes the source accessor with the binding-local
+/// one (`crate::enc_if_custom(myflat::z_msg_enc(&v))`).
+#[test]
+fn binding_local_field_splices_through_parent() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_enc_get_id(e: &ZEnc) -> i32 { unimplemented!() }",
+        "pub fn z_msg_enc(m: &ZMsg) -> &ZEnc { unimplemented!() }",
+        "pub fn z_msg_len(m: &ZMsg) -> i64 { unimplemented!() }",
+        "pub fn z_msg_make() -> ZMsg { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZEnc {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZMsg {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    for src in fns {
+        items.push((
+            syn::Item::Fn(syn::parse_str(src).expect("parse fn")),
+            loc.clone(),
+        ));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("msg")
+                .class(crate::ptr_class!(ZEnc).method(crate::fun!(z_enc_get_id)))
+                .class(crate::ptr_class!(ZMsg))
+                .fun(crate::fun!(z_msg_make)),
+        )
+        .expand(
+            crate::expand_return!(ZEnc)
+                .field(crate::fun!(z_enc_get_id))
+                .field(crate::field!("handle").with(
+                    crate::ty!(Option<&ZEnc>),
+                    crate::path!(crate::enc_if_custom),
+                )),
+        )
+        .expand(
+            crate::expand_return!(ZMsg)
+                .field(crate::fun!(z_msg_len).name("len"))
+                .field(crate::fun!(z_msg_enc).name("enc")),
+        );
+    let dir = unique_test_dir("jnigen_local_field_splice");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("crate::enc_if_custom(myflat::z_msg_enc("),
+        "{rust}"
+    );
+
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let raw = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let all: String = raw.split_whitespace().collect();
+    // Spliced child leaves: prefixed id + prefixed NULLABLE handle.
+    assert!(all.contains("enc__zEncGetId:Int"), "{raw}");
+    assert!(all.contains("enc__handle:ZEnc?"), "{raw}");
+}
+
 /// `.gc_managed()`: the typed handle extends `GcNativeHandle` (pointer in a
 /// separate atomic cell), registers a Cleaner action capturing only the cell,
 /// and every release path settles the once-only untagged→tagged CAS ticket —

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1096,10 +1096,7 @@ fn binding_local_fn_names_flow_through_manglers() {
         // (constructors are excluded from output decomposition by design).
         "pub fn z_thing_query() -> ZThing { unimplemented!() }",
     ] {
-        items.push((
-            syn::Item::Fn(syn::parse_str(src).unwrap()),
-            loc.clone(),
-        ));
+        items.push((syn::Item::Fn(syn::parse_str(src).unwrap()), loc.clone()));
     }
     let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new()
@@ -1129,10 +1126,7 @@ fn binding_local_fn_names_flow_through_manglers() {
                         ),
                 )
                 // local FREE FN, no .name(): fun hook sees `zThingTag`.
-                .fun(
-                    crate::fun!(crate::sub::z_thing_tag)
-                        .sig(crate::sig!((t: &ZThing) -> i64)),
-                )
+                .fun(crate::fun!(crate::sub::z_thing_tag).sig(crate::sig!((t: &ZThing) -> i64)))
                 .fun(crate::fun!(z_thing_query)),
         )
         // local FIELD, no .name(): defaults to camel(last segment). A second
@@ -1140,13 +1134,13 @@ fn binding_local_fn_names_flow_through_manglers() {
         // a single leaf would deliver by direct return, hiding the name.
         .expand(
             crate::expand_return!(ZThing)
-                .field(
-                    crate::fun!(crate::sub::z_thing_len)
-                        .sig(crate::sig!((t: &ZThing) -> i64)),
-                )
+                .field(crate::fun!(crate::sub::z_thing_len).sig(crate::sig!((t: &ZThing) -> i64)))
                 .field_self(),
         );
-    let raw = write_all(registry.resolve(jni).expect("resolve"), "jnigen_local_mangle");
+    let raw = write_all(
+        registry.resolve(jni).expect("resolve"),
+        "jnigen_local_mangle",
+    );
     let all: String = raw.split_whitespace().collect();
     // Method named by the class hook over the camel-cased last segment.
     assert!(all.contains("funcls_zThingRatio(scale:Double,"), "{raw}");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -834,8 +834,10 @@ fn binding_local_field_conditional_handle() {
 }
 
 /// A binding-local field's callable must be crate-qualified: the generated
-/// file calls it by path, so a bare single-segment name is a hard error.
+/// file calls it by path, so a bare single-segment name is a hard error —
+/// at DECLARATION time (`FieldDecl::with`), like every other decl typo.
 #[test]
+#[should_panic(expected = "crate::")]
 fn binding_local_field_bare_path_rejected() {
     let loc = myflat_loc();
     let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
@@ -861,11 +863,7 @@ fn binding_local_field_bare_path_rejected() {
         .expand(crate::expand_return!(ZEnc).field(
             crate::field!("handle").with(crate::ty!(Option<&ZEnc>), crate::path!(enc_if_custom)),
         ));
-    let err = registry
-        .resolve(jni)
-        .expect_err("bare path must be rejected");
-    let msg = format!("{err}");
-    assert!(msg.contains("crate::"), "{msg}");
+    let _ = registry.resolve(jni);
 }
 
 /// A binding-local fn name colliding with a `#[prebindgen]` item is a hard
@@ -995,6 +993,154 @@ fn binding_local_field_splices_through_parent() {
     // Spliced child leaves: prefixed id + prefixed NULLABLE handle.
     assert!(all.contains("enc__zEncGetId:Int"), "{raw}");
     assert!(all.contains("enc__handle:ZEnc?"), "{raw}");
+}
+
+/// Binding-local FUNCTIONS (`fun!(crate::f).sig(sig!(…))`): a fn defined in
+/// the binding crate exported through the full `FunctionDecl` surface — free
+/// package fn, instance method, companion constructor (also referenced by
+/// ident as an `expand_param!` variant arm). After synthesis it IS a registry
+/// fn: converters, receiver rule, name mangling, expansion defaults all apply;
+/// the generated Rust calls it by its declared path.
+#[test]
+fn binding_local_functions_all_positions() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_thing_len(t: &ZThing) -> i64 { unimplemented!() }",
+        "pub fn z_use(primary: ZThing) -> bool { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZThing {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for src in fns {
+        items.push((
+            syn::Item::Fn(syn::parse_str(src).expect("parse fn")),
+            loc.clone(),
+        ));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("t")
+                .class(
+                    crate::ptr_class!(ZThing)
+                        .method(crate::fun!(z_thing_len))
+                        // binding-local INSTANCE METHOD (receiver &Self first)
+                        .method(
+                            crate::fun!(crate::z_thing_ratio)
+                                .sig(crate::sig!((t: &ZThing, scale: f64) -> f64)),
+                        )
+                        // binding-local COMPANION CONSTRUCTOR
+                        .constructor(
+                            crate::fun!(crate::z_thing_from_len)
+                                .sig(crate::sig!((len: i64) -> ZThing)),
+                        ),
+                )
+                // binding-local FREE FUNCTION, fallible (Result -> onError)
+                .fun(
+                    crate::fun!(crate::z_thing_describe)
+                        .sig(crate::sig!((t: &ZThing, verbose: bool) -> Result<String, String>)),
+                )
+                .fun(crate::fun!(z_use)),
+        )
+        // The local constructor also serves as an expand_param! variant arm,
+        // referenced by IDENT like any registry fn.
+        .expand(
+            crate::expand_param!(ZThing)
+                .variant(crate::fun!(z_thing_from_len))
+                .variant_self(),
+        );
+    let dir = unique_test_dir("jnigen_local_funs");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    // Every binding-local call is qualified by its declared path; registry
+    // fns keep their source qualification.
+    assert!(rc.contains("crate::z_thing_ratio("), "{rust}");
+    assert!(rc.contains("crate::z_thing_from_len("), "{rust}");
+    assert!(rc.contains("crate::z_thing_describe("), "{rust}");
+    assert!(rc.contains("myflat::z_thing_len("), "{rust}");
+
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let raw = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let all: String = raw.split_whitespace().collect();
+    // Method on the class (receiver dropped, stated param names surface).
+    assert!(all.contains("funzThingRatio(scale:Double,"), "{raw}");
+    // Companion factory returning the class.
+    assert!(all.contains("funzThingFromLen(len:Long,"), "{raw}");
+    // Free fn with the Result error routed to onError; its ZThing param
+    // picked up the TYPE-LEVEL expand default (selector form) — expansion
+    // defaults apply to binding-local fns exactly as to registry fns.
+    assert!(all.contains("funzThingDescribe("), "{raw}");
+    assert!(
+        all.contains("tSel:Int,t0:Long?,t1:ZThing?,verbose:Boolean,"),
+        "{raw}"
+    );
+    // The variant arm built from the local ctor: selector slot named after
+    // its single param.
+    assert!(all.contains("primarySel:Int"), "{raw}");
+}
+
+/// A path-built `fun!` without `.sig(…)` is a hard error at acceptance —
+/// a path carries no signature to read.
+#[test]
+#[should_panic(expected = ".sig(sig!(")]
+fn binding_local_fun_missing_sig_rejected() {
+    let _ = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("t").fun(crate::fun!(crate::z_no_sig)));
+}
+
+/// `.sig(…)` on an ident-built (registry) `fun!` is a hard error — the
+/// signature is read from the registry.
+#[test]
+#[should_panic(expected = "read from the")]
+fn sig_on_registry_fun_rejected() {
+    let _ = crate::fun!(z_thing_len).sig(crate::sig!((t: &ZThing) -> i64));
+}
+
+/// A binding-local fn name colliding with a `#[prebindgen]` item is a hard
+/// resolve error — the emitted call would resolve the wrong fn.
+#[test]
+fn binding_local_fun_name_collision_rejected() {
+    let loc = myflat_loc();
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZThing {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    items.push((
+        syn::Item::Fn(
+            syn::parse_str("pub fn z_thing_len(t: &ZThing) -> i64 { unimplemented!() }").unwrap(),
+        ),
+        loc.clone(),
+    ));
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("t").class(crate::ptr_class!(ZThing)).fun(
+            // shadows the #[prebindgen] fn of the same name
+            crate::fun!(crate::z_thing_len).sig(crate::sig!((t: &ZThing) -> i64)),
+        ),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("collision must be rejected");
+    assert!(format!("{err}").contains("collides"), "{err}");
 }
 
 /// `.gc_managed()`: the typed handle extends `GcNativeHandle` (pointer in a

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -811,6 +811,15 @@ fn binding_local_field_conditional_handle() {
     assert!(rc.contains("crate::enc_if_custom("), "{rust}");
     // The registry accessor stays source-qualified.
     assert!(rc.contains("myflat::z_enc_get_id("), "{rust}");
+    // Wire shape: the conditional handle is an Option-unwrapped IDENTITY leaf
+    // — present clones through the handle projection and BOXES the jlong
+    // (matching the `Long?` slot of the raw interface), absent delivers JVM
+    // null. A raw primitive `jvalue { j }` here would desync the descriptor.
+    assert!(rc.contains("box_jlong"), "{rust}");
+    assert!(
+        rc.contains("Option::None=>jni::objects::JObject::null()"),
+        "{rust}"
+    );
 
     let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
     let raw = paths

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -575,8 +575,9 @@ fn convert_via_try_from_is_fallible() {
     );
 }
 
-/// `from!(…).with(…)`/`into!(…).with(…)`: the callable path is emitted verbatim —
-/// binding-local `crate::…` fns need no `#[prebindgen]` marking.
+/// Binding-local conversion fns via the ONE vocabulary —
+/// `fun!(crate::…).sig(sig!(…))`: synthesized into the registry, lowered
+/// through the ordinary `#[prebindgen]`-fn path, called by the declared path.
 #[test]
 fn convert_via_local_fns() {
     let loc = myflat_loc();
@@ -588,8 +589,8 @@ fn convert_via_local_fns() {
         .set_package_prefix("io.test.jni")
         .convert(
             crate::convert!(Label)
-                .input(crate::from!(String).with(crate::path!(crate::conv::label_in)))
-                .output(crate::into!(String).with(crate::path!(crate::conv::label_out))),
+                .input(crate::fun!(crate::conv::label_in).sig(crate::sig!((s: String) -> Label)))
+                .output(crate::fun!(crate::conv::label_out).sig(crate::sig!((l: Label) -> String))),
         )
         .package(crate::package!("m").fun(crate::fun!(label_id)));
     let dir = unique_test_dir("jnigen_convert_local");
@@ -599,8 +600,8 @@ fn convert_via_local_fns() {
     let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
-    assert!(rc.contains("crate::conv::label_in(v)"), "{rust}");
-    assert!(rc.contains("crate::conv::label_out(v)"), "{rust}");
+    assert!(rc.contains("crate::conv::label_in("), "{rust}");
+    assert!(rc.contains("crate::conv::label_out("), "{rust}");
 }
 
 /// Two input conversions on one decl are contradictory — decl-time panic.
@@ -609,7 +610,7 @@ fn convert_via_local_fns() {
 fn convert_duplicate_input_rejected() {
     let _ = crate::convert!(Widget)
         .input(crate::from!(i32))
-        .input(crate::from!(String).with(crate::path!(crate::widget_in)));
+        .input(crate::fun!(crate::widget_in).sig(crate::sig!((v: String) -> Widget)));
 }
 
 /// The source macros state their direction; the acceptor cross-checks it.
@@ -625,30 +626,13 @@ fn convert_output_from_direction_rejected() {
     let _ = crate::convert!(Widget).output(crate::from!(i32));
 }
 
-/// `.error` is only meaningful on a fallible source.
+/// A binding-local conversion source must state its signature — a path
+/// carries nothing to read (the sig's `Result<_, E>` is the error channel,
+/// replacing the former `.error(ty!)`).
 #[test]
-#[should_panic(expected = "an infallible source has no error channel")]
-fn convert_error_on_infallible_source_rejected() {
-    let _ = crate::from!(String)
-        .with(crate::path!(crate::widget_in))
-        .error(crate::ty!(String));
-}
-
-/// `.error` states a `.with(...)` callable's Err type — a bare trait
-/// source's error is its associated type.
-#[test]
-#[should_panic(expected = "chain .with first")]
-fn convert_error_on_trait_source_rejected() {
-    let _ = crate::try_from!(String).error(crate::ty!(String));
-}
-
-/// A fallible local callable must state its error type — a path carries no
-/// signature to read.
-#[test]
-#[should_panic(expected = "state its Err type via .error(...)")]
-fn convert_try_with_missing_error_rejected() {
-    let _ = crate::convert!(Widget)
-        .input(crate::try_from!(String).with(crate::path!(crate::widget_in)));
+#[should_panic(expected = ".sig(sig!(")]
+fn convert_local_source_missing_sig_rejected() {
+    let _ = crate::convert!(Widget).input(crate::fun!(crate::widget_in));
 }
 
 /// A `fun!` conversion source is never surfaced in Kotlin — decorations are
@@ -659,9 +643,9 @@ fn convert_source_fun_with_decorations_rejected() {
     let _ = crate::convert!(Widget).input(crate::fun!(widget_in).name("widgetIn"));
 }
 
-/// `try_from!(…).with(…).error(…)`: the fallible binding-local form — the converter's
-/// error type is the decl-stated one and the fn's `Result` is emitted
-/// verbatim (no `Ok(...)` wrap).
+/// The fallible binding-local form: the sig's `Result<_, E>` IS the error
+/// channel — `E` lands in the converter signature and `Err` routes to the
+/// caller's error handler, exactly like a `#[prebindgen]` conversion fn's.
 #[test]
 fn convert_via_local_try_fn_is_fallible() {
     let loc = myflat_loc();
@@ -674,11 +658,10 @@ fn convert_via_local_try_fn_is_fallible() {
         .convert(
             crate::convert!(Label)
                 .input(
-                    crate::try_from!(String)
-                        .with(crate::path!(crate::conv::label_in))
-                        .error(crate::ty!(String)),
+                    crate::fun!(crate::conv::label_in)
+                        .sig(crate::sig!((s: String) -> Result<Label, String>)),
                 )
-                .output(crate::into!(String).with(crate::path!(crate::conv::label_out))),
+                .output(crate::fun!(crate::conv::label_out).sig(crate::sig!((l: Label) -> String))),
         )
         .package(crate::package!("m").fun(crate::fun!(label_id)));
     let dir = unique_test_dir("jnigen_convert_local_try");
@@ -688,9 +671,7 @@ fn convert_via_local_try_fn_is_fallible() {
     let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
-    // Verbatim body (no Ok-wrap) with the stated error in the signature.
-    assert!(rc.contains("crate::conv::label_in(v)"), "{rust}");
-    assert!(!rc.contains("Ok(crate::conv::label_in(v))"), "{rust}");
+    assert!(rc.contains("crate::conv::label_in("), "{rust}");
     assert!(rc.contains("Result<myflat::Label,String>"), "{rust}");
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1009,6 +1009,15 @@ impl Prebindgen for JniGen {
         self.field_accessor_fns()
     }
 
+    /// Binding-local fns to synthesize into the registry, from both entry
+    /// forms — path-built `fun!(crate::f).sig(…)` decls (full stated
+    /// signature) and `field!("name").with(ty, path)` output fields
+    /// (signature `fn f(v: &Target) -> Ty`). One fn may back several
+    /// declarations only with an identical synthesized signature.
+    fn local_functions(&self) -> Vec<(syn::ItemFn, String)> {
+        self.collect_local_functions()
+    }
+
     /// Methods (`.method`) — their fn ident mapped to the owning class's
     /// `TypeKey`, so input-flattening can skip the receiver parameter.
     fn method_receivers(&self) -> std::collections::HashMap<syn::Ident, TypeKey> {

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -22,8 +22,8 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, ConvertSourceDecl,
-    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
-    IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
+    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FieldDecl,
+    FunctionDecl, IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -22,8 +22,8 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, ConvertSourceDecl,
-    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FieldDecl,
-    FunctionDecl, IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
+    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
+    IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, ValueClassDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -286,9 +286,8 @@ pub mod lang {
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             matching, null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl,
             ConvertDecl, ConvertSourceDecl, DataClassDecl, EnumClassDecl, ExpandDecl,
-            ExpandParamDecl, ExpandReturnDecl, FieldDecl, FunctionDecl, IgnoreDecl,
-            JniBindingError, JniGen, KotlinFile, PackageDecl, PtrClassDecl, ValueClassDecl,
-            WriteKotlinError,
+            ExpandParamDecl, ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError,
+            JniGen, KotlinFile, PackageDecl, PtrClassDecl, ValueClassDecl, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -159,6 +159,18 @@ pub mod __macro_support {
     pub fn parse_expr(s: &str) -> ::syn::Expr {
         ::syn::parse_str(s).unwrap_or_else(|e| panic!("prebindgen: invalid expression `{s}`: {e}"))
     }
+
+    /// Parse a `sig!((params) -> Ret)` body: `s` is the token text between
+    /// the macro's outer parens plus the optional `-> Ret` tail, e.g.
+    /// `"(s: & Summary, verbose: bool) -> String"`. Wrapped into a full fn
+    /// item signature under a placeholder name (replaced by the declaring
+    /// decl's fn ident at synthesis time).
+    pub fn parse_signature(s: &str) -> ::syn::Signature {
+        let full = format!("fn __sig {s}");
+        ::syn::parse_str::<::syn::ItemFn>(&format!("{full} {{ unimplemented!() }}"))
+            .map(|f| f.sig)
+            .unwrap_or_else(|e| panic!("prebindgen: invalid signature `sig!({s})`: {e}"))
+    }
 }
 
 /// Build a `syn::Ident` from a bare identifier token. Unlike

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -286,8 +286,8 @@ pub mod lang {
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             matching, null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl,
             ConvertDecl, ConvertSourceDecl, DataClassDecl, EnumClassDecl, ExpandDecl,
-            ExpandParamDecl, ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError,
-            JniGen, KotlinFile, PackageDecl, PtrClassDecl, ValueClassDecl, WriteKotlinError,
+            ExpandParamDecl, ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen,
+            KotlinFile, PackageDecl, PtrClassDecl, ValueClassDecl, WriteKotlinError,
         },
     };
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -274,8 +274,9 @@ pub mod lang {
             box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string,
             matching, null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl,
             ConvertDecl, ConvertSourceDecl, DataClassDecl, EnumClassDecl, ExpandDecl,
-            ExpandParamDecl, ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen,
-            KotlinFile, PackageDecl, PtrClassDecl, ValueClassDecl, WriteKotlinError,
+            ExpandParamDecl, ExpandReturnDecl, FieldDecl, FunctionDecl, IgnoreDecl,
+            JniBindingError, JniGen, KotlinFile, PackageDecl, PtrClassDecl, ValueClassDecl,
+            WriteKotlinError,
         },
     };
 }


### PR DESCRIPTION
## What

**Binding-local functions**: any fn the *binding crate* defines can back generated output fields, free functions, instance methods, companion constructors, and `convert!` conversion sources — no `#[prebindgen]` source-crate item needed. One vocabulary for all of them:

```rust
// A fn is declared by a ≥2-segment PATH plus its stated signature —
// named params become the foreign-side parameter names, and a
// Result<_, E> return IS the error channel (Err routes to onError):
fun!(crate::summary_describe).sig(sig!((s: &Summary, verbose: bool) -> String))

// usable in every position:
.fun(fun!(crate::summary_describe).sig(sig!((s: &Summary, verbose: bool) -> String)))
.method(fun!(crate::summary_mean).sig(sig!((s: &Summary) -> f64)))
.constructor(fun!(crate::summary_from_mean)
    .sig(sig!((count: i64, mean: f64) -> Result<Summary, String>)))

// output field (the receiver explicit, checked against the expanded type):
.expand(expand_return!(Encoding)
    .field(fun!(encoding_get_id))
    .field(fun!(crate::encoding_if_schema)
        .sig(sig!((e: &Encoding) -> Option<&Encoding>))
        .name("handle")))

// convert! source (trait macros from!/try_from!/into!/try_into! stay TRAIT-only):
.convert(convert!(Label)
    .input(fun!(crate::label_in).sig(sig!((s: String) -> Result<Label, String>)))
    .output(fun!(crate::label_out).sig(sig!((l: Label) -> String))))
```

A bare-ident `fun!(f)` still declares a `#[prebindgen]` registry fn, unchanged. Conditional delivery — an `Option<&Self>` field that is null when a binding-side predicate declines (zenoh's "Encoding handle only when schema-carrying", ZettaScaleLabs/zenoh-flat-jni#6) — is one use among many.

## Mechanism

A new `Prebindgen::local_functions()` hook feeds a synthesis pre-pass at the top of `Registry::resolve`: stated signatures become ordinary registry entries (body never emitted; origin = the path's module prefix, driving the existing `origin_module` call qualification — the generated file compiles inside the binding crate, so `crate::…` resolves). After synthesis a binding-local fn **is** a registry fn: converters, expansion defaults, the method receiver rule, `.split_on_param`, `Result` fallibility, and `expand_param!` variant arms (referenced by ident) all apply unchanged.

**Naming is fully uniform** — `.name()` is never obligatory: the default derivation feeds the mangle hooks the camel-cased **last path segment** with the same package/class context as a registry fn; fields follow the field precedence (override → class-member inheritance → camel-cased segment). Emission detail: an `Option<&T>` field flattens as a **nullable identity leaf** (final-Option unwrap → handle-projection clone → boxed `Long?`/null wire), and a self-typed field degrades to a leaf instead of the splice-cycle error — which is what enables conditional delivery.

Hard errors: single-segment paths, missing `.sig`, `.sig` on a registry fn, ident collisions with `#[prebindgen]` items or between locals with different signatures, path-built `fun!` in variant position (declare first, reference by ident).

## Deleted (0.5 no-shims policy)

Two predecessor vocabularies for the same concept:
- `field!("name").with(ty!, path!)` + `FieldDecl`/`FieldSourceKind`;
- `convert!` sources' `.with(path!)`/`.error(ty!)` + `ConvertSpec::LocalFn` (the sig's `Result` replaces `.error` — it existed only because a bare path carried no signature).

## Tests

- Lib (**272 green**): fields (root, spliced, wire-shape boxed/null), functions (all positions, path-qualified calls, expansion default on a local param, local ctor as variant arm), convert sources (fallible + infallible via sig), the mangling proof (custom hooks receive the camel-cased last segment), and all the hard errors.
- Covertest (**29/29 JVM sections**, every-feature rule): conditional-handle field, `describeSummary`, `Summary.mean()`/`Summary.fromMean` — both **without `.name()`** (the strip-class-prefix hook derives the names automatically, generated output byte-identical), the fallible `fromMean(-1, …)` → `onError` arm, and the Label convert round-trip on the unified form.
- fmt + clippy clean on stable and MSRV 1.85.

Companion PR: ZettaScaleLabs/zenoh-flat-jni#6 (consumes the conditional-handle field; migrated to the final syntax, regen byte-identical; green once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)