### PR TITLE
core: TypeKey — semantic type identity instead of token spelling (#95)

### DIFF
--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -28,46 +28,92 @@ use crate::{
     SourceLocation,
 };
 
-/// Canonical type-shape key — the `to_token_stream().to_string()` form of a
-/// `syn::Type`. Whitespace-normalised (`"Vec<u8>"` and `"Vec < u8 >"` produce
-/// the same key after parse-and-restringify).
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub struct TypeKey(String);
+/// Canonical type-shape key: identity is the token string of the
+/// **normalized** type ([`crate::api::core::types_util::normalize_type`] —
+/// group/paren unwrap, `crate::`/`self::` and std-prelude path reduction;
+/// the complete equivalence rule set is documented there). The normalized
+/// parsed form is kept alongside the string, so [`Self::to_type`] is an
+/// infallible clone — no core invariant depends on serialize-then-reparse
+/// round trips (issue #95).
+#[derive(Clone)]
+pub struct TypeKey {
+    /// Canonical token string — the identity `Eq`/`Hash` compare.
+    canon: std::rc::Rc<str>,
+    /// The normalized parsed form the string was rendered from.
+    ty: std::rc::Rc<syn::Type>,
+}
+
+impl PartialEq for TypeKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.canon == other.canon
+    }
+}
+impl Eq for TypeKey {}
+impl std::hash::Hash for TypeKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.canon.hash(state)
+    }
+}
+// Keep the historical single-field tuple rendering (`TypeKey("Vec < u8 >")`)
+// — error text and test expectations format keys through it.
+impl fmt::Debug for TypeKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TypeKey").field(&&*self.canon).finish()
+    }
+}
+
+/// Structured failure of [`TypeKey::parse`]: the offending input plus the
+/// underlying `syn` parse error.
+#[derive(Debug)]
+pub struct TypeKeyParseError {
+    pub input: String,
+    pub error: syn::Error,
+}
+
+impl fmt::Display for TypeKeyParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid type `{}`: {}", self.input, self.error)
+    }
+}
+
+impl std::error::Error for TypeKeyParseError {}
 
 impl TypeKey {
-    /// Build a key by parsing the input as a type and re-serialising. Panics
-    /// if the input does not parse as a `syn::Type`.
-    pub fn parse(s: &str) -> Self {
-        let ty: syn::Type = syn::parse_str(s)
-            .unwrap_or_else(|e| panic!("TypeKey::parse: invalid type `{}`: {}", s, e));
-        Self::from_type(&ty)
+    /// Build a key by parsing the input as a type and normalizing.
+    pub fn parse(s: &str) -> Result<Self, TypeKeyParseError> {
+        let ty: syn::Type = syn::parse_str(s).map_err(|error| TypeKeyParseError {
+            input: s.to_string(),
+            error,
+        })?;
+        Ok(Self::from_type(&ty))
     }
 
-    /// Build a key directly from a `syn::Type`.
+    /// Build a key directly from a `syn::Type` (normalizing a clone; the
+    /// input is not modified).
     pub fn from_type(ty: &syn::Type) -> Self {
-        Self(ty.to_token_stream().to_string())
+        let mut t = ty.clone();
+        crate::api::core::types_util::normalize_type(&mut t, &[]);
+        Self {
+            canon: t.to_token_stream().to_string().into(),
+            ty: std::rc::Rc::new(t),
+        }
     }
 
     /// The canonical string form.
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.canon
     }
 
-    /// Parse the key back into a `syn::Type`. Always succeeds because the
-    /// key was originally constructed from a parseable type.
+    /// The normalized parsed form. Infallible — a clone of the stored type,
+    /// never a reparse.
     pub fn to_type(&self) -> syn::Type {
-        syn::parse_str(&self.0).unwrap_or_else(|e| {
-            panic!(
-                "TypeKey::to_type: stored key `{}` no longer parses: {}",
-                self.0, e
-            )
-        })
+        (*self.ty).clone()
     }
 }
 
 impl fmt::Display for TypeKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
+        f.write_str(&self.canon)
     }
 }
 
@@ -319,6 +365,16 @@ pub enum ScanError {
     DeclaredNotFound {
         entries: Vec<(&'static str, String)>,
     },
+    /// Declared type keys that qualify a source item with its crate path
+    /// (`ptr_class!(myflat::Foo)` where `myflat` is a chained source crate).
+    /// Source items live in one flat namespace and are keyed by their bare
+    /// name — the qualified spelling can never match a captured signature,
+    /// so it is a hard error with a fix-it instead of a silent miss (issue
+    /// #95). All offenders are collected before failing.
+    QualifiedDeclaredTypes {
+        /// `(qualified spelling, bare fix-it name)` pairs.
+        entries: Vec<(String, String)>,
+    },
 }
 
 impl fmt::Display for ScanError {
@@ -375,6 +431,21 @@ impl fmt::Display for ScanError {
                     f,
                     "a declaration names an item that does not exist — typo in build.rs, \
                      or renamed/removed in the source crate?"
+                )
+            }
+            ScanError::QualifiedDeclaredTypes { entries } => {
+                writeln!(
+                    f,
+                    "{} declared type(s) qualify a source item with its crate path:",
+                    entries.len()
+                )?;
+                for (spelled, bare) in entries {
+                    writeln!(f, "  - `{spelled}` — declare it as `{bare}`")?;
+                }
+                write!(
+                    f,
+                    "source items live in one flat namespace keyed by their bare name; \
+                     a crate-qualified spelling never matches captured signatures"
                 )
             }
         }
