### PR TITLE
jnigen: lower function inputs once into JniFunctionPlan (#90 stage 1)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -243,8 +243,11 @@ pub(crate) struct FlatLeaf {
     pub kt_name: String,
     /// Kotlin `external fun` parameter type (incl. a trailing `?`).
     pub kt_wire_ty: String,
-    /// Kotlin call-site destructure expression feeding this leaf.
-    pub kt_access: String,
+    /// Call-site destructure expression **tail** — everything after the
+    /// object expression (`.field ?: 0`, `?.seq != null`, ` != null`). The
+    /// full access is composed per site via [`Self::kt_access`], so the plan
+    /// itself stays independent of the call form (`payload`, `this`, `__e`).
+    pub kt_access_tail: String,
     /// Per-field input converter ident (`None` for the synthetic present flag).
     pub conv: Option<syn::Ident>,
     /// Struct field this leaf populates. `None` for the struct-level present
@@ -259,6 +262,16 @@ pub(crate) struct FlatLeaf {
     /// field — its `field`'s reconstruct is `if <field>_present { Some(conv(v)) }
     /// else { None }`, gated by the matching per-field present leaf. (Phase 5.)
     pub opt_scalar: bool,
+}
+
+impl FlatLeaf {
+    /// Kotlin call-site destructure expression feeding this leaf, rooted at
+    /// `base` — the object expression at this call site (the camelCase param
+    /// name, `this` for a promoted receiver, `__e` for the vec-build loop
+    /// variable).
+    pub fn kt_access(&self, base: &str) -> String {
+        format!("{base}{}", self.kt_access_tail)
+    }
 }
 
 /// A flattened plan for one struct input parameter. Built once by
@@ -337,16 +350,14 @@ pub(crate) fn kt_leaf_default(sig: &str, nullable: bool) -> Option<String> {
 /// `(<field>_present: Boolean, <field>_value: <prim>)` [`FlatLeaf`] pair, or
 /// `None` to keep the boxed-`JObject` decline. The field-level dual of
 /// [`build_option_scalar_input_plan`]: same boxed-fallback condition (primitive
-/// inner wire, no niche, no projection, no pre-stages). `kt_param` is the call
-/// object expression and `optional` whether the enclosing struct param is itself
-/// `Option<struct>` — when so, the access safe-navigates (`obj?.field`), so an
-/// absent struct yields `present = false` for every field.
-#[allow(clippy::too_many_arguments)]
+/// inner wire, no niche, no projection, no pre-stages). `optional` is whether
+/// the enclosing struct param is itself `Option<struct>` — when so, the access
+/// tail safe-navigates (`?.field`), so an absent struct yields
+/// `present = false` for every field.
 pub(crate) fn option_scalar_field_leaves(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
-    kt_param: &str,
     optional: bool,
     fident: &syn::Ident,
     fcamel: &str,
@@ -366,14 +377,14 @@ pub(crate) fn option_scalar_field_leaves(
         return None;
     }
     let is_enum = ext.is_kotlin_enum(&inner);
-    // `obj.field` / `obj?.field` (safe-nav under an absent `Option<struct>`).
+    // `.field` / `?.field` (safe-nav under an absent `Option<struct>`).
     let field_ref = if optional {
-        format!("{kt_param}?.{fcamel}")
+        format!("?.{fcamel}")
     } else {
-        format!("{kt_param}.{fcamel}")
+        format!(".{fcamel}")
     };
-    let present_access = format!("{field_ref} != null");
-    let value_access = if is_enum {
+    let present_tail = format!("{field_ref} != null");
+    let value_tail = if is_enum {
         format!("{field_ref}?.value ?: {}", prim.kotlin_zero())
     } else {
         format!("{field_ref} ?: {}", prim.kotlin_zero())
@@ -386,7 +397,7 @@ pub(crate) fn option_scalar_field_leaves(
             native_wire_ty: quote!(jni::sys::jboolean),
             kt_name: snake_to_camel(&format!("{}_{}_present", param_name, fident)),
             kt_wire_ty: "Boolean".to_string(),
-            kt_access: present_access,
+            kt_access_tail: present_tail,
             conv: None,
             field: Some(fident.clone()),
             is_present_flag: true,
@@ -397,7 +408,7 @@ pub(crate) fn option_scalar_field_leaves(
             native_wire_ty: quote!(#value_wire),
             kt_name: snake_to_camel(&format!("{}_{}_value", param_name, fident)),
             kt_wire_ty: prim.kotlin_type().to_string(),
-            kt_access: value_access,
+            kt_access_tail: value_tail,
             conv: Some(ie.function.sig.ident.clone()),
             field: Some(fident.clone()),
             is_present_flag: false,
@@ -418,7 +429,6 @@ pub(crate) fn build_flat_input_plan(
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg_ty: &syn::Type,
-    kt_base: &str,
 ) -> Option<FlatInputPlan> {
     // 1. Resolve the struct target through `&`, `Option<…>`, and `impl Into<S>`.
     let (by_ref, t1) = match arg_ty {
@@ -473,11 +483,6 @@ pub(crate) fn build_flat_input_plan(
 
     // 3. Classify every field as a simple leaf, else fall back.
     let struct_module = struct_module_path(ext, registry, st);
-    // `kt_base` is the Kotlin expression for the object at the call site —
-    // normally the camelCase param name, or `this` for a promoted instance
-    // receiver. The native param idents / extern names stay keyed on
-    // `param_name` so the wire signature is independent of the call form.
-    let kt_param = kt_base.to_string();
     let mut leaves: Vec<FlatLeaf> = Vec::new();
 
     // Present gate for `Option<struct>` (first leaf, mirrors the output
@@ -489,7 +494,7 @@ pub(crate) fn build_flat_input_plan(
             native_wire_ty: quote!(jni::sys::jboolean),
             kt_name: snake_to_camel(&format!("{}_present", param_name)),
             kt_wire_ty: "Boolean".to_string(),
-            kt_access: format!("{kt_param} != null"),
+            kt_access_tail: " != null".to_string(),
             conv: None,
             field: None,
             is_present_flag: true,
@@ -512,7 +517,7 @@ pub(crate) fn build_flat_input_plan(
         // from the two raw scalars (no `intValue()` unbox). Detected before the
         // enum-decline guard below so `Option<enum>` fields take this path too.
         if let Some(pair) = option_scalar_field_leaves(
-            ext, registry, param_name, &kt_param, optional, &fident, &fcamel, &field.ty,
+            ext, registry, param_name, optional, &fident, &fcamel, &field.ty,
         ) {
             leaves.extend(pair);
             continue;
@@ -538,17 +543,17 @@ pub(crate) fn build_flat_input_plan(
         let native_wire_ty = annotate_jobject_with_lifetime(wire, "a").to_token_stream();
         let kt_name = snake_to_camel(&format!("{}_{}", param_name, fident));
 
-        // Destructure expression. Under an absent `Option<struct>` parent the
+        // Destructure tail. Under an absent `Option<struct>` parent the
         // leaf still needs a value on the wire (`present` makes Rust ignore
         // it): nullable leaves ride JVM null, non-null leaves a typed default.
-        let kt_access = if optional {
-            let base = format!("{kt_param}?.{fcamel}");
+        let kt_access_tail = if optional {
+            let base = format!("?.{fcamel}");
             match kt_leaf_default(sig, f_opt) {
                 Some(def) => format!("{base} ?: {def}"),
                 None => base,
             }
         } else {
-            format!("{kt_param}.{fcamel}")
+            format!(".{fcamel}")
         };
 
         leaves.push(FlatLeaf {
@@ -556,7 +561,7 @@ pub(crate) fn build_flat_input_plan(
             native_wire_ty,
             kt_name,
             kt_wire_ty,
-            kt_access,
+            kt_access_tail,
             conv: Some(fentry.function.sig.ident.clone()),
             field: Some(fident),
             is_present_flag: false,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -35,8 +35,8 @@ pub(crate) fn vec_build_elem(
     arg_ty: &syn::Type,
 ) -> Option<(syn::Type, bool)> {
     let (elem, by_ref) = slice_or_vec_elem(arg_ty)?;
-    // The element must flatten; the probe ident/base are irrelevant here.
-    build_flat_input_plan(ext, registry, &format_ident!("e"), &elem, "__e")?;
+    // The element must flatten; the probe ident is irrelevant here.
+    build_flat_input_plan(ext, registry, &format_ident!("e"), &elem)?;
     Some((elem, by_ref))
 }
 
@@ -85,7 +85,7 @@ pub(crate) fn vec_build_helpers(
     registry: &Registry<KotlinMeta>,
     elem: &syn::Type,
 ) -> Option<VecBuildHelpers> {
-    let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem, "__e")?;
+    let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)?;
     let key = TypeKey::from_type(elem);
     let kt_fqn = ext
         .types

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -494,7 +494,7 @@ fn emit_input_param(
                 .expect("ParamForm::Expanded ⇒ expansion plan present");
             return emit_expanded_param(ext, registry, fold, leaves, &param.ident, on_err);
         }
-        ParamForm::Single(leaf) => leaf,
+        ParamForm::Single(leaf) => &**leaf,
     };
     let arg_ident = &param.ident;
     let arg_ty = &param.ty;
@@ -622,7 +622,7 @@ fn emit_input_param(
                     original_ident,
                 )
             });
-            emit_plain_decode(&entry, arg_ident, arg_ty, on_err)
+            emit_plain_decode(entry, arg_ident, arg_ty, on_err)
         }
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -186,17 +186,26 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let wire_return = output.wire_return;
     let on_err = output.on_err;
 
-    // Input parameters: look up converter for the param type AS WRITTEN.
-    // No strip — a `&T` param looks up `&T`'s entry (which the `& _`
-    // rank-1 handler resolved by sharing `T`'s function). Call site adds
-    // `&decoded` only for `&T`-shaped originals; that's a Rust call-
-    // convention concern, not a converter concern.
-    for input in &f.sig.inputs {
-        let Some((wp, pre, call_arg)) =
-            emit_input_param(ext, registry, original_ident, input, &on_err)
-        else {
-            continue;
-        };
+    // Input parameters: the lowered plan classifies each param ONCE — the
+    // same classification the Kotlin wrapper and `external fun` renderers
+    // consume — and this site renders the Rust decode for each kind. The
+    // converter is looked up for the param type AS WRITTEN. No strip — a
+    // `&T` param looks up `&T`'s entry (which the `& _` rank-1 handler
+    // resolved by sharing `T`'s function). Call site adds `&decoded` only
+    // for `&T`-shaped originals; that's a Rust call-convention concern, not
+    // a converter concern.
+    let plan = JniFunctionPlan::build(ext, registry, f).unwrap_or_else(|e| match e {
+        PlanError::Unresolved { ty } => panic!(
+            "JniGen::on_function: input type `{}` for `{}` is unresolved",
+            ty, original_ident,
+        ),
+        PlanError::UnresolvedLeaf { ty, param } => panic!(
+            "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
+            ty, param,
+        ),
+    });
+    for param in &plan.params {
+        let (wp, pre, call_arg) = emit_input_param(ext, registry, original_ident, param, &on_err);
         wire_params.extend(wp);
         prelude.extend(pre);
         call_args.push(call_arg);
@@ -462,129 +471,173 @@ fn unfold_builder_param(plan: &crate::api::core::unfold::UnfoldPlan) -> TokenStr
     }
 }
 
-/// Decode one source-fn input parameter: look up its converter for the type AS
-/// WRITTEN (no strip — a `&T` param looks up `&T`'s entry, which the `& _`
-/// rank-1 handler resolved by sharing `T`'s function), then emit its wire
-/// params, prelude decode statements, and the call argument. Returns `None` for
-/// a non-`Typed`/non-`Ident` arg (`self`, patterns), which the caller skips.
-///
-/// Reads only `ext`/`registry`/`original_ident`/`on_err` — independent of any
-/// other input — so the per-input handling stays a self-contained unit.
+/// Render the Rust-side decode for one source-fn parameter from its lowered
+/// [`PlanParam`]: the wire params, prelude decode statements, and the call
+/// argument. The classification (which crossing form) lives in the plan; this
+/// site only renders each [`InputKind`]'s decode.
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     original_ident: &syn::Ident,
-    input: &syn::FnArg,
+    param: &PlanParam,
     on_err: &TokenStream,
-) -> Option<(Vec<TokenStream>, Vec<TokenStream>, TokenStream)> {
-    let syn::FnArg::Typed(pt) = input else {
-        return None;
+) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
+    // Constructor-expansion: this parameter's wire form is the fold plan's
+    // flattened leaves. Decode each leaf with its own converter, run the
+    // (pure-Rust) fold to build the value, then pass it to the call.
+    let leaf = match &param.form {
+        ParamForm::Expanded(leaves) => {
+            let fold = registry
+                .expansion_plans
+                .get(&(original_ident.clone(), param.ident.clone()))
+                .expect("ParamForm::Expanded ⇒ expansion plan present");
+            return emit_expanded_param(ext, registry, fold, leaves, &param.ident, on_err);
+        }
+        ParamForm::Single(leaf) => leaf,
     };
-    let syn::Pat::Ident(pat_id) = &*pt.pat else {
-        return None;
-    };
-    let arg_ident = &pat_id.ident;
-    let arg_ty = &*pt.ty;
+    let arg_ident = &param.ident;
+    let arg_ty = &param.ty;
 
     let mut wire_params: Vec<TokenStream> = Vec::new();
     let mut prelude: Vec<TokenStream> = Vec::new();
 
-    // Constructor-expansion: this parameter's wire form is the fold plan's
-    // flattened leaves. Decode each leaf with its own converter, run the
-    // (pure-Rust) fold to build the value, then pass it to the call.
-    if let Some(plan) = registry
-        .expansion_plans
-        .get(&(original_ident.clone(), arg_ident.clone()))
-    {
-        let (wp, pre, call_arg) = emit_expanded_param(ext, registry, plan, arg_ident, on_err);
-        wire_params.extend(wp);
-        prelude.extend(pre);
-        return Some((wire_params, prelude, call_arg));
-    }
-
-    let entry = registry.input_entry(arg_ty).unwrap_or_else(|| {
-        panic!(
-            "JniGen::on_function: input type `{}` for `{}` is unresolved",
-            TypeKey::from_type(arg_ty),
-            original_ident,
-        )
-    });
-
-    // Flattenable data_class param: cross its fields as separate wire
-    // params and reconstruct the struct inline — no per-call
-    // `env.get_field(...)` reflection. Falls back (None) to the
-    // single-`JObject` path for any shape outside the conservative leaf
-    // set (handles, nested structs, enums, …). The `JNINative` extern and
-    // the Kotlin call-site destructure read the same plan so the three
-    // sites can't drift.
-    if let Some(plan) = build_flat_input_plan(ext, registry, arg_ident, arg_ty, "") {
-        for leaf in &plan.leaves {
-            let pid = &leaf.native_ident;
-            let pty = &leaf.native_wire_ty;
-            wire_params.push(quote!(#pid: #pty));
+    match &leaf.kind {
+        // Flattenable data_class param: cross its fields as separate wire
+        // params and reconstruct the struct inline — no per-call
+        // `env.get_field(...)` reflection. The `JNINative` extern and the
+        // Kotlin call-site destructure read the same plan so the three
+        // sites can't drift.
+        InputKind::FlattenStruct(plan) => {
+            for leaf in &plan.leaves {
+                let pid = &leaf.native_ident;
+                let pty = &leaf.native_wire_ty;
+                wire_params.push(quote!(#pid: #pty));
+            }
+            let (decode, call_arg) = render_flat_input_decode(plan, arg_ident, on_err);
+            prelude.push(decode);
+            (wire_params, prelude, call_arg)
         }
-        let (decode, call_arg) = render_flat_input_decode(&plan, arg_ident, on_err);
-        prelude.push(decode);
-        return Some((wire_params, prelude, call_arg));
-    }
 
-    // Bare `Option<primitive>` / `Option<enum>` param: cross as a
-    // `(present: jboolean, value: <wire>)` pair instead of a boxed
-    // `java.lang.*` `JObject`. The Rust side rebuilds the `Option` from two
-    // raw scalars — no `env.call_method("intValue", …)` unbox. The `JNINative`
-    // extern decl and the Kotlin call site read the same plan (see
-    // `ParamMode::OptionScalar`), so the three sites can't drift.
-    if let Some(sp) = build_option_scalar_input_plan(ext, registry, arg_ident, arg_ty) {
-        let pid = &sp.present_ident;
-        let vid = &sp.value_ident;
-        let vwire = &sp.value_wire;
-        wire_params.push(quote!(#pid: jni::sys::jboolean));
-        wire_params.push(quote!(#vid: #vwire));
-        let conv = &sp.inner_conv;
-        let tmp = format_ident!("__{}_val", arg_ident);
-        prelude.push(quote! {
-            let #arg_ident = if #pid != 0u8 {
-                let #tmp = match #conv(&mut env, &#vid) {
-                    ::core::result::Result::Ok(__v) => __v,
-                    ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
-                        return #on_err;
-                    }
+        // Bare `Option<primitive>` / `Option<enum>` param: cross as a
+        // `(present: jboolean, value: <wire>)` pair instead of a boxed
+        // `java.lang.*` `JObject`. The Rust side rebuilds the `Option` from
+        // two raw scalars — no `env.call_method("intValue", …)` unbox.
+        InputKind::OptionScalar(sp) => {
+            let pid = &sp.present_ident;
+            let vid = &sp.value_ident;
+            let vwire = &sp.value_wire;
+            wire_params.push(quote!(#pid: jni::sys::jboolean));
+            wire_params.push(quote!(#vid: #vwire));
+            let conv = &sp.inner_conv;
+            let tmp = format_ident!("__{}_val", arg_ident);
+            prelude.push(quote! {
+                let #arg_ident = if #pid != 0u8 {
+                    let #tmp = match #conv(&mut env, &#vid) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            let __zd = __ze_defaults(&mut env);
+                            signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                            return #on_err;
+                        }
+                    };
+                    ::core::option::Option::Some(#tmp)
+                } else {
+                    ::core::option::Option::None
                 };
-                ::core::option::Option::Some(#tmp)
-            } else {
-                ::core::option::Option::None
-            };
-        });
-        return Some((wire_params, prelude, quote!(#arg_ident)));
-    }
-
-    // Slice / `Vec` of a flattenable data_class: the param crosses as a single
-    // `jlong` handle to a Rust-side `Vec<T>` that the Kotlin wrapper builds by
-    // pushing each element's decoupled leaves in a loop (see
-    // `build_vec_build_helper_items` + `ParamMode::VecBuild`) — no per-element
-    // `env.get_field(...)`. `&[T]` borrows the boxed Vec; by-value `Vec<T>`
-    // moves it out with `mem::take` (leaving an empty Vec the Kotlin `finally`
-    // frees). Decode is infallible, like the by-value-handle consume below.
-    if let Some((elem, by_ref)) = vec_build_elem(ext, registry, arg_ty) {
-        let handle_ident = format_ident!("{}_handle", arg_ident);
-        wire_params.push(quote!(#handle_ident: jni::sys::jlong));
-        if by_ref {
-            prelude.push(quote!(
-                let #arg_ident: &[#elem] =
-                    unsafe { &*(#handle_ident as *const Vec<#elem>) };
-            ));
-        } else {
-            prelude.push(quote!(
-                let #arg_ident: Vec<#elem> =
-                    unsafe { ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>)) };
-            ));
+            });
+            (wire_params, prelude, quote!(#arg_ident))
         }
-        return Some((wire_params, prelude, quote!(#arg_ident)));
-    }
 
+        // Slice / `Vec` of a flattenable data_class: the param crosses as a
+        // single `jlong` handle to a Rust-side `Vec<T>` that the Kotlin
+        // wrapper builds by pushing each element's decoupled leaves in a loop
+        // (see `build_vec_build_helper_items` + `ParamMode::VecBuild`) — no
+        // per-element `env.get_field(...)`. `&[T]` borrows the boxed Vec;
+        // by-value `Vec<T>` moves it out with `mem::take` (leaving an empty
+        // Vec the Kotlin `finally` frees). Decode is infallible, like the
+        // by-value-handle consume below.
+        InputKind::VecBuild { elem, by_ref } => {
+            let handle_ident = format_ident!("{}_handle", arg_ident);
+            wire_params.push(quote!(#handle_ident: jni::sys::jlong));
+            if *by_ref {
+                prelude.push(quote!(
+                    let #arg_ident: &[#elem] =
+                        unsafe { &*(#handle_ident as *const Vec<#elem>) };
+                ));
+            } else {
+                prelude.push(quote!(
+                    let #arg_ident: Vec<#elem> =
+                        unsafe { ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>)) };
+                ));
+            }
+            (wire_params, prelude, quote!(#arg_ident))
+        }
+
+        // By-value `T` opaque-handle parameter: emit the consume
+        // converter inline, bypassing `OwnedObject`. The Java side
+        // holds the handle's monitor and passes the pointer here;
+        // `Box::from_raw` reconstructs the unique owner and `*box`
+        // moves `T` out, dropping the heap allocation. The
+        // unique-ownership invariant is upheld by the Kotlin wrapper
+        // (monitor + tag-bit close in `finally`), which ensures the
+        // same live pointer cannot be passed twice. No `T: Clone`
+        // bound, so non-Clone handles (e.g. `Publisher<'a>`) work too.
+        // A null or tagged (closed) pointer — a close that raced past
+        // the pre-lock guard — is rejected before any dereference.
+        InputKind::Handle { direct: true } if !matches!(arg_ty, syn::Type::Reference(_)) => {
+            let entry = registry
+                .input_entry(arg_ty)
+                .expect("plan classified Handle ⇒ entry present");
+            let wire_ident = if matches!(&entry.destination, syn::Type::Ptr(_)) {
+                format_ident!("{}_ptr", arg_ident)
+            } else {
+                arg_ident.clone()
+            };
+            wire_params.push(quote!(#wire_ident: jni::sys::jlong));
+            prelude.push(quote!(
+                if #wire_ident == 0 || (#wire_ident & 1) == 1 {
+                    let __zd = __ze_defaults(&mut env);
+                    signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some("Operation on a closed native handle."), &__zd);
+                    return #on_err;
+                }
+                let #arg_ident: #arg_ty = unsafe {
+                    *std::boxed::Box::from_raw(#wire_ident as *mut #arg_ty)
+                };
+            ));
+            (wire_params, prelude, quote!(#arg_ident))
+        }
+
+        // Everything else — borrowed/composed handles, value projections,
+        // callbacks, plain types — decodes through the resolved entry's
+        // ordinary converter chain.
+        InputKind::Callback { .. }
+        | InputKind::Handle { .. }
+        | InputKind::ValueUnwrap { .. }
+        | InputKind::Plain => {
+            let entry = registry.input_entry(arg_ty).unwrap_or_else(|| {
+                panic!(
+                    "JniGen::on_function: input type `{}` for `{}` is unresolved",
+                    TypeKey::from_type(arg_ty),
+                    original_ident,
+                )
+            });
+            emit_plain_decode(&entry, arg_ident, arg_ty, on_err)
+        }
+    }
+}
+
+/// The ordinary converter-chain decode shared by every pass-through kind:
+/// wire param + staged decode prelude + the call argument (`&decoded` /
+/// `.as_deref()` per the source param's Rust shape).
+fn emit_plain_decode(
+    entry: &crate::api::core::registry::TypeEntry<KotlinMeta>,
+    arg_ident: &syn::Ident,
+    arg_ty: &syn::Type,
+    on_err: &TokenStream,
+) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
+    let mut wire_params: Vec<TokenStream> = Vec::new();
+    let mut prelude: Vec<TokenStream> = Vec::new();
     let wire = &entry.destination;
     let conv = entry.converter_ident().clone();
     let wire_ident = if matches!(wire, syn::Type::Ptr(_)) {
@@ -592,34 +645,6 @@ fn emit_input_param(
     } else {
         arg_ident.clone()
     };
-
-    // By-value `T` opaque-handle parameter: emit the consume
-    // converter inline, bypassing `OwnedObject`. The Java side
-    // holds the handle's monitor and passes the pointer here;
-    // `Box::from_raw` reconstructs the unique owner and `*box`
-    // moves `T` out, dropping the heap allocation. The
-    // unique-ownership invariant is upheld by the Kotlin wrapper
-    // (monitor + tag-bit close in `finally`), which ensures the
-    // same live pointer cannot be passed twice. No `T: Clone`
-    // bound, so non-Clone handles (e.g. `Publisher<'a>`) work too.
-    // A null or tagged (closed) pointer — a close that raced past
-    // the pre-lock guard — is rejected before any dereference.
-    let is_consume =
-        !matches!(arg_ty, syn::Type::Reference(_)) && entry.metadata.is_direct_handle();
-    if is_consume {
-        wire_params.push(quote!(#wire_ident: jni::sys::jlong));
-        prelude.push(quote!(
-            if #wire_ident == 0 || (#wire_ident & 1) == 1 {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some("Operation on a closed native handle."), &__zd);
-                return #on_err;
-            }
-            let #arg_ident: #arg_ty = unsafe {
-                *std::boxed::Box::from_raw(#wire_ident as *mut #arg_ty)
-            };
-        ));
-        return Some((wire_params, prelude, quote!(#arg_ident)));
-    }
 
     let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "a");
     wire_params.push(quote!(#wire_ident: #wire_with_lifetime));
@@ -712,13 +737,13 @@ fn emit_input_param(
         }
         _ => quote!(#arg_ident),
     };
-    Some((wire_params, prelude, call_arg))
+    (wire_params, prelude, call_arg)
 }
 
 /// Emit the wire params, decode prelude, and call argument for one
-/// constructor-expanded parameter. Each leaf is decoded with its own resolved
-/// input converter (reusing the by-value-handle consume fast path where the
-/// leaf is a direct owned handle); the leaves then feed
+/// constructor-expanded parameter. Each classified leaf is decoded with its
+/// own resolved input converter (reusing the by-value-handle consume fast
+/// path where the leaf is a direct owned handle); the leaves then feed
 /// [`crate::api::core::expand::emit_fold`], whose `Result<_, String>` is routed
 /// through the same error sink as any fallible input. The returned call
 /// argument is the built value (`&value` when the original parameter was `&T`).
@@ -726,6 +751,7 @@ pub(crate) fn emit_expanded_param(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::expand::FoldPlan,
+    leaves: &[PlanLeaf],
     orig_param: &syn::Ident,
     on_err: &TokenStream,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
@@ -733,26 +759,28 @@ pub(crate) fn emit_expanded_param(
     let mut prelude: Vec<TokenStream> = Vec::new();
     let mut leaf_locals: Vec<syn::Ident> = Vec::new();
 
-    for leaf in &plan.leaves {
+    debug_assert_eq!(plan.leaves.len(), leaves.len());
+    for (leaf, classified) in plan.leaves.iter().zip(leaves) {
         let leaf_ty = &leaf.ty;
-        let entry = registry.input_entry(leaf_ty).unwrap_or_else(|| {
-            panic!(
-                "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
-                TypeKey::from_type(leaf_ty),
-                orig_param,
-            )
-        });
+        let lookup_entry = || {
+            registry.input_entry(leaf_ty).unwrap_or_else(|| {
+                panic!(
+                    "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
+                    TypeKey::from_type(leaf_ty),
+                    orig_param,
+                )
+            })
+        };
         let local = format_ident!("__exp_{}", leaf.name);
 
         // `Option<scalar>` / `Option<enum>` leaf (only produced by a
         // selector-dispatched constructor variant, where each arm's args are
         // `Option`-wrapped by presence): cross as a decoupled
         // `(present: jboolean, value: <wire>)` pair instead of a boxed
-        // `java.lang.*` `JObject`. This matches the Kotlin extern — which
-        // applies the same `build_option_scalar_input_plan` per expanded leaf in
-        // `render_extern_decl` — and the bare top-level `Option<scalar>` param
-        // path, so the JNI arity/types agree on both sides of the wire.
-        if let Some(sp) = build_option_scalar_input_plan(ext, registry, &leaf.name, leaf_ty) {
+        // `java.lang.*` `JObject`. The Kotlin extern and call site consume
+        // the same classified plan, so the JNI arity/types agree on both
+        // sides of the wire.
+        if let InputKind::OptionScalar(sp) = &classified.kind {
             let present_ident = &sp.present_ident;
             let value_ident = &sp.value_ident;
             let value_wire = &sp.value_wire;
@@ -781,8 +809,8 @@ pub(crate) fn emit_expanded_param(
         // Direct owned-handle leaf (e.g. an identity-variant `T`): consume the
         // jlong handle inline, mirroring the normal by-value-handle path —
         // including its null/tagged (closed) pointer guard.
-        let is_consume =
-            !matches!(leaf_ty, syn::Type::Reference(_)) && entry.metadata.is_direct_handle();
+        let is_consume = matches!(classified.kind, InputKind::Handle { direct: true })
+            && !matches!(leaf_ty, syn::Type::Reference(_));
         if is_consume {
             let wire_ident = format_ident!("{}_ptr", leaf.name);
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
@@ -800,6 +828,7 @@ pub(crate) fn emit_expanded_param(
             continue;
         }
 
+        let entry = lookup_entry();
         let wire = &entry.destination;
         let conv = entry.function.sig.ident.clone();
         let wire_ident = if matches!(wire, syn::Type::Ptr(_)) {

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -1,0 +1,254 @@
+//! Input side of the per-function lowered binding plan (issue #90).
+//!
+//! [`JniFunctionPlan`] classifies every input parameter of a bound function
+//! ONCE, deterministically over `(ext, registry, f)`. The three coordinated
+//! emission sites — the Rust `extern "C"` wrapper (`emit_input_param`), the
+//! Kotlin wrapper classifier (`classify_params`), and the `JNINative`
+//! `external fun` declaration (`render_extern_decl`) — all consume the same
+//! [`InputKind`] decision instead of re-running their own copies of the
+//! probe cascade, so the wire arity, types, and call forms agree by
+//! construction. The pattern generalizes [`build_struct_plan`]'s field-level
+//! plan to function granularity; the output side follows in a later stage.
+
+use super::*;
+
+/// The lowered input-side plan for one bound function: one [`PlanParam`] per
+/// source `syn::Signature` parameter (non-`Typed`/non-`Ident` args — `self`,
+/// patterns — are skipped, mirroring every prior walk).
+pub(crate) struct JniFunctionPlan {
+    pub params: Vec<PlanParam>,
+}
+
+/// One source parameter: the ident/type as written plus its lowered form.
+pub(crate) struct PlanParam {
+    pub ident: syn::Ident,
+    pub ty: syn::Type,
+    pub form: ParamForm,
+}
+
+/// How a source parameter crosses the boundary.
+pub(crate) enum ParamForm {
+    /// Ordinary parameter — one classified leaf.
+    Single(PlanLeaf),
+    /// Constructor-expansion ([`FoldPlan`] declared for this `(fn, param)`):
+    /// the wire form is the plan's flattened leaves, classified individually;
+    /// the Rust wrapper folds them back into the built value. Leaves use the
+    /// restricted probe set of the fold path (no struct-flatten / vec-build
+    /// nesting), so all three sites agree on the leaf wire.
+    Expanded(Vec<PlanLeaf>),
+}
+
+/// One classified effective parameter (a source param, or one expansion leaf).
+pub(crate) struct PlanLeaf {
+    pub ident: syn::Ident,
+    pub ty: syn::Type,
+    /// Typed-wrapper surface type: the projection's Kotlin FQN for
+    /// handle/value projections, else the resolved entry's Kotlin name.
+    /// `None` when the metadata lacks a name (the Kotlin wrapper renderer
+    /// skips the function — the escape-hatch path) and for [`InputKind::
+    /// Callback`] (typed from the interface spec at render time).
+    pub kt_public: Option<kt::KtType>,
+    /// The resolved entry's raw `metadata.kotlin_name` — the type the
+    /// `JNINative` extern declares for pass-through leaves (for projections
+    /// this is the erased wire name, not the typed surface).
+    pub kt_meta: Option<kt::KtType>,
+    /// Raw `is_option_type(ty)` — each site applies its own nullability rule
+    /// (handles stay non-null `Long` on the extern but `T?` on the surface).
+    pub optional: bool,
+    /// `true` when the (probed-through `&`/`Option`) type is an
+    /// `enum_class` enum: surface keeps the typed enum, the extern declares
+    /// `Int`/`Int?`, and the call site passes `.value` / `?.value`.
+    pub as_enum_value: bool,
+    pub kind: InputKind,
+}
+
+/// The classified crossing form. Branches are mutually exclusive by
+/// construction (each probe rejects the shapes the others accept), so the
+/// probe order is canonical, not load-bearing.
+pub(crate) enum InputKind {
+    /// `impl Fn(args)` callback: erased `Any` on the wire; the typed
+    /// interface spec is derived at render time ([`callback_iface_spec`]).
+    Callback { args: Vec<syn::Type> },
+    /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
+    /// Vec-handle on the wire, built by pushing element leaves.
+    VecBuild { elem: syn::Type, by_ref: bool },
+    /// Bare `Option<primitive>` / `Option<enum>`: a decoupled
+    /// `(present: jboolean, value: <wire>)` pair.
+    OptionScalar(OptionScalarInputPlan),
+    /// Flattenable data_class: the field leaves cross as separate wire params.
+    FlattenStruct(FlatInputPlan),
+    /// Lockable opaque-handle projection (`jlong` wire). `direct` is
+    /// [`KotlinMeta::is_direct_handle`] — `true` only for the bare
+    /// `T`/`&T` shape, the by-value consume fast-path trigger.
+    Handle { direct: bool },
+    /// Non-lockable value projection (`value_blob`): the call site passes the
+    /// unwrapped inline-class `field`; the extern keeps the erased wire.
+    ValueUnwrap { field: String },
+    /// Everything else: the resolved entry's converter/wire as-is.
+    Plain,
+}
+
+/// Input-plan construction failure. The Rust emitter maps each variant to
+/// its historical panic; the Kotlin renderers map to `None` (skip).
+pub(crate) enum PlanError {
+    /// `registry.input_entry` has no converter for a source param type.
+    Unresolved { ty: TypeKey },
+    /// No converter for a constructor-expansion leaf type.
+    UnresolvedLeaf { ty: TypeKey, param: syn::Ident },
+}
+
+impl JniFunctionPlan {
+    /// Lower `f`'s inputs. Deterministic over `(ext, registry, f)` — until
+    /// plans are built once and stored (a later stage), each emission site
+    /// rebuilds the identical plan, exactly like [`build_struct_plan`].
+    pub fn build(
+        ext: &JniGen,
+        registry: &Registry<KotlinMeta>,
+        f: &syn::ItemFn,
+    ) -> Result<Self, PlanError> {
+        let mut params = Vec::new();
+        for input in &f.sig.inputs {
+            let syn::FnArg::Typed(pt) = input else {
+                continue;
+            };
+            let syn::Pat::Ident(pid) = &*pt.pat else {
+                continue;
+            };
+            let ident = pid.ident.clone();
+            let ty = (*pt.ty).clone();
+
+            let form = if let Some(plan) = registry
+                .expansion_plans
+                .get(&(f.sig.ident.clone(), ident.clone()))
+            {
+                let mut leaves = Vec::new();
+                for leaf in &plan.leaves {
+                    leaves.push(classify_leaf(
+                        ext, registry, &leaf.name, &leaf.ty, /*expanded=*/ true, &ident,
+                    )?);
+                }
+                ParamForm::Expanded(leaves)
+            } else {
+                ParamForm::Single(classify_leaf(
+                    ext, registry, &ident, &ty, /*expanded=*/ false, &ident,
+                )?)
+            };
+            params.push(PlanParam { ident, ty, form });
+        }
+        Ok(Self { params })
+    }
+
+    /// The flattened effective-parameter view (expansion leaves inline) —
+    /// the sequence the Kotlin wrapper and `external fun` declare, in order.
+    pub fn leaves(&self) -> impl Iterator<Item = &PlanLeaf> {
+        self.params.iter().flat_map(|p| match &p.form {
+            ParamForm::Single(l) => std::slice::from_ref(l).iter(),
+            ParamForm::Expanded(ls) => ls.iter(),
+        })
+    }
+}
+
+/// Classify one effective parameter. `expanded` selects the restricted probe
+/// set of the constructor-expansion fold path (its Rust decode handles
+/// scalar-pair / consume / pass-through leaves only — struct-flatten and
+/// vec-build never applied there, so probing them here would desynchronize
+/// the wire).
+fn classify_leaf(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    ident: &syn::Ident,
+    ty: &syn::Type,
+    expanded: bool,
+    source_param: &syn::Ident,
+) -> Result<PlanLeaf, PlanError> {
+    let optional = is_option_type(ty);
+    let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(ty));
+
+    // `impl Fn(args)` first: typed entirely from the interface spec — the
+    // erased entry exists but its metadata carries no surface type.
+    if let Some(args) = extract_fn_trait_args(ty) {
+        return Ok(PlanLeaf {
+            ident: ident.clone(),
+            ty: ty.clone(),
+            kt_public: None,
+            kt_meta: registry
+                .input_entry(ty)
+                .and_then(|e| e.metadata.kotlin_name.clone()),
+            optional,
+            as_enum_value,
+            kind: InputKind::Callback { args },
+        });
+    }
+
+    // Every non-callback leaf requires a resolved input entry — the same
+    // hard boundary the Rust emitter has always enforced.
+    let Some(entry) = registry.input_entry(ty) else {
+        let key = TypeKey::from_type(ty);
+        return Err(if expanded {
+            PlanError::UnresolvedLeaf {
+                ty: key,
+                param: source_param.clone(),
+            }
+        } else {
+            PlanError::Unresolved { ty: key }
+        });
+    };
+
+    let kind = if let Some((elem, by_ref)) = (!expanded)
+        .then(|| vec_build_elem(ext, registry, ty))
+        .flatten()
+    {
+        InputKind::VecBuild { elem, by_ref }
+    } else if let Some(sp) = build_option_scalar_input_plan(ext, registry, ident, ty) {
+        InputKind::OptionScalar(sp)
+    } else if let Some(plan) = (!expanded)
+        .then(|| build_flat_input_plan(ext, registry, ident, ty))
+        .flatten()
+    {
+        InputKind::FlattenStruct(plan)
+    } else {
+        match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
+            Some(ProjectionKind::Handle) => InputKind::Handle {
+                direct: entry.metadata.is_direct_handle(),
+            },
+            Some(ProjectionKind::ValueBlob) => {
+                let proj = entry.metadata.projection.as_ref().expect("checked above");
+                if matches!(proj.strategy, FoldStrategy::Iterable(_)) {
+                    panic!(
+                        "render_wrapper_fn: value-blob `Vec<_>` params aren't \
+                         supported yet (param `{}`); add array codegen to lift this guard.",
+                        kt_param_name(&ident.to_string())
+                    );
+                }
+                let field =
+                    value_projection_field_for_leaf(ext, &proj.leaf_key).unwrap_or_else(|| {
+                        panic!(
+                            "render_wrapper_fn: cannot determine inline-class field for value \
+                     projection param `{}`",
+                            kt_param_name(&ident.to_string())
+                        )
+                    });
+                InputKind::ValueUnwrap { field }
+            }
+            None => InputKind::Plain,
+        }
+    };
+
+    // Typed surface: handle/value projections show their Kotlin class (from
+    // the projection's leaf key); everything else the entry's resolved name.
+    let kt_meta = entry.metadata.kotlin_name.clone();
+    let kt_public = match entry.metadata.projection.as_ref() {
+        Some(p) => ext.kotlin_fqn(&p.leaf_key).map(kt::KtType::cls),
+        None => kt_meta.clone(),
+    };
+
+    Ok(PlanLeaf {
+        ident: ident.clone(),
+        ty: ty.clone(),
+        kt_public,
+        kt_meta,
+        optional,
+        as_enum_value,
+        kind,
+    })
+}

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -26,10 +26,12 @@ pub(crate) struct PlanParam {
     pub form: ParamForm,
 }
 
-/// How a source parameter crosses the boundary.
+/// How a source parameter crosses the boundary. The single leaf is boxed to
+/// keep the variants near the same size (a [`PlanLeaf`] embeds whole
+/// sub-plans; the `Expanded` payload is just a `Vec` header).
 pub(crate) enum ParamForm {
     /// Ordinary parameter — one classified leaf.
-    Single(PlanLeaf),
+    Single(Box<PlanLeaf>),
     /// Constructor-expansion ([`FoldPlan`] declared for this `(fn, param)`):
     /// the wire form is the plan's flattened leaves, classified individually;
     /// the Rust wrapper folds them back into the built value. Leaves use the
@@ -129,9 +131,9 @@ impl JniFunctionPlan {
                 }
                 ParamForm::Expanded(leaves)
             } else {
-                ParamForm::Single(classify_leaf(
+                ParamForm::Single(Box::new(classify_leaf(
                     ext, registry, &ident, &ty, /*expanded=*/ false, &ident,
-                )?)
+                )?))
             };
             params.push(PlanParam { ident, ty, form });
         }
@@ -142,7 +144,7 @@ impl JniFunctionPlan {
     /// the sequence the Kotlin wrapper and `external fun` declare, in order.
     pub fn leaves(&self) -> impl Iterator<Item = &PlanLeaf> {
         self.params.iter().flat_map(|p| match &p.form {
-            ParamForm::Single(l) => std::slice::from_ref(l).iter(),
+            ParamForm::Single(l) => std::slice::from_ref(&**l).iter(),
             ParamForm::Expanded(ls) => ls.iter(),
         })
     }

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -491,6 +491,7 @@ mod selector;
 mod tests;
 mod trait_impl;
 
+mod fn_plan;
 mod fold;
 mod kotlin_emit;
 mod overloads;
@@ -504,6 +505,7 @@ pub(crate) use classify::*;
 pub(crate) use config::*;
 pub use decl::*;
 pub(crate) use emit::*;
+pub(crate) use fn_plan::*;
 pub(crate) use fold::*;
 pub(crate) use iface::*;
 pub(crate) use overloads::*;

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -433,6 +433,15 @@ pub(crate) fn build_typed_handle(
     class
 }
 
+/// True for an `Iterable` fold delivery, including one wrapped in a single
+/// `Optional` layer (`Option<Vec<T>>` → a nullable `List`). Selects the fold
+/// surface (`acc` + `fold`) over a scalar `Optional`/`Base` builder.
+pub(crate) fn is_iterable_fold(shape: &crate::api::core::unfold::UnfoldShape) -> bool {
+    use crate::api::core::unfold::UnfoldShape;
+    matches!(shape, UnfoldShape::Iterable(_))
+        || matches!(shape, UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Iterable(_)))
+}
+
 /// Render one `external fun <mangle_method(package, JNINative, name)>(…): <wire-return>` line
 /// at the JNI **wire** level (matches what the Rust extern receives):
 ///   * opaque-handle (Borrow/Consume) → jlong → `Long`
@@ -443,48 +452,6 @@ pub(crate) fn build_typed_handle(
 /// Opaque returns become `Long`; every other return uses
 /// [`classify_return`]'s `kt_return` (Unit is empty string).
 /// Returns `None` if any parameter's input converter isn't resolved.
-///
-/// Expand a function's inputs into the effective parameter list seen by the
-/// Kotlin wrapper + extern declaration: a parameter carrying a
-/// constructor-expansion [`FoldPlan`] is replaced by its flattened leaves
-/// (each a normal `(name, type)`); every other parameter passes through. The
-/// Rust extern (`emit_jni_function_wrapper`) folds the leaves back into the
-/// built value separately.
-pub(crate) fn effective_inputs(
-    registry: &Registry<KotlinMeta>,
-    f: &syn::ItemFn,
-) -> Vec<(syn::Ident, syn::Type)> {
-    let mut out = Vec::new();
-    for input in &f.sig.inputs {
-        let syn::FnArg::Typed(pt) = input else {
-            continue;
-        };
-        let syn::Pat::Ident(pid) = &*pt.pat else {
-            continue;
-        };
-        if let Some(plan) = registry
-            .expansion_plans
-            .get(&(f.sig.ident.clone(), pid.ident.clone()))
-        {
-            for leaf in &plan.leaves {
-                out.push((leaf.name.clone(), leaf.ty.clone()));
-            }
-        } else {
-            out.push((pid.ident.clone(), (*pt.ty).clone()));
-        }
-    }
-    out
-}
-
-/// True for an `Iterable` fold delivery, including one wrapped in a single
-/// `Optional` layer (`Option<Vec<T>>` → a nullable `List`). Selects the fold
-/// surface (`acc` + `fold`) over a scalar `Optional`/`Base` builder.
-pub(crate) fn is_iterable_fold(shape: &crate::api::core::unfold::UnfoldShape) -> bool {
-    use crate::api::core::unfold::UnfoldShape;
-    matches!(shape, UnfoldShape::Iterable(_))
-        || matches!(shape, UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Iterable(_)))
-}
-
 pub(crate) fn render_extern_decl(
     ext: &JniGen,
     f: &syn::ItemFn,
@@ -495,76 +462,63 @@ pub(crate) fn render_extern_decl(
     let kt_name = kt_snake_to_camel(&rust_name);
     let jni_call = ext.mangle_jni_method(&kt_name);
 
+    // The wire params come straight off the lowered plan — the same
+    // classification the Rust extern and the Kotlin call site consume, so
+    // the three sites agree on arity and types by construction.
+    let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
     let mut params: Vec<(String, String)> = Vec::new();
-    for (eff_ident, eff_ty) in effective_inputs(registry, f) {
-        let name = kt_param_name(&eff_ident.to_string());
-        let arg_ty = &eff_ty;
-
-        // Flattenable data_class param → expand into its leaf wire params
-        // (same plan the native wrapper + call site use).
-        if let Some(plan) = crate::api::lang::jnigen::jni::build_flat_input_plan(
-            ext, registry, &eff_ident, arg_ty, "",
-        ) {
-            for leaf in &plan.leaves {
-                let short = register_fqn(&leaf.kt_wire_ty, imports);
-                params.push((leaf.kt_name.clone(), short));
+    for leaf in fplan.leaves() {
+        let name = kt_param_name(&leaf.ident.to_string());
+        match &leaf.kind {
+            // Flattenable data_class param → its leaf wire params.
+            InputKind::FlattenStruct(plan) => {
+                for l in &plan.leaves {
+                    let short = register_fqn(&l.kt_wire_ty, imports);
+                    params.push((l.kt_name.clone(), short));
+                }
             }
-            continue;
+            // Bare `Option<primitive>` / `Option<enum>` param → a `(present:
+            // Boolean, value: <Prim>)` pair (no boxed `java.lang.*` wire).
+            InputKind::OptionScalar(sp) => {
+                let pshort = register_fqn("Boolean", imports);
+                params.push((sp.present_kt.clone(), pshort));
+                let vshort = register_fqn(&sp.value_kt_type, imports);
+                params.push((sp.value_kt.clone(), vshort));
+            }
+            // Slice/Vec of a flattenable data_class → a single `jlong`
+            // Vec-handle param (the Rust extern decodes the boxed `Vec<T>`).
+            // Elements cross through the synthetic `…VecPush` extern, not
+            // this one.
+            InputKind::VecBuild { .. } => {
+                let short = register_kt_type(&kt::KtType::long(), imports).to_string();
+                params.push((name, short));
+            }
+            // An opaque-**handle** projection (direct `&T`/`T`, `Option<&T>`,
+            // or by-value `Option<T>`) crosses the JNI wire as a primitive
+            // `jlong` with `0` encoding `None` — so the extern param is a
+            // non-null `Long`, and the `?` lives only on the typed-wrapper
+            // surface. (`value_blob` projections are NOT handles; they keep
+            // their erased wire and can be nullable.)
+            InputKind::Handle { .. } => {
+                let short = register_kt_type(&kt::KtType::long(), imports).to_string();
+                params.push((name, short));
+            }
+            InputKind::Callback { .. } | InputKind::ValueUnwrap { .. } | InputKind::Plain => {
+                let kt_type_raw = if leaf.as_enum_value {
+                    // Enum (incl. `Option<enum>`) crosses as jint → Kotlin
+                    // `Int`; the wrapper passes `.value` / `?.value`. The Rust
+                    // converter unboxes a `java.lang.Integer`, so the extern
+                    // must declare `Int`/`Int?`, never the enum object.
+                    kt::KtType::int()
+                } else {
+                    leaf.kt_meta.clone()?
+                };
+                // The extern block is raw text — render the shortened type.
+                let short = register_kt_type(&kt_type_raw, imports).to_string();
+                let suffix = if leaf.optional { "?" } else { "" };
+                params.push((name, format!("{short}{suffix}")));
+            }
         }
-
-        // Bare `Option<primitive>` / `Option<enum>` param → a `(present:
-        // Boolean, value: <Prim>)` pair (no boxed `java.lang.*` wire). Same plan
-        // the native wrapper + Kotlin call site use.
-        if let Some(sp) = crate::api::lang::jnigen::jni::build_option_scalar_input_plan(
-            ext, registry, &eff_ident, arg_ty,
-        ) {
-            let pshort = register_fqn("Boolean", imports);
-            params.push((sp.present_kt.clone(), pshort));
-            let vshort = register_fqn(&sp.value_kt_type, imports);
-            params.push((sp.value_kt.clone(), vshort));
-            continue;
-        }
-
-        // Slice/Vec of a flattenable data_class → a single `jlong` Vec-handle
-        // param (the Rust extern decodes the boxed `Vec<T>`). Elements cross
-        // through the synthetic `…VecPush` extern, not this one. Must match the
-        // `jlong` wire emitted by `emit_input_param`'s VecBuild branch.
-        if crate::api::lang::jnigen::jni::vec_build_elem(ext, registry, arg_ty).is_some() {
-            params.push((name, "Long".to_string()));
-            continue;
-        }
-
-        let entry = registry.input_entry(arg_ty)?;
-
-        // An opaque-**handle** projection (direct `&T`/`T`, `Option<&T>`, or
-        // by-value `Option<T>`) crosses the JNI wire as a primitive `jlong`
-        // with `0` encoding `None` — so the extern param is a non-null `Long`,
-        // and the `?` lives only on the typed-wrapper surface. (`value_blob`
-        // projections are NOT handles; they keep their `ByteArray` wire and
-        // can be nullable.)
-        let proj_is_handle = entry
-            .metadata
-            .projection
-            .as_ref()
-            .map(|p| p.kind == crate::api::lang::jnigen::jni::ProjectionKind::Handle)
-            .unwrap_or(false);
-        let optional = is_option_type(arg_ty) && !proj_is_handle;
-
-        let kt_type_raw = if proj_is_handle {
-            kt::KtType::long()
-        } else if ext.is_kotlin_enum(&enum_probe_type(arg_ty)) {
-            // Enum (incl. `Option<enum>`) crosses as jint → Kotlin `Int`; the
-            // wrapper passes `.value` / `?.value`. The Rust converter unboxes a
-            // `java.lang.Integer`, so the extern must declare `Int`/`Int?`, never
-            // the enum object.
-            kt::KtType::int()
-        } else {
-            entry.metadata.kotlin_name.clone()?
-        };
-        // The extern block is raw text — render the registered/shortened type.
-        let short = register_kt_type(&kt_type_raw, imports).to_string();
-        let suffix = if optional { "?" } else { "" };
-        params.push((name, format!("{short}{suffix}")));
     }
     // Output (data) expansion: a **callback** delivery (`deconstruct_output`)
     // appends the lambda(s) before the error sink and returns the erased result
@@ -795,7 +749,8 @@ pub(crate) fn render_wrapper_fn(
     };
     let jni_call = ext.mangle_jni_method(&default_kt_name);
 
-    let (params, receiver_idx) = classify_params(ext, f, registry, imports, receiver_key)?;
+    let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
+    let (params, receiver_idx) = classify_params(ext, &fplan, registry, imports, receiver_key)?;
     let out = classify_output(ext, f, registry, imports)?;
     let body_expr = build_native_call(ext, &jni_call, &params, &out);
 
@@ -1003,22 +958,25 @@ struct ErrorSink {
     guard_args: String,
 }
 
-/// Classify every effective input into a [`Param`] (Kotlin name/type +
-/// call-site [`ParamMode`]). Returns the params plus the index of the
+/// Type every effective input of the lowered [`JniFunctionPlan`] into a
+/// [`Param`] (Kotlin name/type + call-site [`ParamMode`]). The crossing-form
+/// classification comes from the plan — the same decision the Rust extern and
+/// `external fun` renderers consume — this site only maps each [`InputKind`]
+/// to its Kotlin surface. Returns the params plus the index of the
 /// instance-method receiver (the first param whose peeled type matches
 /// `receiver_key`), which is bound to `this` and dropped from the signature.
 fn classify_params(
     ext: &JniGen,
-    f: &syn::ItemFn,
+    fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<(Vec<Param>, Option<usize>)> {
     let mut receiver_idx: Option<usize> = None;
     let mut params: Vec<Param> = Vec::new();
-    for (eff_ident, eff_ty) in effective_inputs(registry, f) {
-        let mut name = kt_param_name(&eff_ident.to_string());
-        let arg_ty = &eff_ty;
+    for leaf in fplan.leaves() {
+        let mut name = kt_param_name(&leaf.ident.to_string());
+        let arg_ty = &leaf.ty;
 
         // Instance-method receiver: the first parameter whose peeled Rust type
         // is the owning class binds to `this` (so `this_ptr`/`this.ptr`/lock or
@@ -1040,8 +998,8 @@ fn classify_params(
         // calls the typed `run` — value-blob leaves surface as their raw
         // `ByteArray` wire (the SDK wraps), so no call-site adapter exists.
         // Lambda-literal call sites SAM-convert unchanged.
-        if let Some(cb_args) = extract_fn_trait_args(arg_ty) {
-            let spec = callback_iface_spec(ext, registry, &cb_args)?;
+        if let InputKind::Callback { args: cb_args } = &leaf.kind {
+            let spec = callback_iface_spec(ext, registry, cb_args)?;
             let kt_type = spec.kt_ref(vec![]);
             // The extern receives the RAW twin: the generated `asRaw()`
             // proxy (built once per registration) wraps raw leaves into the
@@ -1061,168 +1019,84 @@ fn classify_params(
             continue;
         }
 
-        // Strip leading reference for the type-map lookup; the registry's
-        // input entry is keyed by the param as-written.
-        let entry = registry.input_entry(arg_ty)?;
-        // Opaque-handle params surface as their typed-handle FQN — every
-        // handle is self-contained (its own ptr slot + monitor), so the
-        // wrapper body inlines synchronized blocks directly on the typed
-        // receiver. Detection flows from the folded `Projection` — present
-        // for both `&T` and by-value `T` (the `owned` flag is orthogonal
-        // to presence) — so it's the same source of truth the typed-surface
-        // emitters use.
-        let is_opaque = entry.metadata.projection.is_some();
+        // Typed surface: the projection's Kotlin FQN for opaque handles /
+        // value projections (any `Option<_>` layer is nullable purely on the
+        // typed-wrapper surface — the handle wire stays `jlong` with `0` =
+        // absent), else the resolved entry's Kotlin name. `None` (unresolved
+        // name) skips the wrapper — the escape-hatch path.
+        let kt_type_raw = leaf.kt_public.clone()?;
 
-        // `Option<&T>` / `Option<&mut T>` for opaque T marks the param
-        // nullable; the wrapper body branches on null before lock selection.
-        let is_opt_ref_opaque = is_opaque && is_option_ref(arg_ty);
-        let (kt_type_raw, optional) = if is_opaque {
-            let h = entry.metadata.projection.as_ref()?;
-            let fqn = ext.kotlin_fqn(&h.leaf_key).map(|v| v.to_string())?;
-            // Any `Option<_>` opaque param (borrowed `Option<&T>` or by-value
-            // `Option<T>`) is nullable; value projections likewise. The handle
-            // wire stays `jlong` with `0` = absent, so the `?` is purely the
-            // typed-wrapper surface.
-            (kt::KtType::cls(fqn), is_option_type(arg_ty))
-        } else {
-            // Read the Kotlin name straight off the resolved entry's
-            // metadata — the rank-N handler that built this converter
-            // is also the one that derived the Kotlin name (primitives
-            // from `kotlin_for_wire`, wrappers inherit from inner,
-            // user-declared decoders from `with_kotlin_name`).
-            let kt = entry.metadata.kotlin_name.clone()?;
-            let opt = is_option_type(arg_ty);
-            (kt, opt)
-        };
-
-        // A projection can be a lockable opaque **handle** or a non-lockable
-        // **value projection** (`value_blob` — an inline value class). Only
-        // handles participate in the lock scaffold and pass a `_ptr`; value
-        // projections pass their unwrapped inner field.
-        let proj_kind = entry.metadata.projection.as_ref().map(|p| p.kind.clone());
-        let is_handle = matches!(
-            proj_kind,
-            Some(crate::api::lang::jnigen::jni::ProjectionKind::Handle)
-        );
-        let is_value_proj = matches!(
-            proj_kind,
-            Some(crate::api::lang::jnigen::jni::ProjectionKind::ValueBlob)
-        );
-
-        // Mode: handle → Borrow/Consume by Rust syntactic shape (locked).
-        // Value projection → ValueUnwrap (inline-class field, no lock).
-        // Everything else (primitives, callbacks, data classes) passes through.
-        //
-        // Flattenable data_class params are detected first: the high-level
-        // signature keeps the typed object (`kt_type_raw`), but the
-        // `JNINative` call destructures it into leaf args (same plan the
-        // native wrapper + extern decl consume). The decision is purely
-        // type-based so all three sites agree.
-        let flat_plan = crate::api::lang::jnigen::jni::build_flat_input_plan(
-            ext,
-            registry,
-            &eff_ident,
-            arg_ty,
-            name.as_str(),
-        );
-        let mode = if let Some((elem, _by_ref)) =
-            crate::api::lang::jnigen::jni::vec_build_elem(ext, registry, arg_ty)
-        {
-            // Slice/Vec of a flattenable data_class: build the Rust-side Vec by
-            // pushing each element's leaves, pass the handle (see the body
-            // assembly + `build_vec_build_helper_items`). High-level signature
-            // stays `List<T>` (kt_type_raw, registered below).
-            let h = crate::api::lang::jnigen::jni::vec_build_helpers(ext, registry, &elem)
-                .expect("vec_build_elem Some ⇒ vec_build_helpers Some");
-            let elem_accesses = h
-                .plan
-                .leaves
-                .iter()
-                .filter(|l| !l.is_present_flag)
-                .map(|l| l.kt_access.clone())
-                .collect();
-            ParamMode::VecBuild {
-                base: h.base,
-                elem_accesses,
+        // Map the plan's crossing form to the Kotlin call-site mode.
+        let mode = match &leaf.kind {
+            InputKind::VecBuild { elem, .. } => {
+                // Slice/Vec of a flattenable data_class: build the Rust-side
+                // Vec by pushing each element's leaves, pass the handle (see
+                // the body assembly + `build_vec_build_helper_items`). The
+                // high-level signature stays `List<T>` (registered below).
+                let h = crate::api::lang::jnigen::jni::vec_build_helpers(ext, registry, elem)
+                    .expect("vec_build_elem Some ⇒ vec_build_helpers Some");
+                let elem_accesses = h
+                    .plan
+                    .leaves
+                    .iter()
+                    .filter(|l| !l.is_present_flag)
+                    .map(|l| l.kt_access("__e"))
+                    .collect();
+                ParamMode::VecBuild {
+                    base: h.base,
+                    elem_accesses,
+                }
             }
-        } else if let Some(sp) = crate::api::lang::jnigen::jni::build_option_scalar_input_plan(
-            ext, registry, &eff_ident, arg_ty,
-        ) {
-            // Bare `Option<primitive>` / `Option<enum>`: cross as a `(present,
-            // value)` pair (no boxed object). The high-level signature keeps
-            // `T?` (computed below); only the call-site args split in two.
-            let present_expr = format!("{name} != null");
-            let value_expr = if sp.is_enum {
-                format!("{name}?.value ?: {}", sp.value_kt_zero)
-            } else {
-                format!("{name} ?: {}", sp.value_kt_zero)
-            };
-            ParamMode::OptionScalar {
-                present_expr,
-                value_expr,
+            InputKind::OptionScalar(sp) => {
+                // Bare `Option<primitive>` / `Option<enum>`: cross as a
+                // `(present, value)` pair (no boxed object). The high-level
+                // signature keeps `T?`; only the call-site args split in two.
+                let present_expr = format!("{name} != null");
+                let value_expr = if sp.is_enum {
+                    format!("{name}?.value ?: {}", sp.value_kt_zero)
+                } else {
+                    format!("{name} ?: {}", sp.value_kt_zero)
+                };
+                ParamMode::OptionScalar {
+                    present_expr,
+                    value_expr,
+                }
             }
-        } else if let Some(plan) = flat_plan {
-            ParamMode::FlattenStruct {
-                accesses: plan.leaves.iter().map(|l| l.kt_access.clone()).collect(),
+            InputKind::FlattenStruct(plan) => ParamMode::FlattenStruct {
+                accesses: plan.leaves.iter().map(|l| l.kt_access(&name)).collect(),
+            },
+            InputKind::Handle { .. } => {
+                // Handle → Borrow/Consume by Rust syntactic shape (locked);
+                // `Option<&T>` / by-value `Option<T>` mark the param nullable
+                // and the wrapper body branches on null before lock selection.
+                if is_option_ref(arg_ty) {
+                    ParamMode::BorrowNullable
+                } else if is_option_type(arg_ty) {
+                    // by-value `Option<T>` opaque → nullable consume
+                    ParamMode::ConsumeNullable
+                } else if matches!(arg_ty, syn::Type::Reference(_)) {
+                    ParamMode::Borrow
+                } else {
+                    ParamMode::Consume
+                }
             }
-        } else if is_handle {
-            let borrow = matches!(arg_ty, syn::Type::Reference(_));
-            if is_opt_ref_opaque {
-                ParamMode::BorrowNullable
-            } else if is_option_type(arg_ty) {
-                // by-value `Option<T>` opaque → nullable consume
-                ParamMode::ConsumeNullable
-            } else if borrow {
-                ParamMode::Borrow
-            } else {
-                ParamMode::Consume
-            }
-        } else if is_value_proj {
-            // `@JvmInline value class` (value_blob) param: pass the erased inner
-            // field (`<name>.bytes`, or `<name>?.bytes` when Option) to the
-            // extern, no lock. Supports the Direct (`T` / `&T`) and Nullable
-            // (`Option<T>`) shapes; a collection layer (`Vec<value-blob>`,
-            // i.e. an `Iterable` projection) still needs array codegen and is a
-            // loud build-time error. The inline field is resolved off the
-            // folded projection's `leaf_key`, so `Option<_>` wrappers around the
-            // value blob resolve correctly.
-            let proj = entry.metadata.projection.as_ref()?;
-            if matches!(
-                proj.strategy,
-                crate::api::lang::jnigen::jni::FoldStrategy::Iterable(_)
-            ) {
-                panic!(
-                    "render_wrapper_fn: value-blob `Vec<_>` params aren't \
-                     supported yet (param `{name}`); add array codegen to lift this guard."
-                );
-            }
-            let field =
-                crate::api::lang::jnigen::jni::value_projection_field_for_leaf(ext, &proj.leaf_key)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "render_wrapper_fn: cannot determine inline-class field for value \
-                     projection param `{name}`"
-                        )
-                    });
-            ParamMode::ValueUnwrap { field }
-        } else {
-            ParamMode::PassThrough
+            // `@JvmInline value class` (value_blob) param: pass the erased
+            // inner field (`<name>.bytes`, or `<name>?.bytes` when Option) to
+            // the extern, no lock.
+            InputKind::ValueUnwrap { field } => ParamMode::ValueUnwrap {
+                field: field.clone(),
+            },
+            InputKind::Plain => ParamMode::PassThrough,
+            InputKind::Callback { .. } => unreachable!("callback params handled above"),
         };
 
         let ty = register_kt_type(&kt_type_raw, imports);
-        let kt_type = if optional { ty.nullable() } else { ty };
-        // Strip a leading `&` before the enum check — the `&Priority`
-        // input converter shares Priority's converter (see the rank-1
-        // `& _` arm), and the same `.value` projection applies either
-        // way at the call site.
-        // Detect enums through a leading `&` and through `Option<…>`, so a
-        // nullable enum param passes `?.value` to the (Int?-typed) extern.
-        let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(arg_ty));
+        let kt_type = if leaf.optional { ty.nullable() } else { ty };
         params.push(Param {
             kt_name: name,
             kt_type,
             mode,
-            as_enum_value,
+            as_enum_value: leaf.as_enum_value,
         });
     }
     Some((params, receiver_idx))


### PR DESCRIPTION
First stage of #90: introduce the input side of the per-function lowered binding plan and make all three input walks pure consumers of it.

## What

- **New `jni/fn_plan.rs`** — `JniFunctionPlan::build(ext, registry, f)` classifies every input parameter ONCE into an `InputKind`:
  `Callback` / `VecBuild` / `OptionScalar` / `FlattenStruct` / `Handle { direct }` / `ValueUnwrap` / `Plain`, with constructor-expansion params carrying individually classified leaves (`ParamForm::Expanded`). Each leaf also stores the shared surface facts (`kt_public`, `kt_meta`, `optional`, `as_enum_value`). `PlanError` preserves the historical failure modes: the Rust emitter maps it to its panics, the Kotlin renderers to `None` (skip).
- **Three walks ported**: `emit_input_param` / `emit_expanded_param` (Rust extern), `classify_params` (Kotlin wrapper), and `render_extern_decl` (`JNINative` extern decl) now dispatch on the plan's kind instead of re-running three hand-synchronized probe cascades — wire arity, types, and call forms agree by construction. `effective_inputs` is subsumed by the plan's flattened `leaves()` view.
- **`FlatLeaf` is call-site independent**: `kt_access` became a composable `kt_access_tail` (+ `kt_access(base)`), removing `build_flat_input_plan`'s `kt_base` parameter — one canonical flatten plan serves the wrapper signature, the extern decl, and the call-site destructure.

The plan is still rebuilt deterministically per site (the `build_struct_plan` precedent); building once and storing it becomes the validation-boundary stage of #90.

## Behavioral notes (previously-broken configs only)

- A flattenable-struct or vec-build shape appearing as a constructor-expansion leaf used to flatten on the Kotlin side but cross as a single `JObject` on the Rust side — silent JNI arity drift. Expansion leaves now uniformly use the fold path's restricted probe set on all three sites.
- The value-blob `Vec` / missing-inline-field panics now fire during plan construction (`write_rust`) instead of midway through `write_kotlin` — failing before any artifact is written.

## Verification

- All 283 lib tests pass, including the full snapshot suite.
- The workspace build regenerates the 14 checked-in example Kotlin files byte-identically (covertest/perftest).
- Net −90 lines despite the new module.

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)