### PR TITLE
jnigen: validate all binding plans before any artifact is written (#90 stage 4)

### DIFF
--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -438,6 +438,20 @@ pub trait Prebindgen {
         Ok(())
     }
 
+    /// Post-**resolve** validation boundary — the counterpart of
+    /// [`Self::validate`] that sees the fully resolved registry (converters,
+    /// plans, metadata). Every artifact writer calls it before writing
+    /// anything, so an invalid binding fails cleanly — with every problem
+    /// reported at once — instead of panicking midway after a sibling
+    /// artifact already reached disk. Deterministic over `(self, registry)`;
+    /// it runs once per write call, which keeps artifact writes
+    /// order-independent.
+    ///
+    /// Default: no checks.
+    fn validate_resolved(&self, _registry: &Registry<Self::Metadata>) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Absolute path under which the source crate's items are reachable
     /// from the generated file (e.g. `zenoh_flat`), for adapters that
     /// qualify emitted references against one. Drives the default

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -30,6 +30,10 @@ pub enum WriteError {
         phase: &'static str,
         source: syn::Error,
     },
+    /// The adapter's post-resolve validation
+    /// ([`Prebindgen::validate_resolved`]) rejected the binding — nothing
+    /// was written.
+    Validation(String),
 }
 
 impl std::fmt::Display for WriteError {
@@ -42,6 +46,7 @@ impl std::fmt::Display for WriteError {
                     phase, source
                 )
             }
+            WriteError::Validation(msg) => write!(f, "binding validation failed: {}", msg),
         }
     }
 }
@@ -57,6 +62,12 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     ext: &E,
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
+    // Post-resolve validation boundary: every artifact writer runs it first,
+    // so an invalid binding fails cleanly before ANY file is written —
+    // regardless of which artifact is written first.
+    ext.validate_resolved(registry)
+        .map_err(WriteError::Validation)?;
+
     let mut items: Vec<syn::Item> = Vec::new();
 
     // 0. Adapter prerequisites — runtime-support items (helper structs,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -150,23 +150,10 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // renders the Rust decode/encode for each kind. The output is classified
     // first (inside `build`) so the per-input `match`-arms can splice the
     // function's sentinel into their early-`return` path.
-    let plan = JniFunctionPlan::build(ext, registry, f).unwrap_or_else(|e| match e {
-        PlanError::Unresolved { ty } => panic!(
-            "JniGen::on_function: input type `{}` for `{}` is unresolved",
-            ty, original_ident,
-        ),
-        PlanError::UnresolvedLeaf { ty, param } => panic!(
-            "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
-            ty, param,
-        ),
-        PlanError::UnresolvedOutput { ty } => panic!(
-            "JniGen::on_function: return type `{}` of `{}` has no registered output \
-             converter — register one via `JniGen::output_wrapper(pat, |…| Some((ty, exc, body)))` \
-             (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
-              to bind a domain exception)",
-            ty, original_ident,
-        ),
-    });
+    // Backstop only — `validate_resolved` reports every plan failure before
+    // any writer runs, so this panic is unreachable through the write paths.
+    let plan = JniFunctionPlan::build(ext, registry, f)
+        .unwrap_or_else(|e| panic!("{}", e.message(original_ident)));
     let wrapper_ident = syn::Ident::new(&plan.native_symbol, Span::call_site());
     // Output (data) expansion: when output expansion was declared for this
     // function, the return value is decomposed by the deconstructor. Two

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -198,8 +198,10 @@ pub(crate) enum ReturnSurface {
     Plain { kt: kt::KtType },
 }
 
