### PR TITLE
core+jnigen: record-built Optional(Iterable) fold — <A>(acc, fold): A? surface (#105)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -56,6 +56,7 @@
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
 //! | owned-handle callback (`Fn(Storage)`)| `storage_handler_new` / `storage_emit` |
 //! | `Vec<handle>` / `Option<Vec<handle>>`| `storage_shards` / `storage_shards_opt` (Kotlin-side handle fold) |
+//! | record-built `<A>` fold (bare + `Option`) | `summary_series` / `summary_series_opt` (caller `acc`/`fold`; `A?` return, null = `None`) |
 //! | borrowed-opaque return (`Option<&T>`)| `archive_latest` (clone → fresh owned handle) |
 //! | N-ary sorted handle locking          | `storage_total_len` (3 handles) + a 4-thread smoke |
 //! | `Vec<String>` return                 | `storage_labels` (single-leaf string fold) |
@@ -469,6 +470,14 @@ fn main() {
                 // (`-1` = `None`); the borrow-identity arm clones, so the
                 // caller's handle survives the call.
                 .fun(fun!(summary_total_opt))
+                // Record-built generic folds (#105): `Vec<Summary>` and
+                // `Option<Vec<Summary>>` returns cross as the caller-supplied
+                // `<A>(acc, fold)` surface — decomposed `(count, total)`
+                // leaves per element. The `Option` form returns `A?`: null =
+                // `None` (the fold never invoked), `Some(empty)` = the
+                // untouched accumulator.
+                .fun(fun!(summary_series))
+                .fun(fun!(summary_series_opt))
                 // The borrowed-accessor trio. `archive_latest` suppresses the default
                 // Summary return-field default so the BORROWED handle path (clone into a
                 // fresh owned handle, null when absent) is what crosses.

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -37,6 +37,10 @@ Base package: `io.prebindgen.covertest`
 - `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Long>): Long`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
+- `summary_series` — `fun <A> summarySeries(count: Long, start: Long, acc: A, onError: io.prebindgen.covertest.JniErrorHandler<A>, fold: io.prebindgen.covertest.analytics.SummaryFolder<A>): A`
+  - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
+- `summary_series_opt` — `fun <A> summarySeriesOpt(count: Long, start: Long, acc: A, onError: io.prebindgen.covertest.JniErrorHandler<A?>, fold: io.prebindgen.covertest.analytics.SummaryFolder<A>): A?`
+  - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
 - `summary_total_opt` — `fun summaryTotalOpt(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`
   - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
 - `summary_total_raw` — `fun summaryTotalRaw(s: Summary, onError: io.prebindgen.covertest.JniErrorHandler<Double>): Double`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -765,6 +765,14 @@ internal object CovNative {
         errorSink: Any,
     ): Long
     external fun summaryScaled(s: Long, factor: Double, errorSink: Any): Double
+    external fun summarySeries(count: Long, start: Long, acc: Any?, fold: Any, errorSink: Any): Any?
+    external fun summarySeriesOpt(
+        count: Long,
+        start: Long,
+        acc: Any?,
+        fold: Any,
+        errorSink: Any,
+    ): Any?
     external fun summaryTotal(s: Long, errorSink: Any): Double
     external fun summaryTotalOpt(
         sSel: Int,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -168,6 +168,10 @@ public fun <R> SummaryStorageSummaryProbeBuilder<R>.asRaw(): SummaryStorageSumma
         )
     }
 
+public fun interface SummaryFolder<A> {
+    public fun run(acc: A, count: Long, total: Double): A
+}
+
 /**
  * Summarize a storage (returns a `Summary`; the binding's **default
  * flatten-output** turns it into `(count, total)` leaves).
@@ -623,6 +627,49 @@ public fun summaryTotalOpt(
             )
         }
     }
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/**
+ * A series of `count` summaries starting at `start`: element `i` is
+ * `(start + i, (start + i) * 10.0)`. A **record-built iterable fold** at the
+ * boundary: the caller supplies the accumulator and a per-element `fold`
+ * lambda receiving the decomposed `(count, total)` leaves.
+ *
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <A> summarySeries(
+    count: Long,
+    start: Long,
+    acc: A,
+    onError: JniErrorHandler<A>,
+    fold: SummaryFolder<A>,
+): A {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.summarySeries(count, start, acc, fold, __cap) as A)
+    if (__cap.failed) return onError.run(__cap.je)
+    return __ret
+}
+
+/**
+ * Like [`summary_series`] but `None` when `count < 0` — the record-built
+ * `Optional(Iterable)` shape (#105): `None` skips the fold and the JVM
+ * wrapper returns null; `Some(vec![])` returns the untouched accumulator.
+ *
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <A> summarySeriesOpt(
+    count: Long,
+    start: Long,
+    acc: A,
+    onError: JniErrorHandler<A?>,
+    fold: SummaryFolder<A>,
+): A? {
+    val __cap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.summarySeriesOpt(count, start, acc, fold, __cap) as A?)
     if (__cap.failed) return onError.run(__cap.je)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -14,6 +14,8 @@ import io.prebindgen.covertest.analytics.storageSummaryFull
 import io.prebindgen.covertest.analytics.storageSummaryHandle
 import io.prebindgen.covertest.analytics.summaryMerge
 import io.prebindgen.covertest.analytics.summaryPrefer
+import io.prebindgen.covertest.analytics.summarySeries
+import io.prebindgen.covertest.analytics.summarySeriesOpt
 import io.prebindgen.covertest.analytics.summaryTotalOpt
 import io.prebindgen.covertest.analytics.summaryTotalRaw
 import io.prebindgen.covertest.errors.StorageErrorHandler
@@ -469,6 +471,24 @@ fun main() {
     }
 
     // ── Vec<opaque-handle> return: the Kotlin-side handle fold ───────────────
+    section("record-built <A> fold (summarySeries / summarySeriesOpt)") {
+        // Bare Vec<Summary>: the caller threads the accumulator; each element
+        // arrives as its decomposed (count, total) leaves.
+        val pairs =
+            summarySeries(3L, 10L, mutableListOf<Pair<Long, Double>>(), boom) { acc, count, total ->
+                acc.add(count to total)
+                acc
+            }
+        check(pairs == listOf(10L to 100.0, 11L to 110.0, 12L to 120.0))
+        check(summarySeries(0L, 5L, 0L, boom) { acc, _, _ -> acc + 1 } == 0L)
+        // Option<Vec<Summary>> (#105): null = None (the fold never invoked);
+        // Some(empty) returns the untouched accumulator, distinguishable from
+        // None by the caller.
+        check(summarySeriesOpt(-1L, 0L, 0L, boom) { acc, _, _ -> acc + 1 } == null)
+        check(summarySeriesOpt(0L, 0L, 7L, boom) { acc, _, _ -> acc + 1 } == 7L)
+        check(summarySeriesOpt(2L, 1L, 0.0, boom) { acc, _, total -> acc + total } == 30.0)
+    }
+
     section("Vec<Storage> handle fold (storageShards / storageShardsOpt)") {
         val shards = storageShards(3L, 2L, boom)
         check(shards.size == 3)

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -7707,6 +7707,291 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryScaled<'a
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    count: jni::sys::jlong,
+    start: jni::sys::jlong,
+    __acc: jni::objects::JObject<'a>,
+    __fold: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let start = match jlong_to_i64_fbf9a9bc(&mut env, &start) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/analytics/SummaryFolder";
+    const __CB_DESCR: &str = "(Ljava/lang/Object;JD)Ljava/lang/Object;";
+    let __vec = perftest_flat::summary_series(count, start);
+    let mut __acc = __acc;
+    for __elem in __vec.into_iter() {
+        let __obj0: jni::sys::jvalue = {
+            let __enc0 = match i64_to_jlong_fbf9a9bc(
+                &mut env,
+                perftest_flat::summary_count(&__elem),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    let __zd = __ze_defaults(&mut env);
+                    signal_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        ::core::option::Option::Some(&__e.to_string()),
+                        &__zd,
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            jni::sys::jvalue { j: __enc0 }
+        };
+        let __obj1: jni::sys::jvalue = {
+            let __enc1 = match f64_to_jdouble_9e4a8f70(
+                &mut env,
+                perftest_flat::summary_total(&__elem),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    let __zd = __ze_defaults(&mut env);
+                    signal_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        ::core::option::Option::Some(&__e.to_string()),
+                        &__zd,
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            jni::sys::jvalue { d: __enc1 }
+        };
+        __acc = match __CB_MID
+            .call_object(
+                &mut env,
+                __CB_FQN,
+                "run",
+                __CB_DESCR,
+                &__fold,
+                &[
+                    jni::sys::jvalue {
+                        l: __acc.as_raw(),
+                    },
+                    __obj0,
+                    __obj1,
+                ],
+            )
+        {
+            ::core::result::Result::Ok(__o) => __o,
+            ::core::result::Result::Err(__e) => {
+                let _ = env.exception_describe();
+                let __e2 = <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string());
+                let __zd = __ze_defaults(&mut env);
+                signal_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    ::core::option::Option::Some(&__e2.to_string()),
+                    &__zd,
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+    }
+    __acc
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    count: jni::sys::jlong,
+    start: jni::sys::jlong,
+    __acc: jni::objects::JObject<'a>,
+    __fold: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(unused_variables)]
+    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
+        ::std::vec![]
+    };
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let start = match jlong_to_i64_fbf9a9bc(&mut env, &start) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __zd = __ze_defaults(&mut env);
+            signal_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                ::core::option::Option::Some(&__e.to_string()),
+                &__zd,
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/analytics/SummaryFolder";
+    const __CB_DESCR: &str = "(Ljava/lang/Object;JD)Ljava/lang/Object;";
+    let __out = perftest_flat::summary_series_opt(count, start);
+    match __out {
+        ::core::option::Option::Some(__vec) => {
+            let mut __acc = __acc;
+            for __elem in __vec.into_iter() {
+                let __obj0: jni::sys::jvalue = {
+                    let __enc0 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        perftest_flat::summary_count(&__elem),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            let __zd = __ze_defaults(&mut env);
+                            signal_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                ::core::option::Option::Some(&__e.to_string()),
+                                &__zd,
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { j: __enc0 }
+                };
+                let __obj1: jni::sys::jvalue = {
+                    let __enc1 = match f64_to_jdouble_9e4a8f70(
+                        &mut env,
+                        perftest_flat::summary_total(&__elem),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            let __zd = __ze_defaults(&mut env);
+                            signal_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                ::core::option::Option::Some(&__e.to_string()),
+                                &__zd,
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { d: __enc1 }
+                };
+                __acc = match __CB_MID
+                    .call_object(
+                        &mut env,
+                        __CB_FQN,
+                        "run",
+                        __CB_DESCR,
+                        &__fold,
+                        &[
+                            jni::sys::jvalue {
+                                l: __acc.as_raw(),
+                            },
+                            __obj0,
+                            __obj1,
+                        ],
+                    )
+                {
+                    ::core::result::Result::Ok(__o) => __o,
+                    ::core::result::Result::Err(__e) => {
+                        let _ = env.exception_describe();
+                        let __e2 = <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string());
+                        let __zd = __ze_defaults(&mut env);
+                        signal_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            ::core::option::Option::Some(&__e2.to_string()),
+                            &__zd,
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+            }
+            __acc
+        }
+        ::core::option::Option::None => jni::objects::JObject::null().into(),
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotal<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -190,6 +190,25 @@ pub fn summary_scaled(s: &Summary, factor: f64) -> f64 {
     s.total * factor
 }
 
+/// A series of `count` summaries starting at `start`: element `i` is
+/// `(start + i, (start + i) * 10.0)`. A **record-built iterable fold** at the
+/// boundary: the caller supplies the accumulator and a per-element `fold`
+/// lambda receiving the decomposed `(count, total)` leaves.
+#[prebindgen]
+pub fn summary_series(count: i64, start: i64) -> Vec<Summary> {
+    (0..count)
+        .map(|i| summary_new(start + i, ((start + i) * 10) as f64))
+        .collect()
+}
+
+/// Like [`summary_series`] but `None` when `count < 0` — the record-built
+/// `Optional(Iterable)` shape (#105): `None` skips the fold and the JVM
+/// wrapper returns null; `Some(vec![])` returns the untouched accumulator.
+#[prebindgen]
+pub fn summary_series_opt(count: i64, start: i64) -> Option<Vec<Summary>> {
+    (count >= 0).then(|| summary_series(count, start))
+}
+
 /// Summarize a storage (returns a `Summary`; the binding's **default
 /// flatten-output** turns it into `(count, total)` leaves).
 #[prebindgen]
@@ -721,6 +740,18 @@ mod tests {
         assert!(storage_shards(0, 2).is_empty());
         assert!(storage_shards_opt(0, 2).is_none());
         assert_eq!(storage_shards_opt(2, 1).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn summary_series_shapes() {
+        let s = summary_series(3, 10);
+        assert_eq!(s.len(), 3);
+        assert_eq!(summary_count(&s[2]), 12);
+        assert_eq!(summary_total(&s[2]), 120.0);
+        assert!(summary_series(0, 5).is_empty());
+        assert!(summary_series_opt(-1, 0).is_none());
+        assert!(summary_series_opt(0, 0).unwrap().is_empty());
+        assert_eq!(summary_series_opt(2, 1).unwrap().len(), 2);
     }
 
     #[test]

--- a/prebindgen/src/api/core/shape.rs
+++ b/prebindgen/src/api/core/shape.rs
@@ -37,6 +37,18 @@ impl<N> Shape<N> {
     pub fn iterable(inner: Shape<N>) -> Self {
         Shape::Iterable(Box::new(inner))
     }
+
+    /// True when any layer of the stack is `Iterable`. This is the
+    /// fold-delivery discriminator: a fold surface (accumulator + per-element
+    /// callback) is selected whether or not `Optional` layers wrap the
+    /// iterable, and an iterable-shaped value has no single return.
+    pub fn has_iterable_layer(&self) -> bool {
+        match self {
+            Shape::Base => false,
+            Shape::Optional(_, inner) => inner.has_iterable_layer(),
+            Shape::Iterable(_) => true,
+        }
+    }
 }
 
 /// Bottom-up fold over the layer stack: compute the leaf value with `on_base`,

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -774,21 +774,53 @@ fn process_decl<M>(
             }
         };
 
-        // `Vec<T>` return → `Iterable`. Two element-delivery modes:
+        // Peel an outer `Option` off the success return BEFORE probing for a
+        // `Vec`, so `Option<Vec<T>>` composes as `Optional(Iterable)` — the
+        // fold is skipped and a null result delivered for `None` (issue
+        // #105). The scalar arm below reuses this peel. Error targets keep
+        // the historical probe order (the `Vec` probe runs on `E` itself), so
+        // an `Option<Vec<E>>` error stays whole.
+        let (optional, after_opt) = match ed.target {
+            DeconTarget::Output => match option_inner_type(&ret_ty) {
+                Some(inner) => (true, inner),
+                None => (false, ret_ty.clone()),
+            },
+            DeconTarget::Error => (false, ret_ty.clone()),
+        };
+        // `Vec<T>` / `Option<Vec<T>>` return → `Iterable` (± an `Optional`
+        // layer). Two element-delivery modes:
         //   * **decomposed** (M5): the element type has an accessor →
         //     flatten it into leaves, fold `(acc, leaf0, …) -> acc`.
         //   * **whole** (M4): no accessor → deliver each element whole
         //     via its own output converter + projection, fold `(acc, T) -> acc`.
         // The other shapes (`Option`/scalar) decompose via an accessor
         // (M1–M3). `Vec<Option<…>>` is not supported.
-        let plan = if let Some(inner) = vec_inner_type(&ret_ty) {
+        let plan = if let Some(inner) = vec_inner_type(&after_opt) {
             if option_inner_type(&inner).is_some() {
                 return Err(UnfoldError::Unsupported {
                     func: ed.func.clone(),
                     reason: "Vec<Option<…>> returns",
                 });
             }
-            let shape = UnfoldShape::Iterable(Box::new(UnfoldShape::Base));
+            let iterable = UnfoldShape::Iterable(Box::new(UnfoldShape::Base));
+            let shape = if optional {
+                UnfoldShape::Optional((), Box::new(iterable))
+            } else {
+                iterable
+            };
+            // The fold delivers the return element-by-element, so the
+            // whole-collection converter is not needed — and for an
+            // opaque-handle element it cannot resolve at all (a `jlong` wire
+            // isn't JObject-shaped). De-require the scan-time registrations
+            // (the declared return and, under `Option`, the inner `Vec` its
+            // recursive registration also required) — same reasoning as
+            // [`apply_leaf_vec_folds`] for the fixed folds.
+            if ed.target == DeconTarget::Output {
+                registry.unrequire_output(&ret_ty);
+                if optional {
+                    registry.unrequire_output(&after_opt);
+                }
+            }
             // Element type peeled of a leading `&` (accessors take `&Element`).
             let (by_ref, element) = match &inner {
                 syn::Type::Reference(r) => (true, (*r.elem).clone()),
@@ -825,9 +857,16 @@ fn process_decl<M>(
                 }
             }
         } else {
-            let (optional, core_ty) = match option_inner_type(&ret_ty) {
-                Some(inner) => (true, inner),
-                None => (false, ret_ty.clone()),
+            // Scalar/decomposed arm. The `Option` peel already happened above
+            // for `Output` (exactly one layer — `Option<Option<…>>` is NOT
+            // re-peeled and fails as "no deconstructor" for the inner
+            // `Option`); for `Error` it happens here, unchanged.
+            let (optional, core_ty) = match ed.target {
+                DeconTarget::Output => (optional, after_opt.clone()),
+                DeconTarget::Error => match option_inner_type(&after_opt) {
+                    Some(inner) => (true, inner),
+                    None => (false, after_opt.clone()),
+                },
             };
             let (by_ref, source) = match &core_ty {
                 syn::Type::Reference(r) => (true, (*r.elem).clone()),
@@ -850,11 +889,13 @@ fn process_decl<M>(
         // Delivery is by **leaf count**, not a per-decl flag:
         //   * Output, single leaf, non-Iterable ⇒ Return (wrapper returns the
         //     value via its ordinary output converter — `convert_out_ty`).
-        //   * Output, multiple leaves or Iterable ⇒ Callback (builder / fold).
+        //   * Output, multiple leaves or Iterable (at any layer — an
+        //     `Optional(Iterable)` fold has no single value to return) ⇒
+        //     Callback (builder / fold).
         //   * Error ⇒ always Callback-shaped: every leaf is a `ze` arg after the
         //     fixed `je` (no return-value path; `convert_out_ty` stays None).
         let single_return = ed.target == DeconTarget::Output
-            && !matches!(plan.shape, UnfoldShape::Iterable(_))
+            && !plan.shape.has_iterable_layer()
             && plan.leaves.len() == 1;
         let plan = if single_return {
             let leaf_ty = plan.leaves[0].out_ty.clone();

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -941,6 +941,122 @@ fn vec_output_is_iterable_callback() {
 }
 
 #[test]
+fn option_vec_output_is_optional_iterable_callback() {
+    // An `Option<Vec<T>>` return with `T`'s default deconstructor composes as
+    // a RECORD-BUILT `Optional(Iterable)` fold (issue #105): the auto-apply
+    // peels the `Option` before probing the `Vec`, the elements decompose
+    // into leaves (M5), and `None` skips the fold to deliver a null result.
+    let mut reg = reg_with(&[
+        "fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }",
+        "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
+    ]);
+    let mut acc = Deconstructors::default();
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZZenohId),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_zenoh_id_to_string"),
+                name: "z_zenoh_id_to_string".into(),
+            },
+            DeconRecord::Identity,
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    apply(
+        &mut reg,
+        &acc,
+        &[ident("z_routers_zid")].into_iter().collect(),
+        &acc_set(),
+    )
+    .expect("apply");
+    let plan = reg.unfold_plans.get(&ident("z_routers_zid")).expect("plan");
+    assert!(
+        matches!(&plan.shape,
+            UnfoldShape::Optional((), inner)
+                if matches!(&**inner, UnfoldShape::Iterable(i) if matches!(**i, UnfoldShape::Base))),
+        "shape is Optional(Iterable(Base))"
+    );
+    assert!(!plan.fixed_builder, "record-built, not a fixed singleton");
+    assert_eq!(plan.delivery, Delivery::Callback);
+    assert!(plan.element.is_none(), "decomposed (M5): element not used");
+    assert_eq!(plan.leaves.len(), 2);
+    assert!(!plan.by_ref, "Option<Vec<ZZenohId>> owns its elements");
+}
+
+#[test]
+fn option_vec_single_leaf_stays_callback() {
+    // A SINGLE-leaf `Optional(Iterable)` fold must stay Callback: the
+    // single-Return reclassification is gated on "no Iterable at any layer",
+    // not just a top-level `Iterable` (an `Option<Vec<T>>` fold has no single
+    // value to return through `convert_out_ty`).
+    let mut reg = reg_with(&[
+        "fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }",
+        "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
+    ]);
+    let mut acc = Deconstructors::default();
+    acc.deconstructors.push(DeconstructorDecl {
+        target: syn::parse_quote!(ZZenohId),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_zenoh_id_to_string"),
+            name: "z_zenoh_id_to_string".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    apply(
+        &mut reg,
+        &acc,
+        &[ident("z_routers_zid")].into_iter().collect(),
+        &acc_set(),
+    )
+    .expect("apply");
+    let plan = reg.unfold_plans.get(&ident("z_routers_zid")).expect("plan");
+    assert_eq!(plan.delivery, Delivery::Callback);
+    assert_eq!(plan.leaves.len(), 1);
+    assert!(plan.convert_out_ty.is_none());
+}
+
+#[test]
+fn option_vec_whole_element_plan() {
+    // M4 dual of the decomposed case: an `Option<Vec<T>>` return with an
+    // inline EMPTY record list delivers each element whole through its own
+    // output converter, wrapped in the `Optional` layer.
+    let mut reg =
+        reg_with(&["fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }"]);
+    let mut acc = Deconstructors::default();
+    acc.outputs.push(OutputDecl {
+        func: ident("z_routers_zid"),
+        sel: DeconSel::Inline(vec![]),
+        target: DeconTarget::Output,
+        delivery: Delivery::Callback,
+        declared_source: Some(syn::parse_quote!(ZZenohId)),
+    });
+    apply(
+        &mut reg,
+        &acc,
+        &[ident("z_routers_zid")].into_iter().collect(),
+        &acc_set(),
+    )
+    .expect("apply");
+    let plan = reg.unfold_plans.get(&ident("z_routers_zid")).expect("plan");
+    assert!(
+        matches!(&plan.shape,
+            UnfoldShape::Optional((), inner) if matches!(&**inner, UnfoldShape::Iterable(_))),
+        "shape is Optional(Iterable(Base))"
+    );
+    assert!(!plan.fixed_builder);
+    assert!(
+        plan.leaves.is_empty(),
+        "whole-element: no decomposed leaves"
+    );
+    assert_eq!(
+        plan.element
+            .as_ref()
+            .map(|t| t.to_token_stream().to_string()),
+        Some("ZZenohId".to_string())
+    );
+}
+
+#[test]
 fn value_struct_vec_is_fixed_iterable_fold() {
     // A by-value `data_class` returned as `Option<Vec<T>>` (perftest's
     // `storage_get_vec` contract) synthesizes a FIXED-BUILDER fold wrapped in

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -126,19 +126,21 @@ pub(crate) enum FnOutputPlan {
 /// Rust builder param, the erased extern params, and the typed Kotlin
 /// builder/fold surface all branch on the same booleans.
 pub(crate) struct UnfoldOutputPlan {
-    /// `is_iterable_fold(shape)` — a bare `Iterable` OR one wrapped in a
-    /// single `Optional` layer (`Option<Vec<T>>`). Selects the fold surface
+    /// `is_iterable_fold(shape)` — a bare `Iterable` OR one wrapped in an
+    /// `Optional` layer (`Option<Vec<T>>`). Selects the fold surface
     /// (`acc` + `fold`) over a scalar builder on every tier.
     pub iterable_fold: bool,
-    /// Outer `Optional` layer present — the delivered result is nullable.
+    /// Outer `Optional` layer present — the delivered result is nullable
+    /// (for a fold: `None` skips the fold and delivers null, so the wrapper
+    /// returns `A?`).
     pub optional: bool,
     /// Synthesized fixed-singleton delivery: no caller lambda, not generic.
     pub fixed_builder: bool,
     /// `plan.element.is_some()` — whole-element (M4) vs decomposed (M5) fold.
     pub whole_element: bool,
     /// Kotlin type variable of the wrapper: `None` for a fixed builder,
-    /// `"A"` for a **bare** `Iterable` fold (an `Optional`-wrapped iterable
-    /// takes the scalar-builder surface, hence `"R"`), `"R"` otherwise.
+    /// `"A"` for an `Iterable` fold (bare or `Optional`-wrapped), `"R"`
+    /// otherwise.
     pub generic: Option<&'static str>,
     /// The builder/folder `fun interface` spec the delivery calls into —
     /// [`folder_iface_for_plan`] for an iterable fold (incl. the fixed
@@ -515,11 +517,12 @@ fn build_output(
         let optional = matches!(plan.shape, UnfoldShape::Optional(..));
         let fixed_builder = plan.fixed_builder;
         // The generic-surface rule (see `classify_output`): a fixed builder
-        // is not generic; a **bare** `Iterable` folds with `<A>`; everything
-        // else — including an `Optional`-wrapped iterable — builds with `<R>`.
+        // is not generic; an `Iterable` fold — bare or `Optional`-wrapped —
+        // folds with `<A>` (the wrapped form returns `A?`, null = `None`);
+        // everything else builds with `<R>`.
         let generic = if fixed_builder {
             None
-        } else if iterable_fold && !optional {
+        } else if iterable_fold {
             Some("A")
         } else {
             Some("R")

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -20,7 +20,7 @@
 //! sites independently derive identical specs.
 
 use super::*;
-use crate::api::core::unfold::{dedup_names, DeconId, UnfoldPlan, UnfoldShape};
+use crate::api::core::unfold::{dedup_names, DeconId, UnfoldPlan};
 
 /// The JVM-visible single method name of every generated callback interface.
 pub(crate) const IFACE_METHOD: &str = "run";
@@ -1025,8 +1025,7 @@ pub(crate) fn folder_iface_for_plan(
     plan: &UnfoldPlan,
 ) -> Option<IfaceSpec> {
     debug_assert!(
-        matches!(plan.shape, UnfoldShape::Iterable(_))
-            || matches!(&plan.shape, UnfoldShape::Optional((), i) if matches!(**i, UnfoldShape::Iterable(_))),
+        plan.shape.has_iterable_layer(),
         "folder_iface_for_plan requires an Iterable (or Option<Iterable>) plan"
     );
     match (&plan.element, &plan.decon) {

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -433,13 +433,11 @@ pub(crate) fn build_typed_handle(
     class
 }
 
-/// True for an `Iterable` fold delivery, including one wrapped in a single
-/// `Optional` layer (`Option<Vec<T>>` → a nullable `List`). Selects the fold
+/// True for an `Iterable` fold delivery, including one wrapped in an
+/// `Optional` layer (`Option<Vec<T>>` → a nullable delivery). Selects the fold
 /// surface (`acc` + `fold`) over a scalar `Optional`/`Base` builder.
 pub(crate) fn is_iterable_fold(shape: &crate::api::core::unfold::UnfoldShape) -> bool {
-    use crate::api::core::unfold::UnfoldShape;
-    matches!(shape, UnfoldShape::Iterable(_))
-        || matches!(shape, UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Iterable(_)))
+    shape.has_iterable_layer()
 }
 
 /// Render one `external fun <mangle_method(package, JNINative, name)>(…): <wire-return>` line
@@ -1192,15 +1190,17 @@ fn classify_output(
             };
             (Some(kt), None)
         }
-    } else if let (FnOutputPlan::Unfold(u), Some(plan)) = (&fplan.output, unfold) {
+    } else if let (FnOutputPlan::Unfold(u), Some(_)) = (&fplan.output, unfold) {
         // The builder / fold params are generated typed `fun interface`s
         // (`<Source>Builder<out R>` / `<Element>Folder<A>`); the native side
         // calls their typed `run` with raw jvalues (value-blob leaves surface
         // as `ByteArray` — no call-site adapter). Lambda-literal call sites
         // SAM-convert unchanged.
         generic = u.generic.map(str::to_string);
-        // A **bare** `Iterable` folds with `<A>`; an `Optional`-wrapped
-        // iterable takes the scalar-builder surface below.
+        // An `Iterable` fold — bare or `Optional`-wrapped — folds with `<A>`
+        // (`acc` lead + `fold` lambda). The wrapped form returns `A?`: `None`
+        // skips the fold and delivers null (matching the scalar `R?` and the
+        // fixed path's null `List`), `Some(empty)` returns `acc` unchanged.
         if u.generic == Some("A") {
             let spec = u.iface.as_deref()?;
             builder_lead = Some(("acc".to_string(), kt::KtType::var_("A")));
@@ -1212,24 +1212,14 @@ fn classify_output(
             } else {
                 unfold_call_args.push("fold".to_string());
             }
-            (Some(kt::KtType::var_("A")), None)
-        } else {
-            // A non-fixed `Optional(Iterable)` historically typed its surface
-            // with the BUILDER spec here while the Rust delivery folds — the
-            // plan stores the folder twin for that shape, so keep the local
-            // builder derivation to preserve the (latent, pre-existing)
-            // divergence rather than silently retype the surface.
-            let local_spec;
-            let spec = if u.iterable_fold {
-                let decon = plan
-                    .decon
-                    .as_ref()
-                    .expect("record-built plan carries its DeconId");
-                local_spec = builder_iface_spec(ext, registry, decon)?;
-                &local_spec
+            let kt = if u.optional {
+                kt::KtType::var_("A").nullable()
             } else {
-                u.iface.as_deref()?
+                kt::KtType::var_("A")
             };
+            (Some(kt), None)
+        } else {
+            let spec = u.iface.as_deref()?;
             builder_param = Some(("build".to_string(), spec.kt_ref(vec![kt::KtType::var_r()])));
             if spec.needs_raw() {
                 imports.insert(format!("{}.asRaw", spec.package));

--- a/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
@@ -451,3 +451,89 @@ fn cross_artifact_flatten_vec_callback_builder_agree() {
     let (rust, kotlin) = run_pipeline("jnigen_xart_shapes", items, jni);
     assert_cross_artifact(&rust, &kotlin);
 }
+
+/// Record-built `Iterable` folds, bare AND `Optional`-wrapped (issue #105):
+/// a `Vec<ZThing>` and an `Option<Vec<ZThing>>` return, both decomposed via
+/// the same `expand_return!`. The extern must take the fold pair
+/// (`__acc`/`__fold` ↔ `acc: Any?`/`fold: Any`) for BOTH shapes, and the
+/// wrapper surface must be the generic fold — `<A>(…, acc: A, fold:
+/// ZThingFolder<A>)` returning `A` (bare) / `A?` (`None` ⇒ null, the fold
+/// never invoked).
+#[test]
+fn cross_artifact_optional_iterable_fold_agrees() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_thing_name(this_: &ZThing) -> String {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_things_all() -> Vec<ZThing> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_things_maybe() -> Option<Vec<ZThing>> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))
+                .fun(crate::fun!(z_things_all))
+                .fun(crate::fun!(z_things_maybe)),
+        )
+        .expand(
+            crate::expand_return!(ZThing)
+                .field_self()
+                .field(crate::fun!(z_thing_name)),
+        );
+    let (rust, kotlin) = run_pipeline("jnigen_xart_opt_fold", items, jni);
+    assert_cross_artifact(&rust, &kotlin);
+
+    // Both externs take the fold pair on the Rust side…
+    let rc: String = rust.chars().filter(|c| !c.is_whitespace()).collect();
+    for sym in ["zThingsAll", "zThingsMaybe"] {
+        assert!(
+            rc.contains(&format!(
+                "{sym}<'a>(mutenv:jni::JNIEnv<'a>,_class:jni::objects::JClass<'a>,\
+                 __acc:jni::objects::JObject<'a>,__fold:jni::objects::JObject<'a>,"
+            )),
+            "extern `{sym}` takes the (__acc, __fold) pair:\n{rust}"
+        );
+    }
+    // …and the Kotlin wrapper surface is the generic fold on both, returning
+    // `A` for the bare shape and `A?` for the `Optional`-wrapped one.
+    let wrappers = kotlin
+        .values()
+        .find(|src| src.contains("fun <A> zThingsAll"))
+        .expect("a generated file declares the fold wrappers");
+    let kc: String = wrappers.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(
+        kc.contains("fun<A>zThingsAll(acc:A,onError:JniErrorHandler<A>,fold:ZThingFolder<A>):A{"),
+        "bare fold wrapper surface:\n{wrappers}"
+    );
+    assert!(
+        kc.contains(
+            "fun<A>zThingsMaybe(acc:A,onError:JniErrorHandler<A?>,fold:ZThingFolder<A>):A?{"
+        ),
+        "optional fold wrapper surface (returns A?, null = None):\n{wrappers}"
+    );
+    assert!(
+        kc.contains("JNINative.zThingsMaybe(acc,fold.asRaw(),__cap)asA?"),
+        "optional fold call site casts the erased result to A?:\n{wrappers}"
+    );
+}


### PR DESCRIPTION
Closes #105.

## Premise correction (recording for the issue)

The reported wrapper/extern divergence was **unreachable on main**: the only producers of an `Optional(Iterable)` shape are the two fixed-builder synthesizers (`apply_value_structs`, `apply_leaf_vec_folds`). The record-built path never built it — a fn returning `Option<Vec<T>>` with `expand_return!(T)` **does** match the default auto-apply (`returns_type` peels `Option` then `Vec`), but `process_decl` peeled only the `Option` and then looked up a deconstructor for `Vec<T>` itself, failing `write_rust` with the misleading `NoDeconstructor { target: "Vec<T>" }`. So the real defect was a feature gap behind a bad diagnostic, and the issue's short-term `validate_bindings` rejection is superseded: this PR makes the shape work instead.

## The surface (the semantics decision #105 left open)

`Option<Vec<T>>` under a declared `expand_return!` now generates the **fold surface aligned with the wire**: `<A>(…, acc: A, fold: <X>Folder<A>): A?` — `null` = `None` (the fold is never invoked), `Some(empty)` returns the untouched accumulator, matching the scalar-Optional builder convention (`<R>: R?`) and the fixed path's null `List`. `onError` is typed `JniErrorHandler<A?>`. The Rust extern and delivery already implemented exactly this (`(__acc, __fold)` pair, plain null `JObject` on `None`) — **no Rust-emission changes**.

## Changes

- **core `unfold.rs` `process_decl`** (Output targets only; Error unchanged): peel an outer `Option` *before* the `Vec` probe and wrap the shape in `Optional` — both element modes compose (M5 decomposed / M4 whole-element). De-require the whole-collection converters (declared return + inner `Vec`) exactly like `apply_leaf_vec_folds` — this also fixes the pre-existing resolution failure for record-built folds over opaque-handle elements (bare `Vec<T>` included).
- **`single_return` guard**: new `Shape::has_iterable_layer()` (jnigen's `is_iterable_fold` and the `folder_iface_for_plan` debug assert delegate to it) — a 1-leaf `Optional(Iterable)` stays `Callback` instead of misclassifying as a `Return` of `Option<leaf>`.
- **`fn_plan.rs`**: the generic rule drops the `!optional` carve-out (`iterable_fold ⇒ "A"`); `UnfoldOutputPlan.iface` (the folder twin) is now the single spec — `classify_output`'s divergent local builder derivation is deleted, and the A-arm returns `A?` when the shape is `Optional`-wrapped.

## Tests

- **core unfold**: `Optional(Iterable(Base))` derivation for M5 + M4, non-fixed, `Callback`; the 1-leaf variant stays `Callback` (guard fix).
- **cross-artifact** (#104 infra): bare + Optional record-built folds agree extern-vs-Kotlin on the `(acc, fold)` arity; wrapper surfaces asserted verbatim (`<A>(acc: A, onError: JniErrorHandler<A?>, fold: XFolder<A>): A?` + the `as A?` cast).
- **covertest-kotlin (JVM)**: new `summary_series` / `summary_series_opt` exercise — `Some(vec)` folds through the typed folder descriptor, `Some(empty)` returns the acc, `None` returns null. **PASS – 31 sections**.
- 293 lib tests + all workspace suites green; `regen-check.sh` clean (all pre-existing generated output byte-identical; covertest diffs additive-only); CI fmt/clippy gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)