### PR TITLE
jnigen: accept a CRLF ownership marker (Windows autocrlf)

### DIFF
--- a/prebindgen/src/api/gen/kotlin/file.rs
+++ b/prebindgen/src/api/gen/kotlin/file.rs
@@ -125,6 +125,10 @@ const OWNERSHIP_MARKER_CONTENT: &str = "prebindgen Kotlin output v1\n";
 /// marker. Subsequent writes stage the complete output beside the root before
 /// replacing the marked tree, so stale generated files are removed without
 /// deleting caller-owned files or leaving an old tree half-deleted on failure.
+///
+/// The marker's content is matched ignoring surrounding whitespace and line
+/// endings, so a committed marker checked out with CRLF (git `autocrlf` on
+/// Windows) is still recognized.
 pub fn write_files(files: &[KtFile], kotlin_root: &Path) -> Result<Vec<PathBuf>, WriteKotlinError> {
     let root_state = inspect_root(kotlin_root)?;
     let parent = kotlin_root.parent().unwrap_or_else(|| Path::new("."));
@@ -187,7 +191,11 @@ fn inspect_root(kotlin_root: &Path) -> Result<RootState, WriteKotlinError> {
             kotlin_root.display()
         )));
     }
-    if fs::read_to_string(&marker)? != OWNERSHIP_MARKER_CONTENT {
+    // Compare ignoring surrounding whitespace / line endings: the marker is a
+    // sentinel, and git's `autocrlf` rewrites the committed LF marker to CRLF on
+    // a Windows checkout — an exact-byte compare would then reject the (present,
+    // valid) marker. Trimming still rejects a wrong/foreign/empty marker.
+    if fs::read_to_string(&marker)?.trim() != OWNERSHIP_MARKER_CONTENT.trim() {
         return Err(WriteKotlinError::Other(format!(
             "refusing to replace non-empty Kotlin output root `{}` without a prebindgen ownership marker",
             kotlin_root.display()

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -573,6 +573,33 @@ fn write_files_refuses_nonempty_unowned_root() {
 }
 
 #[test]
+fn write_files_accepts_crlf_marker() {
+    // A committed LF marker is rewritten to CRLF by git's `autocrlf` on a
+    // Windows checkout; the (present, valid) marker must still be recognized so
+    // regeneration succeeds. Simulate that by writing the marker with CRLF.
+    let dir = unique_test_dir("kotlin_crlf_marker");
+    let root = dir.join("generated");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join(".prebindgen-kotlin-output"),
+        "prebindgen Kotlin output v1\r\n",
+    )
+    .unwrap();
+    // A stale generated file from a previous run — must be wiped on rewrite.
+    fs::write(root.join("Stale.kt"), "package stale\n").unwrap();
+
+    let paths = write_files(&[KtFile::new("io.test")], &root)
+        .expect("CRLF marker must be accepted as a prebindgen-owned root");
+    assert!(paths.iter().all(|p| p.exists()));
+    assert!(
+        !root.join("Stale.kt").exists(),
+        "stale file wiped on rewrite"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn write_files_replaces_marked_root_and_preserves_it_on_staging_failure() {
     let dir = unique_test_dir("kotlin_owned_root");
     let root = dir.join("generated");


### PR DESCRIPTION
## Problem

The Kotlin-output ownership marker (`.prebindgen-kotlin-output`) is compared **byte-for-byte** against `"prebindgen Kotlin output v1\n"` (`api/gen/kotlin/file.rs`). A consumer that *commits* the marker — so a fresh checkout is authorized to regenerate (the pattern from zenoh-flat-jni#11) — hits a **Windows-only** failure:

```
error: prebindgen jnigen write_kotlin failed: Kotlin emission error:
refusing to replace non-empty Kotlin output root `...\kotlin\generated`
without a prebindgen ownership marker
```

git's `autocrlf` rewrites the committed LF marker to **CRLF** on a Windows checkout, so the read yields `"...v1\r\n"`, the exact-match rejects the present-and-valid marker, and `write_kotlin` refuses to regenerate — the build fails on Windows while macOS/Linux pass.

## Fix

Match the marker ignoring surrounding whitespace / line endings: `read.trim() != CONTENT.trim()`. The marker is a sentinel — its exact bytes aren't meaningful — so trimming accepts the CRLF checkout (and an accidental trailing blank line) while still rejecting a wrong / foreign / empty / missing marker. The "don't clobber an unowned tree" safety guarantee is unchanged.

## Tests

- New `write_files_accepts_crlf_marker`: a root whose marker is written with **CRLF** is accepted as prebindgen-owned and its stale files wiped on rewrite.
- Existing `write_files_refuses_nonempty_unowned_root` (no marker → still rejected) and jni `write_kotlin_owns_and_resets_the_root` (LF marker, idempotent) stay green.
- 273 lib tests pass; fmt + clippy (`--all-targets --no-default-features --all-features --deny warnings`) clean; no codegen change (goldens unmoved).

Unblocks zenoh-flat-jni's Windows CI (it committed the marker); replaces a downstream `.gitattributes` workaround with the root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)