### PR TITLE
Add bounded representation domains for allocation-free options

### DIFF
--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -79,6 +79,10 @@ for the full table; in brief:
   remains primitive `Long` at the native boundary, using an invalid value as
   the `None` niche. The runtime checks both conversion directions, both domain
   error paths, and the unboxed JNI signature.
+- **fallible stages under structural wrappers:** `Option<Percent>` composes a
+  raw `TryFrom::Error` input stage and a raw `String` output stage. The runtime
+  checks null/value round trips and verifies both stage errors normalize to
+  `JniErrorHandler`.
 - **type mappings:** primitives, `String`/`&str` (incl. a bare `String`
   return), `Option<T>` (param / return / **field**, incl. `Option<enum>` in
   all three positions and `Option<Payload>` in both directions),
@@ -113,7 +117,7 @@ The asserts are grouped into these sections (run order):
 17. `two-caller split storageTryFromStamp`
 18. `input/output wrapper Millis -> Long (+ .name rename)`
 19. `convert! via From/Into impls (Celsius -> Int)`
-20. `convert! via TryFrom (Percent -> Int, fallible input)`
+20. `convert! fallible stages under Option (Percent -> Int?)`
 21. `convert! via binding-local fns (Label -> String, fallible input)`
 22. `record-built <A> fold (summarySeries / summarySeriesOpt)`
 23. `Vec<Storage> handle fold (storageShards / storageShardsOpt)`

--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -13,9 +13,10 @@ benchmark.
 
 The shared Rust library lives in `perftest-flat`. The coverage-only items
 (`Priority`, `Stamp`, `Annotated`, `StorageError`, `Summary`, `Archive`,
-`StorageHandler`, `Millis`, and the analytics/shape functions) are additive and
-opt-in: they sit in `perftest_flat::ext` and are only pulled in by a binding
-that declares them, so `perftest-c` / `perftest-kotlin` are unaffected.
+`StorageHandler`, `Millis`, `Duration`, and the analytics/shape functions) are
+additive and opt-in: they sit in `perftest_flat::ext` and are only pulled in by
+a binding that declares them, so `perftest-c` / `perftest-kotlin` are
+unaffected.
 
 ## Running
 
@@ -30,7 +31,7 @@ re-runs `build.rs` to regenerate both sides of the binding
 the Kotlin asserts. Expected output ends with:
 
 ```
-PASS - 30 sections, every JniGen feature exercised
+PASS - 34 sections, every JniGen feature exercised
 ```
 
 (One section deliberately provokes callback exceptions; the stack traces it
@@ -73,6 +74,11 @@ for the full table; in brief:
 - **per-class:** `.name()` on a type declaration (renames `Archive` → Kotlin
   `SummaryVault`; literal, bypasses the mangle closures).
 - **wrappers:** `input_wrapper` / `output_wrapper` (`Millis` ⇄ `Long`).
+- **bounded representations:** standard-library `Duration` ⇄ millisecond
+  `u64` with `.valid_range(...)`; `Option<Duration>` is `ULong?` publicly but
+  remains primitive `Long` at the native boundary, using an invalid value as
+  the `None` niche. The runtime checks both conversion directions, both domain
+  error paths, and the unboxed JNI signature.
 - **type mappings:** primitives, `String`/`&str` (incl. a bare `String`
   return), `Option<T>` (param / return / **field**, incl. `Option<enum>` in
   all three positions and `Option<Payload>` in both directions),
@@ -88,26 +94,40 @@ for the full table; in brief:
 
 The asserts are grouped into these sections (run order):
 
-1. `data_class Payload`
-2. `enum_class Priority`
-3. `value_class Stamp`
-4. `Option<i64> payloadLabelLen`
-5. `Storage members + Option/Vec round-trips`
-6. `constructor Storage.withPayload`
-7. `callbacks (impl Fn single + slice)`
-8. `flatten_output (default / suppress / with)`
-9. `flatten_input (default / with), leaves + handle`
-10. `Result error channel storageTryWithLabel`
-11. `input/output wrapper Millis -> Long (+ .name rename)`
-12. `Vec<Storage> handle fold (storageShards / storageShardsOpt)`
-13. `owned-handle callback (impl Fn(Storage))`
-14. `nested data_class Annotated + Option fields`
-15. `borrowed-opaque output archiveLatest`
-16. `Vec<String> storageLabels + Option<Payload> input + String return`
-17. `binding error je != null (malformed Stamp bytes)`
-18. `callback exceptions are swallowed (no-throw contract)`
-19. `3-handle locking + 2-thread smoke`
-20. `high-volume callback (localref pressure)`
+1. `top-level const vals (all four value sources)`
+2. `data_class Payload`
+3. `fixed-width unsigned scalars`
+4. `bounded Option<Duration> niche over raw Long`
+5. `enum_class Priority`
+6. `value_class Stamp`
+7. `Option<i64> Payload.labelLen`
+8. `Storage members + Option/Vec round-trips`
+9. `constructor Storage.withPayload`
+10. `.interface() hatch (Api interfaces extended by SDK interfaces)`
+11. `callbacks (impl Fn single + slice)`
+12. `flatten_output (default / suppress / with)`
+13. `binding-local field (fun! + sig!)`
+14. `binding-local functions (fun!(crate::…) + sig!)`
+15. `flatten_input (default / with), leaves + handle`
+16. `Result error channel storageTryWithLabel`
+17. `two-caller split storageTryFromStamp`
+18. `input/output wrapper Millis -> Long (+ .name rename)`
+19. `convert! via From/Into impls (Celsius -> Int)`
+20. `convert! via TryFrom (Percent -> Int, fallible input)`
+21. `convert! via binding-local fns (Label -> String, fallible input)`
+22. `record-built <A> fold (summarySeries / summarySeriesOpt)`
+23. `Vec<Storage> handle fold (storageShards / storageShardsOpt)`
+24. `owned-handle callback (impl Fn(Storage))`
+25. `nested data_class Annotated + Option fields`
+26. `borrowed-opaque output archiveLatest`
+27. `Vec<String> storageLabels + Option<Payload> input + String return`
+28. `binding error je != null (malformed Stamp bytes)`
+29. `callback exceptions are swallowed (no-throw contract)`
+30. `3-handle locking + 2-thread smoke`
+31. `close/take storm (lock-order stability + closed-handle race)`
+32. `high-volume callback (localref pressure)`
+33. `.gc_managed() lifecycle (ticket + Cleaner backstop)`
+34. `JNI native-symbol escaping (esc_pkg / Esc_Probe / snake extern)`
 
 ### Relationship to perftest-kotlin
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -24,7 +24,7 @@
 //! | `convert!` + chained source streams   | `Millis` ⇄ `Long` via `covertest-helpers` fns |
 //! | `Source::builder().crate_name()`      | the helpers dep is RENAMED to `cov_helpers` in Cargo.toml |
 //! | `convert!` `.input(from!)`/`.output(into!)` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
-//! | `convert!` `.input(try_from!)` (fallible) | `Percent` ⇄ `Int`; out-of-range → `onError` |
+//! | fallible conversion stages under `Option` | `Option<Percent>` ⇄ `Int?`; raw `TryFrom::Error` input and binding-local `String` output errors normalize to `JniErrorHandler` |
 //! | `convert!` sources `fun!(crate::…).sig(sig!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); the sig's `Result` = error channel, empty label → `onError` |
 //! | bounded conversion domains + niches | `Option<Duration>` ⇄ bounded millisecond `ULong?`; raw JNI remains primitive `Long`, `None` uses an invalid `u64`, invalid input/output routes to `onError` |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
@@ -168,9 +168,14 @@ fn main() {
         // `Celsius`: canonical conversion via `From`/`Into` impls in the flat
         // crate — the repr (`i32`) is stated, the impls do the work.
         .convert(convert!(Celsius).input(from!(i32)).output(into!(i32)))
-        // `Percent`: fallible input via `TryFrom<i32>` (out-of-range values
-        // from the JVM route the impl's Error to onError); infallible output.
-        .convert(convert!(Percent).input(try_from!(i32)).output(into!(i32)))
+        // `Percent`: fallible in BOTH directions. `Option<Percent>` below
+        // forces both raw stage error types through the structural Option
+        // converter, where they normalize to the binding error channel.
+        .convert(
+            convert!(Percent)
+                .input(try_from!(i32))
+                .output(fun!(crate::percent_out).sig(sig!((p: Percent) -> Result<i32, String>))),
+        )
         // `Label`: conversions are plain fns in THIS binding crate (see
         // src/lib.rs) — no #[prebindgen], no helper crate — declared with
         // the ONE binding-local vocabulary, `fun!(crate::…).sig(sig!(…))`.
@@ -394,6 +399,8 @@ fn main() {
                 // below): Into/From traits, TryFrom trait, binding-local fns.
                 .fun(fun!(celsius_double))
                 .fun(fun!(percent_scale))
+                .fun(fun!(percent_optional))
+                .fun(fun!(percent_invalid_output))
                 .fun(fun!(label_reverse))
                 .fun(fun!(annotated_new))
                 .fun(fun!(annotated_ttl))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -26,6 +26,7 @@
 //! | `convert!` `.input(from!)`/`.output(into!)` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | `convert!` `.input(try_from!)` (fallible) | `Percent` ⇄ `Int`; out-of-range → `onError` |
 //! | `convert!` sources `fun!(crate::…).sig(sig!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); the sig's `Result` = error channel, empty label → `onError` |
+//! | bounded conversion domains + niches | `Option<Duration>` ⇄ bounded millisecond `ULong?`; raw JNI remains primitive `Long`, `None` uses an invalid `u64`, invalid input/output routes to `onError` |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
 //! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones |
@@ -179,6 +180,19 @@ fn main() {
             convert!(Label)
                 .input(fun!(crate::label_in).sig(sig!((s: String) -> Result<Label, String>)))
                 .output(fun!(crate::label_out).sig(sig!((l: Label) -> String))),
+        )
+        // Keep Rust's standard `Duration` as the semantic type while exposing
+        // bounded u64 milliseconds. Values above one day are invalid; one of
+        // those representations becomes the `Option<Duration>` None marker,
+        // so nullable Kotlin `ULong?` crosses JNI as a raw primitive `Long`
+        // without JObject/boxed-Long allocation.
+        .convert(
+            convert!(Duration)
+                .input(fun!(crate::duration_from_millis).sig(sig!((ms: u64) -> Duration)))
+                .output(
+                    fun!(crate::duration_to_millis).sig(sig!((d: Duration) -> Result<u64, String>)),
+                )
+                .valid_range(0u64..=86_400_000u64),
         )
         // ── Base-package types ──────────────────────────────────────────────
         // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
@@ -388,7 +402,9 @@ fn main() {
                 .fun(fun!(unsigned_round_trip))
                 .fun(fun!(unsigned_optional))
                 .fun(fun!(unsigned_emit))
-                .fun(fun!(unsigned_series)),
+                .fun(fun!(unsigned_series))
+                .fun(fun!(duration_optional))
+                .fun(fun!(duration_out_of_range)),
         )
         // analytics: the param-variant / return-field matrix (type default /
         // per-fn override, in + out). Per-fn overrides reuse the SAME

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -56,6 +56,8 @@ Base package: `io.prebindgen.covertest`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
 - `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority`
+- `percent_invalid_output` — `fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int?`
+- `percent_optional` — `fun percentOptional(p: Int?, onError: JniErrorHandler<Int?>): Int?`
 - `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int`
 - `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority>): Priority`
 - `priority_weight` — `fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int`
@@ -154,4 +156,4 @@ Base package: `io.prebindgen.covertest`
 - `convert!(Duration)`: input `#[prebindgen]` fn `duration_from_millis`, output `#[prebindgen]` fn `duration_to_millis`
 - `convert!(Label)`: input `#[prebindgen]` fn `label_in`, output `#[prebindgen]` fn `label_out`
 - `convert!(Millis)`: input `#[prebindgen]` fn `millis_from_long`, output `#[prebindgen]` fn `millis_value`
-- `convert!(Percent)`: input `TryInto` ⇄ `i32`, output `Into` ⇄ `i32`
+- `convert!(Percent)`: input `TryInto` ⇄ `i32`, output `#[prebindgen]` fn `percent_out`

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -52,6 +52,8 @@ Base package: `io.prebindgen.covertest`
 - `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority?`
 - `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long?`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
+- `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
+- `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
 - `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority`
 - `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int`
@@ -149,6 +151,7 @@ Base package: `io.prebindgen.covertest`
 ## conversions
 
 - `convert!(Celsius)`: input `Into` ⇄ `i32`, output `Into` ⇄ `i32`
+- `convert!(Duration)`: input `#[prebindgen]` fn `duration_from_millis`, output `#[prebindgen]` fn `duration_to_millis`
 - `convert!(Label)`: input `#[prebindgen]` fn `label_in`, output `#[prebindgen]` fn `label_out`
 - `convert!(Millis)`: input `#[prebindgen]` fn `millis_from_long`, output `#[prebindgen]` fn `millis_value`
 - `convert!(Percent)`: input `TryInto` ⇄ `i32`, output `Into` ⇄ `i32`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -651,6 +651,10 @@ internal object CovNative {
 
     external fun coverTagRuntime(errorSink: Any): String
 
+    external fun durationOptional(value: Long, errorSink: Any): Long
+
+    external fun durationOutOfRange(errorSink: Any): Long
+
     external fun escapeProbeNew(value: Long, errorSink: Any): Long
 
     external fun escape_probe_value(p: Long, errorSink: Any): Long

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -685,6 +685,10 @@ internal object CovNative {
 
     external fun payloadVecHandlerNew(f: Any, errorSink: Any): Long
 
+    external fun percentInvalidOutput(errorSink: Any): Int?
+
+    external fun percentOptional(p: Int?, errorSink: Any): Int?
+
     external fun percentScale(p: Int, factor: Int, errorSink: Any): Int
 
     external fun priorityOr(pPresent: Boolean, pValue: Int, fallback: Int, errorSink: Any): Int

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -348,3 +348,26 @@ public fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong> {
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as List<ULong>
 }
+
+/**
+ * Round-trip an optional standard-library duration. The source API remains
+ * semantic (`Option<Duration>`); only the binding declares its millisecond
+ * representation and range.
+ */
+public fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.durationOptional(value?.toLong() ?: -1L, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret.let { if (it == -1L) null else it.toULong() }
+}
+
+/**
+ * Deliberately violate the binding's declared output domain so the Kotlin
+ * covertest can verify outbound validation and error routing.
+ */
+public fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.durationOutOfRange(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret.let { if (it == -1L) null else it.toULong() }
+}

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -226,6 +226,29 @@ public fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int
 }
 
 /**
+ * Round-trip an optional percentage. The covertest binding uses this to
+ * compose `Option` with the fallible `TryFrom<i32>` input conversion and its
+ * fallible output conversion.
+ */
+public fun percentOptional(p: Int?, onError: JniErrorHandler<Int?>): Int? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.percentOptional(p, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * Deliberately construct a value outside `Percent`'s semantic invariant so
+ * the covertest can verify a fallible output stage nested under `Option`.
+ */
+public fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.percentInvalidOutput(__bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * Reverse a label's characters (exercises the binding-local conversion on
  * a parameter and the return).
  */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -26,6 +26,8 @@ import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.celsiusDouble
+import io.prebindgen.covertest.model.durationOptional
+import io.prebindgen.covertest.model.durationOutOfRange
 import io.prebindgen.covertest.model.labelReverse
 import io.prebindgen.covertest.model.percentScale
 import io.prebindgen.covertest.model.annotatedPayloadValue
@@ -165,6 +167,45 @@ fun main() {
         expectRangeError(-1, 0, 0L, "u8 input out of range: -1")
         expectRangeError(0, 65_536, 0L, "u16 input out of range: 65536")
         expectRangeError(0, 0, 4_294_967_296L, "u32 input out of range: 4294967296")
+    }
+
+    // ── bounded custom representation: Rust keeps Option<Duration>, Kotlin
+    // sees ULong?, and JNI uses an invalid u64 bit pattern for null so the
+    // native carrier remains primitive long rather than JObject/boxed Long. ─
+    section("bounded Option<Duration> niche over raw Long") {
+        val native = CovNative::class.java.getDeclaredMethod(
+            "durationOptional",
+            java.lang.Long.TYPE,
+            Any::class.java,
+        )
+        check(native.parameterTypes[0] == java.lang.Long.TYPE)
+        check(native.returnType == java.lang.Long.TYPE) {
+            "bounded Option<Duration> must use a primitive Long JNI carrier"
+        }
+
+        check(durationOptional(null, boom) == null)
+        check(durationOptional(0uL, boom) == 0uL)
+        check(durationOptional(86_400_000uL, boom) == 86_400_000uL)
+
+        var inputError: String? = null
+        val inputFallback = durationOptional(86_400_001uL) { je ->
+            inputError = je
+            7uL
+        }
+        check(inputFallback == 7uL)
+        check(inputError?.contains("outside its declared domain") == true) {
+            "invalid duration input did not report its domain error: $inputError"
+        }
+
+        var outputError: String? = null
+        val outputFallback = durationOutOfRange { je ->
+            outputError = je
+            null
+        }
+        check(outputFallback == null)
+        check(outputError?.contains("outside its declared domain") == true) {
+            "invalid duration output did not report its domain error: $outputError"
+        }
     }
 
     // ── enum_class: return / by-value param / Option<enum> param ─────────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -29,6 +29,8 @@ import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.durationOptional
 import io.prebindgen.covertest.model.durationOutOfRange
 import io.prebindgen.covertest.model.labelReverse
+import io.prebindgen.covertest.model.percentInvalidOutput
+import io.prebindgen.covertest.model.percentOptional
 import io.prebindgen.covertest.model.percentScale
 import io.prebindgen.covertest.model.annotatedPayloadValue
 import io.prebindgen.covertest.model.annotatedPriority
@@ -584,19 +586,32 @@ fun main() {
         check(celsiusDouble(21, boom) == 42)
         check(celsiusDouble(-5, boom) == -10)
     }
-    section("convert! via TryFrom (Percent -> Int, fallible input)") {
+    section("convert! fallible stages under Option (Percent -> Int?)") {
         check(percentScale(50, 2, boom) == 100)
         check(percentScale(30, 2, boom) == 60)
+        check(percentOptional(null, boom) == null)
+        check(percentOptional(25, boom) == 25)
         // Out-of-range input: the TryFrom impl's Err(String) routes to
-        // onError through the converter's error slot (je carries the
-        // Display'd message).
+        // onError through an Option-composed stage (je carries the Display'd
+        // message after normalization to __JniErr).
         var msg: String? = null
-        percentScale(150, 1) { je ->
+        percentOptional(150) { je ->
             msg = je
-            0
+            null
         }
         check(msg?.contains("percent out of range: 150") == true) {
-            "percentScale(150) must report the range error, got: $msg"
+            "percentOptional(150) must report the range error, got: $msg"
+        }
+
+        // The output stage has its own raw String error. It must normalize in
+        // the opposite Option composition direction and use the same handler.
+        msg = null
+        percentInvalidOutput { je ->
+            msg = je
+            null
+        }
+        check(msg == "invalid Percent output: 101") {
+            "percentInvalidOutput must report the output conversion error, got: $msg"
         }
     }
     section("convert! via binding-local fns (Label -> String, fallible input)") {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -435,6 +435,38 @@ pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
     Ok(<perftest_flat::Celsius as ::core::convert::Into<i32>>::into(v))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Duration_to_u64_e3980876<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Duration,
+) -> ::core::result::Result<u64, __JniErr> {
+    {
+        match (crate::duration_to_millis(v))
+            .map_err(|__e| {
+                <__JniErr as ::core::convert::From<String>>::from(__e.to_string())
+            })
+        {
+            ::core::result::Result::Ok(
+                __repr,
+            ) if (true && true && (__repr) <= 86400000u64) && !(false) => {
+                ::core::result::Result::Ok(__repr)
+            }
+            ::core::result::Result::Ok(_) => {
+                ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "{} representation is outside its declared domain",
+                            "Duration"
+                        ),
+                    ),
+                )
+            }
+            ::core::result::Result::Err(__e) => ::core::result::Result::Err(__e),
+        }
+    }
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn EscapeProbe_to_jlong_416aab42<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::EscapeProbe,
@@ -517,7 +549,16 @@ pub(crate) unsafe fn JObject_to_Option_Payload_97036642<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Payload>, __JniErr> {
-    Ok({ if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) } })
+    Ok({
+        if v.is_null() {
+            None
+        } else {
+            Some({
+                let __inner_s0 = JObject_to_Payload_98f64326(env, v)?;
+                __inner_s0
+            })
+        }
+    })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
@@ -533,7 +574,10 @@ pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some(jint_to_Priority_447102d2(env, &__unboxed)?)
+            Some({
+                let __inner_s0 = jint_to_Priority_447102d2(env, &__unboxed)?;
+                __inner_s0
+            })
         } else {
             None
         }
@@ -553,7 +597,10 @@ pub(crate) unsafe fn JObject_to_Option_f64_b3f3e9a9<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some(jdouble_to_f64_9e4a8f70(env, &__unboxed)?)
+            Some({
+                let __inner_s0 = jdouble_to_f64_9e4a8f70(env, &__unboxed)?;
+                __inner_s0
+            })
         } else {
             None
         }
@@ -573,7 +620,10 @@ pub(crate) unsafe fn JObject_to_Option_i64_2ba9a5ed<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some(jlong_to_i64_fbf9a9bc(env, &__unboxed)?)
+            Some({
+                let __inner_s0 = jlong_to_i64_fbf9a9bc(env, &__unboxed)?;
+                __inner_s0
+            })
         } else {
             None
         }
@@ -593,7 +643,10 @@ pub(crate) unsafe fn JObject_to_Option_u64_32be16a2<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some(jlong_to_u64_4384a5d6(env, &__unboxed)?)
+            Some({
+                let __inner_s0 = jlong_to_u64_4384a5d6(env, &__unboxed)?;
+                __inner_s0
+            })
         } else {
             None
         }
