### PR TITLE
docs: group declaration macros vs syntax helpers in crate rustdoc (#66)

### DIFF
--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -127,6 +127,31 @@
 //! include!(concat!(env!("OUT_DIR"), "/example_flat.rs"));
 //! ```
 //!
+//! ## Macros
+//!
+//! The declaration surface is built almost entirely from exported macros, which
+//! fall into two groups.
+//!
+//! **Declaration macros** construct a typed [`lang`] `*Decl` from bare Rust
+//! syntax — the domain vocabulary you compose and hand to [`lang::JniGen`]:
+//!
+//! - Kotlin surface: [`package!`](crate::package), [`ptr_class!`](crate::ptr_class),
+//!   [`data_class!`](crate::data_class), [`value_class!`](crate::value_class),
+//!   [`enum_class!`](crate::enum_class)
+//! - Members & constants: [`fun!`](crate::fun), [`constant!`](crate::constant)
+//! - Conversions: [`convert!`](crate::convert), [`from!`](crate::from),
+//!   [`try_from!`](crate::try_from), [`into!`](crate::into),
+//!   [`try_into!`](crate::try_into)
+//! - Boundary expansion: [`expand_param!`](crate::expand_param),
+//!   [`expand_return!`](crate::expand_return)
+//!
+//! **Syntax helpers** produce a bare `syn` node — `Type` / `Path` / `Expr` /
+//! `Signature` / `Ident` — to hand to a declaration method that requires one.
+//! They exist only to sidestep `syn::parse_quote!`'s type-inference ambiguity
+//! (E0283) in a generic argument position, not to express a domain concept:
+//! [`ty!`](crate::ty), [`path!`](crate::path), [`expr!`](crate::expr),
+//! [`sig!`](crate::sig), [`ident!`](crate::ident).
+//!
 
 /// File name for storing the crate name
 const CRATE_NAME_FILE: &str = "crate_name.txt";


### PR DESCRIPTION
## What

The crate exports 20 `#[macro_export]` macros, which rustdoc lists in one flat, alphabetized "Macros" index at the crate root (that placement is forced by `#[macro_export]`). The crate-level `//!` header documented the `core` pipeline and `lang::JniGen` but **never listed the macros**, so a reader couldn't tell the *domain* decl-constructors (`ptr_class!`, `fun!`, …) apart from the *syntax helpers* (`ty!`/`path!`/`expr!`/`sig!`/`ident!`) that only produce a bare `syn` node to sidestep `parse_quote`'s E0283 inference ambiguity.

This adds a curated **`## Macros`** section to the crate `//!` doc that groups them — declaration macros (by purpose) vs syntax helpers — each as an intra-doc link, so the front page guides the reader even though the auto-generated flat index still exists below.

**Documentation-only.** No macro definition, `#[doc(hidden)]`, or cross-reference is touched, and no public surface changes.

## On the `#[doc(hidden)]` half of #66

The issue also floated `#[doc(hidden)]` for macros made redundant by string-accepting runtime methods (#64). **Deferred:** #64's string overloads aren't built yet, and the only current candidate (`ident!`, used solely inside `fun!`/`constant!`) can only be relocated into the `#[doc(hidden)] pub` `__macro_support` module — which is *still external API* — so the swap would trade a clean public macro for a clumsy public function, not remove surface. All syntax helpers stay public.

## Verification

- `cargo doc -p prebindgen --no-deps` — every new `[`macro!`](crate::macro)` link resolves; no new warnings attributable to the section (the crate's 32 pre-existing rustdoc `-D warnings` are unrelated — stale `ConvertSourceDecl::with/error` doc examples, etc.).
- `cargo build -p prebindgen` + `cargo test -p prebindgen --doc` (11 passed, incl. the retained `ident!` doctest).
- `cargo fmt` (CI config) clean; no generated output changes, so `regen-check` is unaffected.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)