### PR TITLE
jnigen: clippy-clean range-checked unsigned input converters

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1879,12 +1879,16 @@ pub(crate) unsafe fn jint_to_u16_28edf527<'env, 'v>(
     v: &jni::sys::jint,
 ) -> ::core::result::Result<u16, __JniErr> {
     Ok(
-        ::core::primitive::u16::try_from(*v)
-            .map_err(|_| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("u16 input out of range: {}", * v))
-            })?,
+        match ::core::primitive::u16::try_from(*v) {
+            ::core::result::Result::Ok(__u) => __u,
+            ::core::result::Result::Err(_) => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("u16 input out of range: {}", * v)),
+                );
+            }
+        },
     )
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -1893,12 +1897,16 @@ pub(crate) unsafe fn jint_to_u8_553cf6ec<'env, 'v>(
     v: &jni::sys::jint,
 ) -> ::core::result::Result<u8, __JniErr> {
     Ok(
-        ::core::primitive::u8::try_from(*v)
-            .map_err(|_| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("u8 input out of range: {}", * v))
-            })?,
+        match ::core::primitive::u8::try_from(*v) {
+            ::core::result::Result::Ok(__u) => __u,
+            ::core::result::Result::Err(_) => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("u8 input out of range: {}", * v)),
+                );
+            }
+        },
     )
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
@@ -2052,12 +2060,16 @@ pub(crate) unsafe fn jlong_to_u32_9594a230<'env, 'v>(
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<u32, __JniErr> {
     Ok(
-        ::core::primitive::u32::try_from(*v)
-            .map_err(|_| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("u32 input out of range: {}", * v))
-            })?,
+        match ::core::primitive::u32::try_from(*v) {
+            ::core::result::Result::Ok(__u) => __u,
+            ::core::result::Result::Err(_) => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("u32 input out of range: {}", * v)),
+                );
+            }
+        },
     )
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -44,32 +44,53 @@ pub(crate) fn primitive_input(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)> 
         ),
         "i32" => (syn::parse_quote!(jni::sys::jint), syn::parse_quote!(*v)),
         "i64" => (syn::parse_quote!(jni::sys::jlong), syn::parse_quote!(*v)),
+        // Range-checked unsigned inputs: unwrap via a transforming `match` with
+        // an early return, so the surrounding `Ok(#body)` wrap yields
+        // `Ok(match { .. })` rather than `Ok(x?)` (which clippy's
+        // `needless_question_mark` rejects). The transforming error arm also
+        // avoids clippy's `question_mark` lint (it fires only for identity
+        // error propagation).
         "u8" => (
             syn::parse_quote!(jni::sys::jint),
-            syn::parse_quote!(::core::primitive::u8::try_from(*v).map_err(|_| {
-                <__JniErr as ::core::convert::From<String>>::from(format!(
-                    "u8 input out of range: {}",
-                    *v
-                ))
-            })?),
+            syn::parse_quote!(match ::core::primitive::u8::try_from(*v) {
+                ::core::result::Result::Ok(__u) => __u,
+                ::core::result::Result::Err(_) => {
+                    return ::core::result::Result::Err(<__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!(
+                        "u8 input out of range: {}",
+                        *v
+                    )));
+                }
+            }),
         ),
         "u16" => (
             syn::parse_quote!(jni::sys::jint),
-            syn::parse_quote!(::core::primitive::u16::try_from(*v).map_err(|_| {
-                <__JniErr as ::core::convert::From<String>>::from(format!(
-                    "u16 input out of range: {}",
-                    *v
-                ))
-            })?),
+            syn::parse_quote!(match ::core::primitive::u16::try_from(*v) {
+                ::core::result::Result::Ok(__u) => __u,
+                ::core::result::Result::Err(_) => {
+                    return ::core::result::Result::Err(<__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!(
+                        "u16 input out of range: {}",
+                        *v
+                    )));
+                }
+            }),
         ),
         "u32" => (
             syn::parse_quote!(jni::sys::jlong),
-            syn::parse_quote!(::core::primitive::u32::try_from(*v).map_err(|_| {
-                <__JniErr as ::core::convert::From<String>>::from(format!(
-                    "u32 input out of range: {}",
-                    *v
-                ))
-            })?),
+            syn::parse_quote!(match ::core::primitive::u32::try_from(*v) {
+                ::core::result::Result::Ok(__u) => __u,
+                ::core::result::Result::Err(_) => {
+                    return ::core::result::Result::Err(<__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!(
+                        "u32 input out of range: {}",
+                        *v
+                    )));
+                }
+            }),
         ),
         // Kotlin's public surface is `ULong`, but the JNI tier receives its
         // underlying `Long` bit pattern. Rust's `as u64` is the inverse of


### PR DESCRIPTION
The generated `u8`/`u16`/`u32` **input** converters unwrapped the range check with a trailing `?`:

```rust
Ok(::core::primitive::u16::try_from(*v).map_err(|_| …)?)
```

The converter body wrapper always wraps as `Ok(#body)`, so this becomes `Ok(x?)` — clippy's `needless_question_mark`. Any consumer that builds its generated bindings with `-D warnings` and has such an input (e.g. an `EncodingId`/`u16` or a `u32` entity id) fails clippy. (Surfaced while giving zenoh-flat's advanced-publisher params their native unsigned types.)

## Fix
Emit the unwrap as a transforming `match` with an early return, so the wrap yields `Ok(match { … })`:

```rust
Ok(match ::core::primitive::u16::try_from(*v) {
    Ok(__u) => __u,
    Err(_) => return Err(<__JniErr as From<String>>::from(format!("u16 input out of range: {}", *v))),
})
```

The transforming error arm also stays clear of clippy's `question_mark` lint (which only fires for identity error propagation).

## Verification
- `covertest-kotlin` exercises `u8`/`u16`/`u32` inputs; its committed golden is regenerated to the clippy-clean form (included).
- `cargo fmt --check`, `cargo clippy --all-targets --no-default-features --all-features -- -D warnings`, and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)