### PR TITLE
Fix bounded optional data-class fields

### DIFF
--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -80,7 +80,9 @@ for the full table; in brief:
   `u64` with `.valid_range(...)`; `Option<Duration>` is `ULong?` publicly but
   remains primitive `Long` at the native boundary, using an invalid value as
   the `None` niche. The runtime checks both conversion directions, both domain
-  error paths, and the unboxed JNI signature.
+  error paths, the unboxed JNI signature, and composition through the
+  `DurationBoundary.delay` data-class field (including explicit whole-object
+  input decoding and primitive-`Long` `fromParts` output).
 - **fallible stages under structural wrappers:** `Option<Percent>` composes a
   raw `TryFrom::Error` input stage and a raw `String` output stage. The runtime
   checks null/value round trips and verifies both stage errors normalize to

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -27,7 +27,7 @@
 //! | `convert!` `.input(from!)`/`.output(into!)` | `Celsius` ⇄ `Int` via `From`/`Into` impls |
 //! | fallible conversion stages under `Option` | `Option<Percent>` ⇄ `Int?`; raw `TryFrom::Error` input and binding-local `String` output errors normalize to `JniErrorHandler` |
 //! | `convert!` sources `fun!(crate::…).sig(sig!)` | `Label` ⇄ `String` via binding-local fns (`crate::label_in`/`label_out`); the sig's `Result` = error channel, empty label → `onError` |
-//! | bounded conversion domains + niches | `Option<Duration>` ⇄ bounded millisecond `ULong?`; raw JNI remains primitive `Long`, `None` uses an invalid `u64`, invalid input/output routes to `onError` |
+//! | bounded conversion domains + niches | `Option<Duration>` ⇄ bounded millisecond `ULong?`; raw JNI remains primitive `Long`, `None` uses an invalid `u64`, invalid input/output routes to `onError`; `DurationBoundary` composes the niche through a data-class field and whole-object decode |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
 //! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones |
