### PR TITLE
jnigen: protect unowned Kotlin output

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -505,7 +505,7 @@ fn main() {
     let kotlin_root = std::path::Path::new(&crate_dir)
         .join("kotlin")
         .join("generated");
-    // The root is generator-owned: `write_kotlin` deletes and recreates it,
+    // The root is prebindgen-owned: `write_kotlin` replaces marked output,
     // so no consumer-side cleanup is needed.
     for path in gen.write_kotlin(&kotlin_root).expect("write_kotlin failed") {
         println!("cargo:warning=Wrote {}", path.display());

--- a/examples/covertest-kotlin/kotlin/generated/.prebindgen-kotlin-output
+++ b/examples/covertest-kotlin/kotlin/generated/.prebindgen-kotlin-output
@@ -1,0 +1,1 @@
+prebindgen Kotlin output v1

--- a/examples/perftest-kotlin/kotlin/generated/.prebindgen-kotlin-output
+++ b/examples/perftest-kotlin/kotlin/generated/.prebindgen-kotlin-output
@@ -1,0 +1,1 @@
+prebindgen Kotlin output v1

--- a/prebindgen/src/api/gen/kotlin/file.rs
+++ b/prebindgen/src/api/gen/kotlin/file.rs
@@ -167,12 +167,16 @@ fn inspect_root(kotlin_root: &Path) -> Result<RootState, WriteKotlinError> {
     }
 
     let marker = kotlin_root.join(OWNERSHIP_MARKER);
-    let marker_metadata = fs::symlink_metadata(&marker).map_err(|_| {
-        WriteKotlinError::Other(format!(
-            "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",
-            kotlin_root.display()
-        ))
-    })?;
+    let marker_metadata = match fs::symlink_metadata(&marker) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(WriteKotlinError::Other(format!(
+                "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",
+                kotlin_root.display()
+            )));
+        }
+        Err(error) => return Err(error.into()),
+    };
     if marker_metadata.file_type().is_symlink() || !marker_metadata.is_file() {
         return Err(WriteKotlinError::Other(format!(
             "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",

--- a/prebindgen/src/api/gen/kotlin/file.rs
+++ b/prebindgen/src/api/gen/kotlin/file.rs
@@ -11,7 +11,9 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    path::{Path, PathBuf},
+    fs,
+    path::{Component, Path, PathBuf},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use super::model::KtFile;
@@ -109,32 +111,153 @@ pub fn merged_file_path(kotlin_root: &Path, file: &KtFile, fallback_name: &str) 
     }
 }
 
+const OWNERSHIP_MARKER: &str = ".prebindgen-kotlin-output";
+const OWNERSHIP_MARKER_CONTENT: &str = "prebindgen Kotlin output v1\n";
+
 /// Render and write every merged file; returns the written paths.
 ///
-/// `kotlin_root` is **generator-owned**: it is deleted and recreated on
-/// every run, so stale files from a previous generation (a renamed
-/// package, a removed declaration) can never linger. Point it at a
-/// dedicated directory (the established convention is
-/// `kotlin/generated/`), never at a tree containing hand-written sources.
+/// A non-empty `kotlin_root` must contain the prebindgen ownership marker.
+/// The initial write accepts a missing or empty directory and creates that
+/// marker. Subsequent writes stage the complete output beside the root before
+/// replacing the marked tree, so stale generated files are removed without
+/// deleting caller-owned files or leaving an old tree half-deleted on failure.
 pub fn write_files(files: &[KtFile], kotlin_root: &Path) -> Result<Vec<PathBuf>, WriteKotlinError> {
-    match std::fs::remove_dir_all(kotlin_root) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(e.into()),
+    let root_state = inspect_root(kotlin_root)?;
+    let parent = kotlin_root.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let staging = unique_sibling_path(kotlin_root, "staging");
+    fs::create_dir(&staging)?;
+
+    let result = write_staging(files, &staging).and_then(|relative_paths| {
+        replace_root(kotlin_root, root_state, &staging)?;
+        Ok(relative_paths
+            .into_iter()
+            .map(|path| kotlin_root.join(path))
+            .collect())
+    });
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&staging);
     }
+    result
+}
+
+#[derive(Clone, Copy)]
+enum RootState {
+    Missing,
+    Empty,
+    Owned,
+}
+
+fn inspect_root(kotlin_root: &Path) -> Result<RootState, WriteKotlinError> {
+    let metadata = match fs::symlink_metadata(kotlin_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(RootState::Missing)
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(WriteKotlinError::Other(format!(
+            "Kotlin output root `{}` must be a directory",
+            kotlin_root.display()
+        )));
+    }
+    if fs::read_dir(kotlin_root)?.next().is_none() {
+        return Ok(RootState::Empty);
+    }
+
+    let marker = kotlin_root.join(OWNERSHIP_MARKER);
+    let marker_metadata = fs::symlink_metadata(&marker).map_err(|_| {
+        WriteKotlinError::Other(format!(
+            "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",
+            kotlin_root.display()
+        ))
+    })?;
+    if marker_metadata.file_type().is_symlink() || !marker_metadata.is_file() {
+        return Err(WriteKotlinError::Other(format!(
+            "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",
+            kotlin_root.display()
+        )));
+    }
+    if fs::read_to_string(&marker)? != OWNERSHIP_MARKER_CONTENT {
+        return Err(WriteKotlinError::Other(format!(
+            "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",
+            kotlin_root.display()
+        )));
+    }
+    Ok(RootState::Owned)
+}
+
+fn write_staging(files: &[KtFile], staging: &Path) -> Result<Vec<PathBuf>, WriteKotlinError> {
+    fs::write(staging.join(OWNERSHIP_MARKER), OWNERSHIP_MARKER_CONTENT)?;
     let mut written = Vec::new();
-    for f in files {
-        let fallback = f
+    for file in files {
+        let fallback = file
             .decls
             .first()
-            .map(|d| d.name().to_string())
+            .map(|decl| decl.name().to_string())
             .unwrap_or_else(|| "Generated".to_string());
-        let path = merged_file_path(kotlin_root, f, &fallback);
+        let relative_path = merged_file_path(Path::new(""), file, &fallback);
+        ensure_relative_output_path(&relative_path)?;
+        let path = staging.join(&relative_path);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            fs::create_dir_all(parent)?;
         }
-        std::fs::write(&path, f.render())?;
-        written.push(path);
+        fs::write(&path, file.render())?;
+        written.push(relative_path);
     }
     Ok(written)
+}
+
+fn ensure_relative_output_path(path: &Path) -> Result<(), WriteKotlinError> {
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::RootDir | Component::Prefix(_) | Component::ParentDir
+        )
+    }) {
+        return Err(WriteKotlinError::Other(format!(
+            "Kotlin output path `{}` escapes the output root",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn replace_root(
+    kotlin_root: &Path,
+    root_state: RootState,
+    staging: &Path,
+) -> Result<(), WriteKotlinError> {
+    match root_state {
+        RootState::Missing => fs::rename(staging, kotlin_root)?,
+        RootState::Empty => {
+            fs::remove_dir(kotlin_root)?;
+            fs::rename(staging, kotlin_root)?;
+        }
+        RootState::Owned => {
+            let backup = unique_sibling_path(kotlin_root, "previous");
+            fs::rename(kotlin_root, &backup)?;
+            if let Err(error) = fs::rename(staging, kotlin_root) {
+                let _ = fs::rename(&backup, kotlin_root);
+                return Err(error.into());
+            }
+            fs::remove_dir_all(backup)?;
+        }
+    }
+    Ok(())
+}
+
+fn unique_sibling_path(kotlin_root: &Path, purpose: &str) -> PathBuf {
+    static SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let name = kotlin_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("kotlin");
+    kotlin_root.with_file_name(format!(
+        ".{name}.prebindgen-{purpose}-{}_{}",
+        std::process::id(),
+        sequence
+    ))
 }

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -1,6 +1,9 @@
 //! Golden-string tests: one per Kotlin construct the jnigen back-end emits.
 
+use std::fs;
+
 use super::{types::ImportSet, *};
+use crate::api::test_util::unique_test_dir;
 
 fn body_of(src: &str) -> &str {
     // Strip banner + package + imports + the separating blank line.
@@ -549,6 +552,46 @@ fn merged_file_path_is_flattened() {
     let empty = KtFile::new("");
     let p2 = file::merged_file_path(std::path::Path::new("/root"), &empty, "NativeHandle");
     assert_eq!(p2, std::path::PathBuf::from("/root/NativeHandle.kt"));
+}
+
+#[test]
+fn write_files_refuses_nonempty_unowned_root() {
+    let dir = unique_test_dir("kotlin_unowned_root");
+    let root = dir.join("generated");
+    fs::create_dir_all(&root).unwrap();
+    let handwritten = root.join("Main.kt");
+    fs::write(&handwritten, "fun main() = Unit\n").unwrap();
+
+    let err = write_files(&[KtFile::new("io.test")], &root).unwrap_err();
+    assert!(err.to_string().contains("ownership marker"), "{err}");
+    assert_eq!(
+        fs::read_to_string(&handwritten).unwrap(),
+        "fun main() = Unit\n"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn write_files_replaces_marked_root_and_preserves_it_on_staging_failure() {
+    let dir = unique_test_dir("kotlin_owned_root");
+    let root = dir.join("generated");
+    let initial = KtFile::new("io.test").decl(KtFun::new("first").body(Code::new()));
+    write_files(&[initial], &root).unwrap();
+    let stale = root.join("stale.kt");
+    fs::write(&stale, "stale\n").unwrap();
+
+    let replacement = KtFile::new("io.test").decl(KtFun::new("second").body(Code::new()));
+    write_files(&[replacement], &root).unwrap();
+    assert!(!stale.exists());
+    assert!(root.join(".prebindgen-kotlin-output").exists());
+    assert!(root.join("io/test.kt").exists());
+
+    let escaping_output = KtFile::new("../outside").decl(KtFun::new("one").body(Code::new()));
+    assert!(write_files(&[escaping_output], &root).is_err());
+    assert!(root.join("io/test.kt").exists());
+
+    let _ = fs::remove_dir_all(dir);
 }
 
 #[test]

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -56,9 +56,10 @@ impl crate::api::core::Generation<JniGen> {
     /// alongside [`write_rust`](Self::write_rust). Each per-kind emitter
     /// builds in-memory [`kt::KtFile`] model fragments; they are merged
     /// into one file per package, rendered, and written under
-    /// `kotlin_root` — which is **generator-owned**: deleted and recreated
-    /// on every run (point it at a dedicated directory like
-    /// `kotlin/generated/`, never at hand-written sources). Pure emission
+    /// `kotlin_root`. The initial write accepts a missing or empty directory
+    /// and marks it generator-owned; later writes replace only marked output
+    /// (point it at a dedicated directory like `kotlin/generated/`, never at
+    /// hand-written sources). Pure emission
     /// over the resolved registry — order-free with respect to
     /// `write_rust`. Returns every path written (one per non-empty
     /// package).

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -677,8 +677,8 @@ fn function_and_native_method_hooks_receive_placement() {
     );
 }
 
-/// C4: the Kotlin root is generator-owned — `write_kotlin` deletes and
-/// recreates it on every run, so stale files from a previous generation
+/// C4: after `write_kotlin` creates its ownership marker, later runs replace
+/// the entire generated tree, so stale files from a previous generation
 /// (renamed package, removed declaration) never linger and consumers need
 /// no cleanup boilerplate. Repeat runs are idempotent.
 #[test]
@@ -696,8 +696,9 @@ fn write_kotlin_owns_and_resets_the_root() {
     let dir = unique_test_dir("jnigen_owned_root");
     let _ = std::fs::remove_dir_all(&dir);
     let root = dir.join("kotlin");
-    // A stale file from a "previous run" at a path this generation won't
-    // write — wiped with the rest of the owned root.
+    // Bootstrap the generator-owned root, then leave a stale file from a
+    // previous generation at a path this generation won't write.
+    gen.write_kotlin(&root).expect("initial write_kotlin");
     let stale_dir = root.join("io/test/jni/old");
     std::fs::create_dir_all(&stale_dir).unwrap();
     let stale = stale_dir.join("stale.kt");


### PR DESCRIPTION
# jnigen: protect unowned Kotlin output

## Summary

`write_kotlin` previously removed its caller-supplied output root recursively before writing output. This change requires a versioned prebindgen ownership marker before replacing a non-empty root, while allowing first writes to missing or empty directories. Output is fully staged beside the destination before replacing a marked tree, preserving prior generated output when staging fails.

Fixes #88

## Changes

- Add an ownership marker and reject non-empty unmarked Kotlin output directories.
- Stage generated Kotlin output before replacing marked roots, removing stale generated files only after a successful stage.
- Mark the repository's committed Kotlin generated-output roots so their build scripts continue to regenerate safely.
- Add regression coverage for unowned source-like roots, marked-root cleanup, and staging failure preservation.

## Testing

- `sandbox-run "cargo test -p prebindgen api::gen::kotlin::tests"` — could not run: the sandbox image does not provide `cargo` (`bash: line 1: cargo: command not found`).
- `sandbox-run "rustup toolchain list && rustup default"` — could not run: the sandbox image does not provide `rustup` (`bash: line 1: rustup: command not found`).
- `rustfmt prebindgen/src/api/gen/kotlin/file.rs prebindgen/src/api/gen/kotlin/tests.rs prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs prebindgen/src/api/lang/jnigen/jni/tests/config.rs` — passed.
- `git diff --check` — passed.
- Verified both committed `examples/*/kotlin/generated/.prebindgen-kotlin-output` files contain the required `prebindgen Kotlin output v1\n` marker.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
