### PR TITLE
jnigen: split the error handler into binding + domain callers (#45)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -51,7 +51,8 @@
 //! | binding-local field `fun!(crate::…).sig(sig!).name(…)` | `storage_summary_probe` — custom field, here a conditional handle via `crate::summary_if_nonempty` |
 //! | binding-local fn `fun!(crate::…)` `.sig(sig!)` as free fn | `describeSummary` ← `crate::summary_describe` |
 //! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean` (NO `.name` — derived by the strip hook); `Summary.fromMean` ← `crate::summary_from_mean` (FALLIBLE — sig `Result` → `onError`) |
-//! | `Result<_, E>` → `onError`           | `storage_try_with_label` |
+//! | `Result<_, E>` → typed domain `onError` | `storage_try_with_label` |
+//! | two-caller split (#45): `onBindingError` + `onError` on one fallible wrapper | `storage_try_from_stamp` (malformed `Stamp` → binding; bad `secs` → domain) |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
 //! | owned-handle callback (`Fn(Storage)`)| `storage_handler_new` / `storage_emit` |
@@ -61,7 +62,7 @@
 //! | N-ary sorted handle locking          | `storage_total_len` (3 handles) + a 4-thread smoke |
 //! | `Vec<String>` return                 | `storage_labels` (single-leaf string fold) |
 //! | `String` return                      | `string_new` |
-//! | binding-error channel (`je != null`) | malformed `Stamp` bytes (value-blob length guard) |
+//! | binding-error channel (`JniErrorHandler`) | malformed `Stamp` bytes (value-blob length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
 //! | `data_class` instance member          | `Payload.labelLen()` (receiver crosses as `this` field leaves) |
 //! | `JniGen::ignore` (exact)              | `string_len` / `storage_put_by_read_and_update` (acknowledged-unbound, no skip warnings) |
@@ -501,6 +502,8 @@ fn main() {
                 .fun(fun!(payload_vec_handler_new))
                 .fun(fun!(storage_callback_vec))
                 .fun(fun!(storage_try_with_label))
+                // Two-caller error split (#45): both channels on one wrapper.
+                .fun(fun!(storage_try_from_stamp))
                 // Vec<opaque-handle> returns (plain + under the Option niche).
                 .fun(fun!(storage_shards))
                 .fun(fun!(storage_shards_opt))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -86,8 +86,10 @@ Base package: `io.prebindgen.covertest`
 - `storage_shards_opt` — `fun storageShardsOpt(count: Long, each: Long, onError: JniErrorHandler<List<Storage>?>): List<Storage>?`
   - shaped by: return `Storage` decomposed → [] (Callback delivery)
 - `storage_total_len` — `fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniErrorHandler<Long>): Long`
-- `storage_try_with_label` — `fun storageTryWithLabel(label: String, onError: StorageErrorHandler<Storage>): Storage`
-  - shaped by: error `StorageError` decomposed → [je, message, handle]
+- `storage_try_from_stamp` — `fun storageTryFromStamp(s: Stamp, onBindingError: JniErrorHandler<Storage>, onError: StorageErrorHandler<Storage>): Storage`
+  - shaped by: domain error `StorageError` decomposed → onError [message, handle] (binding failures → onBindingError)
+- `storage_try_with_label` — `fun storageTryWithLabel(label: String, onBindingError: JniErrorHandler<Storage>, onError: StorageErrorHandler<Storage>): Storage`
+  - shaped by: domain error `StorageError` decomposed → onError [message, handle] (binding failures → onBindingError)
 
 ## class `io.prebindgen.covertest.esc_pkg.Esc_Probe` (ptr_class, Rust `EscapeProbe`)
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -173,16 +173,16 @@ public data class Payload(override val id: Long, override val seq: Int, override
      * / `Option<data-class>` shapes elsewhere.
      */
     public override fun labelLen(onError: JniErrorHandler<Long?>): Long? {
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = CovNative.payloadLabelLen(
             this.id,
             this.seq,
             this.value,
             this.flag,
             this.label,
-            __cap,
+            __bcap,
         )
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -279,24 +279,24 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), StorageApi, C
     /** Number of stored payloads (an **accessor** on `Storage`). */
     public override fun len(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.storageLen(this_ptr, __cap)
+            CovNative.storageLen(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
     /** Whether any stored payload has the given id (a **method** on `Storage`). */
     public override fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.storageContains(this_ptr, id, __cap)
+            CovNative.storageContains(this_ptr, id, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -309,7 +309,7 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), StorageApi, C
          * factory on `Storage`).
          */
         public fun withPayload(payload: Payload, onError: JniErrorHandler<Storage>): Storage {
-            val __cap = JniErrorHandlerCapture.acquire()
+            val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = Storage(
                 CovNative.storageWithPayload(
                     payload.id,
@@ -317,10 +317,10 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), StorageApi, C
                     payload.value,
                     payload.flag,
                     payload.label,
-                    __cap,
+                    __bcap,
                 ),
             )
-            if (__cap.failed) return onError.run(__cap.je)
+            if (__bcap.failed) return onError.run(__bcap.ze0)
             return __ret
         }
     }
@@ -463,10 +463,12 @@ internal object __StringFolderHolder {
 }
 
 /**
- * Error callback for wrappers without a declared error type. `je` is the
- * binding/system failure message (any converter in the chain may fail). The
- * wrapper returns whatever `run` returns; throwing from `run` is safe (it
- * executes after the native call has returned).
+ * Binding-error callback — every wrapper's binding/system failure channel (any
+ * converter in the chain may fail, or a handle may be closed). `je` is the
+ * failure message. For an infallible wrapper this is the sole `onError`; a
+ * fallible wrapper takes it as `onBindingError` alongside the typed domain
+ * handler. The wrapper returns whatever `run` returns;
+ * throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface JniErrorHandler<out R> {
     public fun run(je: String?): R
@@ -474,13 +476,13 @@ public fun interface JniErrorHandler<out R> {
 
 internal class JniErrorHandlerCapture : JniErrorHandler<Unit> {
     @JvmField var failed: Boolean = false
-    @JvmField var je: String? = null
-    override fun run(je: String?) { failed = true; this.je = je }
+    @JvmField var ze0: String? = null
+    override fun run(je: String?) { failed = true; this.ze0 = je }
     companion object {
         private val TL: ThreadLocal<JniErrorHandlerCapture> = ThreadLocal.withInitial { JniErrorHandlerCapture() }
         @JvmStatic fun acquire(): JniErrorHandlerCapture {
             val c = TL.get()
-            c.failed = false; c.je = null
+            c.failed = false; c.ze0 = null
             return c
         }
     }
@@ -491,16 +493,16 @@ internal class JniErrorHandlerCapture : JniErrorHandler<Unit> {
  * returns a `string_t *` (since `String` is declared `opaque_ptr`).
  */
 public fun stringNew(s: String, onError: JniErrorHandler<String>): String {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.stringNew(s, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.stringNew(s, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
 private fun constGetCoverMagic(onError: JniErrorHandler<Long>): Long {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.constGetCoverMagic(__cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverMagic(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -512,9 +514,9 @@ private fun constGetCoverMagic(onError: JniErrorHandler<Long>): Long {
 public val COVER_MAGIC: Long by lazy { constGetCoverMagic(JniErrorHandler { je -> error(je ?: "const COVER_MAGIC: JNI getter failed") }) }
 
 private fun constGetCoverTag(onError: JniErrorHandler<String>): String {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.constGetCoverTag(__cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverTag(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -532,9 +534,9 @@ public val COVER_TAG: String by lazy { constGetCoverTag(JniErrorHandler { je -> 
  * lazily-initialized Kotlin top-level `val`.
  */
 private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.coverTagRuntime(__cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.coverTagRuntime(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -549,9 +551,9 @@ private fun coverTagRuntime(onError: JniErrorHandler<String>): String {
 public val COVER_TAG_RUNTIME: String by lazy { coverTagRuntime(JniErrorHandler { je -> error(je ?: "const COVER_TAG_RUNTIME: JNI getter failed") }) }
 
 private fun constGetCoverVersion(onError: JniErrorHandler<String>): String {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.constGetCoverVersion(__cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverVersion(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -559,9 +561,9 @@ private fun constGetCoverVersion(onError: JniErrorHandler<String>): String {
 public val COVER_VERSION: String by lazy { constGetCoverVersion(JniErrorHandler { je -> error(je ?: "const COVER_VERSION: JNI getter failed") }) }
 
 private fun constGetCoverBanner(onError: JniErrorHandler<String>): String {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.constGetCoverBanner(__cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constGetCoverBanner(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -752,7 +754,9 @@ internal object CovNative {
 
     external fun storageTotalLen(a: Long, b: Long, c: Long, errorSink: Any): Long
 
-    external fun storageTryWithLabel(label: String, errorSink: Any): Long
+    external fun storageTryFromStamp(s: ByteArray, errorSink: Any, domainSink: Any): Long
+
+    external fun storageTryWithLabel(label: String, errorSink: Any, domainSink: Any): Long
 
     external fun storageWithPayload(
         payloadId: Long,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -56,47 +56,47 @@ public class Summary(initialPtr: Long) : GcNativeHandle(initialPtr) {
     /** Number of payloads (flatten-output **field** / **accessor**). */
     public fun count(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.summaryCount(this_ptr, __cap)
+            CovNative.summaryCount(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
     /** Sum of payload values (flatten-output **field** / **accessor**). */
     public fun total(onError: JniErrorHandler<Double>): Double {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.summaryTotal(this_ptr, __cap)
+            CovNative.summaryTotal(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
     /** Total scaled by a factor (an instance **method**: `&Self` receiver + arg). */
     public fun scaled(factor: Double, onError: JniErrorHandler<Double>): Double {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.summaryScaled(this_ptr, factor, __cap)
+            CovNative.summaryScaled(this_ptr, factor, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
     public fun mean(onError: JniErrorHandler<Double>): Double {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.summaryMean(this_ptr, __cap)
+            CovNative.summaryMean(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -109,16 +109,16 @@ public class Summary(initialPtr: Long) : GcNativeHandle(initialPtr) {
          * companion factory, and the build-from **variant** of the flatten-input).
          */
         public fun of(count: Long, total: Double, onError: JniErrorHandler<Summary>): Summary {
-            val __cap = JniErrorHandlerCapture.acquire()
-            val __ret = Summary(CovNative.summaryNew(count, total, __cap))
-            if (__cap.failed) return onError.run(__cap.je)
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = Summary(CovNative.summaryNew(count, total, __bcap))
+            if (__bcap.failed) return onError.run(__bcap.ze0)
             return __ret
         }
 
         public fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary>): Summary {
-            val __cap = JniErrorHandlerCapture.acquire()
-            val __ret = Summary(CovNative.summaryFromMean(count, mean, __cap))
-            if (__cap.failed) return onError.run(__cap.je)
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = Summary(CovNative.summaryFromMean(count, mean, __bcap))
+            if (__bcap.failed) return onError.run(__bcap.ze0)
             return __ret
         }
     }
@@ -181,12 +181,12 @@ public fun interface SummaryFolder<A> {
 @Suppress("UNCHECKED_CAST")
 public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: SummaryBuilder<R>): R {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageSummary(s_ptr, build, __cap) as R)
+        (CovNative.storageSummary(s_ptr, build, __bcap) as R)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -200,7 +200,7 @@ public fun describeSummary(
     onError: JniErrorHandler<String>,
 ): String {
     if (s1 != null && s1.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
         val __locks = ArrayList<NativeHandle>()
         s1?.let { __locks.add(it) }
@@ -214,11 +214,11 @@ public fun describeSummary(
                 s01 ?: 0.0,
                 s1_ptr,
                 verbose,
-                __cap,
+                __bcap,
             )
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -254,7 +254,7 @@ public fun storageMatchesSummary(
     if (expected1 != null && expected1.isClosed()) return onError.run(
         "Operation on a closed native handle.",
     )
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
         val __locks = ArrayList<NativeHandle>()
         __locks.add(s)
@@ -271,14 +271,14 @@ public fun storageMatchesSummary(
                     expected01 != null,
                     expected01 ?: 0.0,
                     expected1_ptr,
-                    __cap,
+                    __bcap,
                 )
             } finally {
                 expected1?.markConsumed()
             }
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -288,12 +288,12 @@ public fun storageMatchesSummary(
  */
 public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): Summary {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        Summary(CovNative.storageSummaryHandle(s_ptr, __cap))
+        Summary(CovNative.storageSummaryHandle(s_ptr, __bcap))
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -303,16 +303,16 @@ public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): 
  */
 public fun summaryTotalRaw(s: Summary, onError: JniErrorHandler<Double>): Double {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         try {
-            CovNative.summaryTotalRaw(s_ptr, __cap)
+            CovNative.summaryTotalRaw(s_ptr, __bcap)
         } finally {
             s.markConsumed()
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -329,12 +329,12 @@ public fun <R> storageSummaryFull(
     build: SummaryStorageSummaryFullBuilder<R>,
 ): R {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageSummaryFull(s_ptr, build.asRaw(), __cap) as R)
+        (CovNative.storageSummaryFull(s_ptr, build.asRaw(), __bcap) as R)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -353,12 +353,12 @@ public fun <R> storageSummaryProbe(
     build: SummaryStorageSummaryProbeBuilder<R>,
 ): R {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageSummaryProbe(s_ptr, build.asRaw(), __cap) as R)
+        (CovNative.storageSummaryProbe(s_ptr, build.asRaw(), __bcap) as R)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -394,7 +394,7 @@ public fun storageExpectSummary(
     if (expected1 != null && expected1.isClosed()) return onError.run(
         "Operation on a closed native handle.",
     )
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
         val __locks = ArrayList<NativeHandle>()
         __locks.add(s)
@@ -411,14 +411,14 @@ public fun storageExpectSummary(
                     expected01 != null,
                     expected01 ?: 0.0,
                     expected1_ptr,
-                    __cap,
+                    __bcap,
                 )
             } finally {
                 expected1?.markConsumed()
             }
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -474,7 +474,7 @@ public fun summaryPrefer(
     if (fallback1 != null && fallback1.isClosed()) return onError.run(
         "Operation on a closed native handle.",
     )
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
         val __locks = ArrayList<NativeHandle>()
         primary1?.let { __locks.add(it) }
@@ -496,7 +496,7 @@ public fun summaryPrefer(
                     fallback01 != null,
                     fallback01 ?: 0.0,
                     fallback1_ptr,
-                    __cap,
+                    __bcap,
                 )
             } finally {
                 primary1?.markConsumed()
@@ -504,7 +504,7 @@ public fun summaryPrefer(
             }
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -573,7 +573,7 @@ public fun <R> summaryMerge(
     if (fallback1 != null && fallback1.isClosed()) return onError.run(
         "Operation on a closed native handle.",
     )
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
         val __locks = ArrayList<NativeHandle>()
         primary1?.let { __locks.add(it) }
@@ -582,14 +582,14 @@ public fun <R> summaryMerge(
             val primary1_ptr = primary1?.ptr ?: 0L
             val fallback1_ptr = fallback1?.ptr ?: 0L
             try {
-                (CovNative.summaryMerge(primarySel, primary00 != null, primary00 ?: 0L, primary01 != null, primary01 ?: 0.0, primary1_ptr, fallbackSel, fallback00 != null, fallback00 ?: 0L, fallback01 != null, fallback01 ?: 0.0, fallback1_ptr, build, __cap) as R)
+                (CovNative.summaryMerge(primarySel, primary00 != null, primary00 ?: 0L, primary01 != null, primary01 ?: 0.0, primary1_ptr, fallbackSel, fallback00 != null, fallback00 ?: 0L, fallback01 != null, fallback01 ?: 0.0, fallback1_ptr, build, __bcap) as R)
             } finally {
                 primary1?.markConsumed()
                 fallback1?.markConsumed()
             }
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -610,7 +610,7 @@ public fun summaryTotalOpt(
     onError: JniErrorHandler<Double>,
 ): Double {
     if (s1 != null && s1.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
         val __locks = ArrayList<NativeHandle>()
         s1?.let { __locks.add(it) }
@@ -623,11 +623,11 @@ public fun summaryTotalOpt(
                 s01 != null,
                 s01 ?: 0.0,
                 s1_ptr,
-                __cap,
+                __bcap,
             )
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -647,9 +647,9 @@ public fun <A> summarySeries(
     onError: JniErrorHandler<A>,
     fold: SummaryFolder<A>,
 ): A {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.summarySeries(count, start, acc, fold, __cap) as A)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.summarySeries(count, start, acc, fold, __bcap) as A)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -668,17 +668,17 @@ public fun <A> summarySeriesOpt(
     onError: JniErrorHandler<A?>,
     fold: SummaryFolder<A>,
 ): A? {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.summarySeriesOpt(count, start, acc, fold, __cap) as A?)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.summarySeriesOpt(count, start, acc, fold, __bcap) as A?)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
 /** Create an empty archive. */
 public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = SummaryVault(CovNative.archiveNew(__cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = SummaryVault(CovNative.archiveNew(__bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -701,7 +701,7 @@ public fun archiveStore(
 ) {
     if (a.isClosed()) { onError.run("Operation on a closed native handle."); return }
     if (s1 != null && s1.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     run {
         val __locks = ArrayList<NativeHandle>()
         __locks.add(a)
@@ -718,14 +718,14 @@ public fun archiveStore(
                     s01 != null,
                     s01 ?: 0.0,
                     s1_ptr,
-                    __cap,
+                    __bcap,
                 )
             } finally {
                 s1?.markConsumed()
             }
         }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -734,11 +734,11 @@ public fun archiveStore(
  */
 public fun archiveLatest(a: SummaryVault, onError: JniErrorHandler<Summary?>): Summary? {
     if (a.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(a) {
         val a_ptr = a.ptr
-        CovNative.archiveLatest(a_ptr, __cap).let { if (it == 0L) null else Summary(it) }
+        CovNative.archiveLatest(a_ptr, __bcap).let { if (it == 0L) null else Summary(it) }
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
@@ -31,12 +31,12 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
      */
     public fun message(onError: JniErrorHandler<String>): String {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.storageErrorMessage(this_ptr, __cap)
+            CovNative.storageErrorMessage(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -47,27 +47,25 @@ public class StorageError(initialPtr: Long) : NativeHandle(initialPtr) {
 }
 
 /**
- * Error callback. Contract: `je != null` ⇒ a binding/system-tier failure — `je` is
- * its message and the remaining parameters carry defaults; `je == null` ⇒ a domain
- * error — the remaining parameters carry the decomposed `StorageError`. The
- * wrapper returns whatever `run` returns; throwing from `run` is safe (it executes
- * after the native call has returned).
+ * Domain-error callback: called only when the native function returns `Err` — the
+ * parameters carry the decomposed `StorageError`. Binding/system failures go to the
+ * separate `onBindingError` (`JniErrorHandler`) channel instead, so there is no `je`
+ * discriminator here. The wrapper returns whatever `run` returns;
+ * throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface StorageErrorHandler<out R> {
-    public fun run(je: String?, message: String, handle: StorageError): R
+    public fun run(message: String, handle: StorageError): R
 }
 
 public fun interface StorageErrorHandlerRaw<out R> {
-    public fun run(je: String?, message: String, handle: Long): R
+    public fun run(message: String, handle: Long): R
 }
 
 public fun <R> StorageErrorHandler<R>.asRaw(): StorageErrorHandlerRaw<R> =
     StorageErrorHandlerRaw<R> {
-        je,
         message,
         handle ->
         run(
-            je,
             message,
             StorageError(handle)
         )
@@ -75,17 +73,16 @@ public fun <R> StorageErrorHandler<R>.asRaw(): StorageErrorHandlerRaw<R> =
 
 internal class StorageErrorHandlerRawCapture : StorageErrorHandlerRaw<Unit> {
     @JvmField var failed: Boolean = false
-    @JvmField var je: String? = null
     @JvmField var ze0: String? = null
     @JvmField var ze1: Long? = null
-    override fun run(je: String?, message: String, handle: Long) {
-        failed = true; this.je = je; this.ze0 = message; this.ze1 = handle
+    override fun run(message: String, handle: Long) {
+        failed = true; this.ze0 = message; this.ze1 = handle
     }
     companion object {
         private val TL: ThreadLocal<StorageErrorHandlerRawCapture> = ThreadLocal.withInitial { StorageErrorHandlerRawCapture() }
         @JvmStatic fun acquire(): StorageErrorHandlerRawCapture {
             val c = TL.get()
-            c.failed = false; c.je = null; c.ze0 = null; c.ze1 = null
+            c.failed = false; c.ze0 = null; c.ze1 = null
             return c
         }
     }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/esc_pkg.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/esc_pkg.kt
@@ -31,12 +31,12 @@ public class Esc_Probe(initialPtr: Long) : NativeHandle(initialPtr) {
      */
     public fun escapeProbeValue(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            CovNative.escape_probe_value(this_ptr, __cap)
+            CovNative.escape_probe_value(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -46,9 +46,9 @@ public class Esc_Probe(initialPtr: Long) : NativeHandle(initialPtr) {
 
         /** Construct an [`EscapeProbe`] (its covertest constructor). */
         public fun escapeProbeNew(value: Long, onError: JniErrorHandler<Esc_Probe>): Esc_Probe {
-            val __cap = JniErrorHandlerCapture.acquire()
-            val __ret = Esc_Probe(CovNative.escapeProbeNew(value, __cap))
-            if (__cap.failed) return onError.run(__cap.je)
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = Esc_Probe(CovNative.escapeProbeNew(value, __bcap))
+            if (__bcap.failed) return onError.run(__bcap.ze0)
             return __ret
         }
     }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -63,17 +63,17 @@ public data class Annotated(val payload: Payload, val ttl: Long?, val priority: 
 public value class Stamp(public val bytes: ByteArray) {
     /** Seconds component (value-class **accessor**, receiver = the value bytes). */
     public fun secs(onError: JniErrorHandler<Long>): Long {
-        val __cap = JniErrorHandlerCapture.acquire()
-        val __ret = CovNative.stampSecs(this.bytes, __cap)
-        if (__cap.failed) return onError.run(__cap.je)
+        val __bcap = JniErrorHandlerCapture.acquire()
+        val __ret = CovNative.stampSecs(this.bytes, __bcap)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
     /** Nanoseconds component (value-class **accessor**). */
     public fun nanos(onError: JniErrorHandler<Long>): Long {
-        val __cap = JniErrorHandlerCapture.acquire()
-        val __ret = CovNative.stampNanos(this.bytes, __cap)
-        if (__cap.failed) return onError.run(__cap.je)
+        val __bcap = JniErrorHandlerCapture.acquire()
+        val __ret = CovNative.stampNanos(this.bytes, __bcap)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 }
@@ -104,19 +104,19 @@ internal object __StampFolderRawHolder {
 
 /** Classify a payload by magnitude of its `value` (enum **return**). */
 public fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority {
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = io.prebindgen.covertest.model.Priority.fromInt(
-        CovNative.payloadPriority(p.id, p.seq, p.value, p.flag, p.label, __cap),
+        CovNative.payloadPriority(p.id, p.seq, p.value, p.flag, p.label, __bcap),
     )
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
 /** Numeric weight of a priority (enum **by-value parameter**). */
 public fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.priorityWeight(p.value, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.priorityWeight(p.value, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -126,19 +126,19 @@ public fun priorityOr(
     fallback: Priority,
     onError: JniErrorHandler<Priority>,
 ): Priority {
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = io.prebindgen.covertest.model.Priority.fromInt(
-        CovNative.priorityOr(p != null, p?.value ?: 0, fallback.value, __cap),
+        CovNative.priorityOr(p != null, p?.value ?: 0, fallback.value, __bcap),
     )
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
 /** Build a [`Stamp`] (value-class **return**). */
 public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = Stamp(CovNative.stampNew(secs, nanos, __cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = Stamp(CovNative.stampNew(secs, nanos, __bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -147,9 +147,9 @@ public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): S
  * `List<ByteArray>`).
  */
 public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp> {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.stampSeries(count, ArrayList<Stamp>(), __StampFolderRawHolder.instance, __cap) as List<Stamp>)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.stampSeries(count, ArrayList<Stamp>(), __StampFolderRawHolder.instance, __bcap) as List<Stamp>)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -158,9 +158,9 @@ public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List
  * parameter and the return).
  */
 public fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.celsiusDouble(c, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.celsiusDouble(c, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -169,9 +169,9 @@ public fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int {
  * input conversion — including its error path — and the `Into` output).
  */
 public fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.percentScale(p, factor, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.percentScale(p, factor, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -180,9 +180,9 @@ public fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int
  * a parameter and the return).
  */
 public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.labelReverse(l, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.labelReverse(l, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -196,7 +196,7 @@ public fun annotatedNew(
     priority: Priority?,
     onError: JniErrorHandler<Annotated>,
 ): Annotated {
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.annotatedNew(
         payload.id,
         payload.seq,
@@ -207,9 +207,9 @@ public fun annotatedNew(
         ttl ?: 0L,
         priority != null,
         priority?.value ?: 0,
-        __cap,
+        __bcap,
     )
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -218,19 +218,19 @@ public fun annotatedNew(
  * **input**).
  */
 public fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long? {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.annotatedTtl(a, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.annotatedTtl(a, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
 /** The metadata priority (`Option<enum>` **return**). */
 public fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority? {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.annotatedPriority(a, __cap)?.let {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.annotatedPriority(a, __bcap)?.let {
         io.prebindgen.covertest.model.Priority.fromInt(it)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -239,8 +239,8 @@ public fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>):
  * input decode).
  */
 public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>): Double {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.annotatedPayloadValue(a, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.annotatedPayloadValue(a, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
@@ -20,13 +20,14 @@ import io.prebindgen.covertest.asRaw
 import io.prebindgen.covertest.errors.StorageError
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.errors.StorageErrorHandlerRawCapture
+import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.withSortedHandleLocks
 
 /** Create a new, empty storage handle. */
 public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = Storage(CovNative.storageNew(__cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = Storage(CovNative.storageNew(__bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -41,12 +42,12 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
  */
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageGet(s_ptr, __PayloadBuilder, __cap) as Payload?)
+        (CovNative.storageGet(s_ptr, __PayloadBuilder, __bcap) as Payload?)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -58,7 +59,7 @@ public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? 
  */
 public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         CovNative.storagePutByTake(
@@ -68,10 +69,10 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
             payload.value,
             payload.flag,
             payload.label,
-            __cap,
+            __bcap,
         )
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -80,7 +81,7 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
  */
 public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         CovNative.storagePutByRead(
@@ -90,10 +91,10 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
             payload.value,
             payload.flag,
             payload.label,
-            __cap,
+            __bcap,
         )
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -102,7 +103,7 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
  */
 public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __vec_payloads = CovNative.payloadVecNew(payloads.size)
     try {
         for (__e in payloads) {
@@ -117,12 +118,12 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
         }
         withSortedHandleLocks(s) {
             val s_ptr = s.ptr
-            CovNative.storagePutSlice(s_ptr, __vec_payloads, __cap)
+            CovNative.storagePutSlice(s_ptr, __vec_payloads, __bcap)
         }
     } finally {
         CovNative.payloadVecFree(__vec_payloads)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -137,12 +138,12 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
  */
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageGetVec(s_ptr, ArrayList<Payload>(), __PayloadFolderRawHolder.instance, __cap) as List<Payload>?)
+        (CovNative.storageGetVec(s_ptr, ArrayList<Payload>(), __PayloadFolderRawHolder.instance, __bcap) as List<Payload>?)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -157,9 +158,9 @@ public fun payloadHandlerNew(
     f: PayloadCallback,
     onError: JniErrorHandler<PayloadHandler>,
 ): PayloadHandler {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadHandler(CovNative.payloadHandlerNew(f.asRaw(), __cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = PayloadHandler(CovNative.payloadHandlerNew(f.asRaw(), __bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -176,13 +177,13 @@ public fun payloadHandlerNew(
 public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
         val handler_ptr = handler.ptr
-        CovNative.storageCallback(s_ptr, handler_ptr, __cap)
+        CovNative.storageCallback(s_ptr, handler_ptr, __bcap)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -194,9 +195,9 @@ public fun payloadVecHandlerNew(
     f: PayloadListCallback,
     onError: JniErrorHandler<PayloadVecHandler>,
 ): PayloadVecHandler {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadVecHandler(CovNative.payloadVecHandlerNew(f, __cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = PayloadVecHandler(CovNative.payloadVecHandlerNew(f, __bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -214,25 +215,54 @@ public fun storageCallbackVec(
 ) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
         val handler_ptr = handler.ptr
-        CovNative.storageCallbackVec(s_ptr, handler_ptr, __cap)
+        CovNative.storageCallbackVec(s_ptr, handler_ptr, __bcap)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
  * Build a storage seeded with a single labelled payload, **failing** on an
  * empty label (`Result<T, E>` routing + a `&str` input).
  *
- * On failure `onError` receives `je` plus the decomposed Rust `StorageError` error (`message`, `handle`).
+ * On a domain error `onError` receives the decomposed Rust `StorageError` error (`message`, `handle`); a binding/system failure goes to `onBindingError` instead.
  */
-public fun storageTryWithLabel(label: String, onError: StorageErrorHandler<Storage>): Storage {
-    val __cap = StorageErrorHandlerRawCapture.acquire()
-    val __ret = Storage(CovNative.storageTryWithLabel(label, __cap))
-    if (__cap.failed) return onError.run(__cap.je, __cap.ze0!!, StorageError(__cap.ze1!!))
+public fun storageTryWithLabel(
+    label: String,
+    onBindingError: JniErrorHandler<Storage>,
+    onError: StorageErrorHandler<Storage>,
+): Storage {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __dcap = StorageErrorHandlerRawCapture.acquire()
+    val __ret = Storage(CovNative.storageTryWithLabel(label, __bcap, __dcap))
+    if (__bcap.failed) return onBindingError.run(__bcap.ze0)
+    if (__dcap.failed) return onError.run(__dcap.ze0!!, StorageError(__dcap.ze1!!))
+    return __ret
+}
+
+/**
+ * Build a storage stamped with `s`, **failing** on a non-positive `secs` (a
+ * domain [`StorageError`]). This takes a `Stamp` **by value** (a value-blob
+ * input), so a malformed `Stamp` blob fails the input decode FIRST — the
+ * binding channel — while a well-formed but rejected value fails in the domain
+ * channel. It is the covertest exercise for issue #45's two-caller split: one
+ * wrapper, both `onBindingError` and `onError` provable independently.
+ *
+ * On a domain error `onError` receives the decomposed Rust `StorageError` error (`message`, `handle`); a binding/system failure goes to `onBindingError` instead.
+ */
+public fun storageTryFromStamp(
+    s: Stamp,
+    onBindingError: JniErrorHandler<Storage>,
+    onError: StorageErrorHandler<Storage>,
+): Storage {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __dcap = StorageErrorHandlerRawCapture.acquire()
+    val __ret = Storage(CovNative.storageTryFromStamp(s.bytes, __bcap, __dcap))
+    if (__bcap.failed) return onBindingError.run(__bcap.ze0)
+    if (__dcap.failed) return onError.run(__dcap.ze0!!, StorageError(__dcap.ze1!!))
     return __ret
 }
 
@@ -246,9 +276,9 @@ public fun storageShards(
     each: Long,
     onError: JniErrorHandler<List<Storage>>,
 ): List<Storage> {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.storageShards(count, each, ArrayList<Storage>(), __StorageFolderRawHolder.instance, __cap) as List<Storage>)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.storageShards(count, each, ArrayList<Storage>(), __StorageFolderRawHolder.instance, __bcap) as List<Storage>)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -261,9 +291,9 @@ public fun storageShardsOpt(
     each: Long,
     onError: JniErrorHandler<List<Storage>?>,
 ): List<Storage>? {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.storageShardsOpt(count, each, ArrayList<Storage>(), __StorageFolderRawHolder.instance, __cap) as List<Storage>?)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = (CovNative.storageShardsOpt(count, each, ArrayList<Storage>(), __StorageFolderRawHolder.instance, __bcap) as List<Storage>?)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -272,9 +302,9 @@ public fun storageHandlerNew(
     f: StorageCallback,
     onError: JniErrorHandler<StorageHandler>,
 ): StorageHandler {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = StorageHandler(CovNative.storageHandlerNew(f.asRaw(), __cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = StorageHandler(CovNative.storageHandlerNew(f.asRaw(), __bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -284,12 +314,12 @@ public fun storageHandlerNew(
  */
 public fun storageEmit(n: Long, h: StorageHandler, onError: JniErrorHandler<Unit>) {
     if (h.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(h) {
         val h_ptr = h.ptr
-        CovNative.storageEmit(n, h_ptr, __cap)
+        CovNative.storageEmit(n, h_ptr, __bcap)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -300,14 +330,14 @@ public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniError
     if (a.isClosed()) return onError.run("Operation on a closed native handle.")
     if (b.isClosed()) return onError.run("Operation on a closed native handle.")
     if (c.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(a, b, c) {
         val a_ptr = a.ptr
         val b_ptr = b.ptr
         val c_ptr = c.ptr
-        CovNative.storageTotalLen(a_ptr, b_ptr, c_ptr, __cap)
+        CovNative.storageTotalLen(a_ptr, b_ptr, c_ptr, __bcap)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -317,19 +347,19 @@ public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniError
  */
 public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): List<String> {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageLabels(s_ptr, ArrayList<String>(), __StringFolderHolder.instance, __cap) as List<String>)
+        (CovNative.storageLabels(s_ptr, ArrayList<String>(), __StringFolderHolder.instance, __bcap) as List<String>)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
 /** Push `p` if present; whether it was pushed (`Option<data-class>` **input**). */
 public fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boolean>): Boolean {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         CovNative.storagePutOpt(
@@ -340,10 +370,10 @@ public fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boole
             p?.value ?: 0.0,
             p?.flag ?: false,
             p?.label,
-            __cap,
+            __bcap,
         )
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -352,8 +382,8 @@ public fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boole
  * the **return**).
  */
 public fun addMillis(a: Long, b: Long, onError: JniErrorHandler<Long>): Long {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.millisAdd(a, b, __cap)
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.millisAdd(a, b, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -53,6 +53,7 @@ import io.prebindgen.covertest.storage.storagePutSlice
 import io.prebindgen.covertest.storage.storageShards
 import io.prebindgen.covertest.storage.storageShardsOpt
 import io.prebindgen.covertest.storage.storageTotalLen
+import io.prebindgen.covertest.storage.storageTryFromStamp
 import io.prebindgen.covertest.storage.storageTryWithLabel
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
@@ -71,13 +72,14 @@ private val boom = JniErrorHandler<Nothing> { je ->
     throw AssertionError("unexpected native error: $je")
 }
 
-/** Same idea as [boom] for the `Result` error channel's dedicated handler type. */
-private val boomStorage = StorageErrorHandler<Nothing> { je, message, handle ->
+/** Same idea as [boom] for the typed domain `onError` channel (issue #45: the
+ *  domain handler no longer carries `je` — that is the separate binding channel). */
+private val boomStorage = StorageErrorHandler<Nothing> { message, handle ->
     handle.close()
-    throw AssertionError("unexpected storage error: je=$je message=$message")
+    throw AssertionError("unexpected storage error: message=$message")
 }
 
-/** Thrown by the [StorageErrorHandler] used to probe the `Result` error channel. */
+/** Thrown by the [StorageErrorHandler] used to probe the domain error channel. */
 private class LabelError(val detail: String) : RuntimeException(detail)
 
 private var sectionCount = 0
@@ -407,18 +409,19 @@ fun main() {
         s.close()
     }
 
-    // ── Result<_, E> → onError channel (ok + domain error) ───────────────────
+    // ── Result<_, E> → two-caller error split (ok + domain error) ────────────
+    // A fallible-typed wrapper takes TWO handlers: `onBindingError` (the binding
+    // channel) and `onError` (the typed domain channel, no `je`). See #45.
     section("Result error channel storageTryWithLabel") {
-        val ok = storageTryWithLabel("hi", boomStorage)
+        val ok = storageTryWithLabel("hi", boom, boomStorage)
         check(ok.len(boom) == 1L)
         ok.close()
 
-        // Domain error: `je` is null (no JNI exception); the StorageError's
+        // Domain error: `onError` fires (NOT `onBindingError`). The StorageError's
         // flatten delivers its `message` field plus — via the type-level
         // `field_self` — the owned error handle itself, live and queryable.
         try {
-            storageTryWithLabel("", StorageErrorHandler<Storage> { je, message, handle ->
-                check(je == null) { "domain error should have a null jni exception, got $je" }
+            storageTryWithLabel("", boom, StorageErrorHandler<Storage> { message, handle ->
                 check(!handle.isClosed())
                 check(handle.message(boom) == "label must not be empty")
                 handle.close()
@@ -428,6 +431,51 @@ fun main() {
         } catch (e: LabelError) {
             check(e.detail == "label must not be empty")
         }
+    }
+
+    // ── #45: both channels of ONE fallible wrapper, each fires independently ──
+    section("two-caller split storageTryFromStamp") {
+        // Happy path: neither channel fires.
+        val ok = storageTryFromStamp(stampNew(5L, 0L, boom), boom, boomStorage)
+        check(ok.len(boom) == 1L)
+        ok.close()
+
+        // DOMAIN error (well-formed Stamp, rejected value): `onError` fires,
+        // `onBindingError` must NOT. The handler returns a throwaway Storage.
+        var domainMsg: String? = null
+        val domainRet = storageTryFromStamp(
+            stampNew(-1L, 0L, boom),
+            JniErrorHandler<Storage> { je ->
+                throw AssertionError("binding channel must not fire on a domain error: $je")
+            },
+            StorageErrorHandler<Storage> { message, handle ->
+                domainMsg = message
+                check(handle.message(boom) == "stamp secs must be positive")
+                handle.close()
+                storageNew(boom)
+            },
+        )
+        check(domainMsg == "stamp secs must be positive") { "domain onError did not fire: $domainMsg" }
+        domainRet.close()
+
+        // BINDING error (malformed Stamp value-blob): `onBindingError` fires,
+        // the domain `onError` must NOT.
+        var bindingJe: String? = null
+        val bindingRet = storageTryFromStamp(
+            Stamp(ByteArray(3)),   // Stamp is 16 bytes; 3 must be rejected on decode
+            JniErrorHandler<Storage> { je ->
+                bindingJe = je
+                storageNew(boom)
+            },
+            StorageErrorHandler<Storage> { _, handle ->
+                handle.close()
+                throw AssertionError("domain channel must not fire on a binding error")
+            },
+        )
+        check(bindingJe != null && bindingJe!!.contains("wrong byte length")) {
+            "binding onBindingError did not fire: $bindingJe"
+        }
+        bindingRet.close()
     }
 
     // ── input_wrapper / output_wrapper: Millis ⇄ Long ────────────────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -38,40 +38,47 @@ impl<T: ?Sized> OwnedObject<T> {
     }
 }
 #[allow(non_snake_case, dead_code)]
-pub(crate) fn signal_error(
+pub(crate) fn signal_binding_error(
     env: &mut jni::JNIEnv,
     sink: &jni::objects::JObject,
     mid: &::prebindgen::lang::CachedIfaceMethod,
     fqn: &str,
     descr: &str,
-    je: ::core::option::Option<&str>,
+    je: &str,
+) {
+    if env.exception_check().unwrap_or(false) {
+        return;
+    }
+    let __je: jni::objects::JObject = match env.new_string(je) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            tracing::error!("signal_binding_error: new_string failed: {}", e);
+            return;
+        }
+    };
+    let __args = [
+        jni::sys::jvalue {
+            l: __je.as_raw(),
+        },
+    ];
+    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, &__args) {
+        tracing::error!("signal_binding_error: error-callback invoke failed: {}", e);
+    }
+}
+#[allow(non_snake_case, dead_code)]
+pub(crate) fn signal_domain_error(
+    env: &mut jni::JNIEnv,
+    sink: &jni::objects::JObject,
+    mid: &::prebindgen::lang::CachedIfaceMethod,
+    fqn: &str,
+    descr: &str,
     ze: &[jni::sys::jvalue],
 ) {
     if env.exception_check().unwrap_or(false) {
         return;
     }
-    let __je: jni::objects::JObject = match je {
-        ::core::option::Option::Some(__m) => {
-            match env.new_string(__m) {
-                Ok(s) => s.into(),
-                Err(e) => {
-                    tracing::error!("signal_error: new_string failed: {}", e);
-                    return;
-                }
-            }
-        }
-        ::core::option::Option::None => jni::objects::JObject::null(),
-    };
-    let mut __args: ::std::vec::Vec<jni::sys::jvalue> = ::std::vec::Vec::with_capacity(
-        1 + ze.len(),
-    );
-    __args
-        .push(jni::sys::jvalue {
-            l: __je.as_raw(),
-        });
-    __args.extend_from_slice(ze);
-    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, &__args) {
-        tracing::error!("signal_error: error-callback invoke failed: {}", e);
+    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, ze) {
+        tracing::error!("signal_domain_error: error-callback invoke failed: {}", e);
     }
 }
 #[no_mangle]
@@ -297,10 +304,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverVer
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -315,15 +318,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverVer
     match String_to_JString_c7f3ca43(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -336,10 +337,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBan
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -354,15 +351,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBan
     match String_to_JString_c7f3ca43(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -1872,10 +1867,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     priority_value: jni::sys::jint,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -1883,15 +1874,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     let __payload_id = match jlong_to_i64_fbf9a9bc(&mut env, &payload_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1899,15 +1888,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     let __payload_seq = match jint_to_i32_a3e3b6ef(&mut env, &payload_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1915,15 +1902,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     let __payload_value = match jdouble_to_f64_9e4a8f70(&mut env, &payload_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1931,15 +1916,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     let __payload_flag = match jboolean_to_bool_31306d98(&mut env, &payload_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1950,15 +1933,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1974,15 +1955,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
         let __ttl_val = match jlong_to_i64_fbf9a9bc(&mut env, &ttl_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -1995,15 +1974,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
         let __priority_val = match jint_to_Priority_447102d2(&mut env, &priority_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -2016,15 +1993,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     match Annotated_to_JObject_b543f0d9(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -2040,10 +2015,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
     a: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jdouble {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2051,15 +2022,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
     let a = match JObject_to_Annotated_b543f0d9(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -2068,15 +2037,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
         }
@@ -2090,10 +2057,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
     a: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2101,15 +2064,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
     let a = match JObject_to_Annotated_b543f0d9(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2118,15 +2079,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
     match Option_Priority_to_JObject_ad5cbb32(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -2140,10 +2099,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
     a: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2151,15 +2106,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
     let a = match JObject_to_Annotated_b543f0d9(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2168,15 +2121,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
     match Option_i64_to_JObject_2ba9a5ed(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -2190,10 +2141,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveLatest<'a
     a: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2201,15 +2148,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveLatest<'a
     let a = match jlong_to_Archive_cd73502c(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2218,15 +2163,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveLatest<'a
     match Option_Summary_to_jlong_828826f3(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2239,10 +2182,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveNew<'a>(
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2251,15 +2190,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveNew<'a>(
     match Archive_to_jlong_cd73502c(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2279,10 +2216,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
     s_1: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2290,15 +2223,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
     let mut a = match jlong_to_Archive_cd73502c(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2306,15 +2237,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
     let __exp_s_sel = match jint_to_i32_a3e3b6ef(&mut env, &s_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2323,15 +2252,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &s_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return ();
             }
@@ -2344,15 +2271,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &s_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return ();
             }
@@ -2364,15 +2289,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
     let __exp_s_1 = match jlong_to_Option_Summary_252ef2ba(&mut env, &s_1) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2420,15 +2343,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return ();
         }
@@ -2437,15 +2358,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -2459,10 +2378,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a
     c: jni::sys::jint,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jint {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2470,15 +2385,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a
     let __c_s0 = match jint_to_i32_a3e3b6ef(&mut env, &c) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -2486,15 +2399,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a
     let c = match i32_to_Celsius_8c363100(&mut env, __c_s0) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -2503,15 +2414,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a
     let __out_s0 = match Celsius_to_i32_88c8e884(&mut env, __out) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -2519,15 +2428,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a
     match i32_to_jint_a3e3b6ef(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jint
         }
@@ -2540,10 +2447,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2552,15 +2455,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
     match String_to_JString_c7f3ca43(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -2574,10 +2475,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escapeProbeNew<'
     value: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2585,15 +2482,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escapeProbeNew<'
     let value = match jlong_to_i64_fbf9a9bc(&mut env, &value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2602,15 +2497,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escapeProbeNew<'
     match EscapeProbe_to_jlong_416aab42(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2624,10 +2517,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escape_1probe_1v
     p: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2635,15 +2524,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escape_1probe_1v
     let p = match jlong_to_EscapeProbe_416aab42(&mut env, &p) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2652,15 +2539,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escape_1probe_1v
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2674,10 +2559,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
     l: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2685,15 +2566,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
     let __l_s0 = match JString_to_String_c7f3ca43(&mut env, &l) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2701,15 +2580,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
     let l = match String_to_Label_c1a79668(&mut env, __l_s0) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2718,15 +2595,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
     let __out_s0 = match Label_to_String_63dec766(&mut env, __out) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2734,15 +2609,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
     match String_to_JString_c7f3ca43(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -2757,10 +2630,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     b: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2768,15 +2637,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     let __a_s0 = match jlong_to_i64_fbf9a9bc(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2784,15 +2651,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     let a = match i64_to_Millis_bb88777a(&mut env, __a_s0) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2800,15 +2665,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     let __b_s0 = match jlong_to_i64_fbf9a9bc(&mut env, &b) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2816,15 +2679,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     let b = match i64_to_Millis_bb88777a(&mut env, __b_s0) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2833,15 +2694,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     let __out_s0 = match Millis_to_i64_61ecf054(&mut env, __out) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2849,15 +2708,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     match i64_to_jlong_fbf9a9bc(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2871,10 +2728,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadHandlerNe
     f: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2882,15 +2735,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadHandlerNe
     let f = match JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906(&mut env, &f) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2899,15 +2750,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadHandlerNe
     match PayloadHandler_to_jlong_d61fd890(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2925,10 +2774,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     p_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -2936,15 +2781,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     let __p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2952,15 +2795,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     let __p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2968,15 +2809,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     let __p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -2984,15 +2823,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     let __p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -3000,15 +2837,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     let __p_label = match JString_to_Option_Box_String_071e4c8c(&mut env, &p_label) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -3024,15 +2859,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     match Option_i64_to_JObject_2ba9a5ed(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -3050,10 +2883,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     p_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jint {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3061,15 +2890,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     let __p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3077,15 +2904,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     let __p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3093,15 +2918,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     let __p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3109,15 +2932,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     let __p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3125,15 +2946,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     let __p_label = match JString_to_Option_Box_String_071e4c8c(&mut env, &p_label) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3149,15 +2968,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     match Priority_to_jint_447102d2(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jint
         }
@@ -3171,10 +2988,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecHandle
     f: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3182,15 +2995,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecHandle
     let f = match JObject_to_impl_Fn_Payload_Send_Sync_static_95073668(&mut env, &f) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -3199,15 +3010,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecHandle
     match PayloadVecHandler_to_jlong_b32d2812(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -3222,10 +3031,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
     factor: jni::sys::jint,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jint {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3233,15 +3038,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
     let __p_s0 = match jint_to_i32_a3e3b6ef(&mut env, &p) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3249,15 +3052,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
     let p = match i32_to_Percent_db3641cc(&mut env, __p_s0) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3265,15 +3066,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
     let factor = match jint_to_i32_a3e3b6ef(&mut env, &factor) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3282,15 +3081,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
     let __out_s0 = match Percent_to_i32_01484801(&mut env, __out) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3298,15 +3095,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
     match i32_to_jint_a3e3b6ef(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jint
         }
@@ -3322,10 +3117,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityOr<'a>(
     fallback: jni::sys::jint,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jint {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3334,15 +3125,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityOr<'a>(
         let __p_val = match jint_to_Priority_447102d2(&mut env, &p_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jint;
             }
@@ -3354,15 +3143,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityOr<'a>(
     let fallback = match jint_to_Priority_447102d2(&mut env, &fallback) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3371,15 +3158,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityOr<'a>(
     match Priority_to_jint_447102d2(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jint
         }
@@ -3393,10 +3178,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityWeight<'
     p: jni::sys::jint,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jint {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3404,15 +3185,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityWeight<'
     let p = match jint_to_Priority_447102d2(&mut env, &p) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jint;
         }
@@ -3421,15 +3200,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityWeight<'
     match i32_to_jint_a3e3b6ef(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jint
         }
@@ -3443,10 +3220,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNanos<'a>(
     s: jni::objects::JByteArray<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3454,15 +3227,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNanos<'a>(
     let s = match JByteArray_to_Stamp_2fc9bd18(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -3471,15 +3242,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNanos<'a>(
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -3494,10 +3263,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNew<'a>(
     nanos: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JByteArray<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3505,15 +3270,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNew<'a>(
     let secs = match jlong_to_i64_fbf9a9bc(&mut env, &secs) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -3521,15 +3284,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNew<'a>(
     let nanos = match jlong_to_i64_fbf9a9bc(&mut env, &nanos) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -3538,15 +3299,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNew<'a>(
     match Stamp_to_JByteArray_2fc9bd18(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -3560,10 +3319,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSecs<'a>(
     s: jni::objects::JByteArray<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3571,15 +3326,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSecs<'a>(
     let s = match JByteArray_to_Stamp_2fc9bd18(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -3588,15 +3341,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSecs<'a>(
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -3612,10 +3363,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSeries<'a>(
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3623,15 +3370,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSeries<'a>(
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -3646,15 +3391,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSeries<'a>(
         let __enc = match Stamp_to_JByteArray_2fc9bd18(&mut env, __elem) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -3683,15 +3426,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSeries<'a>(
                 let __e2 = <__JniErr as ::core::convert::From<
                     String,
                 >>::from(__e.to_string());
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e2.to_string()),
-                    &__zd,
+                    &__e2.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -3708,10 +3449,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallback<
     handler: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3719,15 +3456,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallback<
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -3735,15 +3470,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallback<
     let handler = match jlong_to_PayloadHandler_d61fd890(&mut env, &handler) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -3752,15 +3485,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallback<
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -3775,10 +3506,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallbackV
     handler: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3786,15 +3513,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallbackV
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -3802,15 +3527,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallbackV
     let handler = match jlong_to_PayloadVecHandler_b32d2812(&mut env, &handler) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -3819,15 +3542,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageCallbackV
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -3842,10 +3563,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageContains<
     id: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jboolean {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3853,15 +3570,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageContains<
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -3869,15 +3584,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageContains<
     let id = match jlong_to_i64_fbf9a9bc(&mut env, &id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -3886,15 +3599,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageContains<
     match bool_to_jboolean_31306d98(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jboolean
         }
@@ -3909,10 +3620,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageEmit<'a>(
     h: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3920,15 +3627,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageEmit<'a>(
     let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -3936,15 +3641,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageEmit<'a>(
     let h = match jlong_to_StorageHandler_3b4d3ed3(&mut env, &h) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -3953,15 +3656,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageEmit<'a>(
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -3975,10 +3676,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageErrorMess
     e: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -3986,15 +3683,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageErrorMess
     let e = match jlong_to_StorageError_26b2d298(&mut env, &e) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -4003,15 +3698,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageErrorMess
     match String_to_JString_c7f3ca43(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -4031,10 +3724,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
     expected_1: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jboolean {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4042,15 +3731,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4058,15 +3745,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
     let __exp_expected_sel = match jint_to_i32_a3e3b6ef(&mut env, &expected_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4075,15 +3760,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &expected_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -4096,15 +3779,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &expected_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -4119,15 +3800,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4175,15 +3854,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4192,15 +3869,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageExpectSum
     match bool_to_jboolean_31306d98(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jboolean
         }
@@ -4215,10 +3890,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
     __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4226,15 +3897,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -4250,15 +3919,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                 let __enc0 = match i64_to_jlong_fbf9a9bc(&mut env, __inner.id.clone()) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -4269,15 +3936,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                 let __enc1 = match i32_to_jint_a3e3b6ef(&mut env, __inner.seq.clone()) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -4291,15 +3956,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -4313,15 +3976,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -4335,15 +3996,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -4374,15 +4033,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                     let __e2 = <__JniErr as ::core::convert::From<
                         String,
                     >>::from(__e.to_string());
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(
+                    signal_binding_error(
                         &mut env,
                         &__error_sink,
                         &__SINK_MID,
                         __SINK_FQN,
                         __SINK_DESCR,
-                        ::core::option::Option::Some(&__e2.to_string()),
-                        &__zd,
+                        &__e2.to_string(),
                     );
                     jni::objects::JObject::null().into()
                 }
@@ -4401,10 +4058,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4412,15 +4065,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -4441,15 +4092,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -4463,15 +4112,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -4485,15 +4132,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -4507,15 +4152,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -4529,15 +4172,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -4571,15 +4212,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                         let __e2 = <__JniErr as ::core::convert::From<
                             String,
                         >>::from(__e.to_string());
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e2.to_string()),
-                            &__zd,
+                            &__e2.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -4598,10 +4237,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageHandlerNe
     f: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4609,15 +4244,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageHandlerNe
     let f = match JObject_to_impl_Fn_Storage_Send_Sync_static_2f26edcf(&mut env, &f) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -4626,15 +4259,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageHandlerNe
     match StorageHandler_to_jlong_3b4d3ed3(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -4650,10 +4281,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4661,15 +4288,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -4684,15 +4309,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
         let __enc = match String_to_JString_c7f3ca43(&mut env, __elem) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -4721,15 +4344,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
                 let __e2 = <__JniErr as ::core::convert::From<
                     String,
                 >>::from(__e.to_string());
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e2.to_string()),
-                    &__zd,
+                    &__e2.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -4745,10 +4366,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLen<'a>(
     s: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4756,15 +4373,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLen<'a>(
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -4773,15 +4388,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLen<'a>(
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -4803,10 +4416,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
     expected_1: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jboolean {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4814,15 +4423,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4830,15 +4437,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
     let __exp_expected_sel = match jint_to_i32_a3e3b6ef(&mut env, &expected_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4847,15 +4452,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &expected_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -4868,15 +4471,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &expected_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -4891,15 +4492,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4947,15 +4546,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -4964,15 +4561,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageMatchesSu
     match bool_to_jboolean_31306d98(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jboolean
         }
@@ -4985,10 +4580,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageNew<'a>(
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -4997,15 +4588,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageNew<'a>(
     match Storage_to_jlong_1b233abd(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -5024,10 +4613,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     payload_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5035,15 +4620,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5051,15 +4634,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     let __payload_id = match jlong_to_i64_fbf9a9bc(&mut env, &payload_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5067,15 +4648,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     let __payload_seq = match jint_to_i32_a3e3b6ef(&mut env, &payload_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5083,15 +4662,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     let __payload_value = match jdouble_to_f64_9e4a8f70(&mut env, &payload_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5099,15 +4676,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     let __payload_flag = match jboolean_to_bool_31306d98(&mut env, &payload_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5118,15 +4693,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5142,15 +4715,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -5169,10 +4740,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     payload_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5180,15 +4747,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5196,15 +4761,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     let __payload_id = match jlong_to_i64_fbf9a9bc(&mut env, &payload_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5212,15 +4775,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     let __payload_seq = match jint_to_i32_a3e3b6ef(&mut env, &payload_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5228,15 +4789,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     let __payload_value = match jdouble_to_f64_9e4a8f70(&mut env, &payload_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5244,15 +4803,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     let __payload_flag = match jboolean_to_bool_31306d98(&mut env, &payload_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5263,15 +4820,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5287,15 +4842,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -5315,10 +4868,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
     p_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jboolean {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5326,15 +4875,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jboolean;
         }
@@ -5343,15 +4890,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
         let __p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -5359,15 +4904,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
         let __p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -5375,15 +4918,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
         let __p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -5391,15 +4932,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
         let __p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -5407,15 +4946,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
         let __p_label = match JString_to_Option_Box_String_071e4c8c(&mut env, &p_label) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jboolean;
             }
@@ -5434,15 +4971,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
     match bool_to_jboolean_31306d98(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jboolean
         }
@@ -5457,10 +4992,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutSlice<
     payloads_handle: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5468,15 +4999,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutSlice<
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -5488,15 +5017,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutSlice<
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -5513,10 +5040,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5524,15 +5047,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -5540,15 +5061,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
     let each = match jlong_to_i64_fbf9a9bc(&mut env, &each) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -5563,15 +5082,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
         let __enc = match Storage_to_jlong_1b233abd(&mut env, __elem) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -5597,15 +5114,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
                 let __e2 = <__JniErr as ::core::convert::From<
                     String,
                 >>::from(__e.to_string());
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e2.to_string()),
-                    &__zd,
+                    &__e2.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -5624,10 +5139,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5635,15 +5146,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -5651,15 +5160,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
     let each = match jlong_to_i64_fbf9a9bc(&mut env, &each) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -5676,15 +5183,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
                 let __enc = match Storage_to_jlong_1b233abd(&mut env, __elem) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -5710,15 +5215,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
                         let __e2 = <__JniErr as ::core::convert::From<
                             String,
                         >>::from(__e.to_string());
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e2.to_string()),
-                            &__zd,
+                            &__e2.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -5738,10 +5241,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummary<'
     __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5749,15 +5248,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummary<'
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -5774,15 +5271,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummary<'
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -5796,15 +5291,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummary<'
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -5827,15 +5320,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummary<'
             let __e2 = <__JniErr as ::core::convert::From<
                 String,
             >>::from(__e.to_string());
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e2.to_string()),
-                &__zd,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -5850,10 +5341,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryFu
     __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5861,15 +5348,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryFu
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -5886,15 +5371,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryFu
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -5908,15 +5391,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryFu
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -5942,15 +5423,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryFu
             let __e2 = <__JniErr as ::core::convert::From<
                 String,
             >>::from(__e.to_string());
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e2.to_string()),
-                &__zd,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -5964,10 +5443,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryHa
     s: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -5975,15 +5450,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryHa
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -5992,15 +5465,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryHa
     match Summary_to_jlong_3cb103b9(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -6015,10 +5486,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
     __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6026,15 +5493,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6051,15 +5516,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -6073,15 +5536,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -6093,15 +5554,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
             let __h2: jni::sys::jlong = match Summary_to_jlong_ccacdeac(&mut env, __n0) {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(
+                    signal_binding_error(
                         &mut env,
                         &__error_sink,
                         &__SINK_MID,
                         __SINK_FQN,
                         __SINK_DESCR,
-                        ::core::option::Option::Some(&__e.to_string()),
-                        &__zd,
+                        &__e.to_string(),
                     );
                     return jni::objects::JObject::null().into();
                 }
@@ -6109,15 +5568,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
             match ::prebindgen::lang::box_jlong(&mut env, __h2) {
                 ::core::result::Result::Ok(__o) => __o,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(
+                    signal_binding_error(
                         &mut env,
                         &__error_sink,
                         &__SINK_MID,
                         __SINK_FQN,
                         __SINK_DESCR,
-                        ::core::option::Option::Some(&__e.to_string()),
-                        &__zd,
+                        &__e.to_string(),
                     );
                     return jni::objects::JObject::null().into();
                 }
@@ -6147,15 +5604,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageSummaryPr
             let __e2 = <__JniErr as ::core::convert::From<
                 String,
             >>::from(__e.to_string());
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e2.to_string()),
-                &__zd,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -6171,10 +5626,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTotalLen<
     c: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6182,15 +5633,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTotalLen<
     let a = match jlong_to_Storage_1b233abd(&mut env, &a) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6198,15 +5647,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTotalLen<
     let b = match jlong_to_Storage_1b233abd(&mut env, &b) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6214,15 +5661,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTotalLen<
     let c = match jlong_to_Storage_1b233abd(&mut env, &c) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6231,15 +5676,102 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTotalLen<
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryFromStamp<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    s: jni::objects::JByteArray<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+    __domain_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    #[allow(non_upper_case_globals)]
+    static __DSINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __DSINK_FQN: &str = "io/prebindgen/covertest/errors/StorageErrorHandlerRaw";
+    const __DSINK_DESCR: &str = "(Ljava/lang/String;J)Ljava/lang/Object;";
+    let s = match JByteArray_to_Stamp_2fc9bd18(&mut env, &s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = match perftest_flat::storage_try_from_stamp(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__de) => {
+            let __eze0: jni::objects::JObject = {
+                let __enc0 = match String_to_JString_c7f3ca43(
+                    &mut env,
+                    perftest_flat::storage_error_message(&__de),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return 0 as jni::sys::jlong;
+                    }
+                };
+                __enc0.into()
+            };
+            let __eze1: jni::sys::jvalue = jni::sys::jvalue {
+                j: std::boxed::Box::into_raw(std::boxed::Box::new(__de))
+                    as jni::sys::jlong,
+            };
+            signal_domain_error(
+                &mut env,
+                &__domain_sink,
+                &__DSINK_MID,
+                __DSINK_FQN,
+                __DSINK_DESCR,
+                &[
+                    jni::sys::jvalue {
+                        l: __eze0.as_raw(),
+                    },
+                    __eze1,
+                ],
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    match Storage_to_jlong_1b233abd(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -6252,31 +5784,26 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryWithLa
     _class: jni::objects::JClass<'a>,
     label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
+    __domain_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![
-            env.new_string("").map(| __s | jni::sys::jvalue { l : __s.into_raw() })
-            .unwrap_or(jni::sys::jvalue { l : ::std::ptr::null_mut() }), jni::sys::jvalue
-            { l : ::std::ptr::null_mut() }
-        ]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
-    const __SINK_FQN: &str = "io/prebindgen/covertest/errors/StorageErrorHandlerRaw";
-    const __SINK_DESCR: &str = "(Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/Object;";
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    #[allow(non_upper_case_globals)]
+    static __DSINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __DSINK_FQN: &str = "io/prebindgen/covertest/errors/StorageErrorHandlerRaw";
+    const __DSINK_DESCR: &str = "(Ljava/lang/String;J)Ljava/lang/Object;";
     let label = match JString_to_String_c7f3ca43(&mut env, &label) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6291,15 +5818,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryWithLa
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return 0 as jni::sys::jlong;
                     }
@@ -6310,13 +5835,12 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryWithLa
                 j: std::boxed::Box::into_raw(std::boxed::Box::new(__de))
                     as jni::sys::jlong,
             };
-            signal_error(
+            signal_domain_error(
                 &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                ::core::option::Option::None,
+                &__domain_sink,
+                &__DSINK_MID,
+                __DSINK_FQN,
+                __DSINK_DESCR,
                 &[
                     jni::sys::jvalue {
                         l: __eze0.as_raw(),
@@ -6330,15 +5854,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryWithLa
     match Storage_to_jlong_1b233abd(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -6356,10 +5878,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     payload_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6367,15 +5885,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     let __payload_id = match jlong_to_i64_fbf9a9bc(&mut env, &payload_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6383,15 +5899,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     let __payload_seq = match jint_to_i32_a3e3b6ef(&mut env, &payload_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6399,15 +5913,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     let __payload_value = match jdouble_to_f64_9e4a8f70(&mut env, &payload_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6415,15 +5927,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     let __payload_flag = match jboolean_to_bool_31306d98(&mut env, &payload_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6434,15 +5944,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6458,15 +5966,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     match Storage_to_jlong_1b233abd(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -6480,10 +5986,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stringNew<'a>(
     s: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6491,15 +5993,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stringNew<'a>(
     let s = match JString_to_String_c7f3ca43(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6508,15 +6008,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stringNew<'a>(
     match String_to_JString_c7f3ca43(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -6530,10 +6028,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryCount<'a>
     s: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6541,15 +6035,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryCount<'a>
     let s = match jlong_to_Summary_3cb103b9(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6558,15 +6050,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryCount<'a>
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -6586,10 +6076,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
     verbose: jni::sys::jboolean,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6597,15 +6083,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
     let __exp_s_sel = match jint_to_i32_a3e3b6ef(&mut env, &s_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6614,15 +6098,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &s_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -6635,15 +6117,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &s_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -6655,15 +6135,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
     let __exp_s_1 = match jlong_to_Option_Summary_828826f3(&mut env, &s_1) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6713,15 +6191,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6729,15 +6205,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
     let verbose = match jboolean_to_bool_31306d98(&mut env, &verbose) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6746,15 +6220,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
     match String_to_JString_c7f3ca43(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -6769,10 +6241,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<
     mean: jni::sys::jdouble,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6780,15 +6248,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6796,15 +6262,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<
     let mean = match jdouble_to_f64_9e4a8f70(&mut env, &mean) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6813,15 +6277,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<
     let __out_s0 = match Result_Summary_String_to_Summary_dfdf7f9e(&mut env, __out) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -6829,15 +6291,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<
     match Summary_to_jlong_3cb103b9(&mut env, __out_s0) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -6851,10 +6311,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMean<'a>(
     s: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jdouble {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6862,15 +6318,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMean<'a>(
     let s = match jlong_to_Summary_3cb103b9(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -6879,15 +6333,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMean<'a>(
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
         }
@@ -6913,10 +6365,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
     __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -6924,15 +6372,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
     let __exp_primary_sel = match jint_to_i32_a3e3b6ef(&mut env, &primary_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -6941,15 +6387,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &primary_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -6962,15 +6406,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &primary_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -6982,15 +6424,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
     let __exp_primary_1 = match jlong_to_Option_Summary_252ef2ba(&mut env, &primary_1) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7038,15 +6478,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7054,15 +6492,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
     let __exp_fallback_sel = match jint_to_i32_a3e3b6ef(&mut env, &fallback_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7071,15 +6507,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &fallback_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -7092,15 +6526,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &fallback_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -7115,15 +6547,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7171,15 +6601,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7196,15 +6624,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -7218,15 +6644,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -7249,15 +6673,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryMerge<'a>
             let __e2 = <__JniErr as ::core::convert::From<
                 String,
             >>::from(__e.to_string());
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e2.to_string()),
-                &__zd,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -7272,10 +6694,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
     total: jni::sys::jdouble,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -7283,15 +6701,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7299,15 +6715,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
     let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7316,15 +6730,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryNew<'a>(
     match Summary_to_jlong_3cb103b9(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -7349,10 +6761,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
     fallback_1: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -7360,15 +6768,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
     let __exp_primary_sel = match jint_to_i32_a3e3b6ef(&mut env, &primary_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7377,15 +6783,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &primary_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jlong;
             }
@@ -7398,15 +6802,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &primary_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jlong;
             }
@@ -7418,15 +6820,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
     let __exp_primary_1 = match jlong_to_Option_Summary_252ef2ba(&mut env, &primary_1) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7474,15 +6874,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7490,15 +6888,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
     let __exp_fallback_sel = match jint_to_i32_a3e3b6ef(&mut env, &fallback_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7507,15 +6903,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &fallback_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jlong;
             }
@@ -7528,15 +6922,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &fallback_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0 as jni::sys::jlong;
             }
@@ -7551,15 +6943,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7607,15 +6997,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -7624,15 +7012,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryPrefer<'a
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -7647,10 +7033,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryScaled<'a
     factor: jni::sys::jdouble,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jdouble {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -7658,15 +7040,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryScaled<'a
     let s = match jlong_to_Summary_3cb103b9(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -7674,15 +7054,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryScaled<'a
     let factor = match jdouble_to_f64_9e4a8f70(&mut env, &factor) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -7691,15 +7069,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryScaled<'a
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
         }
@@ -7716,10 +7092,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -7727,15 +7099,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7743,15 +7113,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a
     let start = match jlong_to_i64_fbf9a9bc(&mut env, &start) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7770,15 +7138,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a
             ) {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(
+                    signal_binding_error(
                         &mut env,
                         &__error_sink,
                         &__SINK_MID,
                         __SINK_FQN,
                         __SINK_DESCR,
-                        ::core::option::Option::Some(&__e.to_string()),
-                        &__zd,
+                        &__e.to_string(),
                     );
                     return jni::objects::JObject::null().into();
                 }
@@ -7792,15 +7158,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a
             ) {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(
+                    signal_binding_error(
                         &mut env,
                         &__error_sink,
                         &__SINK_MID,
                         __SINK_FQN,
                         __SINK_DESCR,
-                        ::core::option::Option::Some(&__e.to_string()),
-                        &__zd,
+                        &__e.to_string(),
                     );
                     return jni::objects::JObject::null().into();
                 }
@@ -7829,15 +7193,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeries<'a
                 let __e2 = <__JniErr as ::core::convert::From<
                     String,
                 >>::from(__e.to_string());
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e2.to_string()),
-                    &__zd,
+                    &__e2.to_string(),
                 );
                 return jni::objects::JObject::null().into();
             }
@@ -7856,10 +7218,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -7867,15 +7225,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt
     let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7883,15 +7239,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt
     let start = match jlong_to_i64_fbf9a9bc(&mut env, &start) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -7912,15 +7266,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -7934,15 +7286,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -7971,15 +7321,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summarySeriesOpt
                         let __e2 = <__JniErr as ::core::convert::From<
                             String,
                         >>::from(__e.to_string());
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e2.to_string()),
-                            &__zd,
+                            &__e2.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -7998,10 +7346,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotal<'a>
     s: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jdouble {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -8009,15 +7353,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotal<'a>
     let s = match jlong_to_Summary_3cb103b9(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -8026,15 +7368,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotal<'a>
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
         }
@@ -8053,10 +7393,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
     s_1: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jdouble {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -8064,15 +7400,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
     let __exp_s_sel = match jint_to_i32_a3e3b6ef(&mut env, &s_sel) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -8081,15 +7415,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
         let __v = match jlong_to_i64_fbf9a9bc(&mut env, &s_0_0_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0.0 as jni::sys::jdouble;
             }
@@ -8102,15 +7434,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
         let __v = match jdouble_to_f64_9e4a8f70(&mut env, &s_0_1_value) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
+                signal_binding_error(
                     &mut env,
                     &__error_sink,
                     &__SINK_MID,
                     __SINK_FQN,
                     __SINK_DESCR,
-                    ::core::option::Option::Some(&__e.to_string()),
-                    &__zd,
+                    &__e.to_string(),
                 );
                 return 0.0 as jni::sys::jdouble;
             }
@@ -8122,15 +7452,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
     let __exp_s_1 = match jlong_to_Option_Summary_828826f3(&mut env, &s_1) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -8189,15 +7517,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
             let __je = <__JniErr as ::core::convert::From<
                 ::std::string::String,
             >>::from(__e);
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__je.to_string()),
-                &__zd,
+                &__je.to_string(),
             );
             return 0.0 as jni::sys::jdouble;
         }
@@ -8206,15 +7532,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalOpt<
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
         }
@@ -8228,24 +7552,18 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
     s: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jdouble {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
     if s == 0 || (s & 1) == 1 {
-        let __zd = __ze_defaults(&mut env);
-        signal_error(
+        signal_binding_error(
             &mut env,
             &__error_sink,
             &__SINK_MID,
             __SINK_FQN,
             __SINK_DESCR,
-            ::core::option::Option::Some("Operation on a closed native handle."),
-            &__zd,
+            "Operation on a closed native handle.",
         );
         return 0.0 as jni::sys::jdouble;
     }
@@ -8256,15 +7574,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
         }
@@ -8279,10 +7595,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverMag
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -8291,15 +7603,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverMag
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -8314,10 +7624,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverTag
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JString<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
@@ -8326,15 +7632,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverTag
     match str_to_JString_7b77dc67(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -148,6 +148,30 @@ pub fn storage_try_with_label(label: &str) -> Result<Storage, StorageError> {
     })
 }
 
+/// Build a storage stamped with `s`, **failing** on a non-positive `secs` (a
+/// domain [`StorageError`]). This takes a `Stamp` **by value** (a value-blob
+/// input), so a malformed `Stamp` blob fails the input decode FIRST — the
+/// binding channel — while a well-formed but rejected value fails in the domain
+/// channel. It is the covertest exercise for issue #45's two-caller split: one
+/// wrapper, both `onBindingError` and `onError` provable independently.
+#[prebindgen]
+pub fn storage_try_from_stamp(s: Stamp) -> Result<Storage, StorageError> {
+    if s.secs <= 0 {
+        return Err(StorageError {
+            message: "stamp secs must be positive".to_string(),
+        });
+    }
+    Ok(Storage {
+        payloads: vec![Payload {
+            id: s.secs,
+            seq: 0,
+            value: 0.0,
+            flag: false,
+            label: None,
+        }],
+    })
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Summary — an opaque handle whose fields decompose at the boundary.
 // ─────────────────────────────────────────────────────────────────────────────

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -257,12 +257,12 @@ public class Token(initialPtr: Long) : NativeHandle(initialPtr) {
     /** Read a plain benchmark token. */
     public fun tokenValue(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            JNINative.tokenValue(this_ptr, __cap)
+            JNINative.tokenValue(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -272,9 +272,9 @@ public class Token(initialPtr: Long) : NativeHandle(initialPtr) {
 
         /** Create a plain benchmark token. */
         public fun tokenNew(value: Long, onError: JniErrorHandler<Token>): Token {
-            val __cap = JniErrorHandlerCapture.acquire()
-            val __ret = Token(JNINative.tokenNew(value, __cap))
-            if (__cap.failed) return onError.run(__cap.je)
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = Token(JNINative.tokenNew(value, __bcap))
+            if (__bcap.failed) return onError.run(__bcap.ze0)
             return __ret
         }
     }
@@ -301,12 +301,12 @@ public class TokenGc(initialPtr: Long) : GcNativeHandle(initialPtr) {
     /** Read a gc-managed benchmark token. */
     public fun tokenGcValue(onError: JniErrorHandler<Long>): Long {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
-        val __cap = JniErrorHandlerCapture.acquire()
+        val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
             val this_ptr = this.ptr
-            JNINative.tokenGcValue(this_ptr, __cap)
+            JNINative.tokenGcValue(this_ptr, __bcap)
         }
-        if (__cap.failed) return onError.run(__cap.je)
+        if (__bcap.failed) return onError.run(__bcap.ze0)
         return __ret
     }
 
@@ -316,9 +316,9 @@ public class TokenGc(initialPtr: Long) : GcNativeHandle(initialPtr) {
 
         /** Create a gc-managed benchmark token. */
         public fun tokenGcNew(value: Long, onError: JniErrorHandler<TokenGc>): TokenGc {
-            val __cap = JniErrorHandlerCapture.acquire()
-            val __ret = TokenGc(JNINative.tokenGcNew(value, __cap))
-            if (__cap.failed) return onError.run(__cap.je)
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = TokenGc(JNINative.tokenGcNew(value, __bcap))
+            if (__bcap.failed) return onError.run(__bcap.ze0)
             return __ret
         }
     }
@@ -384,10 +384,12 @@ internal object __PayloadFolderRawHolder {
 }
 
 /**
- * Error callback for wrappers without a declared error type. `je` is the
- * binding/system failure message (any converter in the chain may fail). The
- * wrapper returns whatever `run` returns; throwing from `run` is safe (it
- * executes after the native call has returned).
+ * Binding-error callback — every wrapper's binding/system failure channel (any
+ * converter in the chain may fail, or a handle may be closed). `je` is the
+ * failure message. For an infallible wrapper this is the sole `onError`; a
+ * fallible wrapper takes it as `onBindingError` alongside the typed domain
+ * handler. The wrapper returns whatever `run` returns;
+ * throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface JniErrorHandler<out R> {
     public fun run(je: String?): R
@@ -395,13 +397,13 @@ public fun interface JniErrorHandler<out R> {
 
 internal class JniErrorHandlerCapture : JniErrorHandler<Unit> {
     @JvmField var failed: Boolean = false
-    @JvmField var je: String? = null
-    override fun run(je: String?) { failed = true; this.je = je }
+    @JvmField var ze0: String? = null
+    override fun run(je: String?) { failed = true; this.ze0 = je }
     companion object {
         private val TL: ThreadLocal<JniErrorHandlerCapture> = ThreadLocal.withInitial { JniErrorHandlerCapture() }
         @JvmStatic fun acquire(): JniErrorHandlerCapture {
             val c = TL.get()
-            c.failed = false; c.je = null
+            c.failed = false; c.ze0 = null
             return c
         }
     }

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
@@ -17,9 +17,9 @@ import io.prebindgen.perftest.withSortedHandleLocks
 
 /** Create a new, empty storage handle. */
 public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = Storage(JNINative.storageNew(__cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = Storage(JNINative.storageNew(__bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -34,12 +34,12 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
  */
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (JNINative.storageGet(s_ptr, __PayloadBuilder, __cap) as Payload?)
+        (JNINative.storageGet(s_ptr, __PayloadBuilder, __bcap) as Payload?)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -51,7 +51,7 @@ public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? 
  */
 public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         JNINative.storagePutByTake(
@@ -61,10 +61,10 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
             payload.value,
             payload.flag,
             payload.label,
-            __cap,
+            __bcap,
         )
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -73,7 +73,7 @@ public fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandl
  */
 public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s) {
         val s_ptr = s.ptr
         JNINative.storagePutByRead(
@@ -83,10 +83,10 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
             payload.value,
             payload.flag,
             payload.label,
-            __cap,
+            __bcap,
         )
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -100,9 +100,9 @@ public fun payloadHandlerNew(
     f: PayloadCallback,
     onError: JniErrorHandler<PayloadHandler>,
 ): PayloadHandler {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadHandler(JNINative.payloadHandlerNew(f.asRaw(), __cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = PayloadHandler(JNINative.payloadHandlerNew(f.asRaw(), __bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -119,13 +119,13 @@ public fun payloadHandlerNew(
 public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
         val handler_ptr = handler.ptr
-        JNINative.storageCallback(s_ptr, handler_ptr, __cap)
+        JNINative.storageCallback(s_ptr, handler_ptr, __bcap)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -134,7 +134,7 @@ public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErro
  */
 public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __vec_payloads = JNINative.payloadVecNew(payloads.size)
     try {
         for (__e in payloads) {
@@ -149,12 +149,12 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
         }
         withSortedHandleLocks(s) {
             val s_ptr = s.ptr
-            JNINative.storagePutSlice(s_ptr, __vec_payloads, __cap)
+            JNINative.storagePutSlice(s_ptr, __vec_payloads, __bcap)
         }
     } finally {
         JNINative.payloadVecFree(__vec_payloads)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**
@@ -169,12 +169,12 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
  */
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (JNINative.storageGetVec(s_ptr, ArrayList<Payload>(), __PayloadFolderRawHolder.instance, __cap) as List<Payload>?)
+        (JNINative.storageGetVec(s_ptr, ArrayList<Payload>(), __PayloadFolderRawHolder.instance, __bcap) as List<Payload>?)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -187,9 +187,9 @@ public fun payloadVecHandlerNew(
     f: PayloadListCallback,
     onError: JniErrorHandler<PayloadVecHandler>,
 ): PayloadVecHandler {
-    val __cap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadVecHandler(JNINative.payloadVecHandlerNew(f, __cap))
-    if (__cap.failed) return onError.run(__cap.je)
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = PayloadVecHandler(JNINative.payloadVecHandlerNew(f, __bcap))
+    if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }
 
@@ -207,11 +207,11 @@ public fun storageCallbackVec(
 ) {
     if (s.isClosed()) { onError.run("Operation on a closed native handle."); return }
     if (handler.isClosed()) { onError.run("Operation on a closed native handle."); return }
-    val __cap = JniErrorHandlerCapture.acquire()
+    val __bcap = JniErrorHandlerCapture.acquire()
     withSortedHandleLocks(s, handler) {
         val s_ptr = s.ptr
         val handler_ptr = handler.ptr
-        JNINative.storageCallbackVec(s_ptr, handler_ptr, __cap)
+        JNINative.storageCallbackVec(s_ptr, handler_ptr, __bcap)
     }
-    if (__cap.failed) return onError.run(__cap.je)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -38,40 +38,47 @@ impl<T: ?Sized> OwnedObject<T> {
     }
 }
 #[allow(non_snake_case, dead_code)]
-pub(crate) fn signal_error(
+pub(crate) fn signal_binding_error(
     env: &mut jni::JNIEnv,
     sink: &jni::objects::JObject,
     mid: &::prebindgen::lang::CachedIfaceMethod,
     fqn: &str,
     descr: &str,
-    je: ::core::option::Option<&str>,
+    je: &str,
+) {
+    if env.exception_check().unwrap_or(false) {
+        return;
+    }
+    let __je: jni::objects::JObject = match env.new_string(je) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            tracing::error!("signal_binding_error: new_string failed: {}", e);
+            return;
+        }
+    };
+    let __args = [
+        jni::sys::jvalue {
+            l: __je.as_raw(),
+        },
+    ];
+    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, &__args) {
+        tracing::error!("signal_binding_error: error-callback invoke failed: {}", e);
+    }
+}
+#[allow(non_snake_case, dead_code)]
+pub(crate) fn signal_domain_error(
+    env: &mut jni::JNIEnv,
+    sink: &jni::objects::JObject,
+    mid: &::prebindgen::lang::CachedIfaceMethod,
+    fqn: &str,
+    descr: &str,
     ze: &[jni::sys::jvalue],
 ) {
     if env.exception_check().unwrap_or(false) {
         return;
     }
-    let __je: jni::objects::JObject = match je {
-        ::core::option::Option::Some(__m) => {
-            match env.new_string(__m) {
-                Ok(s) => s.into(),
-                Err(e) => {
-                    tracing::error!("signal_error: new_string failed: {}", e);
-                    return;
-                }
-            }
-        }
-        ::core::option::Option::None => jni::objects::JObject::null(),
-    };
-    let mut __args: ::std::vec::Vec<jni::sys::jvalue> = ::std::vec::Vec::with_capacity(
-        1 + ze.len(),
-    );
-    __args
-        .push(jni::sys::jvalue {
-            l: __je.as_raw(),
-        });
-    __args.extend_from_slice(ze);
-    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, &__args) {
-        tracing::error!("signal_error: error-callback invoke failed: {}", e);
+    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, ze) {
+        tracing::error!("signal_domain_error: error-callback invoke failed: {}", e);
     }
 }
 #[no_mangle]
@@ -1130,10 +1137,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadHandlerNew
     f: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1141,15 +1144,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadHandlerNew
     let f = match JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906(&mut env, &f) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -1158,15 +1159,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadHandlerNew
     match PayloadHandler_to_jlong_d61fd890(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -1180,10 +1179,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadVecHandler
     f: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1191,15 +1186,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadVecHandler
     let f = match JObject_to_impl_Fn_Payload_Send_Sync_static_95073668(&mut env, &f) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -1208,15 +1201,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadVecHandler
     match PayloadVecHandler_to_jlong_b32d2812(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -1231,10 +1222,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallback<'
     handler: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1242,15 +1229,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallback<'
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1258,15 +1243,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallback<'
     let handler = match jlong_to_PayloadHandler_d61fd890(&mut env, &handler) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1275,15 +1258,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallback<'
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -1298,10 +1279,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallbackVe
     handler: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1309,15 +1286,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallbackVe
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1325,15 +1300,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallbackVe
     let handler = match jlong_to_PayloadVecHandler_b32d2812(&mut env, &handler) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1342,15 +1315,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageCallbackVe
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -1365,10 +1336,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
     __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1376,15 +1343,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1400,15 +1365,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                 let __enc0 = match i64_to_jlong_fbf9a9bc(&mut env, __inner.id.clone()) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -1419,15 +1382,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                 let __enc1 = match i32_to_jint_a3e3b6ef(&mut env, __inner.seq.clone()) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -1441,15 +1402,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -1463,15 +1422,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -1485,15 +1442,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e.to_string()),
-                            &__zd,
+                            &__e.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -1524,15 +1479,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                     let __e2 = <__JniErr as ::core::convert::From<
                         String,
                     >>::from(__e.to_string());
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(
+                    signal_binding_error(
                         &mut env,
                         &__error_sink,
                         &__SINK_MID,
                         __SINK_FQN,
                         __SINK_DESCR,
-                        ::core::option::Option::Some(&__e2.to_string()),
-                        &__zd,
+                        &__e2.to_string(),
                     );
                     jni::objects::JObject::null().into()
                 }
@@ -1551,10 +1504,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
     __fold: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1562,15 +1511,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
     let s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return jni::objects::JObject::null().into();
         }
@@ -1591,15 +1538,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -1613,15 +1558,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -1635,15 +1578,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -1657,15 +1598,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -1679,15 +1618,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                     ) {
                         ::core::result::Result::Ok(__w) => __w,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(
+                            signal_binding_error(
                                 &mut env,
                                 &__error_sink,
                                 &__SINK_MID,
                                 __SINK_FQN,
                                 __SINK_DESCR,
-                                ::core::option::Option::Some(&__e.to_string()),
-                                &__zd,
+                                &__e.to_string(),
                             );
                             return jni::objects::JObject::null().into();
                         }
@@ -1721,15 +1658,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                         let __e2 = <__JniErr as ::core::convert::From<
                             String,
                         >>::from(__e.to_string());
-                        let __zd = __ze_defaults(&mut env);
-                        signal_error(
+                        signal_binding_error(
                             &mut env,
                             &__error_sink,
                             &__SINK_MID,
                             __SINK_FQN,
                             __SINK_DESCR,
-                            ::core::option::Option::Some(&__e2.to_string()),
-                            &__zd,
+                            &__e2.to_string(),
                         );
                         return jni::objects::JObject::null().into();
                     }
@@ -1747,10 +1682,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageNew<'a>(
     _class: jni::objects::JClass<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1759,15 +1690,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageNew<'a>(
     match Storage_to_jlong_1b233abd(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -1786,10 +1715,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     payload_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1797,15 +1722,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1813,15 +1736,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     let __payload_id = match jlong_to_i64_fbf9a9bc(&mut env, &payload_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1829,15 +1750,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     let __payload_seq = match jint_to_i32_a3e3b6ef(&mut env, &payload_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1845,15 +1764,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     let __payload_value = match jdouble_to_f64_9e4a8f70(&mut env, &payload_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1861,15 +1778,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     let __payload_flag = match jboolean_to_bool_31306d98(&mut env, &payload_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1880,15 +1795,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1904,15 +1817,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -1931,10 +1842,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     payload_label: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -1942,15 +1849,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1958,15 +1863,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     let __payload_id = match jlong_to_i64_fbf9a9bc(&mut env, &payload_id) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1974,15 +1877,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     let __payload_seq = match jint_to_i32_a3e3b6ef(&mut env, &payload_seq) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -1990,15 +1891,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     let __payload_value = match jdouble_to_f64_9e4a8f70(&mut env, &payload_value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2006,15 +1905,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     let __payload_flag = match jboolean_to_bool_31306d98(&mut env, &payload_flag) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2025,15 +1922,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2049,15 +1944,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -2072,10 +1965,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutSlice<'
     payloads_handle: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> () {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -2083,15 +1972,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutSlice<'
     let mut s = match jlong_to_Storage_1b233abd(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return ();
         }
@@ -2103,15 +1990,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutSlice<'
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             ()
         }
@@ -2125,10 +2010,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcNew<'a>(
     value: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -2136,15 +2017,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcNew<'a>(
     let value = match jlong_to_i64_fbf9a9bc(&mut env, &value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2153,15 +2032,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcNew<'a>(
     match TokenGc_to_jlong_5e58352a(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2175,10 +2052,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcValue<'a>(
     t: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -2186,15 +2059,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcValue<'a>(
     let t = match jlong_to_TokenGc_5e58352a(&mut env, &t) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2203,15 +2074,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenGcValue<'a>(
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2225,10 +2094,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenNew<'a>(
     value: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -2236,15 +2101,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenNew<'a>(
     let value = match jlong_to_i64_fbf9a9bc(&mut env, &value) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2253,15 +2116,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenNew<'a>(
     match Token_to_jlong_4f7adafa(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }
@@ -2275,10 +2136,6 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenValue<'a>(
     t: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
-    #[allow(unused_variables)]
-    let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-        ::std::vec![]
-    };
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
@@ -2286,15 +2143,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenValue<'a>(
     let t = match jlong_to_Token_4f7adafa(&mut env, &t) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             return 0 as jni::sys::jlong;
         }
@@ -2303,15 +2158,13 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_tokenValue<'a>(
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
-            let __zd = __ze_defaults(&mut env);
-            signal_error(
+            signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                ::core::option::Option::Some(&__e.to_string()),
-                &__zd,
+                &__e.to_string(),
             );
             0 as jni::sys::jlong
         }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -1,104 +1,6 @@
-//! Output-expansion delivery: unfold plans, leaf encoding, and the
-//! error-channel (`ze`) defaults.
+//! Output-expansion delivery: unfold plans and leaf encoding.
 
 use super::*;
-
-/// Language-neutral default classification for one plan leaf — what a
-/// **binding** error fills its builder-typed `ze` slot with when the domain
-/// value never materialized. One classifier feeds both renderers — the
-/// native `__ze_defaults` jvalues ([`default_ze_jvalues`]) and the Kotlin
-/// guard literals (`ze_default_kotlin` in render.rs) — so the two sides
-/// cannot drift.
-pub(crate) enum LeafDefault {
-    /// Plan-nullable leaf, or an object kind with no constructible default
-    /// (data classes, …): JVM `null`.
-    Null,
-    /// Raw primitive: zero / `false`.
-    Prim(JniPrim),
-    /// Non-null `String`: `""`.
-    Str,
-    /// Byte array or `Copy` value blob: an empty array.
-    Bytes,
-    /// Collection: an empty list.
-    List,
-}
-
-/// Classify a leaf's binding-error default — see [`LeafDefault`].
-pub(crate) fn leaf_default(
-    _ext: &JniGen,
-    registry: &Registry<KotlinMeta>,
-    leaf: &crate::api::core::unfold::UnfoldLeaf,
-) -> LeafDefault {
-    if leaf.nullable {
-        return LeafDefault::Null;
-    }
-    let e = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
-        panic!(
-            "leaf_default: leaf `{}` has no registered output converter",
-            TypeKey::from_type(&leaf.out_ty)
-        )
-    });
-    if let Some(proj) = &e.metadata.projection {
-        return match proj.kind {
-            // A handle crosses as a raw jlong — `0L` (no handle) is the
-            // default; the receiver's `isClosed()`-style zero check applies.
-            ProjectionKind::Handle => LeafDefault::Prim(JniPrim::Long),
-            ProjectionKind::ValueBlob => LeafDefault::Bytes,
-        };
-    }
-    if let Some(p) = JniPrim::from_wire(&e.destination) {
-        return LeafDefault::Prim(p);
-    }
-    match jni_field_access(&e.destination) {
-        Some(("Ljava/lang/String;", _, _)) => LeafDefault::Str,
-        Some(("[B", _, _)) => LeafDefault::Bytes,
-        _ => match e
-            .metadata
-            .kotlin_name
-            .as_ref()
-            .and_then(|k| k.simple_name())
-        {
-            Some("List" | "MutableList") => LeafDefault::List,
-            _ => LeafDefault::Null,
-        },
-    }
-}
-
-/// The native default-`jvalue` expression per error-plan leaf, rendered from
-/// [`leaf_default`]. Each expression evaluates inside the lazy
-/// `__ze_defaults` closure (`env` in scope); a zeroed union (`l = null`) is
-/// 0 / `false` at every primitive slot. Construction failures fall back to
-/// null (cold path, OOM-class only).
-pub(crate) fn default_ze_jvalues(
-    ext: &JniGen,
-    registry: &Registry<KotlinMeta>,
-    plan: &crate::api::core::unfold::UnfoldPlan,
-) -> Vec<TokenStream> {
-    let null_jv = quote!(jni::sys::jvalue {
-        l: ::std::ptr::null_mut()
-    });
-    plan.leaves
-        .iter()
-        .map(|leaf| match leaf_default(ext, registry, leaf) {
-            LeafDefault::Null | LeafDefault::Prim(_) => null_jv.clone(),
-            LeafDefault::Str => quote! {
-                env.new_string("")
-                    .map(|__s| jni::sys::jvalue { l: __s.into_raw() })
-                    .unwrap_or(#null_jv)
-            },
-            LeafDefault::Bytes => quote! {
-                env.byte_array_from_slice(&[])
-                    .map(|__a| jni::sys::jvalue { l: __a.into_raw() })
-                    .unwrap_or(#null_jv)
-            },
-            LeafDefault::List => quote! {
-                env.new_object("java/util/ArrayList", "()V", &[])
-                    .map(|__o| jni::sys::jvalue { l: __o.into_raw() })
-                    .unwrap_or(#null_jv)
-            },
-        })
-        .collect()
-}
 
 /// Emit the output-expansion delivery body (output phase) for a function
 /// marked `.expand_output()`. The return value (`__out`) is decomposed by the
@@ -145,7 +47,7 @@ pub(crate) fn emit_unfold_delivery(
     // the wrapper's sentinel. Threads through the shared leaf encoder.
     let fail = |msg: TokenStream| -> TokenStream {
         quote! {
-            let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&#msg), &__zd);
+            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &#msg);
             return #on_err;
         }
     };
@@ -183,7 +85,7 @@ pub(crate) fn emit_unfold_delivery(
                     // Clears any pending JVM exception so the sink call is safe.
                     let _ = env.exception_describe();
                     let __e2 = <__JniErr as ::core::convert::From<String>>::from(__e.to_string());
-                    let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e2.to_string()), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e2.to_string());
                     #on_err
                 }
             }
@@ -224,7 +126,7 @@ pub(crate) fn emit_unfold_delivery(
                     ::core::result::Result::Err(__e) => {
                         let _ = env.exception_describe();
                         let __e2 = <__JniErr as ::core::convert::From<String>>::from(__e.to_string());
-                        let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e2.to_string()), &__zd);
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e2.to_string());
                         return #on_err;
                     }
                 };
@@ -269,7 +171,7 @@ pub(crate) fn emit_unfold_delivery(
                 let __enc = match #elem_conv(&mut env, __elem) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                         return #on_err;
                     }
                 };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -614,7 +614,7 @@ pub(crate) fn render_flat_input_decode(
             match #conv(&mut env, &#wid) {
                 ::core::result::Result::Ok(__v) => __v,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                     return #on_err;
                 }
             }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -171,11 +171,9 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // Error-position expansion: when the fn returns `Result<T, E>` and an error
     // plan is declared, the **`?`** is applied here — the extern peels the
     // `Result` (Err arm decomposes `E` into the `ze` leaves and invokes the
-    // error callback), and the success path uses `T`'s converter (not the
-    // `Result<T, E>` rank-2 wrapper). `n_ze` = the error leaf count (the callback
-    // arity after the fixed `je`).
+    // typed DOMAIN handler), and the success path uses `T`'s converter (not the
+    // `Result<T, E>` rank-2 wrapper).
     let error_plan = registry.error_plans.get(original_ident);
-    let n_ze = error_plan.map_or(0, |p| p.leaves.len());
     let is_convert = matches!(&plan.output, FnOutputPlan::Value(v) if v.is_convert);
     // The output converter entry (`None` for callback delivery). The lookup
     // was validated at plan build; re-resolving here keeps the plan free of
@@ -244,23 +242,17 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // `Result<T, E>` peel (the automatic `?`): success ⇒ `T`; on `Err(e)`,
         // decompose `e` into the `ze` leaves — through the SAME shared leaf
         // encoder every output/callback delivery uses (typed jvalues, handle
-        // wraps, Option-nested accessor unwrap) — and invoke the error
-        // callback with `je = None` (a domain error, not a binding one), then
-        // return the sentinel. A failure while ENCODING the error itself
-        // degrades to a binding error: `je` = message, ze = defaults. The
-        // success `T` flows into the normal output phase.
+        // wraps, Option-nested accessor unwrap) — and invoke the typed DOMAIN
+        // handler (no `je`, no defaults), then return the sentinel. A failure
+        // while ENCODING the error itself degrades to the BINDING channel
+        // (`signal_binding_error`). The success `T` flows into the normal
+        // output phase.
         let eze_idents: Vec<syn::Ident> = (0..ep.leaves.len())
             .map(|i| format_ident!("__eze{}", i))
             .collect();
         let ze_fail = |msg: TokenStream| -> TokenStream {
             quote! {
-                let __zd = __ze_defaults(&mut env);
-                signal_error(
-                    &mut env, &__error_sink,
-                    &__SINK_MID, __SINK_FQN, __SINK_DESCR,
-                    ::core::option::Option::Some(&#msg),
-                    &__zd,
-                );
+                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &#msg);
                 return #on_err;
             }
         };
@@ -271,10 +263,9 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                 ::core::result::Result::Ok(__v) => __v,
                 ::core::result::Result::Err(__de) => {
                     #ze_stmts
-                    signal_error(
-                        &mut env, &__error_sink,
-                        &__SINK_MID, __SINK_FQN, __SINK_DESCR,
-                        ::core::option::Option::None,
+                    signal_domain_error(
+                        &mut env, &__domain_sink,
+                        &__DSINK_MID, __DSINK_FQN, __DSINK_DESCR,
                         &[#(#ze_args),*],
                     );
                     return #on_err;
@@ -319,7 +310,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                 let #next_ident = match #stage_fn(&mut env, #prev_out) {
                     ::core::result::Result::Ok(__v) => __v,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                         return #on_err;
                     }
                 };
@@ -331,7 +322,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             match #conv_out(&mut env, #prev_out) {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                     #on_err
                 }
             }
@@ -339,45 +330,52 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         phase
     };
 
-    // `__ze_defaults` — the typed default ze values passed at **binding**
-    // error sites (a `JniError`, where `je` carries the message). The handler
-    // interface types its ze exactly like a builder's leaves, so the defaults
-    // must be valid at those types: zeroed jvalue for raw primitives, `""`,
-    // an empty byte array, a closed (`ptr = 0`) handle instance, JVM null for
-    // plan-nullable leaves. Built LAZILY (the closure runs only on the cold
-    // error path); in scope for the prelude + every helper-generated
-    // `signal_error` call.
-    let ze_default_exprs: Vec<TokenStream> = error_plan
-        .map(|ep| default_ze_jvalues(ext, registry, ep))
-        .unwrap_or_default();
-    debug_assert_eq!(ze_default_exprs.len(), n_ze);
-    // The error sink is a typed `<Err>Handler` / `JniErrorHandler` fun
-    // interface; its `run` method ID is resolved once per process on the
-    // interface class (the sink instance differs per call). The trio is in
-    // scope for every `signal_error` call the prelude/output phases emit.
-    let sink_spec = plan.onerror_iface.as_ref().unwrap_or_else(|| {
+    // Error sinks. Both channels are typed `fun interface`s whose `run` method
+    // ID is resolved once per process on the interface class (the sink instance
+    // differs per call). The BINDING channel (`__error_sink` + `__SINK_*`, the
+    // base `JniErrorHandler`) is always present — every wrapper can hit a
+    // binding/marshalling failure. The DOMAIN channel (`__domain_sink` +
+    // `__DSINK_*`, the typed `<Src>Handler`) is present only for a fallible fn
+    // with a declared error plan; its `Err(E)` decomposition delivers the real
+    // leaves (no `je`, no fabricated defaults).
+    let error_ifaces = plan.onerror_iface.as_ref().unwrap_or_else(|| {
         panic!(
             "jnigen: cannot derive the onError handler interface for `{}`",
             original_ident
         )
     });
-    let sink_fqn_lit = syn::LitStr::new(&sink_spec.raw_slash_fqn(), Span::call_site());
-    let sink_descr_lit = syn::LitStr::new(&sink_spec.descr, Span::call_site());
-    let ze_defaults_setup = quote! {
-        #[allow(unused_variables)]
-        let __ze_defaults = |env: &mut jni::JNIEnv| -> ::std::vec::Vec<jni::sys::jvalue> {
-            ::std::vec![#(#ze_default_exprs),*]
-        };
+    let bsink_fqn_lit = syn::LitStr::new(&error_ifaces.binding.raw_slash_fqn(), Span::call_site());
+    let bsink_descr_lit = syn::LitStr::new(&error_ifaces.binding.descr, Span::call_site());
+    let (domain_setup, domain_sink_param) = match &error_ifaces.domain {
+        Some(dsink) => {
+            let dfqn = syn::LitStr::new(&dsink.raw_slash_fqn(), Span::call_site());
+            let ddescr = syn::LitStr::new(&dsink.descr, Span::call_site());
+            (
+                quote! {
+                    #[allow(non_upper_case_globals)]
+                    static __DSINK_MID: ::prebindgen::lang::CachedIfaceMethod =
+                        ::prebindgen::lang::CachedIfaceMethod::new();
+                    const __DSINK_FQN: &str = #dfqn;
+                    const __DSINK_DESCR: &str = #ddescr;
+                },
+                quote!(__domain_sink: jni::objects::JObject<'a>,),
+            )
+        }
+        None => (quote!(), quote!()),
+    };
+    let sinks_setup = quote! {
         #[allow(non_upper_case_globals)]
         static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod =
             ::prebindgen::lang::CachedIfaceMethod::new();
-        const __SINK_FQN: &str = #sink_fqn_lit;
-        const __SINK_DESCR: &str = #sink_descr_lit;
+        const __SINK_FQN: &str = #bsink_fqn_lit;
+        const __SINK_DESCR: &str = #bsink_descr_lit;
+        #domain_setup
     };
 
-    // The trailing `__error_sink` param is the foreign **error callback** (a
-    // function type `(je: String?, ze…) -> R`); the wrapper passes a capture.
-    // Declared last so the wire param order matches the Kotlin `external fun`.
+    // Trailing sink params: `__error_sink` (binding) always, then
+    // `__domain_sink` (typed domain error) for a fallible fn — a capture is
+    // passed for each. Declared after the wire params + builder so the order
+    // matches the Kotlin `external fun`.
     quote! {
         #[no_mangle]
         #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
@@ -387,8 +385,9 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             #(#wire_params,)*
             #builder_param
             __error_sink: jni::objects::JObject<'a>,
+            #domain_sink_param
         ) -> #wire_return {
-            #ze_defaults_setup
+            #sinks_setup
             #(#prelude)*
             #output_phase
         }
@@ -470,8 +469,7 @@ fn emit_input_param(
                     let #tmp = match #conv(&mut env, &#vid) {
                         ::core::result::Result::Ok(__v) => __v,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                             return #on_err;
                         }
                     };
@@ -531,8 +529,7 @@ fn emit_input_param(
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
             prelude.push(quote!(
                 if #wire_ident == 0 || (#wire_ident & 1) == 1 {
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some("Operation on a closed native handle."), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
                     return #on_err;
                 }
                 let #arg_ident: #arg_ty = unsafe {
@@ -611,7 +608,7 @@ fn emit_plain_decode(
             let #arg_mut #arg_ident = match #decode_call {
                 ::core::result::Result::Ok(__v) => __v,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                     return #on_err;
                 }
             };
@@ -624,7 +621,7 @@ fn emit_plain_decode(
             let #stage0_ident = match #decode_call {
                 ::core::result::Result::Ok(__v) => __v,
                 ::core::result::Result::Err(__e) => {
-                    let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                     return #on_err;
                 }
             };
@@ -647,7 +644,7 @@ fn emit_plain_decode(
                 let #bind_mut #out_ident = match #stage_fn(&mut env, #prev) {
                     ::core::result::Result::Ok(__v) => __v,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                         return #on_err;
                     }
                 };
@@ -726,8 +723,7 @@ pub(crate) fn emit_expanded_param(
                     let __v = match #inner_conv(&mut env, &#value_ident) {
                         ::core::result::Result::Ok(__v) => __v,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env);
-                            signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                             return #on_err;
                         }
                     };
@@ -750,8 +746,7 @@ pub(crate) fn emit_expanded_param(
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
             prelude.push(quote!(
                 if #wire_ident == 0 || (#wire_ident & 1) == 1 {
-                    let __zd = __ze_defaults(&mut env);
-                    signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some("Operation on a closed native handle."), &__zd);
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
                     return #on_err;
                 }
                 let #local: #leaf_ty = unsafe {
@@ -783,7 +778,7 @@ pub(crate) fn emit_expanded_param(
                 let #local = match #decode_call {
                     ::core::result::Result::Ok(__v) => __v,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                         return #on_err;
                     }
                 };
@@ -794,7 +789,7 @@ pub(crate) fn emit_expanded_param(
                 let #stage0 = match #decode_call {
                     ::core::result::Result::Ok(__v) => __v,
                     ::core::result::Result::Err(__e) => {
-                        let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                         return #on_err;
                     }
                 };
@@ -812,7 +807,7 @@ pub(crate) fn emit_expanded_param(
                     let #out_ident = match #stage_fn(&mut env, #prev) {
                         ::core::result::Result::Ok(__v) => __v,
                         ::core::result::Result::Err(__e) => {
-                            let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__e.to_string()), &__zd);
+                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
                             return #on_err;
                         }
                     };
@@ -836,7 +831,7 @@ pub(crate) fn emit_expanded_param(
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
                 let __je = <__JniErr as ::core::convert::From<::std::string::String>>::from(__e);
-                let __zd = __ze_defaults(&mut env); signal_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, ::core::option::Option::Some(&__je.to_string()), &__zd);
+                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__je.to_string());
                 return #on_err;
             }
         };

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -27,14 +27,15 @@ pub(crate) struct JniFunctionPlan {
     /// The spec-escaped JNI export symbol (`Java_<pkg>_<JNINative>_<method>`,
     /// see `symbol`, #86), derived from [`Self::jni_method`].
     pub native_symbol: String,
-    /// The onError sink interface — the typed `<Err>Handler` when an error
-    /// plan exists, the global `JniErrorHandler` otherwise. Shared from the
-    /// [`JniGen::iface_spec`] memo: one derivation feeds the Rust `__SINK_*`
-    /// statics, the Kotlin `onError` wiring, and the interface declaration,
-    /// so the FQN/descriptor pair of the cached `run` lookup cannot drift.
-    /// `None` = underivable (the Rust emitter panics, the Kotlin renderer
-    /// skips).
-    pub onerror_iface: Option<Arc<IfaceSpec>>,
+    /// The onError handler interfaces — the always-present binding
+    /// `JniErrorHandler` plus, for a fallible function, its typed domain
+    /// `<Err>Handler` (see [`ErrorIfaces`]). Shared from the
+    /// [`JniGen::iface_spec`] memo: one derivation per channel feeds the Rust
+    /// `__SINK_*` statics, the Kotlin sink wiring, and the interface
+    /// declarations, so the FQN/descriptor pairs of the cached `run` lookups
+    /// cannot drift. `None` = the domain channel is underivable (the Rust
+    /// emitter panics, the Kotlin renderer skips).
+    pub onerror_iface: Option<ErrorIfaces>,
     pub params: Vec<PlanParam>,
     pub output: FnOutputPlan,
 }

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -277,17 +277,17 @@ impl IfaceSpec {
     /// Safe to reuse per thread: the error sink is invoked **synchronously**
     /// inside the extern on the calling thread (never the async daemon-callback
     /// thread, which has its own thread-local), and the wrapper reads the slots
-    /// into the `onError` arguments *before* any re-entrant call. Assumes the
-    /// error-handler shape: `params[0]` is `je: String?`, the rest are `ze`.
+    /// into the handler arguments *before* any re-entrant call. Slots are
+    /// uniform — one nullable `ze{i}` per interface param, no special leading
+    /// `je` — so the binding `JniErrorHandler` (single `je` param → `ze0`) and a
+    /// typed domain `<Src>Handler` (the decomposed leaves) share one shape.
     pub fn to_capture_decl(&self) -> kt::KtDecl {
         let cap = self.capture_name();
         let raw = self.raw_name();
-        let n_ze = self.params.len() - 1;
+        let n_ze = self.params.len();
 
-        let mut fields = kt::Code::new()
-            .line("@JvmField var failed: Boolean = false")
-            .line("@JvmField var je: String? = null");
-        for (i, p) in self.params[1..].iter().enumerate() {
+        let mut fields = kt::Code::new().line("@JvmField var failed: Boolean = false");
+        for (i, p) in self.params.iter().enumerate() {
             // The slot is nullable (null until the capture fires).
             let ty = p.raw.clone().nullable();
             fields = fields.line(format!("@JvmField var ze{i}: {ty} = null"));
@@ -299,12 +299,12 @@ impl IfaceSpec {
             .map(|p| format!("{}: {}", p.name, p.raw))
             .collect::<Vec<_>>()
             .join(", ");
-        let mut run_body = String::from("failed = true; this.je = je");
-        for (i, p) in self.params[1..].iter().enumerate() {
+        let mut run_body = String::from("failed = true");
+        for (i, p) in self.params.iter().enumerate() {
             run_body.push_str(&format!("; this.ze{i} = {}", p.name));
         }
 
-        let mut reset = String::from("c.failed = false; c.je = null");
+        let mut reset = String::from("c.failed = false");
         for i in 0..n_ze {
             reset.push_str(&format!("; c.ze{i} = null"));
         }
@@ -1207,25 +1207,21 @@ pub(crate) fn fixed_folder_typed_groups(
     ])
 }
 
-/// Interface for a fallible function's **onError** handler: `run(je: String?,
-/// ze-leaves…): R`, `<out R>`. The `ze` leaves are typed EXACTLY like a
-/// builder's for the same decomposition — the error channel IS the output
-/// channel with a fixed leading `je`. Contract: `je != null` ⇒ binding/system
-/// error, the ze carry **default values** (0 / "" / empty / closed handle /
-/// null for plan-nullable leaves); `je == null` ⇒ domain error, the ze carry
-/// the decomposed error. Keyed by the error type's deconstructor declaration.
-/// Named `<decl-base>Handler`, placed in the error type's package.
+/// Interface for a fallible function's **domain** onError handler:
+/// `run(ze-leaves…): R`, `<out R>`. The `ze` leaves are typed EXACTLY like a
+/// builder's for the same decomposition — the domain-error channel IS the
+/// output channel. This handler is called ONLY on a domain error (`Err(E)`);
+/// binding/system failures go to the separate [`jni_error_handler_iface_spec`]
+/// (`JniErrorHandler`) channel, so there is no discriminator and no defaults.
+/// Keyed by the error type's deconstructor declaration. Named
+/// `<decl-base>Handler`, placed in the error type's package.
 pub(crate) fn error_handler_iface_spec(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans.get(decon)?;
-    let mut params: Vec<IfaceParam> = vec![IfaceParam::same(
-        "je".to_string(),
-        kt::KtType::string().nullable(),
-    )];
-    params.extend(plan_leaf_params(ext, registry, &spec.leaves)?);
+    let params: Vec<IfaceParam> = plan_leaf_params(ext, registry, &spec.leaves)?;
     let name = format!(
         "{}Handler",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1240,11 +1236,11 @@ pub(crate) fn error_handler_iface_spec(
         kt::KtType::var_r(),
     );
     iface.kdoc = Some(format!(
-        "Error callback. Contract: `je != null` ⇒ a binding/system-tier failure — `je` is\n\
-         its message and the remaining parameters carry defaults; `je == null` ⇒ a domain\n\
-         error — the remaining parameters carry the decomposed `{source_short}`. The\n\
-         wrapper returns whatever `run` returns; throwing from `run` is safe (it executes\n\
-         after the native call has returned)."
+        "Domain-error callback: called only when the native function returns `Err` — the\n\
+         parameters carry the decomposed `{source_short}`. Binding/system failures go to the\n\
+         separate `onBindingError` (`JniErrorHandler`) channel instead, so there is no `je`\n\
+         discriminator here. The wrapper returns whatever `run` returns;\n\
+         throwing from `run` is safe (it executes after the native call has returned)."
     ));
     Some(iface)
 }
@@ -1265,31 +1261,51 @@ pub(crate) fn jni_error_handler_iface_spec(ext: &JniGen) -> IfaceSpec {
         kt::KtType::var_r(),
     );
     iface.kdoc = Some(
-        "Error callback for wrappers without a declared error type. `je` is the\n\
-         binding/system failure message (any converter in the chain may fail). The\n\
-         wrapper returns whatever `run` returns; throwing from `run` is safe (it\n\
-         executes after the native call has returned)."
+        "Binding-error callback — every wrapper's binding/system failure channel (any\n\
+         converter in the chain may fail, or a handle may be closed). `je` is the\n\
+         failure message. For an infallible wrapper this is the sole `onError`; a\n\
+         fallible wrapper takes it as `onBindingError` alongside the typed domain\n\
+         handler. The wrapper returns whatever `run` returns;\n\
+         throwing from `run` is safe (it executes after the native call has returned)."
             .to_string(),
     );
     iface
 }
 
-/// The onError handler spec for a declared function: its error plan's
-/// declaration-keyed typed handler, or the shared global
-/// `JniErrorHandler`. Thin KEY dispatch into the [`JniGen::iface_spec`]
-/// memo.
+/// The two onError handler interfaces for a declared function. A function has
+/// two independent error channels: a binding/system failure (any converter in
+/// the chain, a closed handle, …) and — for a `Result<_, E>` function — a
+/// domain error (`Err(E)`). Each is delivered to its own SAM handler, so
+/// neither carries a discriminator or fabricated defaults.
+pub(crate) struct ErrorIfaces {
+    /// Binding/system-failure channel — always the base `JniErrorHandler`.
+    pub binding: std::sync::Arc<IfaceSpec>,
+    /// Domain-error channel — the typed `<Src>Handler` (no `je`); `Some` iff
+    /// the function has a declared error plan (returns `Result<_, E>`).
+    pub domain: Option<std::sync::Arc<IfaceSpec>>,
+}
+
+/// The onError handler interfaces for a declared function — the always-present
+/// binding `JniErrorHandler` plus, for a fallible function, its
+/// declaration-keyed typed domain `<Src>Handler`. Thin KEY dispatch into the
+/// [`JniGen::iface_spec`] memo. `None` = the domain handler is underivable
+/// (the Rust emitter panics, the Kotlin renderer skips) — the binding channel
+/// alone always derives.
 pub(crate) fn onerror_iface_spec(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     fn_ident: &syn::Ident,
-) -> Option<std::sync::Arc<IfaceSpec>> {
-    let key = match registry.error_plans.get(fn_ident) {
-        Some(plan) => SpecKey::Handler(
-            plan.decon
+) -> Option<ErrorIfaces> {
+    let binding = ext.iface_spec(registry, &SpecKey::JniErrorHandler)?;
+    let domain = match registry.error_plans.get(fn_ident) {
+        Some(plan) => {
+            let decon = plan
+                .decon
                 .clone()
-                .expect("error plans are always record-built (decon is Some)"),
-        ),
-        None => SpecKey::JniErrorHandler,
+                .expect("error plans are always record-built (decon is Some)");
+            Some(ext.iface_spec(registry, &SpecKey::Handler(decon))?)
+        }
+        None => None,
     };
-    ext.iface_spec(registry, &key)
+    Some(ErrorIfaces { binding, domain })
 }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -541,9 +541,14 @@ pub(crate) fn render_extern_decl(
             params.push(kt::KtParam::new("build", kt::KtType::any()));
         }
     }
-    // Trailing error-sink callback — every extern accepts one. `Any` wire
-    // (JObject); the wrapper passes an `ErrorSink` instance.
+    // Trailing error-sink callbacks — the binding channel (`errorSink`) always,
+    // then the typed domain channel (`domainSink`) for a fallible-typed fn. Both
+    // erased to `Any` (JObject) on the wire; the wrapper passes a capture for
+    // each. A domain plan ⇒ `error_plans` has this fn.
     params.push(kt::KtParam::new("errorSink", kt::KtType::any()));
+    if registry.error_plans.contains_key(&f.sig.ident) {
+        params.push(kt::KtParam::new("domainSink", kt::KtType::any()));
+    }
 
     let wire_return: Option<kt::KtType> = match &fplan.output {
         FnOutputPlan::Unfold(_) => Some(kt::KtType::any().nullable()),
@@ -759,7 +764,7 @@ pub(crate) fn build_wrapper_surface(
         classify_params(ext, &fplan, registry, &mut body_imports, receiver_key)?;
     let out = classify_output(ext, f, &fplan, registry, &mut body_imports)?;
     let r_ty = out.kt_return.clone().unwrap_or_else(kt::KtType::unit);
-    let sink = error_sink_parts(ext, f, &fplan, registry, &mut body_imports, &r_ty)?;
+    let sink = error_sink_parts(f, &fplan, registry, &mut body_imports, &r_ty)?;
 
     let mut fun = kt::KtFun::new(&kt_name).vis(kt::Vis::Public);
     if let Some(g) = &out.generic {
@@ -772,24 +777,35 @@ pub(crate) fn build_wrapper_surface(
         }
         fun = fun.param(kt::KtParam::new(&p.kt_name, p.kt_type.clone()));
     }
-    // The error callback — **required**: the generated code never throws; the
+    // The error callbacks — **required**: the generated code never throws; the
     // consumer decides how a failure surfaces (e.g. by throwing its own type).
-    // When an output-expansion builder/fold lambda exists, it must remain the
-    // **trailing** lambda (Kotlin trailing-lambda call syntax), so `onError` is
-    // placed *before* it — but *after* any non-lambda `builder_lead` (`acc: A`),
-    // which is passed positionally. Without a builder lambda, `onError` is the
-    // last param.
-    let onerr = kt::KtParam::new("onError", sink.onerr_type.clone());
+    // Every wrapper takes the binding handler; a fallible-typed fn additionally
+    // takes the domain handler, ordered `onBindingError, onError` so the DOMAIN
+    // `onError` is the natural trailing lambda. When an output-expansion
+    // builder/fold lambda exists it must stay the **trailing** lambda, so the
+    // error params go *before* it — but *after* any non-lambda `builder_lead`
+    // (`acc: A`), which is passed positionally.
+    let mut err_params = vec![kt::KtParam::new(
+        &sink.binding_param,
+        sink.binding_type.clone(),
+    )];
+    if let Some(d) = &sink.domain {
+        err_params.push(kt::KtParam::new("onError", d.onerr_type.clone()));
+    }
     if let Some((bp_name, bp_ty)) = &out.builder_param {
         if let Some((lead_name, lead_ty)) = &out.builder_lead {
             fun = fun.param(kt::KtParam::new(lead_name, lead_ty.clone()));
         }
+        for ep in err_params {
+            fun = fun.param(ep);
+        }
         fun = fun
-            .param(onerr)
             .param(kt::KtParam::new(bp_name, bp_ty.clone()))
             .annotation("Suppress(\"UNCHECKED_CAST\")");
     } else {
-        fun = fun.param(onerr);
+        for ep in err_params {
+            fun = fun.param(ep);
+        }
     }
     if let Some(rt) = &out.kt_return {
         fun = fun.returns(rt.clone());
@@ -830,7 +846,7 @@ pub(crate) fn render_wrapper_fn(
     // synchronized blocks around them.
     let opaques = collect_opaques(&params);
     let is_unit = fun.ret.is_none();
-    let body_expr = build_native_call(ext, &jni_call, &params, &out);
+    let body_expr = build_native_call(ext, &jni_call, &params, &out, &sink);
     // `render_body` extends `body_imports` with the body's own references; all
     // of them are attached to the body `Code`, so the emitted `KtFun` carries
     // its own imports (signature imports ride the FQN types via the render-time
@@ -1002,16 +1018,35 @@ struct OutputPlan {
     is_option_enum_return: bool,
 }
 
-/// The `onError` wiring: the handler's Kotlin type, the capture holder, and
-/// the two prebuilt argument lists (post-call redispatch / pre-lock guard).
+/// The error-callback wiring for a wrapper. Every wrapper has a **binding**
+/// channel (`JniErrorHandler`, any marshalling/closed-handle failure); a
+/// fallible function with a declared error type additionally has a **domain**
+/// channel (the typed `<Src>Handler`, the decomposed `Err(E)`). Each is a
+/// separate handler param + per-thread capture, so neither carries a `je`
+/// discriminator or fabricated defaults.
 struct ErrorSink {
+    /// Kotlin param name of the binding handler: `"onBindingError"` when a
+    /// domain channel is also present, else `"onError"` (the sole channel).
+    binding_param: String,
+    /// The binding handler's Kotlin type — always `JniErrorHandler<R>`.
+    binding_type: kt::KtType,
+    /// Short name of the base per-thread capture (`JniErrorHandlerCapture`).
+    binding_capture_short: String,
+    /// The single redispatch arg for `<binding_param>.run(...)` — the captured
+    /// message slot (`__bcap.ze0`).
+    binding_call_arg: String,
+    /// The domain channel, present only for a fallible fn with a typed error.
+    domain: Option<DomainSink>,
+}
+
+/// The typed domain-error channel: the `onError` handler, its raw capture, and
+/// the wrapped leaf args for the post-call redispatch (no `je`).
+struct DomainSink {
     onerr_type: kt::KtType,
     /// Short name of the generated per-thread raw capture holder.
     capture_short: String,
-    /// je/ze args for the post-call `onError.run(...)` redispatch.
+    /// Wrapped ze-leaf args for the post-call `onError.run(...)` redispatch.
     call_args: String,
-    /// Wrapped-default args for the pre-lock closed-handle guard.
-    guard_args: String,
 }
 
 /// Type every effective input of the lowered [`JniFunctionPlan`] into a
@@ -1351,7 +1386,13 @@ fn classify_output(
 /// arg (or several, for a flattened data_class); the output plan's extra args
 /// and the trailing `__cap` follow; the result is wrapped per the return
 /// classification (projection / enum / erased-`Any` cast).
-fn build_native_call(ext: &JniGen, jni_call: &str, params: &[Param], out: &OutputPlan) -> String {
+fn build_native_call(
+    ext: &JniGen,
+    jni_call: &str,
+    params: &[Param],
+    out: &OutputPlan,
+    sink: &ErrorSink,
+) -> String {
     let mut args: Vec<String> = Vec::with_capacity(params.len());
     for p in params.iter() {
         // Flattened data_class param expands into multiple call args
@@ -1423,11 +1464,14 @@ fn build_native_call(ext: &JniGen, jni_call: &str, params: &[Param], out: &Outpu
     // Output expansion: the builder / (acc, fold) cross just before the
     // error callback.
     args.extend(out.unfold_call_args.iter().cloned());
-    // Every extern takes a trailing error callback. The wrapper passes a
-    // **capture** (`__cap`) that records `(je, ze…)` and sets a flag — no
-    // throw on the Rust upcall. The wrapper calls the user's `onError` after
-    // the native call returns (see the body below).
-    args.push("__cap".to_string());
+    // Trailing error-sink captures: `__bcap` (binding) always, then `__dcap`
+    // (typed domain error) for a fallible-typed fn — each records its channel's
+    // args and sets a flag (no throw on the Rust upcall). The wrapper reads them
+    // after the native call returns (see the body below).
+    args.push("__bcap".to_string());
+    if sink.domain.is_some() {
+        args.push("__dcap".to_string());
+    }
     let mut call = format!(
         "{}.{jni_call}({})",
         ext.jni_native_class_name(),
@@ -1512,95 +1556,97 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
         .collect()
 }
 
-/// Error callback `onError: <Err>Handler<R>` / `JniErrorHandler<R>` — a
-/// generated typed fun interface `run(je: String?, ze…): R` whose ze params
-/// are typed EXACTLY like a builder's leaves (the error channel is the
-/// output channel with a fixed leading `je`). Contract: `je != null` ⇒
-/// binding/system error, the native side fills the ze with defaults;
-/// `je == null` ⇒ domain error, the ze carry the decomposed error. The
-/// wrapper passes a SAM **capture** to the extern, then — after the native
-/// call — calls `onError.run(je, ze…)` and returns its `R` if a failure
-/// was recorded (no throw on the Rust upcall).
+/// Error-callback wiring — the two independent channels ([`ErrorSink`]). The
+/// **binding** handler `JniErrorHandler<R>.run(je: String?)` is always present
+/// (its captured message slot is `__bcap.ze0`, since the capture is uniform).
+/// A fallible fn with a typed error also gets the **domain** handler
+/// `<Src>Handler<R>.run(ze…)` — no `je`, called only on `Err(E)`. Each is a
+/// separate SAM param; the wrapper passes a per-thread capture to the extern,
+/// then after the native call redispatches to whichever channel fired.
 fn error_sink_parts(
-    ext: &JniGen,
     f: &syn::ItemFn,
     fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     r_ty: &kt::KtType,
 ) -> Option<ErrorSink> {
-    let sink_spec = fplan.onerror_iface.as_ref()?;
-    let error_plan = registry.error_plans.get(&f.sig.ident);
-    // Per ze leaf: (raw capture Kotlin type, raw default literal, raw→typed
-    // wrap) — off the handler interface spec (its first param is the fixed
-    // `je`), defaults from the matching error-plan leaf (same declaration,
-    // same order). The CAPTURE is the raw twin (what the native side calls);
-    // the user's handler is the TYPED interface — the redispatch wraps.
-    let ze_info: Vec<(kt::KtType, String, crate::api::lang::jnigen::jni::WrapKind)> = sink_spec
-        .params[1..]
-        .iter()
-        .enumerate()
-        .map(|(i, p)| {
-            let leaf = error_plan
-                .map(|pl| &pl.leaves[i])
-                .expect("ze params exist only with an error plan");
-            let default =
-                ze_default_kotlin(&leaf_default(ext, registry, leaf), p.raw.is_nullable());
-            if let Some(fqn) = p.wrap.class_fqn() {
-                imports.insert(fqn.to_string());
-            }
-            (p.raw.clone(), default, p.wrap.clone())
+    let ifaces = fplan.onerror_iface.as_ref()?;
+    let binding_spec = &ifaces.binding;
+    let binding_type = binding_spec.kt_ref(vec![r_ty.clone()]);
+    imports.insert(binding_spec.capture_fqn());
+    let binding_capture_short = binding_spec.capture_name();
+
+    // The typed domain channel exists only for a fallible fn with an error
+    // plan; when present, both the interface spec and the error plan are.
+    let domain = if let Some(domain_spec) = &ifaces.domain {
+        let error_plan = registry
+            .error_plans
+            .get(&f.sig.ident)
+            .expect("domain handler ⇒ error plan");
+        // Per ze leaf: (raw capture Kotlin type, raw→typed wrap). The CAPTURE
+        // is the raw twin (what the native side calls); the user's handler is
+        // the TYPED interface — the redispatch wraps each raw slot.
+        let ze_info: Vec<(kt::KtType, crate::api::lang::jnigen::jni::WrapKind)> = domain_spec
+            .params
+            .iter()
+            .map(|p| {
+                if let Some(fqn) = p.wrap.class_fqn() {
+                    imports.insert(fqn.to_string());
+                }
+                (p.raw.clone(), p.wrap.clone())
+            })
+            .collect();
+        debug_assert_eq!(ze_info.len(), error_plan.leaves.len());
+        imports.insert(domain_spec.capture_fqn());
+        // The domain redispatch args — the decomposed leaves only (no `je`).
+        // The native side always fills the raw ze on `Err`, so non-null slots
+        // are asserted `!!` then wrapped raw → typed.
+        let call_args = ze_info
+            .iter()
+            .enumerate()
+            .map(|(i, (raw, wrap))| {
+                if raw.is_nullable() {
+                    wrap.wrap_expr(&format!("__dcap.ze{i}"), true)
+                } else {
+                    wrap.wrap_expr(&format!("__dcap.ze{i}!!"), false)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(DomainSink {
+            onerr_type: domain_spec.kt_ref(vec![r_ty.clone()]),
+            capture_short: domain_spec.capture_name(),
+            call_args,
         })
-        .collect();
-    let n_ze = ze_info.len();
-    let onerr_type = sink_spec.kt_ref(vec![r_ty.clone()]);
-    // The capture is a generated zero-alloc thread-local holder of the RAW
-    // twin (no SAM lambda, no `Ref`-boxed captured vars) — its short name in
-    // raw body text needs the import registered.
-    imports.insert(sink_spec.capture_fqn());
-    let capture_short = sink_spec.capture_name();
-    // The je/ze argument list to call the user's typed `onError.run`. The
-    // native side ALWAYS fills the raw ze (real values or defaults), so the
-    // nullable capture slots are non-null whenever `__cap_failed` — assert
-    // with `!!` for non-null params, then wrap raw → typed.
-    let call_args = std::iter::once("__cap.je".to_string())
-        .chain((0..n_ze).map(|i| {
-            let (raw, _, wrap) = &ze_info[i];
-            if raw.is_nullable() {
-                wrap.wrap_expr(&format!("__cap.ze{i}"), true)
-            } else {
-                wrap.wrap_expr(&format!("__cap.ze{i}!!"), false)
-            }
-        }))
-        .collect::<Vec<_>>()
-        .join(", ");
-    // Default-ze args for a synchronous (pre-call) closed-handle guard, which
-    // calls the typed `onError.run` directly (a binding-class error ⇒ wrapped
-    // raw defaults: `ZErr(0L)`, `ZId(ByteArray(0))`, …).
-    let guard_args = std::iter::once("\"Operation on a closed native handle.\"".to_string())
-        .chain(ze_info.iter().map(|(raw, def, wrap)| {
-            if raw.is_nullable() {
-                "null".to_string()
-            } else {
-                wrap.wrap_expr(def, false)
-            }
-        }))
-        .collect::<Vec<_>>()
-        .join(", ");
+    } else {
+        None
+    };
+
+    // When there is a domain channel, the binding handler is named
+    // `onBindingError` and the domain one is `onError`; otherwise the binding
+    // handler is the sole `onError`.
+    let binding_param = if domain.is_some() {
+        "onBindingError".to_string()
+    } else {
+        "onError".to_string()
+    };
     Some(ErrorSink {
-        onerr_type,
-        capture_short,
-        call_args,
-        guard_args,
+        binding_param,
+        binding_type,
+        binding_capture_short,
+        binding_call_arg: "__bcap.ze0".to_string(),
+        domain,
     })
 }
 
 /// Pre-lock closed-handle guards: a racy-but-safe `isClosed()` check before
-/// the lock, returning `onError.run(...)` (function-level return; no throw).
-/// Racy: a close between this check and the native call is caught by the
-/// Rust-side converter guard (the tag bit survives the race), which routes
-/// through the same error channel.
-fn render_prelock_guards(opaques: &[Opaque], guard_args: &str, is_unit: bool) -> kt::Code {
+/// the lock. A closed handle is a **binding** failure, so it routes to
+/// `<binding_param>.run("Operation on a closed native handle.")` (function-level
+/// return; no throw). Racy: a close between this check and the native call is
+/// caught by the Rust-side converter guard (the tag bit survives the race),
+/// which routes through the same binding channel.
+fn render_prelock_guards(opaques: &[Opaque], binding_param: &str, is_unit: bool) -> kt::Code {
+    const CLOSED_MSG: &str = "\"Operation on a closed native handle.\"";
     let mut guards = kt::Code::new();
     for o in opaques {
         let cond = if o.nullable {
@@ -1610,10 +1656,12 @@ fn render_prelock_guards(opaques: &[Opaque], guard_args: &str, is_unit: bool) ->
         };
         guards = if is_unit {
             guards.wline(format!(
-                "if ({cond}) {{ onError.run({guard_args}); return }}"
+                "if ({cond}) {{ {binding_param}.run({CLOSED_MSG}); return }}"
             ))
         } else {
-            guards.wline(format!("if ({cond}) return onError.run({guard_args})"))
+            guards.wline(format!(
+                "if ({cond}) return {binding_param}.run({CLOSED_MSG})"
+            ))
         };
     }
     guards
@@ -1765,14 +1813,31 @@ fn render_body(
     // The capture is a per-thread reusable holder (zero allocation): the
     // extern writes its `@JvmField` slots via `run`, the wrapper reads
     // them after the (synchronous) call. `acquire()` resets the slots.
-    let mut b = render_prelock_guards(opaques, &sink.guard_args, is_unit)
-        .line(format!("val __cap = {}.acquire()", sink.capture_short));
-    let failed_check = format!("if (__cap.failed) return onError.run({})", sink.call_args);
+    let mut b = render_prelock_guards(opaques, &sink.binding_param, is_unit).line(format!(
+        "val __bcap = {}.acquire()",
+        sink.binding_capture_short
+    ));
+    if let Some(d) = &sink.domain {
+        b = b.line(format!("val __dcap = {}.acquire()", d.capture_short));
+    }
+    // Post-call redispatch: at most one channel fires (the extern signals
+    // binding OR domain, then returns), so check binding first, then domain.
+    let mut failed_checks: Vec<String> = vec![format!(
+        "if (__bcap.failed) return {}.run({})",
+        sink.binding_param, sink.binding_call_arg
+    )];
+    if let Some(d) = &sink.domain {
+        failed_checks.push(format!(
+            "if (__dcap.failed) return onError.run({})",
+            d.call_args
+        ));
+    }
     let bind = if is_unit { "" } else { "val __ret = " };
     if vec_build.is_empty() {
-        b = b
-            .push(render_core_stmt(ext, opaques, body_expr, imports, bind))
-            .wline(failed_check);
+        b = b.push(render_core_stmt(ext, opaques, body_expr, imports, bind));
+        for chk in &failed_checks {
+            b = b.wline(chk);
+        }
     } else {
         let native = ext.jni_native_class_name();
         for (name, base, _) in &vec_build {
@@ -1800,9 +1865,10 @@ fn render_body(
             free = free.wline(format!("{native}.{free_m}(__vec_{name})"));
         }
         let core = render_core_stmt(ext, opaques, body_expr, imports, "");
-        b = b
-            .try_finally(bind, fill.push(core), free)
-            .wline(failed_check);
+        b = b.try_finally(bind, fill.push(core), free);
+        for chk in &failed_checks {
+            b = b.wline(chk);
+        }
     }
     if !is_unit {
         b = b.line("return __ret");
@@ -1915,25 +1981,6 @@ pub(crate) fn whole_value_name(ty: &syn::Type, i: usize) -> String {
         }
     }
     format!("arg{i}")
-}
-
-/// The Kotlin default literal for an error `ze` leaf, used when the
-/// **wrapper itself** raises a binding-class error before the native call
-/// (the pre-lock closed-handle guard) and must call `onError.run` with
-/// builder-typed ze params. Rendered from the shared [`leaf_default`]
-/// classification — the same one the native `__ze_defaults` jvalues use —
-/// so the two sides cannot drift. The [`LeafDefault::Null`] arm renders
-/// `null` (valid for plan-nullable params; an unknown non-null object kind
-/// gets a `null!!` assertion — no constructible default exists for it).
-fn ze_default_kotlin(d: &LeafDefault, kt_nullable: bool) -> String {
-    match d {
-        LeafDefault::Null if kt_nullable => "null".to_string(),
-        LeafDefault::Null => "null!!".to_string(),
-        LeafDefault::Prim(p) => p.kotlin_zero().to_string(),
-        LeafDefault::Str => "\"\"".to_string(),
-        LeafDefault::Bytes => "ByteArray(0)".to_string(),
-        LeafDefault::List => "emptyList()".to_string(),
-    }
 }
 
 /// Fall-back Kotlin type derived directly from the JNI wire type.
@@ -2141,8 +2188,8 @@ fn shape_notes(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<Strin
         let source = plan.source.to_token_stream().to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         notes.push(format!(
-            "On failure `onError` receives `je` plus the decomposed Rust `{source}` \
-             error (`{}`).",
+            "On a domain error `onError` receives the decomposed Rust `{source}` error \
+             (`{}`); a binding/system failure goes to `onBindingError` instead.",
             leaves.join("`, `")
         ));
     }

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -224,7 +224,7 @@ impl crate::api::core::Generation<JniGen> {
         if let Some(plan) = registry.error_plans.get(rust_ident) {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
-                "error `{}` decomposed → [je, {}]",
+                "domain error `{}` decomposed → onError [{}] (binding failures → onBindingError)",
                 plan.source.to_token_stream(),
                 leaves.join(", ")
             ));

--- a/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
@@ -533,7 +533,7 @@ fn cross_artifact_optional_iterable_fold_agrees() {
         "optional fold wrapper surface (returns A?, null = None):\n{wrappers}"
     );
     assert!(
-        kc.contains("JNINative.zThingsMaybe(acc,fold.asRaw(),__cap)asA?"),
+        kc.contains("JNINative.zThingsMaybe(acc,fold.asRaw(),__bcap)asA?"),
         "optional fold call site casts the erased result to A?:\n{wrappers}"
     );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -93,12 +93,13 @@ fn inline_output_gets_own_builder() {
     assert!(all.contains("build:ZThingZMakeBBuilder<R>"), "{all}");
 }
 
-/// Error decomposition is the OUTPUT decomposition with a fixed leading `je`:
-/// the same record kinds work — an identity record (the error itself as an
-/// owned handle), plain accessors, and accessors nested through `Option`
-/// (spliced child decomposition, nullable leaves). The ze params are typed
-/// exactly like a builder's; on a binding error the native side fills typed
-/// defaults (closed handle, "", null for nullable).
+/// Domain-error decomposition is the OUTPUT decomposition (issue #45 split off
+/// the binding channel, so there is no leading `je`): the same record kinds
+/// work — an identity record (the error itself as an owned handle), plain
+/// accessors, and accessors nested through `Option` (spliced child
+/// decomposition, nullable leaves). The ze params are typed exactly like a
+/// builder's; a binding/system failure goes to the separate `onBindingError`
+/// (`JniErrorHandler`) channel, so there are no fabricated defaults.
 #[test]
 fn error_unwrap_universal_records() {
     let loc = myflat_loc();
@@ -148,27 +149,27 @@ fn error_unwrap_universal_records() {
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
-    // Handler descriptor: typed handle class, non-null String, BOXED nullable
-    // Integer for the Option-nested code — exactly the builder typing.
+    // Domain handler descriptor (`__DSINK_DESCR`): typed handle jlong, non-null
+    // String, BOXED nullable Integer for the Option-nested code — exactly the
+    // builder typing, with NO leading `je` String (that is the binding channel).
     assert!(
-        rc.contains(
-            "\"(Ljava/lang/String;JLjava/lang/String;Ljava/lang/Integer;)Ljava/lang/Object;\""
-        ),
+        rc.contains("\"(JLjava/lang/String;Ljava/lang/Integer;)Ljava/lang/Object;\""),
+        "{rust}"
+    );
+    // Binding channel descriptor (`__SINK_DESCR`): the base `JniErrorHandler`.
+    assert!(
+        rc.contains("\"(Ljava/lang/String;)Ljava/lang/Object;\""),
         "{rust}"
     );
     // Domain-error arm: the SAME shared leaf encoder — owned identity moves
     // the error into a boxed handle, the nested Option accessor unwraps via
-    // a match.
+    // a match — delivered through `signal_domain_error` (no `je`, no defaults).
     assert!(rc.contains("std::boxed::Box::new(__de)"), "{rust}");
     assert!(rc.contains("matchmyflat::z_err_detail(&__de)"), "{rust}");
-    // Binding-error defaults: zeroed jlong for the handle (no native
-    // construction), empty string, null for the nullable leaf — built lazily
-    // in the __ze_defaults closure.
-    assert!(
-        !rc.contains("env.new_object(\"io/test/jni/errors/ZErr\""),
-        "{rust}"
-    );
-    assert!(rc.contains("env.new_string(\"\")"), "{rust}");
+    assert!(rc.contains("signal_domain_error("), "{rust}");
+    // No fabricated-defaults machinery — the binding channel carries only a
+    // message string, so there is no `__ze_defaults` closure.
+    assert!(!rc.contains("__ze_defaults"), "{rust}");
 
     let kdir = dir.join("kotlin");
     let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
@@ -179,10 +180,11 @@ fn error_unwrap_universal_records() {
         .join("\n")
         .split_whitespace()
         .collect();
-    // Builder-typed handler interface.
+    // Builder-typed DOMAIN handler interface — no leading `je` (the binding
+    // channel is the separate `JniErrorHandler`).
     assert!(
         all.contains(
-            "funinterfaceZErrHandler<outR>{publicfunrun(je:String?,handle:ZErr,message:String,detail__code:Int?):R"
+            "funinterfaceZErrHandler<outR>{publicfunrun(handle:ZErr,message:String,detail__code:Int?):R"
         ),
         "{all}"
     );
@@ -190,22 +192,32 @@ fn error_unwrap_universal_records() {
     // on redispatch.
     assert!(
         all.contains(
-            "funinterfaceZErrHandlerRaw<outR>{publicfunrun(je:String?,handle:Long,message:String,detail__code:Int?):R"
+            "funinterfaceZErrHandlerRaw<outR>{publicfunrun(handle:Long,message:String,detail__code:Int?):R"
         ),
         "{all}"
     );
+    // The fallible wrapper takes BOTH channels; the domain redispatch wraps the
+    // captured leaves (no `je`), the binding one forwards its single message.
     assert!(
-        all.contains("returnonError.run(__cap.je,ZErr(__cap.ze0!!),__cap.ze1!!,__cap.ze2)"),
+        all.contains("returnonError.run(ZErr(__dcap.ze0!!),__dcap.ze1!!,__dcap.ze2)"),
         "{all}"
     );
-    // Zero-alloc thread-local capture holder generated for the error handler
-    // (no per-call SAM lambda / Ref-boxed vars); the wrapper uses acquire().
+    assert!(
+        all.contains("if(__bcap.failed)returnonBindingError.run(__bcap.ze0)"),
+        "{all}"
+    );
+    // Zero-alloc thread-local capture holders for BOTH channels (no per-call SAM
+    // lambda / Ref-boxed vars); the wrapper uses acquire() on each.
     assert!(
         all.contains("internalclassZErrHandlerRawCapture:ZErrHandlerRaw<Unit>"),
         "{all}"
     );
     assert!(
-        all.contains("val__cap=ZErrHandlerRawCapture.acquire()"),
+        all.contains("val__dcap=ZErrHandlerRawCapture.acquire()"),
+        "{all}"
+    );
+    assert!(
+        all.contains("val__bcap=JniErrorHandlerCapture.acquire()"),
         "{all}"
     );
     assert!(all.contains("ThreadLocal.withInitial"), "{all}");
@@ -336,10 +348,10 @@ fn rust_side_only_error_type() {
         .join("\n")
         .split_whitespace()
         .collect();
-    // Handler in the BASE package with the decomposed message field; no ZErr
-    // class anywhere.
+    // Domain handler in the BASE package with the decomposed message field (no
+    // leading `je`); no ZErr class anywhere.
     assert!(
-        all.contains("funinterfaceZErrHandler<outR>{publicfunrun(je:String?,message:String):R"),
+        all.contains("funinterfaceZErrHandler<outR>{publicfunrun(message:String):R"),
         "{all}"
     );
     assert!(!all.contains("classZErr("), "{all}");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -96,13 +96,18 @@ fn snapshot_rust_side() {
     assert!(rc.contains("align_of::<myflat::ZThing>()<2"), "{rust}");
     // The freePtr destructor ignores tagged (already-closed) pointers.
     assert!(rc.contains("ifptr!=0&&(ptr&1)==0"), "{rust}");
-    // Errors funnel to the single `signal_error` channel fn (no JVM throw); it
-    // now invokes the error callback with `(je, ze…)`.
-    assert!(rc.contains("fnsignal_error"), "{rust}");
+    // Errors funnel to two channel fns (no JVM throw): `signal_binding_error`
+    // (a marshalling/system failure → the base `JniErrorHandler`) and
+    // `signal_domain_error` (a fallible fn's decomposed `Err(E)` → the typed
+    // handler). `z_thing_new`'s `Error` has no declared decomposition, so its
+    // `Err` stringifies through the BINDING channel — no `__ze_defaults`.
+    assert!(rc.contains("fnsignal_binding_error"), "{rust}");
+    assert!(rc.contains("fnsignal_domain_error"), "{rust}");
     assert!(
-        rc.contains("let__zd=__ze_defaults(&mutenv);signal_error(&mutenv,&__error_sink,&__SINK_MID,__SINK_FQN,__SINK_DESCR,::core::option::Option::Some(&__e.to_string()),&__zd"),
+        rc.contains("signal_binding_error(&mutenv,&__error_sink,&__SINK_MID,__SINK_FQN,__SINK_DESCR,&__e.to_string()"),
         "{rust}"
     );
+    assert!(!rc.contains("__ze_defaults"), "{rust}");
     // The sink's typed handler `run` is resolved once per process via the
     // cached interface-method statics.
     assert!(rc.contains("CachedIfaceMethod"), "{rust}");
@@ -188,11 +193,11 @@ fn snapshot_kotlin_side() {
         "package wrappers: {pkg}"
     );
     assert!(
-        pc.contains("if(__cap.failed)returnonError.run("),
+        pc.contains("if(__bcap.failed)returnonError.run("),
         "package wrappers: {pkg}"
     );
     // Pre-lock closed guards go through `isClosed()` (tag-bit aware), not a
-    // raw `ptr == 0L` compare.
+    // raw `ptr == 0L` compare — a closed handle is a binding failure.
     assert!(pc.contains(".isClosed())returnonError.run("), "{pkg}");
     // `onError` is a **required** parameter (no default) and the wrappers
     // never throw — error surfacing is entirely the caller's business.
@@ -202,12 +207,13 @@ fn snapshot_kotlin_side() {
     );
 }
 
-/// Generated onError handler interfaces carry the `je` contract KDoc: the
-/// typed `<Err>Handler` documents the `je != null` (binding/system, defaults)
-/// vs `je == null` (decomposed domain error) split naming the error type; the
-/// shared `JniErrorHandler` documents `je` as the binding/system message.
+/// Generated onError handler interfaces carry the split-channel contract KDoc:
+/// the typed domain `<Err>Handler` documents that it fires only on `Err(E)`
+/// (naming the decomposed error type) and points binding failures at
+/// `onBindingError`; the shared `JniErrorHandler` documents `je` as the
+/// binding/system message.
 #[test]
-fn handler_interfaces_carry_je_contract_kdoc() {
+fn handler_interfaces_carry_split_contract_kdoc() {
     // The snapshot pipeline has no error plan, so it emits the SHARED handler.
     let (_, kotlin) = snapshot_pipeline();
     let shared = kotlin
@@ -216,14 +222,14 @@ fn handler_interfaces_carry_je_contract_kdoc() {
         .cloned()
         .expect("no generated file declares JniErrorHandler");
     assert!(
-        shared.contains("binding/system failure message"),
+        shared.contains("binding/system failure channel"),
         "{shared}"
     );
     assert!(shared.contains("throwing from `run` is safe"), "{shared}");
 
     // A `Result<_, ZErr>` fn with a declared error decomposition emits the
-    // TYPED handler; its KDoc states the je-null/non-null contract and names
-    // the decomposed error type.
+    // TYPED domain handler; its KDoc states it fires only on a domain error,
+    // names the decomposed error type, and points binding failures elsewhere.
     let loc = myflat_loc();
     let fns: &[&str] = &[
         "pub fn z_err_message(e: &ZErr) -> String { unimplemented!() }",
@@ -253,8 +259,9 @@ fn handler_interfaces_carry_je_contract_kdoc() {
         .filter_map(|p| std::fs::read_to_string(p).ok())
         .find(|v| v.contains("fun interface ZErrHandler<"))
         .expect("no generated file declares ZErrHandler");
-    assert!(typed.contains("`je != null`"), "{typed}");
+    assert!(typed.contains("Domain-error callback"), "{typed}");
     assert!(typed.contains("decomposed `ZErr`"), "{typed}");
+    assert!(typed.contains("onBindingError"), "{typed}");
     assert!(typed.contains("throwing from `run` is safe"), "{typed}");
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -388,49 +388,67 @@ fn is_string_type(ty: &syn::Type) -> bool {
         if tp.path.segments.last().is_some_and(|s| s.ident == "String"))
 }
 
-pub(crate) fn build_signal_error_item() -> syn::Item {
+/// The pending-exception guard shared by both signal helpers: if a JVM
+/// exception is already pending (a Java upcall threw during a converter), let
+/// it propagate untouched — do NOT invoke an error callback over it, and do
+/// not clear/describe it (that would swallow the real exception). The extern
+/// returns its sentinel and the pending exception surfaces when control
+/// returns to the JVM.
+pub(crate) fn build_signal_binding_error_item() -> syn::Item {
     syn::parse_quote!(
         #[allow(non_snake_case, dead_code)]
-        pub(crate) fn signal_error(
+        pub(crate) fn signal_binding_error(
             env: &mut jni::JNIEnv,
             sink: &jni::objects::JObject,
             mid: &::prebindgen::lang::CachedIfaceMethod,
             fqn: &str,
             descr: &str,
-            je: ::core::option::Option<&str>,
-            ze: &[jni::sys::jvalue],
+            je: &str,
         ) {
-            // If a JVM exception is already pending (a Java upcall threw during a
-            // converter), let it propagate untouched — do NOT invoke the error
-            // callback over it (and do not clear/describe it: that would swallow
-            // the real exception). The extern returns its sentinel and the pending
-            // exception surfaces when control returns to the JVM.
             if env.exception_check().unwrap_or(false) {
                 return;
             }
-            // `je` (binding message, `Some` only for a `JniError`) crosses as the
-            // fixed first `String?`; the `ze` library-error leaves follow as
-            // pre-encoded object-slot jvalues — all nullable object params of
-            // the sink's typed `<Err>Handler.run` (`mid`/`fqn`/`descr` are the
-            // per-extern cached interface method).
-            let __je: jni::objects::JObject = match je {
-                ::core::option::Option::Some(__m) => match env.new_string(__m) {
-                    Ok(s) => s.into(),
-                    Err(e) => {
-                        tracing::error!("signal_error: new_string failed: {}", e);
-                        return;
-                    }
-                },
-                ::core::option::Option::None => jni::objects::JObject::null(),
+            // The binding message crosses as the single `String` param of the
+            // `JniErrorHandler.run` (`mid`/`fqn`/`descr` are the per-extern
+            // cached interface method).
+            let __je: jni::objects::JObject = match env.new_string(je) {
+                Ok(s) => s.into(),
+                Err(e) => {
+                    tracing::error!("signal_binding_error: new_string failed: {}", e);
+                    return;
+                }
             };
-            let mut __args: ::std::vec::Vec<jni::sys::jvalue> =
-                ::std::vec::Vec::with_capacity(1 + ze.len());
-            __args.push(jni::sys::jvalue { l: __je.as_raw() });
-            __args.extend_from_slice(ze);
+            let __args = [jni::sys::jvalue { l: __je.as_raw() }];
             // On failure leave any pending exception in place (don't describe/
             // clear it) so it propagates rather than being swallowed.
             if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, &__args) {
-                tracing::error!("signal_error: error-callback invoke failed: {}", e);
+                tracing::error!("signal_binding_error: error-callback invoke failed: {}", e);
+            }
+        }
+    )
+}
+
+/// Invoke a fallible function's typed **domain** error handler
+/// (`<Src>Handler.run(ze…)`) with the pre-encoded decomposed-error leaves.
+/// There is no leading `je` and no defaults — this is called ONLY on `Err(E)`.
+pub(crate) fn build_signal_domain_error_item() -> syn::Item {
+    syn::parse_quote!(
+        #[allow(non_snake_case, dead_code)]
+        pub(crate) fn signal_domain_error(
+            env: &mut jni::JNIEnv,
+            sink: &jni::objects::JObject,
+            mid: &::prebindgen::lang::CachedIfaceMethod,
+            fqn: &str,
+            descr: &str,
+            ze: &[jni::sys::jvalue],
+        ) {
+            if env.exception_check().unwrap_or(false) {
+                return;
+            }
+            // On failure leave any pending exception in place (don't describe/
+            // clear it) so it propagates rather than being swallowed.
+            if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, ze) {
+                tracing::error!("signal_domain_error: error-callback invoke failed: {}", e);
             }
         }
     )
@@ -1238,11 +1256,13 @@ impl Prebindgen for JniGen {
         );
         let mut items = vec![alias];
         items.extend(owned_object_prerequisite_items());
-        // The single `signal_error` channel fn the extern bodies call on any
-        // `Err`. Emitted above the converters so wrapper code references it by
-        // bare name; the binding crate reaches it as
-        // `<include_module>::signal_error` from outside the file.
-        items.push(build_signal_error_item());
+        // The two error-channel fns the extern bodies call: `signal_binding_error`
+        // (binding/system failure → `JniErrorHandler`) and `signal_domain_error`
+        // (a fallible fn's `Err(E)` → the typed `<Src>Handler`). Emitted above the
+        // converters so wrapper code references them by bare name; the binding
+        // crate reaches them as `<include_module>::signal_*` from outside the file.
+        items.push(build_signal_binding_error_item());
+        items.push(build_signal_domain_error_item());
         let _ = registry;
         // Handle destructors — one `extern "C" freePtr<suffix>` per
         // non-suppressed opaque handle (the Rust half of the typed-handle


### PR DESCRIPTION
## Problem (#45)

The generated Kotlin error callback for a fallible function with a declared error type was a single typed `<Src>Handler.run(je: String?, message, ...fields)` where `je == null` discriminated a domain error from a binding/system failure. In the `je != null` path every domain field carried a **fabricated default** (`message == ""`, a *closed* handle instance, empty `ByteArray`, `0`). One nullable string as a two-channel discriminator is fragile — a consumer reading a field without checking `je` silently gets a default — and an entire default-fabrication layer existed only to fill the unused channel.

## The split (two callers)

A fallible-typed wrapper now takes **two** handlers:

```kotlin
public fun storageTryWithLabel(
    label: String,
    onBindingError: JniErrorHandler<Storage>,   // run(je: String?)  — binding/system failure
    onError: StorageErrorHandler<Storage>,       // run(message, handle) — decomposed Err(E), NO je
): Storage

// consumers keep lambdas — onError is the natural trailing lambda:
storageTryWithLabel("x", onBindingError) { message, handle -> ... }
```

- `onBindingError` **reuses the existing** `JniErrorHandler<R>` interface (unchanged).
- `onError` is the typed domain handler with `je` **removed** — called only on `Err(E)`.
- Both stay SAM `fun interface`s, so lambdas work everywhere.

**Blast radius is small:** the base `JniErrorHandler<R>.run(je: String?)` interface is untouched — it remains the sole handler for infallible functions and for bare-`String` `Result` errors (whose `Err` still stringifies through `je`). Only the *typed* handler and the *fallible-with-typed-error* wrapper path change.

## What changed in the generator

- `error_handler_iface_spec` drops the leading `je` param; `onerror_iface_spec` → `ErrorIfaces { binding, domain }`.
- Rust `signal_error` splits into `signal_binding_error(je: &str)` and `signal_domain_error(ze)`; the extern gains a second `__domain_sink` for fallible-typed fns.
- The Kotlin wrapper acquires two captures and dispatches whichever channel fired. The per-thread capture is now **uniform** (`ze0..N`, no special `je` slot), so both handler kinds share one shape.
- **Deletes the fake-defaults machinery** entirely (`leaf_default`, `default_ze_jvalues`, `ze_default_kotlin`, the `__ze_defaults` closure) — net **−733** generated lines.

## Covertest exercise (every-feature rule)

New `storage_try_from_stamp(s: Stamp) -> Result<Storage, StorageError>`: a **malformed `Stamp`** value-blob provokes the BINDING channel while a **rejected `secs`** provokes the DOMAIN channel — one wrapper proves `onBindingError` and `onError` fire independently (each asserts the other does *not*). The existing `storageTryWithLabel` section migrates to the two-handler shape.

## Verification

- `cargo test -p prebindgen --lib` — 272 pass (error-model tests migrated to the two-caller shape).
- `cargo test --all --all-features` — green.
- covertest JVM `./gradlew run` — **32 sections PASS** (was 31; +the two-caller section).
- `regen-check.sh` — committed goldens byte-identical to regeneration.
- fmt (CI config) + clippy `--all-targets --no-default-features --all-features --deny warnings` clean; example-cbindgen aarch64 goldens untouched.

## Migration note (downstream, follow-up)

Scope here is **prebindgen only**; the zenoh repos consume the regenerated output next. A `throwZError` adapter of the form `ErrorHandler { je, message -> throw ZError(je ?: message) }` splits into:

```kotlin
val throwBindingError = JniErrorHandler<Nothing> { je -> throw ZError(je) }
val throwDomainError  = ErrorHandler<Nothing>    { message -> throw ZError(message) }
```

Fallible call sites pass the binding handler positionally before the domain one. The signature-coupled surface is funneled through each SDK's `JNIErrorHandlers.kt` (zenoh-java) / `ResultHandlers.kt` (zenoh-kotlin), so ~125 call sites gain one positional arg but need no per-site rewrite.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)