### PR TITLE
jnigen: data-class emitter uses one import mechanism — delete register_kt_type

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -169,9 +169,10 @@ fn factory_from_plan(
                 params.push((base.clone(), wire_ty));
                 parts.push(wrap);
             }
-            // Enum leaf → `Int`, rebuilt via `Enum.fromInt(i)`.
+            // Enum leaf → `Int`, rebuilt via `Enum.fromInt(i)` (raw text: the
+            // enum's short name, its FQN collected as a body import).
             PlanFieldKind::Enum { kotlin, .. } => {
-                let short = register_kt_type(kotlin, imports).to_string();
+                let short = register_fqn(kotlin.leaf_name()?, imports);
                 params.push((base.clone(), kt::KtType::int()));
                 parts.push(format!("{short}.fromInt({base})"));
             }
@@ -179,7 +180,7 @@ fn factory_from_plan(
             // `box_jint`-boxed (JVM `Ljava/lang/Integer;`, null for `None`), so
             // the factory takes `Int?` and rebuilds the nullable enum.
             PlanFieldKind::OptionEnum { kotlin, .. } => {
-                let short = register_kt_type(kotlin, imports).to_string();
+                let short = register_fqn(kotlin.leaf_name()?, imports);
                 params.push((base.clone(), kt::KtType::int().nullable()));
                 parts.push(format!("{base}?.let {{ {short}.fromInt(it) }}"));
             }
@@ -230,12 +231,16 @@ fn factory_from_plan(
                 }
             }
             // Leaf primitive / object (string, byte array, Vec, …) — forwarded
-            // unchanged to the constructor.
+            // unchanged to the constructor. Full-FQN param type; the
+            // render-time `ImportSet` shortens it.
             PlanFieldKind::Leaf {
                 kotlin, nullable, ..
             } => {
-                let ty = register_kt_type(kotlin, imports);
-                let ty = if *nullable { ty.nullable() } else { ty };
+                let ty = if *nullable {
+                    kotlin.clone().nullable()
+                } else {
+                    kotlin.clone()
+                };
                 params.push((base.clone(), ty));
                 parts.push(base);
             }
@@ -426,41 +431,18 @@ pub(crate) fn kotlin_null_sentinel(wire: &syn::Type) -> Option<&'static str> {
     })
 }
 
