### PR TITLE
refactor(jnigen): collapse identical JObject match arm in wire_kotlin_type (#134)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -445,12 +445,6 @@ fn wire_kotlin_type(entry: &crate::api::core::registry::TypeEntry<KotlinMeta>) -
             return match last.ident.to_string().as_str() {
                 "JString" => "String".to_string(),
                 "JByteArray" => "ByteArray".to_string(),
-                "JObject" => entry
-                    .metadata
-                    .kotlin_name
-                    .as_ref()
-                    .map(ToString::to_string)
-                    .unwrap_or_else(|| "Any".to_string()),
                 _ => entry
                     .metadata
                     .kotlin_name


### PR DESCRIPTION
Fixes #134. Drops redundant JObject arm in favor of default wildcard arm in wire_kotlin_type.