### PR TITLE
core: replace cursor-based expansion/deconstruction accumulators with immutable declarations (#96)

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -38,7 +38,7 @@ mod error;
 mod plan;
 
 pub use self::{
-    error::ExpandError,
+    error::{ExpandDeclError, ExpandError},
     plan::{FoldArg, FoldBuild, FoldLeaf, FoldPlan, FoldShape, FoldVariant},
 };
 
@@ -51,25 +51,29 @@ pub use self::{
 /// `Identity`) is the degenerate "single" form: applied unconditionally with no
 /// selector. Two or more variants (or an `Identity` arm) get a runtime selector.
 #[derive(Clone)]
-enum Variant {
+pub enum Variant {
     /// Build the target by calling this constructor function.
     Ctor(syn::Ident),
     /// Pass an already-built target value straight through.
     Identity,
 }
 
+/// A type-level constructor declaration (`expand_param!(T).variant*`): the
+/// complete, ordered variant list for building `target` from flattened
+/// leaves. An immutable record — the variant order is the declaration order
+/// of the `variants` vector.
 #[derive(Clone)]
-struct ConstructorDecl {
-    target: syn::Type,
-    variants: Vec<Variant>,
+pub struct ConstructorDecl {
+    pub target: syn::Type,
+    pub variants: Vec<Variant>,
     /// Auto-`construct` every matching param of every declared fn. Always
     /// `true` for type-level default (`expand_param!` `.variant*`) declarations.
-    default: bool,
+    pub default: bool,
 }
 
 /// How a construct declaration chooses the variants for a parameter.
 #[derive(Clone)]
-enum ExpandSel {
+pub enum ExpandSel {
     /// Use the target type's default constructor (error if none/ambiguous).
     TopLevel,
     /// Per-fn override (`.expand_param`): use exactly these build-from
@@ -77,131 +81,84 @@ enum ExpandSel {
     Subset(Vec<Variant>),
 }
 
+/// A per-fn input expansion (`.expand_param(param, expand_param!(T)…)`) —
+/// construct `param` of `func` from the explicit variant list. Recorded as
+/// an explicit decl so the auto-`default` skips it; an identity-only list
+/// lowers to the skip-default plain form in [`apply`]. Not related to the
+/// jnigen declaration-DSL type of the same name — this is the lowered core
+/// record.
 #[derive(Clone)]
-struct ExpandDecl {
-    func: syn::Ident,
-    param: syn::Ident,
+pub struct ExpandDecl {
+    pub func: syn::Ident,
+    pub param: syn::Ident,
     /// The type the per-fn decl was declared for (`expand_param!(T)`) —
     /// cross-checked against the named param's peeled type in [`apply`].
     /// `None` for the internal `TopLevel` form (the type comes from the
     /// param itself).
-    declared_target: Option<syn::Type>,
-    sel: ExpandSel,
+    pub declared_target: Option<syn::Type>,
+    pub sel: ExpandSel,
 }
 
-/// Constructor / expansion declarations gathered from a language builder.
-/// Embedded in each adapter that supports expansion and handed to [`apply`]
-/// via [`crate::api::core::prebindgen::Prebindgen::expansions`].
+/// Constructor / expansion declarations gathered from a language builder —
+/// an immutable record set: complete values, no build protocol. Declaration
+/// order is the vector order. Handed to [`apply`] via
+/// [`crate::api::core::prebindgen::Prebindgen::expansions`]; empty or
+/// duplicate declarations are diagnosed there (collected), not at
+/// construction.
 #[derive(Clone, Default)]
 pub struct Expansions {
-    constructors: Vec<ConstructorDecl>,
-    expands: Vec<ExpandDecl>,
-    /// Cursor for the constructor builder (`.constructor_variant*` / `.default`).
-    cur_constructor: Option<usize>,
-    /// Cursor for an in-progress per-fn input subset (`.expand_param(...)`
-    /// → `.variant`/`.variant_self`): index into [`Self::expands`].
-    cur_expand: Option<usize>,
+    pub constructors: Vec<ConstructorDecl>,
+    pub expands: Vec<ExpandDecl>,
     /// `.skip_default_construct(param)` opt-outs: `(fn, param)` excluded from a
-    /// constructor `.default()` auto-apply.
-    skip_construct: std::collections::HashSet<(syn::Ident, syn::Ident)>,
-}
-
-impl Expansions {
-    /// Find-or-create the default (always-`default`) constructor for `target`
-    /// and set the cursor to it. Idempotent across a `.variant*` chain —
-    /// the first call creates it, subsequent ones reuse it so variants accumulate.
-    pub fn ensure_default_constructor(&mut self, target: syn::Type) {
-        let key = TypeKey::from_type(&target);
-        if let Some(i) = self
-            .constructors
-            .iter()
-            .position(|c| TypeKey::from_type(&c.target) == key)
-        {
-            self.cur_constructor = Some(i);
-        } else {
-            self.constructors.push(ConstructorDecl {
-                target,
-                variants: Vec::new(),
-                default: true,
-            });
-            self.cur_constructor = Some(self.constructors.len() - 1);
-        }
-    }
-
-    /// Exclude `(func, param)` from constructor default auto-apply — the
-    /// lowered form of an identity-only per-fn variant set (the plain
-    /// handle, no selector).
-    pub fn add_skip_default_construct(&mut self, func: syn::Ident, param: syn::Ident) {
-        self.skip_construct.insert((func, param));
-    }
-
-    /// `expand_param!` `.variant(fun)` — add a constructor-function arm.
-    pub fn add_constructor_variant(&mut self, func: syn::Ident) {
-        let i = self
-            .cur_constructor
-            .expect(".variant called without a current constructor");
-        self.constructors[i].variants.push(Variant::Ctor(func));
-    }
-
-    /// `expand_param!` `.variant_self()` — add the identity arm
-    /// (pass the target value straight through).
-    pub fn add_constructor_variant_id(&mut self) {
-        let i = self
-            .cur_constructor
-            .expect(".variant_self called without a current constructor");
-        self.constructors[i].variants.push(Variant::Identity);
-    }
-
-    /// Begin a per-fn input override (`.expand_param(param, expand_param!(T)…)`):
-    /// construct `param` from an explicit, incrementally-built variant list
-    /// (constructor arms via [`Self::push_subset_variant`] and/or the
-    /// identity/self arm via [`Self::push_subset_self`]). `declared_target`
-    /// is the decl's `T`, cross-checked against the param's peeled type in
-    /// [`apply`]. Recorded as an explicit decl so the auto-`default` skips
-    /// it, and leaves the expand cursor on it. An identity-only list lowers
-    /// to the skip-default plain form in [`apply`].
-    pub fn begin_subset(
-        &mut self,
-        func: syn::Ident,
-        param: syn::Ident,
-        declared_target: syn::Type,
-    ) {
-        self.expands.push(ExpandDecl {
-            func,
-            param,
-            declared_target: Some(declared_target),
-            sel: ExpandSel::Subset(Vec::new()),
-        });
-        self.cur_constructor = None;
-        self.cur_expand = Some(self.expands.len() - 1);
-    }
-
-    /// `.expand_param` `.variant(fun)` — append a build-from
-    /// constructor arm to the current per-fn input subset.
-    pub fn push_subset_variant(&mut self, func: syn::Ident) {
-        let i = self
-            .cur_expand
-            .expect(".variant called without a current constructor");
-        if let ExpandSel::Subset(v) = &mut self.expands[i].sel {
-            v.push(Variant::Ctor(func));
-        }
-    }
-
-    /// `.expand_param` `.variant_self()` — append the identity
-    /// (pass-the-handle-through) arm to the current per-fn subset.
-    pub fn push_subset_self(&mut self) {
-        let i = self
-            .cur_expand
-            .expect(".variant_self called without a current constructor");
-        if let ExpandSel::Subset(v) = &mut self.expands[i].sel {
-            v.push(Variant::Identity);
-        }
-    }
+    /// constructor `.default()` auto-apply — the lowered form of an
+    /// identity-only per-fn variant set (the plain handle, no selector).
+    pub skip_construct: std::collections::HashSet<(syn::Ident, syn::Ident)>,
 }
 
 // ──────────────────────────────────────────────────────────────────────
 // apply
 // ──────────────────────────────────────────────────────────────────────
+
+/// Structural validation of the declaration records — empty variant lists
+/// and duplicate targets. Collects EVERY offender before failing, so a
+/// build surfaces all declaration problems at once.
+fn validate_declarations(exp: &Expansions) -> Result<(), ExpandError> {
+    let mut entries: Vec<ExpandDeclError> = Vec::new();
+    let mut ctor_targets: HashSet<String> = HashSet::new();
+    for c in &exp.constructors {
+        let target = TypeKey::from_type(&c.target).as_str().to_string();
+        if c.variants.is_empty() {
+            entries.push(ExpandDeclError::EmptyConstructor {
+                target: target.clone(),
+            });
+        }
+        if !ctor_targets.insert(target.clone()) {
+            entries.push(ExpandDeclError::DuplicateConstructor { target });
+        }
+    }
+    let mut expand_keys: HashSet<(String, String)> = HashSet::new();
+    for ed in &exp.expands {
+        if let ExpandSel::Subset(v) = &ed.sel {
+            if v.is_empty() {
+                entries.push(ExpandDeclError::EmptySubset {
+                    func: ed.func.clone(),
+                    param: ed.param.clone(),
+                });
+            }
+        }
+        if !expand_keys.insert((ed.func.to_string(), ed.param.to_string())) {
+            entries.push(ExpandDeclError::DuplicateExpand {
+                func: ed.func.clone(),
+                param: ed.param.clone(),
+            });
+        }
+    }
+    if entries.is_empty() {
+        Ok(())
+    } else {
+        Err(ExpandError::InvalidDeclarations { entries })
+    }
+}
 
 /// Resolve every `.construct` declaration (explicit + `.default()`
 /// auto-applied) into a [`FoldPlan`], register each plan's leaf types as required
@@ -218,6 +175,7 @@ pub fn apply<M>(
     accessor_fns: &std::collections::HashSet<syn::Ident>,
     method_receivers: &std::collections::HashMap<syn::Ident, TypeKey>,
 ) -> Result<(), ExpandError> {
+    validate_declarations(exp)?;
     let mut done: HashSet<(String, String)> = HashSet::new();
     let mut skip_construct = exp.skip_construct.clone();
     for ed in &exp.expands {

--- a/prebindgen/src/api/core/expand/error.rs
+++ b/prebindgen/src/api/core/expand/error.rs
@@ -45,6 +45,47 @@ pub enum ExpandError {
         func: syn::Ident,
         reason: &'static str,
     },
+    /// Structurally invalid declaration records — empty variant lists or
+    /// duplicate targets. All offenders are collected before failing
+    /// (mirrors `ScanError::DeclaredNotFound`).
+    InvalidDeclarations {
+        entries: Vec<ExpandDeclError>,
+    },
+}
+
+/// One structurally invalid expansion declaration (see
+/// [`ExpandError::InvalidDeclarations`]).
+#[derive(Debug)]
+pub enum ExpandDeclError {
+    /// A constructor declaration with no variants.
+    EmptyConstructor { target: String },
+    /// A per-fn expand with an empty variant subset.
+    EmptySubset { func: syn::Ident, param: syn::Ident },
+    /// Two constructor declarations for the same target type.
+    DuplicateConstructor { target: String },
+    /// Two per-fn expands for the same `(fn, param)`.
+    DuplicateExpand { func: syn::Ident, param: syn::Ident },
+}
+
+impl std::fmt::Display for ExpandDeclError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpandDeclError::EmptyConstructor { target } => {
+                write!(f, "constructor for `{target}` declares no variants")
+            }
+            ExpandDeclError::EmptySubset { func, param } => write!(
+                f,
+                "expand for parameter `{param}` of `{func}` declares no variants"
+            ),
+            ExpandDeclError::DuplicateConstructor { target } => {
+                write!(f, "duplicate constructor declaration for `{target}`")
+            }
+            ExpandDeclError::DuplicateExpand { func, param } => write!(
+                f,
+                "duplicate expand declaration for parameter `{param}` of `{func}`"
+            ),
+        }
+    }
 }
 
 impl std::fmt::Display for ExpandError {
@@ -119,6 +160,13 @@ impl std::fmt::Display for ExpandError {
                 "expand: optional parameter `{}` of `{}` is not supported: {}",
                 param, func, reason
             ),
+            ExpandError::InvalidDeclarations { entries } => {
+                writeln!(f, "expand: invalid declarations:")?;
+                for e in entries {
+                    writeln!(f, "  - {e}")?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -16,12 +16,12 @@ fn single_constructor_plan_and_fold() {
     let mut exp = Expansions::default();
     // Single build-from variant = one Ctor arm (no selector), declared
     // per-fn (`.expand_param`).
-    exp.begin_subset(
-        ident("z_keyexpr_intersects"),
-        ident("a"),
-        syn::parse_quote!(ZKeyExpr),
-    );
-    exp.push_subset_variant(ident("z_keyexpr_try_from"));
+    exp.expands.push(ExpandDecl {
+        func: ident("z_keyexpr_intersects"),
+        param: ident("a"),
+        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from"))]),
+    });
 
     apply(
         &mut reg,
@@ -56,13 +56,20 @@ fn constructor_plan_and_fold() {
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_keyexpr_intersects"),
-        ident("a"),
-        syn::parse_quote!(ZKeyExpr),
-    );
-    exp.push_subset_variant(ident("z_keyexpr_try_from"));
-    exp.push_subset_self();
+    exp.expands.push(ExpandDecl {
+        func: ident("z_keyexpr_intersects"),
+        param: ident("a"),
+        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        sel: ExpandSel::Subset(vec![
+            Variant::Ctor(ident("z_keyexpr_try_from")),
+            Variant::Identity,
+        ]),
+    });
+    // selector + try_from(String) + identity(ZKeyExpr) = 3 leaves
+    // `&ZKeyExpr` consumer ⇒ borrowed identity leaf (clone-preserving).
+    // Leaf types registered as required inputs (so the resolver builds
+    // their converters).
+    // `attachment: Option<ZZBytes>` with single `z_zbytes_from_vec(Vec<u8>)`.
 
     apply(
         &mut reg,
@@ -117,12 +124,15 @@ fn optional_byvalue_single_ctor() {
         "fn z_session_delete(s: &ZSession, attachment: Option<ZZBytes>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_session_delete"),
-        ident("attachment"),
-        syn::parse_quote!(ZZBytes),
-    );
-    exp.push_subset_variant(ident("z_zbytes_from_vec"));
+    exp.expands.push(ExpandDecl {
+        func: ident("z_session_delete"),
+        param: ident("attachment"),
+        declared_target: Some(syn::parse_quote!(ZZBytes)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_zbytes_from_vec"))]),
+    });
+    // nullable leaf wrapping the ctor param
+    // `encoding: Option<&ZEncoding>` with single, infallible
+    // `z_encoding_from_string(String) -> ZEncoding`.
 
     apply(
         &mut reg,
@@ -167,12 +177,15 @@ fn optional_byref_single_ctor() {
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_session_put"),
-        ident("encoding"),
-        syn::parse_quote!(ZEncoding),
-    );
-    exp.push_subset_variant(ident("z_encoding_from_string"));
+    exp.expands.push(ExpandDecl {
+        func: ident("z_session_put"),
+        param: ident("encoding"),
+        declared_target: Some(syn::parse_quote!(ZEncoding)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_encoding_from_string"))]),
+    });
+    // `encoding: Option<&ZEncoding>` built from a TWO-arg, infallible
+    // `z_encoding_from_id(i32, Option<String>) -> ZEncoding`: an explicit
+    // `present: bool` flag + two plain (non-`Option`-wrapped) arg leaves.
 
     apply(
         &mut reg,
@@ -210,12 +223,19 @@ fn optional_byref_multi_arg_ctor() {
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_session_put"),
-        ident("encoding"),
-        syn::parse_quote!(ZEncoding),
-    );
-    exp.push_subset_variant(ident("z_encoding_from_id"));
+    exp.expands.push(ExpandDecl {
+        func: ident("z_session_put"),
+        param: ident("encoding"),
+        declared_target: Some(syn::parse_quote!(ZEncoding)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_encoding_from_id"))]),
+    });
+    // leaf 0 = present:bool, leaf 1 = id:i32, leaf 2 = schema:Option<String>
+    // `encoding: Option<&ZEncoding>` with TWO variants — build-from
+    // `z_encoding_from_id(i32, Option<String>)` OR identity — composes the
+    // selector dispatch under `Optional`: the selector leaf also encodes
+    // absence (`-1` = `None`). The ctor's own `Option<String>` arg is a
+    // PASSTHROUGH leaf (kept as `Option<String>`, not double-wrapped —
+    // `None` is a legitimate value for the taken arm).
 
     apply(
         &mut reg,
@@ -275,13 +295,23 @@ fn optional_combined_selector_encodes_absence() {
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_session_put"),
-        ident("encoding"),
-        syn::parse_quote!(ZEncoding),
-    );
-    exp.push_subset_variant(ident("z_encoding_from_id"));
-    exp.push_subset_self();
+    exp.expands.push(ExpandDecl {
+        func: ident("z_session_put"),
+        param: ident("encoding"),
+        declared_target: Some(syn::parse_quote!(ZEncoding)),
+        sel: ExpandSel::Subset(vec![
+            Variant::Ctor(ident("z_encoding_from_id")),
+            Variant::Identity,
+        ]),
+    });
+    // leaves: sel:i32, id:Option<i32> (wrapped), schema:Option<String>
+    // (passthrough), identity:Option<&ZEncoding>.
+    // `Iterable(Construct)` is not yet produced by `apply` (no `Vec<_>`
+    // param expansion is declared), but the fold is emit-ready: a hand-built
+    // plan must produce the `into_iter().map(...).collect::<Result<Vec<_>,_>>()`
+    // form, with the inner single-arg ctor applied per element.
+    // A `.default()` ZKeyExpr constructor auto-`construct`s every matching
+    // param of every declared fn — except where `.skip_default_construct`'d.
 
     apply(
         &mut reg,
@@ -393,10 +423,15 @@ fn default_constructor_auto_applies_and_skips() {
         "fn z_session_undeclare(s: &ZSession, k: ZKeyExpr) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.ensure_default_constructor(syn::parse_quote!(ZKeyExpr));
-    exp.add_constructor_variant(ident("z_keyexpr_try_from"));
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
+        default: true,
+    });
     // Opt the undeclare's `k` out (must stay a handle).
-    exp.add_skip_default_construct(ident("z_session_undeclare"), ident("k"));
+    // Opt the undeclare's `k` out (must stay a handle).
+    exp.skip_construct
+        .insert((ident("z_session_undeclare"), ident("k")));
     let declared: std::collections::HashSet<syn::Ident> =
         ["z_keyexpr_intersects", "z_session_undeclare"]
             .iter()
@@ -441,8 +476,11 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
 
     // `.default()` skips the accessor's `ke`, constructs the consumer's a/b.
     let mut exp = Expansions::default();
-    exp.ensure_default_constructor(syn::parse_quote!(ZKeyExpr));
-    exp.add_constructor_variant(ident("z_keyexpr_try_from"));
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
+        default: true,
+    });
     apply(&mut reg, &exp, &declared, &accessor, &Default::default()).expect("apply");
     assert!(reg
         .expansion_plans
@@ -457,12 +495,12 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
         "fn z_keyexpr_clone(ke: &ZKeyExpr) -> ZKeyExpr { todo!() }",
     ]);
     let mut exp2 = Expansions::default();
-    exp2.begin_subset(
-        ident("z_keyexpr_clone"),
-        ident("ke"),
-        syn::parse_quote!(ZKeyExpr),
-    );
-    exp2.push_subset_variant(ident("z_keyexpr_try_from"));
+    exp2.expands.push(ExpandDecl {
+        func: ident("z_keyexpr_clone"),
+        param: ident("ke"),
+        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from"))]),
+    });
     let err = apply(&mut reg2, &exp2, &declared, &accessor, &Default::default()).unwrap_err();
     assert!(matches!(err, ExpandError::ConstructOnAccessor { .. }));
 }
@@ -482,13 +520,30 @@ fn recursive_input_nests_param_constructors() {
     let mut exp = Expansions::default();
     // Default inputs for ZSample (single), ZKeyExpr (combined: try_from|id),
     // ZZBytes (single).
-    exp.ensure_default_constructor(syn::parse_quote!(ZSample));
-    exp.add_constructor_variant(ident("z_sample_new"));
-    exp.ensure_default_constructor(syn::parse_quote!(ZKeyExpr));
-    exp.add_constructor_variant(ident("z_keyexpr_try_from"));
-    exp.add_constructor_variant_id();
-    exp.ensure_default_constructor(syn::parse_quote!(ZZBytes));
-    exp.add_constructor_variant(ident("z_zbytes_from_vec"));
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        variants: vec![Variant::Ctor(ident("z_sample_new"))],
+        default: true,
+    });
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        variants: vec![
+            Variant::Ctor(ident("z_keyexpr_try_from")),
+            Variant::Identity,
+        ],
+        default: true,
+    });
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZZBytes),
+        variants: vec![Variant::Ctor(ident("z_zbytes_from_vec"))],
+        default: true,
+    });
+    // Top: single z_sample_new ctor, 2 args, both recursive Build.
+    // key_expr's nested build is COMBINED (try_from | identity ⇒ selector).
+    // payload's nested build is SINGLE (no selector).
+    // Wire leaves: key-expr selector + try_from String + identity ZKeyExpr +
+    // zbytes Vec<u8> — all flattened into the one signature.
+    // A → B → A constructor cycle is a build error (not an infinite expansion).
     let declared: std::collections::HashSet<syn::Ident> =
         ["z_reply_sample"].iter().map(|s| ident(s)).collect();
     apply(
@@ -552,10 +607,19 @@ fn recursive_input_cycle_errors() {
         "fn consume_a(a: A) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.ensure_default_constructor(syn::parse_quote!(A));
-    exp.add_constructor_variant(ident("make_a"));
-    exp.ensure_default_constructor(syn::parse_quote!(B));
-    exp.add_constructor_variant(ident("make_b"));
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(A),
+        variants: vec![Variant::Ctor(ident("make_a"))],
+        default: true,
+    });
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(B),
+        variants: vec![Variant::Ctor(ident("make_b"))],
+        default: true,
+    });
+    // C5 validation map: a variant ctor ident that names no `#[prebindgen]`
+    // fn is a hard `UnknownConstructor` at resolve time — a typo'd
+    // `expand_param!(...).variant(fun!(…))` cannot silently vanish.
     let declared: std::collections::HashSet<syn::Ident> =
         ["consume_a"].iter().map(|s| ident(s)).collect();
     let err = apply(
@@ -578,12 +642,15 @@ fn unknown_constructor_errors() {
     let mut reg =
         reg_with(&["fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }"]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_keyexpr_intersects"),
-        ident("a"),
-        syn::parse_quote!(ZKeyExpr),
-    );
-    exp.push_subset_variant(ident("z_keyexpr_try_from_typo"));
+    exp.expands.push(ExpandDecl {
+        func: ident("z_keyexpr_intersects"),
+        param: ident("a"),
+        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from_typo"))]),
+    });
+    // C5 validation map: a variant ctor that exists but does not produce the
+    // expanded type is a hard `TargetMismatch` — the ctor's return is
+    // cross-checked against the parameter's type.
     let err = apply(
         &mut reg,
         &exp,
@@ -606,12 +673,12 @@ fn constructor_target_mismatch_errors() {
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
     let mut exp = Expansions::default();
-    exp.begin_subset(
-        ident("z_keyexpr_intersects"),
-        ident("a"),
-        syn::parse_quote!(ZKeyExpr),
-    );
-    exp.push_subset_variant(ident("z_sample_new"));
+    exp.expands.push(ExpandDecl {
+        func: ident("z_keyexpr_intersects"),
+        param: ident("a"),
+        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_sample_new"))]),
+    });
     let err = apply(
         &mut reg,
         &exp,
@@ -621,4 +688,73 @@ fn constructor_target_mismatch_errors() {
     )
     .unwrap_err();
     assert!(matches!(err, ExpandError::TargetMismatch { .. }), "{err}");
+}
+
+/// #96: structurally invalid declaration sets are rejected with COLLECTED
+/// diagnostics — every offender reported in one error, before any plan
+/// resolution.
+#[test]
+fn invalid_declarations_collected() {
+    use crate::api::core::types_util::ident;
+    let mut reg = reg_with(&[
+        "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
+        "fn z_session_get(s: &ZSession, k: &ZKeyExpr) -> bool { todo!() }",
+    ]);
+    let mut exp = Expansions::default();
+    // Duplicate constructor target (two records, same TypeKey).
+    for _ in 0..2 {
+        exp.constructors.push(ConstructorDecl {
+            target: syn::parse_quote!(ZKeyExpr),
+            variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
+            default: true,
+        });
+    }
+    // Empty constructor variant list.
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZEmpty),
+        variants: vec![],
+        default: true,
+    });
+    // Duplicate per-fn expand for the same (fn, param), plus an empty subset.
+    for sel in [
+        ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from"))]),
+        ExpandSel::Subset(vec![]),
+    ] {
+        exp.expands.push(ExpandDecl {
+            func: ident("z_session_get"),
+            param: ident("k"),
+            declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+            sel,
+        });
+    }
+    let err = apply(
+        &mut reg,
+        &exp,
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .unwrap_err();
+    let ExpandError::InvalidDeclarations { entries } = &err else {
+        panic!("expected InvalidDeclarations, got {err}");
+    };
+    // All four problems collected in one pass.
+    assert_eq!(entries.len(), 4, "{err}");
+    let text = err.to_string();
+    assert!(
+        text.contains("duplicate constructor declaration for `ZKeyExpr`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("constructor for `ZEmpty` declares no variants"),
+        "{text}"
+    );
+    assert!(
+        text.contains("expand for parameter `k` of `z_session_get` declares no variants"),
+        "{text}"
+    );
+    assert!(
+        text.contains("duplicate expand declaration for parameter `k` of `z_session_get`"),
+        "{text}"
+    );
 }

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -36,7 +36,7 @@ mod error;
 mod plan;
 
 pub use self::{
-    error::UnfoldError,
+    error::{UnfoldDeclError, UnfoldError},
     plan::{DeconId, DeconSpec, LeafSource, UnfoldLeaf, UnfoldPlan, UnfoldShape},
 };
 
@@ -46,12 +46,12 @@ pub use self::{
 
 /// One record (field) of a deconstructor. A deconstructor is a product: every
 /// record contributes a leaf.
-// large_enum_variant: a handful of records exist per binding, held while
-// declarations replay — boxing the syn payloads would only complicate the
-// arms (same trade-off as `ConvertSourceKind`).
+// large_enum_variant: a handful of records exist per binding — boxing the
+// syn payloads would only complicate the arms (same trade-off as
+// `ConvertSourceKind`).
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
-enum DeconRecord {
+pub enum DeconRecord {
     /// Read this field by calling the accessor function `f(&T) -> &F`. `name`
     /// is the author-supplied leaf name, used **literally** (no casing /
     /// stripping); it may not contain the reserved `"__"` chain separator.
@@ -87,21 +87,24 @@ impl DeconRecord {
     }
 }
 
+/// A type-level deconstructor declaration (`expand_return!(T).field*`): the
+/// complete, ordered record list decomposing `target`. An immutable record —
+/// the leaf order is the declaration order of the `records` vector.
 #[derive(Clone)]
-struct DeconstructorDecl {
-    target: syn::Type,
-    records: Vec<DeconRecord>,
+pub struct DeconstructorDecl {
+    pub target: syn::Type,
+    pub records: Vec<DeconRecord>,
     /// Auto-apply this deconstructor to every matching declared fn (`Some`
     /// carries the inferred `(target-position, delivery)` to use). Always
     /// `Some` for type-level default (`expand_return!`) declarations.
-    default: Option<(DeconTarget, Delivery)>,
+    pub default: Option<(DeconTarget, Delivery)>,
 }
 
 /// How an output expansion chooses the deconstructor for a function's return
 /// type: the type's default (`expand_return!`-declared) or a per-fn
 /// inline record list (`.expand_return`).
 #[derive(Clone)]
-enum DeconSel {
+pub enum DeconSel {
     /// Use the return type's unique deconstructor (error if ambiguous).
     TopLevel,
     /// Per-fn override (`.expand_return`): use exactly these
@@ -130,171 +133,73 @@ pub enum Delivery {
     Return,
 }
 
+/// A per-fn output expansion (`.expand_return(expand_return!(T)…)`) —
+/// decompose `func`'s return (or error position) via the record list.
+/// Recorded as an explicit decl so the auto-`default` skips it; an
+/// identity-only record list lowers to the raw whole-value return in
+/// [`apply`].
 #[derive(Clone)]
-struct OutputDecl {
-    func: syn::Ident,
-    sel: DeconSel,
-    target: DeconTarget,
-    delivery: Delivery,
+pub struct OutputDecl {
+    pub func: syn::Ident,
+    pub sel: DeconSel,
+    pub target: DeconTarget,
+    pub delivery: Delivery,
     /// The type the per-fn decl was declared for (`expand_return!(T)`) —
     /// cross-checked against the fn's peeled return type in [`apply`].
     /// `None` for internally-synthesized decls (the type comes from the
     /// return itself).
-    declared_source: Option<syn::Type>,
+    pub declared_source: Option<syn::Type>,
 }
 
-/// Deconstructor / converter / output-expansion declarations gathered from a
-/// language builder. Embedded in each adapter that supports output expansion
-/// and handed to [`apply`] via
-/// [`crate::api::core::prebindgen::Prebindgen::deconstructors`].
+/// Deconstructor / output-expansion declarations gathered from a language
+/// builder — an immutable record set: complete values, no build protocol.
+/// Declaration order is the vector order; leaf order is each record
+/// vector's order. Handed to [`apply`] via
+/// [`crate::api::core::prebindgen::Prebindgen::deconstructors`]; empty or
+/// duplicate declarations are diagnosed there (collected), not at
+/// construction.
 #[derive(Clone, Default)]
 pub struct Deconstructors {
-    deconstructors: Vec<DeconstructorDecl>,
-    outputs: Vec<OutputDecl>,
-    /// Cursor for the type-level default builder (`expand_return!` →
-    /// `.field`/`.field_self`).
-    cur_deconstructor: Option<usize>,
-    /// Cursor for an in-progress per-fn inline output override
-    /// (`.expand_return`): index into
-    /// [`Self::outputs`].
-    cur_output: Option<usize>,
+    pub deconstructors: Vec<DeconstructorDecl>,
+    pub outputs: Vec<OutputDecl>,
     /// Identity-only per-fn field-set opt-outs: fns excluded from the
-    /// default auto-apply.
-    skip_output: std::collections::HashSet<syn::Ident>,
-}
-
-impl Deconstructors {
-    /// Find-or-create the default (always-`default`) deconstructor for `target`
-    /// and set the cursor to it. Idempotent across a `.field*` chain.
-    /// Delivery is derived from leaf count at emit time (1 ⇒ return, N ⇒ callback),
-    /// so the stored `Delivery` is just a marker.
-    pub fn ensure_default_deconstructor(&mut self, target: syn::Type) {
-        let key = TypeKey::from_type(&target);
-        // Already building a deconstructor of this type — keep the cursor so
-        // records append to it.
-        if let Some(i) = self.cur_deconstructor {
-            if TypeKey::from_type(&self.deconstructors[i].target) == key {
-                return;
-            }
-        }
-        if let Some(i) = self
-            .deconstructors
-            .iter()
-            .position(|d| TypeKey::from_type(&d.target) == key)
-        {
-            self.cur_deconstructor = Some(i);
-        } else {
-            self.deconstructors.push(DeconstructorDecl {
-                target,
-                records: Vec::new(),
-                default: Some((DeconTarget::Output, Delivery::Callback)),
-            });
-            self.cur_deconstructor = Some(self.deconstructors.len() - 1);
-        }
-    }
-
-    /// Exclude `func` from output-position default auto-apply — the lowered
-    /// form of an identity-only per-fn field set (the raw whole-value return).
-    pub fn add_skip_default_output(&mut self, func: syn::Ident) {
-        self.skip_output.insert(func);
-    }
-
-    /// `expand_return!` `.field(fun)` — add an accessor-function
-    /// record with the resolved (literal) leaf `name`.
-    pub fn add_deconstructor_record(&mut self, func: syn::Ident, name: impl Into<String>) {
-        let i = self
-            .cur_deconstructor
-            .expect(".field called without a current deconstructor");
-        self.deconstructors[i].records.push(DeconRecord::Acc {
-            func,
-            name: name.into(),
-        });
-    }
-
-    /// `expand_return!` `.field_self()` — add the identity record
-    /// (the value itself).
-    pub fn add_deconstructor_record_id(&mut self) {
-        let i = self
-            .cur_deconstructor
-            .expect(".field_self called without a current deconstructor");
-        self.deconstructors[i].records.push(DeconRecord::Identity);
-    }
-
-    /// `expand_return!` `.field(field!(name).with(ty, path))` — add a
-    /// **binding-local** accessor record (stated return type + callable).
-    pub fn add_deconstructor_record_local(&mut self, path: syn::Path, name: impl Into<String>) {
-        let i = self
-            .cur_deconstructor
-            .expect(".field called without a current deconstructor");
-        self.deconstructors[i].records.push(DeconRecord::LocalAcc {
-            path,
-            name: name.into(),
-        });
-    }
-
-    /// Begin a per-fn inline output override (`.expand_return(expand_return!(T)…)`):
-    /// decompose `func`'s return via an incrementally-built record list
-    /// (accessor fields via [`Self::push_inline_field`] and/or the identity/self
-    /// field via [`Self::push_inline_field_self`]). `declared_source` is the
-    /// decl's `T`, cross-checked against the fn's peeled return type in
-    /// [`apply`]. Recorded as an explicit decl so the auto-`default` skips it,
-    /// and leaves the output cursor on it. An identity-only field list lowers
-    /// to the raw whole-value return in [`apply`].
-    pub fn begin_inline_output(&mut self, func: syn::Ident, declared_source: syn::Type) {
-        self.outputs.push(OutputDecl {
-            func,
-            sel: DeconSel::Inline(Vec::new()),
-            target: DeconTarget::Output,
-            delivery: Delivery::Callback,
-            declared_source: Some(declared_source),
-        });
-        self.cur_deconstructor = None;
-        self.cur_output = Some(self.outputs.len() - 1);
-    }
-
-    /// `.expand_return` `.field(fun)` — append an
-    /// accessor-function field (named `name`) to the current per-fn inline output.
-    pub fn push_inline_field(&mut self, func: syn::Ident, name: impl Into<String>) {
-        let i = self
-            .cur_output
-            .expect(".field called without a current deconstructor");
-        if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
-            records.push(DeconRecord::Acc {
-                func,
-                name: name.into(),
-            });
-        }
-    }
-
-    /// `.expand_return` `.field_self()` — append the identity
-    /// (the handle itself) field to the current per-fn inline output.
-    pub fn push_inline_field_self(&mut self) {
-        let i = self
-            .cur_output
-            .expect(".field_self called without a current deconstructor");
-        if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
-            records.push(DeconRecord::Identity);
-        }
-    }
-
-    /// `.expand_return` `.field(field!(name).with(ty, path))` — append a
-    /// **binding-local** accessor field to the current per-fn inline output.
-    pub fn push_inline_field_local(&mut self, path: syn::Path, name: impl Into<String>) {
-        let i = self
-            .cur_output
-            .expect(".field called without a current deconstructor");
-        if let DeconSel::Inline(records) = &mut self.outputs[i].sel {
-            records.push(DeconRecord::LocalAcc {
-                path,
-                name: name.into(),
-            });
-        }
-    }
+    /// default auto-apply (the raw whole-value return).
+    pub skip_output: std::collections::HashSet<syn::Ident>,
 }
 
 // ──────────────────────────────────────────────────────────────────────
 // apply
 // ──────────────────────────────────────────────────────────────────────
+
+/// Structural validation of the declaration records — duplicate targets,
+/// collected (EVERY offender before failing) so a build surfaces all
+/// declaration problems at once. Empty record lists are NOT diagnosed:
+/// an empty inline list is the valid whole-element delivery form.
+fn validate_declarations(acc: &Deconstructors) -> Result<(), UnfoldError> {
+    let mut entries: Vec<UnfoldDeclError> = Vec::new();
+    let mut decon_targets: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for d in &acc.deconstructors {
+        let target = TypeKey::from_type(&d.target).as_str().to_string();
+        if !decon_targets.insert(target.clone()) {
+            entries.push(UnfoldDeclError::DuplicateDeconstructor { target });
+        }
+    }
+    let mut output_keys: std::collections::HashSet<(String, DeconTarget)> =
+        std::collections::HashSet::new();
+    for od in &acc.outputs {
+        if !output_keys.insert((od.func.to_string(), od.target)) {
+            entries.push(UnfoldDeclError::DuplicateOutput {
+                func: od.func.clone(),
+                target: od.target,
+            });
+        }
+    }
+    if entries.is_empty() {
+        Ok(())
+    } else {
+        Err(UnfoldError::InvalidDeclarations { entries })
+    }
+}
 
 /// Resolve every output-expansion declaration (explicit + `.default()`
 /// auto-applied) into an [`UnfoldPlan`], register each leaf's `out_ty` as a
@@ -314,6 +219,7 @@ pub fn apply<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
+    validate_declarations(acc)?;
     // Binding-local accessors (`LocalAcc` records) resolve through registry
     // entries synthesized by the adapter's `local_functions()` pre-pass in
     // `Registry::resolve` — by this point they read exactly like

--- a/prebindgen/src/api/core/unfold/error.rs
+++ b/prebindgen/src/api/core/unfold/error.rs
@@ -64,6 +64,41 @@ pub enum UnfoldError {
         declared: String,
         actual: String,
     },
+    /// Structurally invalid declaration records — empty record lists or
+    /// duplicate targets. All offenders are collected before failing
+    /// (mirrors `ScanError::DeclaredNotFound`).
+    InvalidDeclarations {
+        entries: Vec<UnfoldDeclError>,
+    },
+}
+
+/// One structurally invalid output-expansion declaration (see
+/// [`UnfoldError::InvalidDeclarations`]). Note that EMPTY record lists are
+/// deliberately not diagnosed here — an empty inline list is the valid
+/// whole-element (`Vec<T>` per-element) delivery form.
+#[derive(Debug)]
+pub enum UnfoldDeclError {
+    /// Two deconstructor declarations for the same target type.
+    DuplicateDeconstructor { target: String },
+    /// Two per-fn output expansions for the same fn and position.
+    DuplicateOutput {
+        func: syn::Ident,
+        target: super::DeconTarget,
+    },
+}
+
+impl std::fmt::Display for UnfoldDeclError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnfoldDeclError::DuplicateDeconstructor { target } => {
+                write!(f, "duplicate deconstructor declaration for `{target}`")
+            }
+            UnfoldDeclError::DuplicateOutput { func, target } => write!(
+                f,
+                "duplicate output expansion for `{func}` ({target:?} position)"
+            ),
+        }
+    }
 }
 
 impl std::fmt::Display for UnfoldError {
@@ -150,6 +185,13 @@ impl std::fmt::Display for UnfoldError {
                  non-compiling Rust. Declare the `_self` field last.",
                 target
             ),
+            UnfoldError::InvalidDeclarations { entries } => {
+                writeln!(f, "output expansion: invalid declarations:")?;
+                for e in entries {
+                    writeln!(f, "  - {e}")?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -57,8 +57,16 @@ fn accessor_optional_primitive() {
         "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZTimestamp));
-    acc.add_deconstructor_record(ident("z_timestamp_ntp64"), "z_timestamp_ntp64");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZTimestamp),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_timestamp_ntp64"),
+            name: "z_timestamp_ntp64".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // `z_sample_key_expr(&ZSample) -> &ZKeyExpr` decomposed into the keyexpr
+    // handle (identity) + its string form (`z_keyexpr_as_str`).
 
     apply(
         &mut reg,
@@ -96,9 +104,24 @@ fn accessor_plan_byref() {
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // Identity leaf: out_ty `&ZKeyExpr`, empty path, emitted last.
+    // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
+    // Leaf out_tys registered as required outputs so the resolver builds
+    // their converters.
+    // Owned return: the root `.field_self()` MOVES the value, a nested
+    // identity (spliced ZKeyExpr handle) borrows it — id-first is the
+    // order that would generate non-compiling Rust, caught at apply time.
 
     apply(
         &mut reg,
@@ -149,11 +172,23 @@ fn root_identity_before_nested_identity_errors() {
     let accessors: std::collections::HashSet<syn::Ident> =
         ["z_query_key_expr"].iter().map(|s| ident(s)).collect();
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZQuery));
-    acc.add_deconstructor_record_id(); // root identity FIRST — wrong
-    acc.add_deconstructor_record(ident("z_query_key_expr"), "key_expr");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![DeconRecord::Identity],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZQuery),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_query_key_expr"),
+                name: "key_expr".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // root identity FIRST — wrong
     let err = apply(
         &mut reg,
         &acc,
@@ -169,11 +204,22 @@ fn root_identity_before_nested_identity_errors() {
         "fn z_query_key_expr(q: &ZQuery) -> &ZKeyExpr { todo!() }",
     ]);
     let mut acc2 = Deconstructors::default();
-    acc2.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc2.add_deconstructor_record_id();
-    acc2.ensure_default_deconstructor(syn::parse_quote!(ZQuery));
-    acc2.add_deconstructor_record(ident("z_query_key_expr"), "key_expr");
-    acc2.add_deconstructor_record_id(); // root identity last — ok
+    acc2.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![DeconRecord::Identity],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc2.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZQuery),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_query_key_expr"),
+                name: "key_expr".into(),
+            },
+            DeconRecord::Identity,
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    }); // root identity last — ok
     apply(
         &mut reg2,
         &acc2,
@@ -191,8 +237,14 @@ fn accessor_target_mismatch_errors() {
         "fn wrong(x: &ZSample) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record(ident("wrong"), "wrong");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![DeconRecord::Acc {
+            func: ident("wrong"),
+            name: "wrong".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
     let err = apply(
         &mut reg,
         &acc,
@@ -207,9 +259,12 @@ fn accessor_target_mismatch_errors() {
 fn multiple_identity_errors() {
     let mut reg = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record_id();
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![DeconRecord::Identity, DeconRecord::Identity],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // A deconstructor record referencing a non-`.fun_accessor` fn errors.
     let err = apply(
         &mut reg,
         &acc,
@@ -228,9 +283,21 @@ fn record_must_be_fun_accessor() {
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // Empty accessor set ⇒ z_keyexpr_as_str is not a fun_accessor ⇒ error.
+    // With it declared as an accessor, the gate passes.
+    // Two records of one deconstructor given the same literal name ⇒ hard
+    // error (names are emitted verbatim; never auto-disambiguated).
     // Empty accessor set ⇒ z_keyexpr_as_str is not a fun_accessor ⇒ error.
     let err = apply(
         &mut reg,
@@ -256,9 +323,21 @@ fn duplicate_leaf_name_errors() {
         "fn z_sample_payload(s: &ZSample) -> Vec<u8> { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_key_expr"), "field");
-    acc.add_deconstructor_record(ident("z_sample_payload"), "field");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_sample_key_expr"),
+                name: "field".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_payload"),
+                name: "field".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // A record name containing the reserved `"__"` chain separator ⇒ error.
     let err = apply(
         &mut reg,
         &acc,
@@ -280,8 +359,19 @@ fn reserved_separator_in_name_errors() {
         "fn z_sample_key_expr(s: &ZSample) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_key_expr"), "key__expr");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_sample_key_expr"),
+            name: "key__expr".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // M3: `z_reply_sample -> Option<&ZSample>` whose ZSample combined
+    // accessor nests ZKeyExpr (handle+string), ZZBytes (bytes), and a
+    // nullable ZTimestamp (Option<&ZTimestamp> → ntp64), plus a direct enum
+    // leaf. Verifies path prefixes + nullable propagation.
+    // Child accessors (reused via nesting).
     let err = apply(
         &mut reg,
         &acc,
@@ -313,19 +403,68 @@ fn nested_accessor_flatten() {
     ]);
     let mut acc = Deconstructors::default();
     // Child accessors (reused via nesting).
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZZBytes));
-    acc.add_deconstructor_record(ident("z_zbytes_to_bytes"), "z_zbytes_to_bytes");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZTimestamp));
-    acc.add_deconstructor_record(ident("z_timestamp_ntp64"), "z_timestamp_ntp64");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZZBytes),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_zbytes_to_bytes"),
+            name: "z_zbytes_to_bytes".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZTimestamp),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_timestamp_ntp64"),
+            name: "z_timestamp_ntp64".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
     // Parent accessor with nested + direct records.
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_key_expr"), "z_sample_key_expr");
-    acc.add_deconstructor_record(ident("z_sample_payload"), "z_sample_payload");
-    acc.add_deconstructor_record(ident("z_sample_kind"), "z_sample_kind");
-    acc.add_deconstructor_record(ident("z_sample_timestamp"), "z_sample_timestamp");
+    // Parent accessor with nested + direct records.
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_sample_key_expr"),
+                name: "z_sample_key_expr".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_payload"),
+                name: "z_sample_payload".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_kind"),
+                name: "z_sample_kind".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_timestamp"),
+                name: "z_sample_timestamp".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // keyexpr identity (path [z_sample_key_expr]) + string + payload bytes
+    // + kind enum + nullable timestamp ntp64.
+    // Only the timestamp leaf (Option nesting accessor) is nullable.
+    // ZReply-shaped product (Result<Sample, ReplyError> decomposed in the
+    // current product model): the root's records include two
+    // `Option<&Child>` nesting accessors (`z_reply_sample`, `z_reply_err`)
+    // whose children themselves contain `Option` nesting steps and a
+    // nested identity — the double-unwrap case — plus an
+    // `Option<ZZenohId>` Acc record with NO default child, which keeps
+    // the full `Option<…>` as its leaf `out_ty` (its own `Option` is the
+    // converter's business, not a nesting step ⇒ NOT nullable).
 
     apply(
         &mut reg,
@@ -394,23 +533,83 @@ fn reply_product_double_option_flatten() {
         "fn z_zbytes_to_bytes(z: &ZZBytes) -> Vec<u8> { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZTimestamp));
-    acc.add_deconstructor_record(ident("z_timestamp_ntp64"), "z_timestamp_ntp64");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZZBytes));
-    acc.add_deconstructor_record(ident("z_zbytes_to_bytes"), "z_zbytes_to_bytes");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_key_expr"), "z_sample_key_expr");
-    acc.add_deconstructor_record(ident("z_sample_timestamp"), "z_sample_timestamp");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZReplyError));
-    acc.add_deconstructor_record(ident("z_reply_error_payload"), "z_reply_error_payload");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZReply));
-    acc.add_deconstructor_record(ident("z_reply_replier_zid"), "z_reply_replier_zid");
-    acc.add_deconstructor_record(ident("z_reply_is_ok"), "z_reply_is_ok");
-    acc.add_deconstructor_record(ident("z_reply_sample"), "z_reply_sample");
-    acc.add_deconstructor_record(ident("z_reply_err"), "z_reply_err");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZTimestamp),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_timestamp_ntp64"),
+            name: "z_timestamp_ntp64".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZZBytes),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_zbytes_to_bytes"),
+            name: "z_zbytes_to_bytes".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_sample_key_expr"),
+                name: "z_sample_key_expr".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_timestamp"),
+                name: "z_sample_timestamp".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZReplyError),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_reply_error_payload"),
+            name: "z_reply_error_payload".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZReply),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_reply_replier_zid"),
+                name: "z_reply_replier_zid".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_reply_is_ok"),
+                name: "z_reply_is_ok".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_reply_sample"),
+                name: "z_reply_sample".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_reply_err"),
+                name: "z_reply_err".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // Acc leaf keeping its full `Option<…>` return — not a nesting step.
+    // Ok-arm leaves: spliced through the `Option`-returning
+    // `z_reply_sample` ⇒ all nullable, incl. the nested keyexpr identity
+    // and the doubly-`Option` timestamp path.
+    // Err-arm leaf: spliced through `z_reply_err`.
+    // A → B → A nesting is rejected.
 
     apply(
         &mut reg,
@@ -475,10 +674,26 @@ fn nested_cycle_errors() {
         "fn b_to_a(b: &ZB) -> &ZA { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZA));
-    acc.add_deconstructor_record(ident("a_to_b"), "a_to_b");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZB));
-    acc.add_deconstructor_record(ident("b_to_a"), "b_to_a");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZA),
+        records: vec![DeconRecord::Acc {
+            func: ident("a_to_b"),
+            name: "a_to_b".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZB),
+        records: vec![DeconRecord::Acc {
+            func: ident("b_to_a"),
+            name: "b_to_a".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // M4: `z_session_peers_zid(&ZSession) -> Vec<ZZenohId>` → Iterable;
+    // each element delivered WHOLE (no accessor, no leaves): a per-fn
+    // flatten with an empty record list on an element type that has no
+    // deconstructor of its own.
     let err = apply(
         &mut reg,
         &acc,
@@ -497,7 +712,17 @@ fn iterable_whole_element_plan() {
     // deconstructor of its own.
     let mut reg = reg_with(&["fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }"]);
     let mut acc = Deconstructors::default();
-    acc.begin_inline_output(ident("z_session_peers_zid"), syn::parse_quote!(ZZenohId));
+    acc.outputs.push(OutputDecl {
+        func: ident("z_session_peers_zid"),
+        sel: DeconSel::Inline(vec![]),
+        target: DeconTarget::Output,
+        delivery: Delivery::Callback,
+        declared_source: Some(syn::parse_quote!(ZZenohId)),
+    });
+    // M5: `z_session_peers_zid -> Vec<ZZenohId>` with a ZZenohId combined
+    // accessor → Iterable with per-element leaves: the string form + the
+    // value itself via `record_id` (a `value_blob` identity, owned at the
+    // root since `Vec<ZZenohId>` owns its elements).
 
     apply(
         &mut reg,
@@ -541,9 +766,22 @@ fn iterable_decomposed_plan() {
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZZenohId));
-    acc.add_deconstructor_record(ident("z_zenoh_id_to_string"), "z_zenoh_id_to_string");
-    acc.add_deconstructor_record_id();
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZZenohId),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_zenoh_id_to_string"),
+                name: "z_zenoh_id_to_string".into(),
+            },
+            DeconRecord::Identity,
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // Identity leaf: owned value (`ZZenohId`, not `&ZZenohId`) since the Vec
+    // owns its elements (by_ref = false).
+    // `.converter(ZTimestamp, z_timestamp_ntp64)` + `.convert_output()` on
+    // `z_sample_timestamp -> Option<&ZTimestamp>` ⇒ Return delivery, single
+    // leaf, convert_out_ty = Option<i64>.
 
     apply(
         &mut reg,
@@ -584,8 +822,16 @@ fn convert_output_single_value() {
         "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZTimestamp));
-    acc.add_deconstructor_record(ident("z_timestamp_ntp64"), "z_timestamp_ntp64");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZTimestamp),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_timestamp_ntp64"),
+            name: "z_timestamp_ntp64".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // The shaped convert type is registered as a required output.
+    // A two-record deconstructor (handle + string) ⇒ Callback delivery (>1 leaf).
 
     apply(
         &mut reg,
@@ -621,9 +867,18 @@ fn multi_leaf_output_is_callback() {
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // A `Vec` return ⇒ Iterable + Callback (a fold), never a single Return.
     apply(
         &mut reg,
         &acc,
@@ -648,8 +903,28 @@ fn vec_output_is_iterable_callback() {
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZZenohId));
-    acc.add_deconstructor_record(ident("z_zenoh_id_to_string"), "z_zenoh_id_to_string");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZZenohId),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_zenoh_id_to_string"),
+            name: "z_zenoh_id_to_string".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // A by-value `data_class` returned as `Option<Vec<T>>` (perftest's
+    // `storage_get_vec` contract) synthesizes a FIXED-BUILDER fold wrapped in
+    // an Optional layer: the field leaves cross raw per element and the
+    // foreign folder rebuilds + appends them (no Java object is built on the
+    // Rust side); `None` ⇒ a null list. Closes the data_class→Vec milestone.
+    // An `impl Fn(&[data_class])` callback arg (perftest's
+    // `storage_callback_vec`) synthesizes an Iterable fixed-folder
+    // `callback_arg_plans` entry keyed by the `&[Payload]` arg: the
+    // trampoline folds each element's field leaves into a foreign list, the
+    // user callback still sees the whole `List<Payload>`.
+    // A scalar `&Payload` callback arg must stay a Base fixed builder.
+    // The ZError deconstructor (`z_error_message`) auto-applies to every fn
+    // returning `Result<_, ZError>`, storing the plan in `error_plans`. Error
+    // delivery is always Callback (its leaves are the `ze` callback args).
     apply(
         &mut reg,
         &acc,
@@ -791,8 +1066,20 @@ fn convert_error_decomposes_result_e() {
         "fn z_infallible(s: &ZSample) -> bool { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZError));
-    acc.add_deconstructor_record(ident("z_error_message"), "z_error_message");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZError),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_error_message"),
+            name: "z_error_message".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // The infallible fn gets no error plan.
+    // No output plans created (no ZKeyExpr return among the declared fns; the
+    // ZError deconstructor only matches the Result error position).
+    // Default-everywhere: the ZKeyExpr deconstructor auto-applies to BOTH a
+    // `&ZKeyExpr` (borrow) and an owned `ZKeyExpr` return. (`Result<…>` returns
+    // are excluded — they keep a handle — and `fun_accessor`s are skipped.)
     let declared: std::collections::HashSet<syn::Ident> = ["z_keyexpr_try_from", "z_infallible"]
         .iter()
         .map(|s| ident(s))
@@ -830,9 +1117,21 @@ fn default_output_applies_to_owned_and_borrow_returns() {
         "fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // Only the record fn is an accessor; the two return fns are plain.
+    // An `impl Fn(ZSample)` parameter of a declared fn gets a type-level
+    // plan from ZSample's default deconstructor — same leaves a return of
+    // ZSample would produce, but owned (`by_ref = false`).
     // Only the record fn is an accessor; the two return fns are plain.
     let accset: std::collections::HashSet<syn::Ident> =
         ["z_keyexpr_as_str"].iter().map(|s| ident(s)).collect();
@@ -864,12 +1163,38 @@ fn callback_arg_plan_derived() {
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_key_expr"), "z_sample_key_expr");
-    acc.add_deconstructor_record(ident("z_sample_kind"), "z_sample_kind");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_sample_key_expr"),
+                name: "z_sample_key_expr".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_kind"),
+                name: "z_sample_kind".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // Nested keyexpr identity (borrowed: non-root) + string + direct enum.
+    // Leaf out_tys registered so the resolver builds their converters.
+    // No return-position plan was created for the declaring fn.
+    // A BORROWED `impl Fn(&ZSample)` decomposes through the same default
+    // deconstructor as the by-value case, but with `by_ref = true` (leaves
+    // read through the reference) and keyed under the actual `&ZSample` arg
+    // type — so `callback_input`/`callback_iface_spec` find it.
     let declared: std::collections::HashSet<syn::Ident> =
         ["z_declare_sub"].iter().map(|s| ident(s)).collect();
     apply(&mut reg, &acc, &declared, &acc_set()).expect("apply");
@@ -922,12 +1247,35 @@ fn callback_arg_borrowed_decomposed() {
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record_id();
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str"), "z_keyexpr_as_str");
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_key_expr"), "z_sample_key_expr");
-    acc.add_deconstructor_record(ident("z_sample_kind"), "z_sample_kind");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "z_keyexpr_as_str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_sample_key_expr"),
+                name: "z_sample_key_expr".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_kind"),
+                name: "z_sample_kind".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // No plan under the bare `ZSample` key — only under the borrowed arg type.
+    // No deconstructor for ZQuery ⇒ no plan: the arg is delivered whole.
+    // `impl Fn(Vec<ZSample>)`: the arg type key (`Vec<ZSample>`) matches no
+    // deconstructor target ⇒ whole-value fallback, no plan.
     let declared: std::collections::HashSet<syn::Ident> =
         ["z_declare_sub"].iter().map(|s| ident(s)).collect();
     apply(&mut reg, &acc, &declared, &acc_set()).expect("apply");
@@ -986,8 +1334,29 @@ fn callback_arg_nonbare_skipped() {
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
     ]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZSample));
-    acc.add_deconstructor_record(ident("z_sample_kind"), "z_sample_kind");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZSample),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_sample_kind"),
+            name: "z_sample_kind".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    // `Vec<String>` / `Option<Vec<ZenohId>>` returns and an `impl Fn(&[String])`
+    // callback arg synthesize FIXED **whole-element** folds (no decon, element
+    // set, no leaves) — the single-leaf dual of the `data_class` Vec fold.
+    // `Vec<String>` return ⇒ Iterable(Base), whole element.
+    // `Option<Vec<ZenohId>>` ⇒ Optional(Iterable(Base)).
+    // `impl Fn(&[String])` callback arg ⇒ Iterable fold keyed by `&[String]`.
+    // An un-nominated element is left on the ArrayList path (no plan); a fn
+    // that already has a plan is never overwritten.
+    // Pre-seed `strings` with a sentinel plan to prove it is preserved.
+    // C5 validation map: a field accessor ident that names no `#[prebindgen]`
+    // fn is a hard `UnknownAccessor` at resolve time — a typo'd
+    // `expand_return!(...).field(fun!(…))` cannot silently vanish. (At the
+    // jnigen level a registry-absent fn is caught even earlier, by the scan's
+    // `DeclaredNotFound` on the helper channel; this is the core-tier guard
+    // that stands on its own for any adapter.)
     let declared: std::collections::HashSet<syn::Ident> =
         ["z_batched"].iter().map(|s| ident(s)).collect();
     apply(&mut reg, &acc, &declared, &acc_set()).expect("apply");
@@ -1099,8 +1468,14 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
 fn unknown_accessor_errors() {
     let mut reg = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
-    acc.ensure_default_deconstructor(syn::parse_quote!(ZKeyExpr));
-    acc.add_deconstructor_record(ident("z_keyexpr_as_str_typo"), "as_str");
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_keyexpr_as_str_typo"),
+            name: "as_str".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
     let err = apply(
         &mut reg,
         &acc,
@@ -1109,4 +1484,54 @@ fn unknown_accessor_errors() {
     )
     .unwrap_err();
     assert!(matches!(err, UnfoldError::UnknownAccessor(_)), "{err}");
+}
+
+/// #96: duplicate declaration records are rejected with COLLECTED
+/// diagnostics — every offender reported in one error. (Empty record lists
+/// are NOT diagnosed: an empty inline list is the valid whole-element
+/// delivery form.)
+#[test]
+fn duplicate_declarations_collected() {
+    let mut reg = reg_with(&[
+        "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
+        "fn z_session_key(s: &ZSession) -> ZKeyExpr { todo!() }",
+    ]);
+    let mut acc = Deconstructors::default();
+    for _ in 0..2 {
+        acc.deconstructors.push(DeconstructorDecl {
+            target: syn::parse_quote!(ZKeyExpr),
+            records: vec![DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "asStr".into(),
+            }],
+            default: Some((DeconTarget::Output, Delivery::Callback)),
+        });
+        acc.outputs.push(OutputDecl {
+            func: ident("z_session_key"),
+            sel: DeconSel::Inline(vec![DeconRecord::Identity]),
+            target: DeconTarget::Output,
+            delivery: Delivery::Callback,
+            declared_source: Some(syn::parse_quote!(ZKeyExpr)),
+        });
+    }
+    let err = apply(
+        &mut reg,
+        &acc,
+        &[ident("z_session_key")].into_iter().collect(),
+        &acc_set(),
+    )
+    .unwrap_err();
+    let UnfoldError::InvalidDeclarations { entries } = &err else {
+        panic!("expected InvalidDeclarations, got {err}");
+    };
+    assert_eq!(entries.len(), 2, "{err}");
+    let text = err.to_string();
+    assert!(
+        text.contains("duplicate deconstructor declaration for `ZKeyExpr`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("duplicate output expansion for `z_session_key`"),
+        "{text}"
+    );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -84,8 +84,6 @@ impl JniGen {
             ],
             emit_handle_locks: true,
             jni_native_init: None,
-            expansions: crate::api::core::expand::Expansions::default(),
-            deconstructors: crate::api::core::unfold::Deconstructors::default(),
             convert_decls: Vec::new(),
             param_expand_decls: Vec::new(),
             return_expand_decls: Vec::new(),
@@ -434,10 +432,9 @@ impl JniGen {
             let rust_ident = decl.rust_ident.clone();
             let kotlin_name_override = decl.kotlin_name_override.clone();
             self.accept_fn_expands(decl);
-            if kind == MemberKind::Constructor {
-                self.deconstructors
-                    .add_skip_default_output(rust_ident.clone());
-            }
+            // A constructor member's return is a factory, never
+            // output-flattened — derived from `class_members` in
+            // `build_deconstructors` (`skip_output`), not stored separately.
             self.class_members
                 .entry(key.clone())
                 .or_default()
@@ -601,14 +598,20 @@ impl JniGen {
         self.types.get(key).is_some_and(|c| c.class_decl)
     }
 
-    /// Assemble the full [`Expansions`] set at the point of use: the eagerly
-    /// accumulated per-fn overrides plus the raw type-level
-    /// [`ExpandParamDecl`]s. Building on demand keeps declarations
+    /// Lower the raw [`ExpandParamDecl`]s into the core's immutable
+    /// [`Expansions`] record set at the point of use — a pure declaration →
+    /// record mapping. Building on demand keeps declarations
     /// order-independent — a `param_expand` may precede or follow the
     /// `package` that declares its constructors (which is also why the
     /// rust-side-only `_self` check lives here and not at accept time).
+    /// Duplicate targets pass through unmerged; core `apply` diagnoses them.
     pub(crate) fn build_expansions(&self) -> crate::api::core::expand::Expansions {
-        let mut exp = self.expansions.clone();
+        use crate::api::core::expand::{ExpandDecl, ExpandSel, Expansions, Variant};
+        let lower = |v: &LocalVariant| match v {
+            LocalVariant::Ctor(f) => Variant::Ctor(f.clone()),
+            LocalVariant::SelfIdentity => Variant::Identity,
+        };
+        let mut exp = Expansions::default();
         for decl in &self.param_expand_decls {
             assert!(
                 self.is_class_declared(&decl.key)
@@ -628,13 +631,12 @@ impl JniGen {
             if matches!(decl.variants.as_slice(), [LocalVariant::SelfIdentity]) {
                 continue;
             }
-            exp.ensure_default_constructor(decl.key.to_type());
-            for v in &decl.variants {
-                match v {
-                    LocalVariant::Ctor(f) => exp.add_constructor_variant(f.clone()),
-                    LocalVariant::SelfIdentity => exp.add_constructor_variant_id(),
-                }
-            }
+            exp.constructors
+                .push(crate::api::core::expand::ConstructorDecl {
+                    target: decl.key.to_type(),
+                    variants: decl.variants.iter().map(lower).collect(),
+                    default: true,
+                });
         }
         // Per-fn overrides: same decl shape, complete-set semantics; the
         // param-name/type cross-check and the identity-only lowering happen
@@ -651,26 +653,78 @@ impl JniGen {
                  .variant_self() (the type is rust-side-only) or declare the type in a package",
                 k = decl.key.as_str()
             );
-            let param_ident = syn::Ident::new(param, Span::call_site());
-            exp.begin_subset(func.clone(), param_ident, decl.key.to_type());
-            for v in &decl.variants {
-                match v {
-                    LocalVariant::Ctor(f) => exp.push_subset_variant(f.clone()),
-                    LocalVariant::SelfIdentity => exp.push_subset_self(),
-                }
-            }
+            exp.expands.push(ExpandDecl {
+                func: func.clone(),
+                param: syn::Ident::new(param, Span::call_site()),
+                declared_target: Some(decl.key.to_type()),
+                sel: ExpandSel::Subset(decl.variants.iter().map(lower).collect()),
+            });
         }
         exp
     }
 
-    /// Assemble the full [`Deconstructors`] set at the point of use — the
-    /// output-side peer of [`Self::build_expansions`]. Field names resolve
-    /// here, against the complete declaration set: explicit `.name()` first,
-    /// then the class member's Kotlin name (a getter that is both a method
-    /// and a field is named once, on the member), else the camel-cased Rust
-    /// name.
+    /// Lower one raw [`LocalField`] list into core [`DeconRecord`]s with the
+    /// UNIFORM field-name precedence resolved against the complete
+    /// declaration set: explicit `.name()` first, then the class member's
+    /// Kotlin name (a getter that is both a method and a field is named
+    /// once, on the member), else the camel-cased Rust name.
+    fn lower_fields(
+        &self,
+        key: &TypeKey,
+        fields: &[LocalField],
+    ) -> Vec<crate::api::core::unfold::DeconRecord> {
+        use crate::api::core::unfold::DeconRecord;
+        fields
+            .iter()
+            .map(|f| match f {
+                LocalField::Named(func, name_override) => {
+                    let name = name_override
+                        .clone()
+                        .or_else(|| self.class_method_kotlin_name(key, func))
+                        .unwrap_or_else(|| snake_to_camel(&func.to_string()));
+                    DeconRecord::Acc {
+                        func: func.clone(),
+                        name,
+                    }
+                }
+                LocalField::SelfField => DeconRecord::Identity,
+                LocalField::Local {
+                    path,
+                    sig,
+                    name_override,
+                } => {
+                    let name = self.local_field_name(key, path, name_override);
+                    self.check_local_field_ty(key, &name, sig);
+                    DeconRecord::LocalAcc {
+                        path: path.clone(),
+                        name,
+                    }
+                }
+            })
+            .collect()
+    }
+
+    /// Lower the raw [`ExpandReturnDecl`]s into the core's immutable
+    /// [`Deconstructors`] record set — the output-side peer of
+    /// [`Self::build_expansions`], a pure declaration → record mapping.
+    /// Duplicate targets pass through unmerged; core `apply` diagnoses
+    /// them. `skip_output` is derived from the class members: a
+    /// `.constructor()` member's return is a factory, never
+    /// output-flattened.
     pub(crate) fn build_deconstructors(&self) -> crate::api::core::unfold::Deconstructors {
-        let mut dec = self.deconstructors.clone();
+        use crate::api::core::unfold::{
+            DeconSel, DeconTarget, DeconstructorDecl, Deconstructors, Delivery, OutputDecl,
+        };
+        let mut dec = Deconstructors {
+            skip_output: self
+                .class_members
+                .values()
+                .flatten()
+                .filter(|m| m.kind == MemberKind::Constructor)
+                .map(|m| m.rust_ident.clone())
+                .collect(),
+            ..Deconstructors::default()
+        };
         for decl in &self.return_expand_decls {
             assert!(
                 self.is_class_declared(&decl.key)
@@ -683,28 +737,11 @@ impl JniGen {
                  or declare the type in a package",
                 k = decl.key.as_str()
             );
-            dec.ensure_default_deconstructor(decl.key.to_type());
-            for f in &decl.fields {
-                match f {
-                    LocalField::Named(func, name_override) => {
-                        let name = name_override
-                            .clone()
-                            .or_else(|| self.class_method_kotlin_name(&decl.key, func))
-                            .unwrap_or_else(|| snake_to_camel(&func.to_string()));
-                        dec.add_deconstructor_record(func.clone(), name);
-                    }
-                    LocalField::SelfField => dec.add_deconstructor_record_id(),
-                    LocalField::Local {
-                        path,
-                        sig,
-                        name_override,
-                    } => {
-                        let name = self.local_field_name(&decl.key, path, name_override);
-                        self.check_local_field_ty(&decl.key, &name, sig);
-                        dec.add_deconstructor_record_local(path.clone(), name);
-                    }
-                }
-            }
+            dec.deconstructors.push(DeconstructorDecl {
+                target: decl.key.to_type(),
+                records: self.lower_fields(&decl.key, &decl.fields),
+                default: Some((DeconTarget::Output, Delivery::Callback)),
+            });
         }
         // Per-fn overrides: same decl shape and name inheritance; the
         // return-type cross-check and the identity-only lowering happen in
@@ -721,28 +758,13 @@ impl JniGen {
                  .field_self() (the type is rust-side-only) or declare the type in a package",
                 k = decl.key.as_str()
             );
-            dec.begin_inline_output(func.clone(), decl.key.to_type());
-            for f in &decl.fields {
-                match f {
-                    LocalField::Named(afunc, name_override) => {
-                        let name = name_override
-                            .clone()
-                            .or_else(|| self.class_method_kotlin_name(&decl.key, afunc))
-                            .unwrap_or_else(|| snake_to_camel(&afunc.to_string()));
-                        dec.push_inline_field(afunc.clone(), name);
-                    }
-                    LocalField::SelfField => dec.push_inline_field_self(),
-                    LocalField::Local {
-                        path,
-                        sig,
-                        name_override,
-                    } => {
-                        let name = self.local_field_name(&decl.key, path, name_override);
-                        self.check_local_field_ty(&decl.key, &name, sig);
-                        dec.push_inline_field_local(path.clone(), name);
-                    }
-                }
-            }
+            dec.outputs.push(OutputDecl {
+                func: func.clone(),
+                sel: DeconSel::Inline(self.lower_fields(&decl.key, &decl.fields)),
+                target: DeconTarget::Output,
+                delivery: Delivery::Callback,
+                declared_source: Some(decl.key.to_type()),
+            });
         }
         dec
     }

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -401,23 +401,6 @@ pub struct JniGen {
     /// init block — loading stays the consumer's responsibility.
     pub(crate) jni_native_init: Option<String>,
 
-    /// Per-fn constructor-expansion overrides (`.expand_param` on a
-    /// [`FunctionDecl`]), replayed eagerly at accept time. The type-level
-    /// defaults live raw in [`Self::param_expand_decls`]; the two merge on
-    /// demand in [`JniGen::build_expansions`], resolved into
-    /// [`crate::api::core::expand::FoldPlan`]s on the registry during
-    /// `write_rust` and consumed at the parameter-emission site.
-    pub(crate) expansions: crate::api::core::expand::Expansions,
-
-    /// Per-fn output-expansion overrides (`.expand_return` on a
-    /// [`FunctionDecl`]) plus constructor-member skip-defaults, replayed
-    /// eagerly at accept time. The type-level defaults live raw in
-    /// [`Self::return_expand_decls`]; the two merge on demand in
-    /// [`JniGen::build_deconstructors`], resolved into
-    /// [`crate::api::core::unfold::UnfoldPlan`]s on the registry during
-    /// `write_rust` and consumed at the return-emission site.
-    pub(crate) deconstructors: crate::api::core::unfold::Deconstructors,
-
     /// Type-level default input boundaries ([`ExpandParamDecl`], accepted by
     /// [`JniGen::expand`]), stored raw — merged into the expansion set
     /// at the point of use so declarations stay order-independent.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1869,3 +1869,61 @@ fn optional_selector_dispatch_end_to_end() {
     assert!(all.contains("encoding01:String?"), "{raw}");
     assert!(!all.contains("String??"), "{raw}");
 }
+
+/// #96: a `.constructor()` member's return is a factory — it must be
+/// excluded from the type-level `expand_return!` default auto-apply even
+/// though its return type matches. Pins the `skip_output` derivation from
+/// `class_members` (previously an eagerly-mutated accumulator).
+#[test]
+fn constructor_member_skips_default_output_expand() {
+    let loc = myflat_loc();
+    let fns: &[&str] = &[
+        "pub fn z_thing_make() -> ZThing { unimplemented!() }",
+        "pub fn z_thing_name(t: &ZThing) -> String { unimplemented!() }",
+        "pub fn z_thing_get(s: i64) -> ZThing { unimplemented!() }",
+    ];
+    let items: Vec<(syn::Item, SourceLocation)> = fns
+        .iter()
+        .map(|src| {
+            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
+            (syn::Item::Fn(f), loc.clone())
+        })
+        .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("ops")
+                .class(
+                    crate::ptr_class!(ZThing)
+                        .constructor(crate::fun!(z_thing_make).name("make"))
+                        .method(crate::fun!(z_thing_name).name("name")),
+                )
+                .fun(crate::fun!(z_thing_get)),
+        )
+        // Canonical output for ZThing: any ZThing-returning declared fn gets
+        // callback delivery by default…
+        .expand(
+            crate::expand_return!(ZThing)
+                .field_self()
+                .field(crate::fun!(z_thing_name)),
+        );
+    let gen = registry.resolve(jni).expect("resolve");
+    let registry = gen.registry();
+    // …the free fn is decomposed…
+    assert!(
+        registry.unfold_plans.contains_key(&syn::Ident::new(
+            "z_thing_get",
+            proc_macro2::Span::call_site()
+        )),
+        "free fn gets the default output expansion"
+    );
+    // …but the constructor member is NOT (its return is the factory value).
+    assert!(
+        !registry.unfold_plans.contains_key(&syn::Ident::new(
+            "z_thing_make",
+            proc_macro2::Span::call_site()
+        )),
+        "constructor member must skip the default output expansion"
+    );
+}


### PR DESCRIPTION
Implements #96: the core boundary input is now immutable and record-oriented; the cursor protocol is gone.

## What

- **`Expansions` / `Deconstructors` are plain record sets**: `pub` vectors of complete declaration values (`ConstructorDecl`/`ExpandDecl`, `DeconstructorDecl`/`OutputDecl` — promoted to `pub` with `pub` fields and documented) plus the skip sets. All `cur_*` state and the 16 `ensure_default_*`/`begin_*`/`add_*`/`push_*` methods (with their `.expect(".field/.variant called without …")` panics) are deleted. Ordering stays deterministic and explicit in the vectors.
- **Collected diagnostics** (#49-compatible): `apply` runs a structural-validation prologue that reports **every** empty/duplicate declaration in one error (`ExpandError::InvalidDeclarations` / `UnfoldError::InvalidDeclarations`, patterned on `ScanError::DeclaredNotFound`). Unfold diagnoses only duplicates — an empty inline record list is the valid whole-element (`Vec<T>` per-element) delivery form, discovered while porting the tests.
- **JniGen stores one representation**: the raw decl lists. The `expansions` accumulator field was never mutated (dead weight); `deconstructors` only ever received the constructor-member skip marker, now derived from `class_members`. `build_expansions`/`build_deconstructors` are pure declaration → record mappings (shared field-name resolution hoisted into `lower_fields`); duplicates pass through unmerged so core diagnoses them.
- `Prebindgen::expansions()/deconstructors()` signatures, `apply` signatures, and everything downstream of plan construction are untouched.

## Behavior delta (intentional, per the issue)

Previously-silent cross-decl duplicate handling — type-level decls **merged**, per-fn decls **last-wins** — is now a hard collected error. Nothing in-tree or in the examples declares duplicates; single-decl duplicates were already rejected by the decl-builder asserts (unchanged, still pinned by their `should_panic` tests).

## Acceptance criteria

- [x] No `cur_*` state.
- [x] No begin-then-push call sequence anywhere.
- [x] JniGen does not store both accumulators and raw copies.
- [x] Invalid empty/duplicate declarations → collected diagnostics, not cursor panics.
- [x] Ordering deterministic, explicitly vector-represented.
- [x] Plan application unit-testable as a pure declaration-set → plan-set transformation (core tests now construct record literals directly).

## Tests

Core cursor-sequence tests ported mechanically to record literals (assertions unchanged). New: `invalid_declarations_collected` (expand — 4 offenders in one error), `duplicate_declarations_collected` (unfold), and `constructor_member_skips_default_output_expand` (pins the `skip_output` derivation from `class_members`). 289 lib tests and all 20 workspace suites green; checked-in example Kotlin byte-identical; CI clippy/fmt gates pass locally.

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)