### PR TITLE
jnigen: memoize JniFunctionPlan (build-once capstone, #90)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -97,6 +97,7 @@ impl JniGen {
             ignored_const_idents: std::collections::HashSet::new(),
             local_fns: Vec::new(),
             iface_specs: Default::default(),
+            fn_plans: Default::default(),
         };
         // Built-in rank-2 `Result<_, _>` peel: every Result<T, E> succeeds
         // as T and routes E to the error-sink on Err. The rank tables are

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -152,7 +152,8 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // function's sentinel into their early-`return` path.
     // Backstop only — `validate_resolved` reports every plan failure before
     // any writer runs, so this panic is unreachable through the write paths.
-    let plan = JniFunctionPlan::build(ext, registry, f)
+    let plan = ext
+        .fn_plan(registry, f)
         .unwrap_or_else(|e| panic!("{}", e.message(original_ident)));
     let wrapper_ident = syn::Ident::new(&plan.native_symbol, Span::call_site());
     // Output (data) expansion: when output expansion was declared for this

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -207,6 +207,7 @@ pub(crate) enum ReturnSurface {
 /// ([`validate_bindings`]) reports every failure before any artifact is
 /// written; the Rust emitter keeps the same messages as panic backstops and
 /// the Kotlin renderers map to `None` (skip).
+#[derive(Debug)]
 pub(crate) enum PlanError {
     /// `registry.input_entry` has no converter for a source param type.
     Unresolved { ty: TypeKey },
@@ -288,7 +289,7 @@ pub(crate) fn validate_bindings(
             continue;
         }
         let (item_fn, _) = &registry.functions[ident];
-        match JniFunctionPlan::build(ext, registry, item_fn) {
+        match ext.fn_plan(registry, item_fn) {
             Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
             Err(e) => errors.push(e.message(ident)),
         }
@@ -305,7 +306,7 @@ pub(crate) fn validate_bindings(
             }
             let (item_const, _) = &registry.consts[ident];
             let getter = const_getter_fn(item_const);
-            match JniFunctionPlan::build(ext, registry, &getter) {
+            match ext.fn_plan(registry, &getter) {
                 Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
                 Err(e) => errors.push(e.message(&getter.sig.ident)),
             }
@@ -322,7 +323,7 @@ pub(crate) fn validate_bindings(
     expr_decls.sort_by(|a, b| a.kotlin_name.cmp(&b.kotlin_name));
     for decl in expr_decls {
         let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
-        match JniFunctionPlan::build(ext, registry, &getter) {
+        match ext.fn_plan(registry, &getter) {
             Ok(plan) => record_symbol(&plan.native_symbol, decl.kotlin_name.clone(), &mut errors),
             Err(e) => errors.push(e.message(&getter.sig.ident)),
         }
@@ -351,10 +352,38 @@ impl FnOutputPlan {
     }
 }
 
+impl JniGen {
+    /// The memoized lowered plan for one bound function — the "build the plan
+    /// once and store it" stage [`JniFunctionPlan::build`] anticipated (issue
+    /// #90). Keyed by the function's ident (bound functions live in one flat
+    /// namespace, and the synthetic const-getter idents `const_get_*` are
+    /// distinct), so validation and every emitter share ONE derivation
+    /// instead of rebuilding it ~8× per generation. `Ok` is cached; an `Err`
+    /// (an unresolved converter) is passed through — it only occurs at the
+    /// validation phase, which reports it and fails `resolve` before any
+    /// emitter runs. Same interior-mutable contract as
+    /// [`JniGen::iface_spec`]; drift is guarded externally by the byte-identity
+    /// regen check (a plan change alters generated code).
+    pub(crate) fn fn_plan(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        f: &syn::ItemFn,
+    ) -> Result<std::rc::Rc<JniFunctionPlan>, PlanError> {
+        if let Some(hit) = self.fn_plans.borrow().get(&f.sig.ident).cloned() {
+            return Ok(hit);
+        }
+        let plan = std::rc::Rc::new(JniFunctionPlan::build(self, registry, f)?);
+        self.fn_plans
+            .borrow_mut()
+            .insert(f.sig.ident.clone(), plan.clone());
+        Ok(plan)
+    }
+}
+
 impl JniFunctionPlan {
-    /// Lower `f`'s inputs. Deterministic over `(ext, registry, f)` — until
-    /// plans are built once and stored (a later stage), each emission site
-    /// rebuilds the identical plan, exactly like [`build_struct_plan`].
+    /// Lower `f`'s inputs. Deterministic over `(ext, registry, f)`. Emission
+    /// and validation go through the memo [`JniGen::fn_plan`], so the plan is
+    /// built ONCE per function and shared; this is the underlying derivation.
     pub fn build(
         ext: &JniGen,
         registry: &Registry<KotlinMeta>,

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -469,6 +469,18 @@ pub struct JniGen {
     /// `(self, registry)` — cloning the builder just clones the cache.
     pub(crate) iface_specs:
         std::cell::RefCell<std::collections::BTreeMap<SpecKey, std::sync::Arc<IfaceSpec>>>,
+
+    /// Memoized per-function lowered plans, one [`JniFunctionPlan`] per bound
+    /// function/const-getter ident — the single lowering shared by validation
+    /// and every emitter (Rust extern, JNINative extern, Kotlin wrapper,
+    /// report), so a function's binding is derived ONCE per generation
+    /// instead of ~8× (issue #90's deferred "build the plan once and store
+    /// it" — `fn_plan.rs`). Populated eagerly at `resolve` by
+    /// [`validate_bindings`], which builds every declared function's plan for
+    /// the collision tables; the writers then read it. Same interior-mutable
+    /// "derived state, keyed by `(self, registry)`" contract as
+    /// [`Self::iface_specs`].
+    pub(crate) fn_plans: std::cell::RefCell<HashMap<syn::Ident, std::rc::Rc<JniFunctionPlan>>>,
 }
 
 // ── Sibling submodules (carved from the former monolithic file) ─────────

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -472,7 +472,7 @@ pub(crate) fn render_extern_decl(
     // The name and wire params come straight off the lowered plan — the
     // same classification the Rust extern and the Kotlin call site consume,
     // so the three sites agree on arity, types, and symbol by construction.
-    let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
+    let fplan = ext.fn_plan(registry, f).ok()?;
     let jni_call = &fplan.jni_method;
     let mut params: Vec<kt::KtParam> = Vec::new();
     for leaf in fplan.leaves() {
@@ -745,7 +745,7 @@ pub(crate) fn build_wrapper_surface(
     receiver_key: Option<&TypeKey>,
 ) -> Option<WrapperSurface> {
     let mut body_imports = BTreeSet::new();
-    let fplan = JniFunctionPlan::build(ext, registry, f).ok()?;
+    let fplan = ext.fn_plan(registry, f).ok()?;
     // The Kotlin extern in `JNINative` is keyed on the Rust ident (the
     // plan's `jni_method`). The per-entry `.name("...")` override only
     // changes the *user-facing* Kotlin wrapper name; the JNI call still has

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -522,3 +522,45 @@ fn iface_spec_memo_shares_one_derivation() {
     assert!(Arc::ptr_eq(&cb1, &cb2), "callback identity shared");
     assert_eq!(cb1.descr, "(JLjava/lang/String;)V");
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// Function-plan memo (the #90 "build once, store" capstone): validation
+// and every emitter share ONE `JniFunctionPlan` per function ident.
+// ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fn_plan_memo_shares_one_derivation() {
+    use crate::SourceLocation;
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn z_do_thing(x: i64) -> i64 {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("thing").fun(crate::fun!(z_do_thing)));
+    // resolve runs validation, which builds and stores every function's plan.
+    let gen = registry.resolve(jni).expect("resolve");
+    let (ext, registry) = (gen.adapter(), gen.registry());
+    let f = &registry
+        .functions
+        .get(&syn::parse_str::<syn::Ident>("z_do_thing").unwrap())
+        .expect("indexed")
+        .0;
+
+    // The plan is already in the memo (populated at resolve by validation) —
+    // repeated lookups return the SAME allocation, and it equals what a fresh
+    // `JniFunctionPlan::build` derives.
+    let a = ext.fn_plan(registry, f).expect("plan");
+    let b = ext.fn_plan(registry, f).expect("plan");
+    assert!(std::rc::Rc::ptr_eq(&a, &b), "one plan per function ident");
+    assert_eq!(a.native_symbol, b.native_symbol);
+    let fresh = JniFunctionPlan::build(ext, registry, f).expect("fresh build");
+    assert_eq!(a.native_symbol, fresh.native_symbol);
+    assert_eq!(a.jni_method, fresh.jni_method);
+}


### PR DESCRIPTION
## What

Completes the deferred end-state of #90: a bound function's lowered `JniFunctionPlan` is now built **once per generation** and shared by validation and every emitter, instead of being rebuilt ~8× (two validate passes × symbol+surface, the Rust extern, the Kotlin wrapper, the `JNINative` extern-decl, and the report).

This is the build-once lever (item B/E) of the *lower-once / emit-pure* architecture thread, landing on top of the surface-purity work (#122–#125) and validate-once (#123). `JniFunctionPlan`'s own doc already anticipated this stage: *"until plans are built once and stored (a later stage), each emission site rebuilds the identical plan."*

## How

Mirrors the #107 `iface_spec` memo exactly — a `JniGen` field behind interior mutability:

```rust
pub(crate) fn_plans: RefCell<HashMap<syn::Ident, Rc<JniFunctionPlan>>>,
```

so `&self` writers stay pure readers and the generic core `Prebindgen` contract is untouched. `Rc` (not `Arc`) because the plan holds `syn::Type`, which is `!Send` — the same constraint that drove TypeKey's `Rc`.

The memo is populated **eagerly at `resolve`** by `validate_bindings` (which already builds every declared function's plan for the native-symbol collision tables); the writers then read it. All six `JniFunctionPlan::build` call sites (three validate loops, the Rust extern emitter, `render_extern_decl`, `build_wrapper_surface`) now route through the new `JniGen::fn_plan`.

## Keying correctness

Keyed on the function ident. Bound functions share one flat namespace, and the synthetic const-getter idents are `const_get_*`-prefixed, so keys are distinct. Any theoretical synthetic-ident collision produces a duplicate native symbol that `validate_bindings` already rejects at resolve — so the memo can never silently serve a wrong plan.

## Verification

- `cargo test -p prebindgen --lib` — 272 pass, incl. new `fn_plan_memo_shares_one_derivation` (asserts `Rc::ptr_eq` across two lookups + equality vs a fresh build).
- `./examples/regen-check.sh` — **byte-identical** (the memo is storage-only; it cannot change emitted output).
- covertest JVM 31 sections PASS.
- fmt (CI config) + clippy `--all-targets --no-default-features --all-features --deny warnings` clean; example-cbindgen aarch64 goldens untouched.

Refs the architecture doc's *lower-once / emit-pure* plan (item B, subsumed by E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)