@@ -546,14 +617,28 @@ impl<M> Registry<M> {
         I: IntoIterator<Item = (syn::Item, SourceLocation)>,
     {
         let mut registry = Registry::default();
-        for (item, loc) in items {
-            let crate_name = loc.crate_name.clone();
-            if let Some(crate_name) = &crate_name {
+        // Pass 1: collect and gather EVERY source module name first, so
+        // cross-source type references (`source_a::TypeA` in a later-chained
+        // source's signature) normalize order-independently in pass 2.
+        let items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
+        for (_, loc) in &items {
+            if let Some(crate_name) = &loc.crate_name {
                 let module = crate_name.replace('-', "_");
                 if !registry.source_modules.contains(&module) {
                     registry.source_modules.push(module);
                 }
             }
+        }
+        // Pass 2: normalize each item's types to the canonical flat spelling
+        // (`crate::`/source-module paths reduce to the bare indexed name —
+        // see `normalize_type`'s rule list), then index. Every downstream
+        // `TypeKey::from_type` over a signature type therefore sees the
+        // normalized form, so bare adapter declarations match qualified
+        // captured spellings (issue #95).
+        let modules = registry.source_modules.clone();
+        for (mut item, loc) in items {
+            crate::api::core::types_util::normalize_item_types(&mut item, &modules);
+            let crate_name = loc.crate_name.clone();
             let named: Option<syn::Ident> = match &item {
                 syn::Item::Fn(f) => Some(f.sig.ident.clone()),
                 syn::Item::Struct(s) => Some(s.ident.clone()),
@@ -640,6 +725,60 @@ impl<M> Registry<M> {
     }
 
     fn scan_declared_items(&mut self, declared: &DeclaredItems) -> Result<(), ScanError> {
+        // Source-qualified declared types are a hard error (issue #95). The
+        // key's own normalization already reduced `crate::`/`self::` and std
+        // prelude spellings, so a remaining multi-segment declared path
+        // either qualifies a SOURCE item with its crate name (can never
+        // match — the flat namespace keys are bare) or names a genuinely
+        // foreign type (supported verbatim; warned about below only when it
+        // shadows a captured item's name — the likely-mistake heuristic).
+        let mut qualified: Vec<(String, String)> = Vec::new();
+        let mut probed: HashSet<&TypeKey> = HashSet::new();
+        for key in declared
+            .types
+            .iter()
+            .chain(declared.ignored_types.iter())
+            .chain(declared.boundary_only_types.iter())
+        {
+            if !probed.insert(key) {
+                continue;
+            }
+            let ty = key.to_type();
+            // Peel one reference level; the qualified head only appears on
+            // path types.
+            let inner = match &ty {
+                syn::Type::Reference(r) => &*r.elem,
+                other => other,
+            };
+            let syn::Type::Path(tp) = inner else { continue };
+            if tp.qself.is_some() || tp.path.segments.len() < 2 {
+                continue;
+            }
+            let head = tp
+                .path
+                .segments
+                .first()
+                .expect("len checked")
+                .ident
+                .to_string();
+            let last = tp.path.segments.last().expect("len checked");
+            if self.source_modules.contains(&head) {
+                qualified.push((key.to_string(), last.to_token_stream().to_string()));
+            } else if self.structs.contains_key(&last.ident) || self.enums.contains_key(&last.ident)
+            {
+                println!(
+                    "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
+                     captured #[prebindgen] item `{}` exists — if you meant the source item, \
+                     declare it by its bare name",
+                    key, last.ident
+                );
+            }
+        }
+        if !qualified.is_empty() {
+            qualified.sort();
+            return Err(ScanError::QualifiedDeclaredTypes { entries: qualified });
+        }
+
         // Declared-but-missing items are collected across all three loops and
         // reported together as one hard error (see
         // [`ScanError::DeclaredNotFound`]); stale *ignore* entries below only
@@ -783,7 +922,7 @@ impl<M> Registry<M> {
         };
         for ident in self.structs.keys().chain(self.enums.keys()) {
             let name = ident.to_string();
-            let key = TypeKey::parse(&name);
+            let key = TypeKey::parse(&name).expect("item idents parse as types");
             if !type_acknowledged(&key) && !pred_ignored(&name) {
                 skipped_types.push(name);
             }

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -54,6 +54,16 @@ impl std::hash::Hash for TypeKey {
         self.canon.hash(state)
     }
 }
+impl PartialOrd for TypeKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for TypeKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.canon.cmp(&other.canon)
+    }
+}
 // Keep the historical single-field tuple rendering (`TypeKey("Vec < u8 >")`)
 // — error text and test expectations format keys through it.
 impl fmt::Debug for TypeKey {
@@ -97,6 +107,12 @@ impl TypeKey {
             canon: t.to_token_stream().to_string().into(),
             ty: std::rc::Rc::new(t),
         }
+    }
+
+    /// Build a key for a bare item ident — infallible by construction (an
+    /// ident IS a single-segment path type; nothing to parse or normalize).
+    pub fn from_ident(ident: &syn::Ident) -> Self {
+        Self::from_type(&crate::api::core::types_util::type_from_ident(ident))
     }
 
     /// The canonical string form.
@@ -922,7 +938,7 @@ impl<M> Registry<M> {
         };
         for ident in self.structs.keys().chain(self.enums.keys()) {
             let name = ident.to_string();
-            let key = TypeKey::parse(&name).expect("item idents parse as types");
+            let key = TypeKey::from_ident(ident);
             if !type_acknowledged(&key) && !pred_ignored(&name) {
                 skipped_types.push(name);
             }
@@ -1145,7 +1161,7 @@ impl<M> Registry<M> {
 
     fn scan_struct(&mut self, s: &syn::ItemStruct, loc: &SourceLocation) -> Result<(), ScanError> {
         // The struct itself can appear in either direction.
-        let ty: syn::Type = syn::parse_str(&s.ident.to_string()).expect("ident is a valid type");
+        let ty: syn::Type = crate::api::core::types_util::type_from_ident(&s.ident);
         self.ensure_entry(Direction::Input, &ty, false, loc);
         self.ensure_entry(Direction::Output, &ty, false, loc);
 
@@ -1159,7 +1175,7 @@ impl<M> Registry<M> {
     }
 
     fn scan_enum(&mut self, e: &syn::ItemEnum, loc: &SourceLocation) -> Result<(), ScanError> {
-        let ty: syn::Type = syn::parse_str(&e.ident.to_string()).expect("ident is a valid type");
+        let ty: syn::Type = crate::api::core::types_util::type_from_ident(&e.ident);
         self.ensure_entry(Direction::Input, &ty, false, loc);
         self.ensure_entry(Direction::Output, &ty, false, loc);
 

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -119,10 +119,18 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("a").unwrap());
     reg.scan_declared(&ext).unwrap();
-    assert!(reg.required_inputs_scan.contains(&TypeKey::parse("u64")));
-    assert!(reg.required_outputs_scan.contains(&TypeKey::parse("u64")));
-    assert!(!reg.required_inputs_scan.contains(&TypeKey::parse("u32")));
-    assert!(!reg.required_outputs_scan.contains(&TypeKey::parse("u32")));
+    assert!(reg
+        .required_inputs_scan
+        .contains(&TypeKey::parse("u64").expect("test type")));
+    assert!(reg
+        .required_outputs_scan
+        .contains(&TypeKey::parse("u64").expect("test type")));
+    assert!(!reg
+        .required_inputs_scan
+        .contains(&TypeKey::parse("u32").expect("test type")));
+    assert!(!reg
+        .required_outputs_scan
+        .contains(&TypeKey::parse("u32").expect("test type")));
 }
 
 #[test]
@@ -163,7 +171,7 @@ fn scan_declared_rejects_type_declared_and_ignored_overlap() {
     let item: syn::ItemStruct = syn::parse_str("struct Thing { value: u64 }").unwrap();
     let items = vec![(syn::Item::Struct(item), SourceLocation::default())];
     let mut reg: Registry<()> = Registry::from_items(items).unwrap();
-    let key = TypeKey::parse("Thing");
+    let key = TypeKey::parse("Thing").expect("test type");
     let mut ext = StubExt::default();
     ext.types.insert(key.clone());
     ext.ignored_types.insert(key.clone());
@@ -292,7 +300,10 @@ fn type_entry_helpers_expose_converter_chain_contract() {
                 metadata: (),
             },
         ],
-        subs: vec![TypeKey::parse("Rust"), TypeKey::parse("Mid")],
+        subs: vec![
+            TypeKey::parse("Rust").expect("test type"),
+            TypeKey::parse("Mid").expect("test type"),
+        ],
         required: true,
         niches: Niches::empty(),
         metadata: (),
@@ -301,7 +312,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
     assert_eq!(entry.converter_ident(), "__wire");
     assert_eq!(
         TypeKey::from_type(entry.wire_type()),
-        TypeKey::parse("jni::sys::jlong")
+        TypeKey::parse("jni::sys::jlong").expect("test type")
     );
     assert_eq!(
         entry
@@ -448,4 +459,155 @@ fn resolve_surfaces_adapter_invariant_errors() {
         .expect_err("validate Err must abort resolve");
     let msg = format!("{err}");
     assert!(msg.contains("member fun `f` has no receiver"), "{msg}");
+}
+
+// ── issue #95: semantic type identity ───────────────────────────────────
+
+/// A source-crate-stamped location, the way `Source` stamps parsed records.
+fn crate_loc(name: &str) -> SourceLocation {
+    SourceLocation {
+        crate_name: Some(name.to_string()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn typekey_equivalence_rules() {
+    let k = |s: &str| TypeKey::parse(s).expect("test type");
+    // Group/paren unwrap + whitespace.
+    assert_eq!(k("Foo"), k("(Foo)"));
+    assert_eq!(k("Vec<u8>"), k("Vec < u8 >"));
+    // `crate::` / `self::` reduce to the bare flat name, at any depth and
+    // in nested positions.
+    assert_eq!(k("Foo"), k("crate::Foo"));
+    assert_eq!(k("Foo"), k("crate::a::b::Foo"));
+    assert_eq!(k("Foo"), k("self::Foo"));
+    assert_eq!(k("Option<Foo>"), k("Option<crate::a::Foo>"));
+    assert_eq!(k("&Foo"), k("&crate::Foo"));
+    // The std prelude whitelist.
+    assert_eq!(k("Vec<Foo>"), k("std::vec::Vec<crate::Foo>"));
+    assert_eq!(k("Option<i32>"), k("core::option::Option<i32>"));
+    assert_eq!(k("Result<Foo, Bar>"), k("std::result::Result<Foo, Bar>"));
+    assert_eq!(k("String"), k("std::string::String"));
+    assert_eq!(k("Box<Foo>"), k("alloc::boxed::Box<Foo>"));
+    // Distinctness: unknown crate heads and non-whitelisted std paths keep
+    // their spelling; lifetimes are structure, not spelling.
+    assert_ne!(k("a::Foo"), k("b::Foo"));
+    assert_ne!(k("a::Foo"), k("Foo"));
+    assert_ne!(k("std::ffi::CString"), k("CString"));
+    assert_ne!(k("&Foo"), k("&'a Foo"));
+    assert_ne!(k("Foo<'static>"), k("Foo"));
+    // Idempotence: re-keying a key's own type or string is the identity.
+    let once = k("std::vec::Vec<crate::m::Foo>");
+    assert_eq!(once, TypeKey::from_type(&once.to_type()));
+    assert_eq!(once, k(once.as_str()));
+    assert_eq!(once.as_str(), "Vec < Foo >");
+}
+
+#[test]
+fn typekey_parse_returns_structured_error() {
+    let err = TypeKey::parse("not a type !!").expect_err("must fail");
+    assert_eq!(err.input, "not a type !!");
+    assert!(err.to_string().contains("invalid type"), "{err}");
+}
+
+#[test]
+fn qualified_signature_matches_bare_declaration() {
+    // A captured signature may spell an indexed item with the source
+    // crate's own name or `crate::`; ingest normalizes both to the bare
+    // flat spelling, so bare-declared types and bare sub-positions match.
+    let f: syn::ItemFn =
+        syn::parse_str("fn get(x: &myflat::Thing) -> std::vec::Vec<crate::Thing> { todo!() }")
+            .unwrap();
+    let s: syn::ItemStruct = syn::parse_str("pub struct Thing { pub v: u64 }").unwrap();
+    let items = vec![
+        (syn::Item::Struct(s), crate_loc("myflat")),
+        (syn::Item::Fn(f), crate_loc("myflat")),
+    ];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("get").unwrap());
+    ext.types
+        .insert(TypeKey::parse("Thing").expect("test type"));
+    reg.scan_declared(&ext).unwrap();
+    assert!(reg
+        .required_inputs_scan
+        .contains(&TypeKey::parse("&Thing").expect("test type")));
+    assert!(reg
+        .required_outputs_scan
+        .contains(&TypeKey::parse("Vec<Thing>").expect("test type")));
+    // No spelling-variant duplicate cells survive anywhere.
+    let no_paths = |set: &HashSet<TypeKey>| !set.iter().any(|k| k.as_str().contains("::"));
+    assert!(no_paths(&reg.required_inputs_scan));
+    assert!(no_paths(&reg.required_outputs_scan));
+}
+
+#[test]
+fn multi_source_rename_cross_reference_normalizes() {
+    // Source B (a renamed dependency: crate `cov-helpers` = module
+    // `cov_helpers`) references source A's type by A's crate name. B's
+    // items are chained FIRST, so this also proves pass 1 gathers every
+    // module name before pass 2 normalizes (chain-order independence).
+    let b_fn: syn::ItemFn =
+        syn::parse_str("fn use_a(x: &srca::TypeA) -> cov_helpers::TypeB { todo!() }").unwrap();
+    let b_ty: syn::ItemStruct = syn::parse_str("pub struct TypeB { pub v: u64 }").unwrap();
+    let a_ty: syn::ItemStruct = syn::parse_str("pub struct TypeA { pub v: u64 }").unwrap();
+    let items = vec![
+        (syn::Item::Fn(b_fn), crate_loc("cov-helpers")),
+        (syn::Item::Struct(b_ty), crate_loc("cov-helpers")),
+        (syn::Item::Struct(a_ty), crate_loc("srca")),
+    ];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("use_a").unwrap());
+    ext.types
+        .insert(TypeKey::parse("TypeA").expect("test type"));
+    ext.types
+        .insert(TypeKey::parse("TypeB").expect("test type"));
+    reg.scan_declared(&ext).unwrap();
+    assert!(reg
+        .required_inputs_scan
+        .contains(&TypeKey::parse("&TypeA").expect("test type")));
+    assert!(reg
+        .required_outputs_scan
+        .contains(&TypeKey::parse("TypeB").expect("test type")));
+}
+
+#[test]
+fn qualified_declared_type_is_hard_error() {
+    // `ptr_class!(myflat::Thing)`-shaped declaration: the head names a
+    // chained source crate, so the key can never match the flat namespace —
+    // a collected hard error with the bare fix-it, not a silent miss.
+    let s: syn::ItemStruct = syn::parse_str("pub struct Thing { pub v: u64 }").unwrap();
+    let items = vec![(syn::Item::Struct(s), crate_loc("myflat"))];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.types
+        .insert(TypeKey::parse("myflat::Thing").expect("test type"));
+    match reg.scan_declared(&ext) {
+        Err(ScanError::QualifiedDeclaredTypes { entries }) => {
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].0, "myflat :: Thing");
+            assert_eq!(entries[0].1, "Thing");
+            let msg = ScanError::QualifiedDeclaredTypes { entries }.to_string();
+            assert!(msg.contains("declare it as `Thing`"), "{msg}");
+        }
+        other => panic!("expected QualifiedDeclaredTypes, got {:?}", other),
+    }
+}
+
+#[test]
+fn foreign_qualified_declared_type_stays_supported() {
+    // `ptr_class!(zenoh::KeyExpr<'static>)`-style: the head is NOT a source
+    // module, so the declaration passes through verbatim and is marked
+    // required under its own spelling (the no-indexed-body arm).
+    let items = vec![fn_item("fn touch(x: u64) -> u64 { x }")];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    let foreign = TypeKey::parse("zenoh::KeyExpr<'static>").expect("test type");
+    ext.types.insert(foreign.clone());
+    reg.scan_declared(&ext)
+        .expect("foreign qualified declaration is supported");
+    assert!(reg.required_inputs_scan.contains(&foreign));
+    assert!(reg.required_outputs_scan.contains(&foreign));
 }

--- a/prebindgen/src/api/core/resolve/tests.rs
+++ b/prebindgen/src/api/core/resolve/tests.rs
@@ -23,14 +23,14 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
     );
 
     // `Outer` is a required INPUT, unresolved (slot stays `None`).
-    let outer_key = TypeKey::parse("Outer");
+    let outer_key = TypeKey::parse("Outer").expect("test type");
     reg.input_types.insert(outer_key.clone(), None);
     reg.required_inputs_scan.insert(outer_key.clone());
 
     // `ZKeyExpr` is also in the type table (scan recursed into the
     // field) but unresolved and NOT marked required at scan time —
     // exactly the case the BFS is here to catch.
-    let zke_key = TypeKey::parse("ZKeyExpr");
+    let zke_key = TypeKey::parse("ZKeyExpr").expect("test type");
     reg.input_types.insert(zke_key.clone(), None);
 
     let err = final_invariant_check(&reg).expect_err("must surface unresolved");
@@ -72,9 +72,9 @@ fn final_invariant_stops_at_resolved_nodes() {
 
     // `Outer` required & unresolved; `Inner` RESOLVED (with a dummy
     // entry); `Unrelated` unresolved but only reachable through Inner.
-    let outer_key = TypeKey::parse("Outer");
-    let inner_key = TypeKey::parse("Inner");
-    let unrelated_key = TypeKey::parse("Unrelated");
+    let outer_key = TypeKey::parse("Outer").expect("test type");
+    let inner_key = TypeKey::parse("Inner").expect("test type");
+    let unrelated_key = TypeKey::parse("Unrelated").expect("test type");
 
     reg.input_types.insert(outer_key.clone(), None);
     reg.required_inputs_scan.insert(outer_key.clone());

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -6,6 +6,15 @@
 use proc_macro2::Span;
 use quote::ToTokens;
 
+/// The single-segment path type for a bare item ident (`Foo` → `Foo`) —
+/// direct construction, no string round trip, cannot fail.
+pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
+    syn::Type::Path(syn::TypePath {
+        qself: None,
+        path: syn::Path::from(ident.clone()),
+    })
+}
+
 /// Normalize a type to its canonical flat-namespace spelling (issue #95).
 /// The COMPLETE equivalence rule set — any spelling not listed is preserved
 /// verbatim:

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -6,6 +6,128 @@
 use proc_macro2::Span;
 use quote::ToTokens;
 
+/// Normalize a type to its canonical flat-namespace spelling (issue #95).
+/// The COMPLETE equivalence rule set — any spelling not listed is preserved
+/// verbatim:
+///
+/// 1. `Type::Group` / `Type::Paren` wrappers unwrap (`(Foo)` ≡ `Foo`).
+/// 2. A multi-segment path headed by `crate` / `self` reduces to its final
+///    segment, keeping that segment's generic arguments (`crate::a::Foo<T>`
+///    ≡ `Foo<T>`). Sound because the flat namespace indexes at most one
+///    item per bare ident, and a `crate::` path in a captured item can only
+///    denote the source crate's own item.
+/// 3. A multi-segment path headed by a name in `source_modules` (the
+///    `#[prebindgen]` source crates chained into the registry,
+///    hyphens-as-underscores) reduces the same way (`myflat::Foo` ≡ `Foo`).
+///    Pure callers pass `&[]`.
+/// 4. The std prelude whitelist reduces to its bare form — exactly
+///    `std|core|alloc :: vec::Vec | option::Option | result::Result |
+///    string::String | boxed::Box` (with or without a leading `::`).
+///    Nothing else: `std::ffi::CString` stays qualified, and unknown crate
+///    paths (`zenoh::KeyExpr`) are NEVER touched — the registry has no
+///    index of a foreign namespace, so `a::KeyExpr` and `b::KeyExpr` may be
+///    genuinely distinct types and their spelling is their identity.
+/// 5. Lifetimes are NOT normalized (`&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`)
+///    — [`match_pattern`] treats lifetimes as fixed structure and
+///    foreign-type declarations (`ptr_class!(ZKeyExpr<'static>)`) rely on
+///    the verbatim spelling.
+///
+/// Idempotent; recurses through references, slices, tuples, pointers,
+/// generic arguments, and `impl Trait` bounds. Paths with a qualified self
+/// (`<T as Trait>::Assoc`) are left untouched.
+pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
+    use syn::visit_mut::VisitMut;
+    struct Normalizer<'a> {
+        modules: &'a [String],
+    }
+    impl VisitMut for Normalizer<'_> {
+        fn visit_type_mut(&mut self, ty: &mut syn::Type) {
+            // Unwrap (possibly nested) group/paren wrappers in place.
+            loop {
+                match ty {
+                    syn::Type::Group(g) => *ty = (*g.elem).clone(),
+                    syn::Type::Paren(p) => *ty = (*p.elem).clone(),
+                    _ => break,
+                }
+            }
+            if let syn::Type::Path(tp) = ty {
+                if tp.qself.is_none() {
+                    reduce_flat_path(&mut tp.path, self.modules);
+                }
+            }
+            syn::visit_mut::visit_type_mut(self, ty);
+        }
+    }
+    Normalizer {
+        modules: source_modules,
+    }
+    .visit_type_mut(ty);
+}
+
+/// Apply [`normalize_type`] to every type position inside an item — fn
+/// signatures, struct fields, enum variants, const types. The ingest-time
+/// pass ([`crate::api::core::registry::Registry::from_items`]) that makes
+/// captured spellings canonical before any key is formed, so every
+/// downstream `TypeKey::from_type` sees the flat spelling.
+pub fn normalize_item_types(item: &mut syn::Item, source_modules: &[String]) {
+    use syn::visit_mut::VisitMut;
+    struct ItemNormalizer<'a> {
+        modules: &'a [String],
+    }
+    impl VisitMut for ItemNormalizer<'_> {
+        fn visit_type_mut(&mut self, ty: &mut syn::Type) {
+            // Normalizes the whole subtree; no further descent needed.
+            normalize_type(ty, self.modules);
+        }
+    }
+    ItemNormalizer {
+        modules: source_modules,
+    }
+    .visit_item_mut(item);
+}
+
+/// The path-reduction step of [`normalize_type`]: collapse a reducible
+/// multi-segment path to its final segment. See the rule list there.
+fn reduce_flat_path(path: &mut syn::Path, source_modules: &[String]) {
+    if path.segments.len() < 2 {
+        return;
+    }
+    let head = path
+        .segments
+        .first()
+        .expect("len checked")
+        .ident
+        .to_string();
+    let reduce = match head.as_str() {
+        "crate" | "self" => true,
+        "std" | "core" | "alloc" => {
+            let tail: Vec<String> = path
+                .segments
+                .iter()
+                .skip(1)
+                .map(|s| s.ident.to_string())
+                .collect();
+            matches!(
+                tail.iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+                ["vec", "Vec"]
+                    | ["option", "Option"]
+                    | ["result", "Result"]
+                    | ["string", "String"]
+                    | ["boxed", "Box"]
+            )
+        }
+        other => source_modules.iter().any(|m| m == other),
+    };
+    if reduce {
+        let last = path.segments.last().expect("len checked").clone();
+        path.leading_colon = None;
+        path.segments = std::iter::once(last).collect();
+    }
+}
+
 /// Structurally match a concrete type `ty` against a wildcard `pattern` (a
 /// `syn::Type` whose `_` placeholders are [`syn::Type::Infer`]). On success,
 /// returns the subtrees of `ty` captured at each wildcard, in left-to-right

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -96,14 +96,22 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
         "on_struct",
         sorted_items_by_ident(&registry.structs)
             .into_iter()
-            .filter(|(ident, _)| declared_types.contains(&TypeKey::parse(&ident.to_string())))
+            .filter(|(ident, _)| {
+                declared_types.contains(
+                    &TypeKey::parse(&ident.to_string()).expect("item idents parse as types"),
+                )
+            })
             .map(|(_, (item, _))| ext.on_struct(item, registry)),
     )?);
     items.extend(parse_items_from_tokens(
         "on_enum",
         sorted_items_by_ident(&registry.enums)
             .into_iter()
-            .filter(|(ident, _)| declared_types.contains(&TypeKey::parse(&ident.to_string())))
+            .filter(|(ident, _)| {
+                declared_types.contains(
+                    &TypeKey::parse(&ident.to_string()).expect("item idents parse as types"),
+                )
+            })
             .map(|(_, (item, _))| ext.on_enum(item, registry)),
     )?);
     // Consts: an adapter WITH a const declaration mechanism

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -96,22 +96,14 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
         "on_struct",
         sorted_items_by_ident(&registry.structs)
             .into_iter()