@@ -233,6 +233,11 @@ fn main() {
                 // recursive fromParts / recursive leaf decode) plus Option<prim> and
                 // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
                 .class(data_class!(Annotated))
+                // Compose the bounded `Option<Duration>` niche through a
+                // data-class field. Explicit JObject input makes the runtime
+                // execute the whole-object decoder as well as the primitive-
+                // niche `fromParts` encoder (#138).
+                .class(data_class!(DurationBoundary).jobject_input())
                 // These small nested classes form a 127-Long-leaf tree. Its
                 // constructor is legal, but flattening the root function input
                 // would consume 256 JVM slots, so it keeps one JObject input.
@@ -427,6 +432,7 @@ fn main() {
                 .fun(fun!(unsigned_emit))
                 .fun(fun!(unsigned_series))
                 .fun(fun!(duration_optional))
+                .fun(fun!(duration_boundary_echo))
                 .fun(fun!(duration_out_of_range)),
         )
         // analytics: the param-variant / return-field matrix (type default /

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -53,6 +53,8 @@ Base package: `io.prebindgen.covertest`
 - `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority?`
 - `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long?`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
+- `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
+  - shaped by: return `DurationBoundary` decomposed → [delay] (Callback delivery)
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
@@ -141,6 +143,7 @@ Base package: `io.prebindgen.covertest`
 
 - `Annotated`: data_class → `io.prebindgen.covertest.model.Annotated` (wire `jni :: objects :: JObject`)
 - `Archive`: ptr_class → `io.prebindgen.covertest.analytics.SummaryVault` (wire `jni :: sys :: jlong`)
+- `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `ObjectBoundary16`: data_class → `io.prebindgen.covertest.model.ObjectBoundary16` (wire `jni :: objects :: JObject`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -2,6 +2,7 @@
 package io.prebindgen.covertest
 
 import io.prebindgen.covertest.model.Annotated
+import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
@@ -721,6 +722,8 @@ internal object CovNative {
     external fun celsiusDouble(c: Int, errorSink: Any): Int
 
     external fun coverTagRuntime(errorSink: Any): String
+
+    external fun durationBoundaryEcho(value: DurationBoundary, build: Any, errorSink: Any): Any?
 
     external fun durationOptional(value: Long, errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -61,6 +61,20 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
 }
 
 /**
+ * Data-class composition probe for the bounded duration representation.
+ * The coverage binding deliberately marks this class `.jobject_input()` so
+ * its echo executes both the whole-object input decoder and the `fromParts`
+ * output encoder; the nullable duration itself still uses the raw `jlong`
+ * niche whenever it crosses a generated JNI call boundary.
+ */
+public data class DurationBoundary(val delay: ULong?) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(delay: Long): DurationBoundary = DurationBoundary(if (delay == -1L) null else delay.toULong())
+    }
+}
+
+/**
  * Deliberate object-boundary fixture for `data_class!(T).jobject_input()`.
  *
  * Its [`ObjectBoundary64`] and [`ObjectBoundary63`] children recursively
@@ -501,6 +515,25 @@ public value class Stamp(public val bytes: ByteArray) {
     }
 }
 
+public fun interface DurationBoundaryBuilder<out R> {
+    public fun run(delay: ULong?): R
+}
+
+public fun interface DurationBoundaryBuilderRaw<out R> {
+    public fun run(delay: Long): R
+}
+
+public fun <R> DurationBoundaryBuilder<R>.asRaw(): DurationBoundaryBuilderRaw<R> =
+    DurationBoundaryBuilderRaw<R> {
+        delay ->
+        run(
+            if (delay == -1L) null else delay.toULong()
+        )
+    }
+
+internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
+DurationBoundaryBuilderRaw { delay -> DurationBoundary.fromParts(delay) }
+
 public fun interface UnsignedBuilder<out R> {
     public fun run(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?): R
 }
@@ -891,6 +924,22 @@ public fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): UL
     val __ret = CovNative.durationOptional(value?.toLong() ?: -1L, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret.let { if (it == -1L) null else it.toULong() }
+}
+
+/**
+ * Round-trip [`DurationBoundary`] through the explicit object-input bridge.
+ *
+ * The Rust `DurationBoundary` result is delivered decomposed: the builder callback receives (`delay`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun durationBoundaryEcho(
+    value: DurationBoundary,
+    onError: JniErrorHandler<DurationBoundary>,
+): DurationBoundary {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.durationBoundaryEcho(value, __DurationBoundaryBuilderRaw, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as DurationBoundary
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -21,6 +21,7 @@ import io.prebindgen.covertest.analytics.summaryTotalRaw
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.esc_pkg.Esc_Probe
 import io.prebindgen.covertest.model.Annotated
+import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.ObjectBoundary2
 import io.prebindgen.covertest.model.ObjectBoundary4
@@ -37,6 +38,7 @@ import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.annotatedAlternateValue
 import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.durationOptional
+import io.prebindgen.covertest.model.durationBoundaryEcho
 import io.prebindgen.covertest.model.durationOutOfRange
 import io.prebindgen.covertest.model.labelReverse
 import io.prebindgen.covertest.model.percentInvalidOutput
@@ -202,6 +204,20 @@ fun main() {
         check(durationOptional(null, boom) == null)
         check(durationOptional(0uL, boom) == 0uL)
         check(durationOptional(86_400_000uL, boom) == 86_400_000uL)
+
+        // The data-class property is semantic `ULong?`, while its native
+        // output factory receives primitive Long + niche. The echo's explicit
+        // object input also executes the complete ULong -> Duration decoder.
+        val fromParts = DurationBoundary::class.java.getDeclaredMethod(
+            "fromParts",
+            java.lang.Long.TYPE,
+        )
+        check(fromParts.parameterTypes.single() == java.lang.Long.TYPE)
+        check(durationBoundaryEcho(DurationBoundary(null), boom) == DurationBoundary(null))
+        check(
+            durationBoundaryEcho(DurationBoundary(12_345uL), boom) ==
+                DurationBoundary(12_345uL),
+        )
 
         var inputError: String? = null
         val inputFallback = durationOptional(86_400_001uL) { je ->

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -486,6 +486,30 @@ pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
     Ok(<perftest_flat::Celsius as ::core::convert::Into<i32>>::into(v))
 }
 #[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn DurationBoundary_to_JObject_9c5bf9bc<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::DurationBoundary,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___delay: jni::sys::jlong = Option_Duration_to_jlong_1cfa4d44(
+            env,
+            v.delay.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/DurationBoundary",
+                "fromParts",
+                "(J)Lio/prebindgen/covertest/model/DurationBoundary;",
+                &[jni::objects::JValue::from(___delay)],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
 pub(crate) unsafe fn Duration_to_u64_e3980876<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Duration,
@@ -600,6 +624,34 @@ pub(crate) unsafe fn JObject_to_Annotated_b543f0d9<'env, 'v>(
             alternate,
             ttl,
             priority,
+        }
+    })
+}
+#[allow(non_snake_case, unused_mut, unused_variables, unused_braces, dead_code)]
+pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::DurationBoundary, __JniErr> {
+    Ok({
+        let __delay_jobj: jni::objects::JObject = env
+            .get_field(v, "delay", "Lkotlin/ULong;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("DurationBoundary.delay: {}", e)))?;
+        let delay = if __delay_jobj.is_null() {
+            ::core::option::Option::None
+        } else {
+            let __delay_raw: jni::sys::jlong = env
+                .call_method(&__delay_jobj, "unbox-impl", "()J", &[])
+                .and_then(|val| val.j())
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("DurationBoundary.delay: {}", e)))?;
+            jlong_to_Option_Duration_1cfa4d44(env, &__delay_raw)?
+        };
+        perftest_flat::DurationBoundary {
+            delay,
         }
     })
 }
@@ -6326,6 +6378,79 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
                 __SINK_FQN,
                 __SINK_DESCR,
                 &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationBoundaryEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::objects::JObject<'a>,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match JObject_to_DurationBoundary_9c5bf9bc(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/DurationBoundaryBuilderRaw";
+    const __CB_DESCR: &str = "(J)Ljava/lang/Object;";
+    let __out = perftest_flat::duration_boundary_echo(&value);
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match Option_Duration_to_jlong_1cfa4d44(
+            &mut env,
+            __out.delay.clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    match __CB_MID
+        .call_object(&mut env, __CB_FQN, "run", __CB_DESCR, &__builder, &[__obj0])
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -380,6 +380,23 @@ pub fn duration_out_of_range() -> Option<Duration> {
     Some(Duration::from_millis(DURATION_MAX_MILLIS + 1))
 }
 
+/// Data-class composition probe for the bounded duration representation.
+/// The coverage binding deliberately marks this class `.jobject_input()` so
+/// its echo executes both the whole-object input decoder and the `fromParts`
+/// output encoder; the nullable duration itself still uses the raw `jlong`
+/// niche whenever it crosses a generated JNI call boundary.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DurationBoundary {
+    pub delay: Option<Duration>,
+}
+
+/// Round-trip [`DurationBoundary`] through the explicit object-input bridge.
+#[prebindgen]
+pub fn duration_boundary_echo(value: &DurationBoundary) -> DurationBoundary {
+    value.clone()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // convert! source-kind fixtures — one type per conversion source. Like
 // `Millis`, none of these types is `#[prebindgen]`-marked: each crosses the

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -106,9 +106,25 @@ pub(crate) fn struct_input_body(
                 }
                 ProjectionKind::Unsigned64 => {
                     if let Some(inner_ty) = option_inner_type(&field.ty) {
+                        let niche = matches!(
+                            proj.strategy,
+                            FoldStrategy::Optional(NullableKind::Niche, _)
+                        );
                         let inner_conv =
                             registry.input_entry(&inner_ty)?.function.sig.ident.clone();
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
+                        let decode = if niche {
+                            // The Kotlin data-class property is still `ULong?`
+                            // (and therefore boxed in object storage), but its
+                            // JNI converter is niche-keyed on primitive jlong.
+                            // Run the complete field converter so every custom
+                            // semantic stage (e.g. u64 -> Duration) is applied.
+                            quote! { #field_conv(env, &#raw_ident)? }
+                        } else {
+                            quote! {
+                                ::core::option::Option::Some(#inner_conv(env, &#raw_ident)?)
+                            }
+                        };
                         field_preludes.push(quote! {
                             let #tmp_ident: jni::objects::JObject = env
                                 .get_field(v, #camel, "Lkotlin/ULong;")
@@ -121,7 +137,7 @@ pub(crate) fn struct_input_body(
                                     .call_method(&#tmp_ident, "unbox-impl", "()J", &[])
                                     .and_then(|val| val.j())
                                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                                ::core::option::Option::Some(#inner_conv(env, &#raw_ident)?)
+                                #decode
                             };
                         });
                     } else {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -230,7 +230,17 @@ fn encode_plan(
                                 default: quote!(0i64),
                             });
                         }
-                        FoldStrategy::Optional(_, _) => {
+                        FoldStrategy::Optional(NullableKind::Niche, _) => {
+                            preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
+                            slots.push(EncSlot {
+                                ident: id,
+                                wire_ty: quote!(jni::sys::jlong),
+                                descriptor: "J".to_string(),
+                                is_object: false,
+                                default: quote!(0i64),
+                            });
+                        }
+                        FoldStrategy::Optional(NullableKind::Boxed, _) => {
                             preludes
                                 .extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                             slots.push(EncSlot {

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -78,32 +78,36 @@ pub(crate) fn projection_wrap_expr(kind: &ProjectionKind, short: &str, raw: &str
 /// `struct_output_body` passes (handle → `Long` jlong sentinel, value class /
 /// blob → `ByteArray`), and the wrap reconstructs the typed value in JVM
 /// bytecode (`Short(arg)`, with null mapped from the `0L` sentinel for handles
-/// or JVM null for value classes). Only the `Direct` and `Nullable{Direct}`
-/// shapes a scalar projection field can take are supported — a collection
+/// or the declared invalid `Long` for a bounded unsigned representation; JVM
+/// null remains the fallback for non-niche value projections). Only the
+/// `Direct` and `Nullable{Direct}` shapes a scalar projection field can take
+/// are supported — a collection
 /// (`Vec<projection>`) field is rejected (matching the struct bridge's
 /// scalar-only guard).
 pub(crate) fn factory_projection_wire_wrap(
-    kind: &crate::api::lang::jnigen::jni::ProjectionKind,
-    strategy: &crate::api::lang::jnigen::jni::FoldStrategy,
+    proj: &crate::api::lang::jnigen::jni::Projection,
     short: &str,
     name: &str,
 ) -> (kt::KtType, String) {
-    use crate::api::{core::shape::Shape::*, lang::jnigen::jni::ProjectionKind::*};
+    use crate::api::{
+        core::shape::Shape::*,
+        lang::jnigen::jni::{NullableKind, ProjectionKind::*},
+    };
     let direct = |kind: &crate::api::lang::jnigen::jni::ProjectionKind| match kind {
         Handle => (kt::KtType::long(), format!("{short}({name})")),
         ValueBlob => (kt::KtType::byte_array(), format!("{short}({name})")),
         Unsigned64 => (kt::KtType::long(), format!("{name}.toULong()")),
     };
-    match strategy {
-        Base => direct(kind),
-        Optional(_, inner) => {
+    match &proj.strategy {
+        Base => direct(&proj.kind),
+        Optional(nullable, inner) => {
             if !matches!(**inner, Base) {
                 panic!(
                     "factory_projection_wire_wrap: only `Nullable<Direct>` projection struct \
                      fields are supported (field `{name}`)"
                 );
             }
-            match kind {
+            match proj.kind {
                 // Handle null rides the `0L` jlong sentinel.
                 Handle => (
                     kt::KtType::long(),
@@ -114,9 +118,28 @@ pub(crate) fn factory_projection_wire_wrap(
                     kt::KtType::byte_array().nullable(),
                     format!("{name}?.let {{ {short}(it) }}"),
                 ),
-                // `Option<u64>` has no spare bit pattern, so its primitive
-                // wire is boxed and JVM null represents `None`.
-                Unsigned64 => (kt::KtType::long().nullable(), format!("{name}?.toULong()")),
+                Unsigned64 => match nullable {
+                    // A bounded unsigned representation reserves an invalid
+                    // raw value for `None`, so the factory receives primitive
+                    // `Long` and restores the nullable semantic property.
+                    NullableKind::Niche => {
+                        let sentinel = projection_leaf_sentinel(proj).unwrap_or_else(|| {
+                            panic!(
+                                "factory_projection_wire_wrap: niche unsigned field `{name}` \
+                                 has no declared sentinel"
+                            )
+                        });
+                        (
+                            kt::KtType::long(),
+                            format!("if ({name} == {sentinel}) null else {name}.toULong()"),
+                        )
+                    }
+                    // Plain `Option<u64>` has no spare bit pattern, so its
+                    // primitive wire is boxed and JVM null represents `None`.
+                    NullableKind::Boxed => {
+                        (kt::KtType::long().nullable(), format!("{name}?.toULong()"))
+                    }
+                },
             }
         }
         Iterable(_) => panic!(
@@ -188,8 +211,7 @@ fn factory_from_plan(
             // Projection leaf (handle / value class / blob).
             PlanFieldKind::Projection { proj, fqn, .. } => {
                 let short = register_fqn(fqn, imports);
-                let (wire_ty, wrap) =
-                    factory_projection_wire_wrap(&proj.kind, &proj.strategy, &short, &base);
+                let (wire_ty, wrap) = factory_projection_wire_wrap(proj, &short, &base);
                 params.push((base.clone(), wire_ty));
                 parts.push(wrap);
             }

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -50,15 +50,16 @@ pub(crate) enum WrapKind {
     HandleOwned(String),
     /// `Copy` value blob: raw `ByteArray` → `@JvmInline` value class (FQN).
     Blob(String),
-    /// Rust `u64`: raw `Long` bit pattern → typed Kotlin `ULong`.
-    Unsigned64,
+    /// Rust `u64`: raw `Long` bit pattern → typed Kotlin `ULong`. A bounded
+    /// optional representation carries its `None` niche as a primitive value.
+    Unsigned64 { niche_sentinel: Option<String> },
 }
 
 impl WrapKind {
     /// The Kotlin FQN the wrap constructs, if any (for import registration).
     pub fn class_fqn(&self) -> Option<&str> {
         match self {
-            WrapKind::None | WrapKind::Unsigned64 => None,
+            WrapKind::None | WrapKind::Unsigned64 { .. } => None,
             WrapKind::Handle(f) | WrapKind::HandleOwned(f) | WrapKind::Blob(f) => Some(f),
         }
     }
@@ -72,11 +73,16 @@ impl WrapKind {
     /// The wrapping expression over `arg` (`raw_nullable` adds a null-safe
     /// `?.let`): `ZKeyExpr(x)` / `x?.let { ZKeyExpr(it) }` / passthrough.
     pub fn wrap_expr(&self, arg: &str, raw_nullable: bool) -> String {
-        if matches!(self, WrapKind::Unsigned64) {
-            return if raw_nullable {
-                format!("{arg}?.toULong()")
-            } else {
-                format!("{arg}.toULong()")
+        if let WrapKind::Unsigned64 { niche_sentinel } = self {
+            return match (raw_nullable, niche_sentinel) {
+                (true, Some(sentinel)) => {
+                    format!("{arg}?.let {{ if (it == {sentinel}) null else it.toULong() }}")
+                }
+                (true, None) => format!("{arg}?.toULong()"),
+                (false, Some(sentinel)) => {
+                    format!("if ({arg} == {sentinel}) null else {arg}.toULong()")
+                }
+                (false, None) => format!("{arg}.toULong()"),
             };
         }
         match self.class_fqn() {
@@ -710,11 +716,17 @@ fn leaf_iface_param(
                 });
             }
             ProjectionKind::Unsigned64 => {
+                let mut raw = projection_wire_return(proj?);
+                if nullable && !raw.is_nullable() {
+                    raw = raw.nullable();
+                }
                 return Some(IfaceParam {
                     name,
-                    typed: nullable_kt(kt::KtType::cls("ULong")),
-                    raw: nullable_kt(kt::KtType::long()),
-                    wrap: WrapKind::Unsigned64,
+                    typed: builder_kt.clone(),
+                    raw,
+                    wrap: WrapKind::Unsigned64 {
+                        niche_sentinel: projection_leaf_sentinel(proj?),
+                    },
                 });
             }
             ProjectionKind::Handle => {}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -95,6 +95,14 @@ fn flattened_field_composes_bounded_conversion_stages() {
                     unimplemented!()
                 }
             )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn timed_echo(value: &Timed) -> Timed {
+                    unimplemented!()
+                }
+            )),
             loc,
         ),
     ];
@@ -110,7 +118,8 @@ fn flattened_field_composes_bounded_conversion_stages() {
         .package(
             crate::package!()
                 .class(crate::data_class!(Timed))
-                .fun(crate::fun!(timed_use)),
+                .fun(crate::fun!(timed_use))
+                .fun(crate::fun!(timed_echo)),
         );
     let dir = unique_test_dir("jnigen_flat_staged_field");
     let _ = std::fs::remove_dir_all(&dir);
@@ -129,8 +138,30 @@ fn flattened_field_composes_bounded_conversion_stages() {
 
     assert!(kc.contains("valueDelay:Long"), "{kotlin}");
     assert!(kc.contains("value.delay?.toLong()?:-1L"), "{kotlin}");
+    assert!(
+        kc.contains("funfromParts(delay:Long):Timed=Timed(if(delay==-1L)nullelsedelay.toULong())"),
+        "the struct factory must receive the niche as a primitive Long:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("TimedBuilderRaw<outR>{publicfunrun(delay:Long):R}"),
+        "{kotlin}"
+    );
+    assert!(
+        kc.contains("if(delay==-1L)nullelsedelay.toULong()"),
+        "the raw builder adapter must restore the optional niche:\n{kotlin}"
+    );
     assert!(rc.contains("jlong_to_u64"), "{rust}");
     assert!(rc.contains("u64_to_Duration"), "{rust}");
+    assert!(
+        rc.contains("jlong_to_Option_std_time_Duration") && rc.contains("env,&__delay_raw)?"),
+        "whole-JObject input must invoke the complete optional Duration converter:\n{rust}"
+    );
+    assert!(
+        rc.contains("let___delay:jni::sys::jlong=Option_std_time_Duration_to_jlong")
+            && rc.contains("\"(J)Lio/test/jni/Timed;\""),
+        "whole-struct output must pass the niche as primitive jlong:\n{rust}"
+    );
+    assert!(!rc.contains("let___delay:jni::objects::JObject"), "{rust}");
     assert!(
         rc.contains("myflat::Timed{delay:__flat_value_delay"),
         "{rust}"


### PR DESCRIPTION
Fixes #138.

- preserve niche-vs-boxed optional projection metadata in data-class fromParts planning
- run the complete composed converter when decoding bounded unsigned fields from a Kotlin object
- keep bounded optional fields primitive in struct output and decomposed builder callbacks
- add unit coverage and a covertest-kotlin DurationBoundary round trip for null and non-null values

Verified with:
- cargo test -p prebindgen (288 unit tests and 23 doc tests)
- examples/covertest-kotlin/gradlew run (35 runtime sections)