### PR TITLE
core: validate once in resolve, not per-writer — writers are now pure

### DIFF
--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1340,6 +1340,15 @@ impl<M> Registry<M> {
             .map_err(|message| ScanError::AdapterInvariant { message })?;
         self.apply_adapter_plans(&adapter, &declared)?;
         crate::api::core::resolve::resolve(&mut self, &adapter)?;
+        // Post-resolve validation runs ONCE here, so a `Generation` is valid
+        // by construction and the `write_*` emitters are genuinely pure
+        // (previously each writer re-ran this, validating twice per build).
+        // Sibling of the pre-resolve `validate` above — same adapter-invariant
+        // channel. An invalid binding fails `resolve`; no `Generation` is
+        // produced, so nothing can be written.
+        adapter
+            .validate_resolved(&self)
+            .map_err(|message| ScanError::AdapterInvariant { message })?;
         Ok(Generation {
             registry: self,
             adapter,

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -22,6 +22,10 @@ use crate::api::{
 };
 
 /// Errors surfaced by the file-emission phase.
+///
+/// Binding validation is NOT here — it runs once in [`Registry::resolve`]
+/// (see [`Prebindgen::validate_resolved`]), so an invalid binding fails
+/// before a `Generation` exists and never reaches a writer.
 #[derive(Debug)]
 pub enum WriteError {
     /// A `TokenStream` produced by an `on_*` trait method failed to parse
@@ -30,10 +34,6 @@ pub enum WriteError {
         phase: &'static str,
         source: syn::Error,
     },
-    /// The adapter's post-resolve validation
-    /// ([`Prebindgen::validate_resolved`]) rejected the binding — nothing
-    /// was written.
-    Validation(String),
 }
 
 impl std::fmt::Display for WriteError {
@@ -46,7 +46,6 @@ impl std::fmt::Display for WriteError {
                     phase, source
                 )
             }
-            WriteError::Validation(msg) => write!(f, "binding validation failed: {}", msg),
         }
     }
 }
