### PR TITLE
jnigen: lower function output/error side into JniFunctionPlan (#90 stage 2)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -4,12 +4,6 @@
 use super::*;
 use crate::api::core::types_util::result_ok_type;
 
-struct OutputLowering<'a> {
-    entry: Option<&'a crate::api::core::registry::TypeEntry<KotlinMeta>>,
-    wire_return: TokenStream,
-    on_err: TokenStream,
-}
-
 pub(crate) fn emit_jni_function_wrapper(
     ext: &JniGen,
     f: &syn::ItemFn,
@@ -152,48 +146,11 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let mut prelude: Vec<TokenStream> = Vec::new();
     let mut call_args: Vec<TokenStream> = Vec::new();
 
-    // Output is resolved first so the per-input `match`-arms can splice
-    // the function's sentinel into their early-`return` path.
-    let return_ty = fn_return_type(f);
-    // Output (data) expansion: when output expansion was declared for this
-    // function, the return value is decomposed by the deconstructor. Two
-    // deliveries:
-    //   * `Callback` (`deconstruct_output`): the leaves are delivered to a
-    //     foreign builder/fold lambda — the wrapper's wire return is the
-    //     lambda's `JObject` result (no `output_entry`; see `emit_unfold_delivery`).
-    //   * `Return` (`convert_output`): the single decomposed value is **returned**
-    //     directly through its ordinary output converter — the wrapper behaves
-    //     exactly like a normal function whose return type is `convert_out_ty`.
-    use crate::api::core::unfold::Delivery;
-    let unfold_plan = registry.unfold_plans.get(original_ident);
-    let is_convert = unfold_plan.is_some_and(|p| p.delivery == Delivery::Return);
-    // Error-position expansion: when the fn returns `Result<T, E>` and an error
-    // plan is declared, the **`?`** is applied here — the extern peels the
-    // `Result` (Err arm decomposes `E` into the `ze` leaves and invokes the
-    // error callback), and the success path uses `T`'s converter (not the
-    // `Result<T, E>` rank-2 wrapper). `n_ze` = the error leaf count (the callback
-    // arity after the fixed `je`).
-    let error_plan = registry.error_plans.get(original_ident);
-    let n_ze = error_plan.map_or(0, |p| p.leaves.len());
-    let output = lower_output(
-        registry,
-        original_ident,
-        &return_ty,
-        unfold_plan,
-        error_plan,
-    );
-    let output_entry = output.entry;
-    let wire_return = output.wire_return;
-    let on_err = output.on_err;
-
-    // Input parameters: the lowered plan classifies each param ONCE — the
-    // same classification the Kotlin wrapper and `external fun` renderers
-    // consume — and this site renders the Rust decode for each kind. The
-    // converter is looked up for the param type AS WRITTEN. No strip — a
-    // `&T` param looks up `&T`'s entry (which the `& _` rank-1 handler
-    // resolved by sharing `T`'s function). Call site adds `&decoded` only
-    // for `&T`-shaped originals; that's a Rust call-convention concern, not
-    // a converter concern.
+    // The lowered plan classifies both sides ONCE — the same classification
+    // the Kotlin wrapper and `external fun` renderers consume; this site
+    // renders the Rust decode/encode for each kind. The output is classified
+    // first (inside `build`) so the per-input `match`-arms can splice the
+    // function's sentinel into their early-`return` path.
     let plan = JniFunctionPlan::build(ext, registry, f).unwrap_or_else(|e| match e {
         PlanError::Unresolved { ty } => panic!(
             "JniGen::on_function: input type `{}` for `{}` is unresolved",
@@ -203,7 +160,50 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
             ty, param,
         ),
+        PlanError::UnresolvedOutput { ty } => panic!(
+            "JniGen::on_function: return type `{}` of `{}` has no registered output \
+             converter — register one via `JniGen::output_wrapper(pat, |…| Some((ty, exc, body)))` \
+             (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
+              to bind a domain exception)",
+            ty, original_ident,
+        ),
     });