+/// Shorten a class FQN to its simple name for use in **raw body text** (a
+/// `fromParts` reconstruct fragment: `Child.fromParts(…)`, `Enum.fromInt(…)`,
+/// `ZenohId(bytes)`), registering the FQN into `used` — the body `Code`'s own
+/// import list. A non-dotted name (a Kotlin builtin like `String`) needs no
+/// import and passes through. Signature types are NOT shortened this way —
+/// those are full-FQN `KtType`s in the AST, shortened + imported by the
+/// render-time `ImportSet`.
 pub(crate) fn register_fqn(fqn: &str, used: &mut BTreeSet<String>) -> String {
     if fqn.contains('.') {
         used.insert(fqn.to_string());
         fqn.rsplit('.').next().unwrap_or(fqn).to_string()
     } else {
         fqn.to_string()
-    }
-}
-
-/// Structured sibling of [`register_fqn`]: register every dotted FQN leaf of
-/// `t` into the import set and return the type with those leaves shortened —
-/// compositional, so generic arguments and function-type members register
-/// individually instead of the composed text being treated as one name.
-pub(crate) fn register_kt_type(t: &kt::KtType, used: &mut BTreeSet<String>) -> kt::KtType {
-    match t {
-        kt::KtType::Named {
-            fqn,
-            args,
-            nullable,
-        } => kt::KtType::Named {
-            fqn: register_fqn(fqn, used),
-            args: args.iter().map(|a| register_kt_type(a, used)).collect(),
-            nullable: *nullable,
-        },
-        kt::KtType::Function {
-            params,
-            ret,
-            nullable,
-        } => kt::KtType::Function {
-            params: params
-                .iter()
-                .map(|(n, p)| (n.clone(), register_kt_type(p, used)))
-                .collect(),
-            ret: Box::new(register_kt_type(ret, used)),
-            nullable: *nullable,
-        },
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -638,8 +638,11 @@ impl JniGen {
             if item_struct.ident != class_name {
                 aliases.push((item_struct.ident.to_string(), class_name.clone()));
             }
-            let (mut class, mut imports) =
-                build_data_class(self, &class_name, item_struct, registry);
+            let mut class = build_data_class(self, &class_name, item_struct, registry);
+            // The data class is self-contained (property/factory types +
+            // factory-body imports ride the AST/`Code`); this file-level set
+            // is only for the `JNINative` harness the promoted members call.
+            let mut imports: BTreeSet<String> = BTreeSet::new();
             // Members: same shape as the value-blob path — the instance
             // method's receiver re-enters Rust as `this`'s field leaves
             // (the data-class param destructuring, rebased to `this`).

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -59,14 +59,16 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
 }
 
 /// Build the Kotlin `data class` declaration for a `data_class`-declared
-/// Rust struct. Returns the class plus the FQN imports its (pre-shortened)
-/// field/factory type strings reference.
+/// Rust struct. The class is **self-contained**: property/factory-param types
+/// are full-FQN `KtType`s (the render-time `ImportSet` shortens + imports
+/// them), and the `fromParts` factory's raw-text class references carry their
+/// imports on the factory body `Code`.
 pub(crate) fn build_data_class(
     ext: &JniGen,
     class_name: &str,
     item_struct: &syn::ItemStruct,
     registry: &Registry<KotlinMeta>,
-) -> (kt::KtClass, BTreeSet<String>) {
+) -> kt::KtClass {
     let fields_named = match &item_struct.fields {
         syn::Fields::Named(n) => &n.named,
         _ => {
@@ -77,7 +79,6 @@ pub(crate) fn build_data_class(
         }
     };
 
-    let mut imports: BTreeSet<String> = BTreeSet::new();
     let mut ctor_params: Vec<kt::KtCtorParam> = Vec::new();
     // Track per-field destructible (name, folded close strategy) so the
     // bottom emitter can produce a matching `close()` body for each.
@@ -118,11 +119,10 @@ pub(crate) fn build_data_class(
                         item_struct.ident, field_ident, h.leaf_key
                     )
                 });
-            let short = register_fqn(&fqn, &mut imports);
             ctor_params.push(
                 kt::KtCtorParam::new(
                     &kotlin_field_name,
-                    handle_kt_type(&h.strategy, &kt::KtType::cls(short)),
+                    handle_kt_type(&h.strategy, &kt::KtType::cls(fqn)),
                 )
                 .val(),
             );
@@ -147,7 +147,7 @@ pub(crate) fn build_data_class(
                     field_ident
                 )
             });
-        let ty = register_kt_type(&kotlin_ty, &mut imports);
+        let ty = kotlin_ty;
         // `Option<T>` whose wire is a JNI primitive (jlong/jint/jboolean/…)
         // and that *isn't* an opaque handle (handled above) is encoded by
         // the struct emitter as the bare primitive with a sentinel for