-            .filter(|(ident, _)| {
-                declared_types.contains(
-                    &TypeKey::parse(&ident.to_string()).expect("item idents parse as types"),
-                )
-            })
+            .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
             .map(|(_, (item, _))| ext.on_struct(item, registry)),
     )?);
     items.extend(parse_items_from_tokens(
         "on_enum",
         sorted_items_by_ident(&registry.enums)
             .into_iter()
-            .filter(|(ident, _)| {
-                declared_types.contains(
-                    &TypeKey::parse(&ident.to_string()).expect("item idents parse as types"),
-                )
-            })
+            .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
             .map(|(_, (item, _))| ext.on_enum(item, registry)),
     )?);
     // Consts: an adapter WITH a const declaration mechanism

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -23,7 +23,7 @@ impl Prebindgen for IdentityExt {
     fn declared_types(&self) -> HashSet<TypeKey> {
         ["AEnum", "AStruct", "BEnum", "BStruct"]
             .into_iter()
-            .map(TypeKey::parse)
+            .map(|s| TypeKey::parse(s).expect("test type"))
             .collect()
     }
 
@@ -59,8 +59,8 @@ impl Prebindgen for IdentityExt {
 #[test]
 fn dedup_and_sort() {
     let mut reg: Registry<()> = Registry::default();
-    let key_a = TypeKey::parse("u64");
-    let key_b = TypeKey::parse("Sample");
+    let key_a = TypeKey::parse("u64").expect("test type");
+    let key_b = TypeKey::parse("Sample").expect("test type");
     let wire: syn::Type = syn::parse_quote!(i64);
     let wire2: syn::Type = syn::parse_quote!(*const u8);
 

--- a/prebindgen/src/api/lang/cbindgen/tests/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/builder.rs
@@ -196,3 +196,30 @@ fn manglers_generate_all_names() {
     // Return handle rides the return.
     assert!(compact.contains("->*mutz_subscriber_t"), "{src}");
 }
+
+/// Issue #95: a signature spelled with the source crate's own name matches
+/// the bare `opaque_ptr` declaration — ingest normalizes the spelling, and
+/// emission re-qualifies through `.source_module` as before.
+#[test]
+fn qualified_signature_spelling_matches_bare_opaque_ptr() {
+    let loc = SourceLocation {
+        crate_name: Some("zenoh-flat".to_string()),
+        ..Default::default()
+    };
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_keyexpr_len(k: &zenoh_flat::ZKeyExpr) -> i64 {
+            unimplemented!()
+        }
+    );
+    let reg =
+        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+    let cb = Cbindgen::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .opaque_ptr(syn::parse_quote!(ZKeyExpr))
+        .function(syn::parse_quote!(z_keyexpr_len))
+        .panic();
+    let src = write(cb, reg, "q95");
+    let compact: String = src.split_whitespace().collect();
+    assert!(compact.contains("extern\"C\"fnz_keyexpr_len("), "{src}");
+    assert!(compact.contains("zenoh_flat::z_keyexpr_len("), "{src}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1370,7 +1370,7 @@ impl JniGen {
                 let (kotlin_name, value_rust_key) = if rank >= 1 {
                     (
                         inner.metadata.kotlin_name.clone(),
-                        Some(TypeKey::from_type(&args[0]).as_str().to_string()),
+                        Some(TypeKey::from_type(&args[0])),
                     )
                 } else {
                     (inner.metadata.kotlin_name.clone(), None)
@@ -1454,7 +1454,7 @@ impl JniGen {
                         .map(|e| {
                             (
                                 e.metadata.kotlin_name.clone(),
-                                Some(TypeKey::from_type(&args[0]).as_str().to_string()),
+                                Some(TypeKey::from_type(&args[0])),
                             )
                         })
                         .unwrap_or((None, None))
@@ -1500,7 +1500,7 @@ impl JniGen {
                 let (kotlin_name, value_rust_key) = if rank >= 1 {
                     (
                         inner.metadata.kotlin_name.clone(),
-                        Some(TypeKey::from_type(&args[0]).as_str().to_string()),
+                        Some(TypeKey::from_type(&args[0])),
                     )
                 } else {
                     (inner.metadata.kotlin_name.clone(), None)

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -221,12 +221,13 @@ impl JniGen {
     }
 
     /// The registered Kotlin FQN for a canonical Rust type key, derived on
-    /// demand from the type's stored [`NameSpec`].
-    pub(crate) fn kotlin_fqn(&self, rust_canon: &str) -> Option<String> {
+    /// demand from the type's stored [`NameSpec`]. A typed direct lookup —
+    /// declaration keys and probe keys share the [`TypeKey`] constructor, so
+    /// the former linear string scan is gone (issue #95).
+    pub(crate) fn kotlin_fqn(&self, key: &TypeKey) -> Option<String> {
         self.types
-            .iter()
-            .find(|(k, _)| k.as_str() == rust_canon)
-            .and_then(|(_, cfg)| cfg.name_spec.as_ref())
+            .get(key)
+            .and_then(|cfg| cfg.name_spec.as_ref())
             .map(|spec| self.fqn_of(spec))
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -118,7 +118,7 @@ pub(crate) fn struct_input_body(
         let f_inner = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
         if ext.is_kotlin_enum(&f_inner) {
             if let Some(fqn) = bare_path_ident(&f_inner)
-                .and_then(|n| ext.kotlin_fqn(&n.to_string()))
+                .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
                 .map(|v| v.to_string())
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
@@ -193,7 +193,7 @@ pub(crate) fn struct_input_body(
                     })
                     .or_else(|| {
                         bare_path_ident(&slot_ty).and_then(|name| {
-                            ext.kotlin_fqn(&name.to_string())
+                            ext.kotlin_fqn(&TypeKey::from_ident(&name))
                                 .map(|v| format!("L{};", v.replace('.', "/")))
                         })
                     })

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -155,9 +155,8 @@ pub(crate) fn option_inner_ref_mutability(ty: &syn::Type) -> Option<bool> {
 /// Used for `Option<value-blob>` params where the written type isn't the bare
 /// value class but the projection still resolves the leaf — so the wrapper
 /// knows which inline field to unwrap (`<name>.bytes`).
-pub(crate) fn value_projection_field_for_leaf(ext: &JniGen, leaf_key: &str) -> Option<String> {
-    let key = TypeKey::parse(leaf_key).expect("leaf keys are stored canonical type strings");
-    let cfg = ext.types.get(&key)?;
+pub(crate) fn value_projection_field_for_leaf(ext: &JniGen, leaf_key: &TypeKey) -> Option<String> {
+    let cfg = ext.types.get(leaf_key)?;
     if cfg.value_blob {
         return Some("bytes".to_string());
     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -156,7 +156,7 @@ pub(crate) fn option_inner_ref_mutability(ty: &syn::Type) -> Option<bool> {
 /// value class but the projection still resolves the leaf — so the wrapper
 /// knows which inline field to unwrap (`<name>.bytes`).
 pub(crate) fn value_projection_field_for_leaf(ext: &JniGen, leaf_key: &str) -> Option<String> {
-    let key = TypeKey::parse(leaf_key);
+    let key = TypeKey::parse(leaf_key).expect("leaf keys are stored canonical type strings");
     let cfg = ext.types.get(&key)?;
     if cfg.value_blob {
         return Some("bytes".to_string());

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -614,12 +614,14 @@ impl ReturnSurface {
         };
         let outer_meta = registry.output_entry(ty).map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
-        // `value_rust_key`) declare no Kotlin return type.
-        let inner_canon = outer_meta
+        // `value_rust_key`) declare no Kotlin return type. The peeled type
+        // comes straight off the stored key — no reparse, no silent
+        // fallback.
+        let canonical: syn::Type = outer_meta
             .as_ref()
-            .and_then(|m| m.value_rust_key.clone())
-            .unwrap_or_else(|| ty.to_token_stream().to_string());
-        let canonical: syn::Type = syn::parse_str(&inner_canon).unwrap_or_else(|_| ty.clone());
+            .and_then(|m| m.value_rust_key.as_ref())
+            .map(TypeKey::to_type)
+            .unwrap_or_else(|| ty.clone());
         if crate::api::lang::jnigen::util::is_unit(&canonical) {
             return (Self::Unit, canonical);
         }

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -613,8 +613,7 @@ fn subject_short(ty: &syn::Type) -> String {
 /// Package a subject type's interface lives in: the package of the type's
 /// registered Kotlin FQN, the root `ext.package` otherwise.
 fn subject_package(ext: &JniGen, subject: &syn::Type) -> String {
-    let key =
-        TypeKey::from_type(&crate::api::core::types_util::peel_ref_option_vec(subject)).to_string();
+    let key = TypeKey::from_type(&crate::api::core::types_util::peel_ref_option_vec(subject));
     ext.kotlin_fqn(&key)
         .and_then(|fqn| fqn.rsplit_once('.').map(|(p, _)| p.to_string()))
         .unwrap_or_else(|| ext.package.clone())
@@ -725,7 +724,7 @@ fn leaf_iface_param(
     // no `asRaw` proxy is generated.
     if let kt::KtType::Named { fqn: bk_fqn, .. } = &builder_kt {
         if !bk_fqn.contains('.') {
-            if let Some(reg_fqn) = ext.kotlin_fqn(&TypeKey::from_type(out_ty).to_string()) {
+            if let Some(reg_fqn) = ext.kotlin_fqn(&TypeKey::from_type(out_ty)) {
                 let reg_short = reg_fqn.rsplit('.').next().unwrap_or(&reg_fqn);
                 if reg_fqn.contains('.') && reg_short == bk_fqn {
                     let raw = kt::KtType::cls(reg_fqn.to_string());
@@ -784,17 +783,18 @@ pub(crate) fn owned_handle_iface_param(
 /// resolve-time trampoline, the per-function plan, and the declaration
 /// emitter (formerly `write_callback_ifaces`' local `Use` enum). `Ord` so
 /// declaration emission iterates deterministically. Type-shaped identities
-/// store the canonical [`TypeKey`] string; the derivation round-trips it
-/// back to a `syn::Type`, so a key alone fully determines its spec.
+/// store the [`TypeKey`] itself — the derivation reads the key's stored
+/// normalized type, so a key alone fully determines its spec with no
+/// string round trip.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SpecKey {
     /// impl-Fn delivery — the args' canonical type keys (each arg either
     /// decomposes via its type's canonical plan or crosses whole).
-    Callback(Vec<String>),
+    Callback(Vec<TypeKey>),
     Builder(DeconId),
     Folder(DeconId),
     /// Whole-element fold — no declaration; keyed by element type.
-    WholeFolder(String),
+    WholeFolder(TypeKey),
     Handler(DeconId),
     JniErrorHandler,
 }
@@ -802,16 +802,12 @@ pub(crate) enum SpecKey {
 impl SpecKey {
     /// The impl-Fn identity for a callback's arg types.
     pub fn callback(args: &[syn::Type]) -> Self {
-        SpecKey::Callback(
-            args.iter()
-                .map(|t| TypeKey::from_type(t).to_string())
-                .collect(),
-        )
+        SpecKey::Callback(args.iter().map(TypeKey::from_type).collect())
     }
 
     /// The whole-element fold identity for an element type.
     pub fn whole_folder(element: &syn::Type) -> Self {
-        SpecKey::WholeFolder(TypeKey::from_type(element).to_string())
+        SpecKey::WholeFolder(TypeKey::from_type(element))
     }
 }
 
@@ -838,22 +834,22 @@ pub(crate) fn fixed_decon_ids(
 /// by the declaration emitter for the hoisted appender singleton.
 pub(crate) fn fixed_leaf_element_keys(
     registry: &Registry<KotlinMeta>,
-) -> std::collections::HashSet<String> {
+) -> std::collections::HashSet<TypeKey> {
     registry
         .unfold_plans
         .values()
         .chain(registry.callback_arg_plans.values())
         .filter(|p| p.fixed_builder)
         .filter_map(|p| p.element.as_ref())
-        .map(|el| TypeKey::from_type(el).to_string())
+        .map(TypeKey::from_type)
         .collect()
 }
 
 /// Derive the spec for one identity — the SINGLE construction point behind
-/// [`JniGen::iface_spec`]. Reconstructs any `syn` context from the key's
-/// canonical type strings ([`TypeKey::to_type`] round-trip). A `Folder`
-/// derivation folds the fixed-builder typed-group view in per `DeconId`
-/// (see [`fixed_decon_ids`]).
+/// [`JniGen::iface_spec`]. Any `syn` context comes from the key's stored
+/// normalized type ([`TypeKey::to_type`] — a clone, not a reparse). A
+/// `Folder` derivation folds the fixed-builder typed-group view in per
+/// `DeconId` (see [`fixed_decon_ids`]).
 fn derive_iface_spec(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
@@ -861,14 +857,7 @@ fn derive_iface_spec(
 ) -> Option<IfaceSpec> {
     match key {
         SpecKey::Callback(arg_keys) => {
-            let args: Vec<syn::Type> = arg_keys
-                .iter()
-                .map(|k| {
-                    TypeKey::parse(k)
-                        .expect("SpecKey stores canonical type strings")
-                        .to_type()
-                })
-                .collect();
+            let args: Vec<syn::Type> = arg_keys.iter().map(TypeKey::to_type).collect();
             callback_iface_spec(ext, registry, &args)
         }
         SpecKey::Builder(d) => builder_iface_spec(ext, registry, d),
@@ -879,13 +868,7 @@ fn derive_iface_spec(
             }
             Some(spec)
         }
-        SpecKey::WholeFolder(el_key) => whole_folder_iface_spec(
-            ext,
-            registry,
-            &TypeKey::parse(el_key)
-                .expect("SpecKey stores canonical type strings")
-                .to_type(),
-        ),
+        SpecKey::WholeFolder(el_key) => whole_folder_iface_spec(ext, registry, &el_key.to_type()),
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
     }
@@ -977,7 +960,7 @@ pub(crate) fn callback_iface_spec(
                     syn::Type::Reference(r) => (*r.elem).clone(),
                     other => other.clone(),
                 };
-                let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core).to_string())?;
+                let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
                 let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
@@ -1207,7 +1190,7 @@ pub(crate) fn fixed_folder_typed_groups(
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans.get(decon)?;
-    let fqn = ext.kotlin_fqn(&TypeKey::from_type(&spec.source).to_string())?;
+    let fqn = ext.kotlin_fqn(&TypeKey::from_type(&spec.source))?;
     let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
     Some(vec![
         TypedGroup {

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -863,7 +863,11 @@ fn derive_iface_spec(
         SpecKey::Callback(arg_keys) => {
             let args: Vec<syn::Type> = arg_keys
                 .iter()
-                .map(|k| TypeKey::parse(k).to_type())
+                .map(|k| {
+                    TypeKey::parse(k)
+                        .expect("SpecKey stores canonical type strings")
+                        .to_type()
+                })
                 .collect();
             callback_iface_spec(ext, registry, &args)
         }
@@ -875,9 +879,13 @@ fn derive_iface_spec(
             }
             Some(spec)
         }
-        SpecKey::WholeFolder(el_key) => {
-            whole_folder_iface_spec(ext, registry, &TypeKey::parse(el_key).to_type())
-        }
+        SpecKey::WholeFolder(el_key) => whole_folder_iface_spec(
+            ext,
+            registry,
+            &TypeKey::parse(el_key)
+                .expect("SpecKey stores canonical type strings")
+                .to_type(),
+        ),
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
     }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -923,7 +923,7 @@ impl JniGen {
     ) -> kt::KtDecl {
         let source = &registry.decon_plans[decon].source;
         let class_fqn = self
-            .kotlin_fqn(&TypeKey::from_type(source).to_string())
+            .kotlin_fqn(&TypeKey::from_type(source))
             .unwrap_or_else(|| {
                 panic!(
                     "value-struct builder: no Kotlin FQN for {}",
@@ -966,7 +966,7 @@ impl JniGen {
     ) -> kt::KtDecl {
         let source = &registry.decon_plans[decon].source;
         let class_fqn = self
-            .kotlin_fqn(&TypeKey::from_type(source).to_string())
+            .kotlin_fqn(&TypeKey::from_type(source))
             .unwrap_or_else(|| {
                 panic!(
                     "value-struct folder: no Kotlin FQN for {}",
@@ -1389,7 +1389,7 @@ impl JniGen {
         }
 
         let class_fqn = self
-            .kotlin_fqn(key.as_str())
+            .kotlin_fqn(key)
             .unwrap_or_else(|| class_short.to_string());
         let package = class_fqn.rsplit_once('.').map(|(p, _)| p).unwrap_or("");
         let iface_name = self.interface_short_name(package, class_short, name_override.as_deref());

--- a/prebindgen/src/api/lang/jnigen/jni/metadata.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/metadata.rs
@@ -64,10 +64,10 @@ pub enum ProjectionKind {
 /// source of truth instead of a parallel ad-hoc decision tree.
 #[derive(Clone, Debug)]
 pub struct Projection {
-    /// Canonical [`TypeKey`](crate::api::core::registry::TypeKey) string of the
-    /// leaf type (e.g. `"ZKeyExpr"`, `"ZenohId"`); derive the typed Kotlin
-    /// FQN via `JniGen::kotlin_fqn`.
-    pub leaf_key: String,
+    /// Canonical key of the leaf type (e.g. `ZKeyExpr`, `ZenohId`); derive
+    /// the typed Kotlin FQN via `JniGen::kotlin_fqn` — a typed key, so the
+    /// lookup cannot drift from the declaration table's constructor.
+    pub leaf_key: crate::api::core::registry::TypeKey,
     /// `false` for `&T` borrows of a handle — still a projection (param
     /// classification needs this), but not the holder's to close, so
     /// `close()` emission skips it. Always `false` for [`ProjectionKind::ValueBlob`].
@@ -103,8 +103,9 @@ pub struct KotlinMeta {
     /// Populated with `args[0]`'s canonical key for arity-1 wrappers, and
     /// inherited by the built-in `Option<_>` / `Vec<_>` / `&_` wrappers from
     /// their inner type's metadata. `None` for plain values and arity-0
-    /// converters.
-    pub value_rust_key: Option<String>,
+    /// converters. A typed key — readers get the type via `to_type()`, no
+    /// reparse.
+    pub value_rust_key: Option<crate::api::core::registry::TypeKey>,
     /// Present iff this (possibly wrapped) value is an opaque native handle. Set
     /// at the opaque-handle leaf and folded outward by the `&_` / `Option<_>`
     /// wrappers and the `lookup_*` composed branches. The single source of truth

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -151,7 +151,7 @@ fn rust_type_erased(ext: &JniGen, registry: &Registry<KotlinMeta>, ty: &syn::Typ
             if cfg.value_blob {
                 return "ByteArray".to_string();
             }
-            if let Some(fqn) = ext.kotlin_fqn(key.as_str()) {
+            if let Some(fqn) = ext.kotlin_fqn(&key) {
                 return fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1160,7 +1160,7 @@ fn classify_output(
             register_kt_type(&spec.params[1].typed, imports)
         } else {
             let class_fqn = ext
-                .kotlin_fqn(&TypeKey::from_type(&plan.source).to_string())
+                .kotlin_fqn(&TypeKey::from_type(&plan.source))
                 .map(|s| s.to_string())?;
             register_kt_type(&kt::KtType::cls(class_fqn), imports)
         };
@@ -1362,7 +1362,7 @@ fn build_native_call(ext: &JniGen, jni_call: &str, params: &[Param], out: &Outpu
         // the `Niche+primitive` arm of `fold_projection_wrap`.
         let leaf_fqn = ext
             .kotlin_fqn(&p.leaf_key)
-            .unwrap_or_else(|| p.leaf_key.clone());
+            .unwrap_or_else(|| p.leaf_key.to_string());
         let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
         let sentinel = projection_leaf_sentinel(p);
         call = fold_projection_wrap(&p.strategy, &call, &short, sentinel.as_deref());
@@ -1764,7 +1764,7 @@ pub(crate) fn unfold_leaf_kt(
         // leak the `?` into the constructor call).
         let leaf_fqn = ext
             .kotlin_fqn(&p.leaf_key)
-            .unwrap_or_else(|| p.leaf_key.clone());
+            .unwrap_or_else(|| p.leaf_key.to_string());
         let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
         let sentinel = projection_leaf_sentinel(p);
         let mut wrap = fold_projection_wrap(&p.strategy, pk, &short, sentinel.as_deref());

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -99,7 +99,7 @@ impl crate::api::core::Generation<JniGen> {
                 continue;
             }
             let fqn = ext
-                .kotlin_fqn(key.as_str())
+                .kotlin_fqn(key)
                 .unwrap_or_else(|| key.as_str().to_string());
             out.push_str(&format!(
                 "\n## class `{fqn}` ({}, Rust `{}`)\n\n",
@@ -128,7 +128,7 @@ impl crate::api::core::Generation<JniGen> {
                 continue;
             }
             let fqn = ext
-                .kotlin_fqn(key.as_str())
+                .kotlin_fqn(key)
                 .unwrap_or_else(|| key.as_str().to_string());
             let wire = registry
                 .output_entry(&key.to_type())

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -206,7 +206,7 @@ pub(crate) fn build_struct_plan(
                     })
                     .or_else(|| {
                         bare_path_ident(&slot_ty).and_then(|name| {
-                            ext.kotlin_fqn(&name.to_string())
+                            ext.kotlin_fqn(&TypeKey::from_ident(&name))
                                 .map(|v| format!("L{};", v.replace('.', "/")))
                         })
                     })

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -628,7 +628,7 @@ fn ignore_matching_acknowledges_naming_family() {
         assert!(preds[0]("detail_const_a") && !preds[0]("z_len"));
         assert!(jni
             .ignored_types()
-            .contains(&TypeKey::parse("ZUnusedThing")));
+            .contains(&TypeKey::parse("ZUnusedThing").expect("test type")));
     }
     // …and the full pipeline runs clean, emitting only the declared fn.
     let dir = unique_test_dir("jnigen_ignore_funs_where");
@@ -1925,5 +1925,59 @@ fn constructor_member_skips_default_output_expand() {
             proc_macro2::Span::call_site()
         )),
         "constructor member must skip the default output expansion"
+    );
+}
+
+// ── issue #95: qualified signature spellings + bare declarations ─────────
+
+#[test]
+fn qualified_signature_spelling_matches_bare_ptr_class() {
+    // The source crate spells its own types with `myflat::`/`crate::` and a
+    // std-prelude path; ingest normalizes them to the bare flat spelling,
+    // so the bare `ptr_class!(ZThing)` declaration (and the whole
+    // kotlin_fqn / leaf_key chain behind the wrapper) matches.
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_thing_get() -> myflat::ZThing {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_thing_name(this_: &crate::things::ZThing) -> std::string::String {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))
+            .fun(crate::fun!(z_thing_get)),
+    );
+    let dir = unique_test_dir("jnigen_q95");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("qualified spellings resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect();
+    let ac: String = all.split_whitespace().collect();
+    // The typed handle class with its instance method, and the typed factory
+    // wrapper returning the class — the full declaration↔signature chain.
+    assert!(ac.contains("classZThing(initialPtr:Long)"), "{all}");
+    assert!(ac.contains("funname(onError:"), "{all}");
+    assert!(
+        ac.contains("funzThingGet(onError:JniErrorHandler<ZThing>):ZThing"),
+        "{all}"
     );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -62,7 +62,8 @@ fn install_input(
     _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
-    reg.input_types.insert(TypeKey::parse(ty_str), Some(e));
+    reg.input_types
+        .insert(TypeKey::parse(ty_str).expect("test type"), Some(e));
 }
 
 fn install_output(
@@ -71,5 +72,6 @@ fn install_output(
     _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
-    reg.output_types.insert(TypeKey::parse(ty_str), Some(e));
+    reg.output_types
+        .insert(TypeKey::parse(ty_str).expect("test type"), Some(e));
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -235,7 +235,7 @@ impl JniGen {
     fn opaque_leaf_meta(&self, ty: &syn::Type) -> KotlinMeta {
         KotlinMeta {
             projection: Some(Projection {
-                leaf_key: TypeKey::from_type(ty).as_str().to_string(),
+                leaf_key: TypeKey::from_type(ty),
                 owned: true,
                 strategy: FoldStrategy::Base,
                 kind: ProjectionKind::Handle,
@@ -1428,7 +1428,7 @@ impl JniGen {
                 niches,
                 metadata: KotlinMeta {
                     projection: Some(Projection {
-                        leaf_key: key.as_str().to_string(),
+                        leaf_key: key.clone(),
                         owned: false,
                         strategy: FoldStrategy::Base,
                         kind: ProjectionKind::ValueBlob,
@@ -1633,7 +1633,7 @@ impl JniGen {
                 niches,
                 metadata: KotlinMeta {
                     projection: Some(Projection {
-                        leaf_key: key.as_str().to_string(),
+                        leaf_key: key.clone(),
                         owned: false,
                         strategy: FoldStrategy::Base,
                         kind: ProjectionKind::ValueBlob,


### PR DESCRIPTION
Closes #95.

## What

`TypeKey` equated identity with `to_token_stream().to_string()` — whitespace-normalized, meaning-blind. `Foo` / `crate::Foo` / `myflat::Foo` / `std::vec::Vec<T>` / `(Foo)` were unrelated keys while every declaration↔signature match in core and both adapters uses exact key equality, so a bare declaration could silently miss the same type captured under a qualified spelling. `parse`/`to_type` panicked, and the resolver's hot path depended on serialize-then-reparse round trips.

## The three pieces

**1. Interning + pure normalization.** `TypeKey` is now `{ canon: Rc<str>, ty: Rc<syn::Type> }` — identity on the canonical string, the normalized parsed form kept alongside so `to_type()` is an infallible clone (no reparse, no panic). `parse` returns `Result<TypeKey, TypeKeyParseError>`. `normalize_type` (`types_util.rs`) carries the **complete, documented equivalence rule set**: group/paren unwrap; `crate::`/`self::` paths reduce to the final segment (sound — the flat namespace indexes one item per bare ident, same rule functions have always had via bare-`Ident` keying); and the exact std prelude whitelist (`Vec`/`Option`/`Result`/`String`/`Box`). Nothing else: unknown crate heads (`zenoh::KeyExpr`) and non-whitelisted std paths (`std::ffi::CString`) keep their spelling — truly distinct paths stay distinguishable — and lifetimes are untouched (`&'a T` ≠ `&T`; `match_pattern` structure and foreign-type declarations rely on it).

**2. Origin-aware ingest.** `Registry::from_items` is two-pass: gather every chained source crate's module name first (multi-source chains become order-independent), then normalize each item's types — source-crate-headed paths (incl. renamed dependencies) reduce to the bare flat spelling. Every downstream signature key is therefore canonical, so bare adapter declarations match qualified captured spellings with **zero adapter-side changes** — this matches the existing emission model, which was already path-free-keys + `QualifyEmittedTypes` re-qualification.

**3. Declaration diagnostics.** New `ScanError::QualifiedDeclaredTypes`: declaring a source item by its crate path (`ptr_class!(myflat::Foo)`) is a collected hard error with a bare-name fix-it (previously a silent mismatch). Foreign qualified declarations (`ptr_class!(zenoh::KeyExpr<'static>)`) remain supported verbatim, with a `cargo:warning` when a foreign-headed declared path's final segment shadows a captured item's name.

## Acceptance criteria → tests

- Bare declaration matches supported qualified signature forms: registry + jnigen + cbindgen pipeline tests driving `myflat::`/`crate::`/`std::vec::Vec` spellings end-to-end.
- No duplicate converter graphs from std wrapper paths: single-bare-cell assertions.
- Distinct paths distinguishable: `a::Foo` ≠ `b::Foo`, `std::ffi::CString` unchanged.
- No serialize-then-reparse invariants: `to_type` is a stored-form clone.
- Structured parse error: `TypeKeyParseError` test.
- Multi-source + dependency rename: chain-order-independent cross-reference test (`cov-helpers` → `cov_helpers`).

## Verification

Output-preserving: `regen-check.sh` byte-identical (incl. `REPORT.md`), covertest JVM **PASS – 31 sections**, 302 lib tests + all 20 workspace suites green, fmt/clippy gates clean (`Rc` over `Arc` for the `!Send` `syn::Type`; aarch64 goldens restored after the known all-features regeneration).

Deliberate non-goals (documented in the normalizer): lifetime normalization; canonicalizing qualified declarations (rejected with the fix-it instead, per design discussion — bare names are the single way to name source items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)