### PR TITLE
jnigen: preserve wrapper signature metadata in split overloads (#87)

### DIFF
--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -30,7 +30,7 @@ re-runs `build.rs` to regenerate both sides of the binding
 the Kotlin asserts. Expected output ends with:
 
 ```
-PASS - 20 sections, every JniGen feature exercised
+PASS - 29 sections, every JniGen feature exercised
 ```
 
 (One section deliberately provokes callback exceptions; the stack traces it

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -30,6 +30,7 @@
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
 //! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones |
 //! | `FunctionDecl::split_on_param` (#52)  | single: `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); cartesian product: `summaryPrefer` (2 params); manual same-named overload in `ManualOverloads.kt` |
+//! | split × builder-delivered return (#87) | `summaryMerge` — cartesian split + generic `<R>` wrapper; every overload re-declares `<R>` |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
@@ -427,6 +428,14 @@ fn main() {
                 // distinct: build/build, build/handle, handle/build, handle/handle).
                 .fun(
                     fun!(summary_prefer)
+                        .split_on_param("primary")
+                        .split_on_param("fallback"),
+                )
+                // Split × builder-delivered return (#87): both params split AND
+                // the `Summary` return crosses via the decomposed builder, so
+                // the wrapper is generic — every overload must re-declare `<R>`.
+                .fun(
+                    fun!(summary_merge)
                         .split_on_param("primary")
                         .split_on_param("fallback"),
                 )

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -30,6 +30,10 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
 - `summary_describe` — `fun describeSummary(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, verbose: Boolean, onError: io.prebindgen.covertest.JniErrorHandler<String>): String`
   - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
+- `summary_merge` — `fun <R> summaryMerge(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<R>, build: io.prebindgen.covertest.analytics.SummaryBuilder<R>): R`
+  - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
+  - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
+  - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
 - `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -729,6 +729,22 @@ internal object CovNative {
     ): String
     external fun summaryFromMean(count: Long, mean: Double, errorSink: Any): Long
     external fun summaryMean(s: Long, errorSink: Any): Double
+    external fun summaryMerge(
+        primarySel: Int,
+        primary00Present: Boolean,
+        primary00Value: Long,
+        primary01Present: Boolean,
+        primary01Value: Double,
+        primary1: Long,
+        fallbackSel: Int,
+        fallback00Present: Boolean,
+        fallback00Value: Long,
+        fallback01Present: Boolean,
+        fallback01Value: Double,
+        fallback1: Long,
+        build: Any,
+        errorSink: Any,
+    ): Any?
     external fun summaryNew(count: Long, total: Double, errorSink: Any): Long
     external fun summaryPrefer(
         primarySel: Int,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -504,6 +504,91 @@ public fun summaryPrefer(
     return __ret
 }
 
+@Suppress("UNCHECKED_CAST")
+public fun <R> summaryMerge(
+    primaryCount: Long,
+    primaryTotal: Double,
+    fallbackCount: Long,
+    fallbackTotal: Double,
+    onError: JniErrorHandler<R>,
+    build: SummaryBuilder<R>,
+): R = summaryMerge(0, primaryCount, primaryTotal, null, 0, fallbackCount, fallbackTotal, null, onError, build)
+
+@Suppress("UNCHECKED_CAST")
+public fun <R> summaryMerge(
+    primaryCount: Long,
+    primaryTotal: Double,
+    fallback: Summary,
+    onError: JniErrorHandler<R>,
+    build: SummaryBuilder<R>,
+): R = summaryMerge(0, primaryCount, primaryTotal, null, 1, null, null, fallback, onError, build)
+
+@Suppress("UNCHECKED_CAST")
+public fun <R> summaryMerge(
+    primary: Summary,
+    fallbackCount: Long,
+    fallbackTotal: Double,
+    onError: JniErrorHandler<R>,
+    build: SummaryBuilder<R>,
+): R = summaryMerge(1, null, null, primary, 0, fallbackCount, fallbackTotal, null, onError, build)
+
+@Suppress("UNCHECKED_CAST")
+public fun <R> summaryMerge(
+    primary: Summary,
+    fallback: Summary,
+    onError: JniErrorHandler<R>,
+    build: SummaryBuilder<R>,
+): R = summaryMerge(1, null, null, primary, 1, null, null, fallback, onError, build)
+
+/**
+ * Combine two summaries (#87 regression: BOTH parameters are splittable under
+ * the `Summary` flatten-input default AND the `Summary` return is delivered
+ * through the decomposed builder — the wrapper is generic over `<R>`, and
+ * every split overload must re-declare it).
+ *
+ * Parameter `fallback` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `fallbackSel`, `fallback00`, `fallback01`, `fallback1`).
+ * Parameter `primary` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `primarySel`, `primary00`, `primary01`, `primary1`).
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <R> summaryMerge(
+    primarySel: Int,
+    primary00: Long?,
+    primary01: Double?,
+    primary1: Summary?,
+    fallbackSel: Int,
+    fallback00: Long?,
+    fallback01: Double?,
+    fallback1: Summary?,
+    onError: JniErrorHandler<R>,
+    build: SummaryBuilder<R>,
+): R {
+    if (primary1 != null && primary1.isClosed()) return onError.run(
+        "Operation on a closed native handle.",
+    )
+    if (fallback1 != null && fallback1.isClosed()) return onError.run(
+        "Operation on a closed native handle.",
+    )
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        primary1?.let { __locks.add(it) }
+        fallback1?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val primary1_ptr = primary1?.ptr ?: 0L
+            val fallback1_ptr = fallback1?.ptr ?: 0L
+            try {
+                (CovNative.summaryMerge(primarySel, primary00 != null, primary00 ?: 0L, primary01 != null, primary01 ?: 0.0, primary1_ptr, fallbackSel, fallback00 != null, fallback00 ?: 0L, fallback01 != null, fallback01 ?: 0.0, fallback1_ptr, build, __cap) as R)
+            } finally {
+                primary1?.markConsumed()
+                fallback1?.markConsumed()
+            }
+        }
+    }
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
 /**
  * Optionally-supplied summary total — exercises the **Optional
  * combined-selector expansion**: `Summary`'s dual-arm type default (build

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -12,6 +12,7 @@ import io.prebindgen.covertest.analytics.storageSummaryProbe
 import io.prebindgen.covertest.analytics.describeSummary
 import io.prebindgen.covertest.analytics.storageSummaryFull
 import io.prebindgen.covertest.analytics.storageSummaryHandle
+import io.prebindgen.covertest.analytics.summaryMerge
 import io.prebindgen.covertest.analytics.summaryPrefer
 import io.prebindgen.covertest.analytics.summaryTotalOpt
 import io.prebindgen.covertest.analytics.summaryTotalRaw
@@ -361,6 +362,28 @@ fun main() {
         check(summaryPrefer(Summary.of(3L, 99.0, boom), 1L, 1.0, boom) == 1L)     // handle / build
         check(
             summaryPrefer(Summary.of(1L, 1.0, boom), Summary.of(3L, 99.0, boom), boom) == 0L,
+        )                                                                          // handle / handle
+
+        // #87: split × builder-delivered return. `summaryMerge` returns a
+        // `Summary` decomposed through the trailing builder lambda, so its
+        // wrapper — and EVERY split overload — is generic over `<R>`; before
+        // the fix the overloads referenced `R` without declaring it and the
+        // generated Kotlin did not compile.
+        check(
+            summaryMerge(2L, 40.0, 1L, 2.0, boom) { count, total -> count to total } ==
+                (3L to 42.0),
+        )                                                                          // build / build
+        check(
+            summaryMerge(2L, 40.0, Summary.of(1L, 2.0, boom), boom) { count, _ -> count } == 3L,
+        )                                                                          // build / handle
+        check(
+            summaryMerge(Summary.of(2L, 40.0, boom), 1L, 2.0, boom) { _, total -> total } == 42.0,
+        )                                                                          // handle / build
+        check(
+            summaryMerge(Summary.of(2L, 40.0, boom), Summary.of(1L, 2.0, boom), boom) {
+                count, total ->
+                count to total
+            } == (3L to 42.0),
         )                                                                          // handle / handle
 
         // Optional combined-selector expansion: `Option<&Summary>` under the

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -6758,6 +6758,376 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMean<'a>(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    primary_sel: jni::sys::jint,
+    primary_0_0_present: jni::sys::jboolean,
+    primary_0_0_value: jni::sys::jlong,
+    primary_0_1_present: jni::sys::jboolean,
+    primary_0_1_value: jni::sys::jdouble,
+    primary_1: jni::sys::jlong,
+    fallback_sel: jni::sys::jint,
+    fallback_0_0_present: jni::sys::jboolean,
+    fallback_0_0_value: jni::sys::jlong,
+    fallback_0_1_present: jni::sys::jboolean,
+    fallback_0_1_value: jni::sys::jdouble,
+    fallback_1: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __exp_primary_sel = match jint_to_i32_a3e3b6ef(&mut env, &primary_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __exp_primary_0_0: Option<i64> = if primary_0_0_present != 0u8 {
+        let __v = match jlong_to_i64_fbf9a9bc(&mut env, &primary_0_0_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_primary_0_1: Option<f64> = if primary_0_1_present != 0u8 {
+        let __v = match jdouble_to_f64_9e4a8f70(&mut env, &primary_0_1_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_primary_1 = match jlong_to_Option_Summary_252ef2ba(&mut env, &primary_1) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __folded_primary = match {
+        match __exp_primary_sel {
+            0i32 => {
+                match (__exp_primary_0_0, __exp_primary_0_1) {
+                    (
+                        ::core::option::Option::Some(__p0),
+                        ::core::option::Option::Some(__p1),
+                    ) => {
+                        ::core::result::Result::Ok(
+                            perftest_flat::summary_new(__p0, __p1),
+                        )
+                    }
+                    _ => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from(
+                                "constructor variant input missing",
+                            ),
+                        )
+                    }
+                }
+            }
+            1i32 => {
+                match __exp_primary_1 {
+                    ::core::option::Option::Some(__v) => ::core::result::Result::Ok(__v),
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from("identity variant value missing"),
+                        )
+                    }
+                }
+            }
+            __sel => {
+                ::core::result::Result::Err(
+                    ::std::format!("invalid constructor selector: {}", __sel),
+                )
+            }
+        }
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__je.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __exp_fallback_sel = match jint_to_i32_a3e3b6ef(&mut env, &fallback_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __exp_fallback_0_0: Option<i64> = if fallback_0_0_present != 0u8 {
+        let __v = match jlong_to_i64_fbf9a9bc(&mut env, &fallback_0_0_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_fallback_0_1: Option<f64> = if fallback_0_1_present != 0u8 {
+        let __v = match jdouble_to_f64_9e4a8f70(&mut env, &fallback_0_1_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        ::core::option::Option::Some(__v)
+    } else {
+        ::core::option::Option::None
+    };
+    let __exp_fallback_1 = match jlong_to_Option_Summary_252ef2ba(
+        &mut env,
+        &fallback_1,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __folded_fallback = match {
+        match __exp_fallback_sel {
+            0i32 => {
+                match (__exp_fallback_0_0, __exp_fallback_0_1) {
+                    (
+                        ::core::option::Option::Some(__p0),
+                        ::core::option::Option::Some(__p1),
+                    ) => {
+                        ::core::result::Result::Ok(
+                            perftest_flat::summary_new(__p0, __p1),
+                        )
+                    }
+                    _ => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from(
+                                "constructor variant input missing",
+                            ),
+                        )
+                    }
+                }
+            }
+            1i32 => {
+                match __exp_fallback_1 {
+                    ::core::option::Option::Some(__v) => ::core::result::Result::Ok(__v),
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Err(
+                            ::std::string::String::from("identity variant value missing"),
+                        )
+                    }
+                }
+            }
+            __sel => {
+                ::core::result::Result::Err(
+                    ::std::format!("invalid constructor selector: {}", __sel),
+                )
+            }
+        }
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__je.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/analytics/SummaryBuilder";
+    const __CB_DESCR: &str = "(JD)Ljava/lang/Object;";
+    let __out = perftest_flat::summary_merge(__folded_primary, __folded_fallback);
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match i64_to_jlong_fbf9a9bc(
+            &mut env,
+            perftest_flat::summary_count(&__out),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    let __obj1: jni::sys::jvalue = {
+        let __enc1 = match f64_to_jdouble_9e4a8f70(
+            &mut env,
+            perftest_flat::summary_total(&__out),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { d: __enc1 }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e2.to_string()),
+                &__zd,
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct foo_t {
     pub id: u64,
     pub aarch64_field: u64,
-    pub unstable_field: u64,
+    pub stable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -97,7 +97,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         aarch64_field: v.aarch64_field,
-        unstable_field: v.unstable_field,
+        stable_field: v.stable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -208,7 +208,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         aarch64_field: v.aarch64_field,
-        unstable_field: v.unstable_field,
+        stable_field: v.stable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -429,17 +429,6 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
-    let c = match __cbg_in___mut_Calculator(c) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__msg) => {
-            panic!("{}", __msg);
-        }
-    };
-    example_flat::calculator_reset(c);
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -491,7 +480,7 @@ pub unsafe extern "C" fn inside_foo_value(x: inside_foo_t) -> i32 {
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
+        example_flat::FEATURES, "",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -37,7 +37,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t aarch64_field;
-  uint64_t unstable_field;
+  uint64_t stable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -69,8 +69,6 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
-
-void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -209,6 +209,18 @@ pub fn storage_matches_summary(s: &Storage, expected: Summary) -> bool {
     live.count == expected.count && (live.total - expected.total).abs() < f64::EPSILON
 }
 
+/// Combine two summaries (#87 regression: BOTH parameters are splittable under
+/// the `Summary` flatten-input default AND the `Summary` return is delivered
+/// through the decomposed builder — the wrapper is generic over `<R>`, and
+/// every split overload must re-declare it).
+#[prebindgen]
+pub fn summary_merge(primary: Summary, fallback: Summary) -> Summary {
+    Summary {
+        count: primary.count + fallback.count,
+        total: primary.total + fallback.total,
+    }
+}
+
 /// Like [`storage_summary`] but the binding keeps the result as a raw opaque
 /// handle (per-fn **flatten-output-suppress**).
 #[prebindgen]

--- a/prebindgen/src/api/gen/kotlin/mod.rs
+++ b/prebindgen/src/api/gen/kotlin/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 pub use code::Code;
 pub use file::{merge_files, write_files, WriteKotlinError};
 pub use model::{
-    ClassKind, KtClass, KtCtorParam, KtDecl, KtEnumEntry, KtFile, KtFun, KtFunInterface, KtParam,
-    KtProperty, Vis,
+    ClassKind, KtBody, KtClass, KtCtorParam, KtDecl, KtEnumEntry, KtFile, KtFun, KtFunInterface,
+    KtParam, KtProperty, Vis,
 };
 pub use types::KtType;

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -540,21 +540,27 @@ pub(crate) fn render_param_overloads(
             );
         }
 
-        let mut ov = kt::KtFun::new(&sel_fun.name).vis(kt::Vis::Public);
-        for p in params {
-            ov = ov.param(p);
-        }
-        if let Some(rt) = &sel_fun.ret {
-            ov = ov.returns(rt.clone());
-        }
-        ov = ov.expr_body(kt::Code::new().line(format!(
-            "{}({})",
-            sel_fun.name,
-            call_args.join(", ")
-        )));
-        out.push(ov);
+        out.push(overload_shell(
+            sel_fun,
+            params,
+            kt::Code::new().line(format!("{}({})", sel_fun.name, call_args.join(", "))),
+        ));
     }
     out
+}
+
+/// An overload derived from the selector wrapper by a signature-preserving
+/// transform: generics, annotations, modifiers, visibility, and return type
+/// carry over unchanged (a wrapper generic over `R`/`A` — builder/fold
+/// delivery — keeps its `fun <R> …` declaration, #87); only the parameter
+/// list and the delegating body are replaced. Kdoc stays on the selector
+/// form — overloads are bare.
+fn overload_shell(sel_fun: &kt::KtFun, params: Vec<kt::KtParam>, body: kt::Code) -> kt::KtFun {
+    let mut ov = sel_fun.clone();
+    ov.params = params;
+    ov.kdoc = None;
+    ov.body = kt::KtBody::Expr(body);
+    ov
 }
 
 /// Cartesian product of index ranges `0..counts[k]`, as a list of index
@@ -634,5 +640,42 @@ mod tests {
 
         assert_eq!(params[0].0.ty.to_string(), "Long?");
         assert_eq!(params[1].0.ty.to_string(), "Double");
+    }
+
+    /// #87: an overload preserves the selector wrapper's signature metadata —
+    /// generics (`fun <R> …`), annotations, modifiers, visibility, and return
+    /// type — replacing only the parameter list and body; kdoc stays on the
+    /// selector form.
+    #[test]
+    fn overload_shell_preserves_signature_metadata() {
+        let sel_fun = kt::KtFun::new("storageSummary")
+            .vis(kt::Vis::Public)
+            .kdoc("Selector-form docs.")
+            .generic("R")
+            .annotation("Suppress(\"UNCHECKED_CAST\")")
+            .modifier("inline")
+            .param(kt::KtParam::new("sSel", kt::KtType::int()))
+            .returns(kt::KtType::cls("R"))
+            .body(kt::Code::new().line("TODO()"));
+
+        let ov = overload_shell(
+            &sel_fun,
+            vec![kt::KtParam::new("count", kt::KtType::long())],
+            kt::Code::new().line("storageSummary(0, count)"),
+        );
+
+        assert_eq!(ov.name, sel_fun.name);
+        assert_eq!(ov.generics, vec!["R".to_string()]);
+        assert_eq!(ov.annotations, sel_fun.annotations);
+        assert_eq!(ov.modifiers, sel_fun.modifiers);
+        assert!(matches!(ov.vis, kt::Vis::Public));
+        assert_eq!(
+            ov.ret.as_ref().map(|t| t.to_string()),
+            Some("R".to_string())
+        );
+        assert_eq!(ov.kdoc, None);
+        assert_eq!(ov.params.len(), 1);
+        assert_eq!(ov.params[0].name, "count");
+        assert!(matches!(ov.body, kt::KtBody::Expr(_)));
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1425,6 +1425,69 @@ fn split_on_param_cartesian_product() {
     );
 }
 
+/// #87: a split parameter on a function whose return is **builder-delivered**
+/// (decomposed `expand_return!` fields ⇒ generic `<R>` wrapper) keeps the
+/// wrapper's generic declaration on every overload — including the full
+/// cartesian product — instead of referencing an undeclared `R`.
+#[test]
+fn split_on_param_preserves_wrapper_generics() {
+    let registry = split_fixture(&[
+        "pub fn z_summary_count(s: &ZSummary) -> i64 { unimplemented!() }",
+        "pub fn z_summary_total(s: &ZSummary) -> f64 { unimplemented!() }",
+        "pub fn z_summarize(primary: ZSummary, fallback: ZSummary) -> ZSummary { unimplemented!() }",
+    ]);
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZSummary))
+                .fun(
+                    crate::fun!(z_summarize)
+                        .split_on_param("primary")
+                        .split_on_param("fallback"),
+                ),
+        )
+        .expand(
+            crate::expand_param!(ZSummary)
+                .variant(crate::fun!(z_summary_new))
+                .variant_self(),
+        )
+        .expand(
+            crate::expand_return!(ZSummary)
+                .field(crate::fun!(z_summary_count))
+                .field(crate::fun!(z_summary_total)),
+        );
+    let raw = write_all(
+        registry.resolve(jni).expect("resolve"),
+        "jnigen_split_generic",
+    );
+    let all: String = raw.split_whitespace().collect();
+    // The selector wrapper is generic (builder-delivered return)…
+    assert!(all.contains("fun<R>zSummarize(primarySel:Int"), "{raw}");
+    // …and every cartesian overload re-declares `<R>`.
+    assert!(
+        all.contains(
+            "fun<R>zSummarize(primaryCount:Long,primaryTotal:Double,fallbackCount:Long,fallbackTotal:Double,"
+        ),
+        "{raw}"
+    );
+    assert!(
+        all.contains("fun<R>zSummarize(primaryCount:Long,primaryTotal:Double,fallback:ZSummary,"),
+        "{raw}"
+    );
+    assert!(
+        all.contains("fun<R>zSummarize(primary:ZSummary,fallbackCount:Long,fallbackTotal:Double,"),
+        "{raw}"
+    );
+    assert!(
+        all.contains("fun<R>zSummarize(primary:ZSummary,fallback:ZSummary,"),
+        "{raw}"
+    );
+    // No wrapper form may reference `R` without declaring it (the only
+    // non-generic `fun zSummarize` is the `external` JNINative extern).
+    assert!(!all.contains("publicfunzSummarize("), "{raw}");
+}
+
 /// #52: a `.split_on_param` product whose two combinations erase to the same
 /// JVM signature is a hard, per-function error. `from_one(Long)` /
 /// `from_two(Long,Long)` on two params collide at (one,two) vs (two,one).


### PR DESCRIPTION
Fixes #87.

## Problem

`render_param_overloads` rebuilt each `split_on_param` overload as a fresh `KtFun`, copying only the selector wrapper's parameters and return type. A wrapper made generic by builder/fold output delivery (`expand_return!` callback delivery ⇒ `fun <R> …` / `fun <A> …`) produced overloads that reference `R` in parameters and return type without declaring `<R>` — the generated Kotlin did not compile (the standalone Sample-constructor failure).

## Fix

Overloads are now derived by a **signature-preserving transform** (`overload_shell` in `jni/overloads.rs`): clone the selector wrapper, replace only the parameter list and the delegating body. Generics, annotations (`@Suppress("UNCHECKED_CAST")`), modifiers, visibility, and return type carry over; kdoc stays on the selector form (overloads remain bare, as before). All five overload call sites (top-level, class-method, constructor contexts) go through this one function. `KtBody` joins the `kt` root re-exports.

Existing generated output is byte-identical — the covertest regen is purely additive.

## Acceptance criteria → coverage

- **Split + `expand_return!` callback delivery compiles as `fun <R>`** — covertest `summary_merge`: both `Summary` params split under the type default, `Summary` return via the decomposed builder; the selector wrapper and all four cartesian overloads render `fun <R>` and compile (`./gradlew run`: `PASS - 29 sections`).
- **Cartesian multi-split preserves all selector-wrapper generic variables** — `split_on_param_preserves_wrapper_generics` (flatten.rs) asserts `fun<R>` on the selector and every product overload.
- **Compile-level Kotlin covertest** — the `summaryMerge` exercise above, plus JVM `check(...)` asserts through all four typed overloads (build/build, build/handle, handle/build, handle/handle).
- **Unit test asserts signature metadata, not rendered text** — `overload_shell_preserves_signature_metadata` (overloads.rs) checks `generics` / `annotations` / `modifiers` / `vis` / `ret` preserved and `kdoc` cleared on the `KtFun` model.

## Also in this PR

- `example-cbindgen`: restore the plain-build aarch64 goldens — they had been committed in the clippy `--all-features` rewrite state (inconsistent with the CI-maintained x86_64 pair), which made `examples/regen-check.sh` fail on aarch64 hosts.
- covertest README: refresh the expected `PASS` line to the actual section count (29).

## Verification

- `cargo test -p prebindgen --all-features` — 276 lib tests + doctests pass
- `examples/regen-check.sh` — `PASS - regen check clean`
- `examples/covertest-kotlin$ ./gradlew run` — `PASS - 29 sections`
- `cargo fmt` (project config) + `cargo clippy --all-targets --no-default-features --all-features -- --deny warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)