### PR TITLE
jnigen: default Kotlin mangler + whole-artifact symbol validation (#89 stage 1)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -117,7 +117,7 @@ impl JniGen {
     pub(crate) fn mangle_fun(&self, package: &str, name: &str) -> String {
         match &self.fun_name_mangle {
             Some(f) => f(package, name),
-            None => name.to_string(),
+            None => mangle_kotlin_ident(name),
         }
     }
     /// Apply the method-name mangle closure to `name`, providing the package
@@ -125,39 +125,39 @@ impl JniGen {
     pub(crate) fn mangle_method(&self, package: &str, class: &str, name: &str) -> String {
         match &self.method_name_mangle {
             Some(f) => f(package, class, name),
-            None => name.to_string(),
+            None => mangle_kotlin_ident(name),
         }
     }
     /// Apply the ptr-class mangle closure to `name`, returning the closure
-    /// result or `name` verbatim when unset.
+    /// result or the sanitized `name` (issue #89) when unset.
     pub(crate) fn mangle_ptr_class(&self, package: &str, name: &str) -> String {
         match &self.ptr_class_name_mangle {
             Some(f) => f(package, name),
-            None => name.to_string(),
+            None => mangle_kotlin_ident(name),
         }
     }
     /// Apply the data-class mangle closure to `name`, returning the closure
-    /// result or `name` verbatim when unset.
+    /// result or the sanitized `name` (issue #89) when unset.
     pub(crate) fn mangle_data_class(&self, package: &str, name: &str) -> String {
         match &self.data_class_name_mangle {
             Some(f) => f(package, name),
-            None => name.to_string(),
+            None => mangle_kotlin_ident(name),
         }
     }
     /// Apply the enum mangle closure to `name`, returning the closure result
-    /// or `name` verbatim when unset.
+    /// or the sanitized `name` (issue #89) when unset.
     pub(crate) fn mangle_enum(&self, package: &str, name: &str) -> String {
         match &self.enum_name_mangle {
             Some(f) => f(package, name),
-            None => name.to_string(),
+            None => mangle_kotlin_ident(name),
         }
     }
     /// Apply the harness mangle closure to `name`, returning the closure
-    /// result or `name` verbatim when unset.
+    /// result or the sanitized `name` (issue #89) when unset.
     pub(crate) fn mangle_harness(&self, name: &str) -> String {
         match &self.harness_name_mangle {
             Some(f) => f(name),
-            None => name.to_string(),
+            None => mangle_kotlin_ident(name),
         }
     }
     /// The name of the centralized Native object that hosts every JNI

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -71,7 +71,20 @@ impl JniGen {
     /// paths, `_`-mangled JNI extern idents, Kotlin `package` declarations)
     /// are computed from this. Empty = no prefix.
     pub fn set_package_prefix(mut self, p: impl Into<String>) -> Self {
-        self.package = p.into().trim_matches('.').trim_matches('/').to_string();
+        let trimmed = p.into().trim_matches('.').trim_matches('/').to_string();
+        // Sanitize each segment to a valid Kotlin identifier (issue #89); a
+        // no-op for already-legal package names. The base package is read
+        // directly by many emitters, so mangling at this single storage
+        // point keeps every reader consistent; warn here (the raw input is
+        // only available now) when a segment was changed.
+        self.package = mangle_package(&trimmed);
+        if self.package != trimmed {
+            println!(
+                "cargo:warning=prebindgen: package prefix `{trimmed}` sanitized to `{}` \
+                 (invalid Kotlin package identifier)",
+                self.package
+            );
+        }
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -1342,7 +1342,16 @@ impl PackageDecl {
     /// (`package!("model")` / `package!()`).
     pub fn new(name: impl Into<String>) -> Self {
         let name = name.into();
-        let name = name.trim_matches('.').trim_matches('/').to_string();
+        let trimmed = name.trim_matches('.').trim_matches('/').to_string();
+        // Sanitize each subpackage segment to a valid Kotlin identifier
+        // (issue #89); a no-op for already-legal names.
+        let name = crate::api::lang::jnigen::jni::mangle_package(&trimmed);
+        if name != trimmed {
+            println!(
+                "cargo:warning=prebindgen: subpackage `{trimmed}` sanitized to `{name}` \
+                 (invalid Kotlin package identifier)"
+            );
+        }
         Self {
             name,
             classes: Vec::new(),

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -98,7 +98,7 @@ pub(crate) fn synth_value_struct_leaves(
     for field in &named.named {
         let fname = field.ident.as_ref()?.clone();
         let effective_ty = field.ty.clone();
-        let camel = kt_snake_to_camel(&fname.to_string());
+        let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
         let leaf_name = if name_prefix.is_empty() {
             camel
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -260,6 +260,24 @@ pub(crate) fn validate_bindings(
         errors.push(e);
     }
 
+    // Native-symbol collision table (issue #89): every `#[no_mangle]` export
+    // the emitters produce must be unique. Each successfully-built plan
+    // carries its spec-escaped `native_symbol`; a duplicate (two functions
+    // whose name hooks collapse to one JNINative method) is a hard error —
+    // it would otherwise surface only as a duplicate `#[no_mangle]` Rust
+    // symbol at link time. `origin` is the Rust ident that produced it.
+    let mut native: std::collections::BTreeMap<NativeSymbol, String> = Default::default();
+    let mut record_symbol = |sym: &str, origin: String, errors: &mut Vec<String>| {
+        let key = NativeSymbol::new(sym);
+        if let Some(prev) = native.insert(key, origin.clone()) {
+            errors.push(format!(
+                "duplicate native symbol `{sym}`: produced by both `{prev}` and `{origin}` \
+                 — a name mangle hook or `.name()` collapsed two distinct methods onto one \
+                 JNI export",
+            ));
+        }
+    };
+
     // Declared functions (incl. binding-local synthetics and fn-backed
     // constants), in deterministic ident order.
     let declared = ext.declared_functions();
@@ -270,8 +288,9 @@ pub(crate) fn validate_bindings(
             continue;
         }
         let (item_fn, _) = &registry.functions[ident];
-        if let Err(e) = JniFunctionPlan::build(ext, registry, item_fn) {
-            errors.push(e.message(ident));
+        match JniFunctionPlan::build(ext, registry, item_fn) {
+            Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
+            Err(e) => errors.push(e.message(ident)),
         }
     }
 
@@ -286,8 +305,9 @@ pub(crate) fn validate_bindings(
             }
             let (item_const, _) = &registry.consts[ident];
             let getter = const_getter_fn(item_const);
-            if let Err(e) = JniFunctionPlan::build(ext, registry, &getter) {
-                errors.push(e.message(&getter.sig.ident));
+            match JniFunctionPlan::build(ext, registry, &getter) {
+                Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
+                Err(e) => errors.push(e.message(&getter.sig.ident)),
             }
         }
     }
@@ -302,10 +322,14 @@ pub(crate) fn validate_bindings(
     expr_decls.sort_by(|a, b| a.kotlin_name.cmp(&b.kotlin_name));
     for decl in expr_decls {
         let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
-        if let Err(e) = JniFunctionPlan::build(ext, registry, &getter) {
-            errors.push(e.message(&getter.sig.ident));
+        match JniFunctionPlan::build(ext, registry, &getter) {
+            Ok(plan) => record_symbol(&plan.native_symbol, decl.kotlin_name.clone(), &mut errors),
+            Err(e) => errors.push(e.message(&getter.sig.ident)),
         }
     }
+
+    // Kotlin identifier validity + per-package top-level-name collisions.
+    errors.extend(validate_symbols(ext, registry));
 
     if errors.is_empty() {
         Ok(())

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -154,7 +154,7 @@ fn factory_from_plan(
     let mut parts: Vec<String> = Vec::new();
 
     for f in &plan.fields {
-        let camel = kt_snake_to_camel(&f.fname.to_string());
+        let camel = mangle_kotlin_ident(&kt_snake_to_camel(&f.fname.to_string()));
         let base = if prefix.is_empty() {
             camel.clone()
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1343,19 +1343,35 @@ impl JniGen {
         class_short: &str,
         override_: Option<&str>,
     ) -> String {
-        let name = match override_ {
-            Some(n) => n.to_string(),
-            None => match &self.interface_name_mangle {
-                Some(f) => f(package, class_short),
-                None => format!("{class_short}Api"),
-            },
-        };
+        let name = self.interface_short_name_unchecked(package, class_short, override_);
+        // The class-vs-interface collision is reported as a collected error
+        // by `validate_symbols` (issue #89) before any file is written, so
+        // this assert is an unreachable backstop for the emission path.
         assert!(
             name != class_short,
             "the generated interface name `{name}` must differ from the class name \
              `{class_short}` (a class and its interface cannot share a name in one package)"
         );
         name
+    }
+
+    /// The interface short name without the class-collision assert — the
+    /// non-panicking core, used by `validate_symbols` to build the
+    /// per-package name table (where the collision surfaces as a collected
+    /// error naming both origins).
+    pub(crate) fn interface_short_name_unchecked(
+        &self,
+        package: &str,
+        class_short: &str,
+        override_: Option<&str>,
+    ) -> String {
+        match override_ {
+            Some(n) => n.to_string(),
+            None => match &self.interface_name_mangle {
+                Some(f) => f(package, class_short),
+                None => format!("{class_short}Api"),
+            },
+        }
     }
 
     /// Attach interface information to a just-built class. The `.implements`

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -492,6 +492,7 @@ mod render;
 mod report;
 mod struct_plan;
 mod symbol;
+mod symbols;
 
 pub(crate) use builder::*;
 pub(crate) use classify::*;
@@ -505,3 +506,4 @@ pub(crate) use overloads::*;
 pub(crate) use prim::*;
 pub(crate) use render::*;
 pub(crate) use struct_plan::*;
+pub(crate) use symbols::*;

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -20,7 +20,9 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
         crate::api::lang::jnigen::util::enum_discriminant_values(item_enum)
             .into_iter()
             .map(|(ident, value)| kt::KtEnumEntry {
-                name: crate::api::lang::jnigen::util::camel_to_screaming_snake(&ident.to_string()),
+                name: mangle_kotlin_ident(
+                    &crate::api::lang::jnigen::util::camel_to_screaming_snake(&ident.to_string()),
+                ),
                 args: Some(value.to_string()),
             })
             .collect();
@@ -88,7 +90,7 @@ pub(crate) fn build_data_class(
                 item_struct.ident
             )
         });
-        let kotlin_field_name = kt_snake_to_camel(&field_ident.to_string());
+        let kotlin_field_name = mangle_kotlin_ident(&kt_snake_to_camel(&field_ident.to_string()));
 
         // Projection field (opaque handle or value class): the typed Kotlin
         // type (`ZKeyExpr?`, `List<ZKeyExpr>`, `ZenohId`, `List<ZenohId>`, …)
@@ -1955,47 +1957,12 @@ pub(crate) fn kt_snake_to_camel(s: &str) -> String {
     out
 }
 
-/// Camel-case a Rust param ident into a valid Kotlin parameter name. Kotlin
-/// **hard keywords** can't be used as identifiers (not even back-ticked), so a
-/// collision is escaped by appending `_`. Param names don't affect JNI linkage
-/// (only the function name + JVM signature do), so renaming is always safe.
+/// Camel-case a Rust param ident into a valid Kotlin parameter name. Param
+/// names don't affect JNI linkage (only the function name + JVM signature do),
+/// so sanitizing is always safe — this defers to the shared
+/// [`mangle_kotlin_ident`], the single identifier sanitizer (issue #89).
 pub(crate) fn kt_param_name(rust_ident: &str) -> String {
-    let camel = kt_snake_to_camel(rust_ident);
-    const HARD_KEYWORDS: &[&str] = &[
-        "as",
-        "break",
-        "class",
-        "continue",
-        "do",
-        "else",
-        "false",
-        "for",
-        "fun",
-        "if",
-        "in",
-        "interface",
-        "is",
-        "null",
-        "object",
-        "package",
-        "return",
-        "super",
-        "this",
-        "throw",
-        "true",
-        "try",
-        "typealias",
-        "typeof",
-        "val",
-        "var",
-        "when",
-        "while",
-    ];
-    if HARD_KEYWORDS.contains(&camel.as_str()) {
-        format!("{camel}_")
-    } else {
-        camel
-    }
+    mangle_kotlin_ident(&kt_snake_to_camel(rust_ident))
 }
 
 /// A wrapper's KDoc (N1): the Rust fn's `///` prose, then generated notes

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -1,0 +1,380 @@
+//! Kotlin/JVM identifier mangling + the whole-artifact symbol-validation
+//! pass (issue #89).
+//!
+//! Distinct from the sibling [`symbol`](super::symbol) module: that one
+//! escapes **native `Java_…` export symbols** (the JNI ABI charset); this one
+//! sanitizes and validates **Kotlin source identifiers** (class / function /
+//! member / field / package names) and builds the per-package and
+//! native-symbol collision tables.
+//!
+//! ## The "default mangler" design
+//!
+//! [`mangle_kotlin_ident`] is the one deterministic sanitizer that turns any
+//! string into a valid Kotlin identifier. Every DEFAULT (Rust-derived) name
+//! flows through it — the seven name-mangle hooks default to it (see
+//! `builder.rs`) and the four non-hook derived-name sites call it directly —
+//! so the emitter always produces valid names on the default path. The only
+//! ways an invalid name can survive to [`validate_symbols`] are an explicit
+//! `.name()` override or a custom mangle hook; both are author input, so an
+//! invalid one is a hard error the author can correct in build.rs.
+
+use super::*;
+
+/// The whole-artifact Kotlin-identifier + top-level-name validation pass
+/// (issue #89), called from [`validate_bindings`]. Returns the collected
+/// errors (joined into the same message the native-symbol table produces) and
+/// emits `cargo:warning=` lines directly for names the default mangler had to
+/// change. Runs on the resolved registry before any file is written.
+///
+/// * **Invalid-name errors** — a final Kotlin name that is still not a legal
+///   identifier can only come from a `.name()` override or a custom mangle
+///   hook (the default path is mangled → always valid), so it is an author
+///   mistake, easy to correct in build.rs.
+/// * **Top-level collisions** — two class / interface / harness / const-`val`
+///   names colliding in one package, including a collision the mangler
+///   created.
+/// * **Warnings** — where the default mangler sanitized a Rust-derived name.
+pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) -> Vec<String> {
+    let mut errors: Vec<String> = Vec::new();
+    // (package, name) → origin, for top-level-unique Kotlin declarations.
+    let mut top_level: BTreeMap<(String, String), String> = BTreeMap::new();
+
+    let mut add_top_level =
+        |package: &str, name: &str, origin: String, errors: &mut Vec<String>| {
+            if let Some(prev) =
+                top_level.insert((package.to_string(), name.to_string()), origin.clone())
+            {
+                errors.push(format!(
+                    "duplicate top-level Kotlin name `{name}` in package `{package}`: \
+                     declared by both {prev} and {origin}",
+                ));
+            }
+        };
+
+    // Classes (ptr / data / value / enum), in deterministic key order.
+    let mut class_keys: Vec<&TypeKey> = ext
+        .types
+        .iter()
+        .filter(|(_, cfg)| cfg.name_spec.is_some())
+        .map(|(k, _)| k)
+        .collect();
+    class_keys.sort_by_key(|k| k.as_str().to_string());
+    for key in class_keys {
+        let cfg = &ext.types[key];
+        let spec = cfg.name_spec.as_ref().expect("filtered to Some");
+        let fqn = ext.fqn_of(spec);
+        let (package, short) = fqn.rsplit_once('.').unwrap_or(("", fqn.as_str()));
+        let origin = format!("class `{key}`");
+        check_ident(short, &origin, &mut errors);
+        add_top_level(package, short, origin.clone(), &mut errors);
+        if cfg.interface_enabled {
+            let iface = ext.interface_short_name_unchecked(
+                package,
+                short,
+                cfg.interface_name_override.as_deref(),
+            );
+            let iorigin = format!("interface of class `{key}`");
+            check_ident(&iface, &iorigin, &mut errors);
+            add_top_level(package, &iface, iorigin, &mut errors);
+        }
+    }
+
+    // The central JNINative harness object — one per base package.
+    let harness = ext.jni_native_class_name();
+    check_ident(&harness, "the `JNINative` harness object", &mut errors);
+    add_top_level(
+        &ext.package,
+        &harness,
+        "the `JNINative` harness object".to_string(),
+        &mut errors,
+    );
+
+    // Declared package-level functions + their const `val`s, per subpackage.
+    let mut subpackages: Vec<&String> = ext.packages.keys().collect();
+    subpackages.sort();
+    for sub in subpackages {
+        let pkg_cfg = &ext.packages[sub];
+        let package = ext.package_name(sub);
+        for entry in &pkg_cfg.functions {
+            let name = ext.effective_function_name(sub, entry);
+            check_ident(
+                &name,
+                &format!("function `{}`", entry.rust_ident),
+                &mut errors,
+            );
+            // Functions may overload — not added to the uniqueness table
+            // (overload-signature collisions are Stage 2).
+        }
+        // Const `val`s ARE top-level-unique (a property, not an overloadable fn).
+        for entry in pkg_cfg
+            .constants
+            .iter()
+            .chain(pkg_cfg.constant_functions.iter())
+        {
+            let name = entry
+                .kotlin_name_override
+                .clone()
+                .unwrap_or_else(|| mangle_kotlin_ident(&entry.rust_ident.to_string()));
+            let origin = format!("const `{}`", entry.rust_ident);
+            check_ident(&name, &origin, &mut errors);
+            add_top_level(&package, &name, origin, &mut errors);
+        }
+        for decl in &pkg_cfg.constant_exprs {
+            let origin = format!("expression constant `{}`", decl.kotlin_name);
+            check_ident(&decl.kotlin_name, &origin, &mut errors);
+            add_top_level(&package, &decl.kotlin_name, origin, &mut errors);
+        }
+    }
+
+    // Class members (instance methods / companion factories) — validity only;
+    // same-named members overload, and cross-member signature collisions are
+    // Stage 2.
+    let mut member_keys: Vec<&TypeKey> = ext.class_members.keys().collect();
+    member_keys.sort_by_key(|k| k.as_str().to_string());
+    for key in member_keys {
+        for m in &ext.class_members[key] {
+            let name = ext.effective_method_name(key, m);
+            check_ident(&name, &format!("method `{}`", m.rust_ident), &mut errors);
+        }
+    }
+
+    // Warnings: Rust-derived names the DEFAULT mangler had to sanitize (a
+    // struct field / enum variant named like a Kotlin keyword). Author
+    // `.name()` / custom-hook names are covered by the errors above.
+    warn_derived_name_changes(ext, registry);
+
+    errors
+}
+
+/// Error when `name` is not a legal Kotlin identifier — reachable only from a
+/// `.name()` override or a custom mangle hook (see [`validate_symbols`]).
+fn check_ident(name: &str, origin: &str, errors: &mut Vec<String>) {
+    if !is_valid_kotlin_ident(name) {
+        errors.push(format!(
+            "`{name}` ({origin}) is not a valid Kotlin identifier — fix the `.name(...)` \
+             override or the name mangle hook that produced it",
+        ));
+    }
+}
+
+/// Emit a `cargo:warning` for each Rust struct field (data-class property) or
+/// enum variant whose Kotlin name the default mangler had to change.
+fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
+    let warn = |raw: &str, mangled: &str, what: &str, owner: &str| {
+        if raw != mangled {
+            println!(
+                "cargo:warning=prebindgen: {what} `{raw}` of `{owner}` emitted as `{mangled}` \
+                 (invalid Kotlin identifier sanitized)"
+            );
+        }
+    };
+    let mut class_keys: Vec<&TypeKey> = ext
+        .types
+        .iter()
+        .filter(|(_, cfg)| cfg.name_spec.is_some())
+        .map(|(k, _)| k)
+        .collect();
+    class_keys.sort_by_key(|k| k.as_str().to_string());
+    for key in class_keys {
+        let ident = match bare_path_ident(&key.to_type()) {
+            Some(i) => i,
+            None => continue,
+        };
+        if let Some((s, _)) = registry.structs.get(&ident) {
+            for f in &s.fields {
+                if let Some(fname) = &f.ident {
+                    let camel = kt_snake_to_camel(&fname.to_string());
+                    warn(
+                        &camel,
+                        &mangle_kotlin_ident(&camel),
+                        "field",
+                        &ident.to_string(),
+                    );
+                }
+            }
+        }
+        if let Some((e, _)) = registry.enums.get(&ident) {
+            for v in &e.variants {
+                let screaming =
+                    crate::api::lang::jnigen::util::camel_to_screaming_snake(&v.ident.to_string());
+                warn(
+                    &screaming,
+                    &mangle_kotlin_ident(&screaming),
+                    "enum variant",
+                    &ident.to_string(),
+                );
+            }
+        }
+    }
+}
+
+/// Kotlin **hard keywords** — reserved words that cannot be used as an
+/// identifier even back-ticked. The single source of truth: [`kt_param_name`]
+/// (params) and [`mangle_kotlin_ident`] / [`is_valid_kotlin_ident`] (every
+/// other position) all consult this list.
+pub(crate) const HARD_KEYWORDS: &[&str] = &[
+    "as",
+    "break",
+    "class",
+    "continue",
+    "do",
+    "else",
+    "false",
+    "for",
+    "fun",
+    "if",
+    "in",
+    "interface",
+    "is",
+    "null",
+    "object",
+    "package",
+    "return",
+    "super",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typealias",
+    "typeof",
+    "val",
+    "var",
+    "when",
+    "while",
+];
+
+/// True when `s` is a legal, non-keyword Kotlin identifier: non-empty, first
+/// char a Unicode letter or `_`, the rest Unicode letters / digits / `_`, and
+/// not a [hard keyword](HARD_KEYWORDS). (Kotlin also permits back-ticked
+/// identifiers with arbitrary content, but those can't be native-symbol
+/// components and don't round-trip everywhere, so the generator does not emit
+/// them.)
+pub(crate) fn is_valid_kotlin_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_alphabetic()) {
+        return false;
+    }
+    if !chars.all(|c| c == '_' || c.is_alphanumeric()) {
+        return false;
+    }
+    !HARD_KEYWORDS.contains(&s)
+}
+
+/// Deterministically sanitize `s` into a valid Kotlin identifier
+/// ([`is_valid_kotlin_ident`] holds on the result), idempotently:
+///
+/// * a hard keyword gets a trailing `_` (`object` → `object_`);
+/// * every char that isn't a Kotlin identifier char (Unicode letter / digit /
+///   `_`) becomes `_` (`my-name` → `my_name`);
+/// * a leading digit gets a `_` prefix (`1x` → `_1x`);
+/// * an empty string becomes `_`.
+///
+/// This is the one primitive the whole "default mangler" design rests on.
+pub(crate) fn mangle_kotlin_ident(s: &str) -> String {
+    if is_valid_kotlin_ident(s) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 1);
+    for (i, c) in s.chars().enumerate() {
+        if c == '_' || c.is_alphanumeric() {
+            if i == 0 && c.is_numeric() {
+                out.push('_');
+            }
+            out.push(c);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    if HARD_KEYWORDS.contains(&out.as_str()) {
+        out.push('_');
+    }
+    out
+}
+
+/// Sanitize a dot-separated Kotlin package path by [mangling](mangle_kotlin_ident)
+/// each non-empty segment (`fun.my-pkg` → `fun_.my_pkg`). Empty segments are
+/// dropped (a leading/trailing/double dot). Idempotent.
+pub(crate) fn mangle_package(path: &str) -> String {
+    path.split('.')
+        .filter(|s| !s.is_empty())
+        .map(mangle_kotlin_ident)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// A native `Java_…` export symbol — charset-guaranteed valid by
+/// [`symbol::native_symbol`](super::symbol::native_symbol). A newtype so the
+/// collision table's key type documents itself and can't be confused with a
+/// Kotlin name string. (The typed Kotlin-side carriers `KotlinIdent` /
+/// `KotlinFqn` / `JvmSignature` arrive in Stage 2, where the JVM-erasure
+/// overload model needs them.)
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub(crate) struct NativeSymbol(String);
+
+impl NativeSymbol {
+    pub fn new(sym: impl Into<String>) -> Self {
+        NativeSymbol(sym.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_valid_kotlin_ident, mangle_kotlin_ident, mangle_package};
+
+    #[test]
+    fn validity_predicate() {
+        assert!(is_valid_kotlin_ident("foo"));
+        assert!(is_valid_kotlin_ident("_foo"));
+        assert!(is_valid_kotlin_ident("fooBar1"));
+        assert!(is_valid_kotlin_ident("Δelta")); // Unicode letter
+        assert!(!is_valid_kotlin_ident("")); // empty
+        assert!(!is_valid_kotlin_ident("1x")); // leading digit
+        assert!(!is_valid_kotlin_ident("my name")); // space
+        assert!(!is_valid_kotlin_ident("my-name")); // dash
+        assert!(!is_valid_kotlin_ident("object")); // hard keyword
+        assert!(!is_valid_kotlin_ident("when")); // hard keyword
+    }
+
+    #[test]
+    fn mangling() {
+        // Valid names pass through unchanged (byte-identity depends on this).
+        assert_eq!(mangle_kotlin_ident("fooBar"), "fooBar");
+        assert_eq!(mangle_kotlin_ident("_x"), "_x");
+        // Keyword → trailing underscore.
+        assert_eq!(mangle_kotlin_ident("object"), "object_");
+        assert_eq!(mangle_kotlin_ident("when"), "when_");
+        // Leading digit → prefix underscore.
+        assert_eq!(mangle_kotlin_ident("1x"), "_1x");
+        // Illegal char → underscore.
+        assert_eq!(mangle_kotlin_ident("my-name"), "my_name");
+        assert_eq!(mangle_kotlin_ident("a b"), "a_b");
+        // Empty → placeholder.
+        assert_eq!(mangle_kotlin_ident(""), "_");
+    }
+
+    #[test]
+    fn mangling_is_idempotent() {
+        for s in ["object", "1x", "my-name", "when", "", "a b", "fooBar"] {
+            let once = mangle_kotlin_ident(s);
+            assert_eq!(mangle_kotlin_ident(&once), once, "not idempotent for {s:?}");
+            assert!(
+                is_valid_kotlin_ident(&once),
+                "mangle produced invalid: {once:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn package_mangles_each_segment() {
+        assert_eq!(mangle_package("io.zenoh.jni"), "io.zenoh.jni");
+        assert_eq!(mangle_package("fun.my-pkg"), "fun_.my_pkg");
+        assert_eq!(mangle_package("a..b"), "a.b"); // empty segments dropped
+        assert_eq!(mangle_package(""), "");
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -121,10 +121,13 @@ fn ptr_class_duplicate_implements_rejected() {
         .implements("io.other.Resource");
 }
 
-/// The `set_interface_name_mangle` hook receives the class package and final name and
-/// its result must differ (identity is a hard error).
+/// The `set_interface_name_mangle` hook receives the class package and final
+/// name and its result must differ from the class name. An identity hook
+/// makes the interface collide with the class in the same package — now a
+/// COLLECTED error from the whole-artifact symbol pass (issue #89), surfaced
+/// by `write_rust`/`write_kotlin` before any file is written, rather than an
+/// emission-time panic.
 #[test]
-#[should_panic(expected = "must differ from the class name")]
 fn interface_name_mangle_identity_rejected() {
     let loc = myflat_loc();
     let f: syn::ItemFn =
@@ -146,7 +149,16 @@ fn interface_name_mangle_identity_rejected() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let gen = registry.resolve(jni).expect("resolve");
-    let _ = gen.write_kotlin(&dir.join("kotlin"));
+    let err = gen
+        .write_rust(dir.join("gen.rs"))
+        .expect_err("interface==class must be a collected error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("duplicate top-level Kotlin name `ZThing`"),
+        "{msg}"
+    );
+    // The invalid binding must not have written a Rust artifact.
+    assert!(!dir.join("gen.rs").exists());
 }
 
 /// A per-decl `.interface_name(...)` pins the interface name (and implies

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -30,6 +30,7 @@ mod cross_artifact;
 mod flatten;
 mod niches;
 mod snapshots;
+mod symbols;
 mod values;
 
 /// Build a `TypeEntry` for use in tests. The function body is not

--- a/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
@@ -1,0 +1,173 @@
+//! Whole-artifact Kotlin/JVM/native symbol validation (issue #89, stage 1):
+//! the default mangler sanitizes Rust-derived names, while invalid `.name()`
+//! / custom-hook output and genuine collisions are collected hard errors
+//! surfaced before any file is written.
+
+use super::*;
+
+/// Run the pipeline to the `write_rust` boundary and return its result — the
+/// point `validate_resolved` (and thus `validate_symbols`) runs. Also asserts
+/// the Rust artifact is absent on error (nothing reaches disk).
+fn write_result(tag: &str, registry: Registry<KotlinMeta>, jni: JniGen) -> Result<(), String> {
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let out = dir.join("gen.rs");
+    match gen.write_rust(&out) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            assert!(
+                !out.exists(),
+                "no artifact must be written on validation error"
+            );
+            Err(e.to_string())
+        }
+    }
+}
+
+fn one_fn(src: &str) -> Registry<KotlinMeta> {
+    let f: syn::ItemFn = syn::parse_str(src).unwrap();
+    Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), myflat_loc())]).expect("index")
+}
+
+/// A `.name()` override that isn't a legal Kotlin identifier is a hard error
+/// naming the origin — the author can correct it in build.rs.
+#[test]
+fn invalid_name_override_is_error() {
+    let registry = one_fn("pub fn z_do_thing() -> i64 { 0 }");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("thing").fun(crate::fun!(z_do_thing).name("when")));
+    let err = write_result("jni_sym_name", registry, jni).expect_err("invalid .name()");
+    assert!(err.contains("`when`"), "{err}");
+    assert!(err.contains("not a valid Kotlin identifier"), "{err}");
+}
+
+/// A custom mangle hook that returns an illegal identifier is a hard error
+/// (the hook is author code; the mangler was available to it).
+#[test]
+fn invalid_hook_output_is_error() {
+    let registry = one_fn("pub fn z_do_thing() -> i64 { 0 }");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_fun_name_mangle(|_pkg, _name| "1bad".to_string())
+        .package(crate::package!("thing").fun(crate::fun!(z_do_thing)));
+    let err = write_result("jni_sym_hook", registry, jni).expect_err("invalid hook output");
+    assert!(err.contains("`1bad`"), "{err}");
+    assert!(err.contains("not a valid Kotlin identifier"), "{err}");
+}
+
+/// A default (Rust-derived) name that IS a valid Kotlin identifier passes
+/// with no error — the common case, and the reason existing fixtures stay
+/// byte-identical.
+#[test]
+fn valid_default_names_pass() {
+    let registry = one_fn("pub fn z_do_thing() -> i64 { 0 }");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("thing").fun(crate::fun!(z_do_thing)));
+    write_result("jni_sym_ok", registry, jni).expect("valid names must pass");
+}
+
+/// Two functions whose custom method hook collapses them onto one JNINative
+/// method name produce a duplicate native symbol — a hard error naming both,
+/// caught before the duplicate `#[no_mangle]` would fail Rust linking.
+#[test]
+fn duplicate_native_symbol_is_error() {
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_str("pub fn z_alpha() -> i64 { 0 }").unwrap()),
+            myflat_loc(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_str("pub fn z_beta() -> i64 { 0 }").unwrap()),
+            myflat_loc(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    // The JNINative extern method name (which the `Java_…` symbol derives
+    // from) goes through the method hook; collapsing it onto one name for
+    // every function forces two distinct fns to share a native symbol.
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_method_name_mangle(|_pkg, _class, _name| "collide".to_string())
+        .package(
+            crate::package!("thing")
+                .fun(crate::fun!(z_alpha))
+                .fun(crate::fun!(z_beta)),
+        );
+    let err = write_result("jni_sym_dupnative", registry, jni).expect_err("duplicate symbol");
+    assert!(err.contains("duplicate native symbol"), "{err}");
+    assert!(err.contains("z_alpha") && err.contains("z_beta"), "{err}");
+}
+
+/// A Rust struct field named like a Kotlin keyword is silently sanitized by
+/// the default mangler (emitted as `object_`) — no error, and the surrounding
+/// binding still resolves and writes.
+#[test]
+fn keyword_struct_field_is_sanitized_not_error() {
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Payload {
+                    pub object: i64,
+                    pub value: f64,
+                }
+            )),
+            myflat_loc(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_str("pub fn make() -> Payload { todo!() }").unwrap()),
+            myflat_loc(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .class(crate::data_class!(Payload))
+            .fun(crate::fun!(make)),
+    );
+    // The keyword field is sanitized (mangle → `object_`), not rejected.
+    let dir = unique_test_dir("jni_sym_field");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs"))
+        .expect("keyword field sanitized, not an error");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let all: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect();
+    let ac: String = all.split_whitespace().collect();
+    // The property surfaces under its sanitized name.
+    assert!(
+        ac.contains("valobject_:Long") || ac.contains("object_:Long"),
+        "{all}"
+    );
+    assert!(
+        !ac.contains("valobject:Long"),
+        "unsanitized keyword leaked:\n{all}"
+    );
+}
+
+/// The interface forced equal to its class name collides in the same package
+/// — a collected top-level-name error (previously an emission-time panic).
+#[test]
+fn class_interface_collision_is_error() {
+    let registry = one_fn("pub fn z_thing_new() -> ZThing { unimplemented!() }");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .set_interface_name_mangle(|_pkg, n| n.to_string()) // identity → iface == class
+        .package(
+            crate::package!("thing")
+                .class(crate::ptr_class!(ZThing).interface())
+                .fun(crate::fun!(z_thing_new)),
+        );
+    let err = write_result("jni_sym_iface", registry, jni).expect_err("iface==class collision");
+    assert!(
+        err.contains("duplicate top-level Kotlin name `ZThing`"),
+        "{err}"
+    );
+}


### PR DESCRIPTION
Stage 1 of #89 (two-PR split). Stage 2 — the JVM-erasure overload model — follows.

## Problem

Names were validated locally if at all, while the generated artifact has global Kotlin/JVM/native namespaces. The seven mangle hooks, every `.name()` override, author leaf names, struct-field-derived property/leaf names, package segments, and enum variants all reached the artifact unchecked (only `kt_param_name` escaped a keyword subset, and only for parameters); `merge_files` exempted every same-named function. So an invalid Kotlin identifier or a duplicate native export surfaced only as a late, hard-to-attribute compile/link error.

## The "default mangler" design

A single deterministic sanitizer (`jni/symbols.rs::mangle_kotlin_ident` — keyword→`_` suffix, non-identifier char→`_`, leading digit→`_` prefix; idempotent) is the primitive everything rests on. `is_valid_kotlin_ident` and the one canonical `HARD_KEYWORDS` list live beside it (`kt_param_name` now delegates), and it's exposed publicly (`JniGen::mangle_kotlin_ident` via the module API) so custom-hook authors can reuse it.

- **Every default (Rust-derived) name flows through it**: the seven hook wrappers default to the mangler instead of identity, and the four non-hook sites (data-class properties, fold/struct-out leaves, enum variants, package segments) call it directly. The emitter always produces valid names on the default path.
- **`.name()` overrides bypass mangling** — verbatim, since the point of `.name()` is to state the exact Kotlin name.
- **`validate_symbols`** (run from `validate_bindings`, before any file is written):
  - a final name still invalid can only come from a `.name()` / custom hook → **collected hard error** naming the origin;
  - a **duplicate native symbol** (two hooks collapsing onto one JNINative method) or a **duplicate top-level name** in a package (class / interface / harness / const-`val`, including a mangle-induced collision like `object` + `object_`) → **collected hard error** naming both origins;
  - a Rust-derived name the mangler had to change → **`cargo:warning`**.
  - `interface_short_name`'s class-collision `panic!` becomes an unreachable backstop — the validator reports it as a collected error first.

## Policy (as decided during planning)

Author-supplied `.name()`/custom-hook invalid names are **hard errors** ("easy to correct in build.rs"); Rust-derived names are silently **sanitized + warned**; collisions the mangler can't resolve are **hard errors**. Parameters keep auto-escaping (they're local/cosmetic — `kt_param_name` → the shared mangler).

## Tests (map to acceptance criteria)

- `symbols.rs` unit: mangler rules, validity predicate, idempotence, per-segment package mangling.
- `tests/symbols.rs`: invalid `.name()` → error; invalid custom-hook output → error; valid defaults pass; duplicate native symbol → error naming both; keyword struct field → sanitized (`object_`) not error; class==interface → collected top-level collision error. Each asserts no artifact is written on error.
- The existing `cross_artifact` suite already asserts whole-artifact extern-symbol uniqueness / no-orphans (the enumeration-honesty property).

## Verification

Output-preserving — no fixture struct field or fn param is a Kotlin keyword, so the mangler is a no-op everywhere: `regen-check.sh` byte-identical, covertest JVM **31 sections PASS**, 312 lib tests + all workspace suites green, fmt/clippy clean (aarch64 goldens restored after clippy's `--all-features` regeneration).

## Stage 2 (follow-up)

The JVM-erasure model (`JvmSignature`) + per-package/per-class overload-signature tables, replacing #52's narrow arm-erasure comparison; typed `KotlinIdent`/`KotlinFqn` land there where the erasure model needs them. Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)