### PR TITLE
Stage B — cbindgen: tagged_union declarator, repr(C) mirror and converters (#147)

### DIFF
--- a/examples/example-cbindgen/CMakeLists.txt
+++ b/examples/example-cbindgen/CMakeLists.txt
@@ -17,13 +17,14 @@
 #   cmake -S . -B build
 #   cmake --build build                                  # builds both targets
 #   cmake --build build --target show_generated_diff     # show the per-target diff
+#   cmake --build build --target run_smoke               # host C smoke test
 #
 # Options:
 #   -DEXAMPLE_TARGETS="triple-a;triple-b"   override the target triples
 #   -DEXAMPLE_FEATURES=unstable             forward cargo features
 
 cmake_minimum_required(VERSION 3.16)
-project(example_cbindgen_multitarget LANGUAGES NONE)
+project(example_cbindgen_multitarget LANGUAGES C)
 
 find_program(CARGO cargo REQUIRED)
 
@@ -65,5 +66,40 @@ add_custom_target(show_generated_diff
   COMMAND ${CMAKE_COMMAND} -E echo "Per-target generated headers differ by target_arch:"
   COMMAND sh -c "diff '${CMAKE_CURRENT_SOURCE_DIR}/include/example_flat_x86_64.h' '${CMAKE_CURRENT_SOURCE_DIR}/include/example_flat_aarch64.h' || true"
   DEPENDS build_all_targets
+  VERBATIM
+)
+
+# ── Host C smoke test ──────────────────────────────────────────────────────
+#
+# Compiles `c/smoke.c` against the committed header for the HOST architecture
+# and links it to the host cdylib, then runs it. It exercises the tagged union
+# (`shape_t`): every arm, every position (return / parameter / data-struct
+# field), and `shape_drop` freeing the active arm.
+#
+#   cmake --build build --target run_smoke
+
+get_filename_component(_workspace_root "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+set(_host_dir "${_workspace_root}/target/debug")
+set(_host_dylib
+  "${_host_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}example_cbindgen${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+add_custom_command(
+  OUTPUT "${_host_dylib}"
+  COMMAND ${CARGO} build --manifest-path "${_manifest}" -p example-cbindgen ${_feature_args}
+  COMMENT "cargo build example-cbindgen for the host (cdylib + regenerated header)"
+  VERBATIM
+)
+add_custom_target(host_cdylib DEPENDS "${_host_dylib}")
+
+add_executable(example_smoke c/smoke.c)
+add_dependencies(example_smoke host_cdylib)
+target_include_directories(example_smoke PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(example_smoke PRIVATE "${_host_dylib}" m)
+# Find the cdylib at runtime without installing it.
+set_target_properties(example_smoke PROPERTIES BUILD_RPATH "${_host_dir}")
+
+add_custom_target(run_smoke
+  COMMAND example_smoke
+  DEPENDS example_smoke
   VERBATIM
 )

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -105,15 +105,14 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(foo_new),
         pq!(foo_get_id),
         pq!(inside_foo_default),
-        // The tagged union in every position: constructed and returned, taken
-        // by value as a parameter, and carried through a data-struct field.
+        // The tagged union crossing OUT: constructed and returned. Nothing to
+        // validate on this side — Rust always writes a live arm.
         pq!(shape_new_empty),
         pq!(shape_new_circle),
         pq!(shape_new_rect),
-        pq!(shape_area),
-        pq!(shape_get_label),
-        pq!(drawing_new),
-        pq!(drawing_get_shape),
+        // The union crossing IN on a fallible function: an out-of-range tag
+        // reports through the same `char **e` as the domain error.
+        pq!(shape_try_area),
     ] {
         cbindgen = cbindgen.function(function);
     }
@@ -129,9 +128,15 @@ fn generate_ffi_bindings() -> PathBuf {
     // wrapper abort on a null handle. `inside_foo_value` joins them for the same
     // reason with a different fallible input: a C enum is an `int` at the ABI, so
     // its discriminant is validated on the way in (never materialised unchecked),
-    // and with no `char **e` to report an out-of-range one it aborts.
+    // and with no `char **e` to report an out-of-range one it aborts. The three
+    // union-consuming accessors are the same case one level up — the tag a C
+    // caller supplies is validated before the Rust enum exists, here abortively.
     for function in [
         pq!(inside_foo_value),
+        pq!(shape_area),
+        pq!(shape_get_label),
+        pq!(drawing_new),
+        pq!(drawing_get_shape),
         pq!(calculator_new_clone),
         pq!(calculator_get_value),
         pq!(calculator_get_count),

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -72,6 +72,13 @@ fn generate_ffi_bindings() -> PathBuf {
     // The primitive-repr `Operation` enum -> a C enum.
     cbindgen = cbindgen.enum_type(pq!(Operation));
 
+    // The data-carrying `Shape` enum -> a `#[repr(C)]` enum with payload
+    // variants, which cbindgen renders as a C tag + `union`. Its `Labeled` arm
+    // owns a `char *`, so a typed `shape_drop` is generated to free the active
+    // arm. `Drawing` carries one as a by-value field.
+    cbindgen = cbindgen.tagged_union(pq!(Shape));
+    cbindgen = cbindgen.data_struct(pq!(Drawing));
+
     // Multi-target cfg demonstration: `InsideFoo` (a fieldless enum whose
     // discriminants vary by `target_arch`) and `Foo` (a by-value data struct whose
     // field set varies by `target_arch` + feature). Declared unconditionally —
@@ -98,6 +105,15 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(foo_new),
         pq!(foo_get_id),
         pq!(inside_foo_default),
+        // The tagged union in every position: constructed and returned, taken
+        // by value as a parameter, and carried through a data-struct field.
+        pq!(shape_new_empty),
+        pq!(shape_new_circle),
+        pq!(shape_new_rect),
+        pq!(shape_area),
+        pq!(shape_get_label),
+        pq!(drawing_new),
+        pq!(drawing_get_shape),
     ] {
         cbindgen = cbindgen.function(function);
     }
@@ -123,6 +139,8 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(calculator_to_string),
         pq!(calculator_get_history),
         pq!(calculator_for_each),
+        // `&str` label input is fallible (null-checked) with no `Result`.
+        pq!(shape_new_labeled),
     ] {
         cbindgen = cbindgen.function(function).panic();
     }

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -1,0 +1,136 @@
+/*
+ * C smoke test over the prebindgen-generated `example_flat` C ABI, focused on
+ * the **tagged union** (`Shape`, declared `.tagged_union()`).
+ *
+ * A data-carrying Rust enum crosses by value as a `#[repr(C)]` enum with payload
+ * variants, which cbindgen renders as a tag + `union`:
+ *
+ *   typedef struct shape_t {
+ *     shape_t_Tag tag;
+ *     union { struct { double circle; }; Rect_Body rect; Labeled_Body labeled; };
+ *   } shape_t;
+ *
+ * What this exercises:
+ *   - constructing and reading EACH arm — unit, single-payload tuple,
+ *     multi-field named, and the owning tuple arm (`char *` + a C enum);
+ *   - the union in every position: returned, taken by value as a parameter,
+ *     and carried through a `drawing_t` data-struct field;
+ *   - `shape_drop` freeing the ACTIVE arm, and being a no-op the second time
+ *     (the freed slot is nulled) and on a non-owning arm.
+ *
+ * Exits non-zero on the first failed check.
+ */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* The committed header is per target architecture, like the Rust file `lib.rs`
+ * `include!`s — `#[prebindgen]` cfg handling makes the generated surface differ
+ * per target. */
+#if defined(__x86_64__) || defined(_M_X64)
+#include "example_flat_x86_64.h"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#include "example_flat_aarch64.h"
+#else
+#error "no committed example_flat header for this target architecture"
+#endif
+
+static int failures = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);     \
+            failures++;                                                        \
+        }                                                                      \
+    } while (0)
+
+/* Every arm is constructible and reads back as itself. */
+static void test_each_arm(void) {
+    shape_t empty = shape_new_empty();
+    CHECK(empty.tag == Empty);
+    CHECK(shape_area(empty) == 0.0);
+
+    shape_t circle = shape_new_circle(2.0);
+    CHECK(circle.tag == Circle);
+    CHECK(circle.circle == 2.0);
+    CHECK(fabs(shape_area(circle) - 3.14159265358979323846 * 4.0) < 1e-9);
+
+    shape_t rect = shape_new_rect(3.0, 4.0);
+    CHECK(rect.tag == Rect);
+    CHECK(rect.rect.width == 3.0);
+    CHECK(rect.rect.height == 4.0);
+    CHECK(shape_area(rect) == 12.0);
+
+    shape_t labeled = shape_new_labeled("hexagon", Mul);
+    CHECK(labeled.tag == Labeled);
+    CHECK(strcmp(labeled.labeled._0, "hexagon") == 0);
+    CHECK(labeled.labeled._1 == Mul);
+    /* The label reads back across the boundary; `shape_get_label` consumes the
+     * union by value and returns a fresh `char *` block. */
+    char *label = shape_get_label(labeled);
+    CHECK(strcmp(label, "hexagon") == 0);
+    example_free(label);
+    shape_drop(&labeled);
+
+    /* A non-`Labeled` arm reads back as the empty string. */
+    char *none = shape_get_label(shape_new_circle(1.0));
+    CHECK(strcmp(none, "") == 0);
+    example_free(none);
+}
+
+/* The union as a data-struct field: out through `drawing_new`, back in through
+ * `drawing_get_shape`. The struct has no destructor, so the owning field is
+ * released individually — exactly the existing data-struct contract. */
+static void test_struct_field(void) {
+    shape_t inner = shape_new_labeled("triangle", Add);
+    drawing_t d = drawing_new(7, inner);
+    CHECK(d.id == 7);
+    CHECK(d.shape.tag == Labeled);
+    CHECK(strcmp(d.shape.labeled._0, "triangle") == 0);
+
+    /* Passing by value hands the callee a copy, so the caller still owns the
+     * `char *` in its own `d` — the returned shape carries a fresh block. */
+    shape_t back = drawing_get_shape(d);
+    CHECK(back.tag == Labeled);
+    CHECK(strcmp(back.labeled._0, "triangle") == 0);
+    CHECK(back.labeled._1 == Add);
+    shape_drop(&back);
+    shape_drop(&d.shape);
+
+    /* A plain-data arm rides through the field just the same. */
+    drawing_t plain = drawing_new(1, shape_new_rect(2.0, 5.0));
+    shape_t plain_back = drawing_get_shape(plain);
+    CHECK(plain_back.tag == Rect);
+    CHECK(shape_area(plain_back) == 10.0);
+}
+
+/* `shape_drop` frees the active arm, nulls the freed slot, and tolerates being
+ * called again, on a non-owning arm, and on NULL. */
+static void test_drop(void) {
+    shape_t owning = shape_new_labeled("to-free", Sub);
+    CHECK(owning.labeled._0 != NULL);
+    shape_drop(&owning);
+    CHECK(owning.labeled._0 == NULL);
+    shape_drop(&owning); /* second drop: the nulled slot makes it a no-op */
+
+    shape_t plain = shape_new_rect(1.0, 1.0);
+    shape_drop(&plain); /* non-owning arm: nothing to free */
+    CHECK(shape_area(plain) == 1.0);
+
+    shape_drop(NULL);
+}
+
+int main(void) {
+    test_each_arm();
+    test_struct_field();
+    test_drop();
+
+    if (failures != 0) {
+        fprintf(stderr, "FAILED - %d check(s)\n", failures);
+        return 1;
+    }
+    printf("PASS - tagged union: every arm, every position, drop\n");
+    return 0;
+}

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -86,7 +86,12 @@ static void test_each_arm(void) {
 
 /* The union as a data-struct field: out through `drawing_new`, back in through
  * `drawing_get_shape`. The struct has no destructor, so the owning field is
- * released individually — exactly the existing data-struct contract. */
+ * released individually — exactly the existing data-struct contract.
+ *
+ * OWNERSHIP: passing a union by value does NOT transfer its payload. The callee
+ * copies the string contents out, so every union C holds — the argument it
+ * passed and each one it got back — is its own to drop. Each `shape_new_labeled`
+ * below is therefore paired with a `shape_drop`. */
 static void test_struct_field(void) {
     shape_t inner = shape_new_labeled("triangle", Add);
     drawing_t d = drawing_new(7, inner);
@@ -94,16 +99,19 @@ static void test_struct_field(void) {
     CHECK(d.shape.tag == Labeled);
     CHECK(strcmp(d.shape.labeled._0, "triangle") == 0);
 
-    /* Passing by value hands the callee a copy, so the caller still owns the
-     * `char *` in its own `d` — the returned shape carries a fresh block. */
+    /* `d.shape` is a fresh block, not `inner`'s: the argument survives the call
+     * and is still the caller's to release. */
+    CHECK(d.shape.labeled._0 != inner.labeled._0);
+
     shape_t back = drawing_get_shape(d);
     CHECK(back.tag == Labeled);
     CHECK(strcmp(back.labeled._0, "triangle") == 0);
     CHECK(back.labeled._1 == Add);
     shape_drop(&back);
     shape_drop(&d.shape);
+    shape_drop(&inner);
 
-    /* A plain-data arm rides through the field just the same. */
+    /* A plain-data arm rides through the field just the same, and owns nothing. */
     drawing_t plain = drawing_new(1, shape_new_rect(2.0, 5.0));
     shape_t plain_back = drawing_get_shape(plain);
     CHECK(plain_back.tag == Rect);
@@ -162,11 +170,14 @@ static void test_invalid_tag(void) {
     example_free(e);
     e = NULL;
 
-    /* The domain error still comes through the same channel, unchanged. */
-    CHECK(!shape_try_area(shape_new_labeled("hexagon", Add), &out, &e));
+    /* The domain error still comes through the same channel, unchanged. The
+     * argument is by value, so its label block is still ours to release. */
+    shape_t labeled = shape_new_labeled("hexagon", Add);
+    CHECK(!shape_try_area(labeled, &out, &e));
     CHECK(e != NULL);
     CHECK(strstr(e, "no area") != NULL);
     example_free(e);
+    shape_drop(&labeled);
 
     /* `shape_drop` is the other C entry point into these bytes: it checks the
      * tag too, and an out-of-range one is simply nothing to release. */

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -16,7 +16,11 @@
  *   - the union in every position: returned, taken by value as a parameter,
  *     and carried through a `drawing_t` data-struct field;
  *   - `shape_drop` freeing the ACTIVE arm, and being a no-op the second time
- *     (the freed slot is nulled) and on a non-owning arm.
+ *     (the freed slot is nulled) and on a non-owning arm;
+ *   - a tag NO variant has. A C caller can always write one, so the binding
+ *     validates it before a Rust enum exists: `shape_try_area` reports it
+ *     through its `char **e`, and `shape_drop` ignores it. Constructing that
+ *     value is the point of the check — it is not a Rust `shape_t` at all.
  *
  * Exits non-zero on the first failed check.
  */
@@ -122,15 +126,64 @@ static void test_drop(void) {
     shape_drop(NULL);
 }
 
+/* A tag no variant declares — what a buggy or hostile C caller produces. It is
+ * written through the raw bytes because no valid `shape_t` has this value. */
+static shape_t with_raw_tag(int tag) {
+    shape_t s = shape_new_rect(1.0, 1.0);
+    memcpy(&s, &tag, sizeof tag);
+    return s;
+}
+
+/* The fallible route: a rejected tag reaches the error channel, and the call
+ * has no other effect. */
+static void test_invalid_tag(void) {
+    double out = -1.0;
+    char *e = NULL;
+
+    /* A valid arm first, so the comparison is against a working call. */
+    CHECK(shape_try_area(shape_new_rect(3.0, 4.0), &out, &e));
+    CHECK(e == NULL);
+    CHECK(out == 12.0);
+
+    /* 99 selects no variant. */
+    out = -1.0;
+    CHECK(!shape_try_area(with_raw_tag(99), &out, &e));
+    CHECK(e != NULL);
+    CHECK(strstr(e, "invalid tag 99") != NULL);
+    CHECK(out == -1.0);
+    example_free(e);
+    e = NULL;
+
+    /* Negative too: the tag is read as a signed int, not truncated into a
+     * variant. */
+    CHECK(!shape_try_area(with_raw_tag(-1), &out, &e));
+    CHECK(e != NULL);
+    CHECK(strstr(e, "invalid tag -1") != NULL);
+    example_free(e);
+    e = NULL;
+
+    /* The domain error still comes through the same channel, unchanged. */
+    CHECK(!shape_try_area(shape_new_labeled("hexagon", Add), &out, &e));
+    CHECK(e != NULL);
+    CHECK(strstr(e, "no area") != NULL);
+    example_free(e);
+
+    /* `shape_drop` is the other C entry point into these bytes: it checks the
+     * tag too, and an out-of-range one is simply nothing to release. */
+    shape_t bad = with_raw_tag(99);
+    shape_drop(&bad);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
     test_drop();
+    test_invalid_tag();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
         return 1;
     }
-    printf("PASS - tagged union: every arm, every position, drop\n");
+    printf("PASS - tagged union: every arm, every position, drop, invalid tag\n");
     return 0;
 }

--- a/examples/example-cbindgen/cbindgen.toml
+++ b/examples/example-cbindgen/cbindgen.toml
@@ -22,3 +22,10 @@ args = "auto"
 # Configure struct generation
 derive_eq = false
 derive_neq = false
+
+# NOTE: a tagged union (`.tagged_union()`) renders as a tag enum plus a union of
+# the variant bodies, and cbindgen's `[enum]` section is what controls that
+# rendering — e.g. `prefix_with_name = true` would namespace the variant
+# constants as `shape_t_Empty` instead of the default bare `Empty`. This example
+# keeps cbindgen's defaults, so `include/example_flat_*.h` is the reference for
+# exactly what they produce.

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 #[allow(non_camel_case_types)]
 pub struct drawing_t {
     pub id: u64,
-    pub shape: shape_t,
+    pub shape: ::core::mem::MaybeUninit<shape_t>,
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -82,15 +82,21 @@ pub enum shape_t {
     Empty,
     Circle(f64),
     Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, operation_t),
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut shape_t) {
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
     if this_.is_null() {
         return;
     }
-    match &mut *this_ {
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
         shape_t::Labeled(__f0, __f1) => {
             free(*__f0 as *mut ::core::ffi::c_void);
             *__f0 = ::core::ptr::null_mut();
@@ -121,11 +127,13 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(v: drawing_t) -> example_flat::Drawing {
-    example_flat::Drawing {
+pub(crate) unsafe fn __cbg_in_Drawing(
+    v: drawing_t,
+) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
+    ::core::result::Result::Ok(example_flat::Drawing {
         id: v.id,
-        shape: __cbg_in_Shape(v.shape),
-    }
+        shape: __cbg_in_Shape(v.shape)?,
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
@@ -200,27 +208,47 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(v: shape_t) -> example_flat::Shape {
-    match v {
-        shape_t::Empty => example_flat::Shape::Empty,
-        shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
-        shape_t::Rect { width: __f0, height: __f1 } => {
-            example_flat::Shape::Rect {
-                width: __f0,
-                height: __f1,
-            }
-        }
-        shape_t::Labeled(__f0, __f1) => {
-            example_flat::Shape::Labeled(
-                if __f0.is_null() {
-                    ::std::string::String::new()
-                } else {
-                    ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                },
-                __cbg_in_Operation(__f1),
-            )
-        }
+pub(crate) unsafe fn __cbg_in_Shape(
+    v: ::core::mem::MaybeUninit<shape_t>,
+) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return ::core::result::Result::Err(
+            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
+        );
     }
+    let v = v.assume_init();
+    ::core::result::Result::Ok(
+        match v {
+            shape_t::Empty => example_flat::Shape::Empty,
+            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
+            shape_t::Rect { width: __f0, height: __f1 } => {
+                example_flat::Shape::Rect {
+                    width: __f0,
+                    height: __f1,
+                }
+            }
+            shape_t::Labeled(__f0, __f1) => {
+                example_flat::Shape::Labeled(
+                    if __f0.is_null() {
+                        ::std::string::String::new()
+                    } else {
+                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
+                    },
+                    __cbg_in_Operation(__f1)?,
+                )
+            }
+        },
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -359,20 +387,27 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(v: example_flat::Shape) -> shape_t {
-    match v {
-        example_flat::Shape::Empty => shape_t::Empty,
-        example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
-        example_flat::Shape::Rect { width: __f0, height: __f1 } => {
-            shape_t::Rect {
-                width: __f0,
-                height: __f1,
+pub(crate) fn __cbg_out_Shape(
+    v: example_flat::Shape,
+) -> ::core::mem::MaybeUninit<shape_t> {
+    ::core::mem::MaybeUninit::new(
+        match v {
+            example_flat::Shape::Empty => shape_t::Empty,
+            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
+            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+                shape_t::Rect {
+                    width: __f0,
+                    height: __f1,
+                }
             }
-        }
-        example_flat::Shape::Labeled(__f0, __f1) => {
-            shape_t::Labeled(__cbg_alloc_cstr(__f0), __cbg_out_Operation(__f1))
-        }
-    }
+            example_flat::Shape::Labeled(__f0, __f1) => {
+                shape_t::Labeled(
+                    __cbg_alloc_cstr(__f0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
+                )
+            }
+        },
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
@@ -604,18 +639,33 @@ pub unsafe extern "C" fn calculator_to_string(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn drawing_get_shape(d: drawing_t) -> shape_t {
-    let d = __cbg_in_Drawing(d);
+pub unsafe extern "C" fn drawing_get_shape(
+    d: drawing_t,
+) -> ::core::mem::MaybeUninit<shape_t> {
+    let d = match __cbg_in_Drawing(d) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::drawing_get_shape(d);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn drawing_new(id: u64, shape: shape_t) -> drawing_t {
+pub unsafe extern "C" fn drawing_new(
+    id: u64,
+    shape: ::core::mem::MaybeUninit<shape_t>,
+) -> drawing_t {
     let id = __cbg_in_u64(id);
-    let shape = __cbg_in_Shape(shape);
+    let shape = match __cbg_in_Shape(shape) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
     __ret = __cbg_out_Drawing(__v);
@@ -665,8 +715,13 @@ pub unsafe extern "C" fn inside_foo_value(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_area(s: shape_t) -> f64 {
-    let s = __cbg_in_Shape(s);
+pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
+    let s = match __cbg_in_Shape(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
     __ret = __cbg_out_f64(__v);
@@ -674,8 +729,15 @@ pub unsafe extern "C" fn shape_area(s: shape_t) -> f64 {
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_get_label(s: shape_t) -> *mut ::core::ffi::c_char {
-    let s = __cbg_in_Shape(s);
+pub unsafe extern "C" fn shape_get_label(
+    s: ::core::mem::MaybeUninit<shape_t>,
+) -> *mut ::core::ffi::c_char {
+    let s = match __cbg_in_Shape(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
     __ret = __cbg_out_String(__v);
@@ -683,18 +745,20 @@ pub unsafe extern "C" fn shape_get_label(s: shape_t) -> *mut ::core::ffi::c_char
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_new_circle(radius: f64) -> shape_t {
+pub unsafe extern "C" fn shape_new_circle(
+    radius: f64,
+) -> ::core::mem::MaybeUninit<shape_t> {
     let radius = __cbg_in_f64(radius);
     let __v = example_flat::shape_new_circle(radius);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_new_empty() -> shape_t {
+pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
@@ -702,29 +766,70 @@ pub unsafe extern "C" fn shape_new_empty() -> shape_t {
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
-    op: operation_t,
-) -> shape_t {
+    op: ::core::mem::MaybeUninit<operation_t>,
+) -> ::core::mem::MaybeUninit<shape_t> {
     let label = match __cbg_in___str(label) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = __cbg_in_Operation(op);
+    let op = match __cbg_in_Operation(op) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::shape_new_labeled(label, op);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_new_rect(width: f64, height: f64) -> shape_t {
+pub unsafe extern "C" fn shape_new_rect(
+    width: f64,
+    height: f64,
+) -> ::core::mem::MaybeUninit<shape_t> {
     let width = __cbg_in_f64(width);
     let height = __cbg_in_f64(height);
     let __v = example_flat::shape_new_rect(width, height);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_try_area(
+    s: ::core::mem::MaybeUninit<shape_t>,
+    out: *mut f64,
+    e: *mut *mut ::core::ffi::c_char,
+) -> bool {
+    let s = match __cbg_in_Shape(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return false;
+        }
+    };
+    match example_flat::shape_try_area(s) {
+        ::core::result::Result::Ok(__v) => {
+            *out = __cbg_out_f64(__v);
+            true
+        }
+        ::core::result::Result::Err(__err) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(__err);
+            }
+            false
+        }
+    }
 }
 const _: () = {
     konst::assertc_eq!(

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -49,6 +49,12 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct drawing_t {
+    pub id: u64,
+    pub shape: shape_t,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct foo_t {
     pub id: u64,
     pub aarch64_field: u64,
@@ -72,6 +78,28 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, operation_t),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut shape_t) {
+    if this_.is_null() {
+        return;
+    }
+    match &mut *this_ {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -91,6 +119,13 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     ::core::result::Result::Ok(
         *::std::boxed::Box::from_raw(v as *mut example_flat::Calculator),
     )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Drawing(v: drawing_t) -> example_flat::Drawing {
+    example_flat::Drawing {
+        id: v.id,
+        shape: __cbg_in_Shape(v.shape),
+    }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
@@ -163,6 +198,47 @@ pub(crate) unsafe fn __cbg_in_Operation(
     ::core::result::Result::Err(
         ::std::format!("invalid discriminant {} for `operation_t`", __raw),
     )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Shape(v: shape_t) -> example_flat::Shape {
+    match v {
+        shape_t::Empty => example_flat::Shape::Empty,
+        shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
+        shape_t::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Rect {
+                width: __f0,
+                height: __f1,
+            }
+        }
+        shape_t::Labeled(__f0, __f1) => {
+            example_flat::Shape::Labeled(
+                if __f0.is_null() {
+                    ::std::string::String::new()
+                } else {
+                    ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
+                },
+                __cbg_in_Operation(__f1),
+            )
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String(
+    v: *const ::core::ffi::c_char,
+) -> ::core::result::Result<::std::string::String, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null pointer passed for String argument"),
+        );
+    }
+    match ::std::ffi::CStr::from_ptr(v).to_str() {
+        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
+        ::core::result::Result::Err(_) => {
+            ::core::result::Result::Err(
+                ::std::string::String::from("invalid UTF-8 in String argument"),
+            )
+        }
+    }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in___Calculator<'a>(
@@ -248,6 +324,13 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+    drawing_t {
+        id: v.id,
+        shape: __cbg_out_Shape(v.shape),
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
@@ -273,6 +356,22 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Sub => operation_t::Sub,
         example_flat::Operation::Mul => operation_t::Mul,
         example_flat::Operation::Div => operation_t::Div,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Shape(v: example_flat::Shape) -> shape_t {
+    match v {
+        example_flat::Shape::Empty => shape_t::Empty,
+        example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
+        example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            shape_t::Rect {
+                width: __f0,
+                height: __f1,
+            }
+        }
+        example_flat::Shape::Labeled(__f0, __f1) => {
+            shape_t::Labeled(__cbg_alloc_cstr(__f0), __cbg_out_Operation(__f1))
+        }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -505,6 +604,25 @@ pub unsafe extern "C" fn calculator_to_string(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn drawing_get_shape(d: drawing_t) -> shape_t {
+    let d = __cbg_in_Drawing(d);
+    let __v = example_flat::drawing_get_shape(d);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn drawing_new(id: u64, shape: shape_t) -> drawing_t {
+    let id = __cbg_in_u64(id);
+    let shape = __cbg_in_Shape(shape);
+    let __v = example_flat::drawing_new(id, shape);
+    let __ret: drawing_t;
+    __ret = __cbg_out_Drawing(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
     let f = __cbg_in_Foo(f);
     let __v = example_flat::foo_get_id(f);
@@ -543,6 +661,69 @@ pub unsafe extern "C" fn inside_foo_value(
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
     __ret = __cbg_out_i32(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_area(s: shape_t) -> f64 {
+    let s = __cbg_in_Shape(s);
+    let __v = example_flat::shape_area(s);
+    let __ret: f64;
+    __ret = __cbg_out_f64(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_get_label(s: shape_t) -> *mut ::core::ffi::c_char {
+    let s = __cbg_in_Shape(s);
+    let __v = example_flat::shape_get_label(s);
+    let __ret: *mut ::core::ffi::c_char;
+    __ret = __cbg_out_String(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_circle(radius: f64) -> shape_t {
+    let radius = __cbg_in_f64(radius);
+    let __v = example_flat::shape_new_circle(radius);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_empty() -> shape_t {
+    let __v = example_flat::shape_new_empty();
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_labeled(
+    label: *const ::core::ffi::c_char,
+    op: operation_t,
+) -> shape_t {
+    let label = match __cbg_in___str(label) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let op = __cbg_in_Operation(op);
+    let __v = example_flat::shape_new_labeled(label, op);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_rect(width: f64, height: f64) -> shape_t {
+    let width = __cbg_in_f64(width);
+    let height = __cbg_in_f64(height);
+    let __v = example_flat::shape_new_rect(width, height);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
     __ret
 }
 const _: () = {

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -90,6 +90,13 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
     if this_.is_null() {
         return;
     }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         (*this_).as_ptr() as *const ::core::ffi::c_int,
     );

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 #[allow(non_camel_case_types)]
 pub struct drawing_t {
     pub id: u64,
-    pub shape: shape_t,
+    pub shape: ::core::mem::MaybeUninit<shape_t>,
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -82,15 +82,21 @@ pub enum shape_t {
     Empty,
     Circle(f64),
     Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, operation_t),
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut shape_t) {
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
     if this_.is_null() {
         return;
     }
-    match &mut *this_ {
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
         shape_t::Labeled(__f0, __f1) => {
             free(*__f0 as *mut ::core::ffi::c_void);
             *__f0 = ::core::ptr::null_mut();
@@ -121,11 +127,13 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(v: drawing_t) -> example_flat::Drawing {
-    example_flat::Drawing {
+pub(crate) unsafe fn __cbg_in_Drawing(
+    v: drawing_t,
+) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
+    ::core::result::Result::Ok(example_flat::Drawing {
         id: v.id,
-        shape: __cbg_in_Shape(v.shape),
-    }
+        shape: __cbg_in_Shape(v.shape)?,
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
@@ -200,27 +208,47 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(v: shape_t) -> example_flat::Shape {
-    match v {
-        shape_t::Empty => example_flat::Shape::Empty,
-        shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
-        shape_t::Rect { width: __f0, height: __f1 } => {
-            example_flat::Shape::Rect {
-                width: __f0,
-                height: __f1,
-            }
-        }
-        shape_t::Labeled(__f0, __f1) => {
-            example_flat::Shape::Labeled(
-                if __f0.is_null() {
-                    ::std::string::String::new()
-                } else {
-                    ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                },
-                __cbg_in_Operation(__f1),
-            )
-        }
+pub(crate) unsafe fn __cbg_in_Shape(
+    v: ::core::mem::MaybeUninit<shape_t>,
+) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return ::core::result::Result::Err(
+            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
+        );
     }
+    let v = v.assume_init();
+    ::core::result::Result::Ok(
+        match v {
+            shape_t::Empty => example_flat::Shape::Empty,
+            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
+            shape_t::Rect { width: __f0, height: __f1 } => {
+                example_flat::Shape::Rect {
+                    width: __f0,
+                    height: __f1,
+                }
+            }
+            shape_t::Labeled(__f0, __f1) => {
+                example_flat::Shape::Labeled(
+                    if __f0.is_null() {
+                        ::std::string::String::new()
+                    } else {
+                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
+                    },
+                    __cbg_in_Operation(__f1)?,
+                )
+            }
+        },
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -359,20 +387,27 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(v: example_flat::Shape) -> shape_t {
-    match v {
-        example_flat::Shape::Empty => shape_t::Empty,
-        example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
-        example_flat::Shape::Rect { width: __f0, height: __f1 } => {
-            shape_t::Rect {
-                width: __f0,
-                height: __f1,
+pub(crate) fn __cbg_out_Shape(
+    v: example_flat::Shape,
+) -> ::core::mem::MaybeUninit<shape_t> {
+    ::core::mem::MaybeUninit::new(
+        match v {
+            example_flat::Shape::Empty => shape_t::Empty,
+            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
+            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+                shape_t::Rect {
+                    width: __f0,
+                    height: __f1,
+                }
             }
-        }
-        example_flat::Shape::Labeled(__f0, __f1) => {
-            shape_t::Labeled(__cbg_alloc_cstr(__f0), __cbg_out_Operation(__f1))
-        }
-    }
+            example_flat::Shape::Labeled(__f0, __f1) => {
+                shape_t::Labeled(
+                    __cbg_alloc_cstr(__f0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
+                )
+            }
+        },
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
@@ -604,18 +639,33 @@ pub unsafe extern "C" fn calculator_to_string(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn drawing_get_shape(d: drawing_t) -> shape_t {
-    let d = __cbg_in_Drawing(d);
+pub unsafe extern "C" fn drawing_get_shape(
+    d: drawing_t,
+) -> ::core::mem::MaybeUninit<shape_t> {
+    let d = match __cbg_in_Drawing(d) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::drawing_get_shape(d);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn drawing_new(id: u64, shape: shape_t) -> drawing_t {
+pub unsafe extern "C" fn drawing_new(
+    id: u64,
+    shape: ::core::mem::MaybeUninit<shape_t>,
+) -> drawing_t {
     let id = __cbg_in_u64(id);
-    let shape = __cbg_in_Shape(shape);
+    let shape = match __cbg_in_Shape(shape) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
     __ret = __cbg_out_Drawing(__v);
@@ -665,8 +715,13 @@ pub unsafe extern "C" fn inside_foo_value(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_area(s: shape_t) -> f64 {
-    let s = __cbg_in_Shape(s);
+pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
+    let s = match __cbg_in_Shape(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
     __ret = __cbg_out_f64(__v);
@@ -674,8 +729,15 @@ pub unsafe extern "C" fn shape_area(s: shape_t) -> f64 {
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_get_label(s: shape_t) -> *mut ::core::ffi::c_char {
-    let s = __cbg_in_Shape(s);
+pub unsafe extern "C" fn shape_get_label(
+    s: ::core::mem::MaybeUninit<shape_t>,
+) -> *mut ::core::ffi::c_char {
+    let s = match __cbg_in_Shape(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
     __ret = __cbg_out_String(__v);
@@ -683,18 +745,20 @@ pub unsafe extern "C" fn shape_get_label(s: shape_t) -> *mut ::core::ffi::c_char
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_new_circle(radius: f64) -> shape_t {
+pub unsafe extern "C" fn shape_new_circle(
+    radius: f64,
+) -> ::core::mem::MaybeUninit<shape_t> {
     let radius = __cbg_in_f64(radius);
     let __v = example_flat::shape_new_circle(radius);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_new_empty() -> shape_t {
+pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
@@ -702,29 +766,70 @@ pub unsafe extern "C" fn shape_new_empty() -> shape_t {
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
-    op: operation_t,
-) -> shape_t {
+    op: ::core::mem::MaybeUninit<operation_t>,
+) -> ::core::mem::MaybeUninit<shape_t> {
     let label = match __cbg_in___str(label) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = __cbg_in_Operation(op);
+    let op = match __cbg_in_Operation(op) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
     let __v = example_flat::shape_new_labeled(label, op);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn shape_new_rect(width: f64, height: f64) -> shape_t {
+pub unsafe extern "C" fn shape_new_rect(
+    width: f64,
+    height: f64,
+) -> ::core::mem::MaybeUninit<shape_t> {
     let width = __cbg_in_f64(width);
     let height = __cbg_in_f64(height);
     let __v = example_flat::shape_new_rect(width, height);
-    let __ret: shape_t;
+    let __ret: ::core::mem::MaybeUninit<shape_t>;
     __ret = __cbg_out_Shape(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_try_area(
+    s: ::core::mem::MaybeUninit<shape_t>,
+    out: *mut f64,
+    e: *mut *mut ::core::ffi::c_char,
+) -> bool {
+    let s = match __cbg_in_Shape(s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return false;
+        }
+    };
+    match example_flat::shape_try_area(s) {
+        ::core::result::Result::Ok(__v) => {
+            *out = __cbg_out_f64(__v);
+            true
+        }
+        ::core::result::Result::Err(__err) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(__err);
+            }
+            false
+        }
+    }
 }
 const _: () = {
     konst::assertc_eq!(

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -49,6 +49,12 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct drawing_t {
+    pub id: u64,
+    pub shape: shape_t,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct foo_t {
     pub id: u64,
     pub x86_64_field: u64,
@@ -72,6 +78,28 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, operation_t),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut shape_t) {
+    if this_.is_null() {
+        return;
+    }
+    match &mut *this_ {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -91,6 +119,13 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     ::core::result::Result::Ok(
         *::std::boxed::Box::from_raw(v as *mut example_flat::Calculator),
     )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Drawing(v: drawing_t) -> example_flat::Drawing {
+    example_flat::Drawing {
+        id: v.id,
+        shape: __cbg_in_Shape(v.shape),
+    }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
@@ -163,6 +198,47 @@ pub(crate) unsafe fn __cbg_in_Operation(
     ::core::result::Result::Err(
         ::std::format!("invalid discriminant {} for `operation_t`", __raw),
     )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Shape(v: shape_t) -> example_flat::Shape {
+    match v {
+        shape_t::Empty => example_flat::Shape::Empty,
+        shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
+        shape_t::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Rect {
+                width: __f0,
+                height: __f1,
+            }
+        }
+        shape_t::Labeled(__f0, __f1) => {
+            example_flat::Shape::Labeled(
+                if __f0.is_null() {
+                    ::std::string::String::new()
+                } else {
+                    ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
+                },
+                __cbg_in_Operation(__f1),
+            )
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String(
+    v: *const ::core::ffi::c_char,
+) -> ::core::result::Result<::std::string::String, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null pointer passed for String argument"),
+        );
+    }
+    match ::std::ffi::CStr::from_ptr(v).to_str() {
+        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
+        ::core::result::Result::Err(_) => {
+            ::core::result::Result::Err(
+                ::std::string::String::from("invalid UTF-8 in String argument"),
+            )
+        }
+    }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in___Calculator<'a>(
@@ -248,6 +324,13 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+    drawing_t {
+        id: v.id,
+        shape: __cbg_out_Shape(v.shape),
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
@@ -273,6 +356,22 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Sub => operation_t::Sub,
         example_flat::Operation::Mul => operation_t::Mul,
         example_flat::Operation::Div => operation_t::Div,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Shape(v: example_flat::Shape) -> shape_t {
+    match v {
+        example_flat::Shape::Empty => shape_t::Empty,
+        example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
+        example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            shape_t::Rect {
+                width: __f0,
+                height: __f1,
+            }
+        }
+        example_flat::Shape::Labeled(__f0, __f1) => {
+            shape_t::Labeled(__cbg_alloc_cstr(__f0), __cbg_out_Operation(__f1))
+        }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -505,6 +604,25 @@ pub unsafe extern "C" fn calculator_to_string(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn drawing_get_shape(d: drawing_t) -> shape_t {
+    let d = __cbg_in_Drawing(d);
+    let __v = example_flat::drawing_get_shape(d);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn drawing_new(id: u64, shape: shape_t) -> drawing_t {
+    let id = __cbg_in_u64(id);
+    let shape = __cbg_in_Shape(shape);
+    let __v = example_flat::drawing_new(id, shape);
+    let __ret: drawing_t;
+    __ret = __cbg_out_Drawing(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
     let f = __cbg_in_Foo(f);
     let __v = example_flat::foo_get_id(f);
@@ -543,6 +661,69 @@ pub unsafe extern "C" fn inside_foo_value(
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
     __ret = __cbg_out_i32(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_area(s: shape_t) -> f64 {
+    let s = __cbg_in_Shape(s);
+    let __v = example_flat::shape_area(s);
+    let __ret: f64;
+    __ret = __cbg_out_f64(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_get_label(s: shape_t) -> *mut ::core::ffi::c_char {
+    let s = __cbg_in_Shape(s);
+    let __v = example_flat::shape_get_label(s);
+    let __ret: *mut ::core::ffi::c_char;
+    __ret = __cbg_out_String(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_circle(radius: f64) -> shape_t {
+    let radius = __cbg_in_f64(radius);
+    let __v = example_flat::shape_new_circle(radius);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_empty() -> shape_t {
+    let __v = example_flat::shape_new_empty();
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_labeled(
+    label: *const ::core::ffi::c_char,
+    op: operation_t,
+) -> shape_t {
+    let label = match __cbg_in___str(label) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let op = __cbg_in_Operation(op);
+    let __v = example_flat::shape_new_labeled(label, op);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn shape_new_rect(width: f64, height: f64) -> shape_t {
+    let width = __cbg_in_f64(width);
+    let height = __cbg_in_f64(height);
+    let __v = example_flat::shape_new_rect(width, height);
+    let __ret: shape_t;
+    __ret = __cbg_out_Shape(__v);
     __ret
 }
 const _: () = {

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -90,6 +90,13 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
     if this_.is_null() {
         return;
     }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         (*this_).as_ptr() as *const ::core::ffi::c_int,
     );

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -131,4 +131,6 @@ struct shape_t shape_new_labeled(const char *label, enum operation_t op);
 
 struct shape_t shape_new_rect(double width, double height);
 
+bool shape_try_area(struct shape_t s, double *out, char **e);
+
 #endif  /* EXAMPLE_FLAT_H */

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -28,11 +28,44 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
+typedef enum shape_t_Tag {
+  Empty,
+  Circle,
+  Rect,
+  Labeled,
+} shape_t_Tag;
+
+typedef struct Rect_Body {
+  double width;
+  double height;
+} Rect_Body;
+
+typedef struct Labeled_Body {
+  char *_0;
+  enum operation_t _1;
+} Labeled_Body;
+
+typedef struct shape_t {
+  shape_t_Tag tag;
+  union {
+    struct {
+      double circle;
+    };
+    Rect_Body rect;
+    Labeled_Body labeled;
+  };
+} shape_t;
+
 typedef struct closure_value_t {
   void *context;
   void (*call)(double, void*);
   void (*drop)(void*);
 } closure_value_t;
+
+typedef struct drawing_t {
+  uint64_t id;
+  struct shape_t shape;
+} drawing_t;
 
 typedef struct foo_t {
   uint64_t id;
@@ -47,6 +80,8 @@ extern void free(void *ptr);
 void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
+
+void shape_drop(struct shape_t *this_);
 
 bool calculator_apply(struct calculator_t *c,
                       enum operation_t op,
@@ -72,6 +107,10 @@ struct calculator_t *calculator_new_from_str(const char *s, char **e);
 
 char *calculator_to_string(const struct calculator_t *c);
 
+struct shape_t drawing_get_shape(struct drawing_t d);
+
+struct drawing_t drawing_new(uint64_t id, struct shape_t shape);
+
 uint64_t foo_get_id(struct foo_t f);
 
 struct foo_t foo_new(uint64_t id);
@@ -79,5 +118,17 @@ struct foo_t foo_new(uint64_t id);
 enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
+
+double shape_area(struct shape_t s);
+
+char *shape_get_label(struct shape_t s);
+
+struct shape_t shape_new_circle(double radius);
+
+struct shape_t shape_new_empty(void);
+
+struct shape_t shape_new_labeled(const char *label, enum operation_t op);
+
+struct shape_t shape_new_rect(double width, double height);
 
 #endif  /* EXAMPLE_FLAT_H */

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -131,4 +131,6 @@ struct shape_t shape_new_labeled(const char *label, enum operation_t op);
 
 struct shape_t shape_new_rect(double width, double height);
 
+bool shape_try_area(struct shape_t s, double *out, char **e);
+
 #endif  /* EXAMPLE_FLAT_H */

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -28,11 +28,44 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
+typedef enum shape_t_Tag {
+  Empty,
+  Circle,
+  Rect,
+  Labeled,
+} shape_t_Tag;
+
+typedef struct Rect_Body {
+  double width;
+  double height;
+} Rect_Body;
+
+typedef struct Labeled_Body {
+  char *_0;
+  enum operation_t _1;
+} Labeled_Body;
+
+typedef struct shape_t {
+  shape_t_Tag tag;
+  union {
+    struct {
+      double circle;
+    };
+    Rect_Body rect;
+    Labeled_Body labeled;
+  };
+} shape_t;
+
 typedef struct closure_value_t {
   void *context;
   void (*call)(double, void*);
   void (*drop)(void*);
 } closure_value_t;
+
+typedef struct drawing_t {
+  uint64_t id;
+  struct shape_t shape;
+} drawing_t;
 
 typedef struct foo_t {
   uint64_t id;
@@ -47,6 +80,8 @@ extern void free(void *ptr);
 void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
+
+void shape_drop(struct shape_t *this_);
 
 bool calculator_apply(struct calculator_t *c,
                       enum operation_t op,
@@ -72,6 +107,10 @@ struct calculator_t *calculator_new_from_str(const char *s, char **e);
 
 char *calculator_to_string(const struct calculator_t *c);
 
+struct shape_t drawing_get_shape(struct drawing_t d);
+
+struct drawing_t drawing_new(uint64_t id, struct shape_t shape);
+
 uint64_t foo_get_id(struct foo_t f);
 
 struct foo_t foo_new(uint64_t id);
@@ -79,5 +118,17 @@ struct foo_t foo_new(uint64_t id);
 enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
+
+double shape_area(struct shape_t s);
+
+char *shape_get_label(struct shape_t s);
+
+struct shape_t shape_new_circle(double radius);
+
+struct shape_t shape_new_empty(void);
+
+struct shape_t shape_new_labeled(const char *label, enum operation_t op);
+
+struct shape_t shape_new_rect(double width, double height);
 
 #endif  /* EXAMPLE_FLAT_H */

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -121,6 +121,19 @@ pub fn shape_area(s: Shape) -> f64 {
     }
 }
 
+/// Area of a shape, reporting the alternative that has none through the error
+/// channel — the sum in parameter position on a **fallible** function. The C
+/// binding routes a rejected tag (a discriminant no variant has, which a C
+/// caller can always supply) to this same `char **e`, so the boundary check is
+/// observable instead of aborting.
+#[prebindgen]
+pub fn shape_try_area(s: Shape) -> Result<f64, Error> {
+    match s {
+        Shape::Labeled(_, _) => Err("a labeled shape has no area".to_string().into()),
+        other => Ok(shape_area(other)),
+    }
+}
+
 /// The label of a `Labeled` shape, or the empty string for any other alternative.
 #[prebindgen]
 pub fn shape_get_label(s: Shape) -> String {

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -52,6 +52,96 @@ pub enum Operation {
     Div = 3,
 }
 
+/// A **data-carrying enum** (a sum type): exactly one alternative is live, and it
+/// carries that alternative's payload. Written as plain Rust — the invariant is in
+/// the type, not in a doc comment on a struct of optional fields.
+///
+/// The four variant shapes a sum can take are all here: a unit variant, a
+/// single-payload tuple variant, a multi-field named variant, and a tuple variant
+/// with an **owning** payload (a `String`, which crosses to C as a malloc'd
+/// `char *`) beside a payload that is itself a declared enum. The C adapter
+/// lowers the whole thing to a `#[repr(C)]` enum, which cbindgen renders as the
+/// idiomatic tag + `union`. (`lang::Cbindgen` `.tagged_union`.)
+#[prebindgen]
+#[derive(Debug, Clone, PartialEq)]
+pub enum Shape {
+    /// Unit variant: the empty payload group — only the tag is live.
+    Empty,
+    /// Single-payload tuple variant.
+    Circle(f64),
+    /// Multi-field named variant.
+    Rect { width: f64, height: f64 },
+    /// Owning payload: the `String` is handed to C as a malloc'd `char *` that the
+    /// generated `shape_drop` releases, beside a declared-`enum_type` payload.
+    Labeled(String, Operation),
+}
+
+/// A by-value data struct carrying a sum as a **field** — the position that makes
+/// "exactly one of" compose with ordinary product data.
+#[prebindgen]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Drawing {
+    pub id: u64,
+    pub shape: Shape,
+}
+
+/// The empty shape (the unit variant).
+#[prebindgen]
+pub fn shape_new_empty() -> Shape {
+    Shape::Empty
+}
+
+/// A circle of the given radius (single-payload tuple variant).
+#[prebindgen]
+pub fn shape_new_circle(radius: f64) -> Shape {
+    Shape::Circle(radius)
+}
+
+/// A rectangle (multi-field named variant).
+#[prebindgen]
+pub fn shape_new_rect(width: f64, height: f64) -> Shape {
+    Shape::Rect { width, height }
+}
+
+/// A labeled shape (owning `String` payload beside an enum payload).
+#[prebindgen]
+pub fn shape_new_labeled(label: &str, op: Operation) -> Shape {
+    Shape::Labeled(label.to_string(), op)
+}
+
+/// Area of a shape — the sum in **parameter** position, consumed by value. Every
+/// alternative is handled; there is no "both set" or "neither set" case to guard.
+#[prebindgen]
+pub fn shape_area(s: Shape) -> f64 {
+    match s {
+        Shape::Empty => 0.0,
+        Shape::Circle(r) => std::f64::consts::PI * r * r,
+        Shape::Rect { width, height } => width * height,
+        Shape::Labeled(_, _) => f64::NAN,
+    }
+}
+
+/// The label of a `Labeled` shape, or the empty string for any other alternative.
+#[prebindgen]
+pub fn shape_get_label(s: Shape) -> String {
+    match s {
+        Shape::Labeled(label, _) => label,
+        _ => String::new(),
+    }
+}
+
+/// Wrap a shape into a drawing (the sum crossing back out as a struct field).
+#[prebindgen]
+pub fn drawing_new(id: u64, shape: Shape) -> Drawing {
+    Drawing { id, shape }
+}
+
+/// Take a drawing's shape back out (the sum crossing in as a struct field).
+#[prebindgen]
+pub fn drawing_get_shape(d: Drawing) -> Shape {
+    d.shape
+}
+
 /// A stateful accumulator. This is a plain Rust type used as an opaque handle:
 /// the binding holds it behind a pointer and frees it with `calculator_drop`.
 pub struct Calculator {

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -305,7 +305,8 @@ impl Cbindgen {
             !self.opaque.contains_key(&key)
                 && !self.data.contains_key(&key)
                 && !self.value_opaque.contains_key(&key)
-                && !self.enums.contains_key(&key),
+                && !self.enums.contains_key(&key)
+                && !self.tagged_unions.contains_key(&key),
             "Cbindgen::ignore_type cannot ignore `{}` because it is already declared",
             key
         );
@@ -343,6 +344,12 @@ impl Cbindgen {
             Some(CurrentDecl::Enum(key)) => {
                 self.enums.get_mut(&key).expect("entry vanished").base = Some(base);
             }
+            Some(CurrentDecl::TaggedUnion(key)) => {
+                self.tagged_unions
+                    .get_mut(&key)
+                    .expect("entry vanished")
+                    .base = Some(base);
+            }
             Some(CurrentDecl::Callback(key)) => {
                 self.callbacks.get_mut(&key).expect("entry vanished").base = Some(base);
             }
@@ -354,8 +361,8 @@ impl Cbindgen {
             }
             None => panic!(
                 "Cbindgen::base_name must be chained directly after a declaration \
-                 (`opaque_ptr` / `data_struct` / `enum_type` / `callback` / `function` / \
-                 `convert`)"
+                 (`opaque_ptr` / `data_struct` / `enum_type` / `tagged_union` / `callback` / \
+                 `function` / `convert`)"
             ),
         }
         self
@@ -411,6 +418,36 @@ impl Cbindgen {
         );
         self.enums.insert(key.clone(), TypeCfg::default());
         self.current = Some(CurrentDecl::Enum(key));
+        self
+    }
+
+    /// Declare a **data-carrying** enum: it crosses by value as a `#[repr(C)]`
+    /// enum with payload variants, which cbindgen renders as the idiomatic C
+    /// tagged union (a tag enum plus a `union` of the variant bodies). The
+    /// counterpart of [`Self::enum_type`], which is for the unit-variant-only
+    /// case a plain C `enum` can hold. (Mirrors `JniExt`'s `sealed_class`.)
+    ///
+    /// Each payload field crosses as its own wire, chosen by the same policy a
+    /// [`Self::repr_c_struct`] field uses, extended with `String` → `char *`:
+    /// a scalar passes through, a declared [`Self::enum_type`] becomes its C
+    /// enum, a `String` becomes a malloc'd `char *`, and an opaque pointer
+    /// `Option<Box<T>>` / `Box<T>` (with `T` a declared [`Self::opaque_ptr`])
+    /// becomes `*mut t_t`. Anything else is a generation error.
+    ///
+    /// **Ownership.** The union crosses by value, so when any variant's
+    /// payload wire owns memory (`char *`, an opaque pointer) a typed
+    /// `<base>_drop(t_t *)` is generated that frees the **active arm** —
+    /// consistent with the existing typed per-pointer drops. A union whose
+    /// payloads are all plain data needs no drop and gets none.
+    pub fn tagged_union(mut self, ty: syn::Type) -> Self {
+        let key = TypeKey::from_type(&ty);
+        assert!(
+            !self.ignored_types.contains(&key),
+            "Cbindgen::tagged_union cannot declare `{}` because it is already ignored",
+            key
+        );
+        self.tagged_unions.insert(key.clone(), TypeCfg::default());
+        self.current = Some(CurrentDecl::TaggedUnion(key));
         self
     }
 
@@ -580,6 +617,7 @@ impl Cbindgen {
             .or_else(|| self.data.get(&key))
             .or_else(|| self.value_opaque.get(&key).map(|c| &c.cfg))
             .or_else(|| self.enums.get(&key))
+            .or_else(|| self.tagged_unions.get(&key))
     }
 
     /// The opaque counterpart type of a declared inline-opaque type, if any.
@@ -706,6 +744,7 @@ fn describe_current(current: &Option<CurrentDecl>) -> String {
         Some(CurrentDecl::Data(k)) => format!("data_struct `{}`", k.as_str()),
         Some(CurrentDecl::ValueOpaque(k)) => format!("value_opaque `{}`", k.as_str()),
         Some(CurrentDecl::Enum(k)) => format!("enum_type `{}`", k.as_str()),
+        Some(CurrentDecl::TaggedUnion(k)) => format!("tagged_union `{}`", k.as_str()),
         Some(CurrentDecl::Callback(k)) => {
             let args: Vec<&str> = k.iter().map(|t| t.as_str()).collect();
             format!("callback `impl Fn({})`", args.join(", "))

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -439,6 +439,13 @@ impl Cbindgen {
     /// `<base>_drop(t_t *)` is generated that frees the **active arm** —
     /// consistent with the existing typed per-pointer drops. A union whose
     /// payloads are all plain data needs no drop and gets none.
+    ///
+    /// **Validity.** Crossing **into** Rust, the tag a C caller supplied is
+    /// range-checked before any Rust enum is built — so, exactly like
+    /// [`Self::enum_type`], a union taken by value is a fallible input, and a
+    /// function taking one without a `Result` return needs [`Self::panic`].
+    /// A data struct carrying a union field inherits that fallibility. See the
+    /// module docs for the wire this uses and why.
     pub fn tagged_union(mut self, ty: syn::Type) -> Self {
         let key = TypeKey::from_type(&ty);
         assert!(

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -21,6 +21,22 @@ impl Cbindgen {
         {
             return true;
         }
+        // A tagged union with a `String` payload hands out a `char*` per active
+        // arm — allocated by its output converter, released by its typed drop.
+        if self.tagged_unions.keys().any(|key| {
+            let ty = key.to_type();
+            registry.output_entry(&ty).is_some()
+                && self
+                    .enum_variants(registry, &ty)
+                    .map(|vs| {
+                        vs.iter()
+                            .flat_map(|v| v.fields.iter())
+                            .any(|f| is_string(&f.ty))
+                    })
+                    .unwrap_or(false)
+        }) {
+            return true;
+        }
         self.data.keys().any(|key| {
             let ty = key.to_type();
             registry.output_entry(&ty).is_some()
@@ -29,6 +45,59 @@ impl Cbindgen {
                     .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))
                     .unwrap_or(false)
         })
+    }
+
+    /// Variants of a declared enum, looked up from the registry's indexed
+    /// enums. `None` if the type isn't an indexed enum.
+    pub(super) fn enum_variants(
+        &self,
+        registry: &Registry<()>,
+        ty: &syn::Type,
+    ) -> Option<Vec<syn::Variant>> {
+        let ident = type_path_tail(ty)?;
+        let (item, _) = registry.enums.get(&ident)?;
+        Some(item.variants.iter().cloned().collect())
+    }
+
+    /// Wire type of one **tagged-union payload field**: the
+    /// [`Self::mirror_field_wire`] policy (scalar / declared `enum_type` /
+    /// opaque pointer `Option<Box<T>>` / `Box<T>`) extended with `String` →
+    /// a malloc'd `*mut c_char`, the same `char *` lowering a `data_struct`
+    /// field gets. `None` ⇒ the payload type cannot cross a tagged union.
+    ///
+    /// Unlike a `repr_c_struct` mirror — whose fields are reinterpreted
+    /// wholesale by one `Transmute` — a tagged union is rebuilt arm by arm,
+    /// so each wire here is produced by a real per-field conversion. That is
+    /// what lets `String` join the set.
+    pub(super) fn payload_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
+        if is_string(fty) {
+            return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
+        }
+        self.mirror_field_wire(fty)
+    }
+
+    /// Wire type of a `data_struct` field: the free [`c_field_wire`] policy
+    /// (`String` → `char *`, scalar → itself) plus a declared
+    /// [`Cbindgen::tagged_union`] field, which crosses **by value** as its
+    /// `#[repr(C)]` mirror — the same way it crosses as a parameter or a
+    /// return. `None` ⇒ the field type is unsupported in a data struct.
+    ///
+    /// A union field with an owning payload keeps the data struct's existing
+    /// contract: the struct has no destructor, and each owning field is
+    /// released individually — here through the union's own typed drop.
+    pub(super) fn data_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
+        if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
+            let c = self.c_type_ident(fty);
+            return Some(syn::parse_quote!(#c));
+        }
+        c_field_wire(fty)
+    }
+
+    /// True when a payload wire hands owned memory to C — a `char *` block or
+    /// an opaque pointer — and therefore has to be released by the union's
+    /// typed drop.
+    pub(super) fn payload_wire_owns(wire: &syn::Type) -> bool {
+        matches!(wire, syn::Type::Ptr(_))
     }
 
     /// Whether any declared function returns a `Vec<_>` (possibly nested under

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -69,9 +69,20 @@ impl Cbindgen {
     /// wholesale by one `Transmute` — a tagged union is rebuilt arm by arm,
     /// so each wire here is produced by a real per-field conversion. That is
     /// what lets `String` join the set.
+    ///
+    /// Every wire this returns is **bit-pattern-agnostic**: scalars and raw
+    /// pointers hold any bits legally, and a declared `enum_type` payload is
+    /// wrapped in [`::core::mem::MaybeUninit`] so it does too (holding a Rust
+    /// enum with a discriminant no variant has would be UB). That is what makes
+    /// the mirror's tag the *only* thing [`Cbindgen::in_tagged_union`] has to
+    /// validate before `assume_init`.
     pub(super) fn payload_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
         if is_string(fty) {
             return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
+        }
+        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+            let c = self.c_type_ident(fty);
+            return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         self.mirror_field_wire(fty)
     }
@@ -85,10 +96,15 @@ impl Cbindgen {
     /// A union field with an owning payload keeps the data struct's existing
     /// contract: the struct has no destructor, and each owning field is
     /// released individually — here through the union's own typed drop.
+    ///
+    /// Like a union **parameter**, the field is wrapped in
+    /// [`::core::mem::MaybeUninit`]: one mirror struct serves both directions,
+    /// and on the way in its bytes are C's, so the field may not be a Rust enum
+    /// until its tag has been validated. Invisible in C either way.
     pub(super) fn data_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
         if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
             let c = self.c_type_ident(fty);
-            return Some(syn::parse_quote!(#c));
+            return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         c_field_wire(fty)
     }

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -12,7 +12,8 @@
 //!
 //! Items are **opt-in**: nothing is converted unless it is explicitly declared
 //! with [`Cbindgen::function`] / [`Cbindgen::opaque_ptr`] /
-//! [`Cbindgen::data_struct`] / [`Cbindgen::enum_type`]. The C name of a declared
+//! [`Cbindgen::data_struct`] / [`Cbindgen::enum_type`] /
+//! [`Cbindgen::tagged_union`]. The C name of a declared
 //! type's generated destructor can be pinned by chaining [`Cbindgen::name`].
 //!
 //! ## C ABI conventions
@@ -40,6 +41,11 @@
 //!   so a function taking an enum by value needs either a `Result` return or
 //!   [`Cbindgen::panic`]. This relies on cbindgen's C rendering; the `C++`
 //!   language mode is not supported.
+//! * **Tagged union** (declared with [`Cbindgen::tagged_union`]): a
+//!   data-carrying enum crossing by value as a `#[repr(C)]` enum with payload
+//!   variants, which cbindgen renders as a tag enum plus a `union` of the
+//!   variant bodies. When any variant's payload wire owns memory, a typed
+//!   `<name>_drop` frees the **active arm**.
 //! * **Direct `String` output**: a bare `char *` — a `malloc`'d, null-terminated
 //!   raw block (no wrapper struct), freed via the `free_memory_function`.
 //! * **[`Cbindgen::free_memory_function`]**: the single, type-agnostic raw memory
@@ -194,6 +200,7 @@ enum CurrentDecl {
     Data(TypeKey),
     ValueOpaque(TypeKey),
     Enum(TypeKey),
+    TaggedUnion(TypeKey),
     Callback(CallbackKey),
     Function(syn::Ident),
     Convert(TypeKey),
@@ -239,8 +246,12 @@ pub struct Cbindgen {
     /// opaque `#[repr(C, align(_))]` counterpart of identical size+align (no
     /// `Box`). Keyed by the Rust type; the value carries the opaque counterpart.
     value_opaque: HashMap<TypeKey, ValueOpaqueCfg>,
-    /// Enum types.
+    /// Enum types (unit-variant only — a C `enum` is a bare discriminant).
     enums: HashMap<TypeKey, TypeCfg>,
+    /// Data-carrying enum types crossing by value as a `#[repr(C)]` enum with
+    /// payload variants, which cbindgen renders as the idiomatic C tag +
+    /// `union`. Declared with [`Cbindgen::tagged_union`].
+    tagged_unions: HashMap<TypeKey, TypeCfg>,
     /// Declared callback signatures (`impl Fn(...) + Send + Sync + 'static`),
     /// keyed by their argument-type list. Each emits one `#[repr(C)]` closure
     /// struct.
@@ -323,6 +334,85 @@ fn type_short(ty: &syn::Type) -> String {
 fn enum_item<'r>(registry: &'r Registry<()>, ty: &syn::Type) -> Option<&'r syn::ItemEnum> {
     let ident = type_path_tail(ty)?;
     registry.enums.get(&ident).map(|(e, _)| e)
+}
+
+/// Hard error when a `.tagged_union()`-declared enum is unit-only. The
+/// counterpart of [`assert_unit_enum`]: a fieldless enum is exactly a
+/// discriminant, so it belongs to `.enum_type()` — declaring it here would
+/// emit a `union` with no bodies and a needlessly indirect C surface. Neither
+/// declarator silently accepts the other's shape.
+fn assert_payload_enum(e: &syn::ItemEnum) {
+    use crate::api::core::types_util::{enum_shape, EnumShape};
+    if enum_shape(e) == EnumShape::Unit {
+        panic!(
+            "Cbindgen: `{}` has no payload variants: declare it with `.enum_type()`, \
+             not `.tagged_union()` — a fieldless enum crosses as a plain C `enum`",
+            e.ident
+        );
+    }
+}
+
+/// If `fty` is an opaque-pointer payload — `Box<T>` or `Option<Box<T>>` with
+/// `T` a path type — return `T`. The shape check only; whether `T` is a
+/// declared `opaque_ptr` is [`Cbindgen::mirror_field_wire`]'s call, and this
+/// is only reached for a field that already passed it.
+fn opaque_ptr_payload_inner(fty: &syn::Type) -> Option<syn::Type> {
+    if is_option(fty) {
+        first_type_arg(fty).and_then(|inner| box_inner(&inner))
+    } else {
+        box_inner(fty)
+    }
+}
+
+/// The `Type` form of a generated C type ident, for the shared
+/// [`variant_ctor`] helper (which takes the enum's path either as a source
+/// type or as a mirror ident).
+fn cname_ty(cname: &syn::Ident) -> syn::Type {
+    syn::parse_quote!(#cname)
+}
+
+/// `Enum::Variant { a: __f0, .. }` / `Enum::Variant(__f0, ..)` / `Enum::Variant`
+/// — the match pattern binding every field of one variant, shaped like the
+/// variant itself. Used for both the source enum and its C mirror, and for
+/// both directions, so the two sides always destructure the same way.
+fn variant_pattern(
+    enum_path: &impl ToTokens,
+    variant: &syn::Ident,
+    fields: &syn::Fields,
+    binds: &[syn::Ident],
+) -> TokenStream {
+    match fields {
+        syn::Fields::Unit => quote!(#enum_path::#variant),
+        syn::Fields::Named(named) => {
+            let pairs = named.named.iter().zip(binds).map(|(f, b)| {
+                let n = f.ident.as_ref().expect("named field");
+                quote!(#n: #b)
+            });
+            quote!(#enum_path::#variant { #(#pairs),* })
+        }
+        syn::Fields::Unnamed(_) => quote!(#enum_path::#variant(#(#binds),*)),
+    }
+}
+
+/// The constructor counterpart of [`variant_pattern`]: rebuild one variant
+/// from already-converted field expressions.
+fn variant_ctor(
+    enum_path: &impl ToTokens,
+    variant: &syn::Ident,
+    fields: &syn::Fields,
+    exprs: &[TokenStream],
+) -> TokenStream {
+    match fields {
+        syn::Fields::Unit => quote!(#enum_path::#variant),
+        syn::Fields::Named(named) => {
+            let pairs = named.named.iter().zip(exprs).map(|(f, e)| {
+                let n = f.ident.as_ref().expect("named field");
+                quote!(#n: #e)
+            });
+            quote!(#enum_path::#variant { #(#pairs),* })
+        }
+        syn::Fields::Unnamed(_) => quote!(#enum_path::#variant(#(#exprs),*)),
+    }
 }
 
 /// Hard error when an `.enum_type()`-declared enum is not the shape that

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -45,7 +45,14 @@
 //!   data-carrying enum crossing by value as a `#[repr(C)]` enum with payload
 //!   variants, which cbindgen renders as a tag enum plus a `union` of the
 //!   variant bodies. When any variant's payload wire owns memory, a typed
-//!   `<name>_drop` frees the **active arm**.
+//!   `<name>_drop` frees the **active arm**. Inbound it obeys the same rule as
+//!   a plain enum, one level up: the mirror arrives as `MaybeUninit<mirror>`,
+//!   its leading `c_int` tag is range-checked against the variants, and only
+//!   then is the value `assume_init`ed and matched. Every payload wire is
+//!   bit-pattern-agnostic (a declared `enum_type` payload rides as
+//!   `MaybeUninit` too, and is validated by its own converter), so the tag is
+//!   the sole obligation. The typed drop checks it as well and treats an
+//!   out-of-range one as nothing to release.
 //! * **Direct `String` output**: a bare `char *` — a `malloc`'d, null-terminated
 //!   raw block (no wrapper struct), freed via the `free_memory_function`.
 //! * **[`Cbindgen::free_memory_function`]**: the single, type-agnostic raw memory

--- a/prebindgen/src/api/lang/cbindgen/selector.rs
+++ b/prebindgen/src/api/lang/cbindgen/selector.rs
@@ -15,6 +15,7 @@ impl Cbindgen {
             .or_else(|| self.in_data_struct(ty, registry))
             .or_else(|| self.in_value_opaque(ty, registry))
             .or_else(|| self.in_enum(ty, registry))
+            .or_else(|| self.in_tagged_union(ty, registry))
             .or_else(|| self.in_string(ty))
             .or_else(|| self.in_str(ty))
             .or_else(|| self.in_scalar(ty))

--- a/prebindgen/src/api/lang/cbindgen/tests/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/mod.rs
@@ -8,6 +8,7 @@ mod inputs;
 mod lowering;
 mod returns;
 mod structs;
+mod tagged_unions;
 
 fn write(cbindgen: Cbindgen, registry: Registry<()>, tag: &str) -> String {
     let dir = unique_test_dir(&format!("cbindgen_{tag}"));

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -55,7 +55,8 @@ fn tagged_union_mirror_and_converters() {
         .enum_type(syn::parse_quote!(Operation))
         .tagged_union(syn::parse_quote!(Shape))
         .function(syn::parse_quote!(shape_new))
-        .function(syn::parse_quote!(shape_area));
+        .function(syn::parse_quote!(shape_area))
+        .panic();
 
     let src = write(cbindgen, registry, "tagged_union");
     let compact: String = src.split_whitespace().collect();
@@ -65,9 +66,11 @@ fn tagged_union_mirror_and_converters() {
     assert!(compact.contains("Empty,"), "{src}");
     assert!(compact.contains("Circle(f64),"), "{src}");
     assert!(compact.contains("Rect{width:f64,height:f64},"), "{src}");
-    // The owning payload lowers to `char *`; the declared enum to its C enum.
+    // The owning payload lowers to `char *`; the declared enum to its C enum
+    // behind `MaybeUninit`, so no payload wire constrains the bit patterns the
+    // mirror may legally hold — leaving the tag as the only thing to validate.
     assert!(
-        compact.contains("Labeled(*mut::core::ffi::c_char,operation_t),"),
+        compact.contains("Labeled(*mut::core::ffi::c_char,::core::mem::MaybeUninit<operation_t>),"),
         "{src}"
     );
 
@@ -81,16 +84,42 @@ fn tagged_union_mirror_and_converters() {
         "{src}"
     );
     assert!(
-        compact.contains("shape_t::Labeled(__cbg_alloc_cstr(__f0),__cbg_out_Operation(__f1))"),
+        compact.contains("shape_t::Labeled(__cbg_alloc_cstr(__f0),"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),"),
         "{src}"
     );
 
-    // Input: the same match in reverse, through the same per-field policy.
+    // Input: the same match in reverse, through the same per-field policy —
+    // but only after the C-supplied tag has been range-checked, and the enum
+    // payload's own validating decode propagates with `?`.
+    assert!(
+        compact.contains("fn__cbg_in_Shape(v:::core::mem::MaybeUninit<shape_t>,)"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("let__tag:::core::ffi::c_int=::core::ptr::read(v.as_ptr()"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("if!((__tagasi64)>=0&&(__tagasi64)<4i64)"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("invalidtag{}for`shape_t`(expected0..4)"),
+        "{src}"
+    );
+    assert!(compact.contains("letv=v.assume_init();"), "{src}");
     assert!(
         compact.contains("shape_t::Empty=>example_flat::Shape::Empty,"),
         "{src}"
     );
-    assert!(compact.contains("__cbg_in_Operation(__f1),"), "{src}");
+    assert!(compact.contains("__cbg_in_Operation(__f1)?,"), "{src}");
+    // A union taken by value is a fallible input like any other: with no
+    // `Result` channel the declaration had to opt into aborting.
+    assert!(compact.contains("panic!("), "{src}");
 }
 
 /// An owning payload gets a typed drop that frees the **active arm** and nulls
@@ -123,10 +152,17 @@ fn owning_payload_gets_typed_drop() {
     let src = write(cbindgen, registry, "tagged_union_drop");
     let compact: String = src.split_whitespace().collect();
 
+    // The drop is a second C entry point into the same bytes, so it checks the
+    // tag too — and ignores an out-of-range one rather than matching on it.
     assert!(
-        compact.contains("pubunsafeextern\"C\"fnshape_drop(this_:*mutshape_t)"),
+        compact.contains("fnshape_drop(this_:*mut::core::mem::MaybeUninit<shape_t>)"),
         "{src}"
     );
+    assert!(
+        compact.contains("if!((__tagasi64)>=0&&(__tagasi64)<4i64){return;}"),
+        "{src}"
+    );
+    assert!(compact.contains("match(*this_).assume_init_mut()"), "{src}");
     assert!(compact.contains("shape_t::Labeled(__f0,__f1)=>{"), "{src}");
     assert!(
         compact.contains("free(*__f0as*mut::core::ffi::c_void);"),
@@ -203,14 +239,65 @@ fn tagged_union_as_data_struct_field() {
         .enum_type(syn::parse_quote!(Operation))
         .tagged_union(syn::parse_quote!(Shape))
         .data_struct(syn::parse_quote!(Drawing))
-        .function(syn::parse_quote!(drawing_new));
+        .function(syn::parse_quote!(drawing_new))
+        .panic();
 
     let src = write(cbindgen, registry, "tagged_union_field");
     let compact: String = src.split_whitespace().collect();
 
-    assert!(compact.contains("pubshape:shape_t,"), "{src}");
-    assert!(compact.contains("shape:__cbg_in_Shape(v.shape),"), "{src}");
+    // One mirror field type serves both directions, so it is the wire the
+    // inbound side needs — the union's tag is C's until it is checked.
+    assert!(
+        compact.contains("pubshape:::core::mem::MaybeUninit<shape_t>,"),
+        "{src}"
+    );
+    // The field's decode carries the union's fallibility up into the struct's,
+    // so a bad tag in a nested union cannot be silently skipped.
+    assert!(compact.contains("shape:__cbg_in_Shape(v.shape)?,"), "{src}");
+    assert!(
+        compact.contains("fn__cbg_in_Drawing(v:drawing_t,)->::core::result::Result<"),
+        "{src}"
+    );
     assert!(compact.contains("shape:__cbg_out_Shape(v.shape),"), "{src}");
+}
+
+/// A data struct of plain fields keeps its **infallible** decode — only a
+/// union field makes the struct's own conversion able to fail.
+#[test]
+fn plain_data_struct_decode_stays_infallible() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        pub struct Label {
+            pub id: u64,
+            pub text: String,
+        }
+    );
+    let f: syn::ItemFn = syn::parse_quote!(
+        pub fn label_id(l: Label) -> u64 {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Fn(f), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .data_struct(syn::parse_quote!(Label))
+        .function(syn::parse_quote!(label_id));
+
+    let src = write(cbindgen, registry, "plain_data_struct");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("fn__cbg_in_Label(v:label_t)->example_flat::Label"),
+        "{src}"
+    );
+    assert!(!compact.contains("panic!("), "{src}");
 }
 
 /// The two enum declarators are shape-exclusive in both directions, and each

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -382,3 +382,62 @@ fn unsupported_payload_is_a_generation_error() {
     };
     assert!(catch(boom));
 }
+
+/// An opaque-pointer payload is a raw pointer on the wire, so a C caller can
+/// leave it NULL — and the typed drop *nulls the arm it frees*, so a union
+/// passed back in after being dropped arrives exactly that way. A bare
+/// `Box<T>` has no null representation, so the decode reports it instead of
+/// constructing an invalid `Box`; the `Option<Box<T>>` form maps NULL to
+/// `None`, which is what that shape is for.
+#[test]
+fn null_opaque_payload_is_reported_not_materialised() {
+    let loc = SourceLocation::default();
+    let e: syn::ItemEnum = syn::parse_quote!(
+        pub enum Slot {
+            Empty,
+            Filled(Box<Blob>),
+            Maybe(Option<Box<Blob>>),
+        }
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn slot_new() -> Slot {
+            unimplemented!()
+        }
+    );
+    let take: syn::ItemFn = syn::parse_quote!(
+        pub fn slot_take(s: Slot) -> u64 {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Enum(e), loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+        (syn::Item::Fn(take), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .opaque_ptr(syn::parse_quote!(Blob))
+        .tagged_union(syn::parse_quote!(Slot))
+        .function(syn::parse_quote!(slot_new))
+        .function(syn::parse_quote!(slot_take))
+        .panic();
+
+    let src = write(cbindgen, registry, "tagged_union_null_payload");
+    let compact: String = src.split_whitespace().collect();
+
+    // The bare `Box` arm checks before boxing, and names why.
+    assert!(
+        compact.contains("if__f0.is_null(){return::core::result::Result::Err("),
+        "{src}"
+    );
+    assert!(compact.contains("nullpayloadfor`Blob`"), "{src}");
+    // The `Option` arm keeps NULL as a legitimate value.
+    assert!(
+        compact.contains("if__f0.is_null(){::core::option::Option::None}"),
+        "{src}"
+    );
+}

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -1,0 +1,297 @@
+use super::*;
+
+/// The running example: every variant shape a sum can take, including an
+/// owning payload (`String` → `char *`) beside a declared-`enum_type` payload.
+fn shape_enum() -> syn::ItemEnum {
+    syn::parse_quote!(
+        pub enum Shape {
+            Empty,
+            Circle(f64),
+            Rect { width: f64, height: f64 },
+            Labeled(String, Operation),
+        }
+    )
+}
+
+fn operation_enum() -> syn::ItemEnum {
+    syn::parse_quote!(
+        pub enum Operation {
+            Add = 0,
+            Sub = 1,
+        }
+    )
+}
+
+/// A tagged union crosses by value as a `#[repr(C)]` enum with payload
+/// variants — the mirror cbindgen renders as a C tag + `union`. Variant shape
+/// is preserved (unit stays unit, tuple stays tuple, named stays named) and
+/// each payload takes its own wire.
+#[test]
+fn tagged_union_mirror_and_converters() {
+    let loc = SourceLocation::default();
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn shape_new() -> Shape {
+            unimplemented!()
+        }
+    );
+    let take: syn::ItemFn = syn::parse_quote!(
+        pub fn shape_area(s: Shape) -> f64 {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Enum(shape_enum()), loc.clone()),
+        (syn::Item::Enum(operation_enum()), loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+        (syn::Item::Fn(take), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .enum_type(syn::parse_quote!(Operation))
+        .tagged_union(syn::parse_quote!(Shape))
+        .function(syn::parse_quote!(shape_new))
+        .function(syn::parse_quote!(shape_area));
+
+    let src = write(cbindgen, registry, "tagged_union");
+    let compact: String = src.split_whitespace().collect();
+
+    // The mirror: one variant per alternative, each keeping its own shape.
+    assert!(compact.contains("pubenumshape_t{"), "{src}");
+    assert!(compact.contains("Empty,"), "{src}");
+    assert!(compact.contains("Circle(f64),"), "{src}");
+    assert!(compact.contains("Rect{width:f64,height:f64},"), "{src}");
+    // The owning payload lowers to `char *`; the declared enum to its C enum.
+    assert!(
+        compact.contains("Labeled(*mut::core::ffi::c_char,operation_t),"),
+        "{src}"
+    );
+
+    // Output: match the source enum, convert each arm's fields.
+    assert!(
+        compact.contains("example_flat::Shape::Empty=>shape_t::Empty,"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("example_flat::Shape::Circle(__f0)=>shape_t::Circle(__f0),"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("shape_t::Labeled(__cbg_alloc_cstr(__f0),__cbg_out_Operation(__f1))"),
+        "{src}"
+    );
+
+    // Input: the same match in reverse, through the same per-field policy.
+    assert!(
+        compact.contains("shape_t::Empty=>example_flat::Shape::Empty,"),
+        "{src}"
+    );
+    assert!(compact.contains("__cbg_in_Operation(__f1),"), "{src}");
+}
+
+/// An owning payload gets a typed drop that frees the **active arm** and nulls
+/// the freed slot, so a second drop is a no-op. Non-owning arms fall to the
+/// wildcard and free nothing.
+#[test]
+fn owning_payload_gets_typed_drop() {
+    let loc = SourceLocation::default();
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn shape_new() -> Shape {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Enum(shape_enum()), loc.clone()),
+        (syn::Item::Enum(operation_enum()), loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .enum_type(syn::parse_quote!(Operation))
+        .tagged_union(syn::parse_quote!(Shape))
+        .function(syn::parse_quote!(shape_new));
+
+    let src = write(cbindgen, registry, "tagged_union_drop");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("pubunsafeextern\"C\"fnshape_drop(this_:*mutshape_t)"),
+        "{src}"
+    );
+    assert!(compact.contains("shape_t::Labeled(__f0,__f1)=>{"), "{src}");
+    assert!(
+        compact.contains("free(*__f0as*mut::core::ffi::c_void);"),
+        "{src}"
+    );
+    assert!(compact.contains("*__f0=::core::ptr::null_mut();"), "{src}");
+    // The plain-data arms need nothing freed.
+    assert!(compact.contains("_=>{}"), "{src}");
+}
+
+/// A union of plain data owns nothing, so no drop is generated — there is
+/// nothing for the C caller to release.
+#[test]
+fn plain_data_union_has_no_drop() {
+    let loc = SourceLocation::default();
+    let e: syn::ItemEnum = syn::parse_quote!(
+        pub enum Value {
+            Nothing,
+            Int(i64),
+        }
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn value_new() -> Value {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Enum(e), loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .tagged_union(syn::parse_quote!(Value))
+        .function(syn::parse_quote!(value_new));
+
+    let src = write(cbindgen, registry, "tagged_union_plain");
+    assert!(src.contains("pub enum value_t"), "{src}");
+    assert!(!src.contains("value_drop"), "{src}");
+}
+
+/// A sum as a `data_struct` **field** crosses by value as its mirror, and the
+/// struct's converters route the field through the union's own converter.
+#[test]
+fn tagged_union_as_data_struct_field() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        pub struct Drawing {
+            pub id: u64,
+            pub shape: Shape,
+        }
+    );
+    let f: syn::ItemFn = syn::parse_quote!(
+        pub fn drawing_new(id: u64, shape: Shape) -> Drawing {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Enum(shape_enum()), loc.clone()),
+        (syn::Item::Enum(operation_enum()), loc.clone()),
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Fn(f), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .enum_type(syn::parse_quote!(Operation))
+        .tagged_union(syn::parse_quote!(Shape))
+        .data_struct(syn::parse_quote!(Drawing))
+        .function(syn::parse_quote!(drawing_new));
+
+    let src = write(cbindgen, registry, "tagged_union_field");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(compact.contains("pubshape:shape_t,"), "{src}");
+    assert!(compact.contains("shape:__cbg_in_Shape(v.shape),"), "{src}");
+    assert!(compact.contains("shape:__cbg_out_Shape(v.shape),"), "{src}");
+}
+
+/// The two enum declarators are shape-exclusive in both directions, and each
+/// rejection names the declarator to use instead. Neither silently upgrades.
+#[test]
+fn declarators_do_not_accept_each_others_shape() {
+    let loc = SourceLocation::default();
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn shape_new() -> Shape {
+            unimplemented!()
+        }
+    );
+
+    // Payload enum handed to `.enum_type()`.
+    let payload_as_enum = || {
+        let registry = Registry::<()>::from_items([
+            (syn::Item::Enum(shape_enum()), loc.clone()),
+            (syn::Item::Enum(operation_enum()), loc.clone()),
+            (syn::Item::Fn(make.clone()), loc.clone()),
+        ])
+        .expect("index items");
+        let cbindgen = Cbindgen::new()
+            .source_module(syn::parse_quote!(example_flat))
+            .free_memory_function("example_free")
+            .mangle_type_name(|base| format!("{base}_t"))
+            .enum_type(syn::parse_quote!(Shape))
+            .function(syn::parse_quote!(shape_new));
+        let _ = write(cbindgen, registry, "payload_as_enum");
+    };
+    assert!(catch(payload_as_enum));
+
+    // Unit enum handed to `.tagged_union()`.
+    let unit_fn: syn::ItemFn = syn::parse_quote!(
+        pub fn op_new() -> Operation {
+            unimplemented!()
+        }
+    );
+    let unit_as_union = || {
+        let registry = Registry::<()>::from_items([
+            (syn::Item::Enum(operation_enum()), loc.clone()),
+            (syn::Item::Fn(unit_fn.clone()), loc.clone()),
+        ])
+        .expect("index items");
+        let cbindgen = Cbindgen::new()
+            .source_module(syn::parse_quote!(example_flat))
+            .mangle_type_name(|base| format!("{base}_t"))
+            .tagged_union(syn::parse_quote!(Operation))
+            .function(syn::parse_quote!(op_new));
+        let _ = write(cbindgen, registry, "unit_as_union");
+    };
+    assert!(catch(unit_as_union));
+}
+
+/// A payload type outside the supported wire set is a generation error naming
+/// the offending variant field, not a silently wrong wire.
+#[test]
+fn unsupported_payload_is_a_generation_error() {
+    let loc = SourceLocation::default();
+    let e: syn::ItemEnum = syn::parse_quote!(
+        pub enum Weird {
+            Nothing,
+            Odd(Vec<u8>),
+        }
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn weird_new() -> Weird {
+            unimplemented!()
+        }
+    );
+    let boom = || {
+        let registry = Registry::<()>::from_items([
+            (syn::Item::Enum(e.clone()), loc.clone()),
+            (syn::Item::Fn(make.clone()), loc.clone()),
+        ])
+        .expect("index items");
+        let cbindgen = Cbindgen::new()
+            .source_module(syn::parse_quote!(example_flat))
+            .mangle_type_name(|base| format!("{base}_t"))
+            .tagged_union(syn::parse_quote!(Weird))
+            .function(syn::parse_quote!(weird_new));
+        let _ = write(cbindgen, registry, "weird_payload");
+    };
+    assert!(catch(boom));
+}

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -57,6 +57,7 @@ impl Cbindgen {
         let src = self.src_ty(ty);
         let mut inits: Vec<TokenStream> = Vec::new();
         let mut subs: Vec<syn::Type> = Vec::new();
+        let mut fallible = false;
         for (fname, fty) in &fields {
             if is_string(fty) {
                 inits.push(quote!(#fname: if v.#fname.is_null() {
@@ -66,20 +67,35 @@ impl Cbindgen {
                 }));
             } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
                 // A sum field crosses by value as its mirror; its own converter
-                // rebuilds the live arm.
+                // validates the tag and rebuilds the live arm, which is what
+                // makes this whole decode fallible.
                 let conv = Self::in_name(fty);
                 subs.push(fty.clone());
-                inits.push(quote!(#fname: #conv(v.#fname)));
+                fallible = true;
+                inits.push(quote!(#fname: #conv(v.#fname)?));
             } else {
                 inits.push(quote!(#fname: v.#fname));
             }
         }
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name(v: #c_struct) -> #src {
-                #src { #(#inits),* }
-            }
-        );
+        // Only a union field can fail; a struct of strings and scalars keeps
+        // its infallible signature (and its callers keep theirs).
+        let function: syn::ItemFn = if fallible {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(
+                    v: #c_struct,
+                ) -> ::core::result::Result<#src, ::std::string::String> {
+                    ::core::result::Result::Ok(#src { #(#inits),* })
+                }
+            )
+        } else {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(v: #c_struct) -> #src {
+                    #src { #(#inits),* }
+                }
+            )
+        };
         Some(ConverterImpl {
             subs,
             destination: syn::parse_quote!(#c_struct),
@@ -825,16 +841,30 @@ impl Cbindgen {
                 }
             ));
 
-if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
+            if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
                 let drop_ident = self.destructor_symbol(&ty);
+                let n = e.variants.len() as i64;
+                // The drop is a second C entry point into the same bytes, so it
+                // owes the same tag check as the input converter — `&mut *this_`
+                // on an out-of-range tag would be the very UB that check exists
+                // to prevent. Having nowhere to report to, it ignores the value
+                // (there is no live arm to release), which keeps `_drop` the
+                // always-safe no-op it is everywhere else.
                 items.push(syn::parse_quote!(
                     #[no_mangle]
                     #[allow(non_snake_case, unused_variables)]
-                    pub unsafe extern "C" fn #drop_ident(this_: *mut #cname) {
+                    pub unsafe extern "C" fn #drop_ident(
+                        this_: *mut ::core::mem::MaybeUninit<#cname>,
+                    ) {
                         if this_.is_null() {
                             return;
                         }
-                        match &mut *this_ {
+                        let __tag: ::core::ffi::c_int =
+                            ::core::ptr::read((*this_).as_ptr() as *const ::core::ffi::c_int);
+                        if !((__tag as i64) >= 0 && (__tag as i64) < #n) {
+                            return;
+                        }
+                        match (*this_).assume_init_mut() {
                             #(#drop_arms)*
                             _ => {}
                         }
@@ -897,10 +927,23 @@ if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
         )
     }
 
-    /// Tagged-union **input**: `match` the C union back to the source enum,
-    /// converting each arm's payload through the per-field policy. The
-    /// generalization of [`Self::in_enum`] from "match idents" to "match
-    /// idents and convert each arm's fields".
+    /// Tagged-union **input**: **validate the tag**, then `match` the C union
+    /// back to the source enum, converting each arm's payload through the
+    /// per-field policy. The generalization of [`Self::in_enum`] from "match
+    /// idents" to "match idents and convert each arm's fields" — fallible for
+    /// the same reason, and by the same rule (#158): a Rust `enum` must never
+    /// be *materialised* from C-supplied bytes without checking first, because
+    /// an undeclared discriminant is UB at the boundary, before any `match`.
+    ///
+    /// So the wire is [`::core::mem::MaybeUninit`] over the mirror. A
+    /// `#[repr(C)]` enum with payload variants is laid out as a leading
+    /// discriminant of a C `int` followed by the variant union, so the tag is
+    /// read from the front as a plain `c_int` and range-checked against the
+    /// variants (the mirror carries no explicit discriminants, so its tags are
+    /// declaration order `0..N`). Only then is the value `assume_init`ed —
+    /// which is sound because [`Cbindgen::payload_field_wire`] makes every
+    /// payload wire bit-pattern-agnostic, leaving the tag as the sole
+    /// obligation.
     pub(crate) fn in_tagged_union(
         &self,
         ty: &syn::Type,
@@ -942,20 +985,55 @@ if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
                 quote!(#from => #to,)
             })
             .collect();
+        let tag_guard = self.tag_guard(&cname, e.variants.len());
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name(v: #cname) -> #src {
-                match v { #(#arms)* }
+            pub(crate) unsafe fn #name(
+                v: ::core::mem::MaybeUninit<#cname>,
+            ) -> ::core::result::Result<#src, ::std::string::String> {
+                #tag_guard
+                let v = v.assume_init();
+                ::core::result::Result::Ok(match v { #(#arms)* })
             }
         );
         Some(ConverterImpl {
             subs,
-            destination: syn::parse_quote!(#cname),
+            destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
             function,
             pre_stages: vec![],
             niches: Niches::empty(),
             metadata: (),
         })
+    }
+
+    /// The statements that make a C-supplied `MaybeUninit<mirror>` safe to
+    /// `assume_init`: read the leading discriminant as a plain `c_int` and
+    /// reject anything outside `0..variants`. `v` is the `MaybeUninit`
+    /// binding in scope; on rejection the fn returns `Err`.
+    ///
+    /// Shared by the input converter and the typed drop, so a union reached
+    /// through either entry point is checked the same way.
+    fn tag_guard(&self, cname: &syn::Ident, variants: usize) -> TokenStream {
+        let n = variants as i64;
+        let bounds_msg = format!(
+            "`{cname}`: a #[repr(C)] enum with payload variants must be at least as large as \
+             its C `int` discriminant"
+        );
+        let bad_msg = format!("invalid tag {{}} for `{cname}` (expected 0..{variants})");
+        quote!(
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of::<#cname>()
+                        >= ::core::mem::size_of::<::core::ffi::c_int>(),
+                    #bounds_msg
+                );
+            };
+            let __tag: ::core::ffi::c_int =
+                ::core::ptr::read(v.as_ptr() as *const ::core::ffi::c_int);
+            if !((__tag as i64) >= 0 && (__tag as i64) < #n) {
+                return ::core::result::Result::Err(::std::format!(#bad_msg, __tag));
+            }
+        )
     }
 
     /// Tagged-union **output**: `match` the source enum to the C union,
@@ -1001,15 +1079,18 @@ if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
                 quote!(#from => #to,)
             })
             .collect();
+        // Same wire as the input direction — one mirror type serves both, and a
+        // union carried through a `data_struct` field has only one field type
+        // to be. Rust always writes a live arm, so nothing is validated here.
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) fn #name(v: #src) -> #cname {
-                match v { #(#arms)* }
+            pub(crate) fn #name(v: #src) -> ::core::mem::MaybeUninit<#cname> {
+                ::core::mem::MaybeUninit::new(match v { #(#arms)* })
             }
         );
         Some(ConverterImpl {
             subs,
-            destination: syn::parse_quote!(#cname),
+            destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
             function,
             pre_stages: vec![],
             niches: Niches::empty(),
@@ -1029,8 +1110,11 @@ if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
             });
         }
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
+            // The payload rides as `MaybeUninit<enum mirror>` and goes through
+            // the same validating decode a top-level enum parameter does; an
+            // out-of-range one propagates out of the union's own converter.
             let conv = Self::in_name(fty);
-            return quote!(#conv(#b));
+            return quote!(#conv(#b)?);
         }
         if let Some(inner) = opaque_ptr_payload_inner(fty) {
             let src_inner = self.src_ty(&inner);
@@ -1056,7 +1140,7 @@ if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
         }
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
             let conv = Self::out_name(fty);
-            return quote!(#conv(#b));
+            return quote!(::core::mem::MaybeUninit::new(#conv(#b)));
         }
         if let Some(inner) = opaque_ptr_payload_inner(fty) {
             let c = self.c_type_ident(&inner);

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -843,13 +843,15 @@ impl Cbindgen {
 
             if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
                 let drop_ident = self.destructor_symbol(&ty);
-                let n = e.variants.len() as i64;
                 // The drop is a second C entry point into the same bytes, so it
                 // owes the same tag check as the input converter — `&mut *this_`
                 // on an out-of-range tag would be the very UB that check exists
-                // to prevent. Having nowhere to report to, it ignores the value
-                // (there is no live arm to release), which keeps `_drop` the
-                // always-safe no-op it is everywhere else.
+                // to prevent. It emits that check from the same place, and,
+                // having nowhere to report to, ignores the value (there is no
+                // live arm to release), which keeps `_drop` the always-safe
+                // no-op it is everywhere else.
+                let tag_guard =
+                    self.tag_guard(&cname, e.variants.len(), quote!((*this_)), quote!(return;));
                 items.push(syn::parse_quote!(
                     #[no_mangle]
                     #[allow(non_snake_case, unused_variables)]
@@ -859,11 +861,7 @@ impl Cbindgen {
                         if this_.is_null() {
                             return;
                         }
-                        let __tag: ::core::ffi::c_int =
-                            ::core::ptr::read((*this_).as_ptr() as *const ::core::ffi::c_int);
-                        if !((__tag as i64) >= 0 && (__tag as i64) < #n) {
-                            return;
-                        }
+                        #tag_guard
                         match (*this_).assume_init_mut() {
                             #(#drop_arms)*
                             _ => {}
@@ -985,7 +983,16 @@ impl Cbindgen {
                 quote!(#from => #to,)
             })
             .collect();
-        let tag_guard = self.tag_guard(&cname, e.variants.len());
+        let bad_msg = format!(
+            "invalid tag {{}} for `{cname}` (expected 0..{})",
+            e.variants.len()
+        );
+        let tag_guard = self.tag_guard(
+            &cname,
+            e.variants.len(),
+            quote!(v),
+            quote!(return ::core::result::Result::Err(::std::format!(#bad_msg, __tag));),
+        );
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
             pub(crate) unsafe fn #name(
@@ -1008,18 +1015,26 @@ impl Cbindgen {
 
     /// The statements that make a C-supplied `MaybeUninit<mirror>` safe to
     /// `assume_init`: read the leading discriminant as a plain `c_int` and
-    /// reject anything outside `0..variants`. `v` is the `MaybeUninit`
-    /// binding in scope; on rejection the fn returns `Err`.
+    /// reject anything outside `0..variants`.
     ///
-    /// Shared by the input converter; the typed drop performs the same check inline
-    /// (it returns `()` rather than `Result`).
-    fn tag_guard(&self, cname: &syn::Ident, variants: usize) -> TokenStream {
+    /// `slot` is an expression for the `MaybeUninit` in scope and `on_bad` is
+    /// what to do with an out-of-range tag — the **only** thing the two C entry
+    /// points into these bytes differ in (the input converter returns `Err`,
+    /// the typed drop returns `()` and so just bails). Passing that difference
+    /// in, rather than letting the drop repeat the check inline, is what keeps
+    /// the two from drifting apart.
+    fn tag_guard(
+        &self,
+        cname: &syn::Ident,
+        variants: usize,
+        slot: TokenStream,
+        on_bad: TokenStream,
+    ) -> TokenStream {
         let n = variants as i64;
         let bounds_msg = format!(
             "`{cname}`: a #[repr(C)] enum with payload variants must be at least as large as \
              its C `int` discriminant"
         );
-        let bad_msg = format!("invalid tag {{}} for `{cname}` (expected 0..{variants})");
         quote!(
             const _: () = {
                 assert!(
@@ -1029,9 +1044,9 @@ impl Cbindgen {
                 );
             };
             let __tag: ::core::ffi::c_int =
-                ::core::ptr::read(v.as_ptr() as *const ::core::ffi::c_int);
+                ::core::ptr::read(#slot.as_ptr() as *const ::core::ffi::c_int);
             if !((__tag as i64) >= 0 && (__tag as i64) < #n) {
-                return ::core::result::Result::Err(::std::format!(#bad_msg, __tag));
+                #on_bad
             }
         )
     }
@@ -1126,7 +1141,24 @@ impl Cbindgen {
                     ::core::option::Option::Some(#boxed)
                 })
             } else {
-                boxed
+                // A bare `Box<T>` has no null representation, so a NULL slot
+                // cannot be decoded — and it is reachable, not hypothetical:
+                // the typed drop nulls the arm it frees, so a union passed back
+                // in after being dropped arrives here NULL. Same rule as the
+                // tag: report it, never materialise it.
+                let null_msg = format!(
+                    "null payload for `{}` (a non-optional `Box` payload cannot be NULL — the \
+                     union may already have been dropped)",
+                    type_short(&inner)
+                );
+                quote!({
+                    if #b.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_msg),
+                        );
+                    }
+                    #boxed
+                })
             };
         }
         quote!(#b)

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -56,6 +56,7 @@ impl Cbindgen {
         let c_struct = self.c_type_ident(ty);
         let src = self.src_ty(ty);
         let mut inits: Vec<TokenStream> = Vec::new();
+        let mut subs: Vec<syn::Type> = Vec::new();
         for (fname, fty) in &fields {
             if is_string(fty) {
                 inits.push(quote!(#fname: if v.#fname.is_null() {
@@ -63,6 +64,12 @@ impl Cbindgen {
                 } else {
                     ::std::ffi::CStr::from_ptr(v.#fname).to_string_lossy().into_owned()
                 }));
+            } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
+                // A sum field crosses by value as its mirror; its own converter
+                // rebuilds the live arm.
+                let conv = Self::in_name(fty);
+                subs.push(fty.clone());
+                inits.push(quote!(#fname: #conv(v.#fname)));
             } else {
                 inits.push(quote!(#fname: v.#fname));
             }
@@ -74,7 +81,7 @@ impl Cbindgen {
             }
         );
         Some(ConverterImpl {
-            subs: vec![],
+            subs,
             destination: syn::parse_quote!(#c_struct),
             function,
             pre_stages: vec![],
@@ -513,7 +520,7 @@ impl Cbindgen {
             let c_struct = self.c_type_ident(&ty);
             let mut field_defs: Vec<TokenStream> = Vec::new();
             for (fname, fty) in &fields {
-                let wire = c_field_wire(fty).unwrap_or_else(|| {
+                let wire = self.data_field_wire(fty).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
                         fname,
@@ -738,6 +745,335 @@ impl Cbindgen {
         items
     }
 
+    /// Tagged unions: the `#[repr(C)]` mirror with payload variants, which
+    /// cbindgen renders as a tag enum plus a `union` of the variant bodies —
+    /// the idiomatic C tagged union, with no hand-written header fragment.
+    /// Variant shape is mirrored faithfully (named stays named, tuple stays
+    /// tuple, unit stays unit); each payload field takes the wire chosen by
+    /// [`Cbindgen::payload_field_wire`].
+    ///
+    /// A union whose payload wires own memory also gets a typed
+    /// `<base>_drop(t_t *)` that frees the **active arm** and nulls the freed
+    /// slots, so a second drop is a no-op. A union of plain data owns nothing
+    /// and gets no drop.
+    fn prereq_tagged_unions(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+        let mut items: Vec<syn::Item> = Vec::new();
+        for (key, _cfg) in sorted_by_key(&self.tagged_unions) {
+            let ty = key.to_type();
+            if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+                continue;
+            }
+            let Some(e) = enum_item(registry, &ty) else {
+                continue;
+            };
+            assert_payload_enum(e);
+            let cname = self.c_type_ident(&ty);
+
+            let mut variant_defs: Vec<TokenStream> = Vec::new();
+            // Per-variant drop arm, collected only for variants that own
+            // something; the rest fall to a single wildcard arm.
+            let mut drop_arms: Vec<TokenStream> = Vec::new();
+            for v in &e.variants {
+                let vident = &v.ident;
+                let wires: Vec<syn::Type> = v
+                    .fields
+                    .iter()
+                    .map(|f| self.payload_wire_of(&ty, vident, f))
+                    .collect();
+                match &v.fields {
+                    syn::Fields::Unit => variant_defs.push(quote!(#vident)),
+                    syn::Fields::Named(named) => {
+                        let defs = named.named.iter().zip(&wires).map(|(f, w)| {
+                            let n = f.ident.as_ref().expect("named field");
+                            quote!(#n: #w)
+                        });
+                        variant_defs.push(quote!(#vident { #(#defs),* }));
+                    }
+                    syn::Fields::Unnamed(_) => {
+                        variant_defs.push(quote!(#vident(#(#wires),*)));
+                    }
+                }
+
+                // Drop arm: bind every field, free the owning ones.
+                let owning: Vec<(usize, &syn::Field, &syn::Type)> = v
+                    .fields
+                    .iter()
+                    .zip(&wires)
+                    .enumerate()
+                    .filter(|(_, (_, w))| Cbindgen::payload_wire_owns(w))
+                    .map(|(i, (f, w))| (i, f, w))
+                    .collect();
+                if owning.is_empty() {
+                    continue;
+                }
+                let binds: Vec<syn::Ident> = (0..v.fields.len())
+                    .map(|i| format_ident!("__f{}", i))
+                    .collect();
+                let pattern = variant_pattern(&cname, vident, &v.fields, &binds);
+                let frees = owning.iter().map(|(i, f, _)| {
+                    let b = &binds[*i];
+                    self.payload_free_stmt(&f.ty, b)
+                });
+                drop_arms.push(quote!(#pattern => { #(#frees)* }));
+            }
+
+            items.push(syn::parse_quote!(
+                #[repr(C)]
+                #[allow(non_camel_case_types)]
+                pub enum #cname {
+                    #(#variant_defs),*
+                }
+            ));
+
+            if !drop_arms.is_empty() {
+                let drop_ident = self.destructor_symbol(&ty);
+                items.push(syn::parse_quote!(
+                    #[no_mangle]
+                    #[allow(non_snake_case, unused_variables)]
+                    pub unsafe extern "C" fn #drop_ident(this_: *mut #cname) {
+                        if this_.is_null() {
+                            return;
+                        }
+                        match &mut *this_ {
+                            #(#drop_arms)*
+                            _ => {}
+                        }
+                    }
+                ));
+            }
+        }
+        items
+    }
+
+    /// The wire of one payload field, or a generation error naming the
+    /// offending variant field and the supported set.
+    fn payload_wire_of(
+        &self,
+        ty: &syn::Type,
+        variant: &syn::Ident,
+        field: &syn::Field,
+    ) -> syn::Type {
+        self.payload_field_wire(&field.ty).unwrap_or_else(|| {
+            panic!(
+                "Cbindgen::tagged_union: payload `{}::{}{}` has unsupported type `{}` \
+                 (expected a scalar, a `String`, a declared `enum_type`, or an opaque \
+                 pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
+                type_short(ty),
+                variant,
+                match &field.ident {
+                    Some(n) => format!(".{n}"),
+                    None => String::new(),
+                },
+                field.ty.to_token_stream()
+            )
+        })
+    }
+
+    /// Release one owning payload slot held behind `binding` (a `&mut` to the
+    /// wire, from a `match &mut *this_` arm) and null it, so a second drop of
+    /// the same union is a no-op. A `char *` block goes back to the C
+    /// allocator; an opaque pointer is re-boxed and dropped, running the Rust
+    /// destructor.
+    fn payload_free_stmt(&self, fty: &syn::Type, binding: &syn::Ident) -> TokenStream {
+        if is_string(fty) {
+            return quote!(
+                free(*#binding as *mut ::core::ffi::c_void);
+                *#binding = ::core::ptr::null_mut();
+            );
+        }
+        let inner = opaque_ptr_payload_inner(fty).unwrap_or_else(|| {
+            panic!(
+                "Cbindgen::tagged_union: owning payload `{}` is neither a `String` nor an \
+                 opaque pointer",
+                fty.to_token_stream()
+            )
+        });
+        let src_inner = self.src_ty(&inner);
+        quote!(
+            if !(*#binding).is_null() {
+                drop(::std::boxed::Box::from_raw(*#binding as *mut #src_inner));
+                *#binding = ::core::ptr::null_mut();
+            }
+        )
+    }
+
+    /// Tagged-union **input**: `match` the C union back to the source enum,
+    /// converting each arm's payload through the per-field policy. The
+    /// generalization of [`Self::in_enum`] from "match idents" to "match
+    /// idents and convert each arm's fields".
+    pub(crate) fn in_tagged_union(
+        &self,
+        ty: &syn::Type,
+        r: &Registry<()>,
+    ) -> Option<ConverterImpl<()>> {
+        let key = TypeKey::from_type(ty);
+        if !self.tagged_unions.contains_key(&key) {
+            return None;
+        }
+        let e = enum_item(r, ty)?;
+        assert_payload_enum(e);
+        let name = Self::in_name(ty);
+        let cname = self.c_type_ident(ty);
+        let src = self.src_ty(ty);
+        let mut subs: Vec<syn::Type> = Vec::new();
+        let arms: Vec<TokenStream> = e
+            .variants
+            .iter()
+            .map(|v| {
+                let vident = &v.ident;
+                let binds: Vec<syn::Ident> = (0..v.fields.len())
+                    .map(|i| format_ident!("__f{}", i))
+                    .collect();
+                let from = variant_pattern(&cname, vident, &v.fields, &binds);
+                let exprs: Vec<TokenStream> = v
+                    .fields
+                    .iter()
+                    .zip(&binds)
+                    .map(|(f, b)| {
+                        // Payload fields with their own converter (a declared
+                        // `enum_type`) contribute a resolver dependency.
+                        if self.enums.contains_key(&TypeKey::from_type(&f.ty)) {
+                            subs.push(f.ty.clone());
+                        }
+                        self.payload_in_expr(&f.ty, b)
+                    })
+                    .collect();
+                let to = variant_ctor(&src, vident, &v.fields, &exprs);
+                quote!(#from => #to,)
+            })
+            .collect();
+        let function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) unsafe fn #name(v: #cname) -> #src {
+                match v { #(#arms)* }
+            }
+        );
+        Some(ConverterImpl {
+            subs,
+            destination: syn::parse_quote!(#cname),
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
+    /// Tagged-union **output**: `match` the source enum to the C union,
+    /// converting each arm's payload. The counterpart of
+    /// [`Self::in_tagged_union`]; a `String` payload is allocated here and
+    /// released by the union's typed drop.
+    pub(crate) fn out_tagged_union(
+        &self,
+        ty: &syn::Type,
+        r: &Registry<()>,
+    ) -> Option<ConverterImpl<()>> {
+        let key = TypeKey::from_type(ty);
+        if !self.tagged_unions.contains_key(&key) {
+            return None;
+        }
+        let e = enum_item(r, ty)?;
+        assert_payload_enum(e);
+        let name = Self::out_name(ty);
+        let cname = self.c_type_ident(ty);
+        let src = self.src_ty(ty);
+        let mut subs: Vec<syn::Type> = Vec::new();
+        let arms: Vec<TokenStream> = e
+            .variants
+            .iter()
+            .map(|v| {
+                let vident = &v.ident;
+                let binds: Vec<syn::Ident> = (0..v.fields.len())
+                    .map(|i| format_ident!("__f{}", i))
+                    .collect();
+                let from = variant_pattern(&src, vident, &v.fields, &binds);
+                let exprs: Vec<TokenStream> = v
+                    .fields
+                    .iter()
+                    .zip(&binds)
+                    .map(|(f, b)| {
+                        if self.enums.contains_key(&TypeKey::from_type(&f.ty)) {
+                            subs.push(f.ty.clone());
+                        }
+                        self.payload_out_expr(&f.ty, b)
+                    })
+                    .collect();
+                let to = variant_ctor(&cname_ty(&cname), vident, &v.fields, &exprs);
+                quote!(#from => #to,)
+            })
+            .collect();
+        let function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) fn #name(v: #src) -> #cname {
+                match v { #(#arms)* }
+            }
+        );
+        Some(ConverterImpl {
+            subs,
+            destination: syn::parse_quote!(#cname),
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
+    /// One payload field, C wire → Rust value. Mirrors the `data_struct`
+    /// input policy, plus the opaque-pointer and declared-enum cases the
+    /// mirror wire allows.
+    fn payload_in_expr(&self, fty: &syn::Type, b: &syn::Ident) -> TokenStream {
+        if is_string(fty) {
+            return quote!(if #b.is_null() {
+                ::std::string::String::new()
+            } else {
+                ::std::ffi::CStr::from_ptr(#b).to_string_lossy().into_owned()
+            });
+        }
+        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+            let conv = Self::in_name(fty);
+            return quote!(#conv(#b));
+        }
+        if let Some(inner) = opaque_ptr_payload_inner(fty) {
+            let src_inner = self.src_ty(&inner);
+            let boxed = quote!(::std::boxed::Box::from_raw(#b as *mut #src_inner));
+            return if is_option(fty) {
+                quote!(if #b.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    ::core::option::Option::Some(#boxed)
+                })
+            } else {
+                boxed
+            };
+        }
+        quote!(#b)
+    }
+
+    /// One payload field, Rust value → C wire. The `String` arm allocates the
+    /// `char *` block the union's typed drop later frees.
+    fn payload_out_expr(&self, fty: &syn::Type, b: &syn::Ident) -> TokenStream {
+        if is_string(fty) {
+            return quote!(__cbg_alloc_cstr(#b));
+        }
+        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+            let conv = Self::out_name(fty);
+            return quote!(#conv(#b));
+        }
+        if let Some(inner) = opaque_ptr_payload_inner(fty) {
+            let c = self.c_type_ident(&inner);
+            return if is_option(fty) {
+                quote!(match #b {
+                    ::core::option::Option::Some(__b) => {
+                        ::std::boxed::Box::into_raw(__b) as *mut #c
+                    }
+                    ::core::option::Option::None => ::core::ptr::null_mut(),
+                })
+            } else {
+                quote!(::std::boxed::Box::into_raw(#b) as *mut #c)
+            };
+        }
+        quote!(#b)
+    }
+
     /// Callback closure structs: one `#[repr(C)]` `{ context, call, drop }`
     /// per declared signature actually used (its `impl Fn(...)` input
     /// resolved). `call` takes each arg's output wire (the owned handle the
@@ -879,6 +1215,7 @@ impl Prebindgen for Cbindgen {
             .chain(self.data.keys())
             .chain(self.value_opaque.keys())
             .chain(self.enums.keys())
+            .chain(self.tagged_unions.keys())
             .cloned()
             .collect()
     }
@@ -902,6 +1239,7 @@ impl Prebindgen for Cbindgen {
         items.extend(self.prereq_data_structs(registry));
         items.extend(self.prereq_value_opaque(registry));
         items.extend(self.prereq_enums(registry));
+        items.extend(self.prereq_tagged_unions(registry));
         items.extend(self.prereq_callback_structs(registry));
         items.extend(self.prereq_domain_constants(registry));
         items
@@ -1167,9 +1505,14 @@ impl Cbindgen {
             let c_struct = self.c_type_ident(ty);
             let src = self.src_ty(ty);
             let mut inits: Vec<TokenStream> = Vec::new();
+            let mut subs: Vec<syn::Type> = Vec::new();
             for (fname, fty) in &fields {
                 if is_string(fty) {
                     inits.push(quote!(#fname: __cbg_alloc_cstr(v.#fname)));
+                } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
+                    let conv = Self::out_name(fty);
+                    subs.push(fty.clone());
+                    inits.push(quote!(#fname: #conv(v.#fname)));
                 } else {
                     inits.push(quote!(#fname: v.#fname));
                 }
@@ -1181,7 +1524,7 @@ impl Cbindgen {
                 }
             );
             return Some(ConverterImpl {
-                subs: vec![],
+                subs,
                 destination: syn::parse_quote!(#c_struct),
                 function,
                 pre_stages: vec![],
@@ -1238,6 +1581,12 @@ impl Cbindgen {
                 niches: Niches::empty(),
                 metadata: (),
             });
+        }
+
+        // Tagged-union output: `match` the source enum to the C union,
+        // converting each arm's payload.
+        if let Some(c) = self.out_tagged_union(ty, _r) {
+            return Some(c);
         }
 
         None

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -825,7 +825,7 @@ impl Cbindgen {
                 }
             ));
 
-            if !drop_arms.is_empty() {
+if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
                 let drop_ident = self.destructor_symbol(&ty);
                 items.push(syn::parse_quote!(
                     #[no_mangle]

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1011,8 +1011,8 @@ impl Cbindgen {
     /// reject anything outside `0..variants`. `v` is the `MaybeUninit`
     /// binding in scope; on rejection the fn returns `Err`.
     ///
-    /// Shared by the input converter and the typed drop, so a union reached
-    /// through either entry point is checked the same way.
+    /// Shared by the input converter; the typed drop performs the same check inline
+    /// (it returns `()` rather than `Result`).
     fn tag_guard(&self, cname: &syn::Ident, variants: usize) -> TokenStream {
         let n = variants as i64;
         let bounds_msg = format!(


### PR DESCRIPTION
Stage **B** of the sum-type work (umbrella #152, issue #147). Design: `docs/sum-types.md` §5.

**Rebased and unblocked.** #158 called this PR's lowering out as undefined behaviour, and it was
right. It is now stacked on **#163**, which fixes the same defect for the pre-existing plain-enum
case, and the second commit here applies that rule to the union tag. So the stack is
`sum-types` ← #153 (A, now also carrying C+D+E) ← #163 ← **this**, and everything still reaches
`main` through the umbrella. Review the last commit.

## What it does

A data-carrying `#[prebindgen]` enum crosses the C boundary **by value as a tagged union**: a
`#[repr(C)]` enum with payload variants, which cbindgen `=0.29.4` renders as a tag enum plus a `union`
of the variant bodies. No hand-written header fragment, no accessor-function simulation.

```rust
pub enum Shape { Empty, Circle(f64), Rect { width: f64, height: f64 }, Labeled(String, Operation) }
```

```c
typedef enum shape_t_Tag { Empty, Circle, Rect, Labeled } shape_t_Tag;
typedef struct Rect_Body    { double width; double height; } Rect_Body;
typedef struct Labeled_Body { char *_0; enum operation_t _1; } Labeled_Body;
typedef struct shape_t {
  shape_t_Tag tag;
  union { struct { double circle; }; Rect_Body rect; Labeled_Body labeled; };
} shape_t;
void shape_drop(struct shape_t *this_);
```

## Change

- **`.tagged_union(ty)`** beside `.enum_type(ty)`, wired into the three places every declarator
  touches: the already-declared guard, the universal `.base_name()` override, and the `CurrentDecl`
  cursor for error messages. The two enum declarators are shape-exclusive **in both directions** and
  each rejection names the other — a payload enum in `.enum_type()` says "use `.tagged_union()`", a
  unit enum in `.tagged_union()` says "use `.enum_type()`". No silent upgrade either way.
- **`prereq_tagged_unions`** emits the mirror, keeping each variant's own shape (unit stays unit,
  tuple stays tuple, named stays named). Payload wires come from `payload_field_wire`: the
  `mirror_field_wire` policy (scalar, declared `enum_type`, opaque pointer `Option<Box<T>>`/`Box<T>`)
  extended with `String` → `char *`. A `repr_c_struct` mirror is reinterpreted wholesale by one
  `Transmute`; a union is rebuilt **arm by arm**, and that is what lets `String` join the set.
- **`in_tagged_union` / `out_tagged_union`** generalize `in_enum` / `out_enum` from "match idents" to
  "match idents and convert each arm's fields", through the per-field converters the resolver
  produced (a declared-enum payload registers as a `sub`) — **and inbound, from "validate the
  discriminant" to "validate the tag"** (below).
- **Ownership.** When any payload wire owns memory, a typed `<base>_drop` frees the **active arm** and
  nulls the freed slot, so a second drop is a no-op. A union of plain data owns nothing and gets no
  drop at all. `needs_free` accounts for a `String` payload.
- **Sum as a `data_struct` field.** Crosses by value as its mirror; the struct's converters route it
  through the union's own converter. The struct keeps its existing contract — no per-struct
  destructor, each owning field released individually, here through the union's typed drop.

## The #158 fix, applied to the tag

A `#[repr(C)]` payload enum received by value materialises whatever tag the caller wrote, before
`in_tagged_union`'s `match` can look — so §3's locked invalid-tag rule ("a binding error through the
error channel… never a panic across the boundary") was unimplementable in the shape this PR first had.

The wire is now `MaybeUninit<mirror>`, the same instrument #163 uses. The Rust reference lays a
`#[repr(C)]` payload enum out as a leading C-`int` discriminant followed by the variant union — the
same layout cbindgen relies on to render the tag + `union` — so the tag is read from the front as a
plain `c_int` and range-checked against the variant count, and only then is the value `assume_init`ed.

**That `assume_init` is sound because every payload wire is bit-pattern-agnostic**, which is what makes
this a fix rather than a smaller hole: scalars and raw pointers hold any bits legally, and a declared
`enum_type` payload now rides as `MaybeUninit<enum mirror>` too, decoded by #163's validating converter
and propagated with `?`. The tag is the *sole* remaining obligation, and it is discharged.

Two more entry points into the same bytes, closed with it:

- **the union as a `data_struct` field** — one mirror struct serves both directions, so the field is
  `MaybeUninit<mirror>` and the struct's decode becomes fallible, carrying the nested union's tag check
  up rather than skipping it. A struct of scalars and strings keeps its infallible decode.
- **the typed `_drop`** — where `match &mut *this_` on an out-of-range tag is the very UB being
  prevented. It checks the tag and treats a bad one as nothing to release, keeping `_drop` the
  always-safe no-op it is everywhere else.

**The C surface is unchanged by this.** cbindgen simplifies `MaybeUninit<T>` to `T`, so `struct
shape_t`, `enum operation_t _1` inside `Labeled_Body`, and every prototype render exactly as the
goldens above already show. The only header movement is the new `shape_try_area`.

The consequence is the one #163 introduced, one level up: a union taken by value is a fallible input.
`shape_area` / `shape_get_label` / `drawing_new` / `drawing_get_shape` move to the `.panic()` group,
and `example-flat` gains **`shape_try_area`** — the same union input on a `Result`-returning function,
so the rejection is observable instead of abortive.

## Coverage (in this PR)

- `example-flat` gains `Shape` (all four variant shapes, including an owning tuple arm carrying a
  `String` beside a declared enum) and `Drawing { id, shape }`, plus functions putting the sum in
  every position: returned, taken by value as a parameter, and carried through a struct field.
- `example-cbindgen` declares them; `generated/` and `include/` goldens regenerated for **both**
  architectures (aarch64 via `cargo check --target aarch64-unknown-linux-gnu`, so it is no longer
  stale in this PR — it remains the CI blind spot).
- **`c/smoke.c` + a `run_smoke` CMake target** — constructs and reads every arm, exercises every
  position, and checks that `shape_drop` frees the active arm, no-ops on a second call and on a plain
  arm, and tolerates NULL. Plus **`test_invalid_tag`**: writes tags `99` and `-1` into the raw bytes
  (no valid `shape_t` has them), asserts `shape_try_area` reports each through `char **e` naming the
  value, asserts the domain error still comes through that same channel unchanged, and calls
  `shape_drop` on a bad-tagged value. **Those calls are only writable because of the fix** — against
  the original signature, constructing that argument was UB. Runs green:
  `PASS - tagged union: every arm, every position, drop, invalid tag`.
- Seven adapter lib tests: mirror shape + payload wires, both converters (including the tag guard, the
  `assume_init`, and the enum payload's `?`), the drop rule and its tag check, the plain-data no-drop
  case, the struct-field position and its inherited fallibility, both declarator rejections, an
  unsupported payload type, and one pinning that a plain data struct's decode stays infallible.

## Verification

`cargo test --all --all-features` (378 lib tests), `./examples/regen-check.sh` clean, the C smoke
test green, `cargo fmt --check` and `clippy --all-targets --no-default-features --all-features
--deny warnings` clean. Both arch goldens regenerated.

## Still open from #158

**Part 2 — the payload wire policy.** `payload_field_wire` still derives from the layout-preserving
`mirror_field_wire`, so a nested `data_struct`, a direct opaque handle, and a converted leaf
(`Duration` → `u64`) are rejected even though §5 promises them and zenoh-flat#30's `ReplyResult` needs
nested structs. Part 1 decides *whether* the union is safe to read; part 2 decides what goes in each
arm. They were bundled on #158 because both rewrite these converters — but part 1 was the blocker, it
is done, and part 2 changes no signature this PR establishes, so it is better as its own change than as
more diff here.

**Instance 3 — `repr_c_struct` mirror enum fields**, also recorded on #158 and also pre-existing: a
mirror is reinterpreted wholesale by `Transmute`, so no converter is involved and neither this fix nor
#163's has anywhere to hook in. Its own change.

## Notes

cbindgen's `[enum]` section controls the rendered variant/body naming — e.g. `prefix_with_name` would
namespace the constants as `shape_t_Empty`. This example deliberately keeps cbindgen's defaults so
the committed goldens document exactly what they produce; a note to that effect is in
`example-cbindgen/cbindgen.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