@@ -62,12 +61,9 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     ext: &E,
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
-    // Post-resolve validation boundary: every artifact writer runs it first,
-    // so an invalid binding fails cleanly before ANY file is written —
-    // regardless of which artifact is written first.
-    ext.validate_resolved(registry)
-        .map_err(WriteError::Validation)?;
-
+    // Validation already ran ONCE in `Registry::resolve` — a `Generation`
+    // (the only source of a resolved registry) is valid by construction, so
+    // this writer is a pure emission.
     let mut items: Vec<syn::Item> = Vec::new();
 
     // 0. Adapter prerequisites — runtime-support items (helper structs,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -77,11 +77,8 @@ impl JniGen {
         registry: &Registry<KotlinMeta>,
         kotlin_root: &Path,
     ) -> Result<Vec<PathBuf>, WriteKotlinError> {
-        // Post-resolve validation boundary — same pass `write_rust` runs
-        // (plans + #52 split declarations), so whichever artifact is written
-        // first fails before anything reaches disk.
-        self.validate_resolved(registry)
-            .map_err(WriteKotlinError::Other)?;
+        // Validation already ran once in `Registry::resolve` — this emitter
+        // is a pure consumer of the resolved, validated registry.
         let mut fragments: Vec<kt::KtFile> = Vec::new();
         fragments.push(self.write_native_handle());
         fragments.extend(self.write_enum_classes(registry)?);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -123,10 +123,10 @@ fn ptr_class_duplicate_implements_rejected() {
 
 /// The `set_interface_name_mangle` hook receives the class package and final
 /// name and its result must differ from the class name. An identity hook
-/// makes the interface collide with the class in the same package — now a
+/// makes the interface collide with the class in the same package — a
 /// COLLECTED error from the whole-artifact symbol pass (issue #89), surfaced
-/// by `write_rust`/`write_kotlin` before any file is written, rather than an
-/// emission-time panic.
+/// by `resolve` (validation runs once there) before any `Generation` exists,
+/// rather than an emission-time panic.
 #[test]
 fn interface_name_mangle_identity_rejected() {
     let loc = myflat_loc();
@@ -145,20 +145,14 @@ fn interface_name_mangle_identity_rejected() {
                 .class(crate::ptr_class!(ZThing).interface())
                 .fun(crate::fun!(z_thing_new)),
         );
-    let dir = unique_test_dir("jnigen_iface_identity");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let gen = registry.resolve(jni).expect("resolve");
-    let err = gen
-        .write_rust(dir.join("gen.rs"))
-        .expect_err("interface==class must be a collected error");
+    let err = registry
+        .resolve(jni)
+        .expect_err("interface==class must fail resolve");
     let msg = err.to_string();
     assert!(
         msg.contains("duplicate top-level Kotlin name `ZThing`"),
         "{msg}"
     );
-    // The invalid binding must not have written a Rust artifact.
-    assert!(!dir.join("gen.rs").exists());
 }
 
 /// A per-decl `.interface_name(...)` pins the interface name (and implies

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1570,12 +1570,11 @@ fn split_declaration_colliding_variants_rejected() {
     let _ = write_all(registry.resolve(jni).expect("resolve"), "jnigen_split_decl");
 }
 
-/// #90: the validation boundary is cross-artifact — a colliding split
-/// declaration (a Kotlin-side concern) fails `write_rust` too, as a clean
-/// `Err` BEFORE the Rust file is written, so no half-written binding can
-/// exist regardless of write order.
+/// #90: the validation boundary is now in `resolve` — a colliding split
+/// declaration (a Kotlin-side concern) fails `resolve` as a clean `Err`, so
+/// no `Generation` is produced and neither artifact can be written.
 #[test]
-fn split_declaration_collision_fails_write_rust_before_writing() {
+fn split_declaration_collision_fails_resolve() {
     let loc = myflat_loc();
     let srcs: &[&str] = &[
         "pub fn z_name_from_text(text: String) -> ZName { unimplemented!() }",
@@ -1606,21 +1605,12 @@ fn split_declaration_collision_fails_write_rust_before_writing() {
                 .variant(crate::fun!(z_name_from_text))
                 .variant(crate::fun!(z_name_from_label)),
         );
-    let generation = registry.resolve(jni).expect("resolve");
-    let dir = unique_test_dir("jnigen_split_decl_rust_err");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let out = dir.join("gen.rs");
-    let err = generation
-        .write_rust(&out)
-        .expect_err("colliding split declaration must fail write_rust");
+    let err = registry
+        .resolve(jni)
+        .expect_err("colliding split declaration must fail resolve");
     assert!(
         err.to_string().contains("same JVM signature"),
         "unexpected error: {err}"
-    );
-    assert!(
-        !out.exists(),
-        "write_rust must not write on validation failure"
     );
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
@@ -5,24 +5,21 @@
 
 use super::*;
 
-/// Run the pipeline to the `write_rust` boundary and return its result — the
-/// point `validate_resolved` (and thus `validate_symbols`) runs. Also asserts
-/// the Rust artifact is absent on error (nothing reaches disk).
-fn write_result(tag: &str, registry: Registry<KotlinMeta>, jni: JniGen) -> Result<(), String> {
-    let dir = unique_test_dir(tag);
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let gen = registry.resolve(jni).expect("resolve");
-    let out = dir.join("gen.rs");
-    match gen.write_rust(&out) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            assert!(
-                !out.exists(),
-                "no artifact must be written on validation error"
-            );
-            Err(e.to_string())
+/// Resolve the binding and return the result — `validate_resolved` (and thus
+/// `validate_symbols`) now runs inside `resolve`, so an invalid binding fails
+/// here and no `Generation` is produced (nothing can be written). On success,
+/// a real `write_rust` confirms the valid binding also emits.
+fn resolve_result(tag: &str, registry: Registry<KotlinMeta>, jni: JniGen) -> Result<(), String> {
+    match registry.resolve(jni) {
+        Ok(gen) => {
+            let dir = unique_test_dir(tag);
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            gen.write_rust(dir.join("gen.rs"))
+                .expect("valid binding writes");
+            Ok(())
         }
+        Err(e) => Err(e.to_string()),
     }
 }
 
@@ -39,7 +36,7 @@ fn invalid_name_override_is_error() {
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("thing").fun(crate::fun!(z_do_thing).name("when")));
-    let err = write_result("jni_sym_name", registry, jni).expect_err("invalid .name()");
+    let err = resolve_result("jni_sym_name", registry, jni).expect_err("invalid .name()");
     assert!(err.contains("`when`"), "{err}");
     assert!(err.contains("not a valid Kotlin identifier"), "{err}");
 }
@@ -53,7 +50,7 @@ fn invalid_hook_output_is_error() {
         .set_package_prefix("io.test.jni")
         .set_fun_name_mangle(|_pkg, _name| "1bad".to_string())
         .package(crate::package!("thing").fun(crate::fun!(z_do_thing)));
-    let err = write_result("jni_sym_hook", registry, jni).expect_err("invalid hook output");
+    let err = resolve_result("jni_sym_hook", registry, jni).expect_err("invalid hook output");
     assert!(err.contains("`1bad`"), "{err}");
     assert!(err.contains("not a valid Kotlin identifier"), "{err}");
 }
@@ -67,7 +64,7 @@ fn valid_default_names_pass() {
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("thing").fun(crate::fun!(z_do_thing)));
-    write_result("jni_sym_ok", registry, jni).expect("valid names must pass");
+    resolve_result("jni_sym_ok", registry, jni).expect("valid names must pass");
 }
 
 /// Two functions whose custom method hook collapses them onto one JNINative
@@ -97,7 +94,7 @@ fn duplicate_native_symbol_is_error() {
                 .fun(crate::fun!(z_alpha))
                 .fun(crate::fun!(z_beta)),
         );
-    let err = write_result("jni_sym_dupnative", registry, jni).expect_err("duplicate symbol");
+    let err = resolve_result("jni_sym_dupnative", registry, jni).expect_err("duplicate symbol");
     assert!(err.contains("duplicate native symbol"), "{err}");
     assert!(err.contains("z_alpha") && err.contains("z_beta"), "{err}");
 }
@@ -165,7 +162,7 @@ fn class_interface_collision_is_error() {
                 .class(crate::ptr_class!(ZThing).interface())
                 .fun(crate::fun!(z_thing_new)),
         );
-    let err = write_result("jni_sym_iface", registry, jni).expect_err("iface==class collision");
+    let err = resolve_result("jni_sym_iface", registry, jni).expect_err("iface==class collision");
     assert!(
         err.contains("duplicate top-level Kotlin name `ZThing`"),
         "{err}"
@@ -196,7 +193,7 @@ fn same_name_same_signature_functions_collide() {
             .fun(crate::fun!(z_alpha).name("combine"))
             .fun(crate::fun!(z_beta).name("combine")),
     );
-    let err = write_result("jni_ov_collide", registry, jni).expect_err("overload clash");
+    let err = resolve_result("jni_ov_collide", registry, jni).expect_err("overload clash");
     assert!(err.contains("conflicting Kotlin overload"), "{err}");
     assert!(err.contains("combine"), "{err}");
 }
@@ -222,7 +219,7 @@ fn same_name_distinct_signature_functions_allowed() {
             .fun(crate::fun!(z_alpha).name("combine"))
             .fun(crate::fun!(z_beta).name("combine")),
     );
-    write_result("jni_ov_ok", registry, jni).expect("distinct signatures are valid overloads");
+    resolve_result("jni_ov_ok", registry, jni).expect("distinct signatures are valid overloads");
 }
 
 /// A method and a companion factory are separate JVM scopes, so they may
@@ -248,5 +245,5 @@ fn method_and_factory_same_name_do_not_collide() {
         ),
     );
     // Instance method `of()` and companion factory `of()` are distinct scopes.
-    write_result("jni_ov_scopes", registry, jni).expect("method vs factory don't collide");
+    resolve_result("jni_ov_scopes", registry, jni).expect("method vs factory don't collide");
 }


