### PR TITLE
jnigen: support fixed-width unsigned integers

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -53,6 +53,7 @@
 //! | binding-local fn as `.method()` / `.constructor()` | `Summary.mean()` ← `crate::summary_mean` (NO `.name` — derived by the strip hook); `Summary.fromMean` ← `crate::summary_from_mean` (FALLIBLE — sig `Result` → `onError`) |
 //! | `Result<_, E>` → typed domain `onError` | `storage_try_with_label` |
 //! | two-caller split (#45): `onBindingError` + `onError` on one fallible wrapper | `storage_try_from_stamp` (malformed `Stamp` → binding; bad `secs` → domain) |
+//! | fixed-width unsigned scalars (#108) | `Unsigned` + direct/optional/callback/collection max-value round trips |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
 //! | owned-handle callback (`Fn(Storage)`)| `storage_handler_new` / `storage_emit` |
@@ -212,6 +213,9 @@ fn main() {
                 // recursive fromParts / recursive leaf decode) plus Option<prim> and
                 // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
                 .class(data_class!(Annotated))
+                // Fixed-width unsigned mappings: Int / Long widening plus
+                // ULong over a raw jlong bit pattern.
+                .class(data_class!(Unsigned))
                 // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
                 // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
                 // surfaces as `List<ByteArray>`.
@@ -380,7 +384,11 @@ fn main() {
                 .fun(fun!(annotated_new))
                 .fun(fun!(annotated_ttl))
                 .fun(fun!(annotated_priority))
-                .fun(fun!(annotated_payload_value)),
+                .fun(fun!(annotated_payload_value))
+                .fun(fun!(unsigned_round_trip))
+                .fun(fun!(unsigned_optional))
+                .fun(fun!(unsigned_emit))
+                .fun(fun!(unsigned_series)),
         )
         // analytics: the param-variant / return-field matrix (type default /
         // per-fn override, in + out). Per-fn overrides reuse the SAME

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -60,6 +60,12 @@ Base package: `io.prebindgen.covertest`
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
   - shaped by: return `Stamp` decomposed → [] (Callback delivery)
+- `unsigned_emit` — `fun unsignedEmit(value: ULong, f: u64Callback, onError: JniErrorHandler<Unit>)`
+- `unsigned_optional` — `fun unsignedOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
+- `unsigned_round_trip` — `fun unsignedRoundTrip(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?, onError: JniErrorHandler<Unsigned>): Unsigned`
+  - shaped by: return `Unsigned` decomposed → [byte, short, int, long, maybeLong] (Callback delivery)
+- `unsigned_series` — `fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong>`
+  - shaped by: return `u64` decomposed → [] (Callback delivery)
 
 ## package `io.prebindgen.covertest.storage`
 
@@ -138,6 +144,7 @@ Base package: `io.prebindgen.covertest`
 - `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)
 - `StorageHandler`: ptr_class → `io.prebindgen.covertest.StorageHandler` (wire `jni :: sys :: jlong`)
 - `Summary`: ptr_class → `io.prebindgen.covertest.analytics.Summary` (wire `jni :: sys :: jlong`)
+- `Unsigned`: data_class → `io.prebindgen.covertest.model.Unsigned` (wire `jni :: objects :: JObject`)
 
 ## conversions
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -310,18 +310,16 @@ public class Storage(initialPtr: Long) : NativeHandle(initialPtr), StorageApi, C
          */
         public fun withPayload(payload: Payload, onError: JniErrorHandler<Storage>): Storage {
             val __bcap = JniErrorHandlerCapture.acquire()
-            val __ret = Storage(
-                CovNative.storageWithPayload(
-                    payload.id,
-                    payload.seq,
-                    payload.value,
-                    payload.flag,
-                    payload.label,
-                    __bcap,
-                ),
+            val __ret = CovNative.storageWithPayload(
+                payload.id,
+                payload.seq,
+                payload.value,
+                payload.flag,
+                payload.label,
+                __bcap,
             )
             if (__bcap.failed) return onError.run(__bcap.ze0)
-            return __ret
+            return Storage(__ret)
         }
     }
 }
@@ -393,6 +391,22 @@ public fun StorageCallback.asRaw(): StorageCallbackRaw =
         }
     }
 
+public fun interface u64Callback {
+    public fun run(u64: ULong)
+}
+
+public fun interface u64CallbackRaw {
+    public fun run(u64: Long)
+}
+
+public fun u64Callback.asRaw(): u64CallbackRaw =
+    u64CallbackRaw {
+        u64 ->
+        run(
+            u64.toULong()
+        )
+    }
+
 public fun interface PayloadBuilder<out R> {
     public fun run(id: Long, seq: Int, value: Double, flag: Boolean, label: String?): R
 }
@@ -460,6 +474,30 @@ internal object __StringFolderHolder {
     @JvmField
     val instance: StringFolder<ArrayList<String>> =
     StringFolder { acc, element -> acc.add(element); acc }
+}
+
+public fun interface u64Folder<A> {
+    public fun run(acc: A, element: ULong): A
+}
+
+public fun interface u64FolderRaw<A> {
+    public fun run(acc: A, element: Long): A
+}
+
+public fun <A> u64Folder<A>.asRaw(): u64FolderRaw<A> =
+    u64FolderRaw<A> {
+        acc,
+        element ->
+        run(
+            acc,
+            element.toULong()
+        )
+    }
+
+internal object __u64FolderRawHolder {
+    @JvmField
+    val instance: u64FolderRaw<ArrayList<ULong>> =
+    u64FolderRaw { acc, element -> acc.add(element.toULong()); acc }
 }
 
 /**
@@ -846,6 +884,22 @@ internal object CovNative {
     ): Double
 
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double
+
+    external fun unsignedEmit(value: Long, f: Any, errorSink: Any)
+
+    external fun unsignedOptional(value: Long?, errorSink: Any): Long?
+
+    external fun unsignedRoundTrip(
+        byte: Int,
+        short: Int,
+        int: Long,
+        long: Long,
+        maybeLong: Long?,
+        build: Any,
+        errorSink: Any,
+    ): Any?
+
+    external fun unsignedSeries(acc: Any?, fold: Any, errorSink: Any): Any?
 
     external fun constGetCoverMagic(errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -110,16 +110,16 @@ public class Summary(initialPtr: Long) : GcNativeHandle(initialPtr) {
          */
         public fun of(count: Long, total: Double, onError: JniErrorHandler<Summary>): Summary {
             val __bcap = JniErrorHandlerCapture.acquire()
-            val __ret = Summary(CovNative.summaryNew(count, total, __bcap))
+            val __ret = CovNative.summaryNew(count, total, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
-            return __ret
+            return Summary(__ret)
         }
 
         public fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary>): Summary {
             val __bcap = JniErrorHandlerCapture.acquire()
-            val __ret = Summary(CovNative.summaryFromMean(count, mean, __bcap))
+            val __ret = CovNative.summaryFromMean(count, mean, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
-            return __ret
+            return Summary(__ret)
         }
     }
 }
@@ -184,10 +184,10 @@ public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: Su
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageSummary(s_ptr, build, __bcap) as R)
+        CovNative.storageSummary(s_ptr, build, __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as R
 }
 
 /** Parameter `s` is the Rust `Summary` argument, expanded: pass EITHER its `summary_new` inputs OR an existing `Summary` — the selector chooses the arm (crosses as `sSel`, `s00`, `s01`, `s1`). */
@@ -291,10 +291,10 @@ public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): 
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        Summary(CovNative.storageSummaryHandle(s_ptr, __bcap))
+        CovNative.storageSummaryHandle(s_ptr, __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return Summary(__ret)
 }
 
 /**
@@ -332,10 +332,10 @@ public fun <R> storageSummaryFull(
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageSummaryFull(s_ptr, build.asRaw(), __bcap) as R)
+        CovNative.storageSummaryFull(s_ptr, build.asRaw(), __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as R
 }
 
 /**
@@ -356,10 +356,10 @@ public fun <R> storageSummaryProbe(
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageSummaryProbe(s_ptr, build.asRaw(), __bcap) as R)
+        CovNative.storageSummaryProbe(s_ptr, build.asRaw(), __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as R
 }
 
 public fun storageExpectSummary(
@@ -582,7 +582,22 @@ public fun <R> summaryMerge(
             val primary1_ptr = primary1?.ptr ?: 0L
             val fallback1_ptr = fallback1?.ptr ?: 0L
             try {
-                (CovNative.summaryMerge(primarySel, primary00 != null, primary00 ?: 0L, primary01 != null, primary01 ?: 0.0, primary1_ptr, fallbackSel, fallback00 != null, fallback00 ?: 0L, fallback01 != null, fallback01 ?: 0.0, fallback1_ptr, build, __bcap) as R)
+                CovNative.summaryMerge(
+                    primarySel,
+                    primary00 != null,
+                    primary00 ?: 0L,
+                    primary01 != null,
+                    primary01 ?: 0.0,
+                    primary1_ptr,
+                    fallbackSel,
+                    fallback00 != null,
+                    fallback00 ?: 0L,
+                    fallback01 != null,
+                    fallback01 ?: 0.0,
+                    fallback1_ptr,
+                    build,
+                    __bcap,
+                )
             } finally {
                 primary1?.markConsumed()
                 fallback1?.markConsumed()
@@ -590,7 +605,7 @@ public fun <R> summaryMerge(
         }
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as R
 }
 
 /**
@@ -648,9 +663,9 @@ public fun <A> summarySeries(
     fold: SummaryFolder<A>,
 ): A {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.summarySeries(count, start, acc, fold, __bcap) as A)
+    val __ret = CovNative.summarySeries(count, start, acc, fold, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as A
 }
 
 /**
@@ -669,17 +684,17 @@ public fun <A> summarySeriesOpt(
     fold: SummaryFolder<A>,
 ): A? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.summarySeriesOpt(count, start, acc, fold, __bcap) as A?)
+    val __ret = CovNative.summarySeriesOpt(count, start, acc, fold, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as A?
 }
 
 /** Create an empty archive. */
 public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = SummaryVault(CovNative.archiveNew(__bcap))
+    val __ret = CovNative.archiveNew(__bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return SummaryVault(__ret)
 }
 
 public fun archiveStore(a: SummaryVault, count: Long, total: Double, onError: JniErrorHandler<Unit>) = archiveStore(a, 0, count, total, null, onError)