-/// Plan construction failure. The Rust emitter maps each variant to its
-/// historical panic; the Kotlin renderers map to `None` (skip).
+/// Plan construction failure. The validation boundary
+/// ([`validate_bindings`]) reports every failure before any artifact is
+/// written; the Rust emitter keeps the same messages as panic backstops and
+/// the Kotlin renderers map to `None` (skip).
 pub(crate) enum PlanError {
     /// `registry.input_entry` has no converter for a source param type.
     Unresolved { ty: TypeKey },
@@ -207,6 +209,104 @@ pub(crate) enum PlanError {
     UnresolvedLeaf { ty: TypeKey, param: syn::Ident },
     /// `registry.output_entry` has no converter for the output target type.
     UnresolvedOutput { ty: TypeKey },
+}
+
+impl PlanError {
+    /// The historical emission-panic message for this failure, shared by the
+    /// validation boundary and the Rust emitter's backstop panics so the
+    /// wording cannot drift.
+    pub fn message(&self, fn_ident: &syn::Ident) -> String {
+        match self {
+            PlanError::Unresolved { ty } => format!(
+                "JniGen::on_function: input type `{}` for `{}` is unresolved",
+                ty, fn_ident,
+            ),
+            PlanError::UnresolvedLeaf { ty, param } => format!(
+                "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
+                ty, param,
+            ),
+            PlanError::UnresolvedOutput { ty } => format!(
+                "JniGen::on_function: return type `{}` of `{}` has no registered output \
+                 converter — register one via `JniGen::output_wrapper(pat, |…| Some((ty, exc, body)))` \
+                 (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
+                  to bind a domain exception)",
+                ty, fn_ident,
+            ),
+        }
+    }
+}
+
+/// The post-resolve validation boundary (issue #90): build the lowered plan
+/// for every bound function — declared functions, declared-const getters,
+/// and expression-constant getters — and check the split declarations,
+/// collecting every failure. Called by every artifact writer (via
+/// [`Prebindgen::validate_resolved`]) before anything reaches disk, so an
+/// invalid binding can no longer leave one artifact written and its sibling
+/// missing.
+///
+/// [`Prebindgen::validate_resolved`]: crate::api::core::prebindgen::Prebindgen::validate_resolved
+pub(crate) fn validate_bindings(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+) -> Result<(), String> {
+    let mut errors: Vec<String> = Vec::new();
+
+    if let Err(e) = ext.validate_split_declarations(registry) {
+        errors.push(e);
+    }
+
+    // Declared functions (incl. binding-local synthetics and fn-backed
+    // constants), in deterministic ident order.
+    let declared = ext.declared_functions();
+    let mut fn_idents: Vec<&syn::Ident> = registry.functions.keys().collect();
+    fn_idents.sort();
+    for ident in fn_idents {
+        if !declared.contains(ident) {
+            continue;
+        }
+        let (item_fn, _) = &registry.functions[ident];
+        if let Err(e) = JniFunctionPlan::build(ext, registry, item_fn) {
+            errors.push(e.message(ident));
+        }
+    }
+
+    // Declared consts: their synthetic nullary getters run through the same
+    // plan machinery (`JniGen::on_const`).
+    if let Some(declared_consts) = ext.declared_consts() {
+        let mut const_idents: Vec<&syn::Ident> = registry.consts.keys().collect();
+        const_idents.sort();
+        for ident in const_idents {
+            if *ident == "_" || !declared_consts.contains(ident) {
+                continue;
+            }
+            let (item_const, _) = &registry.consts[ident];
+            let getter = const_getter_fn(item_const);
+            if let Err(e) = JniFunctionPlan::build(ext, registry, &getter) {
+                errors.push(e.message(&getter.sig.ident));
+            }
+        }
+    }
+
+    // Expression constants: same synthetic `const_get_*` getter shape,
+    // seeded from the val name.
+    let mut expr_decls: Vec<_> = ext
+        .packages
+        .values()
+        .flat_map(|p| &p.constant_exprs)
+        .collect();
+    expr_decls.sort_by(|a, b| a.kotlin_name.cmp(&b.kotlin_name));
+    for decl in expr_decls {
+        let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
+        if let Err(e) = JniFunctionPlan::build(ext, registry, &getter) {
+            errors.push(e.message(&getter.sig.ident));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
 }
 
 impl FnOutputPlan {

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -77,9 +77,11 @@ impl JniGen {
         registry: &Registry<KotlinMeta>,
         kotlin_root: &Path,
     ) -> Result<Vec<PathBuf>, WriteKotlinError> {
-        // #52: verify every multi-variant expand_param! is splittable up front,
-        // before any per-function `.split_on_param` emission.
-        self.validate_split_declarations(registry);
+        // Post-resolve validation boundary — same pass `write_rust` runs
+        // (plans + #52 split declarations), so whichever artifact is written
+        // first fails before anything reaches disk.
+        self.validate_resolved(registry)
+            .map_err(WriteKotlinError::Other)?;
         let mut fragments: Vec<kt::KtFile> = Vec::new();
         fragments.push(self.write_native_handle());
         fragments.extend(self.write_enum_classes(registry)?);

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -53,8 +53,15 @@ impl JniGen {
     /// [`FunctionDecl::split_on_param`](crate::fun) can emit unambiguous
     /// overloads. Runs regardless of whether any function actually splits the
     /// type, so authorship errors surface early. `.no_split()` opts a decl out.
-    /// A collision panics with a message attributed to the declaration.
-    pub(crate) fn validate_split_declarations(&self, registry: &Registry<KotlinMeta>) {
+    /// A collision errors with a message attributed to the declaration
+    /// (surfaced through the [`validate_resolved`] boundary before any
+    /// artifact is written).
+    ///
+    /// [`validate_resolved`]: crate::api::core::prebindgen::Prebindgen::validate_resolved
+    pub(crate) fn validate_split_declarations(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> Result<(), String> {
         let type_level = self
             .param_expand_decls
             .iter()
@@ -86,7 +93,7 @@ impl JniGen {
             for i in 0..sigs.len() {
                 for j in (i + 1)..sigs.len() {
                     if sigs[i].1 == sigs[j].1 {
-                        panic!(
+                        return Err(format!(
                             "expand_param!({t}) [{site}]: variants {a} and {b} both surface as \
                              `({sig})` — a split would emit two overloads with the same JVM \
                              signature; disambiguate the constructors or add .no_split()",
@@ -94,11 +101,12 @@ impl JniGen {
                             a = sigs[i].0,
                             b = sigs[j].0,
                             sig = sigs[i].1.join(", "),
-                        );
+                        ));
                     }
                 }
             }
         }
+        Ok(())
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1570,6 +1570,60 @@ fn split_declaration_colliding_variants_rejected() {
     let _ = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_decl");
 }
 
+/// #90: the validation boundary is cross-artifact — a colliding split
+/// declaration (a Kotlin-side concern) fails `write_rust` too, as a clean
+/// `Err` BEFORE the Rust file is written, so no half-written binding can
+/// exist regardless of write order.
+#[test]
+fn split_declaration_collision_fails_write_rust_before_writing() {
+    let loc = myflat_loc();
+    let srcs: &[&str] = &[
+        "pub fn z_name_from_text(text: String) -> ZName { unimplemented!() }",
+        "pub fn z_name_from_label(label: String) -> ZName { unimplemented!() }",
+        "pub fn z_use_name(name: ZName) -> bool { unimplemented!() }",
+    ];
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct ZName {
+                _p: u8,
+            }
+        )),
+        loc.clone(),
+    )];
+    for s in srcs {
+        items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(crate::ptr_class!(ZName))
+                .fun(crate::fun!(z_use_name)),
+        )
+        .expand(
+            crate::expand_param!(ZName)
+                .variant(crate::fun!(z_name_from_text))
+                .variant(crate::fun!(z_name_from_label)),
+        );
+    let generation = registry.resolve(jni).expect("resolve");
+    let dir = unique_test_dir("jnigen_split_decl_rust_err");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let out = dir.join("gen.rs");
+    let err = generation
+        .write_rust(&out)
+        .expect_err("colliding split declaration must fail write_rust");
+    assert!(
+        err.to_string().contains("same JVM signature"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !out.exists(),
+        "write_rust must not write on validation failure"
+    );
+}
+
 /// #52: `.no_split()` suppresses the proactive splittability check for a
 /// genuinely non-splittable variant set (used only as the selector form).
 #[test]

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1137,6 +1137,14 @@ impl Prebindgen for JniGen {
         Ok(())
     }
 
+    /// The post-resolve validation boundary (issue #90): every bound
+    /// function's lowered plan must build, and the split declarations must
+    /// be unambiguous, before ANY artifact writer touches disk — see
+    /// [`validate_bindings`].
+    fn validate_resolved(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
+        validate_bindings(self, registry)
+    }
+
     /// Consts acknowledged-but-unexposed via [`JniGen::ignore`].
     fn ignored_consts(&self) -> std::collections::HashSet<syn::Ident> {
         self.ignored_const_idents.clone()


### PR DESCRIPTION
Stage 4 of #90 (stages 1–3: #100, #101, #102): the validation boundary. Invalid plans now fail before ANY artifact is written — the acceptance criterion "Invalid plans fail before any artifact is written."

## The problem

`write_rust` runs first and writes `gen.rs`; `write_kotlin` runs second and could panic (e.g. `validate_split_declarations`' collision panic fired only inside `write_kotlin`) — leaving a half-written binding: Rust artifact on disk, Kotlin missing. Within a single call writes were already atomic (Rust accumulates in memory; Kotlin stages + renames), so the gap was strictly *between* the two calls.

## What

- **New `Prebindgen::validate_resolved` hook** (default: no checks) — the post-resolve counterpart of the existing pre-resolve `validate`. Core `write_rust` calls it first (new `WriteError::Validation` variant); JniGen's `write_kotlin` calls the same impl (`WriteKotlinError::Other`). Deterministic, so artifact writes stay order-independent (`generation_writes_are_order_free` still passes).
- **`validate_bindings` (fn_plan.rs)**: builds the lowered `JniFunctionPlan` for every declared function, declared-const getter, and expression-constant getter, plus the #52 split-declaration check — reporting **all** failures in one message.
- **Panic→Err conversions**: `validate_split_declarations` returns `Result` (same message text); the unresolved input/leaf/output emission panics are subsumed — their exact messages moved into `PlanError::message`, shared by the boundary and the emitter's now-unreachable backstop panic.

## Behavior changes (all intentional, the point of the stage)

- A colliding split declaration now fails `write_rust` too (previously Kotlin-only) — cross-artifact consistency.
- `write_kotlin` returns `Err` for split collisions instead of panicking (the existing `should_panic` test still passes via the caller's `expect`).
- Unresolved-converter failures surface as a clean `Err` listing every problem, instead of a panic mid-assembly at the first one.

## Tests

- New: `split_declaration_collision_fails_write_rust_before_writing` — asserts `write_rust` returns `Err` containing the collision message and that the output file was **not** created.
- 284 lib tests and all 20 workspace suites green; checked-in example Kotlin byte-identical; CI clippy/fmt gates pass locally.

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)