### PR DESCRIPTION
Third step of the **lower-once / emit-pure** architecture thread (after #122's wire-tier extern→AST). This removes the per-writer validation duplication.

## What & why

`validate_resolved` ran at the head of **both** `write_rust` (`write.rs:68`) and `write_kotlin` (`kotlin_emit.rs:83`) with no once-guard — a build writing both artifacts validated twice, each a full re-lower of every function's plan. And `Generation`'s docstring already claimed its `write_*` methods are "pure, order-free emissions" while they in fact ran a full re-lowering validation first.

**Fold validation into `Registry::resolve`:** after `resolve::resolve`, before building the `Generation`, call `adapter.validate_resolved(&self)` through the same `ScanError::AdapterInvariant` channel the pre-resolve `validate` already uses — the two become siblings. Both per-writer calls are deleted, along with the now-dead `WriteError::Validation` variant. The writers no longer mention validation; the docstring's "pure emissions" claim is finally true.

## Consequence (intended — public behavior change)

A validation failure now surfaces at **`resolve`**, not at write. `Registry::resolve(jni)` returns `Err` for an invalid binding, so no `Generation` is produced and "invalid → no artifact" holds even more strongly (nothing to write). Validation runs **once** per build instead of once per writer.

The ~7 tests that asserted a validation error at write time now assert it on `resolve`: `split_declaration_collision_fails_resolve` (renamed; drops the file-not-created check since no writer runs), the #89 symbol tests via a small `resolve_result` helper, and `interface_name_mangle_identity_rejected`.

## Verification

Validation is side-effect-free on valid input, so this is a pure move of *when* it runs: `regen-check.sh` **byte-identical**, covertest JVM **31 sections PASS**, 271 lib tests + all workspace suites green, fmt/clippy clean.

## Roadmap position

The clarity thread's remaining work (tracked in the architecture doc): finish wrapper-**body** surface purity (the last `register_kt_type`/`register_fqn` uses) → the `LoweredBindings` capstone that builds+stores all plans/surfaces once so every emitter is a pure reader. This PR is the self-contained "validate once" win, shippable independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)