@@ -737,8 +752,8 @@ public fun archiveLatest(a: SummaryVault, onError: JniErrorHandler<Summary?>): S
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(a) {
         val a_ptr = a.ptr
-        CovNative.archiveLatest(a_ptr, __bcap).let { if (it == 0L) null else Summary(it) }
+        CovNative.archiveLatest(a_ptr, __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret.let { if (it == 0L) null else Summary(it) }
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/esc_pkg.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/esc_pkg.kt
@@ -47,9 +47,9 @@ public class Esc_Probe(initialPtr: Long) : NativeHandle(initialPtr) {
         /** Construct an [`EscapeProbe`] (its covertest constructor). */
         public fun escapeProbeNew(value: Long, onError: JniErrorHandler<Esc_Probe>): Esc_Probe {
             val __bcap = JniErrorHandlerCapture.acquire()
-            val __ret = Esc_Probe(CovNative.escapeProbeNew(value, __bcap))
+            val __ret = CovNative.escapeProbeNew(value, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
-            return __ret
+            return Esc_Probe(__ret)
         }
     }
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -6,6 +6,9 @@ import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
+import io.prebindgen.covertest.__u64FolderRawHolder
+import io.prebindgen.covertest.asRaw
+import io.prebindgen.covertest.u64Callback
 
 public interface PriorityKind {
     val value: Int
@@ -52,6 +55,24 @@ public data class Annotated(val payload: Payload, val ttl: Long?, val priority: 
 }
 
 /**
+ * Every fixed-width Rust unsigned scalar in one generated Kotlin data class.
+ * The first three fields widen losslessly; `long`/`maybe_long` surface as
+ * `ULong`/`ULong?` over raw JNI `Long` bit patterns.
+ */
+public data class Unsigned(val byte: Int, val short: Int, val int: Long, val long: ULong, val maybeLong: ULong?) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            byte: Int,
+            short: Int,
+            int: Long,
+            long: Long,
+            maybeLong: Long?,
+        ): Unsigned = Unsigned(byte, short, int, long.toULong(), maybeLong?.toULong())
+    }
+}
+
+/**
  * A plain `Copy` timestamp. Declared `value_class` in the binding, so it
  * crosses **by value as its raw bytes** in a `ByteArray` (no heap handle, no
  * `close()`), and `Vec<Stamp>` surfaces as `List<ByteArray>`.
@@ -77,6 +98,33 @@ public value class Stamp(public val bytes: ByteArray) {
         return __ret
     }
 }
+
+public fun interface UnsignedBuilder<out R> {
+    public fun run(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?): R
+}
+
+public fun interface UnsignedBuilderRaw<out R> {
+    public fun run(byte: Int, short: Int, int: Long, long: Long, maybeLong: Long?): R
+}
+
+public fun <R> UnsignedBuilder<R>.asRaw(): UnsignedBuilderRaw<R> =
+    UnsignedBuilderRaw<R> {
+        byte,
+        short,
+        int,
+        long,
+        maybeLong ->
+        run(
+            byte,
+            short,
+            int,
+            long.toULong(),
+            maybeLong?.toULong()
+        )
+    }
+
+internal val __UnsignedBuilderRaw: UnsignedBuilderRaw<Unsigned> =
+UnsignedBuilderRaw { byte, short, int, long, maybeLong -> Unsigned.fromParts(byte, short, int, long, maybeLong) }
 
 public fun interface StampFolder<A> {
     public fun run(acc: A, element: Stamp): A
@@ -105,11 +153,9 @@ internal object __StampFolderRawHolder {
 /** Classify a payload by magnitude of its `value` (enum **return**). */
 public fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = io.prebindgen.covertest.model.Priority.fromInt(
-        CovNative.payloadPriority(p.id, p.seq, p.value, p.flag, p.label, __bcap),
-    )
+    val __ret = CovNative.payloadPriority(p.id, p.seq, p.value, p.flag, p.label, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return io.prebindgen.covertest.model.Priority.fromInt(__ret)
 }
 
 /** Numeric weight of a priority (enum **by-value parameter**). */
@@ -127,30 +173,34 @@ public fun priorityOr(
     onError: JniErrorHandler<Priority>,
 ): Priority {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = io.prebindgen.covertest.model.Priority.fromInt(
-        CovNative.priorityOr(p != null, p?.value ?: 0, fallback.value, __bcap),
-    )
+    val __ret = CovNative.priorityOr(p != null, p?.value ?: 0, fallback.value, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return io.prebindgen.covertest.model.Priority.fromInt(__ret)
 }
 
 /** Build a [`Stamp`] (value-class **return**). */
 public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = Stamp(CovNative.stampNew(secs, nanos, __bcap))
+    val __ret = CovNative.stampNew(secs, nanos, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return Stamp(__ret)
 }
 
 /**
  * A monotonically increasing run of stamps (`Vec<value-class>` →
  * `List<ByteArray>`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp> {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.stampSeries(count, ArrayList<Stamp>(), __StampFolderRawHolder.instance, __bcap) as List<Stamp>)
+    val __ret = CovNative.stampSeries(
+        count,
+        ArrayList<Stamp>(),
+        __StampFolderRawHolder.instance,
+        __bcap,
+    )
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as List<Stamp>
 }
 
 /**
@@ -227,11 +277,9 @@ public fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long? {
 /** The metadata priority (`Option<enum>` **return**). */
 public fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.annotatedPriority(a, __bcap)?.let {
-        io.prebindgen.covertest.model.Priority.fromInt(it)
-    }
+    val __ret = CovNative.annotatedPriority(a, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret?.let { io.prebindgen.covertest.model.Priority.fromInt(it) }
 }
 
 /**
@@ -243,4 +291,60 @@ public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>)
     val __ret = CovNative.annotatedPayloadValue(a, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
+}
+
+/**
+ * Round-trip direct unsigned parameters through an unsigned data-class
+ * return, covering both checked widening and the `ULong` projection.
+ *
+ * The Rust `Unsigned` result is delivered decomposed: the builder callback receives (`byte`, `short`, `int`, `long`, `maybeLong`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun unsignedRoundTrip(
+    byte: Int,
+    short: Int,
+    int: Long,
+    long: ULong,
+    maybeLong: ULong?,
+    onError: JniErrorHandler<Unsigned>,
+): Unsigned {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.unsignedRoundTrip(
+        byte,
+        short,
+        int,
+        long.toLong(),
+        maybeLong?.toLong(),
+        __UnsignedBuilderRaw,
+        __bcap,
+    )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Unsigned
+}
+
+/** Direct nullable `u64` projection in both directions. */
+public fun unsignedOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.unsignedOptional(value?.toLong(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret?.let { it.toULong() }
+}
+
+/** Deliver a `u64` through the generated typed/raw callback twin. */
+public fun unsignedEmit(value: ULong, f: u64Callback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.unsignedEmit(value.toLong(), f.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Output collection fold whose raw `jlong` leaves become `ULong` values on
+ * the Kotlin side.
+ */
+@Suppress("UNCHECKED_CAST")
+public fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong> {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.unsignedSeries(ArrayList<ULong>(), __u64FolderRawHolder.instance, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as List<ULong>
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
@@ -26,9 +26,9 @@ import io.prebindgen.covertest.withSortedHandleLocks
 /** Create a new, empty storage handle. */
 public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = Storage(CovNative.storageNew(__bcap))
+    val __ret = CovNative.storageNew(__bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return Storage(__ret)
 }
 
 /**
@@ -40,15 +40,16 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
  *
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageGet(s_ptr, __PayloadBuilder, __bcap) as Payload?)
+        CovNative.storageGet(s_ptr, __PayloadBuilder, __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Payload?
 }
 
 /**
@@ -136,15 +137,21 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
  *
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageGetVec(s_ptr, ArrayList<Payload>(), __PayloadFolderRawHolder.instance, __bcap) as List<Payload>?)
+        CovNative.storageGetVec(
+            s_ptr,
+            ArrayList<Payload>(),
+            __PayloadFolderRawHolder.instance,
+            __bcap,
+        )
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as List<Payload>?
 }
 
 /**
@@ -159,9 +166,9 @@ public fun payloadHandlerNew(
     onError: JniErrorHandler<PayloadHandler>,
 ): PayloadHandler {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadHandler(CovNative.payloadHandlerNew(f.asRaw(), __bcap))
+    val __ret = CovNative.payloadHandlerNew(f.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return PayloadHandler(__ret)
 }
 
 /**
@@ -196,9 +203,9 @@ public fun payloadVecHandlerNew(
     onError: JniErrorHandler<PayloadVecHandler>,
 ): PayloadVecHandler {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadVecHandler(CovNative.payloadVecHandlerNew(f, __bcap))
+    val __ret = CovNative.payloadVecHandlerNew(f, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return PayloadVecHandler(__ret)
 }
 
 /**
@@ -237,10 +244,10 @@ public fun storageTryWithLabel(
 ): Storage {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __dcap = StorageErrorHandlerRawCapture.acquire()
-    val __ret = Storage(CovNative.storageTryWithLabel(label, __bcap, __dcap))
+    val __ret = CovNative.storageTryWithLabel(label, __bcap, __dcap)
     if (__bcap.failed) return onBindingError.run(__bcap.ze0)
     if (__dcap.failed) return onError.run(__dcap.ze0!!, StorageError(__dcap.ze1!!))
-    return __ret
+    return Storage(__ret)
 }
 
 /**
@@ -260,10 +267,10 @@ public fun storageTryFromStamp(
 ): Storage {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __dcap = StorageErrorHandlerRawCapture.acquire()
-    val __ret = Storage(CovNative.storageTryFromStamp(s.bytes, __bcap, __dcap))
+    val __ret = CovNative.storageTryFromStamp(s.bytes, __bcap, __dcap)
     if (__bcap.failed) return onBindingError.run(__bcap.ze0)
     if (__dcap.failed) return onError.run(__dcap.ze0!!, StorageError(__dcap.ze1!!))
-    return __ret
+    return Storage(__ret)
 }
 
 /**
@@ -271,30 +278,44 @@ public fun storageTryFromStamp(
  * `Vec<opaque-handle>` **return** — each element crosses as a raw pointer the
  * Kotlin folder wraps into a typed `Storage` handle).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageShards(
     count: Long,
     each: Long,
     onError: JniErrorHandler<List<Storage>>,
 ): List<Storage> {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.storageShards(count, each, ArrayList<Storage>(), __StorageFolderRawHolder.instance, __bcap) as List<Storage>)
+    val __ret = CovNative.storageShards(
+        count,
+        each,
+        ArrayList<Storage>(),
+        __StorageFolderRawHolder.instance,
+        __bcap,
+    )
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as List<Storage>
 }
 
 /**
  * Like [`storage_shards`] but `None` when `count == 0`
  * (`Option<Vec<opaque-handle>>` — the fold under the null niche).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageShardsOpt(
     count: Long,
     each: Long,
     onError: JniErrorHandler<List<Storage>?>,
 ): List<Storage>? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = (CovNative.storageShardsOpt(count, each, ArrayList<Storage>(), __StorageFolderRawHolder.instance, __bcap) as List<Storage>?)
+    val __ret = CovNative.storageShardsOpt(
+        count,
+        each,
+        ArrayList<Storage>(),
+        __StorageFolderRawHolder.instance,
+        __bcap,
+    )
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as List<Storage>?
 }
 
 /** Wrap a `Fn(Storage)` closure into a reusable [`StorageHandler`]. */
@@ -303,9 +324,9 @@ public fun storageHandlerNew(
     onError: JniErrorHandler<StorageHandler>,
 ): StorageHandler {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = StorageHandler(CovNative.storageHandlerNew(f.asRaw(), __bcap))
+    val __ret = CovNative.storageHandlerNew(f.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return StorageHandler(__ret)
 }
 
 /**
@@ -345,15 +366,16 @@ public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniError
  * All present labels, in storage order (`Vec<String>` **return** — the
  * single-leaf string fold).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): List<String> {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (CovNative.storageLabels(s_ptr, ArrayList<String>(), __StringFolderHolder.instance, __bcap) as List<String>)
+        CovNative.storageLabels(s_ptr, ArrayList<String>(), __StringFolderHolder.instance, __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as List<String>
 }
 
 /** Push `p` if present; whether it was pushed (`Option<data-class>` **input**). */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -23,6 +23,7 @@ import io.prebindgen.covertest.esc_pkg.Esc_Probe
 import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Stamp
+import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.labelReverse
@@ -35,6 +36,10 @@ import io.prebindgen.covertest.model.priorityOr
 import io.prebindgen.covertest.model.priorityWeight
 import io.prebindgen.covertest.model.stampNew
 import io.prebindgen.covertest.model.stampSeries
+import io.prebindgen.covertest.model.unsignedEmit
+import io.prebindgen.covertest.model.unsignedOptional
+import io.prebindgen.covertest.model.unsignedRoundTrip
+import io.prebindgen.covertest.model.unsignedSeries
 import io.prebindgen.covertest.storage.addMillis
 import io.prebindgen.covertest.storage.payloadHandlerNew
 import io.prebindgen.covertest.storage.payloadVecHandlerNew
@@ -112,6 +117,54 @@ fun main() {
         val p = Payload(1L, 2, 3.5, true, "hello")
         check(p.id == 1L && p.seq == 2 && p.value == 3.5 && p.flag && p.label == "hello")
         check(Payload.fromParts(9L, 9, 9.0, false, null).label == null)
+    }
+
+    // ── #108: fixed-width unsigned scalars. Small widths widen losslessly;
+    // u64 keeps all bits through the public ULong ↔ raw Long projection. ─────
+    section("fixed-width unsigned scalars") {
+        val max = unsignedRoundTrip(
+            UByte.MAX_VALUE.toInt(),
+            UShort.MAX_VALUE.toInt(),
+            UInt.MAX_VALUE.toLong(),
+            ULong.MAX_VALUE,
+            ULong.MAX_VALUE,
+            boom,
+        )
+        check(
+            max == Unsigned(
+                UByte.MAX_VALUE.toInt(),
+                UShort.MAX_VALUE.toInt(),
+                UInt.MAX_VALUE.toLong(),
+                ULong.MAX_VALUE,
+                ULong.MAX_VALUE,
+            ),
+        ) { "unsigned max round trip mismatch: $max" }
+        check(unsignedOptional(null, boom) == null)
+        check(unsignedOptional(ULong.MAX_VALUE, boom) == ULong.MAX_VALUE)
+
+        var emitted = 0uL
+        unsignedEmit(ULong.MAX_VALUE, u64Callback { emitted = it }, boom)
+        check(emitted == ULong.MAX_VALUE)
+        check(unsignedSeries(boom) == listOf(0uL, ULong.MAX_VALUE))
+
+        fun expectRangeError(
+            byte: Int,
+            short: Int,
+            int: Long,
+            expected: String,
+        ) {
+            var message: String? = null
+            val fallback = Unsigned(0, 0, 0L, 0uL, null)
+            val result = unsignedRoundTrip(byte, short, int, 0uL, null) { je ->
+                message = je
+                fallback
+            }
+            check(result == fallback)
+            check(message?.contains(expected) == true) { "unexpected range error: $message" }
+        }
+        expectRangeError(-1, 0, 0L, "u8 input out of range: -1")
+        expectRangeError(0, 65_536, 0L, "u16 input out of range: 65536")
+        expectRangeError(0, 0, 4_294_967_296L, "u32 input out of range: 4294967296")
     }
 
     // ── enum_class: return / by-value param / Option<enum> param ─────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -580,6 +580,26 @@ pub(crate) unsafe fn JObject_to_Option_i64_2ba9a5ed<'env, 'v>(
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn JObject_to_Option_u64_32be16a2<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Option<u64>, __JniErr> {
+    Ok({
+        if !v.is_null() {
+            let __unboxed: jni::sys::jlong = env
+                .call_method(&v, "longValue", "()J", &[])
+                .and_then(|val| val.j())
+                .map(|__x| __x as jni::sys::jlong)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Option unbox: {}", e)))?;
+            Some(jlong_to_u64_4384a5d6(env, &__unboxed)?)
+        } else {
+            None
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -627,6 +647,66 @@ pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
             value,
             flag,
             label,
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn JObject_to_Unsigned_7e3cc618<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Unsigned, __JniErr> {
+    Ok({
+        let __byte_raw: jni::sys::jint = env
+            .get_field(v, "byte", "I")
+            .and_then(|val| val.i())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unsigned.byte: {}", e)))? as _;
+        let byte = jint_to_u8_553cf6ec(env, &__byte_raw)?;
+        let __short_raw: jni::sys::jint = env
+            .get_field(v, "short", "I")
+            .and_then(|val| val.i())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unsigned.short: {}", e)))? as _;
+        let short = jint_to_u16_28edf527(env, &__short_raw)?;
+        let __int_raw: jni::sys::jlong = env
+            .get_field(v, "int", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unsigned.int: {}", e)))? as _;
+        let int = jlong_to_u32_9594a230(env, &__int_raw)?;
+        let __long_raw: jni::sys::jlong = env
+            .get_field(v, "long", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unsigned.long: {}", e)))?;
+        let long = jlong_to_u64_4384a5d6(env, &__long_raw)?;
+        let __maybe_long_jobj: jni::objects::JObject = env
+            .get_field(v, "maybeLong", "Lkotlin/ULong;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unsigned.maybeLong: {}", e)))?;
+        let maybe_long = if __maybe_long_jobj.is_null() {
+            ::core::option::Option::None
+        } else {
+            let __maybe_long_raw: jni::sys::jlong = env
+                .call_method(&__maybe_long_jobj, "unbox-impl", "()J", &[])
+                .and_then(|val| val.j())
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unsigned.maybeLong: {}", e)))?;
+            ::core::option::Option::Some(jlong_to_u64_4384a5d6(env, &__maybe_long_raw)?)
+        };
+        perftest_flat::Unsigned {
+            byte,
+            short,
+            int,
+            long,
+            maybe_long,
         }
     })
 }
@@ -1167,6 +1247,76 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Storage_Send_Sync_static_2f26edcf<'env, 
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn JObject_to_impl_Fn_u64_Send_Sync_static_c7830b57<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<impl Fn(u64) + Send + Sync + 'static, __JniErr> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to get callback class for {}: {}", "Fn(u64)", e)))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(J)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(u64)", e)))?;
+        Box::new(move |__cb_arg0: u64| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(u64)", e)))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(u64)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __cb0_enc = u64_to_jlong_4384a5d6(&mut env, __cb_arg0)?;
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[jni::sys::jvalue { j: __cb0_enc }],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(u64)"));
+        })
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JString<'v>,
@@ -1302,6 +1452,24 @@ pub(crate) unsafe fn Option_i64_to_JObject_2ba9a5ed<'a>(
         match v {
             Some(value) => {
                 let __raw: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, value)?;
+                ::prebindgen::lang::box_jlong(env, __raw)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option box: {}", e)))?
+            }
+            None => jni::objects::JObject::null(),
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Option_u64_to_JObject_32be16a2<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<u64>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        match v {
+            Some(value) => {
+                let __raw: jni::sys::jlong = u64_to_jlong_4384a5d6(env, value)?;
                 ::prebindgen::lang::box_jlong(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -1498,6 +1666,40 @@ pub(crate) unsafe fn Summary_to_jlong_ccacdeac<'a>(
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v.clone())) as i64)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Unsigned_to_JObject_7e3cc618<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Unsigned,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___byte: jni::sys::jint = u8_to_jint_553cf6ec(env, v.byte.clone())?;
+        let ___short: jni::sys::jint = u16_to_jint_28edf527(env, v.short.clone())?;
+        let ___int: jni::sys::jlong = u32_to_jlong_9594a230(env, v.int.clone())?;
+        let ___long: jni::sys::jlong = u64_to_jlong_4384a5d6(env, v.long.clone())?;
+        let ___maybe_long: jni::objects::JObject = Option_u64_to_JObject_32be16a2(
+            env,
+            v.maybe_long.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Unsigned",
+                "fromParts",
+                "(IIJJLjava/lang/Long;)Lio/prebindgen/covertest/model/Unsigned;",
+                &[
+                    jni::objects::JValue::from(___byte),
+                    jni::objects::JValue::from(___short),
+                    jni::objects::JValue::from(___int),
+                    jni::objects::JValue::from(___long),
+                    jni::objects::JValue::Object(&___maybe_long),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<perftest_flat::Payload>,
@@ -1672,6 +1874,34 @@ pub(crate) unsafe fn jint_to_i32_a3e3b6ef<'env, 'v>(
     Ok(*v)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jint_to_u16_28edf527<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jint,
+) -> ::core::result::Result<u16, __JniErr> {
+    Ok(
+        ::core::primitive::u16::try_from(*v)
+            .map_err(|_| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("u16 input out of range: {}", * v))
+            })?,
+    )
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jint_to_u8_553cf6ec<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jint,
+) -> ::core::result::Result<u8, __JniErr> {
+    Ok(
+        ::core::primitive::u8::try_from(*v)
+            .map_err(|_| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("u8 input out of range: {}", * v))
+            })?,
+    )
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn jlong_to_Archive_cd73502c<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -1817,6 +2047,27 @@ pub(crate) unsafe fn jlong_to_i64_fbf9a9bc<'env, 'v>(
     Ok(*v)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jlong_to_u32_9594a230<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<u32, __JniErr> {
+    Ok(
+        ::core::primitive::u32::try_from(*v)
+            .map_err(|_| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("u32 input out of range: {}", * v))
+            })?,
+    )
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jlong_to_u64_4384a5d6<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<u64, __JniErr> {
+    Ok(*v as ::core::primitive::u64)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn std_boxed_Box_std_string_String_to_JString_cfbab680<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: ::std::boxed::Box<::std::string::String>,
@@ -1843,6 +2094,34 @@ pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
                 >>::from(format!("encode_str: {}", e))
             })?
     })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn u16_to_jint_28edf527<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: u16,
+) -> ::core::result::Result<jni::sys::jint, __JniErr> {
+    Ok(v as jni::sys::jint)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn u32_to_jlong_9594a230<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: u32,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(v as jni::sys::jlong)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn u64_to_jlong_4384a5d6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: u64,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(v as jni::sys::jlong)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn u8_to_jint_553cf6ec<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: u8,
+) -> ::core::result::Result<jni::sys::jint, __JniErr> {
+    Ok(v as jni::sys::jint)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn unit_to_unit_9ecccf8e<'a>(
@@ -7585,6 +7864,390 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
             0.0 as jni::sys::jdouble
         }
     }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedEmit<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::sys::jlong,
+    f: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match jlong_to_u64_4384a5d6(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let f = match JObject_to_impl_Fn_u64_Send_Sync_static_c7830b57(&mut env, &f) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::unsigned_emit(value, f);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedOptional<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match JObject_to_Option_u64_32be16a2(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::unsigned_optional(value);
+    match Option_u64_to_JObject_32be16a2(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedRoundTrip<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    byte: jni::sys::jint,
+    short: jni::sys::jint,
+    int: jni::sys::jlong,
+    long: jni::sys::jlong,
+    maybe_long: jni::objects::JObject<'a>,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let byte = match jint_to_u8_553cf6ec(&mut env, &byte) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let short = match jint_to_u16_28edf527(&mut env, &short) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let int = match jlong_to_u32_9594a230(&mut env, &int) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let long = match jlong_to_u64_4384a5d6(&mut env, &long) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let maybe_long = match JObject_to_Option_u64_32be16a2(&mut env, &maybe_long) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/UnsignedBuilderRaw";
+    const __CB_DESCR: &str = "(IIJJLjava/lang/Long;)Ljava/lang/Object;";
+    let __out = perftest_flat::unsigned_round_trip(byte, short, int, long, maybe_long);
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match u8_to_jint_553cf6ec(&mut env, __out.byte.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { i: __enc0 }
+    };
+    let __obj1: jni::sys::jvalue = {
+        let __enc1 = match u16_to_jint_28edf527(&mut env, __out.short.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { i: __enc1 }
+    };
+    let __obj2: jni::sys::jvalue = {
+        let __enc2 = match u32_to_jlong_9594a230(&mut env, __out.int.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc2 }
+    };
+    let __obj3: jni::sys::jvalue = {
+        let __enc3 = match u64_to_jlong_4384a5d6(&mut env, __out.long.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc3 }
+    };
+    let __obj4: jni::objects::JObject = {
+        let __enc4 = match Option_u64_to_JObject_32be16a2(
+            &mut env,
+            __out.maybe_long.clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        __enc4
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                __obj3,
+                jni::sys::jvalue {
+                    l: __obj4.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedSeries<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __acc: jni::objects::JObject<'a>,
+    __fold: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/u64FolderRaw";
+    const __CB_DESCR: &str = "(Ljava/lang/Object;J)Ljava/lang/Object;";
+    let __vec = perftest_flat::unsigned_series();
+    let mut __acc = __acc;
+    for __elem in __vec.into_iter() {
+        let __enc = match u64_to_jlong_4384a5d6(&mut env, __elem) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        __acc = match __CB_MID
+            .call_object(
+                &mut env,
+                __CB_FQN,
+                "run",
+                __CB_DESCR,
+                &__fold,
+                &[
+                    jni::sys::jvalue {
+                        l: __acc.as_raw(),
+                    },
+                    jni::sys::jvalue { j: __enc },
+                ],
+            )
+        {
+            ::core::result::Result::Ok(__o) => __o,
+            ::core::result::Result::Err(__e) => {
+                let _ = env.exception_describe();
+                let __e2 = <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string());
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e2.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+    }
+    __acc
 }
 /// The storage capacity limit advertised to bindings (a primitive const).
 pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -482,6 +482,61 @@ pub fn annotated_payload_value(a: &Annotated) -> f64 {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Fixed-width unsigned integers — widened Kotlin scalars + ULong projection.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Every fixed-width Rust unsigned scalar in one generated Kotlin data class.
+/// The first three fields widen losslessly; `long`/`maybe_long` surface as
+/// `ULong`/`ULong?` over raw JNI `Long` bit patterns.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Unsigned {
+    pub byte: u8,
+    pub short: u16,
+    pub int: u32,
+    pub long: u64,
+    pub maybe_long: Option<u64>,
+}
+
+/// Round-trip direct unsigned parameters through an unsigned data-class
+/// return, covering both checked widening and the `ULong` projection.
+#[prebindgen]
+pub fn unsigned_round_trip(
+    byte: u8,
+    short: u16,
+    int: u32,
+    long: u64,
+    maybe_long: Option<u64>,
+) -> Unsigned {
+    Unsigned {
+        byte,
+        short,
+        int,
+        long,
+        maybe_long,
+    }
+}
+
+/// Direct nullable `u64` projection in both directions.
+#[prebindgen]
+pub fn unsigned_optional(value: Option<u64>) -> Option<u64> {
+    value
+}
+
+/// Deliver a `u64` through the generated typed/raw callback twin.
+#[prebindgen]
+pub fn unsigned_emit(value: u64, f: impl Fn(u64) + Send + Sync + 'static) {
+    f(value)
+}
+
+/// Output collection fold whose raw `jlong` leaves become `ULong` values on
+/// the Kotlin side.
+#[prebindgen]
+pub fn unsigned_series() -> Vec<u64> {
+    vec![0, u64::MAX]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Vec<opaque-handle> outputs — the Kotlin-side handle fold.
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -273,9 +273,9 @@ public class Token(initialPtr: Long) : NativeHandle(initialPtr) {
         /** Create a plain benchmark token. */
         public fun tokenNew(value: Long, onError: JniErrorHandler<Token>): Token {
             val __bcap = JniErrorHandlerCapture.acquire()
-            val __ret = Token(JNINative.tokenNew(value, __bcap))
+            val __ret = JNINative.tokenNew(value, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
-            return __ret
+            return Token(__ret)
         }
     }
 }
@@ -317,9 +317,9 @@ public class TokenGc(initialPtr: Long) : GcNativeHandle(initialPtr) {
         /** Create a gc-managed benchmark token. */
         public fun tokenGcNew(value: Long, onError: JniErrorHandler<TokenGc>): TokenGc {
             val __bcap = JniErrorHandlerCapture.acquire()
-            val __ret = TokenGc(JNINative.tokenGcNew(value, __bcap))
+            val __ret = JNINative.tokenGcNew(value, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
-            return __ret
+            return TokenGc(__ret)
         }
     }
 }

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
@@ -18,9 +18,9 @@ import io.prebindgen.perftest.withSortedHandleLocks
 /** Create a new, empty storage handle. */
 public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = Storage(JNINative.storageNew(__bcap))
+    val __ret = JNINative.storageNew(__bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return Storage(__ret)
 }
 
 /**
@@ -32,15 +32,16 @@ public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
  *
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageGet(s: Storage, onError: JniErrorHandler<Payload?>): Payload? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (JNINative.storageGet(s_ptr, __PayloadBuilder, __bcap) as Payload?)
+        JNINative.storageGet(s_ptr, __PayloadBuilder, __bcap)
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Payload?
 }
 
 /**
@@ -101,9 +102,9 @@ public fun payloadHandlerNew(
     onError: JniErrorHandler<PayloadHandler>,
 ): PayloadHandler {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadHandler(JNINative.payloadHandlerNew(f.asRaw(), __bcap))
+    val __ret = JNINative.payloadHandlerNew(f.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return PayloadHandler(__ret)
 }
 
 /**
@@ -167,15 +168,21 @@ public fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErro
  *
  * The Rust `Payload` result is delivered decomposed: the builder callback receives (`id`, `seq`, `value`, `flag`, `label`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
         val s_ptr = s.ptr
-        (JNINative.storageGetVec(s_ptr, ArrayList<Payload>(), __PayloadFolderRawHolder.instance, __bcap) as List<Payload>?)
+        JNINative.storageGetVec(
+            s_ptr,
+            ArrayList<Payload>(),
+            __PayloadFolderRawHolder.instance,
+            __bcap,
+        )
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as List<Payload>?
 }
 
 /**
@@ -188,9 +195,9 @@ public fun payloadVecHandlerNew(
     onError: JniErrorHandler<PayloadVecHandler>,
 ): PayloadVecHandler {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = PayloadVecHandler(JNINative.payloadVecHandlerNew(f, __bcap))
+    val __ret = JNINative.payloadVecHandlerNew(f, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return PayloadVecHandler(__ret)
 }
 
 /**

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -228,7 +228,11 @@ pub(crate) fn callback_input(
         // passes its raw primitive; everything else casts to JObject. Output
         // converters take the value by move; `cb_arg` is the closure
         // parameter, so pass it directly.
-        let arg_is_prim = arg_entry.metadata.projection.is_none()
+        let arg_is_prim = arg_entry
+            .metadata
+            .projection
+            .as_ref()
+            .is_none_or(|p| p.kind == ProjectionKind::Unsigned64)
             && !is_option_type(arg_ty)
             && matches!(jni_field_access(&arg_wire), Some((_, _, false)));
         if arg_is_prim {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -44,6 +44,40 @@ pub(crate) fn primitive_input(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)> 
         ),
         "i32" => (syn::parse_quote!(jni::sys::jint), syn::parse_quote!(*v)),
         "i64" => (syn::parse_quote!(jni::sys::jlong), syn::parse_quote!(*v)),
+        "u8" => (
+            syn::parse_quote!(jni::sys::jint),
+            syn::parse_quote!(::core::primitive::u8::try_from(*v).map_err(|_| {
+                <__JniErr as ::core::convert::From<String>>::from(format!(
+                    "u8 input out of range: {}",
+                    *v
+                ))
+            })?),
+        ),
+        "u16" => (
+            syn::parse_quote!(jni::sys::jint),
+            syn::parse_quote!(::core::primitive::u16::try_from(*v).map_err(|_| {
+                <__JniErr as ::core::convert::From<String>>::from(format!(
+                    "u16 input out of range: {}",
+                    *v
+                ))
+            })?),
+        ),
+        "u32" => (
+            syn::parse_quote!(jni::sys::jlong),
+            syn::parse_quote!(::core::primitive::u32::try_from(*v).map_err(|_| {
+                <__JniErr as ::core::convert::From<String>>::from(format!(
+                    "u32 input out of range: {}",
+                    *v
+                ))
+            })?),
+        ),
+        // Kotlin's public surface is `ULong`, but the JNI tier receives its
+        // underlying `Long` bit pattern. Rust's `as u64` is the inverse of
+        // Kotlin's `ULong.toLong()` for all 64 bits.
+        "u64" => (
+            syn::parse_quote!(jni::sys::jlong),
+            syn::parse_quote!(*v as ::core::primitive::u64),
+        ),
         "f64" => (syn::parse_quote!(jni::sys::jdouble), syn::parse_quote!(*v)),
         "Duration" | "std :: time :: Duration" => (
             syn::parse_quote!(jni::sys::jlong),
@@ -90,6 +124,14 @@ pub(crate) fn primitive_output(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)>
             syn::parse_quote!(v as jni::sys::jint),
         ),
         "i64" => (
+            syn::parse_quote!(jni::sys::jlong),
+            syn::parse_quote!(v as jni::sys::jlong),
+        ),
+        "u8" | "u16" => (
+            syn::parse_quote!(jni::sys::jint),
+            syn::parse_quote!(v as jni::sys::jint),
+        ),
+        "u32" | "u64" => (
             syn::parse_quote!(jni::sys::jlong),
             syn::parse_quote!(v as jni::sys::jlong),
         ),

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -563,6 +563,64 @@ pub(crate) fn encode_plan_leaves(
                         stmts.extend(bind_obj(obj_ident, expr));
                     }
                 }
+                ProjectionKind::Unsigned64 => {
+                    let enc_ident = format_ident!("__enc{}", idx);
+                    let encode = |reached: TokenStream| {
+                        quote! {{
+                            let #enc_ident: jni::sys::jlong = match #conv(&mut env, #reached) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    #conv_fail
+                                }
+                            };
+                            jni::sys::jvalue { j: #enc_ident }
+                        }}
+                    };
+                    if leaf.path.is_empty() && !by_ref {
+                        let expr = encode(value.clone());
+                        stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
+                    } else if !leaf.nullable {
+                        let expr = reach_leaf(
+                            &qualify,
+                            &leaf.path,
+                            &returns_option,
+                            value.clone(),
+                            by_ref,
+                            true,
+                            0,
+                            &|reached| encode(quote!(*#reached)),
+                        );
+                        stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
+                    } else {
+                        let box_fail = fail(quote!(__e.to_string()));
+                        let expr = reach_leaf(
+                            &qualify,
+                            &leaf.path,
+                            &returns_option,
+                            value.clone(),
+                            by_ref,
+                            true,
+                            0,
+                            &|reached| {
+                                quote! {{
+                                    let #enc_ident: jni::sys::jlong = match #conv(&mut env, *#reached) {
+                                        ::core::result::Result::Ok(__w) => __w,
+                                        ::core::result::Result::Err(__e) => {
+                                            #conv_fail
+                                        }
+                                    };
+                                    match ::prebindgen::lang::box_jlong(&mut env, #enc_ident) {
+                                        ::core::result::Result::Ok(__o) => __o,
+                                        ::core::result::Result::Err(__e) => {
+                                            #box_fail
+                                        }
+                                    }
+                                }}
+                            },
+                        );
+                        stmts.extend(bind_obj(obj_ident, expr));
+                    }
+                }
             }
             continue;
         }
@@ -660,7 +718,7 @@ pub(crate) fn leaf_is_prim(
     // stay objects (`[B`).
     let proj_ok = match &entry.metadata.projection {
         None => true,
-        Some(p) => p.kind == ProjectionKind::Handle,
+        Some(p) => matches!(p.kind, ProjectionKind::Handle | ProjectionKind::Unsigned64),
     };
     proj_ok && matches!(jni_field_access(&entry.destination), Some((_, _, false)))
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -104,6 +104,36 @@ pub(crate) fn struct_input_body(
                         let #fname_ident = #field_conv(env, &#raw_ident)?;
                     });
                 }
+                ProjectionKind::Unsigned64 => {
+                    if let Some(inner_ty) = option_inner_type(&field.ty) {
+                        let inner_conv =
+                            registry.input_entry(&inner_ty)?.function.sig.ident.clone();
+                        let tmp_ident = format_ident!("__{}_jobj", fname_ident);
+                        field_preludes.push(quote! {
+                            let #tmp_ident: jni::objects::JObject = env
+                                .get_field(v, #camel, "Lkotlin/ULong;")
+                                .and_then(|val| val.l())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                            let #fname_ident = if #tmp_ident.is_null() {
+                                ::core::option::Option::None
+                            } else {
+                                let #raw_ident: jni::sys::jlong = env
+                                    .call_method(&#tmp_ident, "unbox-impl", "()J", &[])
+                                    .and_then(|val| val.j())
+                                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                                ::core::option::Option::Some(#inner_conv(env, &#raw_ident)?)
+                            };
+                        });
+                    } else {
+                        field_preludes.push(quote! {
+                            let #raw_ident: jni::sys::jlong = env
+                                .get_field(v, #camel, "J")
+                                .and_then(|val| val.j())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                            let #fname_ident = #field_conv(env, &#raw_ident)?;
+                        });
+                    }
+                }
             }
             field_init.push(quote!(#fname_ident));
             continue;
@@ -524,6 +554,67 @@ pub(crate) fn build_flat_input_plan(
         }
 
         let fentry = registry.input_entry(&field.ty)?;
+        // Rust `u64` projection: the public data-class property is `ULong`,
+        // while flattened JNI leaves stay raw `Long`. `Option<u64>` uses the
+        // same present/value pair as other optional scalars because all 64
+        // bit patterns are live values and no niche is available.
+        if fentry
+            .metadata
+            .projection
+            .as_ref()
+            .is_some_and(|p| p.kind == ProjectionKind::Unsigned64)
+        {
+            let inner_ty = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
+            let inner = registry.input_entry(&inner_ty)?;
+            let conv = inner.function.sig.ident.clone();
+            let field_ref = if optional {
+                format!("?.{fcamel}")
+            } else {
+                format!(".{fcamel}")
+            };
+            if option_inner_type(&field.ty).is_some() {
+                leaves.push(FlatLeaf {
+                    native_ident: format_ident!("{}_{}_present", param_name, fident),
+                    native_wire_ty: quote!(jni::sys::jboolean),
+                    kt_name: snake_to_camel(&format!("{}_{}_present", param_name, fident)),
+                    kt_wire_ty: "Boolean".to_string(),
+                    kt_access_tail: format!("{field_ref} != null"),
+                    conv: None,
+                    field: Some(fident.clone()),
+                    is_present_flag: true,
+                    opt_scalar: false,
+                });
+                leaves.push(FlatLeaf {
+                    native_ident: format_ident!("{}_{}_value", param_name, fident),
+                    native_wire_ty: quote!(jni::sys::jlong),
+                    kt_name: snake_to_camel(&format!("{}_{}_value", param_name, fident)),
+                    kt_wire_ty: "Long".to_string(),
+                    kt_access_tail: format!("{field_ref}?.toLong() ?: 0L"),
+                    conv: Some(conv),
+                    field: Some(fident.clone()),
+                    is_present_flag: false,
+                    opt_scalar: true,
+                });
+            } else {
+                let tail = if optional {
+                    format!("{field_ref}?.toLong() ?: 0L")
+                } else {
+                    format!("{field_ref}.toLong()")
+                };
+                leaves.push(FlatLeaf {
+                    native_ident: format_ident!("{}_{}", param_name, fident),
+                    native_wire_ty: quote!(jni::sys::jlong),
+                    kt_name: snake_to_camel(&format!("{}_{}", param_name, fident)),
+                    kt_wire_ty: "Long".to_string(),
+                    kt_access_tail: tail,
+                    conv: Some(conv),
+                    field: Some(fident.clone()),
+                    is_present_flag: false,
+                    opt_scalar: false,
+                });
+            }
+            continue;
+        }
         // Reject anything outside the simple-leaf set (keeps the object path).
         if !fentry.pre_stages.is_empty() {
             return None;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -219,6 +219,32 @@ fn encode_plan(
                             default: quote!(jni::objects::JObject::null()),
                         });
                     }
+                    ProjectionKind::Unsigned64 => match proj.strategy {
+                        FoldStrategy::Base => {
+                            preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
+                            slots.push(EncSlot {
+                                ident: id,
+                                wire_ty: quote!(jni::sys::jlong),
+                                descriptor: "J".to_string(),
+                                is_object: false,
+                                default: quote!(0i64),
+                            });
+                        }
+                        FoldStrategy::Optional(_, _) => {
+                            preludes
+                                .extend(quote! { let #id: jni::objects::JObject = #value_expr; });
+                            slots.push(EncSlot {
+                                ident: id,
+                                wire_ty: quote!(jni::objects::JObject),
+                                descriptor: "Ljava/lang/Long;".to_string(),
+                                is_object: true,
+                                default: quote!(jni::objects::JObject::null()),
+                            });
+                        }
+                        FoldStrategy::Iterable(_) => unreachable!(
+                            "projection collection fields are rejected by build_struct_plan"
+                        ),
+                    },
                 }
             }
             // Enum leaf → jint discriminant (Kotlin `fromParts` calls `fromInt`).

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -545,6 +545,7 @@ fn emit_input_param(
         InputKind::Callback { .. }
         | InputKind::Handle { .. }
         | InputKind::ValueUnwrap { .. }
+        | InputKind::Unsigned64
         | InputKind::Plain => {
             let entry = registry.input_entry(arg_ty).unwrap_or_else(|| {
                 panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -112,6 +112,9 @@ pub(crate) enum InputKind {
     /// Non-lockable value projection (`value_blob`): the call site passes the
     /// unwrapped inline-class `field`; the extern keeps the erased wire.
     ValueUnwrap { field: String },
+    /// Rust `u64`: typed Kotlin `ULong`, raw JNI `Long`. The wrapper passes
+    /// the bit-preserving `toLong()` representation and takes no lock.
+    Unsigned64,
     /// Everything else: the resolved entry's converter/wire as-is.
     Plain,
 }
@@ -527,6 +530,7 @@ fn classify_leaf(
                     });
                 InputKind::ValueUnwrap { field }
             }
+            Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64,
             None => InputKind::Plain,
         }
     };
@@ -535,7 +539,7 @@ fn classify_leaf(
     // the projection's leaf key); everything else the entry's resolved name.
     let kt_meta = entry.metadata.kotlin_name.clone();
     let kt_public = match entry.metadata.projection.as_ref() {
-        Some(p) => ext.kotlin_fqn(&p.leaf_key).map(kt::KtType::cls),
+        Some(p) => projection_leaf_kt(ext, p),
         None => kt_meta.clone(),
     };
 
@@ -684,7 +688,7 @@ impl ReturnSurface {
         // return type's converter metadata — one source of truth, no
         // shape-specific peeling.
         if let Some(h) = outer_meta.as_ref().and_then(|m| m.projection.clone()) {
-            let leaf_fqn = ext.kotlin_fqn(&h.leaf_key);
+            let leaf_fqn = projection_leaf_kt(ext, &h).map(|t| t.to_string());
             return (
                 Self::Projected {
                     projection: h,

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -52,6 +52,26 @@ pub(crate) fn handle_kt_type(strategy: &FoldStrategy, leaf: &kt::KtType) -> kt::
     )
 }
 
+/// Typed Kotlin leaf of a projection. Declared handle/value-blob projections
+/// take their configured class FQN; the built-in `u64` projection is Kotlin's
+/// stable unsigned scalar type.
+pub(crate) fn projection_leaf_kt(ext: &JniGen, proj: &Projection) -> Option<kt::KtType> {
+    match proj.kind {
+        ProjectionKind::Handle | ProjectionKind::ValueBlob => {
+            ext.kotlin_fqn(&proj.leaf_key).map(kt::KtType::cls)
+        }
+        ProjectionKind::Unsigned64 => Some(kt::KtType::cls("ULong")),
+    }
+}
+
+/// Wrap one raw projection leaf into its typed Kotlin form.
+pub(crate) fn projection_wrap_expr(kind: &ProjectionKind, short: &str, raw: &str) -> String {
+    match kind {
+        ProjectionKind::Handle | ProjectionKind::ValueBlob => format!("{short}({raw})"),
+        ProjectionKind::Unsigned64 => format!("{raw}.toULong()"),
+    }
+}
+
 /// For a projection (handle / value-class / value-blob) **struct field**,
 /// compute the `(wire_param_type, wrap_expr)` the data class's `fromParts`
 /// factory uses: the wire param type matches the leaf wire
@@ -72,6 +92,7 @@ pub(crate) fn factory_projection_wire_wrap(
     let direct = |kind: &crate::api::lang::jnigen::jni::ProjectionKind| match kind {
         Handle => (kt::KtType::long(), format!("{short}({name})")),
         ValueBlob => (kt::KtType::byte_array(), format!("{short}({name})")),
+        Unsigned64 => (kt::KtType::long(), format!("{name}.toULong()")),
     };
     match strategy {
         Base => direct(kind),
@@ -93,6 +114,9 @@ pub(crate) fn factory_projection_wire_wrap(
                     kt::KtType::byte_array().nullable(),
                     format!("{name}?.let {{ {short}(it) }}"),
                 ),
+                // `Option<u64>` has no spare bit pattern, so its primitive
+                // wire is boxed and JVM null represents `None`.
+                Unsigned64 => (kt::KtType::long().nullable(), format!("{name}?.toULong()")),
             }
         }
         Iterable(_) => panic!(
@@ -306,6 +330,7 @@ pub(crate) fn render_handle_close(
 pub(crate) fn fold_projection_wrap(
     strategy: &crate::api::lang::jnigen::jni::FoldStrategy,
     receiver: &str,
+    kind: &crate::api::lang::jnigen::jni::ProjectionKind,
     wrap_class: &str,
     niche_sentinel: Option<&str>,
 ) -> String {
@@ -313,22 +338,27 @@ pub(crate) fn fold_projection_wrap(
     fn go(
         s: &crate::api::lang::jnigen::jni::FoldStrategy,
         r: &str,
+        kind: &crate::api::lang::jnigen::jni::ProjectionKind,
         w: &str,
         sentinel: Option<&str>,
         depth: usize,
     ) -> String {
         match s {
-            Base => format!("{w}({r})"),
-            Optional(kind, inner) => match (kind, &**inner) {
+            Base => projection_wrap_expr(kind, w, r),
+            Optional(nullable_kind, inner) => match (nullable_kind, &**inner) {
                 // Primitive-wired niche → can't carry null on the wire, so
                 // compare against the sentinel and synthesize null on the
                 // Kotlin side.
                 (NullableKind::Niche, Base) if sentinel.is_some() => {
                     let s = sentinel.unwrap();
-                    format!("{r}.let {{ if (it == {s}) null else {w}(it) }}")
+                    let wrapped = projection_wrap_expr(kind, w, "it");
+                    format!("{r}.let {{ if (it == {s}) null else {wrapped} }}")
                 }
                 // Object-wired niche or fully boxed Nullable → `?.let { W(it) }`.
-                (_, Base) => format!("{r}?.let {{ {w}(it) }}"),
+                (_, Base) => {
+                    let wrapped = projection_wrap_expr(kind, w, "it");
+                    format!("{r}?.let {{ {wrapped} }}")
+                }
                 // Deeper nesting. The niche/boxed distinction is only
                 // observable at the outermost layer covering a `Direct`
                 // leaf; intermediate layers (nullable-of-iterable etc.)
@@ -338,23 +368,26 @@ pub(crate) fn fold_projection_wrap(
                     let v = format!("e{depth}");
                     format!(
                         "{r}?.let {{ {v} -> {} }}",
-                        go(inner, &v, w, sentinel, depth + 1)
+                        go(inner, &v, kind, w, sentinel, depth + 1)
                     )
                 }
             },
             Iterable(inner) => match &**inner {
-                Base => format!("{r}.map {{ {w}(it) }}"),
+                Base => {
+                    let wrapped = projection_wrap_expr(kind, w, "it");
+                    format!("{r}.map {{ {wrapped} }}")
+                }
                 _ => {
                     let v = format!("e{depth}");
                     format!(
                         "{r}.map {{ {v} -> {} }}",
-                        go(inner, &v, w, sentinel, depth + 1)
+                        go(inner, &v, kind, w, sentinel, depth + 1)
                     )
                 }
             },
         }
     }
-    go(strategy, receiver, wrap_class, niche_sentinel, 0)
+    go(strategy, receiver, kind, wrap_class, niche_sentinel, 0)
 }
 
 /// JNI extern's declared Kotlin wire-return for a projection. The leaf wire
@@ -372,6 +405,7 @@ pub(crate) fn projection_wire_return(
         ProjectionKind::Handle => (kt::KtType::long(), true),
         // Value-blob's inner wire is always `ByteArray` (object-shaped).
         ProjectionKind::ValueBlob => (kt::KtType::byte_array(), false),
+        ProjectionKind::Unsigned64 => (kt::KtType::long(), true),
     };
     fold_shape(
         &proj.strategy,
@@ -403,6 +437,9 @@ pub(crate) fn projection_leaf_sentinel(
         // primitive sentinel; JVM `null` represents the absent value, so
         // `?.let` covers nullability.
         ProjectionKind::ValueBlob => syn::parse_quote!(jni::objects::JByteArray),
+        // No niche exists for `u64`; `Option<u64>` uses the boxed path, so a
+        // primitive sentinel must never be synthesized.
+        ProjectionKind::Unsigned64 => return None,
     };
     kotlin_null_sentinel(&leaf_wire).map(|s| s.to_string())
 }

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -50,13 +50,15 @@ pub(crate) enum WrapKind {
     HandleOwned(String),
     /// `Copy` value blob: raw `ByteArray` → `@JvmInline` value class (FQN).
     Blob(String),
+    /// Rust `u64`: raw `Long` bit pattern → typed Kotlin `ULong`.
+    Unsigned64,
 }
 
 impl WrapKind {
     /// The Kotlin FQN the wrap constructs, if any (for import registration).
     pub fn class_fqn(&self) -> Option<&str> {
         match self {
-            WrapKind::None => None,
+            WrapKind::None | WrapKind::Unsigned64 => None,
             WrapKind::Handle(f) | WrapKind::HandleOwned(f) | WrapKind::Blob(f) => Some(f),
         }
     }
@@ -70,6 +72,13 @@ impl WrapKind {
     /// The wrapping expression over `arg` (`raw_nullable` adds a null-safe
     /// `?.let`): `ZKeyExpr(x)` / `x?.let { ZKeyExpr(it) }` / passthrough.
     pub fn wrap_expr(&self, arg: &str, raw_nullable: bool) -> String {
+        if matches!(self, WrapKind::Unsigned64) {
+            return if raw_nullable {
+                format!("{arg}?.toULong()")
+            } else {
+                format!("{arg}.toULong()")
+            };
+        }
         match self.class_fqn() {
             None => arg.to_string(),
             Some(fqn) => {
@@ -677,7 +686,7 @@ fn leaf_iface_param(
             out_ty = &peeled;
         }
     }
-    let (builder_kt, _wire_kt, _wrap, is_vb) =
+    let (builder_kt, _wire_kt, _wrap, is_value_projection) =
         unfold_leaf_kt(ext, registry, out_ty, nullable, "x")?;
     let proj = registry
         .output_entry(out_ty)
@@ -689,16 +698,27 @@ fn leaf_iface_param(
             t
         }
     };
-    if is_vb {
-        let fqn = proj
-            .and_then(|p| ext.kotlin_fqn(&p.leaf_key))
-            .map(|f| f.to_string())?;
-        return Some(IfaceParam {
-            name,
-            typed: nullable_kt(kt::KtType::cls(fqn.clone())),
-            raw: nullable_kt(kt::KtType::byte_array()),
-            wrap: WrapKind::Blob(fqn),
-        });
+    if is_value_projection {
+        match proj?.kind {
+            ProjectionKind::ValueBlob => {
+                let fqn = ext.kotlin_fqn(&proj?.leaf_key)?.to_string();
+                return Some(IfaceParam {
+                    name,
+                    typed: nullable_kt(kt::KtType::cls(fqn.clone())),
+                    raw: nullable_kt(kt::KtType::byte_array()),
+                    wrap: WrapKind::Blob(fqn),
+                });
+            }
+            ProjectionKind::Unsigned64 => {
+                return Some(IfaceParam {
+                    name,
+                    typed: nullable_kt(kt::KtType::cls("ULong")),
+                    raw: nullable_kt(kt::KtType::long()),
+                    wrap: WrapKind::Unsigned64,
+                });
+            }
+            ProjectionKind::Handle => {}
+        }
     }
     if let Some(p) = proj.filter(|p| p.kind == ProjectionKind::Handle) {
         let fqn = ext.kotlin_fqn(&p.leaf_key)?.to_string();

--- a/prebindgen/src/api/lang/jnigen/jni/metadata.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/metadata.rs
@@ -53,6 +53,10 @@ pub enum ProjectionKind {
     /// no Rust struct field to resolve. The typed class has a single
     /// `bytes: ByteArray` field; the wire is `JByteArray`. Never closeable.
     ValueBlob,
+    /// Rust `u64`: raw JNI `jlong` bit pattern with a typed Kotlin `ULong`
+    /// surface. It owns no resource; wrapping/unwrapping is
+    /// `Long.toULong()` / `ULong.toLong()`.
+    Unsigned64,
 }
 
 /// Folded description of a Kotlin newtype projection (opaque handle or value

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -109,22 +109,15 @@ pub(crate) fn build_data_class(
                     .and_then(|e| e.metadata.projection.clone())
             });
         if let Some(h) = field_projection {
-            let fqn = ext
-                .kotlin_fqn(&h.leaf_key)
-                .map(|v| v.to_string())
-                .unwrap_or_else(|| {
-                    panic!(
-                        "render_data_class_source: projection field `{}.{}` leaf `{}` has no \
+            let leaf = projection_leaf_kt(ext, &h).unwrap_or_else(|| {
+                panic!(
+                    "render_data_class_source: projection field `{}.{}` leaf `{}` has no \
                          Kotlin FQN registered (ptr_class / value_class)",
-                        item_struct.ident, field_ident, h.leaf_key
-                    )
-                });
-            ctor_params.push(
-                kt::KtCtorParam::new(
-                    &kotlin_field_name,
-                    handle_kt_type(&h.strategy, &kt::KtType::cls(fqn)),
+                    item_struct.ident, field_ident, h.leaf_key
                 )
-                .val(),
+            });
+            ctor_params.push(
+                kt::KtCtorParam::new(&kotlin_field_name, handle_kt_type(&h.strategy, &leaf)).val(),
             );
             if matches!(
                 h.kind,
@@ -513,7 +506,10 @@ pub(crate) fn render_extern_decl(
             InputKind::Handle { .. } => {
                 params.push(kt::KtParam::new(name, kt::KtType::long()));
             }
-            InputKind::Callback { .. } | InputKind::ValueUnwrap { .. } | InputKind::Plain => {
+            InputKind::Callback { .. }
+            | InputKind::ValueUnwrap { .. }
+            | InputKind::Unsigned64
+            | InputKind::Plain => {
                 let ty = if leaf.as_enum_value {
                     // Enum (incl. `Option<enum>`) crosses as jint → Kotlin
                     // `Int`; the wrapper passes `.value` / `?.value`. The Rust
@@ -613,6 +609,8 @@ enum ParamMode {
     ValueUnwrap {
         field: String,
     },
+    /// Kotlin `ULong` projected to its raw JNI `Long` bit pattern.
+    Unsigned64,
     /// Flattenable `data_class` param: the high-level Kotlin signature keeps the
     /// typed object, but the `JNINative` call destructures it into the leaf
     /// access expressions (no `JObject` crosses, so the Rust side skips
@@ -799,13 +797,14 @@ pub(crate) fn build_wrapper_surface(
         for ep in err_params {
             fun = fun.param(ep);
         }
-        fun = fun
-            .param(kt::KtParam::new(bp_name, bp_ty.clone()))
-            .annotation("Suppress(\"UNCHECKED_CAST\")");
+        fun = fun.param(kt::KtParam::new(bp_name, bp_ty.clone()));
     } else {
         for ep in err_params {
             fun = fun.param(ep);
         }
+    }
+    if out.cast_return {
+        fun = fun.annotation("Suppress(\"UNCHECKED_CAST\")");
     }
     if let Some(rt) = &out.kt_return {
         fun = fun.returns(rt.clone());
@@ -847,6 +846,11 @@ pub(crate) fn render_wrapper_fn(
     let opaques = collect_opaques(&params);
     let is_unit = fun.ret.is_none();
     let body_expr = build_native_call(ext, &jni_call, &params, &out, &sink);
+    let return_mode = if is_unit {
+        BodyReturn::Unit
+    } else {
+        BodyReturn::Value(build_success_return(ext, &out, "__ret"))
+    };
     // `render_body` extends `body_imports` with the body's own references; all
     // of them are attached to the body `Code`, so the emitted `KtFun` carries
     // its own imports (signature imports ride the FQN types via the render-time
@@ -858,7 +862,7 @@ pub(crate) fn render_wrapper_fn(
         &opaques,
         &sink,
         &body_expr,
-        is_unit,
+        &return_mode,
         &mut body_imports,
     );
     for fqn in body_imports {
@@ -1177,6 +1181,7 @@ fn classify_params(
             InputKind::ValueUnwrap { field } => ParamMode::ValueUnwrap {
                 field: field.clone(),
             },
+            InputKind::Unsigned64 => ParamMode::Unsigned64,
             InputKind::Plain => ParamMode::PassThrough,
             InputKind::Callback { .. } => unreachable!("callback params handled above"),
         };
@@ -1382,10 +1387,11 @@ fn classify_output(
     })
 }
 
-/// Build the JNINative call expression. Every param maps to exactly one call
-/// arg (or several, for a flattened data_class); the output plan's extra args
-/// and the trailing `__cap` follow; the result is wrapped per the return
-/// classification (projection / enum / erased-`Any` cast).
+/// Build the raw JNINative call expression. Every param maps to exactly one
+/// call arg (or several, for a flattened data_class); the output plan's extra
+/// args and the trailing `__cap` follow. Kotlin-side result projections are
+/// deliberately deferred to [`build_success_return`], after the native error
+/// captures have been checked.
 fn build_native_call(
     ext: &JniGen,
     jni_call: &str,
@@ -1433,6 +1439,13 @@ fn build_native_call(
                     format!("{}.{}", p.kt_name, field)
                 }
             }
+            ParamMode::Unsigned64 => {
+                if p.kt_type.is_nullable() {
+                    format!("{}?.toLong()", p.kt_name)
+                } else {
+                    format!("{}.toLong()", p.kt_name)
+                }
+            }
             ParamMode::PassThrough => {
                 if p.as_enum_value {
                     // Enum → its `Int` discriminant for the extern. Nullable
@@ -1472,11 +1485,18 @@ fn build_native_call(
     if sink.domain.is_some() {
         args.push("__dcap".to_string());
     }
-    let mut call = format!(
+    format!(
         "{}.{jni_call}({})",
         ext.jni_native_class_name(),
         args.join(", ")
-    );
+    )
+}
+
+/// Transform a successful raw native return into the public Kotlin return.
+/// This expression is emitted only after binding/domain captures have been
+/// checked, so a native failure placeholder can never reach an enum lookup,
+/// value projection, or erased-result cast.
+fn build_success_return(ext: &JniGen, out: &OutputPlan, raw: &str) -> String {
     if let Some(p) = &out.projection {
         // Fold the wrap through the projection strategy. The wrap class is
         // the projection leaf's typed short name (Handle's typed-handle
@@ -1488,13 +1508,13 @@ fn build_native_call(
             .unwrap_or_else(|| p.leaf_key.to_string());
         let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
         let sentinel = projection_leaf_sentinel(p);
-        call = fold_projection_wrap(&p.strategy, &call, &short, sentinel.as_deref());
+        fold_projection_wrap(&p.strategy, raw, &p.kind, &short, sentinel.as_deref())
     } else if out.is_enum_return {
         let enum_kt = out
             .kt_return
             .as_ref()
             .expect("enum return has a Kotlin type");
-        call = format!("{enum_kt}.fromInt({call})");
+        format!("{enum_kt}.fromInt({raw})")
     } else if out.is_option_enum_return {
         // `kt_return` renders nullable (`Priority?`); the companion lives
         // on the non-null class name.
@@ -1504,24 +1524,16 @@ fn build_native_call(
             .expect("Option<enum> return has a Kotlin type")
             .to_string();
         let enum_kt = enum_kt.trim_end_matches('?');
-        call = format!("{call}?.let {{ {enum_kt}.fromInt(it) }}");
+        format!("{raw}?.let {{ {enum_kt}.fromInt(it) }}")
     } else if out.cast_return {
-        // Callback delivery: the extern returns the builder's erased `Any?`;
-        // cast to the shape type (`R` / `R?` / `List<R>`). The builder always
-        // produces `R`, so the unchecked cast is sound — suppressed below.
         let cast_kt = out
             .kt_return
             .as_ref()
             .expect("callback delivery returns R/A");
-        // The class(es) in the cast type are imported via the wrapper's
-        // return type; render with short names (the return type is FQN in
-        // the AST, so the render-time `ImportSet` imports them).
-        call = format!("({call} as {})", kt_type_short(cast_kt));
+        format!("{raw} as {}", kt_type_short(cast_kt))
+    } else {
+        raw.to_string()
     }
-    // Return delivery (`convert_output`): the extern returns the real typed
-    // wire; the projection wrap above (if any) already produced the value
-    // class / handle — no cast needed.
-    call
 }
 
 /// The opaque-handle params (Borrow/Consume modes) — the set the lock
@@ -1791,15 +1803,21 @@ fn render_core_stmt(
 /// a `finally` (always — the target wrapper either borrows the boxed `Vec` or
 /// `mem::take`s it, leaving an empty `Vec` to drop). The transient handle is
 /// not a `NativeHandle`, so it never joins the lock set.
+enum BodyReturn {
+    Unit,
+    Value(String),
+}
+
 fn render_body(
     ext: &JniGen,
     params: &[Param],
     opaques: &[Opaque],
     sink: &ErrorSink,
     body_expr: &str,
-    is_unit: bool,
+    return_mode: &BodyReturn,
     imports: &mut BTreeSet<String>,
 ) -> kt::Code {
+    let is_unit = matches!(return_mode, BodyReturn::Unit);
     let vec_build: Vec<(&String, &String, &Vec<String>)> = params
         .iter()
         .filter_map(|p| match &p.mode {
@@ -1870,14 +1888,15 @@ fn render_body(
             b = b.wline(chk);
         }
     }
-    if !is_unit {
-        b = b.line("return __ret");
-    }
+    b = match return_mode {
+        BodyReturn::Unit => b,
+        BodyReturn::Value(expr) => b.line(format!("return {expr}")),
+    };
     b
 }
 
 /// The Kotlin typing of one delivered lambda leaf: `(builder_kt, wire_kt,
-/// wrap, is_value_blob)` — the type the *user's* lambda sees, the type the
+/// wrap, is_value_projection)` — the type the *user's* lambda sees, the type the
 /// extern delivers, and the expression rebuilding the former from the latter
 /// (`pk` is the adapter's parameter name; passthrough unless the leaf is a
 /// `value_blob`, whose `@JvmInline value class` can't be built Rust-side).
@@ -1892,9 +1911,15 @@ pub(crate) fn unfold_leaf_kt(
     let proj = registry
         .output_entry(out_ty)
         .and_then(|e| e.metadata.projection.clone());
-    let is_vb = proj
+    let is_value_projection = proj
         .as_ref()
-        .map(|p| p.kind == crate::api::lang::jnigen::jni::ProjectionKind::ValueBlob)
+        .map(|p| {
+            matches!(
+                p.kind,
+                crate::api::lang::jnigen::jni::ProjectionKind::ValueBlob
+                    | crate::api::lang::jnigen::jni::ProjectionKind::Unsigned64
+            )
+        })
         .unwrap_or(false);
     // builder_kt: enum → Int; otherwise the normal classified type
     // (handle class / value class / String / ByteArray / Long …).
@@ -1904,7 +1929,7 @@ pub(crate) fn unfold_leaf_kt(
         let rt: syn::ReturnType = syn::parse_quote!(-> #out_ty);
         classify_return(ext, &rt, registry)?.0?
     };
-    let (mut wire_kt, wrap) = if is_vb {
+    let (mut wire_kt, wrap) = if is_value_projection {
         let p = proj.as_ref().unwrap();
         // Wrap class = the projection leaf's typed short name — NOT
         // `builder_kt` (which is `Short?` for an `Option<…>` leaf and would
@@ -1914,7 +1939,7 @@ pub(crate) fn unfold_leaf_kt(
             .unwrap_or_else(|| p.leaf_key.to_string());
         let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
         let sentinel = projection_leaf_sentinel(p);
-        let mut wrap = fold_projection_wrap(&p.strategy, pk, &short, sentinel.as_deref());
+        let mut wrap = fold_projection_wrap(&p.strategy, pk, &p.kind, &short, sentinel.as_deref());
         // A `nullable` leaf (an `Option` nesting step on its path) makes the
         // wire nullable even when the strategy itself is `Direct` — guard the
         // wrap so a null wire stays null instead of feeding the constructor.
@@ -1924,7 +1949,8 @@ pub(crate) fn unfold_leaf_kt(
                 crate::api::lang::jnigen::jni::FoldStrategy::Base
             )
         {
-            wrap = format!("{pk}?.let {{ {short}(it) }}");
+            let inner = projection_wrap_expr(&p.kind, &short, "it");
+            wrap = format!("{pk}?.let {{ {inner} }}");
         }
         // Raw-text wire for the callback/builder descriptor — `KtType`'s
         // Display matches the historical string (`Long`/`ByteArray`/`List<…>`).
@@ -1938,7 +1964,7 @@ pub(crate) fn unfold_leaf_kt(
     } else {
         builder_kt
     };
-    Some((builder_kt, wire_kt, wrap, is_vb))
+    Some((builder_kt, wire_kt, wrap, is_value_projection))
 }
 
 /// Kotlin parameter names for a plan's delivered leaves, in leaf order. The

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -120,7 +120,7 @@ pub(crate) fn build_struct_plan(
                     s.ident, fname
                 );
             }
-            let fqn = ext.kotlin_fqn(&proj.leaf_key).map(|v| v.to_string())?;
+            let fqn = projection_leaf_kt(ext, &proj)?.to_string();
             fields.push(PlanField {
                 fname,
                 kind: PlanFieldKind::Projection { conv, proj, fqn },

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -421,6 +421,8 @@ fn boxed_primitive(simple: &str) -> Option<&'static str> {
 /// * a type variable declared on the function (`R` / `A`) → `Object`;
 /// * a non-null primitive → itself; a **nullable** primitive → its box
 ///   (`Int?` → `java.lang.Integer`) — a distinct descriptor;
+/// * non-null `ULong` → its inline-class carrier `Long`; nullable `ULong?` →
+///   the boxed `kotlin.ULong` class;
 /// * `String` / `ByteArray` / `Any` → their JVM types (object nullability is
 ///   irrelevant to the descriptor);
 /// * a `@JvmInline value class` → its underlying wire (`byte[]`), so two
@@ -438,6 +440,12 @@ pub(crate) fn erase_kt_type(ext: &JniGen, generics: &[String], ty: &kt::KtType) 
                 "java.lang.Object".to_string()
             } else if ext.is_value_blob_kotlin(simple) {
                 "byte[]".to_string()
+            } else if simple == "ULong" {
+                if *nullable {
+                    "kotlin.ULong".to_string()
+                } else {
+                    "Long".to_string()
+                }
             } else if let Some(boxed) = boxed_primitive(simple) {
                 if *nullable {
                     boxed.to_string()
@@ -513,6 +521,18 @@ mod tests {
             erase(&[], kt::KtType::int()),
             erase(&[], kt::KtType::int().nullable()),
             "Int and Int? must NOT clash"
+        );
+        // Kotlin's ULong is an inline class backed by a primitive long. Its
+        // nullable form is boxed as kotlin.ULong, not java.lang.Long.
+        assert_eq!(erase(&[], kt::KtType::cls("ULong")), "Long");
+        assert_eq!(
+            erase(&[], kt::KtType::cls("ULong").nullable()),
+            "kotlin.ULong"
+        );
+        assert_eq!(
+            erase(&[], kt::KtType::cls("ULong")),
+            erase(&[], kt::KtType::long()),
+            "ULong and Long share the same JVM carrier"
         );
         // Object types: nullability is irrelevant to the descriptor.
         assert_eq!(erase(&[], kt::KtType::string()), "java.lang.String");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -104,6 +104,40 @@ fn declared_consts_emit_getter_and_val() {
     assert!(nc.contains("externalfunconstGetGreeting("), "{native}");
 }
 
+/// A `u64` const uses the same typed/raw projection as an ordinary function
+/// return: public `ULong`, private/native `Long`, with a bit-preserving wrap.
+#[test]
+fn unsigned_const_uses_ulong_surface() {
+    let registry = Registry::<KotlinMeta>::from_items(vec![(
+        syn::Item::Const(syn::parse_quote!(
+            pub const MAX_UNSIGNED: u64 = u64::MAX;
+        )),
+        myflat_loc(),
+    )])
+    .expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("cfg").constant(crate::constant!(MAX_UNSIGNED)));
+    let dir = unique_test_dir("jnigen_consts_unsigned");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let kotlin = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+    assert!(kc.contains("valMAX_UNSIGNED:ULongbylazy"), "{kotlin}");
+    assert!(kc.contains("privatefunconstGetMaxUnsigned("), "{kotlin}");
+    assert!(kc.contains("):ULong"), "{kotlin}");
+    assert!(kc.contains("externalfunconstGetMaxUnsigned("), "{kotlin}");
+    assert!(kc.contains("):Long"), "{kotlin}");
+    assert!(kc.contains(".toULong()"), "{kotlin}");
+}
+
 /// An undeclared const emits nothing (JniGen has a const declaration
 /// mechanism, so const emission is declared-only); `ignore_const`
 /// acknowledges it without emitting.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
@@ -532,8 +532,19 @@ fn cross_artifact_optional_iterable_fold_agrees() {
         ),
         "optional fold wrapper surface (returns A?, null = None):\n{wrappers}"
     );
+    let call = kc
+        .find("val__ret=JNINative.zThingsMaybe(acc,fold.asRaw(),__bcap)")
+        .expect("optional fold stores the erased native result");
+    let check = call
+        + kc[call..]
+            .find("if(__bcap.failed)returnonError.run(__bcap.ze0)")
+            .expect("optional fold checks the binding-error capture");
+    let cast = check
+        + kc[check..]
+            .find("return__retasA?")
+            .expect("optional fold casts the successful result to A?");
     assert!(
-        kc.contains("JNINative.zThingsMaybe(acc,fold.asRaw(),__bcap)asA?"),
-        "optional fold call site casts the erased result to A?:\n{wrappers}"
+        call < check && check < cast,
+        "optional fold must redispatch a native error before casting its erased result:\n{wrappers}"
     );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -748,3 +748,112 @@ fn data_class_members_reenter_as_field_leaves() {
     assert!(pb.contains("funorigin("), "{all}");
     assert!(pb.contains("funfromParts("), "{all}");
 }
+
+/// #108: fixed-width unsigned scalars use lossless signed JNI carriers. The
+/// public Kotlin surface widens `u8/u16/u32` and projects `u64` to `ULong`,
+/// while the harness stays primitive (`Int`/`Long`) and nullable `u64` keeps
+/// a raw `Long?` twin.
+#[test]
+fn unsigned_scalars_use_lossless_kotlin_surface_and_raw_jni_wires() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Unsigned {
+                    pub byte: u8,
+                    pub short: u16,
+                    pub int: u32,
+                    pub long: u64,
+                    pub maybe_long: Option<u64>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn unsigned_round_trip(
+                    byte: u8,
+                    short: u16,
+                    int: u32,
+                    long: u64,
+                    maybe_long: Option<u64>,
+                ) -> Unsigned {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn unsigned_callback(f: impl Fn(u64) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn unsigned_result(value: u64) -> Result<u64, String> {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::data_class!(Unsigned))
+            .fun(crate::fun!(unsigned_round_trip))
+            .fun(crate::fun!(unsigned_callback))
+            .fun(crate::fun!(unsigned_result)),
+    );
+    let dir = unique_test_dir("jnigen_unsigned");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = registry.resolve(jni).expect("resolve");
+    let rust_path = generation
+        .write_rust(dir.join("gen.rs"))
+        .expect("write_rust");
+    let rust = std::fs::read_to_string(rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+    assert!(rc.contains("u8::try_from(*v)"), "{rust}");
+    assert!(rc.contains("u16::try_from(*v)"), "{rust}");
+    assert!(rc.contains("u32::try_from(*v)"), "{rust}");
+    assert!(rc.contains("*vas::core::primitive::u64"), "{rust}");
+
+    let paths = generation
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin");
+    let kotlin = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    // Typed wrapper + data-class surface.
+    assert!(kc.contains("byte:Int"), "{kotlin}");
+    assert!(kc.contains("short:Int"), "{kotlin}");
+    assert!(kc.contains("int:Long"), "{kotlin}");
+    assert!(kc.contains("long:ULong"), "{kotlin}");
+    assert!(kc.contains("maybeLong:ULong?"), "{kotlin}");
+
+    // Raw harness and wrapper bridges retain stable JNI primitives.
+    assert!(kc.contains("externalfununsignedRoundTrip("), "{kotlin}");
+    assert!(kc.contains("long:Long"), "{kotlin}");
+    assert!(kc.contains("maybeLong:Long?"), "{kotlin}");
+    assert!(kc.contains("long.toLong()"), "{kotlin}");
+    assert!(kc.contains("maybeLong?.toLong()"), "{kotlin}");
+    assert!(kc.contains(".toULong()"), "{kotlin}");
+
+    // Callback gets a typed interface plus a raw Long twin and adapter.
+    assert!(kc.contains("funrun(u64:ULong)"), "{kotlin}");
+    assert!(kc.contains("funrun(u64:Long)"), "{kotlin}");
+    assert!(kc.contains("u64.toULong()"), "{kotlin}");
+
+    // The projection composes through Result's success arm while retaining
+    // the ordinary typed domain-error callback.
+    assert!(kc.contains("fununsignedResult(value:ULong"), "{kotlin}");
+    assert!(kc.contains("):ULong"), "{kotlin}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -244,6 +244,21 @@ impl JniGen {
         }
     }
 
+    /// Leaf metadata for Rust `u64`: the JNI value-context stays `Long`, while
+    /// projection-aware Kotlin emitters surface `ULong` and insert the
+    /// bit-preserving `toLong()` / `toULong()` bridge.
+    fn unsigned64_leaf_meta(&self) -> KotlinMeta {
+        KotlinMeta {
+            projection: Some(Projection {
+                leaf_key: TypeKey::parse("u64").expect("builtin type key"),
+                owned: false,
+                strategy: FoldStrategy::Base,
+                kind: ProjectionKind::Unsigned64,
+            }),
+            ..self.framework_meta(Some(kt::KtType::long()))
+        }
+    }
+
     /// If the user pinned a Kotlin name for `outer_ty` via
     /// [`Self::data_class`] (or it's an opaque-handle entry that
     /// kept its FQN in `kotlin_name`), use that name; otherwise leave
@@ -832,9 +847,11 @@ impl JniGen {
             // and multi-field data classes are not leaf-folded — data classes go
             // through `value_struct_decons`.
             Some(cfg) => cfg.value_blob || cfg.opaque.is_some(),
-            // Undeclared: only the `String` builtin crosses as a single
-            // JObject-shaped leaf (`JString`); other builtins are primitives.
-            None => is_string_type(elem),
+            // Undeclared: `String` is JObject-shaped; `u64` is the built-in
+            // scalar projection whose raw jlong leaf the Kotlin folder wraps
+            // into `ULong`. Other primitive collections retain their existing
+            // unsupported status (`Vec<u8>` is the rank-0 ByteArray special).
+            None => is_string_type(elem) || TypeKey::from_type(elem).as_str() == "u64",
         }
     }
 }
@@ -1545,13 +1562,18 @@ impl JniGen {
         if let Some((wire, body)) = primitive_input(ty) {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
+            let metadata = if TypeKey::from_type(ty).as_str() == "u64" {
+                self.unsigned64_leaf_meta()
+            } else {
+                self.framework_meta(kotlin_name)
+            };
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
                 function: self.build_input_fn(ty, &wire, &body, None),
                 destination: wire,
                 niches,
-                metadata: self.framework_meta(kotlin_name),
+                metadata,
             });
         }
         if let Some(name) = bare_path_ident(ty) {
@@ -1750,13 +1772,18 @@ impl JniGen {
         if let Some((wire, body)) = primitive_output(ty) {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
+            let metadata = if TypeKey::from_type(ty).as_str() == "u64" {
+                self.unsigned64_leaf_meta()
+            } else {
+                self.framework_meta(kotlin_name)
+            };
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
                 function: self.build_output_fn(ty, &wire, &body, None),
                 destination: wire,
                 niches,
-                metadata: self.framework_meta(kotlin_name),
+                metadata,
             });
         }
         if let Some(name) = bare_path_ident(ty) {

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -14,6 +14,24 @@
 //!   3. [`jni::JniGen::write_kotlin`] walks the resolved registry to emit the
 //!      secondary Kotlin artifacts (typed-handle classes, data/enum classes,
 //!      exception classes, the centralized `JNINative` holder).
+//!
+//! # Fixed-width unsigned integers
+//!
+//! JniGen exposes Rust's fixed-width unsigned scalars without narrowing their
+//! domain at the Kotlin boundary:
+//!
+//! | Rust | Kotlin surface | JNI wire |
+//! |------|----------------|----------|
+//! | `u8` | `Int` | `jint` |
+//! | `u16` | `Int` | `jint` |
+//! | `u32` | `Long` | `jlong` |
+//! | `u64` | `ULong` | `jlong` / `Long` bit pattern |
+//!
+//! Inputs for `u8`, `u16`, and `u32` are range-checked and report a
+//! [`JniBindingError`] through the generated binding-error handler. `u64`
+//! uses Kotlin's bit-preserving `ULong.toLong()` / `Long.toULong()` bridge.
+//! These mappings compose through nullable/result outputs, generated data
+//! classes, callbacks, const getters, and supported output collections.
 
 pub mod jni;
 pub(crate) mod util;


### PR DESCRIPTION
Fixes #108.

## Summary

- add lossless built-in JniGen mappings: `u8 -> Int/jint`, `u16 -> Int/jint`, `u32 -> Long/jlong`, and `u64 -> ULong` over a raw `Long/jlong` bit pattern
- range-check widened `u8`, `u16`, and `u32` inputs and route failures through `JniBindingError`
- compose the `u64` projection through nullable/result values, data classes, callbacks, consts, and supported output collection folds while preserving the existing `Vec<u8> -> ByteArray` special case
- model `ULong` JVM erasure and defer Kotlin return projections until after native error captures are checked
- add focused generator tests plus max-value, nullability, callback, collection, and invalid-range JVM runtime coverage

## Validation

- `cargo test --all --all-features`
- `cargo clippy --all-targets --no-default-features --all-features -- --deny warnings`
- `cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"`
- `examples/covertest-kotlin/gradlew run --console=plain` (33 sections pass)
- release-regenerated Kotlin/JNI artifacts are byte-identical across consecutive builds