### PR TITLE
jnigen: memoize IfaceSpec derivation — one spec per identity across all tiers (#107)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -96,6 +96,7 @@ impl JniGen {
             ignored_class_types: std::collections::HashSet::new(),
             ignored_const_idents: std::collections::HashSet::new(),
             local_fns: Vec::new(),
+            iface_specs: Default::default(),
         };
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
         // as T and routes E to the error-sink on Err. The rank tables are

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -249,9 +249,10 @@ pub(crate) fn callback_input(
         total += 1;
     }
 
-    // Typed `run` descriptor of the generated callback interface — derived
-    // from the same plans/leaf classification as the jvalues above.
-    let spec = callback_iface_spec(ext, registry, args)?;
+    // Typed `run` descriptor of the generated callback interface — the SAME
+    // memoized spec (`SpecKey::Callback`) the wrapper surface and the
+    // interface declaration read, so it cannot drift from the jvalues above.
+    let spec = ext.iface_spec(registry, &SpecKey::callback(args))?;
     let descr_lit = syn::LitStr::new(&spec.descr, Span::call_site());
     // Local-frame capacity: roughly an encoded wire + a wrapped object per
     // delivered leaf, plus call temporaries.

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -28,11 +28,13 @@ pub(crate) struct JniFunctionPlan {
     /// see `symbol`, #86), derived from [`Self::jni_method`].
     pub native_symbol: String,
     /// The onError sink interface — the typed `<Err>Handler` when an error
-    /// plan exists, the global `JniErrorHandler` otherwise. One spec feeds
-    /// the Rust `__SINK_*` statics and the Kotlin `onError` wiring, so the
-    /// FQN/descriptor pair of the cached `run` lookup cannot drift. `None` =
-    /// underivable (the Rust emitter panics, the Kotlin renderer skips).
-    pub onerror_iface: Option<IfaceSpec>,
+    /// plan exists, the global `JniErrorHandler` otherwise. Shared from the
+    /// [`JniGen::iface_spec`] memo: one derivation feeds the Rust `__SINK_*`
+    /// statics, the Kotlin `onError` wiring, and the interface declaration,
+    /// so the FQN/descriptor pair of the cached `run` lookup cannot drift.
+    /// `None` = underivable (the Rust emitter panics, the Kotlin renderer
+    /// skips).
+    pub onerror_iface: Option<Arc<IfaceSpec>>,
     pub params: Vec<PlanParam>,
     pub output: FnOutputPlan,
 }