@@ -174,15 +174,22 @@ pub(crate) fn build_data_class(
     // `fromParts` companion factory — recursively flattened the same way as the
     // native `flatten_struct_encode`: nested data-class fields are inlined as
     // their leaf wires, so native builds the whole object graph with ONE
-    // `call_static_method`. Any nested child FQN it references is registered
-    // into `imports`.
-    let (factory_params, factory_reconstruct) =
-        flatten_struct_factory(ext, registry, item_struct, "", class_name, &mut imports, 0)
-            .unwrap_or_else(|| {
-                panic!(
-                    "render_data_class_source: could not build fromParts factory for `{class_name}`"
-                )
-            });
+    // `call_static_method`. Its raw-text class references (`Child.fromParts`,
+    // `Enum.fromInt`, projection wraps) use short names; the FQNs they need are
+    // collected here and attached to the factory body `Code` below.
+    let mut factory_imports: BTreeSet<String> = BTreeSet::new();
+    let (factory_params, factory_reconstruct) = flatten_struct_factory(
+        ext,
+        registry,
+        item_struct,
+        "",
+        class_name,
+        &mut factory_imports,
+        0,
+    )
+    .unwrap_or_else(|| {
+        panic!("render_data_class_source: could not build fromParts factory for `{class_name}`")
+    });
 
     let mut class = kt::KtClass::new(kt::ClassKind::Data, class_name).vis(kt::Vis::Public);
     if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_struct.attrs) {
@@ -213,11 +220,17 @@ pub(crate) fn build_data_class(
     // this factory reassembles it (incl. nested `Child.fromParts(...)`) in
     // JVM bytecode. `public`, not `internal`: an `internal` fun is mangled
     // to `fromParts$<module>`, unresolvable by native (`NoSuchMethodError`).
+    // The factory body's raw-text class references (short names) carry their
+    // imports on this `Code`, so the whole `data class` is self-contained.
+    let mut factory_body = kt::Code::new().line(factory_reconstruct);
+    for fqn in factory_imports {
+        factory_body = factory_body.import(fqn);
+    }
     let mut factory = kt::KtFun::new("fromParts")
         .vis(kt::Vis::Public)
         .annotation("JvmStatic")
         .returns(kt::KtType::cls(class_name))
-        .expr_body(kt::Code::new().line(factory_reconstruct));
+        .expr_body(factory_body);
     for (name, ty) in &factory_params {
         factory = factory.param(kt::KtParam::new(name, ty.clone()));
     }
@@ -226,7 +239,7 @@ pub(crate) fn build_data_class(
             .vis(kt::Vis::Public)
             .member(factory),
     );
-    (class, imports)
+    class
 }
 
 /// Render one typed-handle Kotlin source file. Pure-shell form (with a


### PR DESCRIPTION
Fifth step of the **lower-once / emit-pure** thread. The data-class emitter was the last user of the derivation-layer shortening helpers `register_kt_type` / `register_fqn`, which shortened a type **and** registered its import into a file-level `BTreeSet` that shadowed the render-time `ImportSet`. This completes collapsing to one import mechanism.

## What

- **`build_data_class`**: property (ctor-param) types are now full-FQN `KtType`s — the render-time `ImportSet` shortens + imports them (collision-correctly). The `fromParts` factory's raw-text class references keep short names, and the FQNs they need are attached to the factory body `Code`. The `data class` is thus self-contained; `build_data_class` returns just `KtClass`.
- **`factory_from_plan`**: leaf param types → full-FQN; the raw-text reconstruct fragments (`Child.fromParts`, `Enum.fromInt`, projection wraps) use short names via `register_fqn`, whose imports now ride the body `Code`.
- **`register_kt_type` deleted** — the compositional shortener that duplicated the `ImportSet`. `register_fqn` survives ONLY as the raw-body-text helper (short name + `Code` import for a `fromParts` fragment) — the legitimate "Code's own import list for raw fragments" the AST renderer can't derive.
- `write_data_classes` keeps a small file-level set only for the `JNINative` harness the promoted members call — no longer for the (now self-contained) data class.

## Verification

**Byte-identical**: the raw-text short names match the old `register_fqn` output, so `regen-check.sh` is byte-identical. covertest JVM **31 sections PASS**, 271 lib tests + all workspace suites green, fmt/clippy clean.

## Roadmap position

The derivation layer no longer shortens types or shadows imports: signature types are FQN in the AST (render-time `ImportSet`), raw body fragments carry their imports on the `Code`. With `build_wrapper_surface` already pure (#124), the remaining piece is the **`LoweredBindings` capstone** — build + store every plan/surface once at resolve so all emitters become pure readers (the "one place a function becomes its binding" clarity win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)