### PR TITLE
Fix #144: redundant double-Elvis on non-null enum field under nullable-context

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -57,6 +57,7 @@
 //! | two-caller split (#45): `onBindingError` + `onError` on one fallible wrapper | `storage_try_from_stamp` (malformed `Stamp` → binding; bad `secs` → domain) |
 //! | fixed-width unsigned scalars (#108) | `Unsigned` + direct/optional/callback/collection max-value round trips |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
+//! | non-null enum field under nullable-context (#144) | `Option<CacheConfig>` → nested `RepliesConfig.priority` (single Elvis default) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
 //! | owned-handle callback (`Fn(Storage)`)| `storage_handler_new` / `storage_emit` |
 //! | `Vec<handle>` / `Option<Vec<handle>>`| `storage_shards` / `storage_shards_opt` (Kotlin-side handle fold) |
@@ -233,6 +234,13 @@ fn main() {
                 // recursive fromParts / recursive leaf decode) plus Option<prim> and
                 // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
                 .class(data_class!(Annotated))
+                // #144: a NON-NULL enum field (`RepliesConfig.priority`) reached
+                // through an outer `Option<CacheConfig>` param. The outer
+                // optional propagates `nullable_context` into the non-optional
+                // nested struct, so its enum field must decode with exactly one
+                // Elvis default (regression guard for the dead `?: 0 ?: 0`).
+                .class(data_class!(RepliesConfig))
+                .class(data_class!(CacheConfig))
                 // Compose the bounded `Option<Duration>` niche through a
                 // data-class field. Explicit JObject input makes the runtime
                 // execute the whole-object decoder as well as the primitive-
@@ -425,6 +433,9 @@ fn main() {
                 .fun(fun!(annotated_ttl))
                 .fun(fun!(annotated_priority))
                 .fun(fun!(annotated_payload_value))
+                // #144: `Option<CacheConfig>` input reaching a non-null enum
+                // field through the nested `RepliesConfig`.
+                .fun(fun!(cache_config_weight))
                 .fun(fun!(object_boundary_value))
                 .fun(fun!(unsigned_round_trip))
                 .fun(fun!(unsigned_optional))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -52,6 +52,7 @@ Base package: `io.prebindgen.covertest`
 - `annotated_payload_value` — `fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>): Double`
 - `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority?`
 - `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long?`
+- `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
   - shaped by: return `DurationBoundary` decomposed → [delay] (Callback delivery)
@@ -143,6 +144,7 @@ Base package: `io.prebindgen.covertest`
 
 - `Annotated`: data_class → `io.prebindgen.covertest.model.Annotated` (wire `jni :: objects :: JObject`)
 - `Archive`: ptr_class → `io.prebindgen.covertest.analytics.SummaryVault` (wire `jni :: sys :: jlong`)
+- `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
@@ -158,6 +160,7 @@ Base package: `io.prebindgen.covertest`
 - `PayloadHandler`: ptr_class → `io.prebindgen.covertest.PayloadHandler` (wire `jni :: sys :: jlong`)
 - `PayloadVecHandler`: ptr_class → `io.prebindgen.covertest.PayloadVecHandler` (wire `jni :: sys :: jlong`)
 - `Priority`: enum_class → `io.prebindgen.covertest.model.Priority` (wire `jni :: sys :: jint`)
+- `RepliesConfig`: data_class → `io.prebindgen.covertest.model.RepliesConfig` (wire `jni :: objects :: JObject`)
 - `Stamp`: value_class → `io.prebindgen.covertest.model.Stamp` (wire `jni :: objects :: JByteArray`)
 - `Storage`: ptr_class → `io.prebindgen.covertest.Storage` (wire `jni :: sys :: jlong`)
 - `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -719,6 +719,14 @@ internal object CovNative {
         errorSink: Any,
     )
 
+    external fun cacheConfigWeight(
+        cachePresent: Boolean,
+        cacheRepliesPriority: Int,
+        cacheRepliesMaxSamples: Long,
+        cacheTtl: Long,
+        errorSink: Any,
+    ): Int
+
     external fun celsiusDouble(c: Int, errorSink: Any): Int
 
     external fun coverTagRuntime(errorSink: Any): String

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -61,6 +61,22 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
 }
 
 /**
+ * Outer cache config crossed as `Option<CacheConfig>`. Its optional-ness
+ * propagates into the non-optional nested [`RepliesConfig`], whose non-null
+ * `priority` enum field must decode with exactly **one** Elvis default (#144).
+ */
+public data class CacheConfig(val replies: RepliesConfig, val ttl: Long) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            replies_priority: Int,
+            replies_maxSamples: Long,
+            ttl: Long,
+        ): CacheConfig = CacheConfig(RepliesConfig.fromParts(replies_priority, replies_maxSamples), ttl)
+    }
+}
+
+/**
  * Data-class composition probe for the bounded duration representation.
  * The coverage binding deliberately marks this class `.jobject_input()` so
  * its echo executes both the whole-object input decoder and the `fromParts`
@@ -471,6 +487,21 @@ public data class ObjectBoundaryLeaf(val value: Long) {
 }
 
 /**
+ * Inner, **non-optional** delivery config carrying a **non-null enum field**
+ * (`priority`). Nested inside [`CacheConfig`], which crosses as
+ * `Option<CacheConfig>`, so the outer optional's `nullable_context`
+ * propagates down to this non-optional struct — the exact shape that made the
+ * JNI input builder emit a dead double-Elvis default (`?.value ?: 0 ?: 0`)
+ * for a non-null enum field (#144).
+ */
+public data class RepliesConfig(val priority: Priority, val maxSamples: Long) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(priority: Int, maxSamples: Long): RepliesConfig = RepliesConfig(Priority.fromInt(priority), maxSamples)
+    }
+}
+
+/**
  * Every fixed-width Rust unsigned scalar in one generated Kotlin data class.
  * The first three fields widen losslessly; `long`/`maybe_long` surface as
  * `ULong`/`ULong?` over raw JNI `Long` bit patterns.
@@ -825,6 +856,24 @@ public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>)
         a.ttl ?: 0L,
         a.priority != null,
         a.priority?.value ?: 0,
+        __bcap,
+    )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * The cache's replies-priority weight plus its `ttl`, or `-1` when the cache
+ * is absent (`Option<CacheConfig>` **input** — the #144 reproduction: a
+ * non-null enum field reached through the outer optional data class).
+ */
+public fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.cacheConfigWeight(
+        cache != null,
+        cache?.replies?.priority?.value ?: 0,
+        cache?.replies?.maxSamples ?: 0L,
+        cache?.ttl ?: 0L,
         __bcap,
     )
     if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -21,6 +21,8 @@ import io.prebindgen.covertest.analytics.summaryTotalRaw
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.esc_pkg.Esc_Probe
 import io.prebindgen.covertest.model.Annotated
+import io.prebindgen.covertest.model.CacheConfig
+import io.prebindgen.covertest.model.RepliesConfig
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.ObjectBoundary2
@@ -47,6 +49,7 @@ import io.prebindgen.covertest.model.percentScale
 import io.prebindgen.covertest.model.annotatedPayloadValue
 import io.prebindgen.covertest.model.annotatedPriority
 import io.prebindgen.covertest.model.annotatedTtl
+import io.prebindgen.covertest.model.cacheConfigWeight
 import io.prebindgen.covertest.model.objectBoundaryValue
 import io.prebindgen.covertest.model.payloadPriority
 import io.prebindgen.covertest.model.priorityOr
@@ -733,6 +736,21 @@ fun main() {
         check(annotatedPriority(c, boom) == Priority.LOW)
         check(annotatedPayloadValue(c, boom) == 9.0)
         check(annotatedAlternateValue(c, boom) == 11.0)
+    }
+
+    // ── #144: non-null enum field reached through Option<data_class> input ────
+    // The outer `Option<CacheConfig>` propagates nullable-context into the
+    // non-optional nested `RepliesConfig`, whose non-null `priority` enum field
+    // must decode with a SINGLE Elvis default. Before the fix the generated
+    // Kotlin was `cache?.replies?.priority?.value ?: 0 ?: 0` — a dead second
+    // default that the Kotlin compiler warned about. This exercises the decode
+    // (present + absent) and is the regression guard for that codegen.
+    section("Option<data_class> with non-null nested enum field (#144)") {
+        val cache = CacheConfig(RepliesConfig(Priority.HIGH, 4L), 7L)
+        check(cacheConfigWeight(cache, boom) == 17)   // weight(HIGH)=10 + ttl 7
+        check(cacheConfigWeight(null, boom) == -1)    // absent outer optional
+        val low = CacheConfig(RepliesConfig(Priority.LOW, 0L), 3L)
+        check(cacheConfigWeight(low, boom) == 4)      // weight(LOW)=1 + ttl 3
     }
 
     section("data_class JVM-slot-limited JObject input boundary") {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -509,6 +509,49 @@ pub(crate) unsafe fn Archive_to_jlong_cd73502c<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn CacheConfig_to_JObject_db89a97c<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::CacheConfig,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___replies_priority: jni::sys::jint = Priority_to_jint_447102d2(
+            env,
+            v.replies.priority.clone(),
+        )?;
+        let ___replies_max_samples: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+            env,
+            v.replies.max_samples.clone(),
+        )?;
+        let ___ttl: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.ttl.clone())?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/CacheConfig",
+                "fromParts",
+                "(IJJ)Lio/prebindgen/covertest/model/CacheConfig;",
+                &[
+                    jni::objects::JValue::from(___replies_priority),
+                    jni::objects::JValue::from(___replies_max_samples),
+                    jni::objects::JValue::from(___ttl),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Celsius,
@@ -704,6 +747,42 @@ pub(crate) unsafe fn JObject_to_Annotated_b543f0d9<'env, 'v>(
             alternate,
             ttl,
             priority,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_CacheConfig_db89a97c<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::CacheConfig, __JniErr> {
+    Ok({
+        let __replies_raw: jni::objects::JObject = env
+            .get_field(v, "replies", "Lio/prebindgen/covertest/model/RepliesConfig;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("CacheConfig.replies: {}", e)))?;
+        let replies = JObject_to_RepliesConfig_eb8e9079(env, &__replies_raw)?;
+        let __ttl_raw: jni::sys::jlong = env
+            .get_field(v, "ttl", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("CacheConfig.ttl: {}", e)))? as _;
+        let ttl = jlong_to_i64_fbf9a9bc(env, &__ttl_raw)?;
+        perftest_flat::CacheConfig {
+            replies,
+            ttl,
         }
     })
 }
@@ -1104,6 +1183,25 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary_dc5ac22b<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Option_CacheConfig_a6be794d<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Option<perftest_flat::CacheConfig>, __JniErr> {
+    Ok({
+        if v.is_null() { None } else { Some(JObject_to_CacheConfig_db89a97c(env, v)?) }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Option_Payload_97036642<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -1325,6 +1423,48 @@ pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
             value,
             flag,
             label,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_RepliesConfig_eb8e9079<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::RepliesConfig, __JniErr> {
+    Ok({
+        let __priority_jobj: jni::objects::JObject = env
+            .get_field(v, "priority", "Lio/prebindgen/covertest/model/Priority;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("RepliesConfig.priority: {}", e)))?;
+        let __priority_raw: jni::sys::jint = env
+            .call_method(&__priority_jobj, "getValue", "()I", &[])
+            .and_then(|val| val.i())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("RepliesConfig.priority: {}", e)))?;
+        let priority = jint_to_Priority_447102d2(env, &__priority_raw)?;
+        let __max_samples_raw: jni::sys::jlong = env
+            .get_field(v, "maxSamples", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("RepliesConfig.maxSamples: {}", e)))? as _;
+        let max_samples = jlong_to_i64_fbf9a9bc(env, &__max_samples_raw)?;
+        perftest_flat::RepliesConfig {
+            priority,
+            max_samples,
         }
     })
 }
@@ -4827,6 +4967,47 @@ pub(crate) unsafe fn Priority_to_jint_447102d2<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn RepliesConfig_to_JObject_eb8e9079<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::RepliesConfig,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___priority: jni::sys::jint = Priority_to_jint_447102d2(
+            env,
+            v.priority.clone(),
+        )?;
+        let ___max_samples: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+            env,
+            v.max_samples.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/RepliesConfig",
+                "fromParts",
+                "(IJ)Lio/prebindgen/covertest/model/RepliesConfig;",
+                &[
+                    jni::objects::JValue::from(___priority),
+                    jni::objects::JValue::from(___max_samples),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Result_Storage_StorageError_to_Storage_7ccce404<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Result<perftest_flat::Storage, perftest_flat::StorageError>,
@@ -7383,6 +7564,98 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
                 &__e.to_string(),
             );
             ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeight<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    cache_present: jni::sys::jboolean,
+    cache_replies_priority: jni::sys::jint,
+    cache_replies_max_samples: jni::sys::jlong,
+    cache_ttl: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jint {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_cache = if cache_present != 0u8 {
+        let __flat_cache_replies_priority = match jint_to_Priority_447102d2(
+            &mut env,
+            &cache_replies_priority,
+        ) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jint;
+            }
+        };
+        let __flat_cache_replies_max_samples = match jlong_to_i64_fbf9a9bc(
+            &mut env,
+            &cache_replies_max_samples,
+        ) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jint;
+            }
+        };
+        let __flat_cache_replies = perftest_flat::RepliesConfig {
+            priority: __flat_cache_replies_priority,
+            max_samples: __flat_cache_replies_max_samples,
+        };
+        let __flat_cache_ttl = match jlong_to_i64_fbf9a9bc(&mut env, &cache_ttl) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jint;
+            }
+        };
+        ::core::option::Option::Some(perftest_flat::CacheConfig {
+            replies: __flat_cache_replies,
+            ttl: __flat_cache_ttl,
+        })
+    } else {
+        ::core::option::Option::None
+    };
+    let cache = __flat_cache;
+    let __out = perftest_flat::cache_config_weight(cache);
+    match i32_to_jint_a3e3b6ef(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jint
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -554,6 +554,45 @@ pub fn annotated_payload_value(a: &Annotated) -> f64 {
     a.payload.value
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// CacheConfig / RepliesConfig — a non-null enum field reached through an outer
+// `Option<data_class>` (the nullable-context input path, issue #144).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Inner, **non-optional** delivery config carrying a **non-null enum field**
+/// (`priority`). Nested inside [`CacheConfig`], which crosses as
+/// `Option<CacheConfig>`, so the outer optional's `nullable_context`
+/// propagates down to this non-optional struct — the exact shape that made the
+/// JNI input builder emit a dead double-Elvis default (`?.value ?: 0 ?: 0`)
+/// for a non-null enum field (#144).
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RepliesConfig {
+    pub priority: Priority,
+    pub max_samples: i64,
+}
+
+/// Outer cache config crossed as `Option<CacheConfig>`. Its optional-ness
+/// propagates into the non-optional nested [`RepliesConfig`], whose non-null
+/// `priority` enum field must decode with exactly **one** Elvis default (#144).
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheConfig {
+    pub replies: RepliesConfig,
+    pub ttl: i64,
+}
+
+/// The cache's replies-priority weight plus its `ttl`, or `-1` when the cache
+/// is absent (`Option<CacheConfig>` **input** — the #144 reproduction: a
+/// non-null enum field reached through the outer optional data class).
+#[prebindgen]
+pub fn cache_config_weight(cache: Option<CacheConfig>) -> i32 {
+    match cache {
+        Some(c) => priority_weight(c.replies.priority) + c.ttl as i32,
+        None => -1,
+    }
+}
+
 /// One `i64` leaf in the deliberately wide [`ObjectBoundary`] tree.
 #[prebindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1021,6 +1060,20 @@ mod tests {
         let b = annotated_new(payload(1, 0.0, None), None, None);
         assert_eq!(annotated_ttl(&b), None);
         assert_eq!(annotated_priority(&b), None);
+    }
+
+    #[test]
+    fn cache_config_weight_reaches_nested_enum() {
+        let cache = CacheConfig {
+            replies: RepliesConfig {
+                priority: Priority::High,
+                max_samples: 4,
+            },
+            ttl: 7,
+        };
+        // priority_weight(High) == 10, plus ttl 7.
+        assert_eq!(cache_config_weight(Some(cache)), 17);
+        assert_eq!(cache_config_weight(None), -1);
     }
 
     #[test]

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -918,8 +918,13 @@ fn build_flat_struct_node(
         }
 
         let field_is_option = option_inner_type(&field.ty).is_some();
+        // The enum branch is self-contained: when it coalesces (`?.value ?: 0`)
+        // it already yields a non-null `Int`, so block (B) below must not append
+        // a second default (which produced the dead `?: 0 ?: 0`, issue #144).
+        let mut enum_coalesced = false;
         let mut access = if ext.is_kotlin_enum(&flat_probe_inner(&field.ty)) {
             if field_is_option || nullable_context {
+                enum_coalesced = true;
                 format!("{field_ref}?.value ?: 0")
             } else {
                 format!("{field_ref}.value")
@@ -927,7 +932,7 @@ fn build_flat_struct_node(
         } else {
             field_ref.clone()
         };
-        if nullable_context && !field_is_option {
+        if nullable_context && !field_is_option && !enum_coalesced {
             if let Some((sig, _, _)) = jni_field_access(&fentry.destination) {
                 if let Some(default) = kt_leaf_default(sig, false) {
                     access = format!("{access} ?: {default}");


### PR DESCRIPTION
## Summary

Fixes #144. On the JniGen **input** path (the `JObject_to_<Struct>` builder), a **non-null Kotlin-enum field** reached through an outer `Option<data_class>` chain got a **redundant double Elvis default** — `?.value ?: 0 ?: 0`. The generated Kotlin was functionally correct (the second `?:` is dead) but the Kotlin compiler warned:

```
Elvis operator (?:) always returns the left operand of non-nullable type Int
```

## Root cause

In `prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs`, the field-access builder:

- Branch **(A)** — the Kotlin-enum branch — already coalesces to a non-null `Int` (`?.value ?: 0`) under `field_is_option || nullable_context`.
- Block **(B)** — the nullable-context default — was gated only on `nullable_context && !field_is_option`, so for a **non-null enum field** under `nullable_context` it appended a *second* `?: 0`.

The enum branch is self-contained, so (B) must not also apply to it.

## Fix

Track whether branch (A) coalesced (`enum_coalesced`) and gate block (B) on `!enum_coalesced`. Non-enum nullable-context fields (which legitimately need the (B) default) are unaffected; every other case already skipped (B).

## Covertest (every-feature rule)

Added the missing shape that combines *nullable-context propagation* with a *non-null enum field*:

- `perftest-flat`: `CacheConfig { replies: RepliesConfig, ttl }` where `RepliesConfig { priority: Priority, max_samples }` — the outer `Option<CacheConfig>` param propagates `nullable_context` into the non-optional nested `RepliesConfig`, whose non-null `Priority` enum field is the trigger. Plus `cache_config_weight(Option<CacheConfig>) -> i32` and a Rust unit test.
- `covertest-kotlin`: declared both data classes + the fn in `build.rs`; added a Test.kt section exercising present + absent decode; regenerated committed bindings.

The regenerated Kotlin now emits the single-Elvis form:

```kotlin
cache?.replies?.priority?.value ?: 0
```

## Verification

- `cargo test -p prebindgen -p perftest-flat` — all pass (288 lib + new `cache_config_weight_reaches_nested_enum`).
- `cargo fmt --check` (unstable_features, imports_granularity=Crate, group_imports=StdExternalCrate) — clean.
- `cargo clippy --all-targets --no-default-features --all-features -- --deny warnings` — clean.
- example-cbindgen aarch64 goldens restored (untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)