@@ -90,10 +92,10 @@ pub(crate) struct PlanLeaf {
 /// probe order is canonical, not load-bearing.
 pub(crate) enum InputKind {
     /// `impl Fn(args)` callback: erased `Any` on the wire. `iface` is the
-    /// typed `fun interface` spec ([`callback_iface_spec`], keyed on the arg
-    /// types); `None` = underivable, the Kotlin wrapper renderer skips.
-    /// Boxed — an [`IfaceSpec`] would dominate the variant sizes.
-    Callback { iface: Option<Box<IfaceSpec>> },
+    /// typed `fun interface` spec (memoized under [`SpecKey::Callback`] —
+    /// the same allocation the trampoline and the declaration emitter read);
+    /// `None` = underivable, the Kotlin wrapper renderer skips.
+    Callback { iface: Option<Arc<IfaceSpec>> },
     /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
     /// Vec-handle on the wire, built by pushing element leaves.
     VecBuild { elem: syn::Type, by_ref: bool },
@@ -144,12 +146,13 @@ pub(crate) struct UnfoldOutputPlan {
     pub generic: Option<&'static str>,
     /// The builder/folder `fun interface` spec the delivery calls into —
     /// [`folder_iface_for_plan`] for an iterable fold (incl. the fixed
-    /// whole-element form), [`builder_iface_spec`] otherwise. One spec feeds
-    /// the Rust upcall statics and every Kotlin surface read, so the cached
-    /// `run` FQN/descriptor pair cannot drift. `None` = underivable (the
-    /// Rust emitter keeps its historical `expect`s, the Kotlin renderer
-    /// skips). Boxed to keep the variant small.
-    pub iface: Option<Box<IfaceSpec>>,
+    /// whole-element form), the memoized [`SpecKey::Builder`] spec
+    /// otherwise. Shared from the [`JniGen::iface_spec`] memo: one
+    /// derivation feeds the Rust upcall statics, every Kotlin surface read,
+    /// and the interface declaration, so the cached `run` FQN/descriptor
+    /// pair cannot drift. `None` = underivable (the Rust emitter keeps its
+    /// historical `expect`s, the Kotlin renderer skips).
+    pub iface: Option<Arc<IfaceSpec>>,
 }
 
 /// Value-return facts: the resolved conversion target and wire on the Rust
@@ -408,7 +411,7 @@ fn classify_leaf(
     // `impl Fn(args)` first: typed entirely from the interface spec — the
     // erased entry exists but its metadata carries no surface type.
     if let Some(args) = extract_fn_trait_args(ty) {
-        let iface = callback_iface_spec(ext, registry, &args).map(Box::new);
+        let iface = ext.iface_spec(registry, &SpecKey::callback(&args));
         return Ok(PlanLeaf {
             ty: ty.clone(),
             kt_name,
@@ -528,13 +531,13 @@ fn build_output(
             Some("R")
         };
         let iface = if iterable_fold {
-            folder_iface_for_plan(ext, registry, plan).map(Box::new)
+            folder_iface_for_plan(ext, registry, plan)
         } else {
             let decon = plan
                 .decon
-                .as_ref()
+                .clone()
                 .expect("record-built plan carries its DeconId");
-            builder_iface_spec(ext, registry, decon).map(Box::new)
+            ext.iface_spec(registry, &SpecKey::Builder(decon))
         };
         return Ok(FnOutputPlan::Unfold(UnfoldOutputPlan {
             iterable_fold,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -16,8 +16,12 @@
 //! `run` with raw typed `jvalue`s: no per-leaf boxing upcalls, no erased
 //! `FunctionN`.
 //!
-//! All constructors are deterministic over `(ext, registry)`, so the three
-//! sites independently derive identical specs.
+//! Each identity's spec is derived ONCE, through the [`JniGen::iface_spec`]
+//! memo keyed by [`SpecKey`], and shared by all three sites — the
+//! FQN/descriptor pair cannot drift between the artifact tiers (issue #107).
+//! The constructors stay deterministic over `(ext, registry)`; in debug
+//! builds every memo hit re-derives and asserts equality, so the
+//! determinism is a checked invariant rather than a convention.
 
 use super::*;
 use crate::api::core::unfold::{dedup_names, DeconId, UnfoldPlan};
@@ -772,6 +776,149 @@ pub(crate) fn owned_handle_iface_param(
     })
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// Spec identities + the per-generator memo (issue #107)
+// ──────────────────────────────────────────────────────────────────────
+
+/// One distinct generated-interface identity — the memo key shared by the
+/// resolve-time trampoline, the per-function plan, and the declaration
+/// emitter (formerly `write_callback_ifaces`' local `Use` enum). `Ord` so
+/// declaration emission iterates deterministically. Type-shaped identities
+/// store the canonical [`TypeKey`] string; the derivation round-trips it
+/// back to a `syn::Type`, so a key alone fully determines its spec.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SpecKey {
+    /// impl-Fn delivery — the args' canonical type keys (each arg either
+    /// decomposes via its type's canonical plan or crosses whole).
+    Callback(Vec<String>),
+    Builder(DeconId),
+    Folder(DeconId),
+    /// Whole-element fold — no declaration; keyed by element type.
+    WholeFolder(String),
+    Handler(DeconId),
+    JniErrorHandler,
+}
+
+impl SpecKey {
+    /// The impl-Fn identity for a callback's arg types.
+    pub fn callback(args: &[syn::Type]) -> Self {
+        SpecKey::Callback(
+            args.iter()
+                .map(|t| TypeKey::from_type(t).to_string())
+                .collect(),
+        )
+    }
+
+    /// The whole-element fold identity for an element type.
+    pub fn whole_folder(element: &syn::Type) -> Self {
+        SpecKey::WholeFolder(TypeKey::from_type(element).to_string())
+    }
+}
+
+/// DeconIds whose builder/folder is a synthesized by-value `data_class`
+/// (`fixed_builder` plans). Fixedness is a property of the DECLARATION
+/// identity — the JVM resolves calls against the single declared interface —
+/// so it is computed per `DeconId` over all plans, shared by the memo
+/// derivation ([`SpecKey::Folder`]'s typed groups) and the declaration
+/// emitter (the hoisted `fromParts`/appender singletons).
+pub(crate) fn fixed_decon_ids(
+    registry: &Registry<KotlinMeta>,
+) -> std::collections::HashSet<DeconId> {
+    registry
+        .unfold_plans
+        .values()
+        .chain(registry.callback_arg_plans.values())
+        .filter(|p| p.fixed_builder)
+        .filter_map(|p| p.decon.clone())
+        .collect()
+}
+
+/// Element type keys whose whole-element fold is fixed (a synthesized
+/// single-leaf `Vec<T>` fold) — the leaf dual of [`fixed_decon_ids`], used
+/// by the declaration emitter for the hoisted appender singleton.
+pub(crate) fn fixed_leaf_element_keys(
+    registry: &Registry<KotlinMeta>,
+) -> std::collections::HashSet<String> {
+    registry
+        .unfold_plans
+        .values()
+        .chain(registry.callback_arg_plans.values())
+        .filter(|p| p.fixed_builder)
+        .filter_map(|p| p.element.as_ref())
+        .map(|el| TypeKey::from_type(el).to_string())
+        .collect()
+}
+
+/// Derive the spec for one identity — the SINGLE construction point behind
+/// [`JniGen::iface_spec`]. Reconstructs any `syn` context from the key's
+/// canonical type strings ([`TypeKey::to_type`] round-trip). A `Folder`
+/// derivation folds the fixed-builder typed-group view in per `DeconId`
+/// (see [`fixed_decon_ids`]).
+fn derive_iface_spec(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    key: &SpecKey,
+) -> Option<IfaceSpec> {
+    match key {
+        SpecKey::Callback(arg_keys) => {
+            let args: Vec<syn::Type> = arg_keys
+                .iter()
+                .map(|k| TypeKey::parse(k).to_type())
+                .collect();
+            callback_iface_spec(ext, registry, &args)
+        }
+        SpecKey::Builder(d) => builder_iface_spec(ext, registry, d),
+        SpecKey::Folder(d) => {
+            let mut spec = folder_iface_spec(ext, registry, d)?;
+            if fixed_decon_ids(registry).contains(d) {
+                spec.typed_groups = fixed_folder_typed_groups(ext, registry, d)?;
+            }
+            Some(spec)
+        }
+        SpecKey::WholeFolder(el_key) => {
+            whole_folder_iface_spec(ext, registry, &TypeKey::parse(el_key).to_type())
+        }
+        SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
+        SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
+    }
+}
+
+impl JniGen {
+    /// The memoized spec for one interface identity: derived once per
+    /// generator run and shared by every consumer — the resolve-time
+    /// trampoline, the per-function plan, and the declaration emitter — so
+    /// the FQN/descriptor pair cannot drift between artifact tiers (issue
+    /// #107). `None` (not yet derivable — e.g. leaf converters still
+    /// unresolved) is NOT cached: the resolve-time caller defers and
+    /// retries. In debug builds a cache hit re-derives and asserts equality,
+    /// so any nondeterminism in the constructors fails loudly under test
+    /// instead of shipping descriptor drift.
+    pub(crate) fn iface_spec(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        key: &SpecKey,
+    ) -> Option<std::sync::Arc<IfaceSpec>> {
+        let hit = self.iface_specs.borrow().get(key).cloned();
+        if let Some(hit) = hit {
+            #[cfg(debug_assertions)]
+            {
+                let fresh = derive_iface_spec(self, registry, key);
+                debug_assert_eq!(
+                    fresh.as_ref().map(|s| format!("{s:?}")),
+                    Some(format!("{:?}", *hit)),
+                    "IfaceSpec derivation drifted for {key:?}"
+                );
+            }
+            return Some(hit);
+        }
+        let spec = std::sync::Arc::new(derive_iface_spec(self, registry, key)?);
+        self.iface_specs
+            .borrow_mut()
+            .insert(key.clone(), spec.clone());
+        Some(spec)
+    }
+}
+
 /// Interface for an `impl Fn(args)` delivery: one `run` parameter per
 /// flattened leaf of each arg's callback plan (the arg whole when plan-less),
 /// returning `Unit`. Named `<ArgShorts>Callback` (`Fn()` → `VoidCallback`),
@@ -1017,26 +1164,22 @@ pub(crate) fn whole_folder_iface_spec(
 }
 
 /// The folder spec for an `Iterable` plan: declaration-keyed when the
-/// element decomposes, whole-element otherwise. Thin dispatch — the
-/// derivation itself is keyed.
+/// element decomposes, whole-element otherwise. Thin KEY dispatch into the
+/// [`JniGen::iface_spec`] memo — the fixed-builder typed-group view is
+/// applied there per `DeconId` (the declaration identity the JVM resolves
+/// against), not per this plan's own `fixed_builder` flag.
 pub(crate) fn folder_iface_for_plan(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     plan: &UnfoldPlan,
-) -> Option<IfaceSpec> {
+) -> Option<std::sync::Arc<IfaceSpec>> {
     debug_assert!(
         plan.shape.has_iterable_layer(),
         "folder_iface_for_plan requires an Iterable (or Option<Iterable>) plan"
     );
     match (&plan.element, &plan.decon) {
-        (Some(el), _) => whole_folder_iface_spec(ext, registry, el),
-        (None, Some(d)) => {
-            let mut spec = folder_iface_spec(ext, registry, d)?;
-            if plan.fixed_builder {
-                spec.typed_groups = fixed_folder_typed_groups(ext, registry, d)?;
-            }
-            Some(spec)
-        }
+        (Some(el), _) => ext.iface_spec(registry, &SpecKey::whole_folder(el)),
+        (None, Some(d)) => ext.iface_spec(registry, &SpecKey::Folder(d.clone())),
         (None, None) => None,
     }
 }
@@ -1142,21 +1285,21 @@ pub(crate) fn jni_error_handler_iface_spec(ext: &JniGen) -> IfaceSpec {
 }
 
 /// The onError handler spec for a declared function: its error plan's
-/// declaration-keyed typed handler, or the shared
-/// [`jni_error_handler_iface_spec`].
+/// declaration-keyed typed handler, or the shared global
+/// `JniErrorHandler`. Thin KEY dispatch into the [`JniGen::iface_spec`]
+/// memo.
 pub(crate) fn onerror_iface_spec(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     fn_ident: &syn::Ident,
-) -> Option<IfaceSpec> {
-    match registry.error_plans.get(fn_ident) {
-        Some(plan) => error_handler_iface_spec(
-            ext,
-            registry,
+) -> Option<std::sync::Arc<IfaceSpec>> {
+    let key = match registry.error_plans.get(fn_ident) {
+        Some(plan) => SpecKey::Handler(
             plan.decon
-                .as_ref()
+                .clone()
                 .expect("error plans are always record-built (decon is Some)"),
         ),
-        None => Some(jni_error_handler_iface_spec(ext)),
-    }
+        None => SpecKey::JniErrorHandler,
+    };
+    ext.iface_spec(registry, &key)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -755,24 +755,10 @@ impl JniGen {
     pub(crate) fn write_callback_ifaces(&self, registry: &Registry<KotlinMeta>) -> Vec<kt::KtFile> {
         use crate::api::core::unfold::{DeconId, Delivery};
 
-        /// One distinct interface identity in use. Ordered so emission is
-        /// deterministic.
-        #[derive(PartialEq, Eq, PartialOrd, Ord)]
-        enum Use {
-            /// impl-Fn delivery — identified by the args' canonical type keys
-            /// (each arg uses its type's canonical decomposition or crosses
-            /// whole; the spec carries the arg types).
-            Callback(Vec<String>),
-            Builder(DeconId),
-            Folder(DeconId),
-            /// Whole-element fold — no declaration; keyed by element type.
-            WholeFolder(String),
-            Handler(DeconId),
-            JniErrorHandler,
-        }
-        // Identity → the syn-typed context the spec constructor needs (arg
-        // types for Callback, the element type for WholeFolder).
-        let mut uses: BTreeMap<Use, Vec<syn::Type>> = BTreeMap::new();
+        // Distinct interface identities in use — [`SpecKey`] (`Ord`, so
+        // emission is deterministic). The memo derives each spec from the
+        // key alone, so no side context is carried.
+        let mut uses: BTreeSet<SpecKey> = BTreeSet::new();
 
         /// A hoisted-singleton request emitted alongside an interface: the
         /// `fromParts` builder / folder for a synthesized `data_class`, or the
@@ -784,28 +770,12 @@ impl JniGen {
             LeafFolder,
         }
 
-        // DeconIds whose builder is a synthesized by-value `data_class`
-        // (`fixed_builder`): these get a hoisted `__<Name>Builder` singleton
-        // (the `fromParts` factory) emitted alongside the interface, so the
-        // wrapper references it instead of taking a caller `build` param.
-        let fixed_decons: std::collections::HashSet<DeconId> = registry
-            .unfold_plans
-            .values()
-            .chain(registry.callback_arg_plans.values())
-            .filter(|p| p.fixed_builder)
-            .filter_map(|p| p.decon.clone())
-            .collect();
-        // Element type keys whose whole-element fold is fixed (a synthesized
-        // single-leaf `Vec<T>` fold): these get a hoisted `__<Elem>FolderRaw`
-        // appender singleton, the leaf dual of `fixed_decons`.
-        let fixed_leaf_elements: std::collections::HashSet<String> = registry
-            .unfold_plans
-            .values()
-            .chain(registry.callback_arg_plans.values())
-            .filter(|p| p.fixed_builder)
-            .filter_map(|p| p.element.as_ref())
-            .map(|el| TypeKey::from_type(el).to_string())
-            .collect();
+        // Fixedness sets shared with the memo derivation (`iface.rs`): a
+        // fixed DeconId gets a hoisted `__<Name>Builder` / folder-appender
+        // singleton emitted alongside its interface; a fixed whole-element
+        // key gets the `__<Elem>FolderRaw` appender, the leaf dual.
+        let fixed_decons = fixed_decon_ids(registry);
+        let fixed_leaf_elements = fixed_leaf_element_keys(registry);
 
         // Walk every declared function — free `.fun`s AND class methods/factories
         // (`.method`/`.accessor`/`.constructor`): a method can also need a
@@ -832,11 +802,7 @@ impl JniGen {
                         continue;
                     };
                     if let Some(cb_args) = extract_fn_trait_args(&pt.ty) {
-                        let key = cb_args
-                            .iter()
-                            .map(|t| TypeKey::from_type(t).to_string())
-                            .collect();
-                        uses.insert(Use::Callback(key), cb_args);
+                        uses.insert(SpecKey::callback(&cb_args));
                     }
                 }
                 if let Some(plan) = registry
@@ -847,16 +813,13 @@ impl JniGen {
                     let iterable = is_iterable_fold(&plan.shape);
                     match (iterable, &plan.element, &plan.decon) {
                         (true, Some(el), _) => {
-                            uses.insert(
-                                Use::WholeFolder(TypeKey::from_type(el).to_string()),
-                                vec![el.clone()],
-                            );
+                            uses.insert(SpecKey::whole_folder(el));
                         }
                         (true, None, Some(d)) => {
-                            uses.insert(Use::Folder(d.clone()), vec![]);
+                            uses.insert(SpecKey::Folder(d.clone()));
                         }
                         (false, _, Some(d)) => {
-                            uses.insert(Use::Builder(d.clone()), vec![]);
+                            uses.insert(SpecKey::Builder(d.clone()));
                         }
                         _ => {}
                     }
@@ -867,69 +830,48 @@ impl JniGen {
                             .decon
                             .clone()
                             .expect("error plans are always record-built (decon is Some)");
-                        uses.insert(Use::Handler(d), vec![]);
+                        uses.insert(SpecKey::Handler(d));
                     }
                     None => {
-                        uses.insert(Use::JniErrorHandler, vec![]);
+                        uses.insert(SpecKey::JniErrorHandler);
                     }
                 }
             }
         }
 
         uses.into_iter()
-            .filter_map(|(u, tys)| {
-                // `is_error` ⇒ also emit the zero-alloc capture holder used by
-                // the generated wrappers' error channel. `fixed` carries the
-                // builder's DeconId when it is a synthesized `data_class`, so a
-                // hoisted `__<Name>Builder` singleton is emitted with it.
-                // `fixed` carries a hoisted-singleton request: `(decon, is_folder)`.
-                // `is_folder` picks the folder-appender singleton (`Vec<data_class>`
-                // fold) over the scalar `fromParts` builder.
-                let (spec, is_error, fixed) = match u {
-                    Use::Callback(_) => (callback_iface_spec(self, registry, &tys), false, None),
-                    Use::Builder(d) => {
-                        let fixed = fixed_decons
-                            .contains(&d)
-                            .then(|| FixedSingleton::StructBuilder(d.clone()));
-                        (builder_iface_spec(self, registry, &d), false, fixed)
-                    }
-                    Use::Folder(d) => {
-                        // A fixed-builder fold groups the leaves into a typed
-                        // `(acc, element)` view (raw twin keeps the leaves) so the
-                        // emitted interface matches the wrapper's
-                        // `folder_iface_for_plan`; an explicit-accessor fold keeps
-                        // its 1:1 leaf view unchanged.
-                        let is_fixed = fixed_decons.contains(&d);
-                        let spec = folder_iface_spec(self, registry, &d).map(|mut s| {
-                            if is_fixed {
-                                s.typed_groups = fixed_folder_typed_groups(self, registry, &d)
-                                    .unwrap_or_default();
-                            }
-                            s
-                        });
-                        (
-                            spec,
-                            false,
-                            is_fixed.then(|| FixedSingleton::StructFolder(d.clone())),
-                        )
-                    }
-                    Use::WholeFolder(_) => {
-                        // A synthesized single-leaf `Vec<T>` fold gets a hoisted
-                        // appender singleton; an explicit caller-fold whole-element
-                        // deconstruction (not `fixed_builder`) does not.
-                        let fixed = fixed_leaf_elements
-                            .contains(&TypeKey::from_type(&tys[0]).to_string())
-                            .then_some(FixedSingleton::LeafFolder);
-                        (
-                            whole_folder_iface_spec(self, registry, &tys[0]),
-                            false,
-                            fixed,
-                        )
-                    }
-                    Use::Handler(d) => (error_handler_iface_spec(self, registry, &d), true, None),
-                    Use::JniErrorHandler => (Some(jni_error_handler_iface_spec(self)), true, None),
+            .filter_map(|u| {
+                // Every spec comes from the SAME memo the wrappers and the
+                // resolve-time trampoline read ([`JniGen::iface_spec`]) —
+                // this site only classifies the extras: `is_error` ⇒ also
+                // emit the zero-alloc capture holder used by the generated
+                // wrappers' error channel; `fixed` carries a
+                // hoisted-singleton request (the `fromParts` builder /
+                // folder-appender for a synthesized `data_class`, or the
+                // single-leaf appender for a fixed whole-element fold).
+                let (is_error, fixed) = match &u {
+                    SpecKey::Callback(_) => (false, None),
+                    SpecKey::Builder(d) => (
+                        false,
+                        fixed_decons
+                            .contains(d)
+                            .then(|| FixedSingleton::StructBuilder(d.clone())),
+                    ),
+                    SpecKey::Folder(d) => (
+                        false,
+                        fixed_decons
+                            .contains(d)
+                            .then(|| FixedSingleton::StructFolder(d.clone())),
+                    ),
+                    SpecKey::WholeFolder(el_key) => (
+                        false,
+                        fixed_leaf_elements
+                            .contains(el_key)
+                            .then_some(FixedSingleton::LeafFolder),
+                    ),
+                    SpecKey::Handler(_) | SpecKey::JniErrorHandler => (true, None),
                 };
-                spec.map(|s| (s, is_error, fixed))
+                self.iface_spec(registry, &u).map(|s| (s, is_error, fixed))
             })
             .map(|(s, is_error, fixed)| {
                 // Typed (user-facing) interface; when any leaf's raw view

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -459,6 +459,16 @@ pub struct JniGen {
     /// stated signature)`. Synthesized into registry entries by the
     /// [`Prebindgen::local_functions`] pre-pass.
     pub(crate) local_fns: Vec<(syn::Ident, syn::Path, syn::Signature)>,
+
+    /// Memoized callback-interface specs, one per [`SpecKey`] identity —
+    /// populated lazily via [`JniGen::iface_spec`] (first touch may be the
+    /// resolve-time trampoline, which runs before any function plan exists)
+    /// and shared by every later consumer, so the FQN/descriptor pair cannot
+    /// drift between the Rust, Kotlin-wrapper, and interface-declaration
+    /// tiers (issue #107). Not a setting: derived state, keyed entirely by
+    /// `(self, registry)` — cloning the builder just clones the cache.
+    pub(crate) iface_specs:
+        std::cell::RefCell<std::collections::BTreeMap<SpecKey, std::sync::Arc<IfaceSpec>>>,
 }
 
 // ── Sibling submodules (carved from the former monolithic file) ─────────

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -812,7 +812,7 @@ pub(crate) fn render_const_val(
     let kdoc = crate::api::lang::jnigen::util::doc_string(&c.attrs)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
-    render_val_over_helper(ext, helper, val_name, kdoc, imports)
+    render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
 }
 
 /// Render one fn-sourced constant (see `ConstDecl::fun`):
@@ -842,7 +842,7 @@ pub(crate) fn render_constant_fn_val(
     let kdoc = crate::api::lang::jnigen::util::doc_string(&f.attrs)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
-    render_val_over_helper(ext, helper, val_name, kdoc, imports)
+    render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
 }
 
 /// Render one expression-backed constant (see `ConstDecl::expr`):
@@ -866,7 +866,14 @@ pub(crate) fn render_const_expr_val(
         "Binding-defined constant: `{expr}` (evaluated lazily, once, through \
          the generated JNI getter on first use)."
     );
-    render_val_over_helper(ext, helper, decl.kotlin_name.clone(), kdoc, imports)
+    render_val_over_helper(
+        ext,
+        registry,
+        helper,
+        decl.kotlin_name.clone(),
+        kdoc,
+        imports,
+    )
 }
 
 /// Shared val-rendering core for both constant kinds (`ConstDecl` /
@@ -878,6 +885,7 @@ pub(crate) fn render_const_expr_val(
 /// not fire one JNI call per `val` at class-load (issue #58).
 fn render_val_over_helper(
     ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
     mut helper: kt::KtFun,
     val_name: String,
     kdoc: String,
@@ -888,7 +896,7 @@ fn render_val_over_helper(
     // A constant always carries a value type; a helper with no return would
     // mean the type never resolved — skip like an unresolvable fn.
     let val_ty = helper.ret.clone()?;
-    let spec = jni_error_handler_iface_spec(ext);
+    let spec = ext.iface_spec(registry, &SpecKey::JniErrorHandler)?;
     imports.insert(spec.fqn());
     let init = format!(
         "{helper_name}(JniErrorHandler {{ je -> error(je ?: \"const {val_name}: JNI getter failed\") }})"

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -431,3 +431,94 @@ fn callback_double_option_unwrap_pipeline() {
 // differently-decomposed functions get distinct interfaces instead of
 // colliding on one type-keyed name.
 // ────────────────────────────────────────────────────────────────────────
+
+// ────────────────────────────────────────────────────────────────────────
+// Spec memo (issue #107): every consumer — resolve-time trampoline,
+// per-function plan, declaration emitter — reads ONE derivation per
+// interface identity through `JniGen::iface_spec`.
+// ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn iface_spec_memo_shares_one_derivation() {
+    use crate::SourceLocation;
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_thing_name(this_: &ZThing) -> String {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_things_all() -> Vec<ZThing> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_thing_sub(cb: impl Fn(ZThing) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))
+                .fun(crate::fun!(z_things_all))
+                .fun(crate::fun!(z_thing_sub)),
+        )
+        .expand(
+            crate::expand_return!(ZThing)
+                .field_self()
+                .field(crate::fun!(z_thing_name)),
+        );
+    let gen = registry.resolve(jni).expect("resolve");
+    let (ext, registry) = (gen.adapter(), gen.registry());
+
+    // Same key twice ⇒ the same allocation (resolve already populated the
+    // memo through the trampoline — a hit also exercises the debug-build
+    // re-derivation assert).
+    let a = ext
+        .iface_spec(registry, &SpecKey::JniErrorHandler)
+        .expect("global handler spec");
+    let b = ext
+        .iface_spec(registry, &SpecKey::JniErrorHandler)
+        .expect("global handler spec");
+    assert!(Arc::ptr_eq(&a, &b), "one derivation per identity");
+
+    // The plan-facing dispatcher and a direct key lookup share one
+    // allocation — the wrapper surface and the interface declaration cannot
+    // diverge from the fold upcall's descriptor.
+    let plan = registry
+        .unfold_plans
+        .get(&syn::parse_str::<syn::Ident>("z_things_all").unwrap())
+        .expect("fold plan");
+    let via_plan = folder_iface_for_plan(ext, registry, plan).expect("folder spec");
+    let decon = plan.decon.clone().expect("record-built fold");
+    let direct = ext
+        .iface_spec(registry, &SpecKey::Folder(decon))
+        .expect("folder spec");
+    assert!(Arc::ptr_eq(&via_plan, &direct), "folder identity shared");
+
+    // The impl-Fn identity: the trampoline (resolve time) and the wrapper
+    // surface key on the same canonical arg types.
+    let args: Vec<syn::Type> = vec![syn::parse_quote!(ZThing)];
+    let cb1 = ext
+        .iface_spec(registry, &SpecKey::callback(&args))
+        .expect("callback spec");
+    let cb2 = ext
+        .iface_spec(registry, &SpecKey::callback(&args))
+        .expect("callback spec");
+    assert!(Arc::ptr_eq(&cb1, &cb2), "callback identity shared");
+    assert_eq!(cb1.descr, "(JLjava/lang/String;)V");
+}


### PR DESCRIPTION
Closes #107.

## What

A callback interface's `IfaceSpec` (FQN + `run` descriptor + param views) was derived **independently at three times** — the resolve-time trampoline (`emit/callback.rs`, baking the descriptor into tokens during converter resolution, before any function plan exists), the per-function plan (`fn_plan.rs`, per-function `Box` copies), and the declaration emitter (`write_callback_ifaces`, keyed by its local `Use` enum with its own duplicated `fixed_decons` derivation). Correctness rested on the `iface.rs` module-doc convention that all constructors are deterministic over `(ext, registry)`; drift means a wrong JVM descriptor and a runtime `GetMethodID` failure, caught only by the covertest JVM run.

Now every identity is derived **once** and shared by all three tiers:

- **`SpecKey`** (the former local `Use` enum, hoisted to `iface.rs`): `Callback(arg-type-keys) | Builder | Folder | WholeFolder(elem-key) | Handler | JniErrorHandler`. Type-shaped identities store canonical `TypeKey` strings and the derivation round-trips them via `TypeKey::to_type`, so a key alone fully determines its spec.
- **`JniGen::iface_spec`** over a `RefCell<BTreeMap<SpecKey, Arc<IfaceSpec>>>` field: get-or-derive, caching `Some` only — a `None` (leaf converters not yet resolved) stays retryable for the resolve-time rank deferral. **On a cache hit, debug builds re-derive and assert equality** — the determinism convention is now a checked invariant exercised by every test run instead of an unverified comment.
- `folder_iface_for_plan` / `onerror_iface_spec` become thin key-dispatchers; `fn_plan`'s `Box<IfaceSpec>` fields become the memo's `Arc<IfaceSpec>`; `write_callback_ifaces` keeps only the identity walk plus the singleton/error classification; the const-`val` helper threads the registry and reads the global handler from the memo.
- `fixed_decon_ids` / `fixed_leaf_element_keys` hoisted to `iface.rs`, shared by the memo derivation and the declaration emitter.

## Behavioral note

The fixed-folder typed-group view is now keyed per **DeconId** (the declaration identity the JVM resolves against) everywhere; previously `folder_iface_for_plan` keyed it on the individual plan's `fixed_builder` flag. The two can diverge only if one DeconId had both fixed and record-built folder plans — believed unconstructible; per-DeconId is the correct identity either way.

## Verification

- **Output-preserving**: `regen-check.sh` byte-identical; covertest JVM run **PASS – 31 sections**; 294 lib tests and all 20 workspace suites green; CI fmt/clippy gates pass locally.
- New test `iface_spec_memo_shares_one_derivation`: `Arc::ptr_eq` across repeated lookups, across the plan-facing dispatcher vs a direct key lookup, and a descriptor spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)