### PR TITLE
jnigen: lower names and interface specs into JniFunctionPlan (#90 stage 3)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -127,6 +127,7 @@ pub(crate) fn emit_unfold_delivery(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::unfold::UnfoldPlan,
+    iface: Option<&IfaceSpec>,
     call_expr: &TokenStream,
     on_err: &TokenStream,
 ) -> TokenStream {
@@ -211,10 +212,8 @@ pub(crate) fn emit_unfold_delivery(
         _ => None,
     };
     if let Some(optional) = opt_iterable {
-        let statics = iface_statics(
-            &folder_iface_for_plan(ext, registry, plan)
-                .expect("folder interface spec derivable for a resolved plan"),
-        );
+        let statics =
+            iface_statics(iface.expect("folder interface spec derivable for a resolved plan"));
         let fold_invoke = |arg_exprs: &[TokenStream]| -> TokenStream {
             quote! {
                 __acc = match __CB_MID.call_object(
@@ -317,13 +316,8 @@ pub(crate) fn emit_unfold_delivery(
 
     match &plan.shape {
         UnfoldShape::Base => {
-            let decon = plan
-                .decon
-                .as_ref()
-                .expect("record-built plan carries its DeconId");
             let statics = iface_statics(
-                &builder_iface_spec(ext, registry, decon)
-                    .expect("builder interface spec derivable for a registered declaration"),
+                iface.expect("builder interface spec derivable for a registered declaration"),
             );
             let body = emit_decompose(&quote!(__out));
             quote! {
@@ -340,13 +334,8 @@ pub(crate) fn emit_unfold_delivery(
                      Iterable (`Option<Vec<T>>`, handled above)"
                 ),
             }
-            let decon = plan
-                .decon
-                .as_ref()
-                .expect("record-built plan carries its DeconId");
             let statics = iface_statics(
-                &builder_iface_spec(ext, registry, decon)
-                    .expect("builder interface spec derivable for a registered declaration"),
+                iface.expect("builder interface spec derivable for a registered declaration"),
             );
             // `None` ⇒ null result (builder skipped); `Some` ⇒ decompose inner.
             let body = emit_decompose(&quote!(__inner));

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -61,12 +61,6 @@ impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
     }
 }
 
-pub(crate) fn mangle_jni_name(ext: &JniGen, ident: &syn::Ident) -> syn::Ident {
-    let camel = snake_to_camel(&ident.to_string());
-    let mangled = ext.mangle_jni_method(&camel);
-    syn::Ident::new(&ext.native_method_symbol(&mangled), Span::call_site())
-}
-
 /// If `ty` is a `&T` borrow with no explicit lifetime, splice in `'<life>`.
 /// Otherwise return `ty` unchanged.
 pub(crate) fn annotate_borrow_with_lifetime(ty: &syn::Type, life: &str) -> syn::Type {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -113,8 +113,8 @@ pub(crate) fn vec_helper_method_name(ext: &JniGen, base: &str, suffix: &str) -> 
 }
 
 /// Full Rust JNI symbol for a vec helper — the same spec-escaped
-/// `Java_<pkg>_<JNINative>_…` scheme function wrappers use via
-/// [`mangle_jni_name`] (see `symbol`, #86); these helpers live on the
+/// `Java_<pkg>_<JNINative>_…` scheme function wrappers use via the plan's
+/// `native_symbol` (see `symbol`, #86); these helpers live on the
 /// `JNINative` object, so they share its class path.
 fn vec_helper_symbol(ext: &JniGen, base: &str, suffix: &str) -> String {
     ext.native_method_symbol(&vec_helper_method_name(ext, base, suffix))

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -136,7 +136,6 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     callee: Option<syn::Expr>,
 ) -> TokenStream {
     let original_ident = &f.sig.ident;
-    let wrapper_ident = mangle_jni_name(ext, original_ident);
 
     let mut wire_params: Vec<TokenStream> = Vec::new();
     // Each entry is a per-input decode statement. Fallible decodes are
@@ -168,6 +167,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             ty, original_ident,
         ),
     });
+    let wrapper_ident = syn::Ident::new(&plan.native_symbol, Span::call_site());
     // Output (data) expansion: when output expansion was declared for this
     // function, the return value is decomposed by the deconstructor. Two
     // deliveries:
@@ -310,7 +310,14 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // Decompose/Optional: a single `__builder` callback.
         let uplan = unfold_plan.expect("Unfold output ⇒ unfold plan present");
         builder_param = Some(unfold_builder_param(u.iterable_fold));
-        emit_unfold_delivery(ext, registry, uplan, &call_expr, &on_err)
+        emit_unfold_delivery(
+            ext,
+            registry,
+            uplan,
+            u.iface.as_deref(),
+            &call_expr,
+            &on_err,
+        )
     } else {
         let output_entry = output_entry.expect("normal path has an output entry");
         let mut phase: TokenStream = quote! { let __out = #call_expr; };
@@ -360,7 +367,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // interface; its `run` method ID is resolved once per process on the
     // interface class (the sink instance differs per call). The trio is in
     // scope for every `signal_error` call the prelude/output phases emit.
-    let sink_spec = onerror_iface_spec(ext, registry, original_ident).unwrap_or_else(|| {
+    let sink_spec = plan.onerror_iface.as_ref().unwrap_or_else(|| {
         panic!(
             "jnigen: cannot derive the onError handler interface for `{}`",
             original_ident

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -17,6 +17,22 @@ use super::*;
 /// patterns — are skipped, mirroring every prior walk), plus the classified
 /// output side.
 pub(crate) struct JniFunctionPlan {
+    /// The mangled `JNINative` extern method name — the one name the Rust
+    /// export symbol, the Kotlin `external fun` declaration, and the wrapper
+    /// call target all key on. Computed ONCE as
+    /// `ext.mangle_jni_method(&kt_snake_to_camel(rust_ident))`, so the three
+    /// tiers agree by construction (previously the Rust symbol camelCased
+    /// with a different helper — a silent mismatch for non-snake idents).
+    pub jni_method: String,
+    /// The spec-escaped JNI export symbol (`Java_<pkg>_<JNINative>_<method>`,
+    /// see `symbol`, #86), derived from [`Self::jni_method`].
+    pub native_symbol: String,
+    /// The onError sink interface — the typed `<Err>Handler` when an error
+    /// plan exists, the global `JniErrorHandler` otherwise. One spec feeds
+    /// the Rust `__SINK_*` statics and the Kotlin `onError` wiring, so the
+    /// FQN/descriptor pair of the cached `run` lookup cannot drift. `None` =
+    /// underivable (the Rust emitter panics, the Kotlin renderer skips).
+    pub onerror_iface: Option<IfaceSpec>,
     pub params: Vec<PlanParam>,
     pub output: FnOutputPlan,
 }
@@ -44,8 +60,11 @@ pub(crate) enum ParamForm {
 
 /// One classified effective parameter (a source param, or one expansion leaf).
 pub(crate) struct PlanLeaf {
-    pub ident: syn::Ident,
     pub ty: syn::Type,
+    /// Kotlin parameter name (`kt_param_name(ident)`: camelCase +
+    /// hard-keyword escaping) — shared by the wrapper signature and the
+    /// `external fun` declaration.
+    pub kt_name: String,
     /// Typed-wrapper surface type: the projection's Kotlin FQN for
     /// handle/value projections, else the resolved entry's Kotlin name.
     /// `None` when the metadata lacks a name (the Kotlin wrapper renderer
@@ -70,9 +89,11 @@ pub(crate) struct PlanLeaf {
 /// construction (each probe rejects the shapes the others accept), so the
 /// probe order is canonical, not load-bearing.
 pub(crate) enum InputKind {
-    /// `impl Fn(args)` callback: erased `Any` on the wire; the typed
-    /// interface spec is derived at render time ([`callback_iface_spec`]).
-    Callback { args: Vec<syn::Type> },
+    /// `impl Fn(args)` callback: erased `Any` on the wire. `iface` is the
+    /// typed `fun interface` spec ([`callback_iface_spec`], keyed on the arg
+    /// types); `None` = underivable, the Kotlin wrapper renderer skips.
+    /// Boxed — an [`IfaceSpec`] would dominate the variant sizes.
+    Callback { iface: Option<Box<IfaceSpec>> },
     /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
     /// Vec-handle on the wire, built by pushing element leaves.
     VecBuild { elem: syn::Type, by_ref: bool },
@@ -119,6 +140,14 @@ pub(crate) struct UnfoldOutputPlan {
     /// `"A"` for a **bare** `Iterable` fold (an `Optional`-wrapped iterable
     /// takes the scalar-builder surface, hence `"R"`), `"R"` otherwise.
     pub generic: Option<&'static str>,
+    /// The builder/folder `fun interface` spec the delivery calls into —
+    /// [`folder_iface_for_plan`] for an iterable fold (incl. the fixed
+    /// whole-element form), [`builder_iface_spec`] otherwise. One spec feeds
+    /// the Rust upcall statics and every Kotlin surface read, so the cached
+    /// `run` FQN/descriptor pair cannot drift. `None` = underivable (the
+    /// Rust emitter keeps its historical `expect`s, the Kotlin renderer
+    /// skips). Boxed to keep the variant small.
+    pub iface: Option<Box<IfaceSpec>>,
 }
 
 /// Value-return facts: the resolved conversion target and wire on the Rust
@@ -202,6 +231,9 @@ impl JniFunctionPlan {
         registry: &Registry<KotlinMeta>,
         f: &syn::ItemFn,
     ) -> Result<Self, PlanError> {
+        let jni_method = ext.mangle_jni_method(&kt_snake_to_camel(&f.sig.ident.to_string()));
+        let native_symbol = ext.native_method_symbol(&jni_method);
+        let onerror_iface = onerror_iface_spec(ext, registry, &f.sig.ident);
         // Output first: the Rust emitter historically resolved the output
         // before the inputs, so an unresolved-output failure takes precedence
         // over an unresolved-input one.
@@ -235,7 +267,13 @@ impl JniFunctionPlan {
             };
             params.push(PlanParam { ident, ty, form });
         }
-        Ok(Self { params, output })
+        Ok(Self {
+            jni_method,
+            native_symbol,
+            onerror_iface,
+            params,
+            output,
+        })
     }
 
     /// The flattened effective-parameter view (expansion leaves inline) —
@@ -263,20 +301,22 @@ fn classify_leaf(
 ) -> Result<PlanLeaf, PlanError> {
     let optional = is_option_type(ty);
     let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(ty));
+    let kt_name = kt_param_name(&ident.to_string());
 
     // `impl Fn(args)` first: typed entirely from the interface spec — the
     // erased entry exists but its metadata carries no surface type.
     if let Some(args) = extract_fn_trait_args(ty) {
+        let iface = callback_iface_spec(ext, registry, &args).map(Box::new);
         return Ok(PlanLeaf {
-            ident: ident.clone(),
             ty: ty.clone(),
+            kt_name,
             kt_public: None,
             kt_meta: registry
                 .input_entry(ty)
                 .and_then(|e| e.metadata.kotlin_name.clone()),
             optional,
             as_enum_value,
-            kind: InputKind::Callback { args },
+            kind: InputKind::Callback { iface },
         });
     }
 
@@ -316,16 +356,14 @@ fn classify_leaf(
                 if matches!(proj.strategy, FoldStrategy::Iterable(_)) {
                     panic!(
                         "render_wrapper_fn: value-blob `Vec<_>` params aren't \
-                         supported yet (param `{}`); add array codegen to lift this guard.",
-                        kt_param_name(&ident.to_string())
+                         supported yet (param `{kt_name}`); add array codegen to lift this guard."
                     );
                 }
                 let field =
                     value_projection_field_for_leaf(ext, &proj.leaf_key).unwrap_or_else(|| {
                         panic!(
                             "render_wrapper_fn: cannot determine inline-class field for value \
-                     projection param `{}`",
-                            kt_param_name(&ident.to_string())
+                     projection param `{kt_name}`"
                         )
                     });
                 InputKind::ValueUnwrap { field }
@@ -343,8 +381,8 @@ fn classify_leaf(
     };
 
     Ok(PlanLeaf {
-        ident: ident.clone(),
         ty: ty.clone(),
+        kt_name,
         kt_public,
         kt_meta,
         optional,
@@ -386,12 +424,22 @@ fn build_output(
         } else {
             Some("R")
         };
+        let iface = if iterable_fold {
+            folder_iface_for_plan(ext, registry, plan).map(Box::new)
+        } else {
+            let decon = plan
+                .decon
+                .as_ref()
+                .expect("record-built plan carries its DeconId");
+            builder_iface_spec(ext, registry, decon).map(Box::new)
+        };
         return Ok(FnOutputPlan::Unfold(UnfoldOutputPlan {
             iterable_fold,
             optional,
             fixed_builder,
             whole_element: plan.element.is_some(),
             generic,
+            iface,
         }));
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -458,17 +458,14 @@ pub(crate) fn render_extern_decl(
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
 ) -> Option<kt::Code> {
-    let rust_name = f.sig.ident.to_string();
-    let kt_name = kt_snake_to_camel(&rust_name);
-    let jni_call = ext.mangle_jni_method(&kt_name);
-
-    // The wire params come straight off the lowered plan — the same
-    // classification the Rust extern and the Kotlin call site consume, so
-    // the three sites agree on arity and types by construction.
+    // The name and wire params come straight off the lowered plan — the
+    // same classification the Rust extern and the Kotlin call site consume,
+    // so the three sites agree on arity, types, and symbol by construction.
     let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
+    let jni_call = &fplan.jni_method;
     let mut params: Vec<(String, String)> = Vec::new();
     for leaf in fplan.leaves() {
-        let name = kt_param_name(&leaf.ident.to_string());
+        let name = leaf.kt_name.clone();
         match &leaf.kind {
             // Flattenable data_class param → its leaf wire params.
             InputKind::FlattenStruct(plan) => {
@@ -726,20 +723,16 @@ pub(crate) fn render_wrapper_fn(
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<kt::KtFun> {
-    let rust_name = f.sig.ident.to_string();
-    // The Kotlin extern in `JNINative` is keyed on the Rust ident
-    // (`kt_snake_to_camel(rust_name)` → the `JNINative` method mangler). The per-entry
-    // `.name("...")` override only changes the *user-facing* Kotlin
-    // wrapper name; the JNI call still has to hit the one extern that
-    // the Rust extern actually emits.
-    let default_kt_name = kt_snake_to_camel(&rust_name);
+    let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
+    // The Kotlin extern in `JNINative` is keyed on the Rust ident (the
+    // plan's `jni_method`). The per-entry `.name("...")` override only
+    // changes the *user-facing* Kotlin wrapper name; the JNI call still has
+    // to hit the one extern that the Rust extern actually emits.
     let kt_name = match kotlin_name_override {
         Some(n) => n.to_string(),
-        None => default_kt_name.clone(),
+        None => kt_snake_to_camel(&f.sig.ident.to_string()),
     };
-    let jni_call = ext.mangle_jni_method(&default_kt_name);
-
-    let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
+    let jni_call = fplan.jni_method.clone();
     let (params, receiver_idx) = classify_params(ext, &fplan, registry, imports, receiver_key)?;
     let out = classify_output(ext, f, &fplan, registry, imports)?;
     let body_expr = build_native_call(ext, &jni_call, &params, &out);
@@ -749,7 +742,7 @@ pub(crate) fn render_wrapper_fn(
     let opaques = collect_opaques(&params);
     let is_unit = out.kt_return.is_none();
     let r_ty = out.kt_return.clone().unwrap_or_else(kt::KtType::unit);
-    let sink = error_sink_parts(ext, f, registry, imports, &r_ty)?;
+    let sink = error_sink_parts(ext, f, &fplan, registry, imports, &r_ty)?;
 
     let mut fun = kt::KtFun::new(&kt_name).vis(kt::Vis::Public);
     // KDoc: the Rust fn's `///` prose first, then generated notes for every
@@ -965,7 +958,7 @@ fn classify_params(
     let mut receiver_idx: Option<usize> = None;
     let mut params: Vec<Param> = Vec::new();
     for leaf in fplan.leaves() {
-        let mut name = kt_param_name(&leaf.ident.to_string());
+        let mut name = leaf.kt_name.clone();
         let arg_ty = &leaf.ty;
 
         // Instance-method receiver: the first parameter whose peeled Rust type
@@ -988,8 +981,8 @@ fn classify_params(
         // calls the typed `run` — value-blob leaves surface as their raw
         // `ByteArray` wire (the SDK wraps), so no call-site adapter exists.
         // Lambda-literal call sites SAM-convert unchanged.
-        if let InputKind::Callback { args: cb_args } = &leaf.kind {
-            let spec = callback_iface_spec(ext, registry, cb_args)?;
+        if let InputKind::Callback { iface, .. } = &leaf.kind {
+            let spec = iface.as_deref()?;
             let kt_type = spec.kt_ref(vec![]);
             // The extern receives the RAW twin: the generated `asRaw()`
             // proxy (built once per registration) wraps raw leaves into the
@@ -1157,7 +1150,7 @@ fn classify_output(
         // / handle) `plan.source` (e.g. `String`) has no class FQN, so take the
         // element's typed view from the folder interface's element param instead.
         let class_ty = if u.whole_element {
-            let spec = folder_iface_for_plan(ext, registry, plan)?;
+            let spec = u.iface.as_deref()?;
             register_kt_type(&spec.params[1].typed, imports)
         } else {
             let class_fqn = ext
@@ -1172,7 +1165,7 @@ fn classify_output(
             // the threaded accumulator as `List<Class>` (`?`-nullable for an
             // `Option<Vec<…>>` return — `None` yields a null list). Per element
             // only the raw leaves cross — no Java object is built on the Rust side.
-            let spec = folder_iface_for_plan(ext, registry, plan)?;
+            let spec = u.iface.as_deref()?;
             let holder = spec.singleton_holder_name();
             let field = crate::api::lang::jnigen::jni::SINGLETON_FIELD;
             imports.insert(spec.singleton_holder_fqn());
@@ -1188,11 +1181,7 @@ fn classify_output(
         } else {
             // Scalar: the hoisted `__<Name>Builder` singleton calls `fromParts`;
             // the wrapper returns the concrete class (`?`-nullable for `Option`).
-            let decon = plan
-                .decon
-                .as_ref()
-                .expect("synthesized plan carries its DeconId");
-            let spec = builder_iface_spec(ext, registry, decon)?;
+            let spec = u.iface.as_deref()?;
             let singleton = format!("__{}", spec.raw_name());
             imports.insert(format!("{}.{singleton}", spec.package));
             unfold_call_args.push(singleton);
@@ -1213,7 +1202,7 @@ fn classify_output(
         // A **bare** `Iterable` folds with `<A>`; an `Optional`-wrapped
         // iterable takes the scalar-builder surface below.
         if u.generic == Some("A") {
-            let spec = folder_iface_for_plan(ext, registry, plan)?;
+            let spec = u.iface.as_deref()?;
             builder_lead = Some(("acc".to_string(), kt::KtType::var_("A")));
             builder_param = Some(("fold".to_string(), spec.kt_ref(vec![kt::KtType::var_("A")])));
             unfold_call_args.push("acc".to_string());
@@ -1225,11 +1214,22 @@ fn classify_output(
             }
             (Some(kt::KtType::var_("A")), None)
         } else {
-            let decon = plan
-                .decon
-                .as_ref()
-                .expect("record-built plan carries its DeconId");
-            let spec = builder_iface_spec(ext, registry, decon)?;
+            // A non-fixed `Optional(Iterable)` historically typed its surface
+            // with the BUILDER spec here while the Rust delivery folds — the
+            // plan stores the folder twin for that shape, so keep the local
+            // builder derivation to preserve the (latent, pre-existing)
+            // divergence rather than silently retype the surface.
+            let local_spec;
+            let spec = if u.iterable_fold {
+                let decon = plan
+                    .decon
+                    .as_ref()
+                    .expect("record-built plan carries its DeconId");
+                local_spec = builder_iface_spec(ext, registry, decon)?;
+                &local_spec
+            } else {
+                u.iface.as_deref()?
+            };
             builder_param = Some(("build".to_string(), spec.kt_ref(vec![kt::KtType::var_r()])));
             if spec.needs_raw() {
                 imports.insert(format!("{}.asRaw", spec.package));
@@ -1444,11 +1444,12 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
 fn error_sink_parts(
     ext: &JniGen,
     f: &syn::ItemFn,
+    fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     r_ty: &kt::KtType,
 ) -> Option<ErrorSink> {
-    let sink_spec = onerror_iface_spec(ext, registry, &f.sig.ident)?;
+    let sink_spec = fplan.onerror_iface.as_ref()?;
     let error_plan = registry.error_plans.get(&f.sig.ident);
     // Per ze leaf: (raw capture Kotlin type, raw default literal, raw→typed
     // wrap) — off the handler interface spec (its first param is the fixed


### PR DESCRIPTION
Stage 3 of #90 (stage 1: #100, stage 2: #101): lower the per-function names/symbols and the per-function `IfaceSpec` references into the plan, so the Rust and Kotlin emitters read one derivation.

## Names

The JNINative extern method name was computed **three ways with two different casing helpers**: the Rust export symbol via `snake_to_camel` (`mangle_jni_name`), the Kotlin `external fun` decl and the wrapper call target via `kt_snake_to_camel`. The plan now computes `jni_method` once (canonicalized on `kt_snake_to_camel`) and derives `native_symbol` from it (#86 escaping), so the Rust export and the Kotlin extern agree by construction. `mangle_jni_name` is deleted.

**Behavioral note (already-broken configs only):** all Kotlin-visible output is unchanged; the Rust symbol changes only for a leading-uppercase or non-ASCII fn ident — where it already mismatched what the JVM derives from the Kotlin name (unresolvable native at runtime). No such ident exists in-tree.

## Interface specs

The plan stores per-function `IfaceSpec` references, hardening the `CachedIfaceMethod` FQN/descriptor SAFETY contract structurally (previously it held only because the constructors are deterministic):

- `onerror_iface` feeds both the Rust `__SINK_*` statics (historical panic on `None` preserved verbatim) and Kotlin `error_sink_parts` (skip).
- `UnfoldOutputPlan.iface` (folder spec for iterable folds, builder spec otherwise) feeds `emit_unfold_delivery` (exact historical `expect` messages) and the `classify_output` reads. The one divergent case — a non-fixed `Optional(Iterable)`, where the Kotlin surface historically typed with the **builder** spec while the Rust delivery folds — keeps a local builder derivation with an explanatory comment, preserving the pre-existing (latent) behavior rather than silently changing it.
- `InputKind::Callback` carries the `callback_iface_spec` for `classify_params`.

Deliberately out of scope (constraints found in exploration): the resolve-time callback trampoline (`emit/callback.rs` — runs during converter resolution, before any plan exists) and the per-`Use`-deduped interface declarations (`kotlin_emit.rs::write_callback_ifaces` — keyed per DeconId/arg-types/element, not per function).

Also: `PlanLeaf` now carries the Kotlin param name (`kt_name`) shared by the wrapper signature and extern decl; the now-redundant `PlanLeaf.ident` and `Callback.args` fields were dropped.

## Verification

- 283 lib tests and all 20 workspace suites green (`cargo test --all --all-features`).
- The 14 checked-in example Kotlin files regenerate byte-identical.
- CI gates pass locally: clippy `--all-targets --no-default-features --all-features -- --deny warnings`, rustfmt with the CI config.

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)