+    // Output (data) expansion: when output expansion was declared for this
+    // function, the return value is decomposed by the deconstructor. Two
+    // deliveries:
+    //   * `Callback` (`deconstruct_output`, `FnOutputPlan::Unfold`): the
+    //     leaves are delivered to a foreign builder/fold lambda — the
+    //     wrapper's wire return is the lambda's `JObject` result (no
+    //     `output_entry`; see `emit_unfold_delivery`).
+    //   * `Return` (`convert_output`, `is_convert`): the single decomposed
+    //     value is **returned** directly through its ordinary output
+    //     converter — the wrapper behaves exactly like a normal function
+    //     whose return type is `convert_out_ty`.
+    let unfold_plan = registry.unfold_plans.get(original_ident);
+    // Error-position expansion: when the fn returns `Result<T, E>` and an error
+    // plan is declared, the **`?`** is applied here — the extern peels the
+    // `Result` (Err arm decomposes `E` into the `ze` leaves and invokes the
+    // error callback), and the success path uses `T`'s converter (not the
+    // `Result<T, E>` rank-2 wrapper). `n_ze` = the error leaf count (the callback
+    // arity after the fixed `je`).
+    let error_plan = registry.error_plans.get(original_ident);
+    let n_ze = error_plan.map_or(0, |p| p.leaves.len());
+    let is_convert = matches!(&plan.output, FnOutputPlan::Value(v) if v.is_convert);
+    // The output converter entry (`None` for callback delivery). The lookup
+    // was validated at plan build; re-resolving here keeps the plan free of
+    // registry borrows for the future build-once stage.
+    let output_entry = match &plan.output {
+        FnOutputPlan::Value(v) => Some(
+            registry
+                .output_entry(&v.target_ty)
+                .expect("output entry validated at plan build"),
+        ),
+        FnOutputPlan::Unfold(_) => None,
+    };
+    let wire_ty = plan.output.wire_ty();
+    let wire_return = annotate_jobject_with_lifetime(&wire_ty, "a").to_token_stream();
+    let on_err = sentinel_for_wire(&wire_ty);
+
     for param in &plan.params {
         let (wp, pre, call_arg) = emit_input_param(ext, registry, original_ident, param, &on_err);
         wire_params.extend(wp);
@@ -225,9 +225,9 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // `Optional` ⇒ `raw.map(|inner| acc(inner))`.
     let call_expr: TokenStream = if is_convert {
         use crate::api::core::unfold::UnfoldShape;
-        let plan = unfold_plan.expect("is_convert ⇒ plan");
-        let leaf = &plan.leaves[0];
-        let by_ref = plan.by_ref;
+        let uplan = unfold_plan.expect("is_convert ⇒ plan");
+        let leaf = &uplan.leaves[0];
+        let by_ref = uplan.by_ref;
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
             let mut e = if base_is_ref { base } else { quote!(&#base) };
             for a in &leaf.path {
@@ -236,7 +236,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             }
             e
         };
-        match &plan.shape {
+        match &uplan.shape {
             UnfoldShape::Optional((), _) => {
                 let inner = compose(quote!(__inner), by_ref);
                 quote!({
@@ -305,11 +305,12 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     //     wire-facing converter, routing each `Err` through `signal_error`. (For
     //     convert, `call_expr` above already deconstructed the value.)
     let mut builder_param: Option<TokenStream> = None;
-    let output_phase: TokenStream = if let (Some(plan), false) = (unfold_plan, is_convert) {
+    let output_phase: TokenStream = if let FnOutputPlan::Unfold(u) = &plan.output {
         // Iterable folds: two params (`__acc` accumulator + `__fold` callback).
         // Decompose/Optional: a single `__builder` callback.
-        builder_param = Some(unfold_builder_param(plan));
-        emit_unfold_delivery(ext, registry, plan, &call_expr, &on_err)
+        let uplan = unfold_plan.expect("Unfold output ⇒ unfold plan present");
+        builder_param = Some(unfold_builder_param(u.iterable_fold));
+        emit_unfold_delivery(ext, registry, uplan, &call_expr, &on_err)
     } else {
         let output_entry = output_entry.expect("normal path has an output entry");
         let mut phase: TokenStream = quote! { let __out = #call_expr; };
@@ -399,72 +400,10 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     }
 }
 
-fn fn_return_type(f: &syn::ItemFn) -> syn::Type {
-    match &f.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, ty) => (**ty).clone(),
-    }
-}
-
-fn lower_output<'a>(
-    registry: &'a Registry<KotlinMeta>,
-    original_ident: &syn::Ident,
-    return_ty: &syn::Type,
-    unfold_plan: Option<&crate::api::core::unfold::UnfoldPlan>,
-    error_plan: Option<&crate::api::core::unfold::UnfoldPlan>,
-) -> OutputLowering<'a> {
-    let ok_ty = error_plan.and_then(|_| result_ok_type(return_ty));
-    // The output converter to route through: the converted single value for
-    // `Return`, the `Result` Ok type when peeling, the function's own return for
-    // a normal fn, none for `Callback`.
-    let target_ty = output_target_type(return_ty, unfold_plan, ok_ty.as_ref());
-    let entry = target_ty.as_ref().map(|ty| {
-        registry.output_entry(ty).unwrap_or_else(|| {
-            panic!(
-                "JniGen::on_function: return type `{}` of `{}` has no registered output \
-                 converter — register one via `JniGen::output_wrapper(pat, |…| Some((ty, exc, body)))` \
-                 (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
-                  to bind a domain exception)",
-                TypeKey::from_type(ty),
-                original_ident,
-            )
-        })
-    });
-    let wire_ty = match entry {
-        Some(e) => e.destination.clone(),
-        None => syn::parse_quote!(jni::objects::JObject),
-    };
-    let wire_return = annotate_jobject_with_lifetime(&wire_ty, "a").to_token_stream();
-    let on_err = sentinel_for_wire(&wire_ty);
-    OutputLowering {
-        entry,
-        wire_return,
-        on_err,
-    }
-}
-
-fn output_target_type(
-    return_ty: &syn::Type,
-    unfold_plan: Option<&crate::api::core::unfold::UnfoldPlan>,
-    ok_ty: Option<&syn::Type>,
-) -> Option<syn::Type> {
-    use crate::api::core::unfold::Delivery;
-
-    match unfold_plan {
-        Some(p) if p.delivery == Delivery::Return => Some(
-            p.convert_out_ty
-                .clone()
-                .expect("Return delivery carries convert_out_ty"),
-        ),
-        Some(_) => None,
-        None => Some(ok_ty.cloned().unwrap_or_else(|| return_ty.clone())),
-    }
-}
-
-fn unfold_builder_param(plan: &crate::api::core::unfold::UnfoldPlan) -> TokenStream {
+fn unfold_builder_param(iterable_fold: bool) -> TokenStream {
     // An `Iterable` fold (incl. `Option<Vec<T>>`) takes `(acc, fold)`; every
     // other delivery takes a single `build`.
-    if super::render::is_iterable_fold(&plan.shape) {
+    if iterable_fold {
         quote!(__acc: jni::objects::JObject<'a>, __fold: jni::objects::JObject<'a>,)
     } else {
         quote!(__builder: jni::objects::JObject<'a>,)

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -12,11 +12,13 @@
 
 use super::*;
 
-/// The lowered input-side plan for one bound function: one [`PlanParam`] per
-/// source `syn::Signature` parameter (non-`Typed`/non-`Ident` args — `self`,
-/// patterns — are skipped, mirroring every prior walk).
+/// The lowered plan for one bound function: one [`PlanParam`] per source
+/// `syn::Signature` parameter (non-`Typed`/non-`Ident` args — `self`,
+/// patterns — are skipped, mirroring every prior walk), plus the classified
+/// output side.
 pub(crate) struct JniFunctionPlan {
     pub params: Vec<PlanParam>,
+    pub output: FnOutputPlan,
 }
 
 /// One source parameter: the ident/type as written plus its lowered form.
@@ -90,13 +92,105 @@ pub(crate) enum InputKind {
     Plain,
 }
 
-/// Input-plan construction failure. The Rust emitter maps each variant to
-/// its historical panic; the Kotlin renderers map to `None` (skip).
+/// How the return value crosses the boundary. Mirrors the unfold plan's
+/// [`Delivery`](crate::api::core::unfold::Delivery), resolved per function:
+/// `Unfold` = callback delivery (builder/fold lambda, erased `Any?` wire);
+/// `Value` = everything else, including the `Return`-delivery convert.
+pub(crate) enum FnOutputPlan {
+    Unfold(UnfoldOutputPlan),
+    Value(Box<ValueOutputPlan>),
+}
+
+/// Callback-delivery shape facts, read off the fn's `UnfoldPlan` once so the
+/// Rust builder param, the erased extern params, and the typed Kotlin
+/// builder/fold surface all branch on the same booleans.
+pub(crate) struct UnfoldOutputPlan {
+    /// `is_iterable_fold(shape)` — a bare `Iterable` OR one wrapped in a
+    /// single `Optional` layer (`Option<Vec<T>>`). Selects the fold surface
+    /// (`acc` + `fold`) over a scalar builder on every tier.
+    pub iterable_fold: bool,
+    /// Outer `Optional` layer present — the delivered result is nullable.
+    pub optional: bool,
+    /// Synthesized fixed-singleton delivery: no caller lambda, not generic.
+    pub fixed_builder: bool,
+    /// `plan.element.is_some()` — whole-element (M4) vs decomposed (M5) fold.
+    pub whole_element: bool,
+    /// Kotlin type variable of the wrapper: `None` for a fixed builder,
+    /// `"A"` for a **bare** `Iterable` fold (an `Optional`-wrapped iterable
+    /// takes the scalar-builder surface, hence `"R"`), `"R"` otherwise.
+    pub generic: Option<&'static str>,
+}
+
+/// Value-return facts: the resolved conversion target and wire on the Rust
+/// side, the declared-surface classification on the Kotlin side.
+pub(crate) struct ValueOutputPlan {
+    /// `Return`-delivery convert (`convert_output`) — the wrapper returns the
+    /// single deconstructed value through its ordinary output converter.
+    pub is_convert: bool,
+    /// The type whose output converter runs: `convert_out_ty` for a convert,
+    /// the `Result` Ok type when an error plan peels, else the declared
+    /// return. Its entry is validated at plan build; the Rust emitter
+    /// re-looks it up (`expect`) to keep the plan lifetime-free.
+    pub target_ty: syn::Type,
+    /// The resolved output entry's `destination` — the extern's wire return
+    /// and the sentinel source.
+    pub wire_ty: syn::Type,
+    /// Kotlin surface classification over the **declared** return
+    /// (`convert_out_ty` for a convert, else `f.sig.output` — not
+    /// `target_ty`: the Kotlin error peel rides `value_rust_key`).
+    pub surface: ReturnSurface,
+    /// `enum_class` / `Option<enum>` probes over the canonical
+    /// (`value_rust_key`-peeled) declared return. The extern decl uses them
+    /// raw; the wrapper surface masks them with `!is_convert` (the historical
+    /// `unfold.is_none()` gate).
+    pub is_enum: bool,
+    pub is_option_enum: bool,
+}
+
+/// The pure classification core of `classify_return` — no import
+/// registration, no name shortening, no panics. The render adapter
+/// (`render_return_surface`) maps it back to the historical
+/// `(kt_return, projection)` pair, panicking on an unregistered projection
+/// FQN exactly where `classify_return` always did (Kotlin render time).
+pub(crate) enum ReturnSurface {
+    /// No Kotlin type resolvable (entry or `kotlin_name` missing): the
+    /// Kotlin renderers skip the function; the Rust emitter ignores it.
+    Skip,
+    /// Unit return, including the canonical peel (`ZResult<()>`).
+    Unit,
+    /// Projection return (opaque handle / value class). `leaf_fqn` is the
+    /// resolved Kotlin FQN; `None` = unregistered (the adapter panics).
+    Projected {
+        projection: Projection,
+        leaf_fqn: Option<String>,
+    },
+    /// Plain return typed by the entry's resolved Kotlin name (unshortened —
+    /// the adapter registers/shortens at render time).
+    Plain { kt: kt::KtType },
+}
+
+/// Plan construction failure. The Rust emitter maps each variant to its
+/// historical panic; the Kotlin renderers map to `None` (skip).
 pub(crate) enum PlanError {
     /// `registry.input_entry` has no converter for a source param type.
     Unresolved { ty: TypeKey },
     /// No converter for a constructor-expansion leaf type.
     UnresolvedLeaf { ty: TypeKey, param: syn::Ident },
+    /// `registry.output_entry` has no converter for the output target type.
+    UnresolvedOutput { ty: TypeKey },
+}
+
+impl FnOutputPlan {
+    /// The extern's wire return type: the erased builder result (`JObject`)
+    /// for a callback delivery, the resolved entry's destination otherwise.
+    /// Feeds `annotate_jobject_with_lifetime` + `sentinel_for_wire` on the
+    /// Rust side.
+    pub fn wire_ty(&self) -> syn::Type {
+        match self {
+            FnOutputPlan::Unfold(_) => syn::parse_quote!(jni::objects::JObject),
+            FnOutputPlan::Value(v) => v.wire_ty.clone(),
+        }
+    }
 }
 
 impl JniFunctionPlan {
@@ -108,6 +202,10 @@ impl JniFunctionPlan {
         registry: &Registry<KotlinMeta>,
         f: &syn::ItemFn,
     ) -> Result<Self, PlanError> {
+        // Output first: the Rust emitter historically resolved the output
+        // before the inputs, so an unresolved-output failure takes precedence
+        // over an unresolved-input one.
+        let output = build_output(ext, registry, f)?;
         let mut params = Vec::new();
         for input in &f.sig.inputs {
             let syn::FnArg::Typed(pt) = input else {
@@ -137,7 +235,7 @@ impl JniFunctionPlan {
             };
             params.push(PlanParam { ident, ty, form });
         }
-        Ok(Self { params })
+        Ok(Self { params, output })
     }
 
     /// The flattened effective-parameter view (expansion leaves inline) —
@@ -253,4 +351,144 @@ fn classify_leaf(
         as_enum_value,
         kind,
     })
+}
+
+/// Lower the output side. Mirrors the historical derivations exactly:
+/// the Rust facts (`is_convert`, target type, wire) from the former
+/// `lower_output`/`output_target_type` (emit/wrapper.rs), the Kotlin
+/// declared-surface facts from `classify_return`'s inputs
+/// (render_extern_decl's `ret_decl` reconstruction).
+fn build_output(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    f: &syn::ItemFn,
+) -> Result<FnOutputPlan, PlanError> {
+    use crate::api::core::{
+        types_util::result_ok_type,
+        unfold::{Delivery, UnfoldShape},
+    };
+    let ident = &f.sig.ident;
+    let unfold_plan = registry.unfold_plans.get(ident);
+
+    // Callback delivery: the return is decomposed to a foreign builder/fold
+    // lambda; no output converter runs and the wire is the erased `JObject`.
+    if let Some(plan) = unfold_plan.filter(|p| p.delivery == Delivery::Callback) {
+        let iterable_fold = super::is_iterable_fold(&plan.shape);
+        let optional = matches!(plan.shape, UnfoldShape::Optional(..));
+        let fixed_builder = plan.fixed_builder;
+        // The generic-surface rule (see `classify_output`): a fixed builder
+        // is not generic; a **bare** `Iterable` folds with `<A>`; everything
+        // else — including an `Optional`-wrapped iterable — builds with `<R>`.
+        let generic = if fixed_builder {
+            None
+        } else if iterable_fold && !optional {
+            Some("A")
+        } else {
+            Some("R")
+        };
+        return Ok(FnOutputPlan::Unfold(UnfoldOutputPlan {
+            iterable_fold,
+            optional,
+            fixed_builder,
+            whole_element: plan.element.is_some(),
+            generic,
+        }));
+    }
+
+    // Value return. The conversion target: the converted single value for a
+    // `Return` delivery, the `Result` Ok type when an error plan peels, else
+    // the function's own return.
+    let is_convert = unfold_plan.is_some();
+    let return_ty: syn::Type = match &f.sig.output {
+        syn::ReturnType::Default => syn::parse_quote!(()),
+        syn::ReturnType::Type(_, ty) => (**ty).clone(),
+    };
+    let error_plan = registry.error_plans.get(ident);
+    let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
+    let target_ty = match unfold_plan {
+        Some(p) => p
+            .convert_out_ty
+            .clone()
+            .expect("Return delivery carries convert_out_ty"),
+        None => ok_ty.unwrap_or(return_ty),
+    };
+    let Some(entry) = registry.output_entry(&target_ty) else {
+        return Err(PlanError::UnresolvedOutput {
+            ty: TypeKey::from_type(&target_ty),
+        });
+    };
+    let wire_ty = entry.destination.clone();
+
+    // The Kotlin surface classifies the DECLARED return — `convert_out_ty`
+    // for a convert, else the signature's own output. (Not `target_ty`: the
+    // Kotlin error peel rides the entry's `value_rust_key`, so the full
+    // `Result<T, E>` type is looked up as written.)
+    let ret_decl: syn::ReturnType = if is_convert {
+        syn::parse_quote!(-> #target_ty)
+    } else {
+        f.sig.output.clone()
+    };
+    let (surface, canonical) = ReturnSurface::classify(ext, registry, &ret_decl);
+    let is_enum = ext.is_kotlin_enum(&canonical);
+    let is_option_enum = crate::api::core::types_util::option_inner_type(&canonical)
+        .map(|inner| ext.is_kotlin_enum(&inner))
+        .unwrap_or(false);
+
+    Ok(FnOutputPlan::Value(Box::new(ValueOutputPlan {
+        is_convert,
+        target_ty,
+        wire_ty,
+        surface,
+        is_enum,
+        is_option_enum,
+    })))
+}
+
+impl ReturnSurface {
+    /// Classify a declared return type. Returns the surface plus the
+    /// canonical (`value_rust_key`-peeled) type the enum probes run over —
+    /// the single peel that subsumed both `classify_return`'s inline peel
+    /// and the former `canonical_return_ty`.
+    pub fn classify(
+        ext: &JniGen,
+        registry: &Registry<KotlinMeta>,
+        output: &syn::ReturnType,
+    ) -> (Self, syn::Type) {
+        let ty = match output {
+            syn::ReturnType::Default => return (Self::Unit, syn::parse_quote!(())),
+            syn::ReturnType::Type(_, t) => &**t,
+        };
+        let outer_meta = registry.output_entry(ty).map(|e| e.metadata.clone());
+        // Unit returns (incl. `ZResult<()>`, whose inner identity rides
+        // `value_rust_key`) declare no Kotlin return type.
+        let inner_canon = outer_meta
+            .as_ref()
+            .and_then(|m| m.value_rust_key.clone())
+            .unwrap_or_else(|| ty.to_token_stream().to_string());
+        let canonical: syn::Type = syn::parse_str(&inner_canon).unwrap_or_else(|_| ty.clone());
+        if crate::api::lang::jnigen::util::is_unit(&canonical) {
+            return (Self::Unit, canonical);
+        }
+        // Projection return (opaque handle or value class): read the folded
+        // `Projection` the type-unfolding mechanism propagated onto this
+        // return type's converter metadata — one source of truth, no
+        // shape-specific peeling.
+        if let Some(h) = outer_meta.as_ref().and_then(|m| m.projection.clone()) {
+            let leaf_fqn = ext.kotlin_fqn(&h.leaf_key);
+            return (
+                Self::Projected {
+                    projection: h,
+                    leaf_fqn,
+                },
+                canonical,
+            );
+        }
+        // Non-opaque: the resolved entry's Kotlin name — the rank-N handler
+        // propagates `ZResult<T>` / `Option<T>` / `Vec<T>` derivations
+        // alongside the wire, so no peel-and-fallback chain is needed here.
+        match outer_meta.and_then(|m| m.kotlin_name) {
+            Some(kt) => (Self::Plain { kt }, canonical),
+            None => (Self::Skip, canonical),
+        }
+    }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -524,12 +524,9 @@ pub(crate) fn render_extern_decl(
     // appends the lambda(s) before the error sink and returns the erased result
     // (`Any?`). A **return** delivery (`convert_output`) appends nothing and
     // returns the real converted wire (handled in `wire_return` below, keyed on
-    // `convert_out_ty`).
-    use crate::api::core::unfold::Delivery;
-    let unfold = registry.unfold_plans.get(&f.sig.ident);
-    let callback_unfold = unfold.filter(|p| p.delivery == Delivery::Callback);
-    if let Some(plan) = callback_unfold {
-        if is_iterable_fold(&plan.shape) {
+    // the plan's `Value` classification over `convert_out_ty`).
+    if let FnOutputPlan::Unfold(u) = &fplan.output {
+        if u.iterable_fold {
             // `acc` is the unbounded accumulator `A` (may be nullable) → `Any?`;
             // `fold` is the non-null adapter callback.
             params.push(("acc".to_string(), "Any?".to_string()));
@@ -543,31 +540,24 @@ pub(crate) fn render_extern_decl(
     // (JObject); the wrapper passes an `ErrorSink` instance.
     params.push(("errorSink".to_string(), "Any".to_string()));
 
-    let wire_return = if callback_unfold.is_some() {
-        "Any?".to_string()
-    } else {
-        // For a `convert_output` (Return) the wire is the converted single
-        // value's; otherwise the function's own return.
-        let ret_decl: syn::ReturnType = match unfold.and_then(|p| p.convert_out_ty.clone()) {
-            Some(cv) => syn::parse_quote!(-> #cv),
-            None => f.sig.output.clone(),
-        };
-        let (kt_return, projection) = classify_return(ext, &ret_decl, registry, imports)?;
-        // enum_class returns cross the JNI wire as jint → Kotlin `Int`.
-        // The public wrapper converts back using `EnumType.fromInt(Int)`.
-        let is_enum_return = return_is_kotlin_enum(ext, &ret_decl, registry);
-        // `Option<enum>` returns cross as the boxed discriminant → `Int?`.
-        let is_option_enum_return = return_is_kotlin_option_enum(ext, &ret_decl, registry);
-        // JNI extern's wire return: handle projections wire as `Long` (the boxed
-        // jlong gets wrapped); value-class projections wire as their inner
-        // converter's Kotlin type folded through the projection's strategy (the
-        // value class is erased to that inner). Enums wire as `Int` (`Int?`
-        // under `Option`); everything else is the declared return.
-        match &projection {
-            Some(p) => projection_wire_return(p),
-            None if is_enum_return => "Int".to_string(),
-            None if is_option_enum_return => "Int?".to_string(),
-            None => kt_return.map(|t| t.to_string()).unwrap_or_default(),
+    let wire_return = match &fplan.output {
+        FnOutputPlan::Unfold(_) => "Any?".to_string(),
+        FnOutputPlan::Value(v) => {
+            // The plan classified the declared surface once — `convert_out_ty`
+            // for a `convert_output` (Return), else the function's own return.
+            let (kt_return, projection) = render_return_surface(&v.surface, imports)?;
+            // JNI extern's wire return: handle projections wire as `Long` (the
+            // boxed jlong gets wrapped); value-class projections wire as their
+            // inner converter's Kotlin type folded through the projection's
+            // strategy (the value class is erased to that inner). Enums wire as
+            // `Int` (`Int?` under `Option`); everything else is the declared
+            // return.
+            match &projection {
+                Some(p) => projection_wire_return(p),
+                None if v.is_enum => "Int".to_string(),
+                None if v.is_option_enum => "Int?".to_string(),
+                None => kt_return.map(|t| t.to_string()).unwrap_or_default(),
+            }
         }
     };
 
@@ -751,7 +741,7 @@ pub(crate) fn render_wrapper_fn(
 
     let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
     let (params, receiver_idx) = classify_params(ext, &fplan, registry, imports, receiver_key)?;
-    let out = classify_output(ext, f, registry, imports)?;
+    let out = classify_output(ext, f, &fplan, registry, imports)?;
     let body_expr = build_native_call(ext, &jni_call, &params, &out);
 
     // Collect the opaque-handle params so we can scaffold pointer-ordered
@@ -1119,12 +1109,11 @@ fn classify_params(
 fn classify_output(
     ext: &JniGen,
     f: &syn::ItemFn,
+    fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
 ) -> Option<OutputPlan> {
-    use crate::api::core::unfold::{Delivery, UnfoldShape};
     let unfold = registry.unfold_plans.get(&f.sig.ident);
-    let is_convert = unfold.is_some_and(|p| p.delivery == Delivery::Return);
     // `builder_param` is the trailing **lambda** param (build / fold) as a
     // `(name, function-type)` pair. For the `Iterable` shape, the non-lambda
     // accumulator (`acc: A`) goes in `builder_lead` — it must precede
@@ -1137,21 +1126,24 @@ fn classify_output(
     // `acc` + the fold callback/adapter for `Iterable`).
     let mut unfold_call_args: Vec<String> = Vec::new();
 
-    let (kt_return, projection) = if let Some(plan) =
-        unfold.filter(|p| p.delivery == Delivery::Return)
+    let (kt_return, projection) = if let FnOutputPlan::Value(v) = &fplan.output {
+        // `convert_output` (Return) and plain returns: the wrapper returns
+        // the value directly — the plan classified the declared surface once
+        // (`convert_out_ty` for a convert, the signature's own output
+        // otherwise). No callback param, no generic, no extra call args; the
+        // extern returns the real wire and `build_call` applies the
+        // projection wrap (value_blob/handle) below.
+        render_return_surface(&v.surface, imports)?
+    } else if let (
+        FnOutputPlan::Unfold(
+            u @ UnfoldOutputPlan {
+                fixed_builder: true,
+                ..
+            },
+        ),
+        Some(plan),
+    ) = (&fplan.output, unfold)
     {
-        // `convert_output` (Return): the wrapper returns the single converted
-        // value directly — classify it exactly like a normal function whose
-        // return type is `convert_out_ty`. No callback param, no generic, no
-        // extra call args; the extern returns the real wire and `build_call`
-        // applies the projection wrap (value_blob/handle) below.
-        let cv = plan
-            .convert_out_ty
-            .clone()
-            .expect("Return delivery carries convert_out_ty");
-        let rt: syn::ReturnType = syn::parse_quote!(-> #cv);
-        classify_return(ext, &rt, registry, imports)?
-    } else if let Some(plan) = unfold.filter(|p| p.fixed_builder) {
         // Synthesized by-value `data_class` delivery via a **fixed, hoisted
         // singleton** — the wrapper takes no caller `build`/`fold` param and is
         // not generic over `R`/`A`. The native side still receives the singleton
@@ -1164,7 +1156,7 @@ fn classify_output(
         // a **whole-element leaf** fold (`plan.element` set — String / value blob
         // / handle) `plan.source` (e.g. `String`) has no class FQN, so take the
         // element's typed view from the folder interface's element param instead.
-        let class_ty = if plan.element.is_some() {
+        let class_ty = if u.whole_element {
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             register_kt_type(&spec.params[1].typed, imports)
         } else {
@@ -1173,7 +1165,7 @@ fn classify_output(
                 .map(|s| s.to_string())?;
             register_kt_type(&kt::KtType::cls(class_fqn), imports)
         };
-        if is_iterable_fold(&plan.shape) {
+        if u.iterable_fold {
             // `Vec<data_class>` fold: allocate an `ArrayList<Class>` accumulator,
             // pass the hoisted **folder-appender** singleton as `fold` (it
             // rebuilds each element via `fromParts` and appends it), and return
@@ -1187,7 +1179,7 @@ fn classify_output(
             unfold_call_args.push(format!("ArrayList<{class_ty}>()"));
             unfold_call_args.push(format!("{holder}.{field}"));
             let list_ty = kt::KtType::generic("List", [class_ty]);
-            let kt = if matches!(plan.shape, UnfoldShape::Optional((), _)) {
+            let kt = if u.optional {
                 list_ty.nullable()
             } else {
                 list_ty
@@ -1204,22 +1196,24 @@ fn classify_output(
             let singleton = format!("__{}", spec.raw_name());
             imports.insert(format!("{}.{singleton}", spec.package));
             unfold_call_args.push(singleton);
-            let kt = match &plan.shape {
-                UnfoldShape::Optional((), _) => class_ty.nullable(),
-                _ => class_ty,
+            let kt = if u.optional {
+                class_ty.nullable()
+            } else {
+                class_ty
             };
             (Some(kt), None)
         }
-    } else if let Some(plan) = unfold {
+    } else if let (FnOutputPlan::Unfold(u), Some(plan)) = (&fplan.output, unfold) {
         // The builder / fold params are generated typed `fun interface`s
         // (`<Source>Builder<out R>` / `<Element>Folder<A>`); the native side
         // calls their typed `run` with raw jvalues (value-blob leaves surface
         // as `ByteArray` — no call-site adapter). Lambda-literal call sites
         // SAM-convert unchanged.
-        let is_iterable = matches!(plan.shape, UnfoldShape::Iterable(_));
-        if is_iterable {
+        generic = u.generic.map(str::to_string);
+        // A **bare** `Iterable` folds with `<A>`; an `Optional`-wrapped
+        // iterable takes the scalar-builder surface below.
+        if u.generic == Some("A") {
             let spec = folder_iface_for_plan(ext, registry, plan)?;
-            generic = Some("A".to_string());
             builder_lead = Some(("acc".to_string(), kt::KtType::var_("A")));
             builder_param = Some(("fold".to_string(), spec.kt_ref(vec![kt::KtType::var_("A")])));
             unfold_call_args.push("acc".to_string());
@@ -1236,7 +1230,6 @@ fn classify_output(
                 .as_ref()
                 .expect("record-built plan carries its DeconId");
             let spec = builder_iface_spec(ext, registry, decon)?;
-            generic = Some("R".to_string());
             builder_param = Some(("build".to_string(), spec.kt_ref(vec![kt::KtType::var_r()])));
             if spec.needs_raw() {
                 imports.insert(format!("{}.asRaw", spec.package));
@@ -1244,22 +1237,25 @@ fn classify_output(
             } else {
                 unfold_call_args.push("build".to_string());
             }
-            let kt = match &plan.shape {
-                UnfoldShape::Optional((), _) => kt::KtType::var_r().nullable(),
-                _ => kt::KtType::var_r(),
+            let kt = if u.optional {
+                kt::KtType::var_r().nullable()
+            } else {
+                kt::KtType::var_r()
             };
             (Some(kt), None)
         }
     } else {
-        classify_return(ext, &f.sig.output, registry, imports)?
+        unreachable!("FnOutputPlan is either Value or Unfold-with-plan")
     };
-    // enum_class returns cross the JNI wire as jint → Kotlin `Int`.
-    // Detect this so `build_call` can wrap the result with `fromInt`.
-    let is_enum_return = unfold.is_none() && return_is_kotlin_enum(ext, &f.sig.output, registry);
-    // `Option<enum>` returns cross as the boxed discriminant (`Int?`);
-    // `build_call` maps back with `?.let { EnumType.fromInt(it) }`.
-    let is_option_enum_return =
-        unfold.is_none() && return_is_kotlin_option_enum(ext, &f.sig.output, registry);
+    // enum_class returns cross the JNI wire as jint → Kotlin `Int` (`Int?`
+    // boxed for `Option<enum>`) — so `build_call` can wrap the result with
+    // `fromInt`. The plan's probes run over the convert-peeled declared type;
+    // the wrapper surface keeps the historical `unfold.is_none()` mask
+    // (`Value` ∧ ¬`is_convert` ⟺ no unfold plan).
+    let (is_enum_return, is_option_enum_return) = match &fplan.output {
+        FnOutputPlan::Value(v) if !v.is_convert => (v.is_enum, v.is_option_enum),
+        _ => (false, false),
+    };
 
     Some(OutputPlan {
         kt_return,
@@ -1268,7 +1264,7 @@ fn classify_output(
         builder_lead,
         generic,
         unfold_call_args,
-        cast_return: unfold.is_some() && !is_convert,
+        cast_return: matches!(&fplan.output, FnOutputPlan::Unfold(_)),
         is_enum_return,
         is_option_enum_return,
     })
@@ -1891,95 +1887,49 @@ pub(crate) fn classify_return(
     Option<kt::KtType>,
     Option<crate::api::lang::jnigen::jni::Projection>,
 )> {
-    let ty = match output {
-        syn::ReturnType::Default => return Some((None, None)),
-        syn::ReturnType::Type(_, t) => &**t,
-    };
-    let outer_meta = registry.output_entry(ty).map(|e| e.metadata.clone());
-    // Unit returns (incl. `ZResult<()>`, whose inner identity rides
-    // `value_rust_key`) declare no Kotlin return type.
-    let inner_canon = outer_meta
-        .as_ref()
-        .and_then(|m| m.value_rust_key.clone())
-        .unwrap_or_else(|| ty.to_token_stream().to_string());
-    let inner: syn::Type = syn::parse_str(&inner_canon).unwrap_or_else(|_| ty.clone());
-    if crate::api::lang::jnigen::util::is_unit(&inner) {
-        return Some((None, None));
-    }
-    // Projection return (opaque handle or value class): read the folded
-    // `Projection` the type-unfolding mechanism propagated onto this return
-    // type's converter metadata — one source of truth, no shape-specific
-    // peeling. The declared return type is the concrete projection class
-    // folded through `Nullable`/`Iterable`; callers fold the wrap and pick
-    // the wire return based on `kind`.
-    if let Some(h) = outer_meta.as_ref().and_then(|m| m.projection.clone()) {
-        let fqn = ext
-            .kotlin_fqn(&h.leaf_key)
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| {
+    let (surface, _canonical) = ReturnSurface::classify(ext, registry, output);
+    render_return_surface(&surface, imports)
+}
+
+/// Map a classified [`ReturnSurface`] back to the historical
+/// `(kt_return, projection)` pair, registering/shortening the Kotlin names
+/// against `imports` at render time (the plan stores unshortened types, so
+/// import registration stays identical across all consumers). Panics on an
+/// unregistered projection FQN — the same Kotlin-render-time failure
+/// `classify_return` always had.
+pub(crate) fn render_return_surface(
+    surface: &ReturnSurface,
+    imports: &mut BTreeSet<String>,
+) -> Option<(
+    Option<kt::KtType>,
+    Option<crate::api::lang::jnigen::jni::Projection>,
+)> {
+    match surface {
+        ReturnSurface::Skip => None,
+        ReturnSurface::Unit => Some((None, None)),
+        ReturnSurface::Projected {
+            projection,
+            leaf_fqn,
+        } => {
+            let fqn = leaf_fqn.clone().unwrap_or_else(|| {
                 panic!(
                     "classify_return: projection return type `{}` has no Kotlin FQN registered \
                      — every opaque/value class must be declared via `JniGen::ptr_class(...)` \
                      / `JniGen::value_class(...)`.",
-                    h.leaf_key
+                    projection.leaf_key
                 )
             });
-        let short = register_fqn(&fqn, imports);
-        return Some((
-            Some(handle_kt_type(&h.strategy, &kt::KtType::cls(short))),
-            Some(h),
-        ));
-    }
-    // Non-opaque: read the Kotlin type straight off the resolved
-    // output entry's metadata — the rank-N handler propagates
-    // `ZResult<T>` / `Option<T>` / `Vec<T>` derivations alongside the
-    // wire, so no peel-and-fallback chain is needed at the use site.
-    if let Some(out_entry) = registry.output_entry(ty) {
-        if let Some(kt) = out_entry.metadata.kotlin_name.clone() {
-            return Some((Some(register_kt_type(&kt, imports)), None));
+            let short = register_fqn(&fqn, imports);
+            Some((
+                Some(handle_kt_type(
+                    &projection.strategy,
+                    &kt::KtType::cls(short),
+                )),
+                Some(projection.clone()),
+            ))
         }
+        ReturnSurface::Plain { kt } => Some((Some(register_kt_type(kt, imports)), None)),
     }
-    None
-}
-
-/// Returns `true` when the function's return type resolves to a type registered
-/// via [`JniGen::enum_class`]. Enum returns cross the JNI wire as `jint` (Kotlin
-/// `Int`); the public wrapper must call `EnumType.fromInt(Int)` to convert back.
-pub(crate) fn return_is_kotlin_enum(
-    ext: &JniGen,
-    output: &syn::ReturnType,
-    registry: &Registry<KotlinMeta>,
-) -> bool {
-    ext.is_kotlin_enum(&canonical_return_ty(output, registry))
-}
-
-/// Returns `true` when the function's return type resolves to `Option<E>` with
-/// `E` a [`JniGen::enum_class`] enum. The native side delivers the discriminant
-/// `box_jint`-boxed (null for `None`), so the extern returns `Int?` and the
-/// public wrapper converts back with `?.let { EnumType.fromInt(it) }`.
-pub(crate) fn return_is_kotlin_option_enum(
-    ext: &JniGen,
-    output: &syn::ReturnType,
-    registry: &Registry<KotlinMeta>,
-) -> bool {
-    crate::api::core::types_util::option_inner_type(&canonical_return_ty(output, registry))
-        .map(|inner| ext.is_kotlin_enum(&inner))
-        .unwrap_or(false)
-}
-
-/// The return type with the error channel peeled: the resolved output entry's
-/// canonical value key (`Result<T, E>` → `T`) when present, else the declared
-/// type verbatim.
-fn canonical_return_ty(output: &syn::ReturnType, registry: &Registry<KotlinMeta>) -> syn::Type {
-    let ty = match output {
-        syn::ReturnType::Default => return syn::parse_quote!(()),
-        syn::ReturnType::Type(_, t) => &**t,
-    };
-    registry
-        .output_entry(ty)
-        .and_then(|e| e.metadata.value_rust_key.clone())
-        .and_then(|canon| syn::parse_str(&canon).ok())
-        .unwrap_or_else(|| ty.clone())
 }
 
 pub(crate) fn kt_snake_to_camel(s: &str) -> String {


### PR DESCRIPTION
Stage 2 of #90 (stage 1: #100): extend the per-function lowered plan with the output/error side, so the Rust extern emitter and both Kotlin renderers consume one classification instead of three independent derivations — the drift class behind #87.

## What

- **`FnOutputPlan`** on `JniFunctionPlan`, built before the input loop (so the unresolved-output panic keeps precedence over unresolved-input, as today):
  - `Unfold(UnfoldOutputPlan)` — callback delivery: `iterable_fold`, `optional`, `fixed_builder`, `whole_element` booleans plus the pre-resolved generic rule (`None` fixed / `"A"` bare-iterable / `"R"` otherwise).
  - `Value(Box<ValueOutputPlan>)` — `is_convert`, the resolved conversion `target_ty` + `wire_ty`, the declared-surface `ReturnSurface`, and the enum-return probes.
- **Three consumers ported**:
  - `emit/wrapper.rs`: `OutputLowering`/`lower_output`/`output_target_type` deleted; wire return + sentinel from `plan.output.wire_ty()`; builder param from `iterable_fold`.
  - `render_extern_decl`: erased builder/fold params and the wire-return cascade (`projection_wire_return` / `Int` / `Int?`) key on the same plan — no more re-running `classify_return` + enum helpers.
  - `classify_output`: all branch keys (convert / fixed-builder / bare-iterable / optional / whole-element) and enum flags from the plan. The typed `IfaceSpec` surface (builder/folder `kt_ref`, `needs_raw`, singletons) deliberately stays at the site — that's stage 3.
- **`classify_return` split** into a pure core (`ReturnSurface::classify`, one `value_rust_key` peel subsuming `canonical_return_ty`) and a render adapter (`render_return_surface`) that registers imports and keeps the unregistered-projection-FQN panic at Kotlin render time. `return_is_kotlin_enum` / `return_is_kotlin_option_enum` / `canonical_return_ty` are deleted.

## Parity notes

- The unresolved-output-converter panic message is preserved verbatim (`PlanError::UnresolvedOutput`), still fired from the Rust emitter during `write_rust`.
- The bare-`Iterable` vs `is_iterable_fold` distinction in the generic-builder branch (`Option<Vec<T>>` takes the scalar-`R` surface) is encoded in the plan's `generic` rule.
- The enum-flag asymmetry is preserved: the extern computes them over the convert-peeled type; the wrapper surface masks with `!is_convert` (≡ the historical `unfold.is_none()`).

## Verification

- 283 lib tests and all 20 workspace suites green (`cargo test --all --all-features`).
- The 14 checked-in example Kotlin files regenerate byte-identical.
- CI gates pass locally: clippy `--all-targets --no-default-features --all-features -- --deny warnings`, rustfmt with the CI config.
- Net diff: +401/−274 including doc comments; render.rs and wrapper.rs both shrink.

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)