### PR TITLE
jnigen: JVM-erasure overload model + whole-artifact collision tables (#89 stage 2)

### DIFF
--- a/prebindgen/src/api/gen/kotlin/file.rs
+++ b/prebindgen/src/api/gen/kotlin/file.rs
@@ -54,7 +54,11 @@ pub fn merge_files(fragments: Vec<KtFile>) -> Result<Vec<KtFile>, WriteKotlinErr
         for d in &frag.decls {
             // Functions may overload (same name, different signature) and Raw
             // blocks are opaque; only class-like identities must be unique
-            // within a package's single merged file.
+            // within a package's single merged file. The "valid overloads"
+            // assumption is now CHECKED upstream: jnigen's `validate_symbols`
+            // (issue #89) rejects two functions with the same erased JVM
+            // signature before any file is written, so a same-named function
+            // reaching here is a genuine overload.
             let unique_required = matches!(
                 d,
                 super::model::KtDecl::Class(_)

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -36,7 +36,7 @@ impl JniGen {
     /// `true` if `simple` is the Kotlin simple name of a `value_blob`
     /// (`@JvmInline value class`) type — which erases to `ByteArray` on the
     /// JVM, so two distinct such classes share one method descriptor.
-    fn is_value_blob_kotlin(&self, simple: &str) -> bool {
+    pub(crate) fn is_value_blob_kotlin(&self, simple: &str) -> bool {
         self.types.values().any(|c| {
             c.value_blob
                 && c.name_spec
@@ -75,7 +75,7 @@ impl JniGen {
                 continue;
             }
             let target = decl.key.to_type();
-            let sigs: Vec<(String, Vec<String>)> = decl
+            let sigs: Vec<(String, Vec<ErasedJvmType>)> = decl
                 .variants
                 .iter()
                 .map(|v| {
@@ -100,7 +100,12 @@ impl JniGen {
                             t = decl.key.as_str(),
                             a = sigs[i].0,
                             b = sigs[j].0,
-                            sig = sigs[i].1.join(", "),
+                            sig = sigs[i]
+                                .1
+                                .iter()
+                                .map(|e| e.to_string())
+                                .collect::<Vec<_>>()
+                                .join(", "),
                         ));
                     }
                 }
@@ -112,12 +117,14 @@ impl JniGen {
 
 /// The JVM-erased type list of one arm: the constructor's parameter types
 /// (build arm), or the single target type (`variant_self`, `ctor == None`).
+/// Uses the shared [`erase_kt_type`] model (issue #89 stage 2) so the split
+/// ambiguity check and the whole-artifact overload table agree on erasure.
 fn arm_erased_sig(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     target: &syn::Type,
     ctor: Option<&syn::Ident>,
-) -> Vec<String> {
+) -> Vec<ErasedJvmType> {
     match ctor {
         Some(cf) => match registry.functions.get(cf) {
             Some((item_fn, _)) => item_fn
@@ -135,49 +142,34 @@ fn arm_erased_sig(
     }
 }
 
-/// The JVM-erased descriptor fragment a Rust type surfaces as: a declared
-/// value-blob class erases to `ByteArray`, another declared class to its simple
-/// Kotlin name, a primitive/`String` to its Kotlin builtin, everything else to
-/// its token string (structural fallback). References are peeled first (a `&T`
-/// handle erases like `T`).
-fn rust_type_erased(ext: &JniGen, registry: &Registry<KotlinMeta>, ty: &syn::Type) -> String {
+/// The [`ErasedJvmType`] a Rust arm type surfaces as: map it to its Kotlin
+/// surface type (a declared class's FQN, else the resolved converter's Kotlin
+/// name) and run the shared [`erase_kt_type`]; a value class folds to `byte[]`
+/// and a plain class to its FQN there. Falls back to the token string for a
+/// type with no resolved surface. References are peeled first (`&T` erases
+/// like `T`).
+fn rust_type_erased(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    ty: &syn::Type,
+) -> ErasedJvmType {
     let peeled = match ty {
         syn::Type::Reference(r) => &*r.elem,
         other => other,
     };
     let key = TypeKey::from_type(peeled);
-    if let Some(cfg) = ext.types.get(&key) {
-        if cfg.name_spec.is_some() {
-            if cfg.value_blob {
-                return "ByteArray".to_string();
-            }
-            if let Some(fqn) = ext.kotlin_fqn(&key) {
-                return fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
-            }
+    if ext.types.get(&key).is_some_and(|c| c.name_spec.is_some()) {
+        if let Some(fqn) = ext.kotlin_fqn(&key) {
+            return erase_kt_type(ext, &[], &kt::KtType::cls(fqn));
         }
     }
     if let Some(kt) = registry
         .input_entry(peeled)
         .and_then(|e| e.metadata.kotlin_name.clone())
     {
-        return erased(ext, &kt);
+        return erase_kt_type(ext, &[], &kt);
     }
-    peeled.to_token_stream().to_string()
-}
-
-/// The JVM-erased descriptor fragment of an already-rendered [`kt::KtType`] —
-/// value classes to `ByteArray`, primitives/`String` to themselves, other
-/// classes to their simple name.
-fn erased(ext: &JniGen, ty: &kt::KtType) -> String {
-    let simple = ty.simple_name().unwrap_or("");
-    if ext.is_value_blob_kotlin(simple) {
-        return "ByteArray".to_string();
-    }
-    match simple {
-        "Int" | "Long" | "Double" | "Float" | "Boolean" | "Byte" | "Short" | "Char" | "String"
-        | "ByteArray" => simple.to_string(),
-        _ => simple.to_string(),
-    }
+    ErasedJvmType::raw(peeled.to_token_stream().to_string())
 }
 
 /// Whether `plan` is a multi-variant expansion that can be turned into
@@ -470,7 +462,7 @@ pub(crate) fn render_param_overloads(
 
     // Product-global JVM-signature collision check (fixed params are identical
     // across every overload, so only the split-arm lists can collide).
-    let sigs: Vec<Vec<String>> = combos
+    let sigs: Vec<Vec<ErasedJvmType>> = combos
         .iter()
         .map(|combo| {
             splits
@@ -493,7 +485,11 @@ pub(crate) fn render_param_overloads(
                     f.sig.ident,
                     combo_label(&splits, &combos[i]),
                     combo_label(&splits, &combos[j]),
-                    sigs[i].join(", "),
+                    sigs[i]
+                        .iter()
+                        .map(|e| e.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
                 );
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -715,14 +715,37 @@ pub(crate) fn peel_receiver_key(ty: &syn::Type) -> TypeKey {
 /// (the inherited `NativeHandle` scope for a `ptr_class` — `this.ptr` + lock —
 /// or `this.bytes` for a `value_class` blob). The JNINative extern/call is
 /// unchanged (keyed on the Rust ident), so only the Kotlin wrapper relocates.
-pub(crate) fn render_wrapper_fn(
+/// The Kotlin surface of a wrapper: the assembled `KtFun` with every
+/// parameter/return type in place but **no body**, plus the emission
+/// internals [`render_wrapper_fn`] needs to fill that body. One derivation of
+/// the overload surface, shared by emission (which adds the body) and
+/// [`validate_symbols`](crate::api::lang::jnigen::jni::validate_symbols)
+/// (which erases `fun` to a JVM signature), so the emitted overload and the
+/// validated one cannot drift (issue #89).
+pub(crate) struct WrapperSurface {
+    /// The wrapper with its full signature and an empty body. The validator
+    /// reads this; [`render_wrapper_fn`] fills the body and adds the KDoc.
+    pub fun: kt::KtFun,
+    // Emission-only internals — computed while assembling the signature,
+    // consumed by `render_wrapper_fn`; opaque to the validator.
+    params: Vec<Param>,
+    out: OutputPlan,
+    sink: ErrorSink,
+    jni_call: String,
+}
+
+/// Build the [`WrapperSurface`]: everything [`render_wrapper_fn`] does up to
+/// (but not including) the body render — the single surface-signature
+/// derivation. Validation calls this directly and skips the body work
+/// (`build_native_call` / `render_body` / KDoc / opaque-lock collection).
+pub(crate) fn build_wrapper_surface(
     ext: &JniGen,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
-) -> Option<kt::KtFun> {
+) -> Option<WrapperSurface> {
     let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
     // The Kotlin extern in `JNINative` is keyed on the Rust ident (the
     // plan's `jni_method`). The per-entry `.name("...")` override only
@@ -735,21 +758,10 @@ pub(crate) fn render_wrapper_fn(
     let jni_call = fplan.jni_method.clone();
     let (params, receiver_idx) = classify_params(ext, &fplan, registry, imports, receiver_key)?;
     let out = classify_output(ext, f, &fplan, registry, imports)?;
-    let body_expr = build_native_call(ext, &jni_call, &params, &out);
-
-    // Collect the opaque-handle params so we can scaffold pointer-ordered
-    // synchronized blocks around them.
-    let opaques = collect_opaques(&params);
-    let is_unit = out.kt_return.is_none();
     let r_ty = out.kt_return.clone().unwrap_or_else(kt::KtType::unit);
     let sink = error_sink_parts(ext, f, &fplan, registry, imports, &r_ty)?;
 
     let mut fun = kt::KtFun::new(&kt_name).vis(kt::Vis::Public);
-    // KDoc: the Rust fn's `///` prose first, then generated notes for every
-    // position an expansion reshaped away from the Rust signature (N1).
-    if let Some(doc) = wrapper_kdoc(f, registry) {
-        fun = fun.kdoc(doc);
-    }
     if let Some(g) = &out.generic {
         fun = fun.generic(g);
     }
@@ -782,6 +794,49 @@ pub(crate) fn render_wrapper_fn(
     if let Some(rt) = &out.kt_return {
         fun = fun.returns(rt.clone());
     }
+    Some(WrapperSurface {
+        fun,
+        params,
+        out,
+        sink,
+        jni_call,
+    })
+}
+
+pub(crate) fn render_wrapper_fn(
+    ext: &JniGen,
+    f: &syn::ItemFn,
+    registry: &Registry<KotlinMeta>,
+    imports: &mut BTreeSet<String>,
+    kotlin_name_override: Option<&str>,
+    receiver_key: Option<&TypeKey>,
+) -> Option<kt::KtFun> {
+    let surface = build_wrapper_surface(
+        ext,
+        f,
+        registry,
+        imports,
+        kotlin_name_override,
+        receiver_key,
+    )?;
+    let WrapperSurface {
+        mut fun,
+        params,
+        out,
+        sink,
+        jni_call,
+    } = surface;
+    // KDoc: the Rust fn's `///` prose first, then generated notes for every
+    // position an expansion reshaped away from the Rust signature (N1).
+    // Emission-only — the validator skips it.
+    if let Some(doc) = wrapper_kdoc(f, registry) {
+        fun = fun.kdoc(doc);
+    }
+    // Collect the opaque-handle params so we can scaffold pointer-ordered
+    // synchronized blocks around them.
+    let opaques = collect_opaques(&params);
+    let is_unit = fun.ret.is_none();
+    let body_expr = build_native_call(ext, &jni_call, &params, &out);
     let body = render_body(ext, &params, &opaques, &sink, &body_expr, is_unit, imports);
     Some(fun.body(body))
 }

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -51,6 +51,28 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             }
         };
 
+    // Overload table: (scope, kotlin name, erased JVM signature) → origin.
+    // `scope` separates the independent overload sets — a package's free
+    // functions, one class's instance methods, one class's companion
+    // factories. Two wrappers landing on the same key have an identical
+    // Kotlin/JVM signature and cannot coexist (a "platform declaration
+    // clash"); distinct signatures are legitimate overloads and pass.
+    let mut overloads: BTreeMap<(String, String, JvmSignature), String> = BTreeMap::new();
+    let mut add_overload = |scope: &str, f: &kt::KtFun, origin: &str, errors: &mut Vec<String>| {
+        let sig = jvm_signature(ext, f);
+        let key = (scope.to_string(), f.name.clone(), sig.clone());
+        if let Some(prev) = overloads.insert(key, origin.to_string()) {
+            errors.push(format!(
+                "conflicting Kotlin overload `{}{sig}` in {scope}: {prev} and {origin} \
+                     have the same erased JVM signature — rename one via `.name(...)` or \
+                     change a parameter type",
+                f.name,
+            ));
+        }
+    };
+    // The surface renderers register imports; the validator discards them.
+    let mut imports = std::collections::BTreeSet::<String>::new();
+
     // Classes (ptr / data / value / enum), in deterministic key order.
     let mut class_keys: Vec<&TypeKey> = ext
         .types
@@ -95,15 +117,25 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
     for sub in subpackages {
         let pkg_cfg = &ext.packages[sub];
         let package = ext.package_name(sub);
+        let fn_scope = format!("package `{package}`");
         for entry in &pkg_cfg.functions {
             let name = ext.effective_function_name(sub, entry);
-            check_ident(
-                &name,
-                &format!("function `{}`", entry.rust_ident),
-                &mut errors,
-            );
-            // Functions may overload — not added to the uniqueness table
-            // (overload-signature collisions are Stage 2).
+            let origin = format!("function `{}`", entry.rust_ident);
+            check_ident(&name, &origin, &mut errors);
+            // Same-named free functions may overload if their erased JVM
+            // signatures differ; the overload table rejects clashes. Render
+            // the exact surface wrapper(s) emission produces (base +
+            // `.split_on_param` shells) and erase each.
+            if let Some((item_fn, _)) = registry.functions.get(&entry.rust_ident) {
+                if let Some(f) =
+                    render_wrapper_fn(ext, item_fn, registry, &mut imports, Some(&name), None)
+                {
+                    for ov in render_param_overloads(ext, item_fn, registry, &f) {
+                        add_overload(&fn_scope, &ov, &origin, &mut errors);
+                    }
+                    add_overload(&fn_scope, &f, &origin, &mut errors);
+                }
+            }
         }
         // Const `val`s ARE top-level-unique (a property, not an overloadable fn).
         for entry in pkg_cfg
@@ -126,15 +158,33 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
         }
     }
 
-    // Class members (instance methods / companion factories) — validity only;
-    // same-named members overload, and cross-member signature collisions are
-    // Stage 2.
+    // Class members: instance methods and companion factories are separate
+    // overload sets (distinct JVM scopes), so a method and a constructor may
+    // share a name. Render each exactly as emission does — a method with the
+    // receiver bound (`receiver_key = Some`), a constructor without — and
+    // collect its overload signature under a per-class, per-kind scope.
     let mut member_keys: Vec<&TypeKey> = ext.class_members.keys().collect();
     member_keys.sort_by_key(|k| k.as_str().to_string());
     for key in member_keys {
         for m in &ext.class_members[key] {
             let name = ext.effective_method_name(key, m);
             check_ident(&name, &format!("method `{}`", m.rust_ident), &mut errors);
+            let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) else {
+                continue;
+            };
+            let (scope, receiver) = match m.kind {
+                MemberKind::Method => (format!("class `{key}` methods"), Some(key)),
+                MemberKind::Constructor => (format!("class `{key}` factories"), None),
+            };
+            let origin = format!("member `{}`", m.rust_ident);
+            if let Some(f) =
+                render_wrapper_fn(ext, item_fn, registry, &mut imports, Some(&name), receiver)
+            {
+                for ov in render_param_overloads(ext, item_fn, registry, &f) {
+                    add_overload(&scope, &ov, &origin, &mut errors);
+                }
+                add_overload(&scope, &f, &origin, &mut errors);
+            }
         }
     }
 
@@ -308,6 +358,124 @@ pub(crate) fn mangle_package(path: &str) -> String {
         .join(".")
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// JVM erasure model (issue #89 stage 2)
+// ──────────────────────────────────────────────────────────────────────
+
+/// A JVM-erased parameter type token: two parameters collide as overloads
+/// iff their tokens are equal. Human-readable, for the diagnostic.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(crate) struct ErasedJvmType(String);
+
+impl ErasedJvmType {
+    /// A verbatim token — the structural fallback for a type with no
+    /// resolved Kotlin surface (used by the #52 split-arm erasure).
+    pub(crate) fn raw(s: impl Into<String>) -> Self {
+        ErasedJvmType(s.into())
+    }
+}
+
+impl std::fmt::Display for ErasedJvmType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The JVM overload signature of a generated wrapper: its erased parameter
+/// types in order. The **return type is intentionally absent** — the JVM
+/// (and Kotlin) resolve overloads by name + parameter types only, so two
+/// functions differing only in return type still clash.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(crate) struct JvmSignature(Vec<ErasedJvmType>);
+
+impl std::fmt::Display for JvmSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(")?;
+        for (i, t) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{t}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+/// The JVM boxed class of a Kotlin primitive — a nullable primitive crosses
+/// as its box (`Int?` → `java.lang.Integer`), a distinct JVM descriptor from
+/// the unboxed primitive, so `f(x: Int)` and `f(x: Int?)` do NOT clash.
+fn boxed_primitive(simple: &str) -> Option<&'static str> {
+    Some(match simple {
+        "Int" => "java.lang.Integer",
+        "Long" => "java.lang.Long",
+        "Short" => "java.lang.Short",
+        "Byte" => "java.lang.Byte",
+        "Char" => "java.lang.Character",
+        "Boolean" => "java.lang.Boolean",
+        "Float" => "java.lang.Float",
+        "Double" => "java.lang.Double",
+        _ => return None,
+    })
+}
+
+/// Erase a Kotlin surface type to its JVM overload token. Rules (the complete
+/// model — issue #89):
+///
+/// * a type variable declared on the function (`R` / `A`) → `Object`;
+/// * a non-null primitive → itself; a **nullable** primitive → its box
+///   (`Int?` → `java.lang.Integer`) — a distinct descriptor;
+/// * `String` / `ByteArray` / `Any` → their JVM types (object nullability is
+///   irrelevant to the descriptor);
+/// * a `@JvmInline value class` → its underlying wire (`byte[]`), so two
+///   distinct value classes clash;
+/// * a generic type → its raw class (`List<T>` → `List`), arguments erased;
+/// * any other class → its FQN (distinct classes stay distinct);
+/// * a function type → `kotlin.Function<arity>`.
+pub(crate) fn erase_kt_type(ext: &JniGen, generics: &[String], ty: &kt::KtType) -> ErasedJvmType {
+    use kt::KtType;
+    let token = match ty {
+        KtType::Function { params, .. } => format!("kotlin.Function{}", params.len()),
+        KtType::Named { fqn, nullable, .. } => {
+            let simple = ty.simple_name().unwrap_or(fqn);
+            if generics.iter().any(|g| g == fqn) {
+                "java.lang.Object".to_string()
+            } else if ext.is_value_blob_kotlin(simple) {
+                "byte[]".to_string()
+            } else if let Some(boxed) = boxed_primitive(simple) {
+                if *nullable {
+                    boxed.to_string()
+                } else {
+                    simple.to_string()
+                }
+            } else {
+                match simple {
+                    "String" => "java.lang.String".to_string(),
+                    "ByteArray" => "byte[]".to_string(),
+                    "Any" => "java.lang.Object".to_string(),
+                    "Unit" => "void".to_string(),
+                    // Generic container (args erased) or a plain class: the
+                    // declared `fqn` (a generic's `fqn` is its raw name, e.g.
+                    // `List`), so `List<X>` and `List<Y>` share one token.
+                    _ => fqn.clone(),
+                }
+            }
+        }
+    };
+    ErasedJvmType(token)
+}
+
+/// The [`JvmSignature`] of a generated wrapper (`render_wrapper_fn` /
+/// `render_param_overloads` output): each parameter erased through
+/// [`erase_kt_type`] under the function's own generic type variables.
+pub(crate) fn jvm_signature(ext: &JniGen, f: &kt::KtFun) -> JvmSignature {
+    JvmSignature(
+        f.params
+            .iter()
+            .map(|p| erase_kt_type(ext, &f.generics, &p.ty))
+            .collect(),
+    )
+}
+
 /// A native `Java_…` export symbol — charset-guaranteed valid by
 /// [`symbol::native_symbol`](super::symbol::native_symbol). A newtype so the
 /// collision table's key type documents itself and can't be confused with a
@@ -325,7 +493,55 @@ impl NativeSymbol {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_valid_kotlin_ident, mangle_kotlin_ident, mangle_package};
+    use super::{
+        erase_kt_type, is_valid_kotlin_ident, mangle_kotlin_ident, mangle_package, JniGen,
+    };
+    use crate::api::gen::kotlin as kt;
+
+    fn erase(generics: &[&str], ty: kt::KtType) -> String {
+        let ext = JniGen::new();
+        let gs: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+        erase_kt_type(&ext, &gs, &ty).to_string()
+    }
+
+    #[test]
+    fn jvm_erasure_rules() {
+        // Non-null primitive is itself; nullable primitive boxes → distinct.
+        assert_eq!(erase(&[], kt::KtType::int()), "Int");
+        assert_eq!(
+            erase(&[], kt::KtType::int().nullable()),
+            "java.lang.Integer"
+        );
+        assert_ne!(
+            erase(&[], kt::KtType::int()),
+            erase(&[], kt::KtType::int().nullable()),
+            "Int and Int? must NOT clash"
+        );
+        // Object types: nullability is irrelevant to the descriptor.
+        assert_eq!(erase(&[], kt::KtType::string()), "java.lang.String");
+        assert_eq!(
+            erase(&[], kt::KtType::string().nullable()),
+            "java.lang.String",
+            "String and String? share one descriptor"
+        );
+        assert_eq!(erase(&[], kt::KtType::byte_array()), "byte[]");
+        assert_eq!(erase(&[], kt::KtType::any()), "java.lang.Object");
+        // Generics erased to the raw class: List<Int> and List<String> clash.
+        assert_eq!(
+            erase(&[], kt::KtType::generic("List", [kt::KtType::int()])),
+            erase(&[], kt::KtType::generic("List", [kt::KtType::string()])),
+        );
+        // A function's own type variable erases to Object.
+        assert_eq!(erase(&["A"], kt::KtType::var_("A")), "java.lang.Object");
+        assert_eq!(erase(&["R"], kt::KtType::var_r()), "java.lang.Object");
+        // A single-letter name that is NOT a declared type var stays a class.
+        assert_eq!(erase(&[], kt::KtType::cls("io.test.Foo")), "io.test.Foo");
+        assert_ne!(
+            erase(&[], kt::KtType::cls("io.test.Foo")),
+            erase(&[], kt::KtType::cls("io.other.Foo")),
+            "distinct FQNs stay distinct"
+        );
+    }
 
     #[test]
     fn validity_predicate() {

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -123,17 +123,18 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             let origin = format!("function `{}`", entry.rust_ident);
             check_ident(&name, &origin, &mut errors);
             // Same-named free functions may overload if their erased JVM
-            // signatures differ; the overload table rejects clashes. Render
-            // the exact surface wrapper(s) emission produces (base +
-            // `.split_on_param` shells) and erase each.
+            // signatures differ; the overload table rejects clashes. The
+            // surface signature (base + `.split_on_param` shells) comes from
+            // the SAME `build_wrapper_surface` emission uses — a body-less
+            // prototype, so the validator doesn't pay for body codegen.
             if let Some((item_fn, _)) = registry.functions.get(&entry.rust_ident) {
-                if let Some(f) =
-                    render_wrapper_fn(ext, item_fn, registry, &mut imports, Some(&name), None)
+                if let Some(s) =
+                    build_wrapper_surface(ext, item_fn, registry, &mut imports, Some(&name), None)
                 {
-                    for ov in render_param_overloads(ext, item_fn, registry, &f) {
+                    for ov in render_param_overloads(ext, item_fn, registry, &s.fun) {
                         add_overload(&fn_scope, &ov, &origin, &mut errors);
                     }
-                    add_overload(&fn_scope, &f, &origin, &mut errors);
+                    add_overload(&fn_scope, &s.fun, &origin, &mut errors);
                 }
             }
         }
@@ -177,13 +178,13 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
                 MemberKind::Constructor => (format!("class `{key}` factories"), None),
             };
             let origin = format!("member `{}`", m.rust_ident);
-            if let Some(f) =
-                render_wrapper_fn(ext, item_fn, registry, &mut imports, Some(&name), receiver)
+            if let Some(s) =
+                build_wrapper_surface(ext, item_fn, registry, &mut imports, Some(&name), receiver)
             {
-                for ov in render_param_overloads(ext, item_fn, registry, &f) {
+                for ov in render_param_overloads(ext, item_fn, registry, &s.fun) {
                     add_overload(&scope, &ov, &origin, &mut errors);
                 }
-                add_overload(&scope, &f, &origin, &mut errors);
+                add_overload(&scope, &s.fun, &origin, &mut errors);
             }
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
@@ -171,3 +171,82 @@ fn class_interface_collision_is_error() {
         "{err}"
     );
 }
+
+// ── Stage 2: JVM-erasure overload collisions ────────────────────────────
+
+/// Two free functions renamed onto the same Kotlin name with the SAME erased
+/// parameter signature clash — a platform declaration clash the JVM/Kotlin
+/// can't resolve. (Distinct signatures would be valid overloads.)
+#[test]
+fn same_name_same_signature_functions_collide() {
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_str("pub fn z_alpha(x: i64) -> i64 { x }").unwrap()),
+            myflat_loc(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_str("pub fn z_beta(y: i64) -> i64 { y }").unwrap()),
+            myflat_loc(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    // Both forced to Kotlin name `combine`; both take one `Long` → same sig.
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .fun(crate::fun!(z_alpha).name("combine"))
+            .fun(crate::fun!(z_beta).name("combine")),
+    );
+    let err = write_result("jni_ov_collide", registry, jni).expect_err("overload clash");
+    assert!(err.contains("conflicting Kotlin overload"), "{err}");
+    assert!(err.contains("combine"), "{err}");
+}
+
+/// Same Kotlin name but DIFFERENT erased parameter signatures are legitimate
+/// overloads — no error.
+#[test]
+fn same_name_distinct_signature_functions_allowed() {
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_str("pub fn z_alpha(x: i64) -> i64 { x }").unwrap()),
+            myflat_loc(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_str("pub fn z_beta(y: bool) -> i64 { 0 }").unwrap()),
+            myflat_loc(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    // Same name `combine`, but one takes Long and the other Boolean.
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing")
+            .fun(crate::fun!(z_alpha).name("combine"))
+            .fun(crate::fun!(z_beta).name("combine")),
+    );
+    write_result("jni_ov_ok", registry, jni).expect("distinct signatures are valid overloads");
+}
+
+/// A method and a companion factory are separate JVM scopes, so they may
+/// share a name and signature without clashing.
+#[test]
+fn method_and_factory_same_name_do_not_collide() {
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![
+        (
+            syn::Item::Fn(syn::parse_str("pub fn thing_size(this_: &Thing) -> i64 { 0 }").unwrap()),
+            myflat_loc(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_str("pub fn thing_make() -> Thing { todo!() }").unwrap()),
+            myflat_loc(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!("thing").class(
+            crate::ptr_class!(Thing)
+                .method(crate::fun!(thing_size).name("of"))
+                .constructor(crate::fun!(thing_make).name("of")),
+        ),
+    );
+    // Instance method `of()` and companion factory `of()` are distinct scopes.
+    write_result("jni_ov_scopes", registry, jni).expect("method vs factory don't collide");
+}


### PR DESCRIPTION
Closes #89. Stage 2 — the JVM-erasure overload model. (Stage 1, #120, added the identifier mangler plus the native-symbol and top-level-name collision tables.)

## What

Stage 1 rejected invalid identifiers, duplicate native symbols, and duplicate top-level names. The remaining acceptance criterion — "two ordinary wrappers with the same erased JVM signature are rejected; valid overloads remain allowed" — needed a real erasure model, which #52's split-overload prototype only sketched (value-blob + ref-peel, no boxing/generics/type-vars).

- **`ErasedJvmType` / `JvmSignature`** (`symbols.rs`): the complete erasure rules —
  - non-null primitive → itself; **nullable primitive → its box** (`Int?` → `java.lang.Integer`), a distinct descriptor, so `f(Int)` and `f(Int?)` don't clash;
  - `String` / `ByteArray` / `Any` → their JVM types (object nullability is irrelevant to the descriptor);
  - `@JvmInline value class` → its `byte[]` wire (two distinct value classes clash);
  - generic → raw class (`List<X>` / `List<Y>` clash);
  - a function's own type variable (`R` / `A`) → `Object`;
  - other classes → their FQN (distinct classes stay distinct).
  - Return type is excluded — the JVM (and Kotlin) resolve overloads by name + parameter types only.

- **Overload tables in `validate_symbols`**: render the exact surface each emission site produces — free functions per package, instance methods per class, companion factories per class (separate JVM scopes) — with the same `render_wrapper_fn` / `render_param_overloads` calls (including `.split_on_param` shells) emission uses, and erase each to `(scope, name, JvmSignature)`. Two landing on one key is a platform declaration clash → collected error naming both; distinct signatures pass. `merge_files`' "functions always overload" assumption is now a **checked** one (comment updated to point at the validator).

- **#52 unified onto the shared model**: the split-declaration ambiguity check (`arm_erased_sig` / `rust_type_erased`) routes through `erase_kt_type` instead of its own thin `erased` (deleted) — one erasure definition, and the split checks keep their proactive per-declaration timing.

## Tests

- Erasure unit table: `Int` ≠ `Int?`, `List<X>` ≡ `List<Y>`, `R`/`A` → `Object`, distinct FQNs stay distinct, object nullability collapses.
- Pipeline: same-name same-signature functions collide (error names both); same-name distinct-signature allowed; an instance method and a companion factory sharing a name/signature don't collide (separate JVM scopes).

## Verification

Output-preserving — no fixture produces a real collision, so the model is a no-op on all committed output: `regen-check.sh` byte-identical, covertest JVM **31 sections PASS**, 316 lib tests + all workspace suites green (including the existing #52 split-overload suite, now on the shared erasure), fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)