@@ -1325,7 +1378,13 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
         if v.is_null() {
             None
         } else {
-            Some(JString_to_std_boxed_Box_std_string_String_cfbab680(env, v)?)
+            Some({
+                let __inner_s0 = JString_to_std_boxed_Box_std_string_String_cfbab680(
+                    env,
+                    v,
+                )?;
+                __inner_s0
+            })
         }
     })
 }
@@ -1390,6 +1449,21 @@ pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
     })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Option_Duration_to_jlong_1cfa4d44<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Duration>,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok({
+        match v {
+            Some(value) => {
+                let __inner_s0 = Duration_to_u64_e3980876(env, value)?;
+                u64_to_jlong_4384a5d6(env, __inner_s0)?
+            }
+            None => -1i64,
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<perftest_flat::Payload>,
@@ -1409,7 +1483,7 @@ pub(crate) unsafe fn Option_Priority_to_JObject_ad5cbb32<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __raw: jni::sys::jint = Priority_to_jint_447102d2(env, value)?;
+                let __raw: jni::sys::jint = { Priority_to_jint_447102d2(env, value)? };
                 ::prebindgen::lang::box_jint(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -1451,7 +1525,7 @@ pub(crate) unsafe fn Option_i64_to_JObject_2ba9a5ed<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __raw: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, value)?;
+                let __raw: jni::sys::jlong = { i64_to_jlong_fbf9a9bc(env, value)? };
                 ::prebindgen::lang::box_jlong(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -1469,7 +1543,7 @@ pub(crate) unsafe fn Option_u64_to_JObject_32be16a2<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __raw: jni::sys::jlong = u64_to_jlong_4384a5d6(env, value)?;
+                let __raw: jni::sys::jlong = { u64_to_jlong_4384a5d6(env, value)? };
                 ::prebindgen::lang::box_jlong(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -1930,6 +2004,23 @@ pub(crate) unsafe fn jlong_to_EscapeProbe_416aab42<'env, 'v>(
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::EscapeProbe) })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<Option<perftest_flat::Duration>, __JniErr> {
+    Ok({
+        if *v == -1i64 {
+            None
+        } else {
+            Some({
+                let __inner_s0 = jlong_to_u64_4384a5d6(env, v)?;
+                let __inner_s1 = u64_to_Duration_7c0845f9(env, __inner_s0)?;
+                __inner_s1
+            })
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -2108,6 +2199,27 @@ pub(crate) unsafe fn u32_to_jlong_9594a230<'a>(
     v: u32,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(v as jni::sys::jlong)
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn u64_to_Duration_7c0845f9<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: u64,
+) -> ::core::result::Result<perftest_flat::Duration, __JniErr> {
+    {
+        if (true && true && (v) <= 86400000u64) && !(false) {
+            ::core::result::Result::Ok(crate::duration_from_millis(v))
+        } else {
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        "{} representation is outside its declared domain", "Duration"
+                    ),
+                ),
+            )
+        }
+    }
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn u64_to_jlong_4384a5d6<'a>(
@@ -2743,6 +2855,75 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
                 &__e.to_string(),
             );
             jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationOptional<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match jlong_to_Option_Duration_1cfa4d44(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::duration_optional(value);
+    match Option_Duration_to_jlong_1cfa4d44(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationOutOfRange<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::duration_out_of_range();
+    match Option_Duration_to_jlong_1cfa4d44(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -549,16 +549,7 @@ pub(crate) unsafe fn JObject_to_Option_Payload_97036642<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Payload>, __JniErr> {
-    Ok({
-        if v.is_null() {
-            None
-        } else {
-            Some({
-                let __inner_s0 = JObject_to_Payload_98f64326(env, v)?;
-                __inner_s0
-            })
-        }
-    })
+    Ok({ if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) } })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
@@ -574,10 +565,7 @@ pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some({
-                let __inner_s0 = jint_to_Priority_447102d2(env, &__unboxed)?;
-                __inner_s0
-            })
+            Some(jint_to_Priority_447102d2(env, &__unboxed)?)
         } else {
             None
         }
@@ -597,10 +585,7 @@ pub(crate) unsafe fn JObject_to_Option_f64_b3f3e9a9<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some({
-                let __inner_s0 = jdouble_to_f64_9e4a8f70(env, &__unboxed)?;
-                __inner_s0
-            })
+            Some(jdouble_to_f64_9e4a8f70(env, &__unboxed)?)
         } else {
             None
         }
@@ -620,10 +605,7 @@ pub(crate) unsafe fn JObject_to_Option_i64_2ba9a5ed<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some({
-                let __inner_s0 = jlong_to_i64_fbf9a9bc(env, &__unboxed)?;
-                __inner_s0
-            })
+            Some(jlong_to_i64_fbf9a9bc(env, &__unboxed)?)
         } else {
             None
         }
@@ -643,10 +625,7 @@ pub(crate) unsafe fn JObject_to_Option_u64_32be16a2<'env, 'v>(
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Option unbox: {}", e)))?;
-            Some({
-                let __inner_s0 = jlong_to_u64_4384a5d6(env, &__unboxed)?;
-                __inner_s0
-            })
+            Some(jlong_to_u64_4384a5d6(env, &__unboxed)?)
         } else {
             None
         }
@@ -1378,13 +1357,7 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
         if v.is_null() {
             None
         } else {
-            Some({
-                let __inner_s0 = JString_to_std_boxed_Box_std_string_String_cfbab680(
-                    env,
-                    v,
-                )?;
-                __inner_s0
-            })
+            Some(JString_to_std_boxed_Box_std_string_String_cfbab680(env, v)?)
         }
     })
 }
