### PR TITLE
jnigen: document the nullable-handle lock-path trade-off (#68)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1602,6 +1602,14 @@ fn render_core_stmt(
         // Pass the handles positionally to the allocation-free fixed-arity
         // `withSortedHandleLocks` overload. Otherwise build a `List` and use
         // the recursive overload.
+        //
+        // Deliberate trade-off (#68): ANY nullable handle takes the `List`
+        // path, even when the present/absent split could reach a fixed-arity
+        // overload (`if (h != null) withSortedHandleLocks(a, h) {…} else …`).
+        // The small-list allocation is benchmark-noise, and the branch would
+        // duplicate the whole call body per arm — longer generated code for
+        // no measured gain. All three overloads stay: each is exercised by
+        // all-non-null wrappers (the common case).
         let fixed_arity = !opaques.iter().any(|o| o.nullable) && (1..=3).contains(&opaques.len());
         if !ext.package.is_empty() {
             imports.insert(format!("{}.withSortedHandleLocks", ext.package));


### PR DESCRIPTION
Comment-only change recording the resolution of #68 in the code, at the `fixed_arity` predicate in `render_core_stmt`. See the closing comment on #68 for the full evidence; short version: the fixed-arity overloads are not dead (all three are exercised by checked-in output), the List-path allocation for nullable-handle wrappers is benchmark-noise, and branching into fixed-arity arms would duplicate call bodies — longer generated code for no measured gain.

No behavioral change; generated output byte-identical; 289 lib tests, clippy `-D warnings`, and rustfmt gates pass.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)