@@ -1483,7 +1456,7 @@ pub(crate) unsafe fn Option_Priority_to_JObject_ad5cbb32<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __raw: jni::sys::jint = { Priority_to_jint_447102d2(env, value)? };
+                let __raw: jni::sys::jint = Priority_to_jint_447102d2(env, value)?;
                 ::prebindgen::lang::box_jint(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -1525,7 +1498,7 @@ pub(crate) unsafe fn Option_i64_to_JObject_2ba9a5ed<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __raw: jni::sys::jlong = { i64_to_jlong_fbf9a9bc(env, value)? };
+                let __raw: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, value)?;
                 ::prebindgen::lang::box_jlong(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -1543,7 +1516,7 @@ pub(crate) unsafe fn Option_u64_to_JObject_32be16a2<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __raw: jni::sys::jlong = { u64_to_jlong_4384a5d6(env, value)? };
+                let __raw: jni::sys::jlong = u64_to_jlong_4384a5d6(env, value)?;
                 ::prebindgen::lang::box_jlong(env, __raw)
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -552,6 +552,33 @@ pub(crate) unsafe fn JObject_to_Option_Payload_97036642<'env, 'v>(
     Ok({ if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) } })
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn JObject_to_Option_Percent_544dd364<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Option<perftest_flat::Percent>, __JniErr> {
+    Ok({
+        if !v.is_null() {
+            let __unboxed: jni::sys::jint = env
+                .call_method(&v, "intValue", "()I", &[])
+                .and_then(|val| val.i())
+                .map(|__x| __x as jni::sys::jint)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Option unbox: {}", e)))?;
+            Some({
+                let __inner_s0 = jint_to_i32_a3e3b6ef(env, &__unboxed)?;
+                let __inner_s1 = i32_to_Percent_db3641cc(env, __inner_s0)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
+                __inner_s1
+            })
+        } else {
+            None
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -1429,7 +1456,10 @@ pub(crate) unsafe fn Option_Duration_to_jlong_1cfa4d44<'a>(
     Ok({
         match v {
             Some(value) => {
-                let __inner_s0 = Duration_to_u64_e3980876(env, value)?;
+                let __inner_s0 = Duration_to_u64_e3980876(env, value)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
                 u64_to_jlong_4384a5d6(env, __inner_s0)?
             }
             None => -1i64,
@@ -1445,6 +1475,30 @@ pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
         match v {
             Some(value) => Payload_to_JObject_98f64326(env, value)?,
             None => jni::objects::JObject::null().into(),
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn Option_Percent_to_JObject_544dd364<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Percent>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        match v {
+            Some(value) => {
+                let __raw: jni::sys::jint = {
+                    let __inner_s0 = Percent_to_i32_01484801(env, value)
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    i32_to_jint_a3e3b6ef(env, __inner_s0)?
+                };
+                ::prebindgen::lang::box_jint(env, __raw)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option box: {}", e)))?
+            }
+            None => jni::objects::JObject::null(),
         }
     })
 }
@@ -1612,8 +1666,8 @@ pub(crate) unsafe fn Payload_to_JObject_98f64326<'a>(
 pub(crate) unsafe fn Percent_to_i32_01484801<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Percent,
-) -> ::core::result::Result<i32, __JniErr> {
-    Ok(<perftest_flat::Percent as ::core::convert::Into<i32>>::into(v))
+) -> ::core::result::Result<i32, String> {
+    crate::percent_out(v)
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Priority_to_jint_447102d2<'a>(
@@ -1987,7 +2041,10 @@ pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
         } else {
             Some({
                 let __inner_s0 = jlong_to_u64_4384a5d6(env, v)?;
-                let __inner_s1 = u64_to_Duration_7c0845f9(env, __inner_s0)?;
+                let __inner_s1 = u64_to_Duration_7c0845f9(env, __inner_s0)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
                 __inner_s1
             })
         }
@@ -3452,6 +3509,75 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecHandle
                 &__e.to_string(),
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentInvalidOutput<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::percent_invalid_output();
+    match Option_Percent_to_JObject_544dd364(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentOptional<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    p: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let p = match JObject_to_Option_Percent_544dd364(&mut env, &p) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::percent_optional(p);
+    match Option_Percent_to_JObject_544dd364(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -31,6 +31,17 @@ pub fn duration_to_millis(d: perftest_flat::Duration) -> Result<u64, String> {
         .map_err(|_| "duration does not fit in u64 milliseconds".to_string())
 }
 
+// Fallible output peer of `Percent`'s `TryFrom<i32>` input. Keeping the error
+// type as raw `String` exercises Option's stage-error normalization in the
+// opposite conversion direction.
+pub fn percent_out(p: perftest_flat::Percent) -> Result<i32, String> {
+    if p.0 <= 100 {
+        Ok(i32::from(p.0))
+    } else {
+        Err(format!("invalid Percent output: {}", p.0))
+    }
+}
+
 // Binding-local FUNCTIONS (`fun!(crate::…).sig(sig!(…))`): full fns defined
 // in THIS crate and exported through the ordinary FunctionDecl surface —
 // free package fn, instance method, companion constructor. No source-crate

--- a/examples/covertest-kotlin/src/lib.rs
+++ b/examples/covertest-kotlin/src/lib.rs
@@ -19,6 +19,18 @@ pub fn label_out(l: perftest_flat::Label) -> String {
     l.0
 }
 
+// Binding-local canonical conversion for `std::time::Duration`. The semantic
+// Rust type stays intact; build.rs declares that the foreign representation is
+// bounded `u64` milliseconds, whose invalid values provide Option niches.
+pub fn duration_from_millis(ms: u64) -> perftest_flat::Duration {
+    perftest_flat::Duration::from_millis(ms)
+}
+
+pub fn duration_to_millis(d: perftest_flat::Duration) -> Result<u64, String> {
+    u64::try_from(d.as_millis())
+        .map_err(|_| "duration does not fit in u64 milliseconds".to_string())
+}
+
 // Binding-local FUNCTIONS (`fun!(crate::…).sig(sig!(…))`): full fns defined
 // in THIS crate and exported through the ordinary FunctionDecl surface —
 // free package fn, instance method, companion constructor. No source-crate

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -437,6 +437,21 @@ pub fn percent_scale(p: Percent, factor: i32) -> Percent {
     Percent(((p.0 as i32) * factor).clamp(0, 100) as u8)
 }
 
+/// Round-trip an optional percentage. The covertest binding uses this to
+/// compose `Option` with the fallible `TryFrom<i32>` input conversion and its
+/// fallible output conversion.
+#[prebindgen]
+pub fn percent_optional(p: Option<Percent>) -> Option<Percent> {
+    p
+}
+
+/// Deliberately construct a value outside `Percent`'s semantic invariant so
+/// the covertest can verify a fallible output stage nested under `Option`.
+#[prebindgen]
+pub fn percent_invalid_output() -> Option<Percent> {
+    Some(Percent(101))
+}
+
 /// A text label. Crosses via plain conversion fns declared **in the binding
 /// crate** (`convert!(Label).input_with(ty!(String), path!(crate::label_in))…`)
 /// — no `#[prebindgen]` marking anywhere in the conversion.

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -17,6 +17,11 @@
 //!   (→ flatten-input / flatten-output).
 //! * [`Millis`] — a newtype crossing as a plain `Long` via a custom
 //!   input/output wrapper.
+//! * [`Duration`] — the standard-library semantic type crossing as bounded
+//!   milliseconds, with `Option<Duration>` using an invalid representation as
+//!   an allocation-free niche.
+
+pub use std::time::Duration;
 
 use prebindgen_proc_macro::prebindgen;
 
@@ -347,6 +352,31 @@ pub struct Millis(pub u64);
 #[prebindgen]
 pub fn millis_add(a: Millis, b: Millis) -> Millis {
     Millis(a.0 + b.0)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Duration — std semantic type crossing as bounded u64 milliseconds.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Largest duration accepted by the covertest binding: one day in
+/// milliseconds. The binding's representation-domain declaration reserves all
+/// larger `u64` values, allowing `Option<Duration>` to use one as `None` while
+/// keeping the JNI carrier a primitive `jlong`.
+pub const DURATION_MAX_MILLIS: u64 = 86_400_000;
+
+/// Round-trip an optional standard-library duration. The source API remains
+/// semantic (`Option<Duration>`); only the binding declares its millisecond
+/// representation and range.
+#[prebindgen]
+pub fn duration_optional(value: Option<Duration>) -> Option<Duration> {
+    value
+}
+
+/// Deliberately violate the binding's declared output domain so the Kotlin
+/// covertest can verify outbound validation and error routing.
+#[prebindgen]
+pub fn duration_out_of_range() -> Option<Duration> {
+    Some(Duration::from_millis(DURATION_MAX_MILLIS + 1))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/core/domain.rs
+++ b/prebindgen/src/api/core/domain.rs
@@ -145,6 +145,38 @@ impl ScalarValue {
             _ => unreachable!(),
         }
     }
+
+    fn is_integer_min(self) -> bool {
+        matches!(
+            self,
+            Self::I8(i8::MIN)
+                | Self::I16(i16::MIN)
+                | Self::I32(i32::MIN)
+                | Self::I64(i64::MIN)
+                | Self::I128(i128::MIN)
+                | Self::U8(u8::MIN)
+                | Self::U16(u16::MIN)
+                | Self::U32(u32::MIN)
+                | Self::U64(u64::MIN)
+                | Self::U128(u128::MIN)
+        )
+    }
+
+    fn is_integer_max(self) -> bool {
+        matches!(
+            self,
+            Self::I8(i8::MAX)
+                | Self::I16(i16::MAX)
+                | Self::I32(i32::MAX)
+                | Self::I64(i64::MAX)
+                | Self::I128(i128::MAX)
+                | Self::U8(u8::MAX)
+                | Self::U16(u16::MAX)
+                | Self::U32(u32::MAX)
+                | Self::U64(u64::MAX)
+                | Self::U128(u128::MAX)
+        )
+    }
 }
 
 #[derive(Clone)]
@@ -333,6 +365,8 @@ fn float64_candidates(out: &mut Vec<ScalarValue>, n: usize) {
 fn bound_expr(bound: &Bound<ScalarValue>, value: &TokenStream, lower: bool) -> TokenStream {
     match bound {
         Bound::Unbounded => quote!(true),
+        Bound::Included(v) if lower && v.is_integer_min() => quote!(true),
+        Bound::Included(v) if !lower && v.is_integer_max() => quote!(true),
         Bound::Included(v) if lower => v.cmp_expr(value, ">="),
         Bound::Excluded(v) if lower => v.cmp_expr(value, ">"),
         Bound::Included(v) => v.cmp_expr(value, "<="),
@@ -444,6 +478,19 @@ mod tests {
                 ScalarValue::U64(u64::MAX - 2),
             ]
         );
+    }
+
+    #[test]
+    fn integer_extreme_bounds_do_not_emit_useless_comparisons() {
+        let domain = RepresentationDomain::range(0u64..=1_000_000);
+        let expr = domain.contains_expr(quote!(value)).to_string();
+        assert!(!expr.contains(">= 0u64"), "{expr}");
+        assert!(expr.contains("<= 1000000u64"), "{expr}");
+
+        let full = RepresentationDomain::range(i32::MIN..=i32::MAX);
+        let expr = full.contains_expr(quote!(value)).to_string();
+        assert!(!expr.contains(">="), "{expr}");
+        assert!(!expr.contains("<="), "{expr}");
     }
 
     #[test]

--- a/prebindgen/src/api/core/domain.rs
+++ b/prebindgen/src/api/core/domain.rs
@@ -88,6 +88,7 @@ impl ScalarValue {
 
     /// A literal expression suitable for C header generation. Arbitrary NaN
     /// payloads and infinities have no portable C constant spelling.
+    #[cfg(feature = "unstable-cbindgen")]
     pub(crate) fn portable_expr(self) -> Option<syn::Expr> {
         match self {
             Self::F32(bits) => {

--- a/prebindgen/src/api/core/domain.rs
+++ b/prebindgen/src/api/core/domain.rs
@@ -1,0 +1,471 @@
+//! Valid subsets of scalar representations used by custom conversions.
+
+use std::ops::{Bound, RangeBounds};
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+/// Scalar representations that can carry a declarative domain.
+pub trait DomainScalar: Copy + 'static {
+    #[doc(hidden)]
+    fn domain_value(self) -> ScalarValue;
+    #[doc(hidden)]
+    fn domain_type() -> syn::Type;
+}
+
+macro_rules! impl_ints {
+    ($(($t:ty, $v:ident)),* $(,)?) => {$(
+        impl DomainScalar for $t {
+            fn domain_value(self) -> ScalarValue { ScalarValue::$v(self) }
+            fn domain_type() -> syn::Type { syn::parse_quote!($t) }
+        }
+    )*};
+}
+impl_ints!(
+    (i8, I8),
+    (i16, I16),
+    (i32, I32),
+    (i64, I64),
+    (i128, I128),
+    (u8, U8),
+    (u16, U16),
+    (u32, U32),
+    (u64, U64),
+    (u128, U128),
+);
+
+impl DomainScalar for f32 {
+    fn domain_value(self) -> ScalarValue {
+        ScalarValue::F32(self.to_bits())
+    }
+    fn domain_type() -> syn::Type {
+        syn::parse_quote!(f32)
+    }
+}
+impl DomainScalar for f64 {
+    fn domain_value(self) -> ScalarValue {
+        ScalarValue::F64(self.to_bits())
+    }
+    fn domain_type() -> syn::Type {
+        syn::parse_quote!(f64)
+    }
+}
+
+/// Type-erased scalar. Floats retain their raw IEEE representation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ScalarValue {
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    F32(u32),
+    F64(u64),
+}
+
+impl ScalarValue {
+    pub fn rust_expr(self) -> syn::Expr {
+        match self {
+            Self::I8(v) => syn::parse_quote!(#v),
+            Self::I16(v) => syn::parse_quote!(#v),
+            Self::I32(v) => syn::parse_quote!(#v),
+            Self::I64(v) => syn::parse_quote!(#v),
+            Self::I128(v) => syn::parse_quote!(#v),
+            Self::U8(v) => syn::parse_quote!(#v),
+            Self::U16(v) => syn::parse_quote!(#v),
+            Self::U32(v) => syn::parse_quote!(#v),
+            Self::U64(v) => syn::parse_quote!(#v),
+            Self::U128(v) => syn::parse_quote!(#v),
+            Self::F32(v) => syn::parse_quote!(f32::from_bits(#v)),
+            Self::F64(v) => syn::parse_quote!(f64::from_bits(#v)),
+        }
+    }
+
+    /// A literal expression suitable for C header generation. Arbitrary NaN
+    /// payloads and infinities have no portable C constant spelling.
+    pub(crate) fn portable_expr(self) -> Option<syn::Expr> {
+        match self {
+            Self::F32(bits) => {
+                let value = f32::from_bits(bits);
+                value
+                    .is_finite()
+                    .then(|| syn::parse_str(&format!("{value:?}f32")).expect("finite f32 literal"))
+            }
+            Self::F64(bits) => {
+                let value = f64::from_bits(bits);
+                value
+                    .is_finite()
+                    .then(|| syn::parse_str(&format!("{value:?}f64")).expect("finite f64 literal"))
+            }
+            _ => Some(self.rust_expr()),
+        }
+    }
+
+    pub fn ty(self) -> syn::Type {
+        match self {
+            Self::I8(_) => syn::parse_quote!(i8),
+            Self::I16(_) => syn::parse_quote!(i16),
+            Self::I32(_) => syn::parse_quote!(i32),
+            Self::I64(_) => syn::parse_quote!(i64),
+            Self::I128(_) => syn::parse_quote!(i128),
+            Self::U8(_) => syn::parse_quote!(u8),
+            Self::U16(_) => syn::parse_quote!(u16),
+            Self::U32(_) => syn::parse_quote!(u32),
+            Self::U64(_) => syn::parse_quote!(u64),
+            Self::U128(_) => syn::parse_quote!(u128),
+            Self::F32(_) => syn::parse_quote!(f32),
+            Self::F64(_) => syn::parse_quote!(f64),
+        }
+    }
+
+    fn raw_eq(self, value: &TokenStream) -> TokenStream {
+        match self {
+            Self::F32(bits) => quote!((#value).to_bits() == #bits),
+            Self::F64(bits) => quote!((#value).to_bits() == #bits),
+            _ => {
+                let v = self.rust_expr();
+                quote!((#value) == #v)
+            }
+        }
+    }
+
+    fn cmp_expr(self, value: &TokenStream, op: &str) -> TokenStream {
+        let v = self.rust_expr();
+        match op {
+            ">" => quote!((#value) > #v),
+            ">=" => quote!((#value) >= #v),
+            "<" => quote!((#value) < #v),
+            "<=" => quote!((#value) <= #v),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum Base {
+    Range {
+        start: Bound<ScalarValue>,
+        end: Bound<ScalarValue>,
+    },
+    Values(Vec<ScalarValue>),
+}
+
+/// Legal values of a custom conversion's scalar representation.
+#[derive(Clone)]
+pub struct RepresentationDomain {
+    ty: syn::Type,
+    base: Base,
+    excluded: Vec<ScalarValue>,
+}
+
+impl RepresentationDomain {
+    pub fn range<T: DomainScalar, R: RangeBounds<T>>(range: R) -> Self {
+        let cvt = |b: Bound<&T>| match b {
+            Bound::Included(v) => Bound::Included((*v).domain_value()),
+            Bound::Excluded(v) => Bound::Excluded((*v).domain_value()),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let start = cvt(range.start_bound());
+        let end = cvt(range.end_bound());
+        assert!(
+            !bound_is_nan(&start) && !bound_is_nan(&end),
+            "representation-domain range bounds cannot be NaN"
+        );
+        assert!(
+            range_is_nonempty(&start, &end),
+            "representation-domain range cannot be empty"
+        );
+        Self {
+            ty: T::domain_type(),
+            base: Base::Range { start, end },
+            excluded: vec![],
+        }
+    }
+
+    pub fn values<T: DomainScalar>(values: impl IntoIterator<Item = T>) -> Self {
+        let values = dedup(values.into_iter().map(T::domain_value).collect());
+        assert!(
+            !values.is_empty(),
+            "representation-domain valid set cannot be empty"
+        );
+        Self {
+            ty: T::domain_type(),
+            base: Base::Values(values),
+            excluded: vec![],
+        }
+    }
+
+    pub fn exclude<T: DomainScalar>(&mut self, values: impl IntoIterator<Item = T>) {
+        assert_eq!(
+            crate::api::core::registry::TypeKey::from_type(&self.ty),
+            crate::api::core::registry::TypeKey::from_type(&T::domain_type()),
+            "representation-domain exclusions must use the base domain's scalar type"
+        );
+        self.excluded
+            .extend(values.into_iter().map(T::domain_value));
+        self.excluded = dedup(std::mem::take(&mut self.excluded));
+    }
+
+    pub fn ty(&self) -> &syn::Type {
+        &self.ty
+    }
+
+    pub(crate) fn contains_expr(&self, value: TokenStream) -> TokenStream {
+        let base = match &self.base {
+            Base::Range { start, end } => {
+                let lo = bound_expr(start, &value, true);
+                let hi = bound_expr(end, &value, false);
+                let not_nan = if matches!(
+                    self.ty.to_token_stream().to_string().as_str(),
+                    "f32" | "f64"
+                ) {
+                    quote!(!(#value).is_nan())
+                } else {
+                    quote!(true)
+                };
+                quote!(#not_nan && #lo && #hi)
+            }
+            Base::Values(values) => {
+                let checks = values.iter().map(|v| v.raw_eq(&value));
+                quote!(false #(|| #checks)*)
+            }
+        };
+        let excluded = self.excluded.iter().map(|v| v.raw_eq(&value));
+        quote!((#base) && !(false #(|| #excluded)*))
+    }
+
+    /// Derive a bounded number of stable values outside the legal domain.
+    pub(crate) fn niche_values(&self, limit: usize) -> Vec<ScalarValue> {
+        let mut out = Vec::new();
+        let extra = match &self.base {
+            Base::Values(v) => v.len(),
+            _ => 0,
+        };
+        let budget = limit.saturating_add(extra).max(1);
+        match self.ty.to_token_stream().to_string().as_str() {
+            "i8" => ints!(out, self, i8, I8, budget),
+            "i16" => ints!(out, self, i16, I16, budget),
+            "i32" => ints!(out, self, i32, I32, budget),
+            "i64" => ints!(out, self, i64, I64, budget),
+            "i128" => ints!(out, self, i128, I128, budget),
+            "u8" => ints!(out, self, u8, U8, budget),
+            "u16" => ints!(out, self, u16, U16, budget),
+            "u32" => ints!(out, self, u32, U32, budget),
+            "u64" => ints!(out, self, u64, U64, budget),
+            "u128" => ints!(out, self, u128, U128, budget),
+            "f32" => float32_candidates(&mut out, budget),
+            "f64" => float64_candidates(&mut out, budget),
+            _ => unreachable!(),
+        }
+        out.extend(self.excluded.iter().copied());
+        let mut selected = Vec::new();
+        for value in out {
+            if !self.contains(value) && !selected.contains(&value) {
+                selected.push(value);
+                if selected.len() == limit {
+                    break;
+                }
+            }
+        }
+        selected
+    }
+
+    fn contains(&self, value: ScalarValue) -> bool {
+        let base = match &self.base {
+            Base::Range { start, end } => {
+                !is_nan(value) && lower_ok(value, start) && upper_ok(value, end)
+            }
+            Base::Values(values) => values.contains(&value),
+        };
+        base && !self.excluded.contains(&value)
+    }
+}
+
+macro_rules! ints {
+    ($out:expr, $d:expr, $ty:ty, $variant:ident, $budget:expr) => {{
+        let mut hi = <$ty>::MAX;
+        let mut lo = <$ty>::MIN;
+        for _ in 0..$budget {
+            let h = ScalarValue::$variant(hi);
+            if !$d.contains(h) {
+                $out.push(h);
+            }
+            hi = hi.saturating_sub(1);
+            let l = ScalarValue::$variant(lo);
+            if !$d.contains(l) {
+                $out.push(l);
+            }
+            lo = lo.saturating_add(1);
+        }
+    }};
+}
+use ints;
+
+fn float32_candidates(out: &mut Vec<ScalarValue>, n: usize) {
+    for i in 0..n {
+        out.push(ScalarValue::F32(f32::MAX.to_bits() - i as u32));
+        out.push(ScalarValue::F32((-f32::MAX).to_bits() - i as u32));
+    }
+    out.push(ScalarValue::F32(f32::INFINITY.to_bits()));
+    out.push(ScalarValue::F32(f32::NEG_INFINITY.to_bits()));
+    for i in 0..n {
+        out.push(ScalarValue::F32(0x7fc0_0000 + i as u32));
+    }
+}
+fn float64_candidates(out: &mut Vec<ScalarValue>, n: usize) {
+    for i in 0..n {
+        out.push(ScalarValue::F64(f64::MAX.to_bits() - i as u64));
+        out.push(ScalarValue::F64((-f64::MAX).to_bits() - i as u64));
+    }
+    out.push(ScalarValue::F64(f64::INFINITY.to_bits()));
+    out.push(ScalarValue::F64(f64::NEG_INFINITY.to_bits()));
+    for i in 0..n {
+        out.push(ScalarValue::F64(0x7ff8_0000_0000_0000 + i as u64));
+    }
+}
+
+fn bound_expr(bound: &Bound<ScalarValue>, value: &TokenStream, lower: bool) -> TokenStream {
+    match bound {
+        Bound::Unbounded => quote!(true),
+        Bound::Included(v) if lower => v.cmp_expr(value, ">="),
+        Bound::Excluded(v) if lower => v.cmp_expr(value, ">"),
+        Bound::Included(v) => v.cmp_expr(value, "<="),
+        Bound::Excluded(v) => v.cmp_expr(value, "<"),
+    }
+}
+fn lower_ok(v: ScalarValue, b: &Bound<ScalarValue>) -> bool {
+    match b {
+        Bound::Unbounded => true,
+        Bound::Included(x) => cmp(v, *x).is_some_and(|v| v >= 0),
+        Bound::Excluded(x) => cmp(v, *x).is_some_and(|v| v > 0),
+    }
+}
+fn upper_ok(v: ScalarValue, b: &Bound<ScalarValue>) -> bool {
+    match b {
+        Bound::Unbounded => true,
+        Bound::Included(x) => cmp(v, *x).is_some_and(|v| v <= 0),
+        Bound::Excluded(x) => cmp(v, *x).is_some_and(|v| v < 0),
+    }
+}
+fn cmp(a: ScalarValue, b: ScalarValue) -> Option<i8> {
+    macro_rules! c {
+        ($a:expr, $b:expr) => {
+            Some(if $a < $b {
+                -1
+            } else if $a > $b {
+                1
+            } else {
+                0
+            })
+        };
+    }
+    match (a, b) {
+        (ScalarValue::I8(a), ScalarValue::I8(b)) => c!(a, b),
+        (ScalarValue::I16(a), ScalarValue::I16(b)) => c!(a, b),
+        (ScalarValue::I32(a), ScalarValue::I32(b)) => c!(a, b),
+        (ScalarValue::I64(a), ScalarValue::I64(b)) => c!(a, b),
+        (ScalarValue::I128(a), ScalarValue::I128(b)) => c!(a, b),
+        (ScalarValue::U8(a), ScalarValue::U8(b)) => c!(a, b),
+        (ScalarValue::U16(a), ScalarValue::U16(b)) => c!(a, b),
+        (ScalarValue::U32(a), ScalarValue::U32(b)) => c!(a, b),
+        (ScalarValue::U64(a), ScalarValue::U64(b)) => c!(a, b),
+        (ScalarValue::U128(a), ScalarValue::U128(b)) => c!(a, b),
+        (ScalarValue::F32(a), ScalarValue::F32(b)) => {
+            f32::from_bits(a).partial_cmp(&f32::from_bits(b)).map(ord)
+        }
+        (ScalarValue::F64(a), ScalarValue::F64(b)) => {
+            f64::from_bits(a).partial_cmp(&f64::from_bits(b)).map(ord)
+        }
+        _ => None,
+    }
+}
+fn ord(v: std::cmp::Ordering) -> i8 {
+    match v {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Equal => 0,
+        std::cmp::Ordering::Greater => 1,
+    }
+}
+fn is_nan(v: ScalarValue) -> bool {
+    match v {
+        ScalarValue::F32(v) => f32::from_bits(v).is_nan(),
+        ScalarValue::F64(v) => f64::from_bits(v).is_nan(),
+        _ => false,
+    }
+}
+fn bound_is_nan(v: &Bound<ScalarValue>) -> bool {
+    match v {
+        Bound::Included(v) | Bound::Excluded(v) => is_nan(*v),
+        Bound::Unbounded => false,
+    }
+}
+fn range_is_nonempty(start: &Bound<ScalarValue>, end: &Bound<ScalarValue>) -> bool {
+    let (start_value, start_included) = match start {
+        Bound::Unbounded => return true,
+        Bound::Included(value) => (*value, true),
+        Bound::Excluded(value) => (*value, false),
+    };
+    let (end_value, end_included) = match end {
+        Bound::Unbounded => return true,
+        Bound::Included(value) => (*value, true),
+        Bound::Excluded(value) => (*value, false),
+    };
+    cmp(start_value, end_value)
+        .is_some_and(|ordering| ordering < 0 || (ordering == 0 && start_included && end_included))
+}
+fn dedup(values: Vec<ScalarValue>) -> Vec<ScalarValue> {
+    let mut out = Vec::new();
+    for v in values {
+        if !out.contains(&v) {
+            out.push(v);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integer_range_derives_extreme_niches() {
+        let domain = RepresentationDomain::range(0u64..=1_000_000);
+        assert_eq!(
+            domain.niche_values(3),
+            vec![
+                ScalarValue::U64(u64::MAX),
+                ScalarValue::U64(u64::MAX - 1),
+                ScalarValue::U64(u64::MAX - 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn valid_set_and_exclusions_use_raw_float_bits() {
+        let domain = RepresentationDomain::values([0.0f64, -0.0f64, 1.0]);
+        assert!(domain.contains(ScalarValue::F64(0.0f64.to_bits())));
+        assert!(domain.contains(ScalarValue::F64((-0.0f64).to_bits())));
+
+        let mut range = RepresentationDomain::range(-1.0f64..=1.0f64);
+        range.exclude([0.5f64]);
+        assert!(!range.contains(ScalarValue::F64(0.5f64.to_bits())));
+        assert!(!range.contains(ScalarValue::F64(f64::NAN.to_bits())));
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot be NaN")]
+    fn nan_range_bound_is_rejected() {
+        let _ = RepresentationDomain::range(f64::NAN..=1.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "range cannot be empty")]
+    fn empty_range_is_rejected() {
+        let _ = RepresentationDomain::range(2u8..2u8);
+    }
+}

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -19,6 +19,7 @@
 //! Secondary artifacts such as C headers or Kotlin sources are produced by the
 //! language adapter after the Rust registry is resolved.
 
+pub mod domain;
 pub mod expand;
 pub mod gravestone;
 pub mod niches;
@@ -31,6 +32,7 @@ pub mod unfold;
 pub(crate) mod write;
 
 pub use self::{
+    domain::{DomainScalar, RepresentationDomain, ScalarValue},
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -104,6 +104,29 @@ impl Cbindgen {
         self
     }
 
+    /// Declare a canonical scalar conversion shared with JniGen. A domain on
+    /// the [`ConvertDecl`] is validated in both directions; invalid scalar
+    /// values become by-value niches for `Option`/`Result`, with public C
+    /// constants derived from the conversion's naming base.
+    pub fn convert(mut self, decl: ConvertDecl) -> Self {
+        assert!(
+            decl.input.is_some() || decl.output.is_some(),
+            "Cbindgen::convert declares no input or output conversion"
+        );
+        let key = decl.key.clone();
+        assert!(
+            !self
+                .convert_decls
+                .iter()
+                .any(|existing| existing.key == key),
+            "Cbindgen::convert already declares {}",
+            key
+        );
+        self.convert_decls.push(decl);
+        self.current = Some(CurrentDecl::Convert(key));
+        self
+    }
+
     /// Mark a `#[prebindgen]` function as intentionally ignored by this
     /// adapter. Root-level modifier: suppresses the registry's
     /// "skipping undeclared" warning for that function without scanning or
@@ -324,9 +347,13 @@ impl Cbindgen {
             Some(CurrentDecl::Function(ident)) => {
                 self.functions.get_mut(&ident).expect("entry vanished").base = Some(base);
             }
+            Some(CurrentDecl::Convert(key)) => {
+                self.convert_bases.insert(key, base);
+            }
             None => panic!(
                 "Cbindgen::base_name must be chained directly after a declaration \
-                 (`opaque_ptr` / `data_struct` / `enum_type` / `callback` / `function`)"
+                 (`opaque_ptr` / `data_struct` / `enum_type` / `callback` / `function` / \
+                 `convert`)"
             ),
         }
         self
@@ -677,5 +704,6 @@ fn describe_current(current: &Option<CurrentDecl>) -> String {
             format!("callback `impl Fn({})`", args.join(", "))
         }
         Some(CurrentDecl::Function(i)) => format!("function `{i}`"),
+        Some(CurrentDecl::Convert(k)) => format!("convert `{k}`"),
     }
 }

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -1,0 +1,368 @@
+use super::*;
+
+impl Cbindgen {
+    pub(crate) fn prereq_domain_constants(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+        let mut items = Vec::new();
+        for decl in &self.convert_decls {
+            let Some(domain) = &decl.domain else { continue };
+            let demand = [Direction::Input, Direction::Output]
+                .into_iter()
+                .flat_map(|direction| registry.type_table(direction).keys())
+                .map(|candidate| option_depth(candidate, &decl.key))
+                .max()
+                .unwrap_or(0);
+            let ty = domain.ty();
+            let base = self
+                .convert_bases
+                .get(&decl.key)
+                .cloned()
+                .unwrap_or_else(|| {
+                    let short = type_short(&decl.key.to_type());
+                    self.mangle_rust_type
+                        .as_ref()
+                        .map(|m| m(&short))
+                        .unwrap_or_else(|| snake_case(&short))
+                })
+                .to_ascii_uppercase();
+            for (index, value) in domain
+                .niche_values(demand.saturating_add(8))
+                .into_iter()
+                .filter_map(crate::core::ScalarValue::portable_expr)
+                .take(demand)
+                .enumerate()
+            {
+                let name = format_ident!("{}_NICHE_{}", base, index);
+                items.push(syn::parse_quote!(
+                    #[doc = "Reserved representation value used by generated sum-type ABIs."]
+                    pub const #name: #ty = #value;
+                ));
+                if index == 0 {
+                    let none = format_ident!("{}_NONE", base);
+                    items.push(syn::parse_quote!(
+                        #[doc = "Representation of None for the first optional layer."]
+                        pub const #none: #ty = #value;
+                    ));
+                }
+            }
+        }
+        items
+    }
+
+    pub(crate) fn in_custom(
+        &self,
+        ty: &syn::Type,
+        registry: &Registry<()>,
+    ) -> Option<ConverterImpl<()>> {
+        let key = TypeKey::from_type(ty);
+        let decl = self.convert_decls.iter().find(|d| d.key == key)?;
+        let spec = decl.input.as_ref()?;
+        let (repr, conversion, fallible) = self.input_conversion(decl, spec, registry);
+        assert!(
+            is_scalar(&repr),
+            "Cbindgen custom representations must be C scalar types"
+        );
+        if let Some(domain) = &decl.domain {
+            assert_eq!(
+                TypeKey::from_type(domain.ty()),
+                TypeKey::from_type(&repr),
+                "Cbindgen conversion domain type does not match its input representation"
+            );
+        }
+        let src = self.src_ty(ty);
+        let wire = repr.clone();
+        let name = Self::in_name(ty);
+        let valid = decl
+            .domain
+            .as_ref()
+            .map(|d| d.contains_expr(quote!(v)))
+            .unwrap_or_else(|| quote!(true));
+        let msg = format!("{} representation is outside its declared domain", key);
+        let function: syn::ItemFn = if decl.domain.is_some() || fallible {
+            let converted = if fallible {
+                quote!((#conversion).map_err(|e| e.to_string()))
+            } else {
+                quote!(::core::result::Result::Ok(#conversion))
+            };
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #wire)
+                    -> ::core::result::Result<#src, ::std::string::String>
+                {
+                    if !(#valid) {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#msg)
+                        );
+                    }
+                    #converted
+                }
+            )
+        } else {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #wire) -> #src {
+                    #conversion
+                }
+            )
+        };
+        let niches = self.c_domain_niches(decl, registry, Direction::Input);
+        Some(ConverterImpl {
+            subs: vec![repr],
+            destination: wire,
+            function,
+            pre_stages: vec![],
+            niches,
+            metadata: (),
+        })
+    }
+
+    pub(crate) fn out_custom(
+        &self,
+        ty: &syn::Type,
+        registry: &Registry<()>,
+    ) -> Option<ConverterImpl<()>> {
+        let key = TypeKey::from_type(ty);
+        let decl = self.convert_decls.iter().find(|d| d.key == key)?;
+        let spec = decl.output.as_ref()?;
+        let (repr, conversion, fallible) = self.output_conversion(decl, spec, registry);
+        assert!(
+            is_scalar(&repr),
+            "Cbindgen custom representations must be C scalar types"
+        );
+        if let Some(domain) = &decl.domain {
+            assert_eq!(
+                TypeKey::from_type(domain.ty()),
+                TypeKey::from_type(&repr),
+                "Cbindgen conversion domain type does not match its output representation"
+            );
+        }
+        let src = self.src_ty(ty);
+        let wire = repr.clone();
+        let name = Self::out_name(ty);
+        let valid = decl
+            .domain
+            .as_ref()
+            .map(|d| d.contains_expr(quote!(__repr)))
+            .unwrap_or_else(|| quote!(true));
+        let msg = format!("{} representation is outside its declared domain", key);
+        let function: syn::ItemFn = if decl.domain.is_some() || fallible {
+            let repr_expr = if fallible {
+                quote!((#conversion).map_err(|error| error.to_string())?)
+            } else {
+                quote!(#conversion)
+            };
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #src)
+                    -> ::core::result::Result<#wire, ::std::string::String>
+                {
+                    let __repr: #repr = #repr_expr;
+                    if !(#valid) {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#msg)
+                        );
+                    }
+                    ::core::result::Result::Ok(__repr)
+                }
+            )
+        } else {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #src) -> #wire {
+                    #conversion
+                }
+            )
+        };
+        let niches = self.c_domain_niches(decl, registry, Direction::Output);
+        Some(ConverterImpl {
+            subs: vec![repr],
+            destination: wire,
+            function,
+            pre_stages: vec![],
+            niches,
+            metadata: (),
+        })
+    }
+
+    fn input_conversion(
+        &self,
+        decl: &ConvertDecl,
+        spec: &ConvertSpec,
+        registry: &Registry<()>,
+    ) -> (syn::Type, syn::Expr, bool) {
+        let target = self.src_ty(&decl.key.to_type());
+        match spec {
+            ConvertSpec::PrebindgenFn(f) => {
+                let item = &registry
+                    .functions
+                    .get(f)
+                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f))
+                    .0;
+                let (repr, by_ref) = one_param(item);
+                let ret = fn_ret(item);
+                let (ok, fallible) = match result_parts(&ret) {
+                    Some((ok, _)) => (ok, true),
+                    None => (ret, false),
+                };
+                assert_eq!(TypeKey::from_type(&ok), decl.key);
+                let path = self.conversion_fn_path(registry, f);
+                let expr = if by_ref {
+                    syn::parse_quote!(#path(&v))
+                } else {
+                    syn::parse_quote!(#path(v))
+                };
+                (repr, expr, fallible)
+            }
+            ConvertSpec::Trait { repr, fallible } => {
+                let expr = if *fallible {
+                    syn::parse_quote!(
+                        <#repr as ::core::convert::TryInto<#target>>::try_into(v)
+                    )
+                } else {
+                    syn::parse_quote!(
+                        <#repr as ::core::convert::Into<#target>>::into(v)
+                    )
+                };
+                (repr.clone(), expr, *fallible)
+            }
+        }
+    }
+
+    fn output_conversion(
+        &self,
+        decl: &ConvertDecl,
+        spec: &ConvertSpec,
+        registry: &Registry<()>,
+    ) -> (syn::Type, syn::Expr, bool) {
+        let target = self.src_ty(&decl.key.to_type());
+        match spec {
+            ConvertSpec::PrebindgenFn(f) => {
+                let item = &registry
+                    .functions
+                    .get(f)
+                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f))
+                    .0;
+                let (param, by_ref) = one_param(item);
+                assert_eq!(TypeKey::from_type(&param), decl.key);
+                let ret = fn_ret(item);
+                let (repr, fallible) = match result_parts(&ret) {
+                    Some((ok, _)) => (ok, true),
+                    None => (ret, false),
+                };
+                let path = self.conversion_fn_path(registry, f);
+                let expr = if by_ref {
+                    syn::parse_quote!(#path(&v))
+                } else {
+                    syn::parse_quote!(#path(v))
+                };
+                (repr, expr, fallible)
+            }
+            ConvertSpec::Trait { repr, fallible } => {
+                let expr = if *fallible {
+                    syn::parse_quote!(
+                        <#target as ::core::convert::TryInto<#repr>>::try_into(v)
+                    )
+                } else {
+                    syn::parse_quote!(
+                        <#target as ::core::convert::Into<#repr>>::into(v)
+                    )
+                };
+                (repr.clone(), expr, *fallible)
+            }
+        }
+    }
+
+    fn c_domain_niches(
+        &self,
+        decl: &ConvertDecl,
+        registry: &Registry<()>,
+        direction: Direction,
+    ) -> Niches {
+        let Some(domain) = &decl.domain else {
+            return Niches::empty();
+        };
+        let demand = registry
+            .type_table(direction)
+            .keys()
+            .map(|candidate| option_depth(candidate, &decl.key))
+            .max()
+            .unwrap_or(0);
+        Niches::from_slots(
+            domain
+                .niche_values(demand.saturating_add(8))
+                .into_iter()
+                .filter_map(|value| value.portable_expr().map(|literal| (value, literal)))
+                .take(demand)
+                .map(|(value, literal)| {
+                    let matches = match value {
+                        crate::core::ScalarValue::F32(bits) => {
+                            syn::parse_quote!(v.to_bits() == #bits)
+                        }
+                        crate::core::ScalarValue::F64(bits) => {
+                            syn::parse_quote!(v.to_bits() == #bits)
+                        }
+                        _ => syn::parse_quote!(v == #literal),
+                    };
+                    NicheSlot {
+                        value: literal,
+                        matches,
+                    }
+                }),
+        )
+    }
+
+    fn conversion_fn_path(&self, registry: &Registry<()>, ident: &syn::Ident) -> syn::Path {
+        let Some(mut module) = registry.origin_module(ident) else {
+            return self.src_fn(ident);
+        };
+        module.segments.push(syn::PathSegment::from(ident.clone()));
+        module
+    }
+}
+
+fn one_param(item: &syn::ItemFn) -> (syn::Type, bool) {
+    let params: Vec<_> = item
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|p| {
+            if let syn::FnArg::Typed(p) = p {
+                Some(&*p.ty)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(
+        params.len(),
+        1,
+        "conversion functions take exactly one parameter"
+    );
+    match params[0] {
+        syn::Type::Reference(r) => ((*r.elem).clone(), true),
+        ty => (ty.clone(), false),
+    }
+}
+
+fn fn_ret(item: &syn::ItemFn) -> syn::Type {
+    match &item.sig.output {
+        syn::ReturnType::Default => syn::parse_quote!(()),
+        syn::ReturnType::Type(_, ty) => (**ty).clone(),
+    }
+}
+
+fn option_depth(candidate: &TypeKey, target: &TypeKey) -> usize {
+    let mut ty = candidate.to_type();
+    let mut depth = 0;
+    while is_option(&ty) {
+        let Some(inner) = first_type_arg(&ty) else {
+            return 0;
+        };
+        ty = inner;
+        depth += 1;
+    }
+    if TypeKey::from_type(&ty) == *target {
+        depth
+    } else {
+        0
+    }
+}

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -144,6 +144,7 @@ impl Cbindgen {
             Some((ok, e)) => (ok, Some(e)),
             None => (return_ty.clone(), None),
         };
+        let has_fallible_output = self.output_is_fallible(&value_ty, registry);
 
         // Error wiring: the error type must be declared via `.error()`.
         let err_bits = err_ty.as_ref().map(|err_ty| {
@@ -174,9 +175,9 @@ impl Cbindgen {
         if err_ty.is_none() {
             let allows_panic = self.functions.get(orig).map(|c| c.panic).unwrap_or(false);
             assert!(
-                !has_fallible_input || allows_panic,
-                "Cbindgen: function `{}` has a fallible input (e.g. a `String` or \
-                 opaque-by-value argument) but does not return `Result`; add \
+                !(has_fallible_input || has_fallible_output) || allows_panic,
+                "Cbindgen: function `{}` has a fallible binding conversion but does not \
+                 return `Result`; add \
                  `.panic()` after its `.function(...)` declaration to allow aborting \
                  on the internal error, or change its signature",
                 orig,
@@ -188,7 +189,8 @@ impl Cbindgen {
         //   * Result without a free niche     → `bool` status, value to out-params;
         //   * no Result                       → field 0 is the C return, rest out.
         let shape = self.lower_shape(&value_ty, registry);
-        let result_in_band = err_ty.is_some() && shape.has_niche; // value rides the return
+        let result_slot = shape.niches.clone().carve().map(|(slot, _)| slot);
+        let result_in_band = err_ty.is_some() && result_slot.is_some();
         let field0_is_return = result_in_band || err_ty.is_none();
 
         // Partition fields into the (optional) C return value + out-parameters,
@@ -238,7 +240,9 @@ impl Cbindgen {
         // Input decode: route a fallible-input failure to the error out-param
         // (with the wrapper's fail value) when there is a `Result`, else panic.
         let fail_return = if result_in_band {
-            null_for(field0_wire.as_ref().expect("in-band ⇒ pointer return"))
+            let slot = result_slot.as_ref().expect("in-band result has a niche");
+            let value = &slot.value;
+            quote!(#value)
         } else {
             quote!(false)
         };
@@ -263,7 +267,8 @@ impl Cbindgen {
             // No `Result`: straight-line. `void` when there are no fields.
             (None, _) => {
                 if let Some(field0_wire) = field0_wire.as_ref() {
-                    let enc = self.encode_value(&value_ty, quote!(__v), &targets, registry);
+                    let enc =
+                        self.encode_value(&value_ty, quote!(__v), &targets, registry, &input_route);
                     quote!(
                         #(#decodes)*
                         let __v = #call;
@@ -278,8 +283,12 @@ impl Cbindgen {
             // `Result` with a free niche: value in-band, NULL marks `Err`.
             (Some((_, e_conv, _)), true) => {
                 let field0_wire = field0_wire.as_ref().expect("in-band ⇒ pointer return");
-                let null = null_for(field0_wire);
-                let enc = self.encode_value(&value_ty, quote!(__v), &targets, registry);
+                let null = &result_slot
+                    .as_ref()
+                    .expect("in-band result has a niche")
+                    .value;
+                let enc =
+                    self.encode_value(&value_ty, quote!(__v), &targets, registry, &input_route);
                 quote!(
                     #(#decodes)*
                     match #call {
@@ -293,7 +302,8 @@ impl Cbindgen {
             }
             // `Result` without a free niche: `bool` status, value to out-params.
             (Some((_, e_conv, _)), false) => {
-                let enc = self.encode_value(&value_ty, quote!(__v), &targets, registry);
+                let enc =
+                    self.encode_value(&value_ty, quote!(__v), &targets, registry, &input_route);
                 quote!(
                     #(#decodes)*
                     match #call {
@@ -321,15 +331,15 @@ impl Cbindgen {
     }
 
     /// Lower how a *present / ok* value of `ty` is carried over the C ABI: an
-    /// ordered list of wire components, plus whether `fields[0]` is a pointer
-    /// whose NULL bit-pattern is still free for an enclosing `Option`/`Result`
-    /// layer to claim. Mirrors the niche-stacking model in `core::niches`.
+    /// ordered list of wire components plus the representation niches still
+    /// available for enclosing `Option`/`Result` layers. Mirrors the
+    /// niche-stacking model in `core::niches`.
     #[allow(clippy::only_used_in_recursion)]
     pub(super) fn lower_shape(&self, ty: &syn::Type, registry: &Registry<()>) -> ValueShape {
         if is_unit(ty) {
             return ValueShape {
                 fields: vec![],
-                has_niche: false,
+                niches: Niches::empty(),
             };
         }
         // `Vec<T>` → `T_wire* + size_t`. The element must lower to a single C
@@ -360,7 +370,7 @@ impl Cbindgen {
                         wire: syn::parse_quote!(usize),
                     },
                 ],
-                has_niche: false,
+                niches: Niches::empty(),
             };
         }
         // `Cow<'_, [T]>` → `T_wire* + size_t`. The C side receives an owned
@@ -384,19 +394,19 @@ impl Cbindgen {
                         wire: syn::parse_quote!(usize),
                     },
                 ],
-                has_niche: false,
+                niches: Niches::empty(),
             };
         }
-        // `Option<T>` consumes one discriminant. If the inner value still has a
-        // free pointer niche, reuse it (NULL = `None`); otherwise prepend an
-        // explicit `present: bool`. Either way the result exposes no niche.
+        // `Option<T>` consumes one available inner niche. This includes NULL
+        // pointers and invalid scalar values declared by `convert!`; without a
+        // niche it prepends an explicit `present: bool`.
         if is_option(ty) {
             let inner_ty = first_type_arg(ty).expect("Option<T> has a type argument");
             let inner = self.lower_shape(&inner_ty, registry);
-            if inner.has_niche {
+            if let Some((_slot, rest)) = inner.niches.clone().carve() {
                 return ValueShape {
                     fields: inner.fields,
-                    has_niche: false,
+                    niches: rest,
                 };
             }
             let mut fields = vec![WireField {
@@ -406,11 +416,12 @@ impl Cbindgen {
             fields.extend(inner.fields);
             return ValueShape {
                 fields,
-                has_niche: false,
+                niches: Niches::empty(),
             };
         }
-        // Base value: one wire component from its rank-0/1 converter. A pointer
-        // wire (String, opaque handle, `&'static`) carries a free NULL niche.
+        // Base value: one wire component from its rank-0/1 converter. Custom
+        // conversions may declare scalar niches; otherwise a pointer wire
+        // (String, opaque handle, `&'static`) carries a free NULL niche.
         let entry = registry.output_entry(ty).unwrap_or_else(|| {
             panic!(
                 "Cbindgen::on_function: type `{}` has no output converter",
@@ -418,10 +429,15 @@ impl Cbindgen {
             )
         });
         let wire = entry.destination.clone();
-        let has_niche = matches!(wire, syn::Type::Ptr(_));
+        let niches = if entry.niches.is_empty() && matches!(wire, syn::Type::Ptr(_)) {
+            let null = null_for(&wire);
+            Niches::one(syn::parse_quote!(#null), syn::parse_quote!(v.is_null()))
+        } else {
+            entry.niches.clone()
+        };
         ValueShape {
             fields: vec![WireField { suffix: "", wire }],
-            has_niche,
+            niches,
         }
     }
 
@@ -433,6 +449,7 @@ impl Cbindgen {
         val: TokenStream,
         targets: &[TokenStream],
         registry: &Registry<()>,
+        route: &ErrRoute,
     ) -> TokenStream {
         if is_unit(ty) {
             return quote!();
@@ -444,13 +461,26 @@ impl Cbindgen {
             let elem_wire = entry.destination.clone();
             let t_ptr = &targets[0];
             let t_len = &targets[1];
-            return quote!(
-                let __arr: ::std::vec::Vec<#elem_wire> =
-                    #val.into_iter().map(#elem_conv).collect();
-                let (__p, __n) = __cbg_alloc_array(__arr);
-                #t_ptr = __p;
-                #t_len = __n;
-            );
+            if returns_result(&entry.function.sig.output) {
+                let converted = route_result(quote!(#elem_conv(__value)), route);
+                return quote!(
+                    let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
+                    for __value in #val {
+                        __arr.push(#converted);
+                    }
+                    let (__p, __n) = __cbg_alloc_array(__arr);
+                    #t_ptr = __p;
+                    #t_len = __n;
+                );
+            } else {
+                return quote!(
+                    let __arr: ::std::vec::Vec<#elem_wire> =
+                        #val.into_iter().map(#elem_conv).collect();
+                    let (__p, __n) = __cbg_alloc_array(__arr);
+                    #t_ptr = __p;
+                    #t_len = __n;
+                );
+            }
         }
         if let Some(elem) = cow_slice_elem(ty) {
             let entry = registry
@@ -460,21 +490,34 @@ impl Cbindgen {
             let elem_wire = entry.destination.clone();
             let t_ptr = &targets[0];
             let t_len = &targets[1];
-            return quote!(
-                let __arr: ::std::vec::Vec<#elem_wire> =
-                    #val.iter().copied().map(#elem_conv).collect();
-                let (__p, __n) = __cbg_alloc_array(__arr);
-                #t_ptr = __p;
-                #t_len = __n;
-            );
+            if returns_result(&entry.function.sig.output) {
+                let converted = route_result(quote!(#elem_conv(__value)), route);
+                return quote!(
+                    let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
+                    for __value in #val.iter().copied() {
+                        __arr.push(#converted);
+                    }
+                    let (__p, __n) = __cbg_alloc_array(__arr);
+                    #t_ptr = __p;
+                    #t_len = __n;
+                );
+            } else {
+                return quote!(
+                    let __arr: ::std::vec::Vec<#elem_wire> =
+                        #val.iter().copied().map(#elem_conv).collect();
+                    let (__p, __n) = __cbg_alloc_array(__arr);
+                    #t_ptr = __p;
+                    #t_len = __n;
+                );
+            }
         }
         if is_option(ty) {
             let inner_ty = first_type_arg(ty).expect("Option<T> has a type argument");
             let inner = self.lower_shape(&inner_ty, registry);
-            if inner.has_niche {
-                // None reuses the inner pointer's NULL; Some encodes inline.
-                let inner_enc = self.encode_value(&inner_ty, quote!(__x), targets, registry);
-                let null = null_for(&inner.fields[0].wire);
+            if let Some((slot, _rest)) = inner.niches.clone().carve() {
+                // None reuses the next inner niche; Some encodes inline.
+                let inner_enc = self.encode_value(&inner_ty, quote!(__x), targets, registry, route);
+                let null = &slot.value;
                 let t0 = &targets[0];
                 return quote!(
                     match #val {
@@ -485,7 +528,8 @@ impl Cbindgen {
             }
             // Explicit `present` flag in targets[0]; inner value follows.
             let present = &targets[0];
-            let inner_enc = self.encode_value(&inner_ty, quote!(__x), &targets[1..], registry);
+            let inner_enc =
+                self.encode_value(&inner_ty, quote!(__x), &targets[1..], registry, route);
             return quote!(
                 match #val {
                     ::core::option::Option::Some(__x) => { #present = true; #inner_enc }
@@ -497,7 +541,25 @@ impl Cbindgen {
         let entry = registry.output_entry(ty).expect("base value converter");
         let conv = entry.function.sig.ident.clone();
         let t0 = &targets[0];
-        quote!( #t0 = #conv(#val); )
+        if returns_result(&entry.function.sig.output) {
+            let converted = route_result(quote!(#conv(#val)), route);
+            quote!( #t0 = #converted; )
+        } else {
+            quote!( #t0 = #conv(#val); )
+        }
+    }
+
+    fn output_is_fallible(&self, ty: &syn::Type, registry: &Registry<()>) -> bool {
+        if is_option(ty) || is_vec(ty) {
+            return first_type_arg(ty)
+                .is_some_and(|inner| self.output_is_fallible(&inner, registry));
+        }
+        if let Some(inner) = cow_slice_elem(ty) {
+            return self.output_is_fallible(&inner, registry);
+        }
+        registry
+            .output_entry(ty)
+            .is_some_and(|entry| returns_result(&entry.function.sig.output))
     }
 
     /// Build the wire param list, per-input decode statements, and call-site

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -144,7 +144,7 @@ impl Cbindgen {
             Some((ok, e)) => (ok, Some(e)),
             None => (return_ty.clone(), None),
         };
-        let has_fallible_output = self.output_is_fallible(&value_ty, registry);
+        let has_fallible_output = Self::output_is_fallible(&value_ty, registry);
 
         // Error wiring: the error type must be declared via `.error()`.
         let err_bits = err_ty.as_ref().map(|err_ty| {
@@ -549,13 +549,13 @@ impl Cbindgen {
         }
     }
 
-    fn output_is_fallible(&self, ty: &syn::Type, registry: &Registry<()>) -> bool {
+    fn output_is_fallible(ty: &syn::Type, registry: &Registry<()>) -> bool {
         if is_option(ty) || is_vec(ty) {
             return first_type_arg(ty)
-                .is_some_and(|inner| self.output_is_fallible(&inner, registry));
+                .is_some_and(|inner| Self::output_is_fallible(&inner, registry));
         }
         if let Some(inner) = cow_slice_elem(ty) {
-            return self.output_is_fallible(&inner, registry);
+            return Self::output_is_fallible(&inner, registry);
         }
         registry
             .output_entry(ty)

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -78,12 +78,14 @@ pub(crate) use crate::api::core::types_util::{
     first_type_arg, is_option_type as is_option, is_result_type as is_result, is_unit,
     is_vec_type as is_vec, path_tail_ident as type_path_tail, result_parts,
 };
-use crate::api::core::{
-    niches::{NicheSlot, Niches},
-    prebindgen::{ConverterImpl, Prebindgen},
-    registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
+use crate::api::{
+    core::{
+        niches::{NicheSlot, Niches},
+        prebindgen::{ConverterImpl, Prebindgen},
+        registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
+    },
+    lang::jnigen::{ConvertDecl, ConvertSpec},
 };
-use crate::api::lang::jnigen::{ConvertDecl, ConvertSpec};
 
 /// Identity of a declared callback signature: its argument-type list (the
 /// dedup key, since two `impl Fn` params with the same args share one closure

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -79,10 +79,11 @@ pub(crate) use crate::api::core::types_util::{
     is_vec_type as is_vec, path_tail_ident as type_path_tail, result_parts,
 };
 use crate::api::core::{
-    niches::Niches,
+    niches::{NicheSlot, Niches},
     prebindgen::{ConverterImpl, Prebindgen},
-    registry::{extract_fn_trait_args, Registry, TypeKey},
+    registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
 };
+use crate::api::lang::jnigen::{ConvertDecl, ConvertSpec};
 
 /// Identity of a declared callback signature: its argument-type list (the
 /// dedup key, since two `impl Fn` params with the same args share one closure
@@ -178,6 +179,7 @@ enum CurrentDecl {
     Enum(TypeKey),
     Callback(CallbackKey),
     Function(syn::Ident),
+    Convert(TypeKey),
 }
 
 /// Where a fallible input-decode failure is routed in a generated wrapper.
@@ -206,6 +208,10 @@ pub struct Cbindgen {
     source_module: Option<syn::Path>,
     /// `#[prebindgen]` functions explicitly declared for conversion.
     functions: HashMap<syn::Ident, FnCfg>,
+    /// Canonical scalar conversions shared with JniGen.
+    convert_decls: Vec<ConvertDecl>,
+    /// Per-conversion C naming base used for generated niche constants.
+    convert_bases: HashMap<TypeKey, String>,
     /// `#[prebindgen]` functions intentionally not exported by this adapter.
     ignored_functions: HashSet<syn::Ident>,
     /// Opaque-handle types (`Box` + `void*` lifecycle, auto `_drop`).
@@ -265,6 +271,7 @@ type Mangle1 = Box<dyn Fn(&str) -> String>;
 type MangleN = Box<dyn Fn(&[String]) -> String>;
 
 mod builder;
+mod convert;
 mod emit;
 mod selector;
 #[cfg(test)]
@@ -458,13 +465,12 @@ struct WireField {
     wire: syn::Type,
 }
 
-/// How a *present / ok* value of a return type is carried over the C ABI:
-/// an ordered list of wire components, plus whether `fields[0]` is a pointer
-/// whose NULL bit-pattern is still free for an enclosing `Option`/`Result`
-/// layer to claim (the niche).
+/// How a *present / ok* value of a return type is carried over the C ABI: an
+/// ordered list of wire components plus the representation niches still free
+/// for enclosing `Option`/`Result` layers.
 struct ValueShape {
     fields: Vec<WireField>,
-    has_niche: bool,
+    niches: Niches,
 }
 
 /// Whether a converter function's return type is `Result<_, _>` (⇒ fallible).
@@ -472,6 +478,36 @@ fn returns_result(output: &syn::ReturnType) -> bool {
     match output {
         syn::ReturnType::Type(_, ty) => is_result(ty),
         syn::ReturnType::Default => false,
+    }
+}
+
+fn route_result(call: TokenStream, route: &ErrRoute<'_>) -> TokenStream {
+    match route {
+        ErrRoute::Result {
+            e_conv,
+            e_ty_src,
+            fail_return,
+        } => quote! {
+            match #call {
+                ::core::result::Result::Ok(value) => value,
+                ::core::result::Result::Err(message) => {
+                    if !e.is_null() {
+                        *e = #e_conv(
+                            <#e_ty_src as ::core::convert::From<
+                                ::std::string::String
+                            >>::from(message)
+                        );
+                    }
+                    return #fail_return;
+                }
+            }
+        },
+        ErrRoute::Panic => quote! {
+            match #call {
+                ::core::result::Result::Ok(value) => value,
+                ::core::result::Result::Err(message) => panic!("{}", message),
+            }
+        },
     }
 }
 

--- a/prebindgen/src/api/lang/cbindgen/selector.rs
+++ b/prebindgen/src/api/lang/cbindgen/selector.rs
@@ -10,7 +10,8 @@ impl Cbindgen {
         ty: &syn::Type,
         registry: &Registry<()>,
     ) -> Option<ConverterImpl<()>> {
-        self.in_opaque_handle(ty)
+        self.in_custom(ty, registry)
+            .or_else(|| self.in_opaque_handle(ty))
             .or_else(|| self.in_data_struct(ty, registry))
             .or_else(|| self.in_value_opaque(ty, registry))
             .or_else(|| self.in_enum(ty, registry))
@@ -27,7 +28,8 @@ impl Cbindgen {
         ty: &syn::Type,
         registry: &Registry<()>,
     ) -> Option<ConverterImpl<()>> {
-        self.out_terminal(ty, registry)
+        self.out_custom(ty, registry)
+            .or_else(|| self.out_terminal(ty, registry))
             .or_else(|| self.out_wrappers(ty, registry))
     }
 }

--- a/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
@@ -1,5 +1,149 @@
 use super::*;
 
+#[test]
+fn bounded_duration_option_is_one_scalar_with_named_niche() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn duration_from_millis(v: u64) -> std::time::Duration { unimplemented!() }",
+        "pub fn duration_to_millis(v: &std::time::Duration) -> u64 { unimplemented!() }",
+        "pub fn duration_echo(v: Option<std::time::Duration>) -> Option<std::time::Duration> { unimplemented!() }",
+        "pub fn duration_nested_echo(v: Option<Option<std::time::Duration>>) -> Option<Option<std::time::Duration>> { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let function: syn::ItemFn = syn::parse_str(source).unwrap();
+        (syn::Item::Fn(function), loc.clone())
+    })
+    .collect();
+    let registry = Registry::<()>::from_items(items).unwrap();
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            crate::convert!(std::time::Duration)
+                .input(crate::fun!(duration_from_millis))
+                .output(crate::fun!(duration_to_millis))
+                .valid_range(0u64..=1_000_000u64),
+        )
+        .base_name("z_duration")
+        .function(syn::parse_quote!(duration_echo))
+        .panic()
+        .function(syn::parse_quote!(duration_nested_echo))
+        .panic();
+
+    let src = write(cbindgen, registry, "bounded_duration");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("pubconstZ_DURATION_NICHE_0:u64=18446744073709551615"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("pubconstZ_DURATION_NICHE_1:u64=18446744073709551614"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("pubconstZ_DURATION_NONE:u64=18446744073709551615"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("extern\"C\"fnduration_echo(v:u64)->u64"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("extern\"C\"fnduration_nested_echo(v:u64)->u64"),
+        "{src}"
+    );
+    assert!(!compact.contains("v:*constu64"), "{src}");
+    assert!(!compact.contains("_present"), "{src}");
+    assert!(compact.contains("ifv==18446744073709551615"), "{src}");
+}
+
+#[test]
+fn bounded_float_option_uses_a_finite_bit_exact_niche() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn ratio_from_f64(v: f64) -> Ratio { unimplemented!() }",
+        "pub fn ratio_to_f64(v: Ratio) -> f64 { unimplemented!() }",
+        "pub fn ratio_echo(v: Option<Ratio>) -> Option<Ratio> { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let function: syn::ItemFn = syn::parse_str(source).unwrap();
+        (syn::Item::Fn(function), loc.clone())
+    })
+    .collect();
+    let registry = Registry::<()>::from_items(items).unwrap();
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            crate::convert!(Ratio)
+                .input(crate::fun!(ratio_from_f64))
+                .output(crate::fun!(ratio_to_f64))
+                .valid_range(0.0f64..=1.0f64),
+        )
+        .base_name("z_ratio")
+        .function(syn::parse_quote!(ratio_echo))
+        .panic();
+
+    let src = write(cbindgen, registry, "bounded_float");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("pubconstZ_RATIO_NONE:f64=1.7976931348623157e308f64"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("extern\"C\"fnratio_echo(v:f64)->f64"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("v.to_bits()==9218868437227405311"),
+        "{src}"
+    );
+    assert!(compact.contains("myflat::ratio_to_f64(v)"), "{src}");
+}
+
+#[test]
+fn custom_conversion_without_domain_stays_infallible() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn ratio_from_f64(v: f64) -> Ratio { unimplemented!() }",
+        "pub fn ratio_to_f64(v: Ratio) -> f64 { unimplemented!() }",
+        "pub fn ratio_echo(v: Ratio) -> Ratio { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let function: syn::ItemFn = syn::parse_str(source).unwrap();
+        (syn::Item::Fn(function), loc.clone())
+    })
+    .collect();
+    let registry = Registry::<()>::from_items(items).unwrap();
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            crate::convert!(Ratio)
+                .input(crate::fun!(ratio_from_f64))
+                .output(crate::fun!(ratio_to_f64)),
+        )
+        .function(syn::parse_quote!(ratio_echo));
+
+    let src = write(cbindgen, registry, "unbounded_conversion");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("fn__cbg_in_Ratio(v:f64)->myflat::Ratio"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("fn__cbg_out_Ratio(v:myflat::Ratio)->f64"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("extern\"C\"fnratio_echo(v:f64)->f64"),
+        "{src}"
+    );
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -778,6 +778,41 @@ impl Prebindgen for Cbindgen {
         self.ignored_functions.clone()
     }
 
+    fn helper_functions(&self) -> HashSet<syn::Ident> {
+        self.convert_decls
+            .iter()
+            .flat_map(|decl| decl.input.iter().chain(decl.output.iter()))
+            .filter_map(|spec| match spec {
+                ConvertSpec::PrebindgenFn(ident) => Some(ident.clone()),
+                ConvertSpec::Trait { .. } => None,
+            })
+            .filter(|ident| !self.functions.contains_key(ident))
+            .collect()
+    }
+
+    fn local_functions(&self) -> Vec<(syn::ItemFn, String)> {
+        let mut result = Vec::new();
+        let mut seen = HashMap::<syn::Ident, String>::new();
+        for (ident, path, sig) in self.convert_decls.iter().flat_map(|decl| &decl.locals) {
+            let origin = crate::api::lang::jnigen::jni::local_path_prefix(path);
+            let mut sig = sig.clone();
+            sig.ident = ident.clone();
+            let signature = quote!(#origin #sig).to_string();
+            match seen.get(ident) {
+                Some(previous) if previous == &signature => continue,
+                Some(_) => panic!(
+                    "binding-local conversion fn `{ident}` is declared with two different signatures"
+                ),
+                None => {
+                    seen.insert(ident.clone(), signature);
+                }
+            }
+            let item: syn::ItemFn = syn::parse_quote!(#sig { unimplemented!() });
+            result.push((item, origin));
+        }
+        result
+    }
+
     fn declared_types(&self) -> HashSet<TypeKey> {
         self.opaque
             .keys()
@@ -808,6 +843,7 @@ impl Prebindgen for Cbindgen {
         items.extend(self.prereq_value_opaque(registry));
         items.extend(self.prereq_enums(registry));
         items.extend(self.prereq_callback_structs(registry));
+        items.extend(self.prereq_domain_constants(registry));
         items
     }
 
@@ -1175,6 +1211,49 @@ impl Cbindgen {
                 syn::ReturnType::Type(_, t) => ((**t).clone(), false),
                 syn::ReturnType::Default => (syn::parse_quote!(()), false),
             };
+            if let Some((slot, rest)) = entry.niches.clone().carve() {
+                let pred = &slot.matches;
+                let name =
+                    format_ident!("__cbg_in_option_{}", sanitize(&TypeKey::from_type(&inner)));
+                let function: syn::ItemFn = if fallible {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) unsafe fn #name(
+                            v: #inner_wire,
+                        ) -> ::core::result::Result<
+                            ::core::option::Option<#inner_ok>,
+                            ::std::string::String
+                        > {
+                            if #pred {
+                                ::core::result::Result::Ok(::core::option::Option::None)
+                            } else {
+                                #inner_conv(v).map(::core::option::Option::Some)
+                            }
+                        }
+                    )
+                } else {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) unsafe fn #name(
+                            v: #inner_wire,
+                        ) -> ::core::option::Option<#inner_ok> {
+                            if #pred {
+                                ::core::option::Option::None
+                            } else {
+                                ::core::option::Option::Some(#inner_conv(v))
+                            }
+                        }
+                    )
+                };
+                return Some(ConverterImpl {
+                    subs: vec![inner],
+                    destination: inner_wire,
+                    function,
+                    pre_stages: vec![],
+                    niches: rest,
+                    metadata: (),
+                });
+            }
             let is_ptr = matches!(inner_wire, syn::Type::Ptr(_));
             let wire: syn::Type = if is_ptr {
                 inner_wire.clone()

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1027,7 +1027,7 @@ impl JniGen {
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         let target = key.to_type();
-        match decl.input.as_ref()? {
+        let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
                 let (item_fn, _) = registry.functions.get(f).unwrap_or_else(|| {
                     panic!(
@@ -1085,7 +1085,9 @@ impl JniGen {
               // pass the qualification visitor untouched). With a declared
               // error type the fn returns `Result<T, E>` — emitted as-is, `E`
               // riding the standard exc slot.
-        }
+        };
+        let (repr, exc, body) = result?;
+        Some(self.apply_input_domain(decl, repr, exc, body))
     }
 
     /// Output-direction peer of [`Self::convert_input_body`]: the conversion
@@ -1097,7 +1099,7 @@ impl JniGen {
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         let target = key.to_type();
-        match decl.output.as_ref()? {
+        let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
                 let (item_fn, _) = registry.functions.get(g).unwrap_or_else(|| {
                     panic!(
@@ -1113,8 +1115,18 @@ impl JniGen {
                     got = TypeKey::from_type(&param_ty).as_str()
                 );
                 let ret = fn_return_type(item_fn);
+                let (repr, exc) = match crate::api::core::types_util::result_ok_type(&ret) {
+                    Some(ok) => (
+                        ok,
+                        Some(
+                            crate::api::core::types_util::result_err_type(&ret)
+                                .expect("result_ok_type implies result_err_type"),
+                        ),
+                    ),
+                    None => (ret, None),
+                };
                 assert!(
-                    TypeKey::from_type(&ret) != *key,
+                    TypeKey::from_type(&repr) != *key,
                     "convert!({k}).output({g}): the function must return the converted form, \
                      not `{k}`",
                     k = key.as_str()
@@ -1125,7 +1137,7 @@ impl JniGen {
                 } else {
                     syn::parse_quote!(#module::#g(v))
                 };
-                Some((ret, None, body))
+                Some((repr, exc, body))
             }
             ConvertSpec::Trait { repr, fallible } => {
                 if *fallible {
@@ -1143,12 +1155,102 @@ impl JniGen {
                     Some((repr.clone(), None, body))
                 }
             }
-        }
+        };
+        let (repr, exc, body) = result?;
+        Some(self.apply_output_domain(decl, repr, exc, body))
     }
 
     /// Idents of every `#[prebindgen]`-fn conversion source — scanned as
     /// helper functions ([`Prebindgen::helper_functions`]) so their extern
     /// emission is suppressed. Trait/local-fn sources have no registry item.
+    fn apply_input_domain(
+        &self,
+        decl: &ConvertDecl,
+        repr: syn::Type,
+        exc: Option<syn::Type>,
+        body: syn::Expr,
+    ) -> (syn::Type, Option<syn::Type>, syn::Expr) {
+        let Some(domain) = &decl.domain else {
+            return (repr, exc, body);
+        };
+        assert_eq!(
+            TypeKey::from_type(domain.ty()),
+            TypeKey::from_type(&repr),
+            "convert!({}): domain type {} does not match input representation {}",
+            decl.key.as_str(),
+            TypeKey::from_type(domain.ty()),
+            TypeKey::from_type(&repr),
+        );
+        let valid = domain.contains_expr(quote!(v));
+        let key = decl.key.as_str();
+        let converted = if exc.is_some() {
+            quote!((#body).map_err(|__e| {
+                <__JniErr as ::core::convert::From<String>>::from(__e.to_string())
+            }))
+        } else {
+            quote!(::core::result::Result::Ok(#body))
+        };
+        let body = syn::parse_quote!({
+            if #valid {
+                #converted
+            } else {
+                ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<String>>::from(
+                        format!("{} representation is outside its declared domain", #key)
+                    )
+                )
+            }
+        });
+        (repr, Some(syn::parse_quote!(__JniErr)), body)
+    }
+
+    fn apply_output_domain(
+        &self,
+        decl: &ConvertDecl,
+        repr: syn::Type,
+        exc: Option<syn::Type>,
+        body: syn::Expr,
+    ) -> (syn::Type, Option<syn::Type>, syn::Expr) {
+        let Some(domain) = &decl.domain else {
+            return (repr, exc, body);
+        };
+        assert_eq!(
+            TypeKey::from_type(domain.ty()),
+            TypeKey::from_type(&repr),
+            "convert!({}): domain type {} does not match output representation {}",
+            decl.key.as_str(),
+            TypeKey::from_type(domain.ty()),
+            TypeKey::from_type(&repr),
+        );
+        let valid = domain.contains_expr(quote!(__repr));
+        let key = decl.key.as_str();
+        let converted = if exc.is_some() {
+            quote!((#body).map_err(|__e| {
+                <__JniErr as ::core::convert::From<String>>::from(__e.to_string())
+            }))
+        } else {
+            quote!(::core::result::Result::Ok(#body))
+        };
+        let body = syn::parse_quote!({
+            match #converted {
+                ::core::result::Result::Ok(__repr) if #valid => {
+                    ::core::result::Result::Ok(__repr)
+                }
+                ::core::result::Result::Ok(_) => {
+                    ::core::result::Result::Err(
+                        <__JniErr as ::core::convert::From<String>>::from(
+                            format!("{} representation is outside its declared domain", #key)
+                        )
+                    )
+                }
+                ::core::result::Result::Err(__e) => {
+                    ::core::result::Result::Err(__e)
+                }
+            }
+        });
+        (repr, Some(syn::parse_quote!(__JniErr)), body)
+    }
+
     pub(crate) fn convert_fns(&self) -> impl Iterator<Item = syn::Ident> + '_ {
         self.convert_decls
             .iter()
@@ -1218,6 +1320,75 @@ impl JniGen {
             kotlin_name,
             value_rust_key: None,
             projection: None,
+        }
+    }
+
+    fn conversion_domain_niches(
+        &self,
+        key: &TypeKey,
+        registry: &Registry<KotlinMeta>,
+        direction: Direction,
+        wire: &syn::Type,
+    ) -> (Niches, Vec<String>) {
+        let Some(domain) = self
+            .convert_decls
+            .iter()
+            .find(|d| &d.key == key)
+            .and_then(|d| d.domain.as_ref())
+        else {
+            return (Niches::empty(), Vec::new());
+        };
+        if TypeKey::from_type(domain.ty()).as_str() != "u64"
+            || crate::api::core::types_util::path_tail_ident(wire)
+                .is_none_or(|ident| ident != "jlong")
+        {
+            return (Niches::empty(), Vec::new());
+        }
+        let demand = registry
+            .type_table(direction)
+            .keys()
+            .map(|candidate| {
+                let mut ty = candidate.to_type();
+                let mut depth = 0;
+                while crate::api::core::types_util::is_option_type(&ty) {
+                    let Some(inner) = crate::api::core::types_util::first_type_arg(&ty) else {
+                        return 0;
+                    };
+                    ty = inner;
+                    depth += 1;
+                }
+                if TypeKey::from_type(&ty) == *key {
+                    depth
+                } else {
+                    0
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        let mut slots = Vec::new();
+        let mut kotlin = Vec::new();
+        for value in domain.niche_values(demand) {
+            let ScalarValue::U64(value) = value else {
+                continue;
+            };
+            let raw = value as i64;
+            let literal = if raw == i64::MIN {
+                "Long.MIN_VALUE".to_string()
+            } else {
+                format!("{raw}L")
+            };
+            slots.push(NicheSlot {
+                value: syn::parse_quote!(#raw),
+                matches: syn::parse_quote!(*v == #raw),
+            });
+            kotlin.push(literal);
+        }
+        (Niches::from_slots(slots), kotlin)
+    }
+
+    fn attach_domain_sentinels(metadata: &mut KotlinMeta, sentinels: Vec<String>) {
+        if let Some(projection) = metadata.projection.as_mut() {
+            projection.niche_sentinels = sentinels;
         }
     }
 
@@ -1376,25 +1547,29 @@ impl JniGen {
                 } else {
                     (inner.metadata.kotlin_name.clone(), None)
                 };
-                let niches = if rank == 0 {
-                    Niches::empty()
+                let (niches, sentinels) = if rank == 0 {
+                    self.conversion_domain_niches(
+                        &key,
+                        registry,
+                        Direction::Input,
+                        &inner.destination,
+                    )
                 } else {
-                    default_niches_for_wire(&inner.destination)
+                    (default_niches_for_wire(&inner.destination), Vec::new())
                 };
+                let mut metadata = KotlinMeta {
+                    kotlin_name,
+                    value_rust_key,
+                    projection: inner.metadata.projection.clone(),
+                };
+                Self::attach_domain_sentinels(&mut metadata, sentinels);
                 Some(ConverterImpl {
                     subs: vec![],
                     function: inner.function.clone(),
                     destination: inner.destination.clone(),
                     pre_stages,
                     niches,
-                    metadata: KotlinMeta {
-                        kotlin_name,
-                        value_rust_key,
-                        // Identity propagation: a composed wrapper (e.g.
-                        // `Result<Handle,Error>`) projects to its inner value,
-                        // so a handle inner stays a handle (same strategy).
-                        projection: inner.metadata.projection.clone(),
-                    },
+                    metadata,
                 })
             }
         }
@@ -1506,25 +1681,29 @@ impl JniGen {
                 } else {
                     (inner.metadata.kotlin_name.clone(), None)
                 };
-                let niches = if rank == 0 {
-                    Niches::empty()
+                let (niches, sentinels) = if rank == 0 {
+                    self.conversion_domain_niches(
+                        &key,
+                        registry,
+                        Direction::Output,
+                        &inner.destination,
+                    )
                 } else {
-                    default_niches_for_wire(&inner.destination)
+                    (default_niches_for_wire(&inner.destination), Vec::new())
                 };
+                let mut metadata = KotlinMeta {
+                    kotlin_name,
+                    value_rust_key,
+                    projection: inner.metadata.projection.clone(),
+                };
+                Self::attach_domain_sentinels(&mut metadata, sentinels);
                 Some(ConverterImpl {
                     subs: vec![],
                     function: inner.function.clone(),
                     destination: inner.destination.clone(),
                     pre_stages,
                     niches,
-                    metadata: KotlinMeta {
-                        kotlin_name,
-                        value_rust_key,
-                        // Identity propagation: a composed wrapper (e.g.
-                        // `Result<Handle,Error>`) projects to its inner value,
-                        // so a handle inner stays a handle (same strategy).
-                        projection: inner.metadata.projection.clone(),
-                    },
+                    metadata,
                 })
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1351,7 +1351,7 @@ impl JniGen {
                 let mut ty = candidate.to_type();
                 let mut depth = 0;
                 while crate::api::core::types_util::is_option_type(&ty) {
-                    let Some(inner) = crate::api::core::types_util::first_type_arg(&ty) else {
+                    let Some(inner) = option_inner_type(&ty) else {
                         return 0;
                     };
                     ty = inner;

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -1400,15 +1400,22 @@ impl PackageDecl {
 /// ```rust,ignore
 /// .convert(convert!(Millis)
 ///     .input(fun!(millis_from_long))   // fn(u64) -> Millis    (wire → rust)
-///     .output(fun!(millis_value)))     // fn(&Millis) -> u64   (rust → wire)
+///     .output(fun!(millis_value))      // fn(&Millis) -> u64   (rust → wire)
+///     .valid_range(0u64..=86_400_000)) // rejects invalid values; Option uses a niche
 /// .convert(convert!(Celsius).input(from!(i32)).output(into!(i32)))
 /// .convert(convert!(Label)
 ///     .input(try_from!(String).with(path!(crate::label_in)).error(ty!(String)))
 ///     .output(into!(String).with(path!(crate::label_out))))
 /// ```
 ///
-/// The Kotlin surface derives from the conversion's other-side type
-/// (`u64` ⇒ `Long`) — nothing is stated verbatim. A `try_` source's `Err`
+/// The foreign surface derives from the conversion's other-side type
+/// (`u64` ⇒ Kotlin `ULong` / C `uint64_t`) — nothing is stated verbatim.
+/// [`valid_range`](ConvertDecl::valid_range) and
+/// [`valid_values`](ConvertDecl::valid_values) declare the legal subset of a
+/// scalar representation. Generated converters validate the subset, and
+/// adapters may reuse values outside it as allocation-free `Option`/`Result`
+/// markers; [`exclude_values`](ConvertDecl::exclude_values) reserves holes in
+/// an otherwise legal domain. A `try_` source's `Err`
 /// routes to the caller's error handler. Conversion fns may live in the flat
 /// crate or in a **helper crate** whose item stream is chained into the same
 /// [`crate::core::Registry::from_items`] call; generated calls qualify each
@@ -1575,6 +1582,7 @@ pub struct ConvertDecl {
     pub(crate) key: TypeKey,
     pub(crate) input: Option<ConvertSpec>,
     pub(crate) output: Option<ConvertSpec>,
+    pub(crate) domain: Option<crate::core::RepresentationDomain>,
     /// Binding-local fn sources declared on this convert (`fun!(crate::f)
     /// .sig(…)`): drained into [`JniGen::local_fns`] at acceptance so the
     /// synthesis pre-pass covers them.
@@ -1604,6 +1612,7 @@ impl ConvertDecl {
             key: TypeKey::from_type(&rust_type),
             input: None,
             output: None,
+            domain: None,
             locals: Vec::new(),
         }
     }
@@ -1695,6 +1704,59 @@ impl ConvertDecl {
     pub fn output(mut self, src: impl Into<ConvertSourceDecl>) -> Self {
         let spec = self.spec_of(ConvertDirection::Output, "output", src.into());
         self.set_output(spec)
+    }
+
+    /// Restrict the scalar representation to a numeric range. Values outside
+    /// the range are rejected and may be reused by wrappers such as `Option`.
+    /// Floating-point ranges reject every NaN; use [`Self::valid_values`] when
+    /// exact raw IEEE values (including a specific NaN payload) are intended.
+    pub fn valid_range<T, R>(mut self, range: R) -> Self
+    where
+        T: crate::core::DomainScalar,
+        R: ::core::ops::RangeBounds<T>,
+    {
+        assert!(
+            self.domain.is_none(),
+            "convert!({}): the representation domain is already declared",
+            self.key.as_str()
+        );
+        self.domain = Some(crate::core::RepresentationDomain::range(range));
+        self
+    }
+
+    /// Restrict the scalar representation to a finite valid-value set. Float
+    /// membership uses raw IEEE bits, so `0.0`, `-0.0`, and NaN payloads remain
+    /// distinct.
+    pub fn valid_values<T>(mut self, values: impl IntoIterator<Item = T>) -> Self
+    where
+        T: crate::core::DomainScalar,
+    {
+        assert!(
+            self.domain.is_none(),
+            "convert!({}): the representation domain is already declared",
+            self.key.as_str()
+        );
+        self.domain = Some(crate::core::RepresentationDomain::values(values));
+        self
+    }
+
+    /// Remove finite values from the previously declared base domain. Float
+    /// exclusions use raw IEEE bits.
+    pub fn exclude_values<T>(mut self, values: impl IntoIterator<Item = T>) -> Self
+    where
+        T: crate::core::DomainScalar,
+    {
+        self.domain
+            .as_mut()
+            .unwrap_or_else(|| {
+                panic!(
+                    "convert!({}): .exclude_values(...) requires .valid_range(...) \
+                     or .valid_values(...) first",
+                    self.key.as_str()
+                )
+            })
+            .exclude(values);
+        self
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -1,6 +1,7 @@
 //! Scalar / `Option` / enum converter bodies and their wire probes.
 
 use super::*;
+use crate::api::core::registry::TypeEntry;
 
 /// Sentinel value to return through the wrapper signature when the inner
 /// closure errors. Must compile against any wire type we emit.
@@ -165,6 +166,48 @@ pub(crate) fn primitive_output(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)>
 // Option<_> wrappers
 // ──────────────────────────────────────────────────────────────────────
 
+/// Invoke an inner input converter's complete `wire -> Rust` chain.
+///
+/// Structural wrappers cannot call only [`TypeEntry::function`]: custom
+/// conversions may carry semantic steps in `pre_stages` (for example
+/// `jlong -> u64 -> Duration`). Keep those steps inside the `Some` arm so a
+/// niche discriminator is tested before any conversion runs.
+fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn::Expr {
+    let converter = inner.converter_ident();
+    let mut body = quote! {
+        let __inner_s0 = #converter(env, #wire)?;
+    };
+    let mut previous = format_ident!("__inner_s0");
+    for (order, (_, stage)) in inner.input_stage_order().enumerate() {
+        let stage_fn = &stage.function.sig.ident;
+        let next = format_ident!("__inner_s{}", order + 1);
+        body.extend(quote! {
+            let #next = #stage_fn(env, #previous)?;
+        });
+        previous = next;
+    }
+    body.extend(quote!(#previous));
+    syn::parse2(quote!({ #body })).expect("composed input chain is a valid expression")
+}
+
+/// Invoke an inner output converter's complete `Rust -> wire` chain.
+/// Mirror of [`composed_inner_input`].
+fn composed_inner_output(inner: &TypeEntry<KotlinMeta>, value: TokenStream) -> syn::Expr {
+    let mut body = TokenStream::new();
+    let mut previous = value;
+    for (order, (_, stage)) in inner.output_stage_order().enumerate() {
+        let stage_fn = &stage.function.sig.ident;
+        let next = format_ident!("__inner_s{}", order);
+        body.extend(quote! {
+            let #next = #stage_fn(env, #previous)?;
+        });
+        previous = quote!(#next);
+    }
+    let converter = inner.converter_ident();
+    body.extend(quote!(#converter(env, #previous)?));
+    syn::parse2(quote!({ #body })).expect("composed output chain is a valid expression")
+}
+
 /// Build `Option<T>`'s input converter.
 ///
 /// Two paths, picked in this order:
@@ -191,7 +234,7 @@ pub(crate) fn option_input(
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
     let inner_entry = registry.input_entry(t1)?;
     let inner_wire = inner_entry.destination.clone();
-    let inner_conv = inner_entry.function.sig.ident.clone();
+    let inner_decode = composed_inner_input(inner_entry, quote!(v));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -214,7 +257,7 @@ pub(crate) fn option_input(
             })
         } else {
             syn::parse_quote!({
-                if #pred { None } else { Some(#inner_conv(env, v)?) }
+                if #pred { None } else { Some(#inner_decode) }
             })
         };
         return Some((inner_wire, body, rest));
@@ -226,6 +269,7 @@ pub(crate) fn option_input(
         let unbox_sig = jni_unbox_sig(&inner_wire);
         let getter = jni_unbox_getter(&inner_wire);
         let getter_id = format_ident!("{}", getter);
+        let inner_decode = composed_inner_input(inner_entry, quote!(&__unboxed));
         let body: syn::Expr = syn::parse_quote!({
             if !v.is_null() {
                 let __unboxed: #inner_wire = env
@@ -237,7 +281,7 @@ pub(crate) fn option_input(
                     .and_then(|val| val.#getter_id())
                     .map(|__x| __x as #inner_wire)
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Option unbox: {}", e)))?;
-                Some(#inner_conv(env, &__unboxed)?)
+                Some(#inner_decode)
             } else {
                 None
             }
@@ -256,14 +300,14 @@ pub(crate) fn option_output(
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
     let inner_entry = registry.output_entry(t1)?;
     let inner_wire = inner_entry.destination.clone();
-    let inner_conv = inner_entry.function.sig.ident.clone();
+    let inner_encode = composed_inner_output(inner_entry, quote!(value));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
         let none_value = &slot.value;
         let body: syn::Expr = syn::parse_quote!({
             match v {
-                Some(value) => #inner_conv(env, value)?,
+                Some(value) => #inner_encode,
                 None => #none_value,
             }
         });
@@ -272,10 +316,11 @@ pub(crate) fn option_output(
 
     // 2. Boxed-primitive fallback (cached box class + `valueOf` method ID).
     if let Some(helper) = box_helper_for_wire(&inner_wire) {
+        let inner_encode = composed_inner_output(inner_entry, quote!(value));
         let body: syn::Expr = syn::parse_quote!({
             match v {
                 Some(value) => {
-                    let __raw: #inner_wire = #inner_conv(env, value)?;
+                    let __raw: #inner_wire = #inner_encode;
                     ::prebindgen::lang::#helper(env, __raw)
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Option box: {}", e)))?
                 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -79,10 +79,6 @@ pub(crate) fn primitive_input(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)> 
             syn::parse_quote!(*v as ::core::primitive::u64),
         ),
         "f64" => (syn::parse_quote!(jni::sys::jdouble), syn::parse_quote!(*v)),
-        "Duration" | "std :: time :: Duration" => (
-            syn::parse_quote!(jni::sys::jlong),
-            syn::parse_quote!(std::time::Duration::from_millis(*v as u64)),
-        ),
         "String" => (
             syn::parse_quote!(jni::objects::JString),
             syn::parse_quote!({

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -174,6 +174,10 @@ pub(crate) fn primitive_output(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)>
 /// niche discriminator is tested before any conversion runs.
 fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn::Expr {
     let converter = inner.converter_ident();
+    if inner.pre_stages.is_empty() {
+        return syn::parse2(quote!(#converter(env, #wire)?))
+            .expect("single-stage input call is a valid expression");
+    }
     let mut body = quote! {
         let __inner_s0 = #converter(env, #wire)?;
     };
@@ -193,6 +197,11 @@ fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn
 /// Invoke an inner output converter's complete `Rust -> wire` chain.
 /// Mirror of [`composed_inner_input`].
 fn composed_inner_output(inner: &TypeEntry<KotlinMeta>, value: TokenStream) -> syn::Expr {
+    let converter = inner.converter_ident();
+    if inner.pre_stages.is_empty() {
+        return syn::parse2(quote!(#converter(env, #value)?))
+            .expect("single-stage output call is a valid expression");
+    }
     let mut body = TokenStream::new();
     let mut previous = value;
     for (order, (_, stage)) in inner.output_stage_order().enumerate() {
@@ -203,7 +212,6 @@ fn composed_inner_output(inner: &TypeEntry<KotlinMeta>, value: TokenStream) -> s
         });
         previous = quote!(#next);
     }
-    let converter = inner.converter_ident();
     body.extend(quote!(#converter(env, #previous)?));
     syn::parse2(quote!({ #body })).expect("composed output chain is a valid expression")
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -186,7 +186,8 @@ fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn
         let stage_fn = &stage.function.sig.ident;
         let next = format_ident!("__inner_s{}", order + 1);
         body.extend(quote! {
-            let #next = #stage_fn(env, #previous)?;
+            let #next = #stage_fn(env, #previous)
+                .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(__e.to_string()))?;
         });
         previous = next;
     }
@@ -208,7 +209,8 @@ fn composed_inner_output(inner: &TypeEntry<KotlinMeta>, value: TokenStream) -> s
         let stage_fn = &stage.function.sig.ident;
         let next = format_ident!("__inner_s{}", order);
         body.extend(quote! {
-            let #next = #stage_fn(env, #previous)?;
+            let #next = #stage_fn(env, #previous)
+                .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(__e.to_string()))?;
         });
         previous = quote!(#next);
     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -545,7 +545,7 @@ fn emit_input_param(
         InputKind::Callback { .. }
         | InputKind::Handle { .. }
         | InputKind::ValueUnwrap { .. }
-        | InputKind::Unsigned64
+        | InputKind::Unsigned64 { .. }
         | InputKind::Plain => {
             let entry = registry.input_entry(arg_ty).unwrap_or_else(|| {
                 panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -114,7 +114,7 @@ pub(crate) enum InputKind {
     ValueUnwrap { field: String },
     /// Rust `u64`: typed Kotlin `ULong`, raw JNI `Long`. The wrapper passes
     /// the bit-preserving `toLong()` representation and takes no lock.
-    Unsigned64,
+    Unsigned64 { niche: Option<String> },
     /// Everything else: the resolved entry's converter/wire as-is.
     Plain,
 }
@@ -530,7 +530,13 @@ fn classify_leaf(
                     });
                 InputKind::ValueUnwrap { field }
             }
-            Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64,
+            Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
+                niche: entry.metadata.projection.as_ref().and_then(|p| {
+                    is_option_type(ty)
+                        .then(|| p.niche_sentinels.first().cloned())
+                        .flatten()
+                }),
+            },
             None => InputKind::Plain,
         }
     };

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -430,6 +430,9 @@ pub(crate) fn projection_wire_return(
 pub(crate) fn projection_leaf_sentinel(
     proj: &crate::api::lang::jnigen::jni::Projection,
 ) -> Option<String> {
+    if let Some(sentinel) = proj.niche_sentinels.first() {
+        return Some(sentinel.clone());
+    }
     use crate::api::lang::jnigen::jni::ProjectionKind;
     let leaf_wire: syn::Type = match proj.kind {
         ProjectionKind::Handle => syn::parse_quote!(jni::sys::jlong),

--- a/prebindgen/src/api/lang/jnigen/jni/metadata.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/metadata.rs
@@ -80,6 +80,9 @@ pub struct Projection {
     pub strategy: FoldStrategy,
     /// Handle vs value class — see [`ProjectionKind`].
     pub kind: ProjectionKind,
+    /// Kotlin literals for representation-domain niches, in carve order.
+    /// Empty for ordinary projections; bounded u64 conversions populate it.
+    pub niche_sentinels: Vec<String>,
 }
 
 /// Per-converter language-specific extras carried by every converter this

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -49,9 +49,10 @@ pub use string_helpers::{decode_string, encode_string, null_string};
 pub(crate) use crate::api::gen::kotlin as kt;
 pub(crate) use crate::api::{
     core::{
-        niches::Niches,
+        domain::ScalarValue,
+        niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen, Stage},
-        registry::{extract_fn_trait_args, Registry, TypeKey},
+        registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
         types_util::{
             bare_path_ident, is_option_ref, is_option_type, option_inner_type, vec_inner_type,
         },

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -508,7 +508,7 @@ pub(crate) fn render_extern_decl(
             }
             InputKind::Callback { .. }
             | InputKind::ValueUnwrap { .. }
-            | InputKind::Unsigned64
+            | InputKind::Unsigned64 { .. }
             | InputKind::Plain => {
                 let ty = if leaf.as_enum_value {
                     // Enum (incl. `Option<enum>`) crosses as jint → Kotlin
@@ -519,7 +519,13 @@ pub(crate) fn render_extern_decl(
                 } else {
                     leaf.kt_meta.clone()?
                 };
-                let ty = if leaf.optional { ty.nullable() } else { ty };
+                let niche_primitive =
+                    matches!(&leaf.kind, InputKind::Unsigned64 { niche: Some(_) });
+                let ty = if leaf.optional && !niche_primitive {
+                    ty.nullable()
+                } else {
+                    ty
+                };
                 params.push(kt::KtParam::new(name, ty));
             }
         }
@@ -610,7 +616,9 @@ enum ParamMode {
         field: String,
     },
     /// Kotlin `ULong` projected to its raw JNI `Long` bit pattern.
-    Unsigned64,
+    Unsigned64 {
+        niche: Option<String>,
+    },
     /// Flattenable `data_class` param: the high-level Kotlin signature keeps the
     /// typed object, but the `JNINative` call destructures it into the leaf
     /// access expressions (no `JObject` crosses, so the Rust side skips
@@ -1181,7 +1189,9 @@ fn classify_params(
             InputKind::ValueUnwrap { field } => ParamMode::ValueUnwrap {
                 field: field.clone(),
             },
-            InputKind::Unsigned64 => ParamMode::Unsigned64,
+            InputKind::Unsigned64 { niche } => ParamMode::Unsigned64 {
+                niche: niche.clone(),
+            },
             InputKind::Plain => ParamMode::PassThrough,
             InputKind::Callback { .. } => unreachable!("callback params handled above"),
         };
@@ -1439,9 +1449,12 @@ fn build_native_call(
                     format!("{}.{}", p.kt_name, field)
                 }
             }
-            ParamMode::Unsigned64 => {
+            ParamMode::Unsigned64 { niche } => {
                 if p.kt_type.is_nullable() {
-                    format!("{}?.toLong()", p.kt_name)
+                    match niche {
+                        Some(niche) => format!("{}?.toLong() ?: {}", p.kt_name, niche),
+                        None => format!("{}?.toLong()", p.kt_name),
+                    }
                 } else {
                     format!("{}.toLong()", p.kt_name)
                 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1,5 +1,100 @@
 use super::*;
 
+#[test]
+fn bounded_duration_option_uses_u64_niche_without_boxing() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn duration_from_millis(v: u64) -> std::time::Duration { unimplemented!() }",
+        "pub fn duration_to_millis(v: &std::time::Duration) -> u64 { unimplemented!() }",
+        "pub fn duration_echo(v: Option<std::time::Duration>) -> Option<std::time::Duration> { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let function: syn::ItemFn = syn::parse_str(source).unwrap();
+        (syn::Item::Fn(function), loc.clone())
+    })
+    .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .convert(
+            crate::convert!(std::time::Duration)
+                .input(crate::fun!(duration_from_millis))
+                .output(crate::fun!(duration_to_millis))
+                .valid_range(0u64..=1_000_000u64),
+        )
+        .package(crate::package!("time").fun(crate::fun!(duration_echo)));
+    let dir = unique_test_dir("jnigen_bounded_duration");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = registry.resolve(jni).unwrap();
+    let rust_path = generation.write_rust(dir.join("gen.rs")).unwrap();
+    let rust = std::fs::read_to_string(rust_path).unwrap();
+    let paths = generation.write_kotlin(&dir.join("kotlin")).unwrap();
+    let kotlin = paths
+        .iter()
+        .map(|path| std::fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let rc: String = rust.split_whitespace().collect();
+    let kc: String = kotlin.split_whitespace().collect();
+
+    assert!(rc.contains("outsideitsdeclareddomain"), "{rust}");
+    assert!(
+        rc.contains("None=>-1i64") || rc.contains("None=>-1"),
+        "{rust}"
+    );
+    assert!(!rc.contains("Optionbox:"), "{rust}");
+    assert!(kc.contains("v:ULong?"), "{kotlin}");
+    assert!(kc.contains("v?.toLong()?:-1L"), "{kotlin}");
+    assert!(kc.contains("v:Long"), "{kotlin}");
+}
+
+#[test]
+fn duration_requires_an_explicit_conversion() {
+    let function: syn::ItemFn = syn::parse_str(
+        "pub fn duration_echo(v: std::time::Duration) -> std::time::Duration { unimplemented!() }",
+    )
+    .unwrap();
+    let registry = Registry::<KotlinMeta>::from_items([(syn::Item::Fn(function), myflat_loc())])
+        .expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!("time").fun(crate::fun!(duration_echo)));
+
+    let error = registry
+        .resolve(jni)
+        .expect_err("Duration must not have an implicit unchecked converter")
+        .to_string();
+    assert!(error.contains("Duration"), "{error}");
+}
+
+#[test]
+#[should_panic(expected = "domain type i64 does not match input representation u64")]
+fn conversion_domain_must_match_the_representation() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn duration_from_millis(v: u64) -> std::time::Duration { unimplemented!() }",
+        "pub fn duration_use(v: std::time::Duration) { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let function: syn::ItemFn = syn::parse_str(source).unwrap();
+        (syn::Item::Fn(function), loc.clone())
+    })
+    .collect();
+    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
+    let jni = JniGen::new()
+        .convert(
+            crate::convert!(std::time::Duration)
+                .input(crate::fun!(duration_from_millis))
+                .valid_range(0i64..=1_000i64),
+        )
+        .package(crate::package!("time").fun(crate::fun!(duration_use)));
+
+    let _ = registry.resolve(jni);
+}
+
 /// Phase 4: a bare `Option<primitive>` / `Option<enum>` **input** parameter
 /// crosses as a decoupled `(present: Boolean, value: <prim>)` pair instead of a
 /// boxed `java.lang.*` `JObject`. The Rust side reassembles the `Option` from

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -681,6 +681,45 @@ fn convert_via_try_from_is_fallible() {
     );
 }
 
+/// Structural `Option<T>` converters return `__JniErr`, while a custom
+/// conversion stage may retain its raw `E`. Both input and output composition
+/// must normalize that `E` before using `?`.
+#[test]
+fn option_composition_normalizes_fallible_stage_errors() {
+    let loc = myflat_loc();
+    let f: syn::ItemFn = syn::parse_str(
+        "pub fn pct_optional(p: Option<Percent>) -> Option<Percent> { unimplemented!() }",
+    )
+    .unwrap();
+    let registry =
+        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .convert(
+            crate::convert!(Percent)
+                .input(crate::try_from!(i32))
+                .output(
+                    crate::fun!(crate::conv::pct_out)
+                        .sig(crate::sig!((p: Percent) -> Result<i32, String>)),
+                ),
+        )
+        .package(crate::package!("m").fun(crate::fun!(pct_optional)));
+    let dir = unique_test_dir("jnigen_option_fallible_stages");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+
+    assert!(
+        rc.matches("__e.to_string()").count() >= 2,
+        "input and output stages must both normalize their raw errors:\n{rust}"
+    );
+    assert!(rc.contains("JObject_to_Option_Percent"), "{rust}");
+    assert!(rc.contains("Option_Percent_to_JObject"), "{rust}");
+}
+
 /// Binding-local conversion fns via the ONE vocabulary —
 /// `fun!(crate::…).sig(sig!(…))`: synthesized into the registry, lowered
 /// through the ordinary `#[prebindgen]`-fn path, called by the declared path.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -44,6 +44,17 @@ fn bounded_duration_option_uses_u64_niche_without_boxing() {
         rc.contains("None=>-1i64") || rc.contains("None=>-1"),
         "{rust}"
     );
+    assert!(
+        rc.contains("Some({let__inner_s0=jlong_to_u64_")
+            && rc.contains("let__inner_s1=u64_to_Duration_"),
+        "Option input must compose the raw u64 decoder with the Duration stage:\n{rust}"
+    );
+    assert!(
+        rc.contains("Some(value)=>{let__inner_s0=")
+            && rc.contains("Duration_to_u64_")
+            && rc.contains("u64_to_jlong_"),
+        "Option output must compose the Duration stage with the raw u64 encoder:\n{rust}"
+    );
     assert!(!rc.contains("Optionbox:"), "{rust}");
     assert!(kc.contains("v:ULong?"), "{kotlin}");
     assert!(kc.contains("v?.toLong()?:-1L"), "{kotlin}");

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -239,6 +239,7 @@ impl JniGen {
                 owned: true,
                 strategy: FoldStrategy::Base,
                 kind: ProjectionKind::Handle,
+                niche_sentinels: Vec::new(),
             }),
             ..self.framework_meta(Some(kt::KtType::cls("Long")))
         }
@@ -254,6 +255,7 @@ impl JniGen {
                 owned: false,
                 strategy: FoldStrategy::Base,
                 kind: ProjectionKind::Unsigned64,
+                niche_sentinels: Vec::new(),
             }),
             ..self.framework_meta(Some(kt::KtType::long()))
         }
@@ -1469,6 +1471,7 @@ impl JniGen {
                         owned: false,
                         strategy: FoldStrategy::Base,
                         kind: ProjectionKind::ValueBlob,
+                        niche_sentinels: Vec::new(),
                     }),
                     ..self.framework_meta(Some(kt::KtType::cls("ByteArray")))
                 },
@@ -1679,6 +1682,7 @@ impl JniGen {
                         owned: false,
                         strategy: FoldStrategy::Base,
                         kind: ProjectionKind::ValueBlob,
+                        niche_sentinels: Vec::new(),
                     }),
                     ..self.framework_meta(Some(kt::KtType::cls("ByteArray")))
                 },

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -36,6 +36,7 @@
 pub mod jni;
 pub(crate) mod util;
 
+#[cfg(feature = "unstable-cbindgen")]
 pub(crate) use jni::ConvertSpec;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -36,6 +36,7 @@
 pub mod jni;
 pub(crate) mod util;
 
+pub(crate) use jni::ConvertSpec;
 pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -288,8 +288,9 @@ macro_rules! ident {
 /// with the `unstable-cbindgen` feature.
 pub mod core {
     pub use crate::api::core::{
-        ConverterImpl, Direction, Generation, Gravestone, NicheSlot, Niches, Prebindgen, Registry,
-        ScanError, Stage, Transmute, TypeEntry, TypeKey, WriteRustError,
+        ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot, Niches,
+        Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage, Transmute,
+        TypeEntry, TypeKey, WriteRustError,
     };
 }
 


### PR DESCRIPTION
## Summary

- add `valid_range`, `valid_values`, and `exclude_values` to custom conversion declarations
- validate declared scalar domains on both inbound and outbound conversion paths
- derive invalid representation values as nested `Option` niches instead of allocating or boxing
- keep `Option<Duration>` as Kotlin `ULong?` over one raw JNI `Long`, with no `JObject` on the Rust side
- compose complete custom conversion chains inside niche-backed `Option` wrappers
- normalize raw fallible stage errors into the JNI binding error channel under structural wrappers
- add the same custom conversion and niche mechanism to Cbindgen, including named C constants
- remove the old implicit unchecked `Duration` input conversion

This is the bounded-value follow-up to #108 and #130.

## Example

```rust
convert!(std::time::Duration)
    .input(fun!(duration_from_millis))
    .output(fun!(duration_to_millis))
    .valid_range(0u64..=MAX_MILLIS)
```

Values above `MAX_MILLIS` are rejected by generated converters. The highest invalid `u64` values are then available as allocation-free markers for `Option` layers.

## Verification

- `cargo test -p prebindgen --all-features` (332 unit tests plus doc tests)
- `cargo +1.85.0 clippy -p prebindgen --all-targets --no-default-features --all-features -- --deny warnings`
- `cargo check -p prebindgen --no-default-features`
- repository rustfmt configuration and `git diff --check`
- `examples/covertest-kotlin/gradlew run` (34 runtime sections)
- `examples/regen-check.sh` (generated output byte-identical)

The Kotlin covertest now declares a real standard-library `Option<Duration>` surface and verifies nullable `ULong?`, primitive `Long -> Long` JNI reflection, null/zero/max round trips, and inbound/outbound domain failures. It also exercises `Option<Percent>` with raw fallible input and output stage errors and verifies both normalize into `JniErrorHandler`. Coverage additionally includes nested C `Option` niches, finite `f64` niches with raw-bit matching, domain mismatch rejection, and unchanged infallible conversions without a domain.