### PR TITLE
Stage D — jnigen: tag-gated variant groups on the flatten paths (#149)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -15,9 +15,9 @@ A source crate cannot currently express "exactly one of these alternatives". Bot
 payload variants outright:
 
 - `lang::Cbindgen` — `assert_unit_variants` guards the mirror emission and both converters
-  (`src/api/lang/cbindgen/trait_impl.rs:231`, `:660`, `:1159`).
+  (`prebindgen/src/api/lang/cbindgen/trait_impl.rs:231`, `:660`, `:1159`).
 - `lang::JniGen` — `enum_class!`'s contract is "the enum must be unit-variant only"
-  (`src/api/lang/jnigen/jni/decl.rs:739-748`).
+  (`prebindgen/src/api/lang/jnigen/jni/decl.rs:739-748`).
 
 So authors encode sums as products and demote the invariant to prose. Two live examples in
 zenoh-flat:
@@ -71,14 +71,15 @@ Two facts make this cheap to build:
 
 1. **The type graph already walks variant payloads.** `Registry::scan_enum` and
    `Registry::immediate_edges` register every variant field type in both directions
-   (`src/api/core/registry.rs:1177-1189`, `:1285-1292`), so payload converters resolve with no core
-   change.
+   (`prebindgen/src/api/core/registry.rs:1177-1189`, `:1285-1292`), so payload converters
+   resolve with no core change.
 2. **Both directions already gate leaf groups — with `N = 1`.** An `Option<Struct>` input crosses as
    a synthetic `present: Boolean` plus field slots that are wire-defaulted when absent
-   (`FlatLeaf::is_present_flag`, `src/api/lang/jnigen/jni/emit/flat_input.rs:306`); an
+   (`FlatLeaf::is_present_flag`, `prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs:306`); an
    `Option<nested>` output does the same in the `fromParts` bridge
-   (`PlanFieldKind::Nested { optional }`, `src/api/lang/jnigen/jni/struct_plan.rs:66`). A sum is that
-   mechanism with an `Int` tag instead of a `Boolean` flag and `N` groups instead of one.
+   (`PlanFieldKind::Nested { optional }`,
+   `prebindgen/src/api/lang/jnigen/jni/struct_plan.rs:66`). A sum is that mechanism with an `Int`
+   tag instead of a `Boolean` flag and `N` groups instead of one.
 
 ### Chosen lowering: flattened, always
 
@@ -88,16 +89,16 @@ Rust-side. Rejected alternative: give the sum an ordinary terminal converter wit
 in every position immediately, but it reintroduces the per-crossing JVM object and per-field JNI
 reflection that this codebase deliberately removed (the `fromParts` flattening was worth 2.4×,
 leaf folds 3–8×), and it would force an exemption to the rule that a data class flattens *completely*
-or generation fails (`src/api/lang/jnigen/jni/decl.rs:814-819`). `ReplyStruct` is on the
+or generation fails (`prebindgen/src/api/lang/jnigen/jni/decl.rs:814-819`). `ReplyStruct` is on the
 per-message path, so the slow shape would not have survived anyway.
 
 ## 3. Locked decisions
 
 | Decision | Rule |
 |---|---|
-| **Tag numbering** | Declaration order, `0..N-1`. Payload enums carry no `repr` — a `repr` is a wire detail the neutral tier must not name. Unit enums keep explicit-discriminant support through `enum_discriminant_values` (`src/api/lang/jnigen/util.rs:98`), which **moves into core** so both adapters share one implementation instead of two. |
-| **Leaf naming** | Variant field leaf = `<variant_snake>_<field>`, matching the existing nested-prefix convention (`payload_id` for the nested field `payload.id`). Tuple field ⇒ `<variant_snake>_0`. The synthetic tag leaf = `<field>__tag`, using the same double-underscore marker as the existing `<field>__present` gate. Core `DeconSpec` leaf names keep their `__` chain separator. |
-| **Kotlin surface** | `sealed interface E` with the variant classes **nested inside it** — `data class PeriodicQueries(val period: Long) : E`, `data object Heartbeat : E` — so variant names cannot collide package-wide. Tuple payload fields are named `v0`, `v1`, …. A `fromParts(tag, …)` companion on the interface reassembles from the tag + slots. |
+| **Tag numbering** | Declaration order, `0..N-1`. Payload enums carry no `repr` — a `repr` is a wire detail the neutral tier must not name. Unit enums keep explicit-discriminant support through `enum_discriminant_values` (`prebindgen/src/api/lang/jnigen/util.rs:98`), which **moves into core** so both adapters share one implementation instead of two. |
+| **Leaf naming** | A variant field's **wire slot** = `<variantCamel>_<property>` (`range_low`, `exact_v0`), matching the existing nested-prefix convention (`payload_id` for the nested field `payload.id`). It is keyed on the **Kotlin** variant name, so a `variant!(V).name(...)` rename carries through to the slots. Under a parent field the slot is prefixed with it (`mode_periodicQueries_period`) and the synthetic tag leaf is `<field>__tag`, using the same double-underscore marker as the existing `<field>__present` gate; standing alone (a sum in return position) the tag leaf is just `tag`. Core's neutral `SumField::name` (`<variant_snake>_<field>`, tuple ⇒ `<variant_snake>_0`) is a language-agnostic label an adapter may ignore — the JNI wire slot is the rule above. Core `DeconSpec` leaf names keep their `__` chain separator. |
+| **Kotlin surface** | `sealed interface E` with the variant classes **nested inside it** — `data class PeriodicQueries(val period: Long) : E`, `data object Heartbeat : E` — so variant names cannot collide package-wide. A named payload field keeps its camelCased name; tuple payload fields are named `v0`, `v1`, … (so a tuple variant `Exact(i64)` surfaces as `data class Exact(val v0: Long)` with the slot `exact_v0`). A `fromParts(tag, …)` companion on the interface reassembles from the tag + slots. |
 | **Unit-only enums** | Unchanged path. Handing a payload enum to `enum_class!` / `.enum_type()` is a **hard error** naming `sealed_class!` / `.tagged_union()` — no silent upgrade, matching the "invalid = ERROR" declaration policy. |
 | **Handle payloads** | Allowed. `ReplyResult` (flat #30) needs them: `SampleStruct` carries `KeyExpr`, `ZBytes`, `Encoding`. A tag-gated handle leaf reuses `FlatLeaf::handle_nullable`, which already means "gated by an optional ancestor" (`flat_input.rs:315-317`), and joins the existing N-ary `withSortedHandleLocks` collection unchanged. |
 | **Optionality** | `Option<E>` keeps its own present-flag gate; the tag domain is never overloaded with a `-1 = absent`. Optionality and choice are independent facts and stay independent leaves. |
@@ -110,8 +111,8 @@ Running example:
 
 ```rust
 pub enum RecoveryMode {
-    PeriodicQueries(Duration),   // tag 0
-    Heartbeat,                   // tag 1
+    PeriodicQueries { period: Duration },   // tag 0
+    Heartbeat,                              // tag 1
 }
 pub struct RecoveryConfig {
     pub mode: Option<RecoveryMode>,
@@ -123,10 +124,14 @@ pub struct RecoveryConfig {
 
 ```rust
 .package(package!("io.zenoh.jni")
-    .class(sealed_class!(RecoveryMode)
-        .variant(variant!(PeriodicQueries).name("Periodic")))   // optional per-variant rename
+    .class(sealed_class!(RecoveryMode))
     .class(data_class!(RecoveryConfig)))
 ```
+
+A per-variant `.variant(variant!(V).name("…"))` renames the emitted class **and every slot derived
+from it**, so the surface stays self-consistent; the running example below keeps the source names so
+each snippet reads as one contract. `examples/covertest-kotlin` exercises the rename
+(`variant!(Labeled).name("Tagged")` ⇒ the class `Tagged` and the slots `tagged_v0` / `tagged_v1`).
 
 `sealed_class!(E)` is a fifth class kind beside `ptr_class!` / `data_class!` / `enum_class!` /
 `value_class!`: one simple argument, sub-builder, `.name()`, per-variant `.variant(variant!(V))`, and
@@ -180,15 +185,15 @@ public data class RecoveryConfig(val mode: RecoveryMode?, val retentionPeriod: L
 ### 4.3 Output path (Rust → Kotlin)
 
 `PlanFieldKind::Sum { tag_slot, variants }` joins the shared bridge plan
-(`src/api/lang/jnigen/jni/struct_plan.rs`). The Rust encoder emits **one `match`** binding the tag
-and every slot, inert slots filled by the existing `primitive_default_for_descriptor`
-(`src/api/lang/jnigen/jni/emit/struct_out.rs:51`):
+(`prebindgen/src/api/lang/jnigen/jni/struct_plan.rs`). The Rust encoder emits **one `match`**
+binding the tag and every slot, inert slots filled by the existing
+`primitive_default_for_descriptor` (`prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs:51`):
 
 ```rust
 let (mode__present, mode__tag, mode_periodic_queries_period) = match &v.mode {
     None => (false, 0i32, 0i64),
-    Some(RecoveryMode::PeriodicQueries(p)) => (true, 0i32, __out_Duration(p.clone())),
-    Some(RecoveryMode::Heartbeat)          => (true, 1i32, 0i64),
+    Some(RecoveryMode::PeriodicQueries { period }) => (true, 0i32, __out_Duration(period.clone())),
+    Some(RecoveryMode::Heartbeat)                 => (true, 1i32, 0i64),
 };
 ```
 
@@ -198,9 +203,10 @@ for the sum, and both sides enumerate the same slots in the same order because b
 
 ### 4.4 Input path (Kotlin → Rust)
 
-`FlatFieldNode::Sum` joins `Value` / `Nested` (`src/api/lang/jnigen/jni/emit/flat_input.rs:349`), and
-`FlatInputPlan.root` generalizes from `FlatStructNode` to a struct-or-sum root so a **sum-typed
-parameter** flattens too. Extern signature:
+`FlatFieldNode::Sum` joins `Value` / `Nested`
+(`prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs:349`), and `FlatInputPlan.root` generalizes
+from `FlatStructNode` to a struct-or-sum root so a **sum-typed parameter** flattens too. Extern
+signature:
 
 ```kotlin
 external fun sessionDeclareAdvancedSubscriber(
@@ -220,7 +226,7 @@ Rust reconstruct, with an invalid tag going to the binding-error channel rather 
 ```rust
 let mode = if mode_present {
     Some(match mode_tag {
-        0 => RecoveryMode::PeriodicQueries(__in_Duration(mode_periodic_queries_period)),
+        0 => RecoveryMode::PeriodicQueries { period: __in_Duration(mode_periodic_queries_period) },
         1 => RecoveryMode::Heartbeat,
         t => return __jni_err(env, error_sink, format!("RecoveryMode: invalid tag {t}")),
     })
@@ -249,11 +255,12 @@ recoveryModeTag = when (recovery?.mode) {
 
 A sum returned by a function (or delivered as a callback argument) is the one position that needs
 core work, because `api/core/unfold.rs` is a deterministic **product** — "every record always runs
-and contributes its leaf … there is no selector" (`src/api/core/unfold.rs:8-11`). It gains one:
+and contributes its leaf … there is no selector" (`prebindgen/src/api/core/unfold.rs:8-11`). It
+gains one:
 
 - `LeafSource::VariantField { variant, member }` beside `Accessor` / `Field`
-  (`src/api/core/unfold/plan.rs`), so a leaf can be reached through a variant pattern rather
-  than a field chain, plus `LeafSource::SumTag` for the synthesized selector.
+  (`prebindgen/src/api/core/unfold/plan.rs`), so a leaf can be reached through a variant pattern
+  rather than a field chain, plus `LeafSource::SumTag` for the synthesized selector.
 - Per-leaf group membership (`UnfoldLeaf::group`), so the Rust emitter emits one `match` over
   the value instead of independent per-leaf expressions. The tag leaf is the one leaf with **no
   converter** (`UnfoldLeaf::has_converter()`): it is assigned per arm, so requiring an output
@@ -266,7 +273,7 @@ and contributes its leaf … there is no selector" (`src/api/core/unfold.rs:8-11
   bare type.
 
 `Option` / `Vec` layers need nothing new — they ride the existing `Shape` fold
-(`src/api/core/shape.rs`), same as for a data class.
+(`prebindgen/src/api/core/shape.rs`), same as for a data class.
 
 **The wire target is the hoisted builder singleton, not `Sum.fromParts`.** §4.2's `fromParts` is the
 Kotlin-facing convenience: its parameters are the variants' **property** types (`Priority`, not the
@@ -309,16 +316,17 @@ Generation errors, each naming the offending path:
 
 ### 5.1 Declaration
 
-`.tagged_union(ty)` beside `.enum_type(ty)` (`src/api/lang/cbindgen/builder.rs:398`), wired into the
-same three places every declarator touches: the already-declared guard (`:306`), the universal
-`.name()` override, and the `CurrentDecl` cursor for error messages (`:701`). `.enum_type()` on a
-payload enum errors with a pointer to it.
+`.tagged_union(ty)` beside `.enum_type(ty)` (`prebindgen/src/api/lang/cbindgen/builder.rs:398`),
+wired into the same three places every declarator touches: the already-declared guard (`:306`), the
+universal `.name()` override, and the `CurrentDecl` cursor for error messages (`:701`).
+`.enum_type()` on a payload enum errors with a pointer to it.
 
 ### 5.2 The mirror type
 
-`prereq_tagged_unions` mirrors `prereq_enums` (`src/api/lang/cbindgen/trait_impl.rs:650`), emitting a
-`#[repr(C)]` enum whose payload fields carry **wire** types chosen by the same `mirror_field_wire`
-policy `data_struct` uses (`trait_impl.rs:513`):
+`prereq_tagged_unions` mirrors `prereq_enums`
+(`prebindgen/src/api/lang/cbindgen/trait_impl.rs:650`), emitting a `#[repr(C)]` enum whose payload
+fields carry **wire** types chosen by the same `mirror_field_wire` policy `data_struct` uses
+(`trait_impl.rs:513`):
 
 ```rust
 #[repr(C)]
@@ -343,7 +351,7 @@ reusing the per-field converters the resolver already produced:
 pub(crate) fn __in_z_recovery_mode_t(v: z_recovery_mode_t) -> RecoveryMode {
     match v {
         z_recovery_mode_t::PeriodicQueries { period } =>
-            RecoveryMode::PeriodicQueries(__in_Duration(period)),
+            RecoveryMode::PeriodicQueries { period: __in_Duration(period) },
         z_recovery_mode_t::Heartbeat => RecoveryMode::Heartbeat,
     }
 }
@@ -361,15 +369,15 @@ leak.
 
 | Piece | Home |
 |---|---|
-| `EnumShape::{Unit, Sum}` classifier — the single definition of "is this enum C-like" | `src/api/core/types_util.rs` |
-| `SumSpec { key, source, variants: Vec<SumVariant> }`, `SumVariant { ident, tag, fields }`, `SumField { member, name, ty }` — the neutral description both adapters read | `src/api/core/types_util.rs` |
-| `enum_discriminant_values`, moved out of `jnigen/util.rs` | `src/api/core/types_util.rs` |
-| The unfold selector (`LeafSource::VariantField`, tag leaf, group membership, `apply_sum_returns`) | `src/api/core/unfold.rs` |
+| `EnumShape::{Unit, Sum}` classifier — the single definition of "is this enum C-like" | `prebindgen/src/api/core/types_util.rs` |
+| `SumSpec { key, source, variants: Vec<SumVariant> }`, `SumVariant { ident, tag, fields }`, `SumField { member, name, ty }` — the neutral description both adapters read | `prebindgen/src/api/core/types_util.rs` |
+| `enum_discriminant_values`, moved out of `jnigen/util.rs` | `prebindgen/src/api/core/types_util.rs` |
+| The unfold selector (`LeafSource::VariantField`, tag leaf, group membership, `apply_sum_returns`) | `prebindgen/src/api/core/unfold.rs` |
 
 Everything else is adapter-local. Payload **wire** choice stays per-adapter, exactly as `ValueDecon`
 leaves are adapter-built today (`Prebindgen::value_struct_decons`,
-`src/api/core/prebindgen.rs:218`) — core describes the sum, adapters decide what its leaves look like
-on the wire.
+`prebindgen/src/api/core/prebindgen.rs:218`) — core describes the sum, adapters decide what its
+leaves look like on the wire.
 
 ## 7. Test obligations
 
@@ -405,7 +413,7 @@ do not count.
 |---|---|---|---|
 | **A** | [#146](https://github.com/milyin/prebindgen/issues/146) | core: `EnumShape` classifier, `SumSpec`, `enum_discriminant_values` moved into core, the three `assert_unit_variants` sites and `enum_class!`'s contract replaced by classifier-driven errors. No behavior change for existing enums. | — |
 | **B** | [#147](https://github.com/milyin/prebindgen/issues/147) | cbindgen: `.tagged_union()`, `prereq_tagged_unions`, `in_/out_tagged_union`, the payload-ownership drop rule, goldens + C smoke test. | A |
-| **C** | [#148](https://github.com/milyin/prebindgen/issues/148) | jnigen: `sealed_class!` + `variant!`, `TypeKind::Sum`, `TypeConfig.sum_cfg`, the sealed-interface emitter (sibling of `write_enum_classes`, `src/api/lang/jnigen/jni/kotlin_emit.rs:555`). | A |
+| **C** | [#148](https://github.com/milyin/prebindgen/issues/148) | jnigen: `sealed_class!` + `variant!`, `TypeKind::Sum`, `TypeConfig.sum_cfg`, the sealed-interface emitter (sibling of `write_enum_classes`, `prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs:555`). | A |
 | **D** | [#149](https://github.com/milyin/prebindgen/issues/149) | jnigen: tag-gated groups on both flatten paths — `FlatFieldNode::Sum`, the struct-or-sum root, the `kt_access` expression-template refactor, `PlanFieldKind::Sum`. Unblocks flat #31 + #11, and flat #30 in its struct-field form (`ReplyStruct { result: ReplyResult, … }`). | C |
 | **E** | [#150](https://github.com/milyin/prebindgen/issues/150) | core + jnigen: sum-typed returns and callback arguments — the unfold selector. Needed when a function's **own** return (or a callback argument) is the sum, e.g. a `reply_get_result(&Reply) -> ReplyResult` accessor mirroring base's `Reply::result()`. | D |
 

--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -252,16 +252,49 @@ core work, because `api/core/unfold.rs` is a deterministic **product** — "ever
 and contributes its leaf … there is no selector" (`src/api/core/unfold.rs:8-11`). It gains one:
 
 - `LeafSource::VariantField { variant, member }` beside `Accessor` / `Field`
-  (`src/api/core/unfold/plan.rs:63-78`), so a leaf can be reached through a variant pattern rather
-  than a field chain.
-- Per-leaf group membership plus a synthesized tag leaf, so the Rust emitter emits one `match` over
-  the value instead of independent per-leaf expressions.
-- `apply_sum_returns`, modeled on `apply_value_structs` (`src/api/core/unfold.rs:455`): for every
-  declared function returning a declared sum (`E` / `&E` / `Option<E>` / `Vec<E>`), build a
-  `fixed_builder` `UnfoldPlan` whose foreign builder is the sealed interface's `fromParts`.
+  (`src/api/core/unfold/plan.rs`), so a leaf can be reached through a variant pattern rather
+  than a field chain, plus `LeafSource::SumTag` for the synthesized selector.
+- Per-leaf group membership (`UnfoldLeaf::group`), so the Rust emitter emits one `match` over
+  the value instead of independent per-leaf expressions. The tag leaf is the one leaf with **no
+  converter** (`UnfoldLeaf::has_converter()`): it is assigned per arm, so requiring an output
+  converter for it would make every sum depend on an unrelated `i32` crossing existing.
+- `apply_sum_returns`, modeled on `apply_value_structs`: for every declared function returning a
+  declared sum (`E` / `&E` / `Option<E>` / `Vec<E>`) and every `impl Fn(E)` / `impl Fn(&E)`
+  callback parameter, build a `fixed_builder` `UnfoldPlan` over the tag + groups. It also drops the
+  declared return's scan-time output requirement at **every layer** (`E`, `Option<E>`, `Vec<E>`) —
+  a sum has no whole-value converter by construction, and the boundary-only pass only reaches the
+  bare type.
 
 `Option` / `Vec` layers need nothing new — they ride the existing `Shape` fold
 (`src/api/core/shape.rs`), same as for a data class.
+
+**The wire target is the hoisted builder singleton, not `Sum.fromParts`.** §4.2's `fromParts` is the
+Kotlin-facing convenience: its parameters are the variants' **property** types (`Priority`, not the
+`Int` discriminant) and its object slots are non-null, which an inert group's `JObject::null()`
+would trip on inside the JVM's intrinsic null check before any generated code ran. So the return
+path reassembles through the same inlined `when` over the tag that a sum-typed struct field already
+gets, emitted into the hoisted `__<Name>Builder` / folder-appender singleton (and into the `asRaw`
+proxy for a callback argument). Both come from one derivation, so the two positions cannot drift:
+
+```kotlin
+internal val __ReadingBuilder: ReadingBuilder<Reading> =
+    ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 ->
+        when (tag) {
+            0 -> Reading.Missing
+            1 -> Reading.Exact(exact_v0)
+            2 -> Reading.Range(range_low, range_high)
+            3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1))
+            4 -> Reading.Companion(companion_v0)
+            else -> throw IllegalArgumentException("Reading: invalid tag $tag")
+        }
+    }
+```
+
+The `!!` is §4.4's inert-slot rule at the interface boundary: an object-shaped group slot is
+declared nullable (`tagged_v0: String?`) because an inert group is wire-defaulted to JVM null, and
+re-asserted inside its own live arm. Primitive slots keep their `0`/`false` default unboxed — a
+handle payload rides its raw `jlong`, so an inert handle group is the `0L` sentinel that is simply
+never wrapped.
 
 ### 4.6 Rejections
 
@@ -375,3 +408,8 @@ do not count.
 | **C** | [#148](https://github.com/milyin/prebindgen/issues/148) | jnigen: `sealed_class!` + `variant!`, `TypeKind::Sum`, `TypeConfig.sum_cfg`, the sealed-interface emitter (sibling of `write_enum_classes`, `src/api/lang/jnigen/jni/kotlin_emit.rs:555`). | A |
 | **D** | [#149](https://github.com/milyin/prebindgen/issues/149) | jnigen: tag-gated groups on both flatten paths — `FlatFieldNode::Sum`, the struct-or-sum root, the `kt_access` expression-template refactor, `PlanFieldKind::Sum`. Unblocks flat #31 + #11, and flat #30 in its struct-field form (`ReplyStruct { result: ReplyResult, … }`). | C |
 | **E** | [#150](https://github.com/milyin/prebindgen/issues/150) | core + jnigen: sum-typed returns and callback arguments — the unfold selector. Needed when a function's **own** return (or a callback argument) is the sum, e.g. a `reply_get_result(&Reply) -> ReplyResult` accessor mirroring base's `Reply::result()`. | D |
+
+A sum nested as a **data-class field** keeps the whole-value `fromParts` path (stage D's
+`PlanFieldKind::Sum`); the fixed-builder leaf synthesis for value structs still declines a sum
+field. Flattening that too is a wire-width/allocation optimization of an already-correct path, not
+a capability, so it is deliberately not part of stage E.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -236,6 +236,10 @@ fn main() {
                 // .name("Tagged")` exercises the per-variant rename (which
                 // also renames its `fromParts` slots).
                 .class(sealed_class!(Reading).variant(variant!(Labeled).name("Tagged")))
+                // `Lookup` is the sum in RETURN position whose groups own
+                // resources: one alternative carries an opaque handle, one
+                // carries nothing at all.
+                .class(sealed_class!(Lookup))
                 // `Observation` carries that sum as a data-class FIELD —
                 // required (`reading`) and optional (`fallback`) — beside
                 // ordinary flattened leaves, so the tag-gated groups must
@@ -455,6 +459,16 @@ fn main() {
                 .fun(fun!(observation_which))
                 .fun(fun!(tagged_new))
                 .fun(fun!(tagged_rank))
+                // A sum as the function's OWN return (and callback argument):
+                // the tag + groups ride the hoisted builder / folder singleton
+                // instead of a parent's `fromParts`. All four positions —
+                // bare, `Option`, `Vec`, callback — plus a group owning a
+                // native handle.
+                .fun(fun!(reading_of))
+                .fun(fun!(reading_maybe))
+                .fun(fun!(reading_series))
+                .fun(fun!(reading_each))
+                .fun(fun!(lookup_of))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -236,6 +236,11 @@ fn main() {
                 // .name("Tagged")` exercises the per-variant rename (which
                 // also renames its `fromParts` slots).
                 .class(sealed_class!(Reading).variant(variant!(Labeled).name("Tagged")))
+                // `Observation` carries that sum as a data-class FIELD —
+                // required (`reading`) and optional (`fallback`) — beside
+                // ordinary flattened leaves, so the tag-gated groups must
+                // interleave with them on one `fromParts` call.
+                .class(data_class!(Observation))
                 // `Annotated` exercises a NESTED data-class field (`payload`,
                 // recursive fromParts / recursive leaf decode) plus Option<prim> and
                 // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
@@ -439,6 +444,9 @@ fn main() {
                 .fun(fun!(annotated_ttl))
                 .fun(fun!(annotated_priority))
                 .fun(fun!(annotated_payload_value))
+                // A sum as a data-class field, crossing OUT: the tag plus every
+                // variant's group ride the parent's single `fromParts`.
+                .fun(fun!(observation_new))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -447,6 +447,7 @@ fn main() {
                 // A sum as a data-class field, crossing OUT: the tag plus every
                 // variant's group ride the parent's single `fromParts`.
                 .fun(fun!(observation_new))
+                .fun(fun!(observation_which))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -241,6 +241,11 @@ fn main() {
                 // ordinary flattened leaves, so the tag-gated groups must
                 // interleave with them on one `fromParts` call.
                 .class(data_class!(Observation))
+                // `Marker`'s `Option<enum>` payload is not leaf-shaped, so the
+                // sum degrades to a whole-object crossing instead of failing —
+                // and that path is what reads an enum property back.
+                .class(sealed_class!(Marker))
+                .class(data_class!(Tagged))
                 // `Annotated` exercises a NESTED data-class field (`payload`,
                 // recursive fromParts / recursive leaf decode) plus Option<prim> and
                 // Option<enum> FIELDS (each a decoupled `(present, value)` leaf pair).
@@ -448,6 +453,8 @@ fn main() {
                 // variant's group ride the parent's single `fromParts`.
                 .fun(fun!(observation_new))
                 .fun(fun!(observation_which))
+                .fun(fun!(tagged_new))
+                .fun(fun!(tagged_rank))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -71,6 +71,8 @@ Base package: `io.prebindgen.covertest`
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
   - shaped by: return `Stamp` decomposed → [] (Callback delivery)
+- `tagged_new` — `fun taggedNew(which: Int, onError: JniErrorHandler<Tagged>): Tagged`
+- `tagged_rank` — `fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int`
 - `unsigned_data_maybe` — `fun unsignedDataMaybe(value: Unsigned, onError: JniErrorHandler<ULong?>): ULong?`
 - `unsigned_emit` — `fun unsignedEmit(value: ULong, f: u64Callback, onError: JniErrorHandler<Unit>)`
 - `unsigned_optional` — `fun unsignedOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
@@ -149,6 +151,7 @@ Base package: `io.prebindgen.covertest`
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
+- `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `ObjectBoundary16`: data_class → `io.prebindgen.covertest.model.ObjectBoundary16` (wire `jni :: objects :: JObject`)
 - `ObjectBoundary2`: data_class → `io.prebindgen.covertest.model.ObjectBoundary2` (wire `jni :: objects :: JObject`)
@@ -170,6 +173,7 @@ Base package: `io.prebindgen.covertest`
 - `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)
 - `StorageHandler`: ptr_class → `io.prebindgen.covertest.StorageHandler` (wire `jni :: sys :: jlong`)
 - `Summary`: ptr_class → `io.prebindgen.covertest.analytics.Summary` (wire `jni :: sys :: jlong`)
+- `Tagged`: data_class → `io.prebindgen.covertest.model.Tagged` (wire `jni :: objects :: JObject`)
 - `Unsigned`: data_class → `io.prebindgen.covertest.model.Unsigned` (wire `jni :: objects :: JObject`)
 
 ## conversions

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -60,6 +60,7 @@ Base package: `io.prebindgen.covertest`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
+- `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation>): Observation`
 - `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority`
 - `percent_invalid_output` — `fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int?`
 - `percent_optional` — `fun percentOptional(p: Int?, onError: JniErrorHandler<Int?>): Int?`
@@ -156,6 +157,7 @@ Base package: `io.prebindgen.covertest`
 - `ObjectBoundary64`: data_class → `io.prebindgen.covertest.model.ObjectBoundary64` (wire `jni :: objects :: JObject`)
 - `ObjectBoundary8`: data_class → `io.prebindgen.covertest.model.ObjectBoundary8` (wire `jni :: objects :: JObject`)
 - `ObjectBoundaryLeaf`: data_class → `io.prebindgen.covertest.model.ObjectBoundaryLeaf` (wire `jni :: objects :: JObject`)
+- `Observation`: data_class → `io.prebindgen.covertest.model.Observation` (wire `jni :: objects :: JObject`)
 - `Payload`: data_class → `io.prebindgen.covertest.Payload` (wire `jni :: objects :: JObject`)
 - `PayloadHandler`: ptr_class → `io.prebindgen.covertest.PayloadHandler` (wire `jni :: sys :: jlong`)
 - `PayloadVecHandler`: ptr_class → `io.prebindgen.covertest.PayloadVecHandler` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -59,6 +59,8 @@ Base package: `io.prebindgen.covertest`
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
+- `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
+  - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
 - `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation>): Observation`
 - `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`
@@ -68,6 +70,13 @@ Base package: `io.prebindgen.covertest`
 - `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int`
 - `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority>): Priority`
 - `priority_weight` — `fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int`
+- `reading_each` — `fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>)`
+- `reading_maybe` — `fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading?`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `reading_of` — `fun readingOf(which: Int, onError: JniErrorHandler<Reading>): Reading`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
   - shaped by: return `Stamp` decomposed → [] (Callback delivery)
@@ -151,6 +160,7 @@ Base package: `io.prebindgen.covertest`
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
+- `Lookup`: sealed_class → `io.prebindgen.covertest.model.Lookup` (wire `?`)
 - `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `ObjectBoundary16`: data_class → `io.prebindgen.covertest.model.ObjectBoundary16` (wire `jni :: objects :: JObject`)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -61,6 +61,7 @@ Base package: `io.prebindgen.covertest`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
 - `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation>): Observation`
+- `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`
 - `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority`
 - `percent_invalid_output` — `fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int?`
 - `percent_optional` — `fun percentOptional(p: Int?, onError: JniErrorHandler<Int?>): Int?`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -5,7 +5,6 @@ import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.Observation
-import io.prebindgen.covertest.model.Reading
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
 import java.util.concurrent.atomic.AtomicLong
@@ -753,8 +752,21 @@ internal object CovNative {
 
     external fun observationWhich(
         oId: Long,
-        oReading: Reading,
-        oFallback: io.prebindgen.covertest.model.Reading?,
+        oReadingTag: Int,
+        oReadingExactV0: Long,
+        oReadingRangeLow: Long,
+        oReadingRangeHigh: Long,
+        oReadingTaggedV0: String?,
+        oReadingTaggedV1: Int,
+        oReadingCompanionV0: Long,
+        oFallbackPresent: Boolean,
+        oFallbackTag: Int,
+        oFallbackExactV0: Long,
+        oFallbackRangeLow: Long,
+        oFallbackRangeHigh: Long,
+        oFallbackTaggedV0: String?,
+        oFallbackTaggedV1: Int,
+        oFallbackCompanionV0: Long,
         oNote: String,
         errorSink: Any,
     ): Int

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -4,6 +4,7 @@ package io.prebindgen.covertest
 import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
+import io.prebindgen.covertest.model.Observation
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
 import java.util.concurrent.atomic.AtomicLong
@@ -746,6 +747,8 @@ internal object CovNative {
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
 
     external fun objectBoundaryValue(value: ObjectBoundary, errorSink: Any): Long
+
+    external fun observationNew(which: Int, withFallback: Boolean, errorSink: Any): Observation
 
     external fun payloadHandlerNew(f: Any, errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -746,6 +746,8 @@ internal object CovNative {
 
     external fun labelReverse(l: String, errorSink: Any): String
 
+    external fun lookupOf(count: Long, total: Double, build: Any, errorSink: Any): Any?
+
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
 
     external fun objectBoundaryValue(value: ObjectBoundary, errorSink: Any): Long
@@ -804,6 +806,14 @@ internal object CovNative {
     external fun priorityOr(pPresent: Boolean, pValue: Int, fallback: Int, errorSink: Any): Int
 
     external fun priorityWeight(p: Int, errorSink: Any): Int
+
+    external fun readingEach(n: Int, sink: Any, errorSink: Any)
+
+    external fun readingMaybe(which: Int, build: Any, errorSink: Any): Any?
+
+    external fun readingOf(which: Int, build: Any, errorSink: Any): Any?
+
+    external fun readingSeries(n: Int, acc: Any?, fold: Any, errorSink: Any): Any?
 
     external fun stampNanos(s: ByteArray, errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -3,8 +3,10 @@ package io.prebindgen.covertest
 
 import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.DurationBoundary
+import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.Observation
+import io.prebindgen.covertest.model.Tagged
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
 import java.util.concurrent.atomic.AtomicLong
@@ -1000,6 +1002,10 @@ internal object CovNative {
     ): Double
 
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double
+
+    external fun taggedNew(which: Int, errorSink: Any): Tagged
+
+    external fun taggedRank(tId: Long, tMarker: Marker, errorSink: Any): Int
 
     external fun unsignedDataMaybe(
         valueByte: Int,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -5,6 +5,7 @@ import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.Observation
+import io.prebindgen.covertest.model.Reading
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
 import java.util.concurrent.atomic.AtomicLong
@@ -749,6 +750,14 @@ internal object CovNative {
     external fun objectBoundaryValue(value: ObjectBoundary, errorSink: Any): Long
 
     external fun observationNew(which: Int, withFallback: Boolean, errorSink: Any): Observation
+
+    external fun observationWhich(
+        oId: Long,
+        oReading: Reading,
+        oFallback: io.prebindgen.covertest.model.Reading?,
+        oNote: String,
+        errorSink: Any,
+    ): Int
 
     external fun payloadHandlerNew(f: Any, errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -973,6 +973,17 @@ public fun observationNew(
 }
 
 /**
+ * Which alternative an [`Observation`]'s `reading` holds, by declaration
+ * order — the sum crossing back **in** as part of a data-class parameter.
+ */
+public fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.observationWhich(o.id, o.reading, o.fallback, o.note, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * The cache's replies-priority weight plus its `ttl`, or `-1` when the cache
  * is absent (`Option<CacheConfig>` **input** — the #144 reproduction: a
  * non-null enum field reached through the outer optional data class).

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -544,6 +544,43 @@ public data class ObjectBoundaryLeaf(val value: Long) {
 }
 
 /**
+ * A data class carrying a **sum** as a field — the position where "exactly one
+ * of" composes with ordinary product data.
+ *
+ * `reading` is required and `fallback` optional, so the binding has to gate a
+ * tag *and* a present flag independently; both sit beside already-flattened
+ * siblings (`id`, `note`) so the tag-gated groups must interleave correctly
+ * with ordinary leaves rather than only working in isolation. `Reading`'s
+ * `Labeled` arm carries a `String`, which is the payload that proves an inert
+ * group's object slot is wire-defaulted to null and therefore nullable in the
+ * generated `fromParts`.
+ */
+public data class Observation(val id: Long, val reading: Reading, val fallback: Reading?, val note: String) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            id: Long,
+            reading__tag: Int,
+            reading_exact_v0: Long,
+            reading_range_low: Long,
+            reading_range_high: Long,
+            reading_tagged_v0: String?,
+            reading_tagged_v1: Int,
+            reading_companion_v0: Long,
+            fallback__present: Boolean,
+            fallback__tag: Int,
+            fallback_exact_v0: Long,
+            fallback_range_low: Long,
+            fallback_range_high: Long,
+            fallback_tagged_v0: String?,
+            fallback_tagged_v1: Int,
+            fallback_companion_v0: Long,
+            note: String,
+        ): Observation = Observation(id, when (reading__tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(reading_exact_v0); 2 -> Reading.Range(reading_range_low, reading_range_high); 3 -> Reading.Tagged(reading_tagged_v0!!, Priority.fromInt(reading_tagged_v1)); 4 -> Reading.Companion(reading_companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $reading__tag") }, if (fallback__present) when (fallback__tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(fallback_exact_v0); 2 -> Reading.Range(fallback_range_low, fallback_range_high); 3 -> Reading.Tagged(fallback_tagged_v0!!, Priority.fromInt(fallback_tagged_v1)); 4 -> Reading.Companion(fallback_companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $fallback__tag") } else null, note)
+    }
+}
+
+/**
  * Inner, **non-optional** delivery config carrying a **non-null enum field**
  * (`priority`). Nested inside [`CacheConfig`], which crosses as
  * `Option<CacheConfig>`, so the outer optional's `nullable_context`
@@ -915,6 +952,22 @@ public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>)
         a.priority?.value ?: 0,
         __bcap,
     )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * Build an [`Observation`] carrying the selected alternative, optionally with
+ * a `fallback` (the next alternative round-robin) — a **sum as a struct
+ * field** crossing Rust → Kotlin, required and optional in one value.
+ */
+public fun observationNew(
+    which: Int,
+    withFallback: Boolean,
+    onError: JniErrorHandler<Observation>,
+): Observation {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.observationNew(which, withFallback, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -978,7 +978,34 @@ public fun observationNew(
  */
 public fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.observationWhich(o.id, o.reading, o.fallback, o.note, __bcap)
+    val __ret = CovNative.observationWhich(
+        o.id,
+        when (o.reading) {
+            is io.prebindgen.covertest.model.Reading.Missing,
+            ->
+            0; is io.prebindgen.covertest.model.Reading.Exact -> 1; is io.prebindgen.covertest.model.Reading.Range -> 2; is io.prebindgen.covertest.model.Reading.Tagged -> 3; is io.prebindgen.covertest.model.Reading.Companion -> 4
+        },
+        (o.reading as? io.prebindgen.covertest.model.Reading.Exact)?.v0 ?: 0L,
+        (o.reading as? io.prebindgen.covertest.model.Reading.Range)?.low ?: 0L,
+        (o.reading as? io.prebindgen.covertest.model.Reading.Range)?.high ?: 0L,
+        (o.reading as? io.prebindgen.covertest.model.Reading.Tagged)?.v0,
+        (o.reading as? io.prebindgen.covertest.model.Reading.Tagged)?.v1?.value ?: 0,
+        (o.reading as? io.prebindgen.covertest.model.Reading.Companion)?.v0 ?: 0L,
+        o.fallback != null,
+        when (o.fallback) {
+            null,
+            ->
+            0; is io.prebindgen.covertest.model.Reading.Missing -> 0; is io.prebindgen.covertest.model.Reading.Exact -> 1; is io.prebindgen.covertest.model.Reading.Range -> 2; is io.prebindgen.covertest.model.Reading.Tagged -> 3; is io.prebindgen.covertest.model.Reading.Companion -> 4
+        },
+        (o.fallback as? io.prebindgen.covertest.model.Reading.Exact)?.v0 ?: 0L,
+        (o.fallback as? io.prebindgen.covertest.model.Reading.Range)?.low ?: 0L,
+        (o.fallback as? io.prebindgen.covertest.model.Reading.Range)?.high ?: 0L,
+        (o.fallback as? io.prebindgen.covertest.model.Reading.Tagged)?.v0,
+        (o.fallback as? io.prebindgen.covertest.model.Reading.Tagged)?.v1?.value ?: 0,
+        (o.fallback as? io.prebindgen.covertest.model.Reading.Companion)?.v0 ?: 0L,
+        o.note,
+        __bcap,
+    )
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -33,6 +33,31 @@ public enum class Priority(public override val value: Int) : PriorityKind, Ranke
 }
 
 /**
+ * A second sum whose payload is **not leaf-shaped**: `Option<Priority>` is an
+ * enum object (or null) in the JVM slot, which the tag-gated flat form cannot
+ * express. The binding therefore lets this one cross as a whole object through
+ * its own converter rather than failing — the degradation path — which is also
+ * what exercises the `Option<enum>` property read.
+ *
+ * JVM-side surface for the native Rust `Marker` sum: exactly one alternative is live.
+ */
+public sealed interface Marker {
+    public data object None_ : Marker
+
+    public data class Ranked(public val v0: Priority?) : Marker
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(tag: Int, ranked_v0: Priority?): Marker =
+            when (tag) {
+                0 -> None_
+                1 -> Ranked(ranked_v0)
+                else -> throw IllegalArgumentException("Marker: invalid tag $tag")
+            }
+    }
+}
+
+/**
  * A sensor reading: exactly **one** of these alternatives is live, and it
  * carries that alternative's payload. Written as plain Rust — the "exactly
  * one of" invariant is in the type, not in a doc comment on a struct of
@@ -595,6 +620,14 @@ public data class RepliesConfig(val priority: Priority, val maxSamples: Long) {
     }
 }
 
+/** A data class carrying the object-shaped sum. */
+public data class Tagged(val id: Long, val marker: Marker) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(id: Long, marker__tag: Int, marker_ranked_v0: Int?): Tagged = Tagged(id, when (marker__tag) { 0 -> Marker.None_; 1 -> Marker.Ranked(marker_ranked_v0?.let { Priority.fromInt(it) }); else -> throw IllegalArgumentException("Marker: invalid tag $marker__tag") })
+    }
+}
+
 /**
  * Every fixed-width Rust unsigned scalar in one generated Kotlin data class.
  * The first three fields widen losslessly; `long`/`maybe_long` surface as
@@ -1006,6 +1039,25 @@ public fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int 
         o.note,
         __bcap,
     )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/** Build a [`Tagged`]: `which` 0 = `None_`, 1 = `Ranked(None)`, 2 = `Ranked(Some(High))`. */
+public fun taggedNew(which: Int, onError: JniErrorHandler<Tagged>): Tagged {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.taggedNew(which, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * Read it back — the whole-object sum decode, including the `Option<enum>`
+ * payload, crossing Kotlin → Rust.
+ */
+public fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.taggedRank(t.id, t.marker, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -7,6 +7,7 @@ import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.__u64FolderRawHolder
+import io.prebindgen.covertest.analytics.Summary
 import io.prebindgen.covertest.asRaw
 import io.prebindgen.covertest.u64Callback
 
@@ -29,6 +30,40 @@ public enum class Priority(public override val value: Int) : PriorityKind, Ranke
     public companion object {
         @JvmStatic
         public fun fromInt(value: Int): Priority = entries.first { it.value == value }
+    }
+}
+
+/**
+ * A sum whose alternatives are a **payload-less** variant and one carrying an
+ * opaque **handle** — the shape a real lookup/reply result takes, and the one
+ * that proves a tag-gated group can own a native resource: the live group
+ * hands over a fresh handle, the inert group's slot stays a null pointer that
+ * is never wrapped.
+ *
+ * JVM-side surface for the native Rust `Lookup` sum: exactly one alternative is live.
+ */
+public sealed interface Lookup {
+    /** Nothing matched — only the tag is live. */
+    public data object Absent : Lookup
+
+    /** What matched, as a handle the caller owns (and must close). */
+    public data class Found(public val v0: Summary) : Lookup
+
+    /**
+     * Why the lookup could not run — a `String` beside the handle group, so an
+     * inert object slot is exercised alongside an inert primitive one.
+     */
+    public data class Failed(public val v0: String) : Lookup
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(tag: Int, found_v0: Summary, failed_v0: String): Lookup =
+            when (tag) {
+                0 -> Absent
+                1 -> Found(found_v0)
+                2 -> Failed(failed_v0)
+                else -> throw IllegalArgumentException("Lookup: invalid tag $tag")
+            }
     }
 }
 
@@ -673,6 +708,36 @@ public value class Stamp(public val bytes: ByteArray) {
     }
 }
 
+public fun interface ReadingCallback {
+    public fun run(reading: Reading)
+}
+
+public fun interface ReadingCallbackRaw {
+    public fun run(
+        tag: Int,
+        exact_v0: Long,
+        range_low: Long,
+        range_high: Long,
+        tagged_v0: String?,
+        tagged_v1: Int,
+        companion_v0: Long,
+    )
+}
+
+public fun ReadingCallback.asRaw(): ReadingCallbackRaw =
+    ReadingCallbackRaw {
+        tag,
+        exact_v0,
+        range_low,
+        range_high,
+        tagged_v0,
+        tagged_v1,
+        companion_v0 ->
+        run(
+            when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+        )
+    }
+
 public fun interface DurationBoundaryBuilder<out R> {
     public fun run(delay: ULong?): R
 }
@@ -691,6 +756,48 @@ public fun <R> DurationBoundaryBuilder<R>.asRaw(): DurationBoundaryBuilderRaw<R>
 
 internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
 DurationBoundaryBuilderRaw { delay -> DurationBoundary.fromParts(delay) }
+
+public fun interface LookupBuilder<out R> {
+    public fun run(tag: Int, found_v0: Summary, failed_v0: String?): R
+}
+
+public fun interface LookupBuilderRaw<out R> {
+    public fun run(tag: Int, found_v0: Long, failed_v0: String?): R
+}
+
+public fun <R> LookupBuilder<R>.asRaw(): LookupBuilderRaw<R> =
+    LookupBuilderRaw<R> {
+        tag,
+        found_v0,
+        failed_v0 ->
+        run(
+            tag,
+            Summary(found_v0),
+            failed_v0
+        )
+    }
+
+internal val __LookupBuilderRaw: LookupBuilderRaw<Lookup> =
+LookupBuilderRaw { tag, found_v0, failed_v0 ->
+    when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
+}
+
+public fun interface ReadingBuilder<out R> {
+    public fun run(
+        tag: Int,
+        exact_v0: Long,
+        range_low: Long,
+        range_high: Long,
+        tagged_v0: String?,
+        tagged_v1: Int,
+        companion_v0: Long,
+    ): R
+}
+
+internal val __ReadingBuilder: ReadingBuilder<Reading> =
+ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 ->
+    when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+}
 
 public fun interface UnsignedBuilder<out R> {
     public fun run(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?): R
@@ -718,6 +825,45 @@ public fun <R> UnsignedBuilder<R>.asRaw(): UnsignedBuilderRaw<R> =
 
 internal val __UnsignedBuilderRaw: UnsignedBuilderRaw<Unsigned> =
 UnsignedBuilderRaw { byte, short, int, long, maybeLong -> Unsigned.fromParts(byte, short, int, long, maybeLong) }
+
+public fun interface ReadingFolder<A> {
+    public fun run(acc: A, element: Reading): A
+}
+
+public fun interface ReadingFolderRaw<A> {
+    public fun run(
+        acc: A,
+        tag: Int,
+        exact_v0: Long,
+        range_low: Long,
+        range_high: Long,
+        tagged_v0: String?,
+        tagged_v1: Int,
+        companion_v0: Long,
+    ): A
+}
+
+public fun <A> ReadingFolder<A>.asRaw(): ReadingFolderRaw<A> =
+    ReadingFolderRaw<A> {
+        acc,
+        tag,
+        exact_v0,
+        range_low,
+        range_high,
+        tagged_v0,
+        tagged_v1,
+        companion_v0 ->
+        run(
+            acc,
+            when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+        )
+    }
+
+internal object __ReadingFolderRawHolder {
+    @JvmField
+    val instance: ReadingFolderRaw<ArrayList<Reading>> =
+    ReadingFolderRaw { acc, tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 -> acc.add(when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }); acc }
+}
 
 public fun interface StampFolder<A> {
     public fun run(acc: A, element: Stamp): A
@@ -1060,6 +1206,78 @@ public fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int {
     val __ret = CovNative.taggedRank(t.id, t.marker, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
+}
+
+/**
+ * The selected alternative as the function's **own return** — a sum in
+ * return position, where nothing but the value's own tag says which group is
+ * live. Unlike a struct field (whose slots ride the parent's `fromParts`),
+ * there is no surrounding product to carry the tag, so the decomposition
+ * itself has to.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun readingOf(which: Int, onError: JniErrorHandler<Reading>): Reading {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.readingOf(which, __ReadingBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Reading
+}
+
+/**
+ * `Option<sum>` return: `which < 0` yields `None`. Optionality and choice stay
+ * independent — the present layer nulls the whole result rather than becoming
+ * an extra tag value.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.readingMaybe(which, __ReadingBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Reading?
+}
+
+/**
+ * `Vec<sum>` return: alternatives `0..n`, each folded into the foreign list
+ * element by element.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading> {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.readingSeries(
+        n,
+        ArrayList<Reading>(),
+        __ReadingFolderRawHolder.instance,
+        __bcap,
+    )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as List<Reading>
+}
+
+/** A sum as a **callback argument**: alternatives `0..n` delivered in turn. */
+public fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.readingEach(n, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Build a [`Lookup`]: `count < 0` is a failure, `count == 0` is absent,
+ * anything else is found.
+ *
+ * The Rust `Lookup` result is delivered decomposed: the builder callback receives (`tag`, `found_v0`, `failed_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.lookupOf(count, total, __LookupBuilderRaw, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Lookup
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -368,6 +368,26 @@ fun main() {
                 boom,
             ) == 3
         )
+
+        // A tag outside 0..N-1 reaches the binding-error channel — never a
+        // panic across the boundary (the locked rule in the design). The
+        // generated wrapper computes the tag from an exhaustive `when` and so
+        // can never produce one, which is exactly why this calls the extern
+        // directly: it is the only way to exercise the guard.
+        var invalidTag: String? = null
+        val cap = JniErrorHandlerCapture.acquire()
+        CovNative.observationWhich(
+            1L,
+            99, 0L, 0L, 0L, null, 0, 0L,
+            false,
+            0, 0L, 0L, 0L, null, 0, 0L,
+            "n",
+            cap,
+        )
+        if (cap.failed) invalidTag = cap.ze0
+        check(invalidTag != null && invalidTag!!.contains("Reading: invalid tag")) {
+            "expected the binding-error channel to carry the invalid tag, got: $invalidTag"
+        }
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -54,6 +54,7 @@ import io.prebindgen.covertest.model.cacheConfigWeight
 import io.prebindgen.covertest.model.objectBoundaryValue
 import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
+import io.prebindgen.covertest.model.observationWhich
 import io.prebindgen.covertest.model.payloadPriority
 import io.prebindgen.covertest.model.priorityOr
 import io.prebindgen.covertest.model.priorityWeight
@@ -352,6 +353,21 @@ fun main() {
         // Both sums live at once, each with its own tag.
         val both = observationNew(4, true, boom)
         check(both.reading == Reading.Companion(5L) && both.fallback == Reading.Missing)
+
+        // …and back IN as part of a data-class parameter: every alternative
+        // reconstructs the same Rust variant it came from.
+        for (which in 0..4) {
+            check(observationWhich(observationNew(which, false, boom), boom) == which)
+        }
+        // A Kotlin-constructed value (not one that came from Rust) crosses in
+        // just the same.
+        check(observationWhich(Observation(1L, Reading.Range(2L, 3L), null, "n"), boom) == 2)
+        check(
+            observationWhich(
+                Observation(1L, Reading.Tagged("x", Priority.LOW), Reading.Missing, "n"),
+                boom,
+            ) == 3
+        )
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -34,6 +34,7 @@ import io.prebindgen.covertest.model.ObjectBoundary63
 import io.prebindgen.covertest.model.ObjectBoundary64
 import io.prebindgen.covertest.model.ObjectBoundaryLeaf
 import io.prebindgen.covertest.model.Priority
+import io.prebindgen.covertest.model.Lookup
 import io.prebindgen.covertest.model.Reading
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Unsigned
@@ -55,6 +56,11 @@ import io.prebindgen.covertest.model.objectBoundaryValue
 import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.observationWhich
+import io.prebindgen.covertest.model.lookupOf
+import io.prebindgen.covertest.model.readingEach
+import io.prebindgen.covertest.model.readingMaybe
+import io.prebindgen.covertest.model.readingOf
+import io.prebindgen.covertest.model.readingSeries
 import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.Tagged
 import io.prebindgen.covertest.model.taggedNew
@@ -392,6 +398,73 @@ fun main() {
         check(invalidTag != null && invalidTag!!.contains("Reading: invalid tag")) {
             "expected the binding-error channel to carry the invalid tag, got: $invalidTag"
         }
+    }
+
+    // ── a sum as the function's OWN return / callback argument ────────────────
+    // Nothing surrounds the value here, so the decomposition carries its own
+    // tag: the wrapper hands the native side a hoisted builder (or folder)
+    // singleton, and the live group is picked by a `when` over that tag. Still
+    // no JVM object built on the Rust side — only the tag and the raw slots
+    // cross.
+    section("sum in return position (tag + groups through a fixed builder)") {
+        // Bare `E` return: every variant shape survives, including the
+        // payload-less one and the ones whose groups carry object slots.
+        check(readingOf(0, boom) == Reading.Missing)
+        check(readingOf(1, boom) == Reading.Exact(42L))
+        check(readingOf(2, boom) == Reading.Range(1L, 9L))
+        check(readingOf(3, boom) == Reading.Tagged("warm", Priority.HIGH))
+        check(readingOf(4, boom) == Reading.Companion(5L))
+        // The payload-less alternative is still the singleton `data object` —
+        // the tag alone rebuilt it, no group was read.
+        check(readingOf(0, boom) === Reading.Missing)
+
+        // `Option<E>` return: the present layer nulls the whole result and is
+        // independent of the tag (which is 0 — `Missing` — in the null case,
+        // and must not be mistaken for one).
+        check(readingMaybe(-1, boom) == null)
+        check(readingMaybe(0, boom) == Reading.Missing)
+        check(readingMaybe(3, boom) == Reading.Tagged("warm", Priority.HIGH))
+
+        // `Vec<E>` return: each element's tag + groups cross raw and the
+        // folder singleton appends the rebuilt alternative.
+        check(readingSeries(0, boom).isEmpty())
+        check(
+            readingSeries(5, boom) == listOf(
+                Reading.Missing,
+                Reading.Exact(42L),
+                Reading.Range(1L, 9L),
+                Reading.Tagged("warm", Priority.HIGH),
+                Reading.Companion(5L),
+            )
+        )
+
+        // Callback argument: the user callback receives the whole reassembled
+        // sum while the wire still carries decoupled slots.
+        val seen = ArrayList<Reading>()
+        readingEach(5, { r -> seen.add(r) }, boom)
+        check(seen == readingSeries(5, boom))
+    }
+
+    // ── a tag-gated group that owns a native resource ─────────────────────────
+    // `Lookup.Found` carries an opaque handle: the live group hands over a
+    // freshly boxed pointer the caller owns, while an inert handle slot stays
+    // the `0L` sentinel that is never wrapped (wrapping it would fabricate a
+    // handle to nothing). `Failed`'s `String` group proves an inert OBJECT slot
+    // arrives as JVM null and so must be nullable in the raw builder.
+    section("sum return with a handle payload") {
+        check(lookupOf(0L, 0.0, boom) === Lookup.Absent)
+
+        val failed = lookupOf(-1L, 0.0, boom)
+        check(failed is Lookup.Failed && (failed as Lookup.Failed).v0 == "negative count")
+
+        val found = lookupOf(3L, 7.5, boom)
+        check(found is Lookup.Found)
+        val summary = (found as Lookup.Found).v0
+        // The handle is live and owns its own copy of the native object.
+        check(summary.count(boom) == 3L)
+        check(summary.total(boom) == 7.5)
+        summary.close()
+        check(summary.isClosed())
     }
 
     // ── a sum whose payload is NOT leaf-shaped ────────────────────────────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -55,6 +55,10 @@ import io.prebindgen.covertest.model.objectBoundaryValue
 import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.observationWhich
+import io.prebindgen.covertest.model.Marker
+import io.prebindgen.covertest.model.Tagged
+import io.prebindgen.covertest.model.taggedNew
+import io.prebindgen.covertest.model.taggedRank
 import io.prebindgen.covertest.model.payloadPriority
 import io.prebindgen.covertest.model.priorityOr
 import io.prebindgen.covertest.model.priorityWeight
@@ -388,6 +392,24 @@ fun main() {
         check(invalidTag != null && invalidTag!!.contains("Reading: invalid tag")) {
             "expected the binding-error channel to carry the invalid tag, got: $invalidTag"
         }
+    }
+
+    // ── a sum whose payload is NOT leaf-shaped ────────────────────────────────
+    // `Marker.Ranked` carries `Option<Priority>` — an enum object or null in the
+    // JVM slot, which tag-gated groups cannot express. The sum degrades to a
+    // whole-object crossing rather than failing the build, and that path is what
+    // reads an enum property back (bare and optional read differently: the slot
+    // holds the enum OBJECT, not a boxed Int).
+    section("sum with a non-leaf payload (whole-object crossing, Option<enum>)") {
+        check(taggedRank(taggedNew(0, boom), boom) == -1)
+        check(taggedRank(taggedNew(1, boom), boom) == 0)
+        check(taggedRank(taggedNew(2, boom), boom) == 10)
+
+        // Kotlin-constructed values cross identically — including the two
+        // `Ranked` shapes that differ only by the optional being present.
+        check(taggedRank(Tagged(1L, Marker.None_), boom) == -1)
+        check(taggedRank(Tagged(1L, Marker.Ranked(null)), boom) == 0)
+        check(taggedRank(Tagged(1L, Marker.Ranked(Priority.HIGH)), boom) == 10)
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -52,6 +52,8 @@ import io.prebindgen.covertest.model.annotatedPriority
 import io.prebindgen.covertest.model.annotatedTtl
 import io.prebindgen.covertest.model.cacheConfigWeight
 import io.prebindgen.covertest.model.objectBoundaryValue
+import io.prebindgen.covertest.model.Observation
+import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.payloadPriority
 import io.prebindgen.covertest.model.priorityOr
 import io.prebindgen.covertest.model.priorityWeight
@@ -320,6 +322,36 @@ fun main() {
             invalid = e.message
         }
         check(invalid == "Reading: invalid tag 5")
+    }
+
+    // ── a sum as a data-class FIELD, crossing Rust → Kotlin ───────────────────
+    // The tag and every variant's group ride the parent's single `fromParts`;
+    // inert groups are wire-defaulted, which is why an inert object slot must
+    // be nullable (`reading_tagged_v0: String?`) and re-asserted `!!` in its
+    // own live arm. No JVM object is built for the sum itself.
+    section("sum as a data-class field (tag-gated groups on one fromParts)") {
+        // Every alternative survives the crossing, including the payload-less
+        // one and the two whose groups sit beside object-shaped slots.
+        check(observationNew(0, false, boom).reading == Reading.Missing)
+        check(observationNew(1, false, boom).reading == Reading.Exact(42L))
+        check(observationNew(2, false, boom).reading == Reading.Range(1L, 9L))
+        check(observationNew(3, false, boom).reading == Reading.Tagged("warm", Priority.HIGH))
+        check(observationNew(4, false, boom).reading == Reading.Companion(5L))
+
+        // The sum sits beside ordinary flattened leaves — they must not be
+        // disturbed by the tag-gated groups interleaved with them.
+        val obs = observationNew(3, false, boom)
+        check(obs.id == 7L && obs.note == "obs")
+
+        // `Option<sum>`: the present flag and the tag are independent facts,
+        // so an absent optional is null regardless of what its tag slot holds.
+        check(observationNew(1, false, boom).fallback == null)
+        check(observationNew(1, true, boom).fallback == Reading.Range(1L, 9L))
+        // …and an object-payload variant round-trips through the optional too.
+        check(observationNew(2, true, boom).fallback == Reading.Tagged("warm", Priority.HIGH))
+        // Both sums live at once, each with its own tag.
+        val both = observationNew(4, true, boom)
+        check(both.reading == Reading.Companion(5L) && both.fallback == Reading.Missing)
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -835,6 +835,117 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
+    Ok({
+        let __obj = v;
+        (|| -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Lookup: null value where a variant was required".to_string(),
+                    ),
+                );
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Absent")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Lookup", ": instanceof ",
+                        "io/prebindgen/covertest/model/Lookup$Absent", ": {}"), e
+                    ),
+                ))?
+            {
+                return ::core::result::Result::Ok(perftest_flat::Lookup::Absent);
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Found")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Lookup", ": instanceof ",
+                        "io/prebindgen/covertest/model/Lookup$Found", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(
+                        __obj,
+                        "v0",
+                        "Lio/prebindgen/covertest/analytics/Summary;",
+                    )
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Lookup.Found.v0: {}", e)))?;
+                let __p_v0_raw: jni::sys::jlong = if __p_v0_obj.is_null() {
+                    0
+                } else {
+                    env.call_method(&__p_v0_obj, "peek", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Lookup.Found.v0: {}", e)))?
+                };
+                if __p_v0_raw == 0 || (__p_v0_raw & 1) == 1 {
+                    return ::core::result::Result::Err(
+                        <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from("Operation on a closed native handle.".to_string()),
+                    );
+                }
+                let __p_v0: perftest_flat::Summary = unsafe {
+                    *std::boxed::Box::from_raw(__p_v0_raw as *mut perftest_flat::Summary)
+                };
+                return ::core::result::Result::Ok(perftest_flat::Lookup::Found(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Failed")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Lookup", ": instanceof ",
+                        "io/prebindgen/covertest/model/Lookup$Failed", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Lookup.Failed.v0: {}", e)))?;
+                let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
+                let __p_v0 = JString_to_String_c7f3ca43(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Lookup::Failed(__p_v0));
+            }
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from("Lookup: value is not one of its declared variants".to_string()),
+            )
+        })()?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Marker_3dc81334<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -2370,6 +2481,242 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
                 Ok(())
             })()
                 .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(& Payload)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Reading) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Reading)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(IJJJLjava/lang/String;IJ)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Reading)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Reading| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Reading)", e)))?;
+                env.push_local_frame(20)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Reading)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __cb0_obj0: jni::sys::jvalue;
+                    let __cb0_obj1: jni::sys::jvalue;
+                    let __cb0_obj2: jni::sys::jvalue;
+                    let __cb0_obj3: jni::sys::jvalue;
+                    let __cb0_obj4: jni::objects::JObject;
+                    let __cb0_obj5: jni::sys::jvalue;
+                    let __cb0_obj6: jni::sys::jvalue;
+                    match &__cb_arg0 {
+                        perftest_flat::Reading::Missing => {
+                            __cb0_obj0 = jni::sys::jvalue { i: 0 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Exact(__sv0) => {
+                            let __enc___cb0_obj1 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj1 = jni::sys::jvalue {
+                                j: __enc___cb0_obj1,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 1 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                            let __enc___cb0_obj2 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj2 = jni::sys::jvalue {
+                                j: __enc___cb0_obj2,
+                            };
+                            let __enc___cb0_obj3 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv1.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj3 = jni::sys::jvalue {
+                                j: __enc___cb0_obj3,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 2 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                            let __enc___cb0_obj4 = match String_to_JString_c7f3ca43(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj4 = __enc___cb0_obj4.into();
+                            let __enc___cb0_obj5 = match Priority_to_jint_447102d2(
+                                &mut env,
+                                __sv1.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj5 = jni::sys::jvalue {
+                                i: __enc___cb0_obj5,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 3 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Companion(__sv0) => {
+                            let __enc___cb0_obj6 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj6 = jni::sys::jvalue {
+                                j: __enc___cb0_obj6,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 4 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                        }
+                    }
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                __cb0_obj2,
+                                __cb0_obj3,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj4.as_raw(),
+                                },
+                                __cb0_obj5,
+                                __cb0_obj6,
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Reading)"));
         })
     })
 }
@@ -8677,6 +9024,140 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_lookupOf<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    count: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/LookupBuilderRaw";
+    const __CB_DESCR: &str = "(IJLjava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::lookup_of(count, total);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    let __obj2: jni::objects::JObject;
+    match &__out {
+        perftest_flat::Lookup::Absent => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::objects::JObject::null();
+        }
+        perftest_flat::Lookup::Found(__sv0) => {
+            let __enc___obj1 = match Summary_to_jlong_3cb103b9(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+            __obj2 = jni::objects::JObject::null();
+        }
+        perftest_flat::Lookup::Failed(__sv0) => {
+            let __enc___obj2 = match String_to_JString_c7f3ca43(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = __enc___obj2.into();
+            __obj0 = jni::sys::jvalue { i: 2 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                jni::sys::jvalue {
+                    l: __obj2.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -9797,6 +10278,760 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityWeight<'
             0 as jni::sys::jint
         }
     }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jint,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jint_to_i32_a3e3b6ef(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::reading_each(n, sink);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingMaybe<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
+    const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::reading_maybe(which);
+    match __out {
+        ::core::option::Option::Some(__inner) => {
+            let __obj0: jni::sys::jvalue;
+            let __obj1: jni::sys::jvalue;
+            let __obj2: jni::sys::jvalue;
+            let __obj3: jni::sys::jvalue;
+            let __obj4: jni::objects::JObject;
+            let __obj5: jni::sys::jvalue;
+            let __obj6: jni::sys::jvalue;
+            match &__inner {
+                perftest_flat::Reading::Missing => {
+                    __obj0 = jni::sys::jvalue { i: 0 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Exact(__sv0) => {
+                    let __enc___obj1 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj1 = jni::sys::jvalue {
+                        j: __enc___obj1,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 1 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                    let __enc___obj2 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj2 = jni::sys::jvalue {
+                        j: __enc___obj2,
+                    };
+                    let __enc___obj3 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv1.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj3 = jni::sys::jvalue {
+                        j: __enc___obj3,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 2 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                    let __enc___obj4 = match String_to_JString_c7f3ca43(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj4 = __enc___obj4.into();
+                    let __enc___obj5 = match Priority_to_jint_447102d2(
+                        &mut env,
+                        __sv1.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj5 = jni::sys::jvalue {
+                        i: __enc___obj5,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 3 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Companion(__sv0) => {
+                    let __enc___obj6 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj6 = jni::sys::jvalue {
+                        j: __enc___obj6,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 4 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                }
+            }
+            match __CB_MID
+                .call_object(
+                    &mut env,
+                    __CB_FQN,
+                    "run",
+                    __CB_DESCR,
+                    &__builder,
+                    &[
+                        __obj0,
+                        __obj1,
+                        __obj2,
+                        __obj3,
+                        jni::sys::jvalue {
+                            l: __obj4.as_raw(),
+                        },
+                        __obj5,
+                        __obj6,
+                    ],
+                )
+            {
+                ::core::result::Result::Ok(__o) => __o,
+                ::core::result::Result::Err(__e) => {
+                    let _ = env.exception_describe();
+                    let __e2 = <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string());
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e2.to_string(),
+                    );
+                    jni::objects::JObject::null().into()
+                }
+            }
+        }
+        ::core::option::Option::None => jni::objects::JObject::null().into(),
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingOf<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
+    const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::reading_of(which);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    let __obj2: jni::sys::jvalue;
+    let __obj3: jni::sys::jvalue;
+    let __obj4: jni::objects::JObject;
+    let __obj5: jni::sys::jvalue;
+    let __obj6: jni::sys::jvalue;
+    match &__out {
+        perftest_flat::Reading::Missing => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Exact(__sv0) => {
+            let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+            let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = jni::sys::jvalue {
+                j: __enc___obj2,
+            };
+            let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj3 = jni::sys::jvalue {
+                j: __enc___obj3,
+            };
+            __obj0 = jni::sys::jvalue { i: 2 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+            let __enc___obj4 = match String_to_JString_c7f3ca43(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj4 = __enc___obj4.into();
+            let __enc___obj5 = match Priority_to_jint_447102d2(&mut env, __sv1.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj5 = jni::sys::jvalue {
+                i: __enc___obj5,
+            };
+            __obj0 = jni::sys::jvalue { i: 3 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Companion(__sv0) => {
+            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj6 = jni::sys::jvalue {
+                j: __enc___obj6,
+            };
+            __obj0 = jni::sys::jvalue { i: 4 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                __obj3,
+                jni::sys::jvalue {
+                    l: __obj4.as_raw(),
+                },
+                __obj5,
+                __obj6,
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingSeries<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jint,
+    __acc: jni::objects::JObject<'a>,
+    __fold: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jint_to_i32_a3e3b6ef(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingFolderRaw";
+    const __CB_DESCR: &str = "(Ljava/lang/Object;IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __vec = perftest_flat::reading_series(n);
+    let mut __acc = __acc;
+    for __elem in __vec.into_iter() {
+        let __obj0: jni::sys::jvalue;
+        let __obj1: jni::sys::jvalue;
+        let __obj2: jni::sys::jvalue;
+        let __obj3: jni::sys::jvalue;
+        let __obj4: jni::objects::JObject;
+        let __obj5: jni::sys::jvalue;
+        let __obj6: jni::sys::jvalue;
+        match &__elem {
+            perftest_flat::Reading::Missing => {
+                __obj0 = jni::sys::jvalue { i: 0 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Exact(__sv0) => {
+                let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj1 = jni::sys::jvalue {
+                    j: __enc___obj1,
+                };
+                __obj0 = jni::sys::jvalue { i: 1 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj2 = jni::sys::jvalue {
+                    j: __enc___obj2,
+                };
+                let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj3 = jni::sys::jvalue {
+                    j: __enc___obj3,
+                };
+                __obj0 = jni::sys::jvalue { i: 2 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                let __enc___obj4 = match String_to_JString_c7f3ca43(
+                    &mut env,
+                    __sv0.clone(),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj4 = __enc___obj4.into();
+                let __enc___obj5 = match Priority_to_jint_447102d2(
+                    &mut env,
+                    __sv1.clone(),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj5 = jni::sys::jvalue {
+                    i: __enc___obj5,
+                };
+                __obj0 = jni::sys::jvalue { i: 3 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Companion(__sv0) => {
+                let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj6 = jni::sys::jvalue {
+                    j: __enc___obj6,
+                };
+                __obj0 = jni::sys::jvalue { i: 4 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+            }
+        }
+        __acc = match __CB_MID
+            .call_object(
+                &mut env,
+                __CB_FQN,
+                "run",
+                __CB_DESCR,
+                &__fold,
+                &[
+                    jni::sys::jvalue {
+                        l: __acc.as_raw(),
+                    },
+                    __obj0,
+                    __obj1,
+                    __obj2,
+                    __obj3,
+                    jni::sys::jvalue {
+                        l: __obj4.as_raw(),
+                    },
+                    __obj5,
+                    __obj6,
+                ],
+            )
+        {
+            ::core::result::Result::Ok(__o) => __o,
+            ::core::result::Result::Err(__e) => {
+                let _ = env.exception_describe();
+                let __e2 = <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string());
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e2.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+    }
+    __acc
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -8699,6 +8699,103 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationNew<'
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationWhich<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    o_id: jni::sys::jlong,
+    o_reading: jni::objects::JObject<'a>,
+    o_fallback: jni::objects::JObject<'a>,
+    o_note: jni::objects::JString<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jint {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_o_id = match jlong_to_i64_fbf9a9bc(&mut env, &o_id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __flat_o_reading = match JObject_to_Reading_2261050f(&mut env, &o_reading) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __flat_o_fallback = match JObject_to_Option_Reading_80df84a9(
+        &mut env,
+        &o_fallback,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __flat_o_note = match JString_to_String_c7f3ca43(&mut env, &o_note) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __flat_o = perftest_flat::Observation {
+        id: __flat_o_id,
+        reading: __flat_o_reading,
+        fallback: __flat_o_fallback,
+        note: __flat_o_note,
+    };
+    let o = __flat_o;
+    let __out = perftest_flat::observation_which(o);
+    match i32_to_jint_a3e3b6ef(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jint
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadHandlerNew<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1183,6 +1183,59 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary_dc5ac22b<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Observation_435b0724<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Observation, __JniErr> {
+    Ok({
+        let __id_raw: jni::sys::jlong = env
+            .get_field(v, "id", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Observation.id: {}", e)))? as _;
+        let id = jlong_to_i64_fbf9a9bc(env, &__id_raw)?;
+        let __reading_raw: jni::objects::JObject = env
+            .get_field(v, "reading", "Lio/prebindgen/covertest/model/Reading;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Observation.reading: {}", e)))?;
+        let reading = JObject_to_Reading_2261050f(env, &__reading_raw)?;
+        let __fallback_raw: jni::objects::JObject = env
+            .get_field(v, "fallback", "Lio/prebindgen/covertest/model/Reading;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Observation.fallback: {}", e)))?;
+        let fallback = JObject_to_Option_Reading_80df84a9(env, &__fallback_raw)?;
+        let __note_jobj: jni::objects::JObject = env
+            .get_field(v, "note", "Ljava/lang/String;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Observation.note: {}", e)))?;
+        let __note_raw: jni::objects::JString = __note_jobj.into();
+        let note = JString_to_String_c7f3ca43(env, &__note_raw)?;
+        perftest_flat::Observation {
+            id,
+            reading,
+            fallback,
+            note,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Option_CacheConfig_a6be794d<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -1274,6 +1327,23 @@ pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
             None
         }
     })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Option_Reading_80df84a9<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Option<perftest_flat::Reading>, __JniErr> {
+    Ok({ if v.is_null() { None } else { Some(JObject_to_Reading_2261050f(env, v)?) } })
 }
 #[allow(
     non_snake_case,
@@ -1424,6 +1494,155 @@ pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
             flag,
             label,
         }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Reading_2261050f<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
+    Ok({
+        let __obj = v;
+        (|| -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Missing")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Reading", ": instanceof ",
+                        "io/prebindgen/covertest/model/Reading$Missing", ": {}"), e
+                    ),
+                ))?
+            {
+                return ::core::result::Result::Ok(perftest_flat::Reading::Missing);
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Exact")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Reading", ": instanceof ",
+                        "io/prebindgen/covertest/model/Reading$Exact", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_raw: jni::sys::jlong = env
+                    .get_field(__obj, "v0", "J")
+                    .and_then(|val| val.j())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Exact.v0: {}", e)))? as _;
+                let __p_v0 = jlong_to_i64_fbf9a9bc(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Reading::Exact(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Range")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Reading", ": instanceof ",
+                        "io/prebindgen/covertest/model/Reading$Range", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_low_raw: jni::sys::jlong = env
+                    .get_field(__obj, "low", "J")
+                    .and_then(|val| val.j())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Range.low: {}", e)))? as _;
+                let __p_low = jlong_to_i64_fbf9a9bc(env, &__p_low_raw)?;
+                let __p_high_raw: jni::sys::jlong = env
+                    .get_field(__obj, "high", "J")
+                    .and_then(|val| val.j())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Range.high: {}", e)))? as _;
+                let __p_high = jlong_to_i64_fbf9a9bc(env, &__p_high_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Reading::Range {
+                    low: __p_low,
+                    high: __p_high,
+                });
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Tagged")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Reading", ": instanceof ",
+                        "io/prebindgen/covertest/model/Reading$Tagged", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Tagged.v0: {}", e)))?;
+                let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
+                let __p_v0 = JString_to_String_c7f3ca43(env, &__p_v0_raw)?;
+                let __p_v1_obj: jni::objects::JObject = env
+                    .get_field(__obj, "v1", "Lio/prebindgen/covertest/model/Priority;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Tagged.v1: {}", e)))?;
+                let __p_v1_raw: jni::sys::jint = env
+                    .call_method(&__p_v1_obj, "getValue", "()I", &[])
+                    .and_then(|val| val.i())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Tagged.v1: {}", e)))?;
+                let __p_v1 = jint_to_Priority_447102d2(env, &__p_v1_raw)?;
+                return ::core::result::Result::Ok(
+                    perftest_flat::Reading::Labeled(__p_v0, __p_v1),
+                );
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Companion")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Reading", ": instanceof ",
+                        "io/prebindgen/covertest/model/Reading$Companion", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_raw: jni::sys::jlong = env
+                    .get_field(__obj, "v0", "J")
+                    .and_then(|val| val.j())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Reading.Companion.v0: {}", e)))? as _;
+                let __p_v0 = jlong_to_i64_fbf9a9bc(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(
+                    perftest_flat::Reading::Companion(__p_v0),
+                );
+            }
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    "Reading: value is not one of its declared variants".to_string(),
+                ),
+            )
+        })()?
     })
 }
 #[allow(
@@ -4527,6 +4746,234 @@ pub(crate) unsafe fn ObjectBoundary_to_JObject_dc5ac22b<'a>(
                     jni::objects::JValue::from(___right_leaves2_left_value),
                     jni::objects::JValue::from(___right_leaves2_right_value),
                     jni::objects::JValue::from(___right_leaf_value),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Observation_to_JObject_435b0724<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Observation,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.id.clone())?;
+        let ___reading__tag: jni::sys::jint;
+        let ___reading_g0: jni::sys::jlong;
+        let ___reading_g1: jni::sys::jlong;
+        let ___reading_g2: jni::sys::jlong;
+        let ___reading_g3: jni::objects::JObject;
+        let ___reading_g4: jni::sys::jint;
+        let ___reading_g5: jni::sys::jlong;
+        match &v.reading {
+            perftest_flat::Reading::Missing => {
+                ___reading__tag = 0;
+                ___reading_g0 = 0i64;
+                ___reading_g1 = 0i64;
+                ___reading_g2 = 0i64;
+                ___reading_g3 = jni::objects::JObject::null();
+                ___reading_g4 = 0i32;
+                ___reading_g5 = 0i64;
+            }
+            perftest_flat::Reading::Exact(__s0_0) => {
+                let ___reading_exact_v0: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                ___reading__tag = 1;
+                ___reading_g0 = ___reading_exact_v0;
+                ___reading_g1 = 0i64;
+                ___reading_g2 = 0i64;
+                ___reading_g3 = jni::objects::JObject::null();
+                ___reading_g4 = 0i32;
+                ___reading_g5 = 0i64;
+            }
+            perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
+                let ___reading_range_low: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                let ___reading_range_high: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                    env,
+                    __s0_1.clone(),
+                )?;
+                ___reading__tag = 2;
+                ___reading_g1 = ___reading_range_low;
+                ___reading_g2 = ___reading_range_high;
+                ___reading_g0 = 0i64;
+                ___reading_g3 = jni::objects::JObject::null();
+                ___reading_g4 = 0i32;
+                ___reading_g5 = 0i64;
+            }
+            perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
+                let ___reading_tagged_v0: jni::objects::JObject = String_to_JString_c7f3ca43(
+                        env,
+                        __s0_0.clone(),
+                    )?
+                    .into();
+                let ___reading_tagged_v1: jni::sys::jint = Priority_to_jint_447102d2(
+                    env,
+                    __s0_1.clone(),
+                )?;
+                ___reading__tag = 3;
+                ___reading_g3 = ___reading_tagged_v0;
+                ___reading_g4 = ___reading_tagged_v1;
+                ___reading_g0 = 0i64;
+                ___reading_g1 = 0i64;
+                ___reading_g2 = 0i64;
+                ___reading_g5 = 0i64;
+            }
+            perftest_flat::Reading::Companion(__s0_0) => {
+                let ___reading_companion_v0: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                ___reading__tag = 4;
+                ___reading_g5 = ___reading_companion_v0;
+                ___reading_g0 = 0i64;
+                ___reading_g1 = 0i64;
+                ___reading_g2 = 0i64;
+                ___reading_g3 = jni::objects::JObject::null();
+                ___reading_g4 = 0i32;
+            }
+        }
+        let ___fallback_present: jni::sys::jboolean;
+        let ___fallback__tag: jni::sys::jint;
+        let ___fallback_g0: jni::sys::jlong;
+        let ___fallback_g1: jni::sys::jlong;
+        let ___fallback_g2: jni::sys::jlong;
+        let ___fallback_g3: jni::objects::JObject;
+        let ___fallback_g4: jni::sys::jint;
+        let ___fallback_g5: jni::sys::jlong;
+        match &v.fallback {
+            ::core::option::Option::Some(__o0) => {
+                ___fallback_present = 1u8;
+                match __o0 {
+                    perftest_flat::Reading::Missing => {
+                        ___fallback__tag = 0;
+                        ___fallback_g0 = 0i64;
+                        ___fallback_g1 = 0i64;
+                        ___fallback_g2 = 0i64;
+                        ___fallback_g3 = jni::objects::JObject::null();
+                        ___fallback_g4 = 0i32;
+                        ___fallback_g5 = 0i64;
+                    }
+                    perftest_flat::Reading::Exact(__s0_0) => {
+                        let ___fallback_exact_v0: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                            env,
+                            __s0_0.clone(),
+                        )?;
+                        ___fallback__tag = 1;
+                        ___fallback_g0 = ___fallback_exact_v0;
+                        ___fallback_g1 = 0i64;
+                        ___fallback_g2 = 0i64;
+                        ___fallback_g3 = jni::objects::JObject::null();
+                        ___fallback_g4 = 0i32;
+                        ___fallback_g5 = 0i64;
+                    }
+                    perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
+                        let ___fallback_range_low: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                            env,
+                            __s0_0.clone(),
+                        )?;
+                        let ___fallback_range_high: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                            env,
+                            __s0_1.clone(),
+                        )?;
+                        ___fallback__tag = 2;
+                        ___fallback_g1 = ___fallback_range_low;
+                        ___fallback_g2 = ___fallback_range_high;
+                        ___fallback_g0 = 0i64;
+                        ___fallback_g3 = jni::objects::JObject::null();
+                        ___fallback_g4 = 0i32;
+                        ___fallback_g5 = 0i64;
+                    }
+                    perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
+                        let ___fallback_tagged_v0: jni::objects::JObject = String_to_JString_c7f3ca43(
+                                env,
+                                __s0_0.clone(),
+                            )?
+                            .into();
+                        let ___fallback_tagged_v1: jni::sys::jint = Priority_to_jint_447102d2(
+                            env,
+                            __s0_1.clone(),
+                        )?;
+                        ___fallback__tag = 3;
+                        ___fallback_g3 = ___fallback_tagged_v0;
+                        ___fallback_g4 = ___fallback_tagged_v1;
+                        ___fallback_g0 = 0i64;
+                        ___fallback_g1 = 0i64;
+                        ___fallback_g2 = 0i64;
+                        ___fallback_g5 = 0i64;
+                    }
+                    perftest_flat::Reading::Companion(__s0_0) => {
+                        let ___fallback_companion_v0: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+                            env,
+                            __s0_0.clone(),
+                        )?;
+                        ___fallback__tag = 4;
+                        ___fallback_g5 = ___fallback_companion_v0;
+                        ___fallback_g0 = 0i64;
+                        ___fallback_g1 = 0i64;
+                        ___fallback_g2 = 0i64;
+                        ___fallback_g3 = jni::objects::JObject::null();
+                        ___fallback_g4 = 0i32;
+                    }
+                }
+            }
+            ::core::option::Option::None => {
+                ___fallback_present = 0u8;
+                ___fallback__tag = 0i32;
+                ___fallback_g0 = 0i64;
+                ___fallback_g1 = 0i64;
+                ___fallback_g2 = 0i64;
+                ___fallback_g3 = jni::objects::JObject::null();
+                ___fallback_g4 = 0i32;
+                ___fallback_g5 = 0i64;
+            }
+        }
+        let ___note: jni::objects::JObject = String_to_JString_c7f3ca43(
+                env,
+                v.note.clone(),
+            )?
+            .into();
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Observation",
+                "fromParts",
+                "(JIJJJLjava/lang/String;IJZIJJJLjava/lang/String;IJLjava/lang/String;)Lio/prebindgen/covertest/model/Observation;",
+                &[
+                    jni::objects::JValue::from(___id),
+                    jni::objects::JValue::from(___reading__tag),
+                    jni::objects::JValue::from(___reading_g0),
+                    jni::objects::JValue::from(___reading_g1),
+                    jni::objects::JValue::from(___reading_g2),
+                    jni::objects::JValue::Object(&___reading_g3),
+                    jni::objects::JValue::from(___reading_g4),
+                    jni::objects::JValue::from(___reading_g5),
+                    jni::objects::JValue::from(___fallback_present),
+                    jni::objects::JValue::from(___fallback__tag),
+                    jni::objects::JValue::from(___fallback_g0),
+                    jni::objects::JValue::from(___fallback_g1),
+                    jni::objects::JValue::from(___fallback_g2),
+                    jni::objects::JValue::Object(&___fallback_g3),
+                    jni::objects::JValue::from(___fallback_g4),
+                    jni::objects::JValue::from(___fallback_g5),
+                    jni::objects::JValue::Object(&___note),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -8190,6 +8637,63 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_objectBoundaryVa
                 &__e.to_string(),
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    with_fallback: jni::sys::jboolean,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let with_fallback = match jboolean_to_bool_31306d98(&mut env, &with_fallback) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::observation_new(which, with_fallback);
+    match Observation_to_JObject_435b0724(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -8703,8 +8703,21 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationWhich
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
     o_id: jni::sys::jlong,
-    o_reading: jni::objects::JObject<'a>,
-    o_fallback: jni::objects::JObject<'a>,
+    o_reading__tag: jni::sys::jint,
+    o_reading_exact_v0: jni::sys::jlong,
+    o_reading_range_low: jni::sys::jlong,
+    o_reading_range_high: jni::sys::jlong,
+    o_reading_tagged_v0: jni::objects::JString<'a>,
+    o_reading_tagged_v1: jni::sys::jint,
+    o_reading_companion_v0: jni::sys::jlong,
+    o_fallback_present: jni::sys::jboolean,
+    o_fallback__tag: jni::sys::jint,
+    o_fallback_exact_v0: jni::sys::jlong,
+    o_fallback_range_low: jni::sys::jlong,
+    o_fallback_range_high: jni::sys::jlong,
+    o_fallback_tagged_v0: jni::objects::JString<'a>,
+    o_fallback_tagged_v1: jni::sys::jint,
+    o_fallback_companion_v0: jni::sys::jlong,
     o_note: jni::objects::JString<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jint {
@@ -8726,36 +8739,282 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationWhich
             return 0 as jni::sys::jint;
         }
     };
-    let __flat_o_reading = match JObject_to_Reading_2261050f(&mut env, &o_reading) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
+    let __flat_o_reading: perftest_flat::Reading = match o_reading__tag {
+        0 => perftest_flat::Reading::Missing,
+        1 => {
+            let __flat_o_reading_o_reading_exact_v0 = match jlong_to_i64_fbf9a9bc(
+                &mut env,
+                &o_reading_exact_v0,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            };
+            perftest_flat::Reading::Exact(__flat_o_reading_o_reading_exact_v0)
+        }
+        2 => {
+            let __flat_o_reading_o_reading_range_low = match jlong_to_i64_fbf9a9bc(
+                &mut env,
+                &o_reading_range_low,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            };
+            let __flat_o_reading_o_reading_range_high = match jlong_to_i64_fbf9a9bc(
+                &mut env,
+                &o_reading_range_high,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            };
+            perftest_flat::Reading::Range {
+                low: __flat_o_reading_o_reading_range_low,
+                high: __flat_o_reading_o_reading_range_high,
+            }
+        }
+        3 => {
+            let __flat_o_reading_o_reading_tagged_v0 = match JString_to_String_c7f3ca43(
+                &mut env,
+                &o_reading_tagged_v0,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            };
+            let __flat_o_reading_o_reading_tagged_v1 = match jint_to_Priority_447102d2(
+                &mut env,
+                &o_reading_tagged_v1,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            };
+            perftest_flat::Reading::Labeled(
+                __flat_o_reading_o_reading_tagged_v0,
+                __flat_o_reading_o_reading_tagged_v1,
+            )
+        }
+        4 => {
+            let __flat_o_reading_o_reading_companion_v0 = match jlong_to_i64_fbf9a9bc(
+                &mut env,
+                &o_reading_companion_v0,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            };
+            perftest_flat::Reading::Companion(__flat_o_reading_o_reading_companion_v0)
+        }
+        _ => {
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                "Reading: invalid tag",
             );
             return 0 as jni::sys::jint;
         }
     };
-    let __flat_o_fallback = match JObject_to_Option_Reading_80df84a9(
-        &mut env,
-        &o_fallback,
-    ) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
-            signal_binding_error(
-                &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                &__e.to_string(),
-            );
-            return 0 as jni::sys::jint;
-        }
+    let __flat_o_fallback: Option<perftest_flat::Reading> = if o_fallback_present != 0u8
+    {
+        ::core::option::Option::Some(
+            match o_fallback__tag {
+                0 => perftest_flat::Reading::Missing,
+                1 => {
+                    let __flat_o_fallback_o_fallback_exact_v0 = match jlong_to_i64_fbf9a9bc(
+                        &mut env,
+                        &o_fallback_exact_v0,
+                    ) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return 0 as jni::sys::jint;
+                        }
+                    };
+                    perftest_flat::Reading::Exact(__flat_o_fallback_o_fallback_exact_v0)
+                }
+                2 => {
+                    let __flat_o_fallback_o_fallback_range_low = match jlong_to_i64_fbf9a9bc(
+                        &mut env,
+                        &o_fallback_range_low,
+                    ) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return 0 as jni::sys::jint;
+                        }
+                    };
+                    let __flat_o_fallback_o_fallback_range_high = match jlong_to_i64_fbf9a9bc(
+                        &mut env,
+                        &o_fallback_range_high,
+                    ) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return 0 as jni::sys::jint;
+                        }
+                    };
+                    perftest_flat::Reading::Range {
+                        low: __flat_o_fallback_o_fallback_range_low,
+                        high: __flat_o_fallback_o_fallback_range_high,
+                    }
+                }
+                3 => {
+                    let __flat_o_fallback_o_fallback_tagged_v0 = match JString_to_String_c7f3ca43(
+                        &mut env,
+                        &o_fallback_tagged_v0,
+                    ) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return 0 as jni::sys::jint;
+                        }
+                    };
+                    let __flat_o_fallback_o_fallback_tagged_v1 = match jint_to_Priority_447102d2(
+                        &mut env,
+                        &o_fallback_tagged_v1,
+                    ) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return 0 as jni::sys::jint;
+                        }
+                    };
+                    perftest_flat::Reading::Labeled(
+                        __flat_o_fallback_o_fallback_tagged_v0,
+                        __flat_o_fallback_o_fallback_tagged_v1,
+                    )
+                }
+                4 => {
+                    let __flat_o_fallback_o_fallback_companion_v0 = match jlong_to_i64_fbf9a9bc(
+                        &mut env,
+                        &o_fallback_companion_v0,
+                    ) {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return 0 as jni::sys::jint;
+                        }
+                    };
+                    perftest_flat::Reading::Companion(
+                        __flat_o_fallback_o_fallback_companion_v0,
+                    )
+                }
+                _ => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        "Reading: invalid tag",
+                    );
+                    return 0 as jni::sys::jint;
+                }
+            },
+        )
+    } else {
+        ::core::option::Option::None
     };
     let __flat_o_note = match JString_to_String_c7f3ca43(&mut env, &o_note) {
         ::core::result::Result::Ok(__v) => __v,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -835,6 +835,86 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Marker_3dc81334<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Marker, __JniErr> {
+    Ok({
+        let __obj = v;
+        (|| -> ::core::result::Result<perftest_flat::Marker, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Marker: null value where a variant was required".to_string(),
+                    ),
+                );
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Marker$None_")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Marker", ": instanceof ",
+                        "io/prebindgen/covertest/model/Marker$None_", ": {}"), e
+                    ),
+                ))?
+            {
+                return ::core::result::Result::Ok(perftest_flat::Marker::None_);
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Marker$Ranked")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Marker", ": instanceof ",
+                        "io/prebindgen/covertest/model/Marker$Ranked", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "Lio/prebindgen/covertest/model/Priority;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Marker.Ranked.v0: {}", e)))?;
+                let __p_v0 = if __p_v0_obj.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __p_v0_raw: jni::sys::jint = env
+                        .call_method(&__p_v0_obj, "getValue", "()I", &[])
+                        .and_then(|val| val.i())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Marker.Ranked.v0: {}", e)))?;
+                    ::core::option::Option::Some(
+                        jint_to_Priority_447102d2(env, &__p_v0_raw)?,
+                    )
+                };
+                return ::core::result::Result::Ok(perftest_flat::Marker::Ranked(__p_v0));
+            }
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from("Marker: value is not one of its declared variants".to_string()),
+            )
+        })()?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_ObjectBoundary16_e9d41606<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -1514,6 +1594,15 @@ pub(crate) unsafe fn JObject_to_Reading_2261050f<'env, 'v>(
     Ok({
         let __obj = v;
         (|| -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Reading: null value where a variant was required".to_string(),
+                    ),
+                );
+            }
             if env
                 .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Missing")
                 .map_err(|e| <__JniErr as ::core::convert::From<
@@ -1684,6 +1773,42 @@ pub(crate) unsafe fn JObject_to_RepliesConfig_eb8e9079<'env, 'v>(
         perftest_flat::RepliesConfig {
             priority,
             max_samples,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Tagged_641b984c<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Tagged, __JniErr> {
+    Ok({
+        let __id_raw: jni::sys::jlong = env
+            .get_field(v, "id", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Tagged.id: {}", e)))? as _;
+        let id = jlong_to_i64_fbf9a9bc(env, &__id_raw)?;
+        let __marker_raw: jni::objects::JObject = env
+            .get_field(v, "marker", "Lio/prebindgen/covertest/model/Marker;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Tagged.marker: {}", e)))?;
+        let marker = JObject_to_Marker_3dc81334(env, &__marker_raw)?;
+        perftest_flat::Tagged {
+            id,
+            marker,
         }
     })
 }
@@ -5633,6 +5758,57 @@ pub(crate) unsafe fn Summary_to_jlong_ccacdeac<'a>(
     v: &perftest_flat::Summary,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v.clone())) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Tagged_to_JObject_641b984c<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Tagged,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.id.clone())?;
+        let ___marker__tag: jni::sys::jint;
+        let ___marker_g0: jni::objects::JObject;
+        match &v.marker {
+            perftest_flat::Marker::None_ => {
+                ___marker__tag = 0;
+                ___marker_g0 = jni::objects::JObject::null();
+            }
+            perftest_flat::Marker::Ranked(__s0_0) => {
+                let ___marker_ranked_v0: jni::objects::JObject = Option_Priority_to_JObject_ad5cbb32(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                ___marker__tag = 1;
+                ___marker_g0 = ___marker_ranked_v0;
+            }
+        }
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Tagged",
+                "fromParts",
+                "(JILjava/lang/Integer;)Lio/prebindgen/covertest/model/Tagged;",
+                &[
+                    jni::objects::JValue::from(___id),
+                    jni::objects::JValue::from(___marker__tag),
+                    jni::objects::JValue::Object(&___marker_g0),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
 }
 #[allow(
     non_snake_case,
@@ -14000,6 +14176,110 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
                 &__e.to_string(),
             );
             0.0 as jni::sys::jdouble
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_taggedNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::tagged_new(which);
+    match Tagged_to_JObject_641b984c(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_taggedRank<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    t_id: jni::sys::jlong,
+    t_marker: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jint {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_t_id = match jlong_to_i64_fbf9a9bc(&mut env, &t_id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __flat_t_marker = match JObject_to_Marker_3dc81334(&mut env, &t_marker) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jint;
+        }
+    };
+    let __flat_t = perftest_flat::Tagged {
+        id: __flat_t_id,
+        marker: __flat_t_marker,
+    };
+    let t = __flat_t;
+    let __out = perftest_flat::tagged_rank(t);
+    match i32_to_jint_a3e3b6ef(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jint
         }
     }
 }

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct foo_t {
     pub id: u64,
     pub x86_64_field: u64,
-    pub unstable_field: u64,
+    pub stable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -97,7 +97,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        unstable_field: v.unstable_field,
+        stable_field: v.stable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -208,7 +208,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        unstable_field: v.unstable_field,
+        stable_field: v.stable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -429,17 +429,6 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
-    let c = match __cbg_in___mut_Calculator(c) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__msg) => {
-            panic!("{}", __msg);
-        }
-    };
-    example_flat::calculator_reset(c);
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -491,7 +480,7 @@ pub unsafe extern "C" fn inside_foo_value(x: inside_foo_t) -> i32 {
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
+        example_flat::FEATURES, "",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct foo_t {
     pub id: u64,
     pub x86_64_field: u64,
-    pub stable_field: u64,
+    pub unstable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -97,7 +97,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -208,7 +208,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -429,6 +429,17 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
+    let c = match __cbg_in___mut_Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    example_flat::calculator_reset(c);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -480,7 +491,7 @@ pub unsafe extern "C" fn inside_foo_value(x: inside_foo_t) -> i32 {
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "",
+        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -37,7 +37,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t x86_64_field;
-  uint64_t stable_field;
+  uint64_t unstable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -69,6 +69,8 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
+
+void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -37,7 +37,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t x86_64_field;
-  uint64_t unstable_field;
+  uint64_t stable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -69,8 +69,6 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
-
-void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -105,6 +105,50 @@ pub enum Reading {
     Companion(i64),
 }
 
+/// A data class carrying a **sum** as a field — the position where "exactly one
+/// of" composes with ordinary product data.
+///
+/// `reading` is required and `fallback` optional, so the binding has to gate a
+/// tag *and* a present flag independently; both sit beside already-flattened
+/// siblings (`id`, `note`) so the tag-gated groups must interleave correctly
+/// with ordinary leaves rather than only working in isolation. `Reading`'s
+/// `Labeled` arm carries a `String`, which is the payload that proves an inert
+/// group's object slot is wire-defaulted to null and therefore nullable in the
+/// generated `fromParts`.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Observation {
+    pub id: i64,
+    pub reading: Reading,
+    pub fallback: Option<Reading>,
+    pub note: String,
+}
+
+/// The `Reading` alternative selected by `which` (declaration order, so it is
+/// the same numbering as the generated tag).
+fn reading_for(which: i32) -> Reading {
+    match which {
+        0 => Reading::Missing,
+        1 => Reading::Exact(42),
+        2 => Reading::Range { low: 1, high: 9 },
+        3 => Reading::Labeled("warm".to_string(), Priority::High),
+        _ => Reading::Companion(5),
+    }
+}
+
+/// Build an [`Observation`] carrying the selected alternative, optionally with
+/// a `fallback` (the next alternative round-robin) — a **sum as a struct
+/// field** crossing Rust → Kotlin, required and optional in one value.
+#[prebindgen]
+pub fn observation_new(which: i32, with_fallback: bool) -> Observation {
+    Observation {
+        id: 7,
+        reading: reading_for(which),
+        fallback: with_fallback.then(|| reading_for((which + 1) % 5)),
+        note: "obs".to_string(),
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Stamp — a small `Copy` value type (→ Kotlin value class over raw bytes).
 // ─────────────────────────────────────────────────────────────────────────────

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -193,6 +193,67 @@ pub fn tagged_rank(t: Tagged) -> i32 {
     }
 }
 
+/// The selected alternative as the function's **own return** — a sum in
+/// return position, where nothing but the value's own tag says which group is
+/// live. Unlike a struct field (whose slots ride the parent's `fromParts`),
+/// there is no surrounding product to carry the tag, so the decomposition
+/// itself has to.
+#[prebindgen]
+pub fn reading_of(which: i32) -> Reading {
+    reading_for(which)
+}
+
+/// `Option<sum>` return: `which < 0` yields `None`. Optionality and choice stay
+/// independent — the present layer nulls the whole result rather than becoming
+/// an extra tag value.
+#[prebindgen]
+pub fn reading_maybe(which: i32) -> Option<Reading> {
+    (which >= 0).then(|| reading_for(which))
+}
+
+/// `Vec<sum>` return: alternatives `0..n`, each folded into the foreign list
+/// element by element.
+#[prebindgen]
+pub fn reading_series(n: i32) -> Vec<Reading> {
+    (0..n).map(reading_for).collect()
+}
+
+/// A sum as a **callback argument**: alternatives `0..n` delivered in turn.
+#[prebindgen]
+pub fn reading_each(n: i32, sink: impl Fn(Reading) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(reading_for(i));
+    }
+}
+
+/// A sum whose alternatives are a **payload-less** variant and one carrying an
+/// opaque **handle** — the shape a real lookup/reply result takes, and the one
+/// that proves a tag-gated group can own a native resource: the live group
+/// hands over a fresh handle, the inert group's slot stays a null pointer that
+/// is never wrapped.
+#[prebindgen]
+#[derive(Clone)]
+pub enum Lookup {
+    /// Nothing matched — only the tag is live.
+    Absent,
+    /// What matched, as a handle the caller owns (and must close).
+    Found(Summary),
+    /// Why the lookup could not run — a `String` beside the handle group, so an
+    /// inert object slot is exercised alongside an inert primitive one.
+    Failed(String),
+}
+
+/// Build a [`Lookup`]: `count < 0` is a failure, `count == 0` is absent,
+/// anything else is found.
+#[prebindgen]
+pub fn lookup_of(count: i64, total: f64) -> Lookup {
+    match count {
+        c if c < 0 => Lookup::Failed("negative count".to_string()),
+        0 => Lookup::Absent,
+        c => Lookup::Found(summary_new(c, total)),
+    }
+}
+
 /// Which alternative an [`Observation`]'s `reading` holds, by declaration
 /// order — the sum crossing back **in** as part of a data-class parameter.
 #[prebindgen]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -149,6 +149,50 @@ pub fn observation_new(which: i32, with_fallback: bool) -> Observation {
     }
 }
 
+/// A second sum whose payload is **not leaf-shaped**: `Option<Priority>` is an
+/// enum object (or null) in the JVM slot, which the tag-gated flat form cannot
+/// express. The binding therefore lets this one cross as a whole object through
+/// its own converter rather than failing — the degradation path — which is also
+/// what exercises the `Option<enum>` property read.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Marker {
+    None_,
+    Ranked(Option<Priority>),
+}
+
+/// A data class carrying the object-shaped sum.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tagged {
+    pub id: i64,
+    pub marker: Marker,
+}
+
+/// Build a [`Tagged`]: `which` 0 = `None_`, 1 = `Ranked(None)`, 2 = `Ranked(Some(High))`.
+#[prebindgen]
+pub fn tagged_new(which: i32) -> Tagged {
+    Tagged {
+        id: 3,
+        marker: match which {
+            0 => Marker::None_,
+            1 => Marker::Ranked(None),
+            _ => Marker::Ranked(Some(Priority::High)),
+        },
+    }
+}
+
+/// Read it back — the whole-object sum decode, including the `Option<enum>`
+/// payload, crossing Kotlin → Rust.
+#[prebindgen]
+pub fn tagged_rank(t: Tagged) -> i32 {
+    match t.marker {
+        Marker::None_ => -1,
+        Marker::Ranked(None) => 0,
+        Marker::Ranked(Some(p)) => priority_weight(p),
+    }
+}
+
 /// Which alternative an [`Observation`]'s `reading` holds, by declaration
 /// order — the sum crossing back **in** as part of a data-class parameter.
 #[prebindgen]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -149,6 +149,19 @@ pub fn observation_new(which: i32, with_fallback: bool) -> Observation {
     }
 }
 
+/// Which alternative an [`Observation`]'s `reading` holds, by declaration
+/// order — the sum crossing back **in** as part of a data-class parameter.
+#[prebindgen]
+pub fn observation_which(o: Observation) -> i32 {
+    match o.reading {
+        Reading::Missing => 0,
+        Reading::Exact(_) => 1,
+        Reading::Range { .. } => 2,
+        Reading::Labeled(_, _) => 3,
+        Reading::Companion(_) => 4,
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Stamp — a small `Copy` value type (→ Kotlin value class over raw bytes).
 // ─────────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -222,6 +222,24 @@ pub trait Prebindgen {
         Vec::new()
     }
 
+    /// Synthesized **sum** decompositions for this adapter — the
+    /// selector-carrying sibling of [`Self::value_struct_decons`]. Each names a
+    /// data-carrying enum, its synthesized tag leaf and one leaf group per
+    /// alternative. Consulted by `write_rust` right after
+    /// [`Self::value_struct_decons`]: each is wired by
+    /// [`crate::api::core::unfold::apply_sum_returns`] into a fixed-builder
+    /// [`crate::api::core::unfold::UnfoldPlan`] for every function whose own
+    /// return (or callback argument) IS the sum, so the value crosses as a tag
+    /// plus tag-gated groups and the foreign side picks the live alternative.
+    ///
+    /// Default: empty.
+    fn sum_decons(
+        &self,
+        _registry: &Registry<Self::Metadata>,
+    ) -> Vec<crate::api::core::unfold::SumDecon> {
+        Vec::new()
+    }
+
     /// Element types the adapter nominates for a **whole-element leaf fold**: a
     /// `Vec<T>` / `Option<Vec<T>>` return (or `impl Fn(&[T])` callback arg) whose
     /// element `T` is a single boundary leaf (e.g. a String, a value blob, an

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1386,6 +1386,13 @@ impl<M> Registry<M> {
         if !value_decons.is_empty() {
             crate::api::core::unfold::apply_value_structs(self, value_decons, &declared.functions)?;
         }
+        // Synthesized sum decompositions: the same fixed-builder wiring for a
+        // value whose alternatives are chosen at runtime (tag + one leaf group
+        // per variant) rather than being a fixed product.
+        let sum_decons = ext.sum_decons(self);
+        if !sum_decons.is_empty() {
+            crate::api::core::unfold::apply_sum_returns(self, sum_decons, &declared.functions)?;
+        }
         // Single-leaf `Vec<T>`/`&[T]` whole-element folds — the dual of the
         // `data_class` folds above, for String / value-blob / handle elements
         // (so the list is built on the foreign side, not via a Rust ArrayList).

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -458,89 +458,178 @@ pub fn apply_value_structs<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
     for vd in &decons {
-        let decon = DeconId::Default(vd.key.to_string());
-        require_unique_leaf_names(&vd.source, &vd.leaves)?;
-        registry
-            .decon_plans
-            .entry(decon.clone())
-            .or_insert_with(|| DeconSpec {
-                source: vd.source.clone(),
-                leaves: vd.leaves.clone(),
-            });
+        let decon = wire_fixed_decon(registry, &vd.key, &vd.source, &vd.leaves)?;
 
         // Output position: a declared fn returning the struct
         // (`T` / `&T` / `Option<T|&T>` / `Vec<T|&T>`) decomposes into a
         // fixed-builder plan. (`Result<T, E>` is left to the whole-value
         // converter — the synthesizer covers the infallible returns.)
-        for func in declared_fns {
-            let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
-                continue;
-            };
-            let ret = fn_return(&item_fn);
-            if !returns_type(&ret, &vd.key) || registry.unfold_plans.contains_key(func) {
-                continue;
-            }
-            // Shape over the field decomposition: peel an outer `Option`, then a
-            // `Vec`, then a leading `&`. `Vec<T|&T>` ⇒ Iterable (a **fixed
-            // folder**: each element's field leaves cross raw and the foreign
-            // folder rebuilds it via `fromParts` + appends, so no Java object is
-            // built on the Rust side); `Option<…>` wraps the inner shape in
-            // Optional (`None` ⇒ a null result). `element: None` keeps the
-            // decomposed-leaf path. The element/inner borrow-ness sets `by_ref`
-            // (the field reach clones either way).
-            let (optional, after_opt) = match option_inner_type(&ret) {
-                Some(inner) => (true, inner),
-                None => (false, ret.clone()),
-            };
-            let (iterable, core) = match vec_inner_type(&after_opt) {
-                Some(inner) => (true, inner),
-                None => (false, after_opt),
-            };
-            let by_ref = matches!(&core, syn::Type::Reference(_));
-            let inner_shape = if iterable {
-                UnfoldShape::Iterable(Box::new(UnfoldShape::Base))
-            } else {
-                UnfoldShape::Base
-            };
-            let shape = if optional {
-                UnfoldShape::Optional((), Box::new(inner_shape))
-            } else {
-                inner_shape
-            };
-            for leaf in &vd.leaves {
-                registry.require_output(&leaf.out_ty, &loc);
-            }
-            let plan = UnfoldPlan {
-                source: vd.source.clone(),
-                decon: Some(decon.clone()),
-                by_ref,
-                shape,
-                leaves: vd.leaves.clone(),
-                element: None,
-                delivery: Delivery::Callback,
-                convert_out_ty: None,
-                fixed_builder: true,
-            };
-            registry.unfold_plans.insert(func.clone(), plan);
-        }
+        wire_fixed_returns(registry, vd, &decon, declared_fns, false);
 
         // Callback-argument position: an `impl Fn(&T)` / `impl Fn(T)` parameter
         // of a declared fn delivers the flattened leaves to the foreign
         // callback, which reassembles the whole value via the data class's
         // `fromParts` before invoking the user's typed callback (the group
         // reassembly lives in the JNI adapter's `asRaw` proxy).
-        apply_value_struct_callbacks(registry, vd, &decon, declared_fns)?;
+        wire_fixed_callbacks(registry, vd, &decon, declared_fns)?;
     }
     Ok(())
 }
 
+/// A synthesized **sum** decomposition, produced by the language adapter (which
+/// knows how each payload encodes) and fed to [`apply_sum_returns`] — the
+/// selector-carrying sibling of [`ValueDecon`].
+///
+/// Its [`leaves`](Self::leaves) are a [`LeafSource::SumTag`] selector followed
+/// by one **group** per alternative ([`LeafSource::VariantField`] leaves
+/// carrying [`UnfoldLeaf::group`]). Exactly one group is live per value; the
+/// emitter reads the whole list as ONE `match` over the value, filling every
+/// inert slot with its wire default. The foreign side picks the live group by
+/// the tag and rebuilds the alternative, so no object is built on the Rust
+/// side.
+pub struct SumDecon {
+    /// Canonical key of the sum type (the `DeconId::Default` key).
+    pub key: TypeKey,
+    /// The enum type (owned) the leaves decompose.
+    pub source: syn::Type,
+    /// The tag leaf followed by every variant's group, in tag order.
+    pub leaves: Vec<UnfoldLeaf>,
+}
+
+/// Wire the synthesized **sum** decompositions into the registry — the
+/// [`apply_value_structs`] analog for a value whose alternatives are chosen at
+/// runtime instead of being a fixed product.
+///
+/// For every declared function returning the sum (`E` / `&E` / `Option<E>` /
+/// `Vec<E>`) and every `impl Fn(E)` / `impl Fn(&E)` callback parameter, builds a
+/// **fixed-builder** [`UnfoldPlan`] over the tag + group leaves, registering
+/// each leaf's `out_ty` as a required output.
+///
+/// A sum has no converter of its own (it is boundary-only: a tag plus groups is
+/// not a single wire), so the declared return's scan-time output requirement —
+/// including the `Option<E>` / `Vec<E>` layers, which the boundary-only pass
+/// does not reach — is dropped here as the plan takes over.
+///
+/// Runs in `write_rust` right after [`apply_value_structs`] and before `resolve`.
+pub fn apply_sum_returns<M>(
+    registry: &mut Registry<M>,
+    decons: Vec<SumDecon>,
+    declared_fns: &std::collections::HashSet<syn::Ident>,
+) -> Result<(), UnfoldError> {
+    for sd in &decons {
+        let decon = wire_fixed_decon(registry, &sd.key, &sd.source, &sd.leaves)?;
+        let vd = ValueDecon {
+            key: sd.key.clone(),
+            source: sd.source.clone(),
+            leaves: sd.leaves.clone(),
+        };
+        wire_fixed_returns(registry, &vd, &decon, declared_fns, true);
+        wire_fixed_callbacks(registry, &vd, &decon, declared_fns)?;
+    }
+    Ok(())
+}
+
+/// Register the declaration-canonical [`DeconSpec`] of a synthesized
+/// decomposition (first writer wins) and return its identity.
+fn wire_fixed_decon<M>(
+    registry: &mut Registry<M>,
+    key: &TypeKey,
+    source: &syn::Type,
+    leaves: &[UnfoldLeaf],
+) -> Result<DeconId, UnfoldError> {
+    let decon = DeconId::Default(key.to_string());
+    require_unique_leaf_names(source, leaves)?;
+    registry
+        .decon_plans
+        .entry(decon.clone())
+        .or_insert_with(|| DeconSpec {
+            source: source.clone(),
+            leaves: leaves.to_vec(),
+        });
+    Ok(decon)
+}
+
+/// Build the fixed-builder output plan for every declared fn returning the
+/// decomposed type (`T` / `&T` / `Option<T|&T>` / `Vec<T|&T>`). `no_converter`
+/// marks a type that has no whole-value converter at all (a sum), so the
+/// declared return's scan-time output requirement is dropped as the plan
+/// replaces it.
+fn wire_fixed_returns<M>(
+    registry: &mut Registry<M>,
+    vd: &ValueDecon,
+    decon: &DeconId,
+    declared_fns: &std::collections::HashSet<syn::Ident>,
+    no_converter: bool,
+) {
+    for func in declared_fns {
+        let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
+            continue;
+        };
+        let ret = fn_return(&item_fn);
+        if !returns_type(&ret, &vd.key) || registry.unfold_plans.contains_key(func) {
+            continue;
+        }
+        // Shape over the leaf decomposition: peel an outer `Option`, then a
+        // `Vec`, then a leading `&`. `Vec<T|&T>` ⇒ Iterable (a **fixed
+        // folder**: each element's leaves cross raw and the foreign folder
+        // rebuilds it + appends, so no Java object is built on the Rust
+        // side); `Option<…>` wraps the inner shape in Optional (`None` ⇒ a
+        // null result). `element: None` keeps the decomposed-leaf path. The
+        // element/inner borrow-ness sets `by_ref` (the reach clones either
+        // way).
+        let (optional, after_opt) = match option_inner_type(&ret) {
+            Some(inner) => (true, inner),
+            None => (false, ret.clone()),
+        };
+        let (iterable, core) = match vec_inner_type(&after_opt) {
+            Some(inner) => (true, inner),
+            None => (false, after_opt.clone()),
+        };
+        let by_ref = matches!(&core, syn::Type::Reference(_));
+        let inner_shape = if iterable {
+            UnfoldShape::Iterable(Box::new(UnfoldShape::Base))
+        } else {
+            UnfoldShape::Base
+        };
+        let shape = if optional {
+            UnfoldShape::Optional((), Box::new(inner_shape))
+        } else {
+            inner_shape
+        };
+        if no_converter {
+            // The plan delivers the return leaf-by-leaf, so no converter is
+            // needed for the declared return — and for a sum none can exist.
+            // Drop the scan-time registrations of every layer (the boundary-only
+            // pass only reaches the bare type), so the missing converters are not
+            // flagged as unresolved-required.
+            registry.unrequire_output(&ret);
+            registry.unrequire_output(&after_opt);
+        }
+        for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
+            registry.require_output(&leaf.out_ty, &loc);
+        }
+        let plan = UnfoldPlan {
+            source: vd.source.clone(),
+            decon: Some(decon.clone()),
+            by_ref,
+            shape,
+            leaves: vd.leaves.clone(),
+            element: None,
+            delivery: Delivery::Callback,
+            convert_out_ty: None,
+            fixed_builder: true,
+        };
+        registry.unfold_plans.insert(func.clone(), plan);
+    }
+}
+
 /// Build a fixed-builder callback-arg plan for every `impl Fn(&T)` /
-/// `impl Fn(T)` parameter (of a declared fn) whose value is the value struct
-/// `vd`. The foreign callback receives the flattened leaves (reassembled there
-/// via the data class's `fromParts`) instead of a whole value built on the Rust
-/// side. Separate from the output-position wiring so the callback path (which
-/// needs the foreign-side group-reassembly adapter) can be enabled on its own.
-fn apply_value_struct_callbacks<M>(
+/// `impl Fn(T)` parameter (of a declared fn) whose value is the decomposed type
+/// `vd`. The foreign callback receives the flattened leaves (reassembled there)
+/// instead of a whole value built on the Rust side. Separate from the
+/// output-position wiring so the callback path (which needs the foreign-side
+/// group-reassembly adapter) can be enabled on its own.
+fn wire_fixed_callbacks<M>(
     registry: &mut Registry<M>,
     vd: &ValueDecon,
     decon: &DeconId,
@@ -582,7 +671,7 @@ fn apply_value_struct_callbacks<M>(
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                for leaf in &vd.leaves {
+                for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
                     registry.require_output(&leaf.out_ty, &loc);
                 }
                 let plan = UnfoldPlan {
@@ -1147,6 +1236,7 @@ fn flatten<M>(
                     identity: true,
                     nullable,
                     source: LeafSource::Accessor,
+                    group: None,
                 });
             }
             DeconRecord::Acc { name, .. } | DeconRecord::LocalAcc { name, .. } => {
@@ -1244,6 +1334,7 @@ fn flatten<M>(
                         identity,
                         nullable,
                         source: LeafSource::Accessor,
+                        group: None,
                     });
                 }
             }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -59,7 +59,7 @@ pub struct DeconSpec {
 }
 
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum LeafSource {
     /// The path is a chain of `#[prebindgen]` **accessor functions**:
     /// `source_module::f(&value)`, composing nested accessors. Nesting steps
@@ -74,6 +74,27 @@ pub enum LeafSource {
     /// fields cross as decoupled leaves and the foreign side reassembles the
     /// object (so no Java object is built on the Rust side).
     Field,
+    /// The **synthesized selector** of a decomposed sum: an `i32` naming which
+    /// alternative is live. It is not read off the value at all — the emitter
+    /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
+    /// the groups it selects between (see
+    /// [`crate::api::core::unfold::apply_sum_returns`]).
+    SumTag,
+    /// A payload field of ONE alternative of a decomposed sum, reached through
+    /// a **variant pattern** rather than an accessor chain or a field chain:
+    /// the emitter binds `member` inside `variant`'s `match` arm. The leaf is
+    /// live only when [`UnfoldLeaf::group`] equals the value's tag; in every
+    /// other arm its slot carries the wire default.
+    ///
+    /// This is the selector [`Accessor`](Self::Accessor) and
+    /// [`Field`](Self::Field) deliberately lack — both are deterministic
+    /// products, every record contributing unconditionally.
+    VariantField {
+        /// The variant's ident as declared in the source enum.
+        variant: syn::Ident,
+        /// How the payload field is addressed in the arm's pattern.
+        member: syn::Member,
+    },
 }
 
 /// A resolved output expansion for one function.
@@ -146,6 +167,28 @@ pub struct UnfoldLeaf {
     /// `match Some/None`.
     pub nullable: bool,
     /// How [`Self::path`] is reached from the value — an accessor-fn chain
-    /// (default) or a struct-field chain (synthesized `data_class`).
+    /// (default), a struct-field chain (synthesized `data_class`), or a
+    /// variant pattern binding (decomposed sum).
     pub source: LeafSource,
+    /// **Group membership**: `Some(tag)` marks the leaf as belonging to the
+    /// leaf group of the sum alternative with that tag — live only when the
+    /// value's [`LeafSource::SumTag`] leaf equals `tag`, wire-defaulted
+    /// otherwise. `None` for an unconditional (product) leaf, including the
+    /// tag leaf itself, which selects between groups rather than joining one.
+    ///
+    /// Grouping is what turns a leaf list into a `match`: leaves sharing a
+    /// group are emitted together in one arm instead of as independent
+    /// per-leaf expressions.
+    pub group: Option<i32>,
+}
+
+impl UnfoldLeaf {
+    /// Whether this leaf's [`out_ty`](Self::out_ty) needs a resolved **output
+    /// converter**. False only for the synthesized [`LeafSource::SumTag`]
+    /// selector: it is assigned per `match` arm, never converted, so requiring
+    /// a converter for it would make every sum depend on an unrelated `i32`
+    /// crossing existing in the binding.
+    pub fn has_converter(&self) -> bool {
+        self.source != LeafSource::SumTag
+    }
 }

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1072,6 +1072,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Field,
+        group: None,
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
@@ -1124,6 +1125,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Field,
+        group: None,
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
@@ -1650,4 +1652,134 @@ fn duplicate_declarations_collected() {
         text.contains("duplicate output expansion for `z_session_key`"),
         "{text}"
     );
+}
+
+/// The tag + group leaves a sum decomposition is made of. Mirrors what the
+/// JNI adapter synthesizes: a selector followed by one group per alternative.
+fn reading_sum_decon() -> SumDecon {
+    let tag = UnfoldLeaf {
+        name: "tag".to_string(),
+        path: vec![],
+        out_ty: syn::parse_quote!(i32),
+        identity: false,
+        nullable: false,
+        source: LeafSource::SumTag,
+        group: None,
+    };
+    let field = |name: &str, variant: &str, idx: u32, ty: syn::Type, group: i32| UnfoldLeaf {
+        name: name.to_string(),
+        path: vec![],
+        out_ty: ty,
+        identity: false,
+        nullable: false,
+        source: LeafSource::VariantField {
+            variant: ident(variant),
+            member: syn::Member::Unnamed(syn::Index::from(idx as usize)),
+        },
+        group: Some(group),
+    };
+    SumDecon {
+        key: TypeKey::from_type(&syn::parse_quote!(Reading)),
+        source: syn::parse_quote!(Reading),
+        leaves: vec![
+            tag,
+            // group 0 (`Missing`) is empty — a unit variant contributes only
+            // its tag.
+            field("exact_v0", "Exact", 0, syn::parse_quote!(i64), 1),
+        ],
+    }
+}
+
+/// A sum returned by a function decomposes into a **fixed-builder** plan over
+/// its tag and groups — the same delivery a by-value `data_class` gets, with
+/// the selector added. The declared return's own output requirement is dropped:
+/// a sum has no whole-value converter by construction, so leaving it required
+/// would fail the resolve on a converter that must not exist.
+#[test]
+fn sum_return_is_a_fixed_builder_plan() {
+    let mut reg = reg_with(&["fn read_one(which: i32) -> Reading { todo!() }"]);
+    let declared: std::collections::HashSet<syn::Ident> =
+        ["read_one"].iter().map(|s| ident(s)).collect();
+    apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
+
+    let plan = reg.unfold_plans.get(&ident("read_one")).expect("plan");
+    assert!(plan.fixed_builder, "sum ⇒ fixed builder");
+    assert_eq!(plan.delivery, Delivery::Callback);
+    assert!(matches!(plan.shape, UnfoldShape::Base));
+    assert!(!plan.by_ref);
+    assert_eq!(plan.leaves.len(), 2, "the tag plus one group leaf");
+    assert_eq!(plan.leaves[0].source, LeafSource::SumTag);
+    assert_eq!(plan.leaves[0].group, None, "the selector joins no group");
+    assert_eq!(
+        plan.leaves[1].group,
+        Some(1),
+        "the group is its variant's tag"
+    );
+    assert!(matches!(
+        &plan.leaves[1].source,
+        LeafSource::VariantField { variant, .. } if variant == "Exact"
+    ));
+    // The selector is synthesized, so it must not drag an `i32` output
+    // requirement into a binding that has no `i32` crossing of its own.
+    assert!(!plan.leaves[0].has_converter());
+    assert!(plan.leaves[1].has_converter());
+    assert!(
+        !reg.required_outputs_scan
+            .contains(&TypeKey::from_type(&syn::parse_quote!(Reading))),
+        "a sum has no whole-value converter, so its return must not require one"
+    );
+}
+
+/// `Option` and `Vec` layers ride the existing shape fold — a sum needs
+/// nothing new for them — and each layer's own scan-time output requirement is
+/// dropped along with the bare type's.
+#[test]
+fn sum_return_layers_ride_the_shape_fold() {
+    let mut reg = reg_with(&[
+        "fn read_maybe(w: i32) -> Option<Reading> { todo!() }",
+        "fn read_all(n: i32) -> Vec<Reading> { todo!() }",
+    ]);
+    let declared: std::collections::HashSet<syn::Ident> = ["read_maybe", "read_all"]
+        .iter()
+        .map(|s| ident(s))
+        .collect();
+    apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
+
+    let opt = reg.unfold_plans.get(&ident("read_maybe")).expect("plan");
+    assert!(matches!(&opt.shape,
+        UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Base)));
+    let vec_plan = reg.unfold_plans.get(&ident("read_all")).expect("plan");
+    assert!(matches!(&vec_plan.shape,
+        UnfoldShape::Iterable(inner) if matches!(**inner, UnfoldShape::Base)));
+    assert!(vec_plan.element.is_none(), "decomposed-leaf fold");
+    for ty in ["Option<Reading>", "Vec<Reading>", "Reading"] {
+        let ty: syn::Type = syn::parse_str(ty).unwrap();
+        assert!(
+            !reg.required_outputs_scan.contains(&TypeKey::from_type(&ty)),
+            "no layer of a sum return may require a whole-value converter: {}",
+            ty.to_token_stream()
+        );
+    }
+}
+
+/// An `impl Fn(E)` callback argument decomposes the same way a return does —
+/// the plan is keyed by the arg type, so the trampoline delivers the tag and
+/// groups instead of a whole value built on the Rust side.
+#[test]
+fn sum_callback_arg_is_a_fixed_builder_plan() {
+    let mut reg = reg_with(&[
+        "fn read_each(n: i32, f: impl Fn(Reading) + Send + Sync + 'static) { todo!() }",
+    ]);
+    let declared: std::collections::HashSet<syn::Ident> =
+        ["read_each"].iter().map(|s| ident(s)).collect();
+    apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
+
+    let key = TypeKey::from_type(&syn::parse_quote!(Reading));
+    let plan = reg
+        .callback_arg_plans
+        .get(&key)
+        .expect("callback-arg plan keyed by the arg type");
+    assert!(plan.fixed_builder);
+    assert!(matches!(plan.shape, UnfoldShape::Base));
+    assert_eq!(plan.leaves[0].source, LeafSource::SumTag);
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -75,7 +75,8 @@ pub(crate) fn callback_input(
             .filter(|p| super::render::is_iterable_fold(&p.shape))
         {
             // Every leaf converter must already be resolved (deferral safety).
-            for leaf in &plan.leaves {
+            // A synthesized leaf (a sum's tag) has no converter to wait for.
+            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
                 registry.output_entry(&leaf.out_ty)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
@@ -164,8 +165,11 @@ pub(crate) fn callback_input(
         if let Some(plan) = registry.callback_arg_plans.get(&TypeKey::from_type(arg_ty)) {
             // Deferral safety: every leaf converter (and identity-leaf
             // projection) must already be resolved — return None so the rank
-            // resolver retries this converter later otherwise.
-            for leaf in &plan.leaves {
+            // resolver retries this converter later otherwise. A synthesized
+            // leaf (a sum's tag) has no converter to wait for: requiring one
+            // would make the trampoline wait forever on an `i32` crossing the
+            // binding may not have.
+            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
                 let e = registry.output_entry(&leaf.out_ty)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -372,6 +372,13 @@ pub(crate) fn encode_plan_leaves(
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
+    // A decomposed **sum** is the one plan whose leaves are not independent:
+    // only one group is live per value, so the whole list is emitted as ONE
+    // `match` rather than per-leaf expressions. Same contract, different
+    // emitter — see [`encode_sum_leaves`].
+    if is_sum_leaves(&plan.leaves) {
+        return encode_sum_leaves(ext, registry, plan, obj_idents, value, fail);
+    }
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
@@ -634,7 +641,7 @@ pub(crate) fn encode_plan_leaves(
         // Rust expression to `body`.
         use crate::api::core::unfold::LeafSource;
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
-            match leaf.source {
+            match &leaf.source {
                 LeafSource::Accessor => reach_leaf(
                     &qualify,
                     &leaf.path,
@@ -649,6 +656,13 @@ pub(crate) fn encode_plan_leaves(
                     let segs = &leaf.path;
                     body(quote!(#value #(.#segs)*.clone()))
                 }
+                // Group leaves never reach this walk: a plan carrying them is
+                // routed to `encode_sum_leaves` at the top of this function,
+                // because a variant payload has no path — it is bound by a
+                // `match` arm.
+                LeafSource::SumTag | LeafSource::VariantField { .. } => unreachable!(
+                    "sum leaves are encoded by `encode_sum_leaves`, not reached by path"
+                ),
             }
         };
 
@@ -705,10 +719,24 @@ pub(crate) fn leaf_is_prim(
     registry: &Registry<KotlinMeta>,
     leaf: &crate::api::core::unfold::UnfoldLeaf,
 ) -> bool {
+    // The synthesized sum selector is a `jint` by definition — it is assigned,
+    // never converted, so it has no output entry to read a wire from and must
+    // not be made to depend on one resolving.
+    if leaf.source == crate::api::core::unfold::LeafSource::SumTag {
+        return true;
+    }
     if leaf.nullable {
         return false;
     }
-    let Some(entry) = registry.output_entry(&leaf.out_ty) else {
+    leaf_ty_is_prim(registry, &leaf.out_ty)
+}
+
+/// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw
+/// primitive** slot? Split out so the interface derivation can ask the question
+/// about a leaf whose own `nullable` flag it is in the middle of computing (an
+/// inert sum group slot).
+pub(crate) fn leaf_ty_is_prim(registry: &Registry<KotlinMeta>, out_ty: &syn::Type) -> bool {
+    let Some(entry) = registry.output_entry(out_ty) else {
         return false;
     };
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -354,9 +354,21 @@ pub(crate) fn sum_input_body(
     // No arm matched: the JVM object is not one of the declared variants —
     // a binding error through the ordinary channel, never a panic.
     let no_match = format!("{enum_name}: value is not one of its declared variants");
+    // NULL must be rejected BEFORE the dispatch: JNI specifies that
+    // `IsInstanceOf(NULL, any)` is true ("a NULL object can be cast to any
+    // class"), so a null would match the first arm and silently decode as
+    // that variant — for a unit first variant, without even a failed field
+    // read to give it away. An `Option<sum>` never reaches here with null:
+    // its wrapper carves the null niche first and yields `None`.
+    let null_msg = format!("{enum_name}: null value where a variant was required");
     let body: syn::Expr = syn::parse_quote!({
         let __obj = v;
         (|| -> ::core::result::Result<#source_module::#enum_ident, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<String>>::from(#null_msg.to_string()),
+                );
+            }
             #(#arms)*
             ::core::result::Result::Err(
                 <__JniErr as ::core::convert::From<String>>::from(#no_match.to_string()),
@@ -410,21 +422,52 @@ fn read_kotlin_property(
             ));
         }
     }
-    if ext.is_kotlin_enum(ty) {
-        let fqn = bare_path_ident(ty)
+    // An enum property — bare or under `Option` — is stored as the Kotlin
+    // **enum object**, so it is read through `getValue`, NOT through the
+    // generic converters: the bare-enum one is `jint`-keyed and the
+    // `Option<enum>` one unboxes a `java.lang.Integer`, and neither matches
+    // what the JVM slot actually holds. `struct_input_body` makes the same
+    // distinction for data-class fields; this is that logic for a property.
+    let enum_inner = option_inner_type(ty).unwrap_or_else(|| ty.clone());
+    if ext.is_kotlin_enum(&enum_inner) {
+        let fqn = bare_path_ident(&enum_inner)
             .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
             .map(|v| v.to_string())?;
         let sig = format!("L{};", fqn.replace('.', "/"));
         let obj = format_ident!("{}_obj", bind);
+        // Under `Option`, JVM null is `None` and the INNER converter decodes
+        // the discriminant; the outer converter would expect a boxed Integer.
+        let decode = if option_inner_type(ty).is_some() {
+            let inner_conv = registry
+                .input_entry(&enum_inner)?
+                .function
+                .sig
+                .ident
+                .clone();
+            quote! {
+                let #bind = if #obj.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
+                        .and_then(|val| val.i())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                    ::core::option::Option::Some(#inner_conv(env, &#raw)?)
+                };
+            }
+        } else {
+            quote! {
+                let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
+                    .and_then(|val| val.i())
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                let #bind = #conv(env, &#raw)?;
+            }
+        };
         return Some((
             quote! {
                 let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
-                    .and_then(|val| val.i())
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                let #bind = #conv(env, &#raw)?;
+                #decode
             },
             quote!(#bind),
         ));

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -404,6 +404,30 @@ fn read_kotlin_property(
             let fqn = handle_field_fqn(ext, proj).replace('.', "/");
             let sig = format!("L{fqn};");
             let obj = format_ident!("{}_obj", bind);
+            // A required (non-`Option`) handle payload is OWNED by the variant
+            // it builds, so it is decoded by CONSUMING the native object
+            // (`Box::from_raw`) — the mirror of the output side's
+            // `Box::into_raw`. The borrow converter would yield
+            // `OwnedObject<T>`, which cannot populate an owned field. Same rule
+            // (and same reasoning) as an owned handle field of a data class;
+            // `Option<_>` keeps the niche-aware converter (jlong 0 ⇒ `None`).
+            let closed_msg = "Operation on a closed native handle.";
+            let decode = if option_inner_type(ty).is_some() {
+                quote! { let #bind = #conv(env, &#raw)?; }
+            } else {
+                quote! {
+                    if #raw == 0 || (#raw & 1) == 1 {
+                        return ::core::result::Result::Err(
+                            <__JniErr as ::core::convert::From<String>>::from(
+                                #closed_msg.to_string(),
+                            ),
+                        );
+                    }
+                    let #bind: #ty = unsafe {
+                        *std::boxed::Box::from_raw(#raw as *mut #ty)
+                    };
+                }
+            };
             return Some((
                 quote! {
                     let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
@@ -416,7 +440,7 @@ fn read_kotlin_property(
                             .and_then(|val| val.j())
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
                     };
-                    let #bind = #conv(env, &#raw)?;
+                    #decode
                 },
                 quote!(#bind),
             ));

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -269,6 +269,213 @@ pub(crate) fn struct_input_body(
     Some((syn::parse_quote!(jni::objects::JObject), body))
 }
 
+/// Whole-object **input** decode for a `sealed_class` sum: a `JObject` of the
+/// sealed interface → the Rust enum, by `instanceof` dispatch over the nested
+/// variant classes and a property read per payload.
+///
+/// This is the counterpart of a nested data class's own input converter, not
+/// a second mechanism: a sum reached as a **field** sits inside a parent
+/// `JObject` that is already being read field-by-field, so the parent's
+/// generic field branch just delegates here — the same delegation
+/// `Annotated.payload` uses. The tag-gated *flattened* form is the separate
+/// parameter path.
+///
+/// The output direction deliberately has no such converter: a sum crosses
+/// Rust → Kotlin **flattened, always** (`PlanFieldKind::Sum`), which is the
+/// design's rejected-alternative note about per-crossing JVM objects. Reading
+/// one field out of a `JObject` the caller already handed us costs nothing
+/// extra, so the asymmetry is real rather than an oversight.
+pub(crate) fn sum_input_body(
+    ext: &JniGen,
+    e: &syn::ItemEnum,
+    registry: &Registry<KotlinMeta>,
+) -> Option<(syn::Type, syn::Expr)> {
+    use crate::api::core::types_util::SumSpec;
+
+    let key = TypeKey::from_ident(&e.ident);
+    let cfg = ext.types.get(&key)?;
+    let sum_cfg = cfg.sum_cfg.as_ref()?;
+    let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
+    let iface_path = iface_fqn.replace('.', "/");
+    let source_module = ext.fn_module(registry, &e.ident);
+    let enum_ident = &e.ident;
+    let enum_name = e.ident.to_string();
+
+    let spec = SumSpec::from_item_enum(e);
+    let mut arms: Vec<TokenStream> = Vec::new();
+    for (v, item_variant) in spec.variants.iter().zip(&e.variants) {
+        let vident = &v.ident;
+        let kotlin_name = ext.sum_variant_class_name(sum_cfg, vident);
+        // A variant class is NESTED in the interface, so its JVM binary name
+        // is `Outer$Variant`.
+        let jvm_class = format!("{iface_path}${kotlin_name}");
+
+        let mut preludes: Vec<TokenStream> = Vec::new();
+        let mut inits: Vec<TokenStream> = Vec::new();
+        for (f, item_field) in v.fields.iter().zip(item_variant.fields.iter()) {
+            let prop = crate::api::lang::jnigen::jni::struct_plan::sum_field_prop_name(f);
+            let bind = format_ident!("__p_{}", prop);
+            let err_prefix = format!("{enum_name}.{kotlin_name}.{prop}: {{}}");
+            let (pre, value) = read_kotlin_property(
+                ext,
+                registry,
+                &quote!(__obj),
+                &prop,
+                &item_field.ty,
+                &bind,
+                &err_prefix,
+            )?;
+            preludes.push(pre);
+            match &f.member {
+                syn::Member::Named(n) => inits.push(quote!(#n: #value)),
+                syn::Member::Unnamed(_) => inits.push(quote!(#value)),
+            }
+        }
+        let ctor = match item_variant.fields {
+            syn::Fields::Unit => quote!(#source_module::#enum_ident::#vident),
+            syn::Fields::Named(_) => {
+                quote!(#source_module::#enum_ident::#vident { #(#inits),* })
+            }
+            syn::Fields::Unnamed(_) => {
+                quote!(#source_module::#enum_ident::#vident(#(#inits),*))
+            }
+        };
+        arms.push(quote! {
+            if env.is_instance_of(__obj, #jvm_class)
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                    format!(concat!(#enum_name, ": instanceof ", #jvm_class, ": {}"), e)))?
+            {
+                #(#preludes)*
+                return ::core::result::Result::Ok(#ctor);
+            }
+        });
+    }
+
+    // No arm matched: the JVM object is not one of the declared variants —
+    // a binding error through the ordinary channel, never a panic.
+    let no_match = format!("{enum_name}: value is not one of its declared variants");
+    let body: syn::Expr = syn::parse_quote!({
+        let __obj = v;
+        (|| -> ::core::result::Result<#source_module::#enum_ident, __JniErr> {
+            #(#arms)*
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<String>>::from(#no_match.to_string()),
+            )
+        })()?
+    });
+    Some((syn::parse_quote!(jni::objects::JObject), body))
+}
+
+/// Read one Kotlin property off `receiver` and decode it to its Rust value,
+/// binding the result to `bind`. Mirrors the per-field decode
+/// [`struct_input_body`] performs, for the positions that are properties of a
+/// generated class rather than fields of a data class.
+fn read_kotlin_property(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    receiver: &TokenStream,
+    prop: &str,
+    ty: &syn::Type,
+    bind: &syn::Ident,
+    err_prefix: &str,
+) -> Option<(TokenStream, TokenStream)> {
+    let entry = registry.input_entry(ty)?;
+    let wire = entry.destination.clone();
+    let conv = entry.function.sig.ident.clone();
+    let raw = format_ident!("{}_raw", bind);
+
+    // A handle property is a `NativeHandle` object whose raw pointer comes
+    // from `peek()`; an enum property is the Kotlin enum class, decoded
+    // through its `getValue`. Both mirror `struct_input_body`.
+    if let Some(proj) = &entry.metadata.projection {
+        if matches!(proj.kind, ProjectionKind::Handle) {
+            let fqn = handle_field_fqn(ext, proj).replace('.', "/");
+            let sig = format!("L{fqn};");
+            let obj = format_ident!("{}_obj", bind);
+            return Some((
+                quote! {
+                    let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                    let #raw: jni::sys::jlong = if #obj.is_null() {
+                        0
+                    } else {
+                        env.call_method(&#obj, "peek", "()J", &[])
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
+                    };
+                    let #bind = #conv(env, &#raw)?;
+                },
+                quote!(#bind),
+            ));
+        }
+    }
+    if ext.is_kotlin_enum(ty) {
+        let fqn = bare_path_ident(ty)
+            .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
+            .map(|v| v.to_string())?;
+        let sig = format!("L{};", fqn.replace('.', "/"));
+        let obj = format_ident!("{}_obj", bind);
+        return Some((
+            quote! {
+                let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
+                    .and_then(|val| val.i())
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                let #bind = #conv(env, &#raw)?;
+            },
+            quote!(#bind),
+        ));
+    }
+    match jni_field_access(&wire) {
+        Some((sig, accessor, false)) => Some((
+            quote! {
+                let #raw: #wire = env.get_field(#receiver, #prop, #sig)
+                    .and_then(|val| val.#accessor())
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))? as _;
+                let #bind = #conv(env, &#raw)?;
+            },
+            quote!(#bind),
+        )),
+        Some((sig, _, true)) => {
+            let obj = format_ident!("{}_obj", bind);
+            Some((
+                quote! {
+                    let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                    let #raw: #wire = #obj.into();
+                    let #bind = #conv(env, &#raw)?;
+                },
+                quote!(#bind),
+            ))
+        }
+        None => {
+            // Object-shaped wire with no fixed descriptor (a nested data
+            // class, another sum, a `List`): the slot's descriptor is the
+            // registered Kotlin class and the value decodes through its own
+            // converter — the same delegation the data-class path uses.
+            let slot_ty = option_inner_type(ty).unwrap_or_else(|| ty.clone());
+            let sig = bare_path_ident(&slot_ty)
+                .and_then(|name| ext.kotlin_fqn(&TypeKey::from_ident(&name)))
+                .map(|v| format!("L{};", v.replace('.', "/")))
+                .or_else(|| pat_match_top(&slot_ty, "Vec").then(|| "Ljava/util/List;".to_string()))
+                .unwrap_or_else(|| "Ljava/lang/Object;".to_string());
+            Some((
+                quote! {
+                    let #raw: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                    let #bind = #conv(env, &#raw)?;
+                },
+                quote!(#bind),
+            ))
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Struct input flattening (pass a data_class param as its leaf fields)
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -501,6 +501,17 @@ pub(crate) struct FlatLeaf {
     /// full access is composed per site via [`Self::kt_access`], so the plan
     /// itself stays independent of the call form (`payload`, `this`, `__e`).
     pub kt_access_tail: String,
+    /// Text placed **before** the object expression, so the access is a
+    /// template (`prefix + base + tail`) rather than a suffix.
+    ///
+    /// Empty for every ordinary leaf, whose access really is a suffix. A
+    /// tag-gated variant slot is not: it needs
+    /// `(<base>.field as? Reading.Exact)?.v0 ?: 0L`, where the base sits in
+    /// the middle. Both [`Self::kt_access`] and the handle-target composition
+    /// go through it, because a variant slot can equally be a handle — and a
+    /// handle target that ignored the prefix would silently lock and consume
+    /// the wrong expression.
+    pub kt_access_prefix: String,
     /// Per-field input converter ident (`None` for the synthetic present flag).
     pub conv: Option<syn::Ident>,
     /// Struct field this leaf populates. `None` for the struct-level present
@@ -529,7 +540,16 @@ impl FlatLeaf {
     /// name, `this` for a promoted receiver, `__e` for the vec-build loop
     /// variable).
     pub fn kt_access(&self, base: &str) -> String {
-        format!("{base}{}", self.kt_access_tail)
+        format!("{}{base}{}", self.kt_access_prefix, self.kt_access_tail)
+    }
+
+    /// The Kotlin expression yielding the handle this leaf carries, rooted at
+    /// `base` — the thing the lock scaffold locks and `markConsumed()`s.
+    /// `None` when the leaf is not a handle. Composed through the same
+    /// template as [`Self::kt_access`].
+    pub fn kt_handle_target(&self, base: &str) -> Option<String> {
+        let tail = self.handle_target_tail.as_ref()?;
+        Some(format!("{}{base}{tail}", self.kt_access_prefix))
     }
 
     /// Native call argument for this leaf. Handle pointers are bound under
@@ -702,6 +722,7 @@ fn push_present_leaf(
         kt_name: snake_to_camel(native),
         kt_wire_ty: "Boolean".to_string(),
         kt_access_tail: access,
+        kt_access_prefix: String::new(),
         conv: None,
         field,
         is_present_flag: true,
@@ -732,6 +753,7 @@ fn push_value_leaf(
         kt_name: snake_to_camel(native),
         kt_wire_ty,
         kt_access_tail: access,
+        kt_access_prefix: String::new(),
         conv: Some(entry.function.sig.ident.clone()),
         field: Some(field),
         is_present_flag: false,
@@ -756,6 +778,7 @@ fn push_handle_leaf(
         kt_name: snake_to_camel(native),
         kt_wire_ty: "Long".to_string(),
         kt_access_tail: target.clone(),
+        kt_access_prefix: String::new(),
         conv: None,
         field: Some(field),
         is_present_flag: false,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -586,6 +586,31 @@ pub(crate) enum FlatFieldNode {
         field: syn::Ident,
         node: Box<FlatStructNode>,
     },
+    /// A data-carrying enum crossing as an `Int` **tag** leaf plus one leaf
+    /// group per variant, inert groups filled with their wire defaults — the
+    /// N-way form of the `present` gating `Option` already uses.
+    Sum {
+        field: syn::Ident,
+        /// Index of the synthetic tag leaf.
+        tag_leaf: usize,
+        /// Index of the `present` gate when the field is `Option<sum>`.
+        /// Optionality and choice stay independent facts: the tag domain is
+        /// never overloaded with an "absent" value.
+        present_leaf: Option<usize>,
+        /// Qualified path to the source enum, for the reconstruct's arms.
+        source: syn::Path,
+        /// Variants in declaration order; index == tag.
+        variants: Vec<FlatSumVariant>,
+        rust_ty: Box<syn::Type>,
+    },
+}
+
+/// One alternative of a [`FlatFieldNode::Sum`].
+pub(crate) struct FlatSumVariant {
+    pub rust_ident: syn::Ident,
+    /// This variant's payload: how each field is addressed when rebuilding
+    /// it, paired with the leaf carrying its value. Empty for a unit variant.
+    pub fields: Vec<(syn::Member, usize)>,
 }
 
 /// A flattened plan for one struct input parameter. Built once by
@@ -707,6 +732,184 @@ fn wire_kotlin_type(entry: &crate::api::core::registry::TypeEntry<KotlinMeta>) -
             .map(ToString::to_string)
             .unwrap_or_else(|| "Any".to_string())
     }
+}
+
+/// Plan a **data-carrying enum** field as a tag leaf plus one leaf group per
+/// variant, so the sum crosses flattened instead of as one `JObject` per call.
+///
+/// Returns `None` when some payload cannot be expressed as a flat leaf — a
+/// handle, say, whose ownership the group-gated form does not yet model. That
+/// is deliberately a **graceful degradation, not a rejection**: the caller
+/// falls through to the ordinary value leaf, and the sum crosses as a whole
+/// object through its own converter, exactly as it did before this path
+/// existed. Refusing instead would turn a working binding into a build error
+/// for a shape the generator can already handle.
+///
+/// Kotlin references are emitted **fully qualified** (`is io.x.Reading.Exact`)
+/// so the call site needs no import bookkeeping — these expressions are raw
+/// text spliced into a wrapper whose import set this plan does not own.
+#[allow(clippy::too_many_arguments)]
+fn build_flat_sum_field(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    sum_ty: &syn::Type,
+    field: syn::Ident,
+    optional: bool,
+    native_prefix: &str,
+    field_ref: &str,
+    nullable_access: bool,
+    rust_ty: &syn::Type,
+    leaves: &mut Vec<FlatLeaf>,
+) -> Option<FlatFieldNode> {
+    use crate::api::core::types_util::SumSpec;
+
+    let ident = bare_path_ident(sum_ty)?;
+    let (item_enum, _) = registry.enums.get(&ident)?;
+    let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
+    let sum_cfg = cfg.sum_cfg.as_ref()?;
+    let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
+    let spec = SumSpec::from_item_enum(item_enum);
+
+    // Plan every group first: a single unflattenable payload means the whole
+    // sum stays object-shaped, so nothing may be pushed until all of them are
+    // known good.
+    struct Planned {
+        rust_ident: syn::Ident,
+        kotlin: String,
+        fields: Vec<(syn::Member, PlannedLeaf)>,
+    }
+    struct PlannedLeaf {
+        native: String,
+        entry: crate::api::core::registry::TypeEntry<KotlinMeta>,
+        access_tail: String,
+        nullable_wire: bool,
+    }
+    let mut planned: Vec<Planned> = Vec::new();
+    for (v, item_variant) in spec.variants.iter().zip(&item_enum.variants) {
+        let kotlin = ext.sum_variant_class_name(sum_cfg, &v.ident);
+        let mut fields = Vec::new();
+        for (f, item_field) in v.fields.iter().zip(item_variant.fields.iter()) {
+            let entry = registry.input_entry(&item_field.ty)?;
+            // A projection payload (handle / value blob) carries ownership
+            // and locking rules the tag-gated group does not model yet.
+            if entry.metadata.projection.is_some() {
+                return None;
+            }
+            // Nested objects would need their own recursive group; today only
+            // leaf-shaped payloads flatten.
+            let prim = JniPrim::from_wire(&entry.destination);
+            let is_string_like = matches!(&entry.destination, syn::Type::Path(tp)
+                if tp.path.segments.last().is_some_and(|s| s.ident == "JString"));
+            if prim.is_none() && !is_string_like {
+                return None;
+            }
+            let prop = crate::api::lang::jnigen::jni::struct_plan::sum_field_prop_name(f);
+            let slot =
+                crate::api::lang::jnigen::jni::struct_plan::sum_slot_fragment(&kotlin, &prop);
+            // `(<base>.field as? io.x.E.V)?.prop` — inert groups yield null,
+            // so a primitive slot takes its zero and an object slot stays
+            // nullable. The Rust side only converts the live group.
+            //
+            // An `enum_class` payload is a Kotlin enum object whose wire is
+            // the `jint` discriminant, so the access reads `.value` — without
+            // it the slot would be `Priority?` where the wire wants `Int`.
+            let read = if ext.is_kotlin_enum(&item_field.ty) {
+                format!("{prop}?.value")
+            } else {
+                prop.clone()
+            };
+            let cast = format!("{field_ref} as? {iface_fqn}.{kotlin})?.{read}");
+            let (access_tail, nullable_wire) = match &prim {
+                Some(p) => (format!("{cast} ?: {}", p.kotlin_zero()), false),
+                None => (cast, true),
+            };
+            fields.push((
+                f.member.clone(),
+                PlannedLeaf {
+                    native: format!("{native_prefix}_{slot}"),
+                    entry: entry.clone(),
+                    access_tail,
+                    nullable_wire,
+                },
+            ));
+        }
+        planned.push(Planned {
+            rust_ident: v.ident.clone(),
+            kotlin,
+            fields,
+        });
+    }
+
+    // Everything flattens — now push the leaves, tag first.
+    let present_leaf = optional.then(|| {
+        push_present_leaf(
+            leaves,
+            &format!("{native_prefix}_present"),
+            format!("{field_ref} != null"),
+            Some(field.clone()),
+        )
+    });
+
+    // The tag is computed once per call site by matching the value against
+    // its own variant classes. A nullable access adds the `null` arm the
+    // present flag already gates on.
+    let mut arms: Vec<String> = Vec::new();
+    if nullable_access || optional {
+        arms.push("null -> 0".to_string());
+    }
+    for (tag, p) in planned.iter().enumerate() {
+        arms.push(format!("is {iface_fqn}.{} -> {tag}", p.kotlin));
+    }
+    let tag_leaf = leaves.len();
+    leaves.push(FlatLeaf {
+        native_ident: format_ident!("{}__tag", native_prefix),
+        native_wire_ty: quote!(jni::sys::jint),
+        kt_name: snake_to_camel(&format!("{native_prefix}__tag")),
+        kt_wire_ty: "Int".to_string(),
+        kt_access_tail: format!("{field_ref}) {{ {} }}", arms.join("; ")),
+        kt_access_prefix: "when (".to_string(),
+        conv: None,
+        field: Some(field.clone()),
+        is_present_flag: false,
+        entry: None,
+        handle_target_tail: None,
+        handle_nullable: false,
+    });
+
+    let variants = planned
+        .into_iter()
+        .map(|p| FlatSumVariant {
+            rust_ident: p.rust_ident,
+            fields: p
+                .fields
+                .into_iter()
+                .map(|(member, l)| {
+                    let idx = push_value_leaf(
+                        leaves,
+                        &l.native,
+                        field.clone(),
+                        &l.entry,
+                        l.access_tail,
+                        l.nullable_wire,
+                    );
+                    // The access is a cast expression, so the base sits in the
+                    // middle rather than at the front.
+                    leaves[idx].kt_access_prefix = "(".to_string();
+                    (member, idx)
+                })
+                .collect(),
+        })
+        .collect();
+
+    let module = ext.fn_module(registry, &ident);
+    Some(FlatFieldNode::Sum {
+        field,
+        tag_leaf,
+        present_leaf,
+        source: syn::parse_quote!(#module::#ident),
+        variants,
+        rust_ty: Box::new(rust_ty.clone()),
+    })
 }
 
 fn push_present_leaf(
@@ -930,6 +1133,27 @@ fn build_flat_struct_node(
             format!("{access_prefix}.{fcamel}")
         };
         let nested_ty = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
+        // A data-carrying enum flattens into a tag plus one group per variant.
+        // `None` means some payload is not leaf-shaped — fall through and let
+        // it cross as one object through its own converter.
+        if matches!(ext.type_kind(registry, &nested_ty), TypeKind::Sum) {
+            let field_optional = option_inner_type(&field.ty).is_some();
+            if let Some(node) = build_flat_sum_field(
+                ext,
+                registry,
+                &nested_ty,
+                fident.clone(),
+                field_optional,
+                &child_native,
+                &field_ref,
+                nullable_context,
+                &field.ty,
+                leaves,
+            ) {
+                fields.push(node);
+                continue;
+            }
+        }
         if let TypeKind::DataStruct {
             st: child,
             cfg: Some(cfg),
@@ -1281,6 +1505,77 @@ fn render_flat_struct_node(
                 decodes.extend(render_flat_struct_node(plan, child, on_err));
                 let child_binding = &child.binding;
                 inits.push(quote!(#field: #child_binding));
+            }
+            // Tag-gated groups: one `match` over the tag rebuilds the live
+            // variant. ONLY that arm's leaves are converted — the inert
+            // groups carry wire defaults nobody reads.
+            FlatFieldNode::Sum {
+                field,
+                tag_leaf,
+                present_leaf,
+                source,
+                variants,
+                rust_ty,
+            } => {
+                let tmp = format_ident!("{}_{}", node.binding, field);
+                let tag = &plan.leaves[*tag_leaf].native_ident;
+                let arms = variants.iter().enumerate().map(|(t, v)| {
+                    let vident = &v.rust_ident;
+                    let tag_lit = proc_macro2::Literal::i32_unsuffixed(t as i32);
+                    let mut pre = TokenStream::new();
+                    let mut inits: Vec<TokenStream> = Vec::new();
+                    for (member, leaf_idx) in &v.fields {
+                        let leaf = &plan.leaves[*leaf_idx];
+                        let entry = leaf.entry.as_ref().expect("sum payload leaf has an entry");
+                        let wire = &leaf.native_ident;
+                        let bind = format_ident!("{}_{}", tmp, wire);
+                        pre.extend(render_entry_decode(entry, wire, &bind, on_err));
+                        match member {
+                            syn::Member::Named(n) => inits.push(quote!(#n: #bind)),
+                            syn::Member::Unnamed(_) => inits.push(quote!(#bind)),
+                        }
+                    }
+                    let ctor = if v.fields.is_empty() {
+                        quote!(#source::#vident)
+                    } else if matches!(v.fields[0].0, syn::Member::Named(_)) {
+                        quote!(#source::#vident { #(#inits),* })
+                    } else {
+                        quote!(#source::#vident(#(#inits),*))
+                    };
+                    quote! { #tag_lit => { #pre #ctor } }
+                });
+                // A tag outside `0..N-1` is a binding error through the
+                // ordinary channel — never a panic across the boundary.
+                let bad_tag = format!(
+                    "{}: invalid tag",
+                    source
+                        .segments
+                        .last()
+                        .map(|s| s.ident.to_string())
+                        .unwrap_or_default()
+                );
+                let build = quote! {
+                    match #tag {
+                        #(#arms)*
+                        _ => {
+                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, #bad_tag);
+                            return #on_err;
+                        }
+                    }
+                };
+                if let Some(p) = present_leaf {
+                    let present = &plan.leaves[*p].native_ident;
+                    decodes.extend(quote! {
+                        let #tmp: #rust_ty = if #present != 0u8 {
+                            ::core::option::Option::Some(#build)
+                        } else {
+                            ::core::option::Option::None
+                        };
+                    });
+                } else {
+                    decodes.extend(quote! { let #tmp: #rust_ty = #build; });
+                }
+                inits.push(quote!(#field: #tmp));
             }
             FlatFieldNode::Value {
                 field,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
@@ -15,6 +15,7 @@ mod delivery;
 mod flat_input;
 mod names;
 mod struct_out;
+mod sum_out;
 mod vec_build;
 mod wrapper;
 
@@ -24,5 +25,6 @@ pub(crate) use delivery::*;
 pub(crate) use flat_input::*;
 pub(crate) use names::*;
 pub(crate) use struct_out::*;
+pub(crate) use sum_out::*;
 pub(crate) use vec_build::*;
 pub(crate) use wrapper::*;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -114,7 +114,15 @@ pub(crate) fn synth_value_struct_leaves(
         // to the whole-value path.
         let probe = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
         let nested = match ext.type_kind(registry, &probe) {
-            TypeKind::Handle | TypeKind::Enum | TypeKind::ValueBlob => return None,
+            // A sum joins the kinds this fixed builder cannot forward: it has
+            // no single leaf and no converter of its own — it crosses as a tag
+            // plus one group per variant, which only the whole-value
+            // `fromParts` path (`PlanFieldKind::Sum`) can lay out. Falling
+            // through to the simple-leaf arm below would silently synthesize a
+            // leaf whose `out_ty` is the sum and then REQUIRE an output
+            // converter for it, failing the resolve with the sum named rather
+            // than the unsupported position.
+            TypeKind::Handle | TypeKind::Enum | TypeKind::ValueBlob | TypeKind::Sum => return None,
             TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
             _ => None,
         };
@@ -188,11 +196,34 @@ fn encode_plan(
     for f in &plan.fields {
         let fname = &f.fname;
         let base = format!("{}_{}", prefix, fname);
+        let value = quote! { #access.#fname };
+        let (pre, sl) = encode_field(&f.kind, &value, &base, depth, env_expr);
+        preludes.extend(pre);
+        slots.extend(sl);
+    }
+    (preludes, slots)
+}
+
+/// Emit the Rust-side wire encode of ONE value position — a struct field or a
+/// sum's variant payload. `value` is the Rust expression yielding it (`v.mode`
+/// at a struct field, the bound pattern variable inside a variant arm), which
+/// is what lets a sum reuse this for its payloads: a payload is encoded by the
+/// same code as a field of the same type, not by a parallel walk.
+fn encode_field(
+    kind: &PlanFieldKind,
+    value: &TokenStream,
+    base: &str,
+    depth: usize,
+    env_expr: &TokenStream,
+) -> (TokenStream, Vec<EncSlot>) {
+    let mut preludes = TokenStream::new();
+    let mut slots: Vec<EncSlot> = Vec::new();
+    {
         let id = format_ident!("__{}", base);
         let conv_value = |conv: &syn::Ident| -> TokenStream {
-            quote! { #conv(#env_expr, #access.#fname.clone())? }
+            quote! { #conv(#env_expr, #value.clone())? }
         };
-        match &f.kind {
+        match kind {
             // Projection leaf (opaque handle → jlong, value class / blob → ByteArray).
             PlanFieldKind::Projection { conv, proj, .. } => {
                 let value_expr = conv_value(conv);
@@ -290,16 +321,15 @@ fn encode_plan(
                 ..
             } => {
                 if !*optional {
-                    let child_access = quote! { #access.#fname };
                     let (child_pre, child_slots) =
-                        encode_plan(child, &child_access, &base, depth + 1, env_expr);
+                        encode_plan(child, value, base, depth + 1, env_expr);
                     preludes.extend(child_pre);
                     slots.extend(child_slots);
                 } else {
                     let cbind = format_ident!("__c{}", depth);
                     let child_access = quote! { #cbind };
                     let (child_pre, child_slots) =
-                        encode_plan(child, &child_access, &base, depth + 1, env_expr);
+                        encode_plan(child, &child_access, base, depth + 1, env_expr);
                     let flag_id = format_ident!("__{}_present", base);
                     let outer_ids: Vec<proc_macro2::Ident> = (0..child_slots.len())
                         .map(|i| format_ident!("__{}_o{}", base, i))
@@ -313,7 +343,7 @@ fn encode_plan(
                     preludes.extend(quote! {
                         let #flag_id: jni::sys::jboolean;
                         #( let #outer_ids: #outer_tys; )*
-                        match &#access.#fname {
+                        match &#value {
                             Some(#cbind) => {
                                 #child_pre
                                 #flag_id = 1u8;
@@ -341,6 +371,164 @@ fn encode_plan(
                             default: sl.default.clone(),
                         });
                     }
+                }
+            }
+            // Data-carrying enum: one `match` binds the tag and EVERY group's
+            // slots — the live group from its payload, the rest from the same
+            // defaults an absent `Option<nested>` uses. One crossing, no JVM
+            // object built for the sum.
+            PlanFieldKind::Sum {
+                source,
+                optional,
+                variants,
+                ..
+            } => {
+                let tag_id = format_ident!("__{}__tag", base);
+
+                // Encode each variant's group once, against its own pattern
+                // bindings. `arms` keeps them aligned with the flat slot list.
+                struct Arm {
+                    pattern: TokenStream,
+                    preludes: TokenStream,
+                    slots: Vec<EncSlot>,
+                }
+                let mut arms: Vec<Arm> = Vec::new();
+                for v in variants {
+                    let vident = &v.rust_ident;
+                    let binds: Vec<syn::Ident> = (0..v.fields.len())
+                        .map(|i| format_ident!("__s{}_{}", depth, i))
+                        .collect();
+                    let mut vpre = TokenStream::new();
+                    let mut vslots: Vec<EncSlot> = Vec::new();
+                    for (f, bind) in v.fields.iter().zip(&binds) {
+                        let fbase = format!("{base}_{}", f.slot);
+                        let bind_expr = quote!(#bind);
+                        let (p, s) = encode_field(&f.kind, &bind_expr, &fbase, depth + 1, env_expr);
+                        vpre.extend(p);
+                        vslots.extend(s);
+                    }
+                    // Bind every payload field, shaped like the variant.
+                    let pattern = match v.fields.first().map(|f| &f.member) {
+                        None => quote!(#source::#vident),
+                        Some(syn::Member::Named(_)) => {
+                            let pairs = v.fields.iter().zip(&binds).map(|(f, b)| {
+                                let syn::Member::Named(n) = &f.member else {
+                                    unreachable!("variant field shapes are uniform")
+                                };
+                                quote!(#n: #b)
+                            });
+                            quote!(#source::#vident { #(#pairs),* })
+                        }
+                        Some(syn::Member::Unnamed(_)) => quote!(#source::#vident(#(#binds),*)),
+                    };
+                    arms.push(Arm {
+                        pattern,
+                        preludes: vpre,
+                        slots: vslots,
+                    });
+                }
+
+                // Outer bindings: the tag plus every group's slots, side by
+                // side in variant order. Each arm assigns its own group from
+                // the values it just computed and defaults all the others.
+                let all: Vec<&EncSlot> = arms.iter().flat_map(|a| a.slots.iter()).collect();
+                let outer_ids: Vec<proc_macro2::Ident> = (0..all.len())
+                    .map(|i| format_ident!("__{}_g{}", base, i))
+                    .collect();
+                let outer_tys: Vec<TokenStream> = all.iter().map(|s| s.wire_ty.clone()).collect();
+                let defaults: Vec<TokenStream> = all.iter().map(|s| s.default.clone()).collect();
+
+                let mut offset = 0usize;
+                let arm_code: Vec<TokenStream> = arms
+                    .iter()
+                    .enumerate()
+                    .map(|(tag, a)| {
+                        let n = a.slots.len();
+                        let live_outer = &outer_ids[offset..offset + n];
+                        let live_inner: Vec<proc_macro2::Ident> =
+                            a.slots.iter().map(|s| s.ident.clone()).collect();
+                        // Every slot outside this arm's own group is inert.
+                        let inert_outer: Vec<proc_macro2::Ident> = outer_ids
+                            .iter()
+                            .enumerate()
+                            .filter(|(i, _)| *i < offset || *i >= offset + n)
+                            .map(|(_, id)| id.clone())
+                            .collect();
+                        let inert_defaults: Vec<TokenStream> = defaults
+                            .iter()
+                            .enumerate()
+                            .filter(|(i, _)| *i < offset || *i >= offset + n)
+                            .map(|(_, d)| d.clone())
+                            .collect();
+                        offset += n;
+                        let pattern = &a.pattern;
+                        let pre = &a.preludes;
+                        let tag_lit = proc_macro2::Literal::i32_unsuffixed(tag as i32);
+                        quote! {
+                            #pattern => {
+                                #pre
+                                #tag_id = #tag_lit;
+                                #( #live_outer = #live_inner; )*
+                                #( #inert_outer = #inert_defaults; )*
+                            }
+                        }
+                    })
+                    .collect();
+
+                let decls = quote! {
+                    let #tag_id: jni::sys::jint;
+                    #( let #outer_ids: #outer_tys; )*
+                };
+                if !*optional {
+                    preludes.extend(quote! {
+                        #decls
+                        match &#value { #(#arm_code)* }
+                    });
+                } else {
+                    // `Option<sum>` keeps its own present flag ahead of the
+                    // tag: optionality and choice are independent facts.
+                    let flag_id = format_ident!("__{}_present", base);
+                    let sbind = format_ident!("__o{}", depth);
+                    let inner_arms: Vec<TokenStream> =
+                        arm_code.iter().map(|a| quote! { #a }).collect();
+                    preludes.extend(quote! {
+                        let #flag_id: jni::sys::jboolean;
+                        #decls
+                        match &#value {
+                            ::core::option::Option::Some(#sbind) => {
+                                #flag_id = 1u8;
+                                match #sbind { #(#inner_arms)* }
+                            }
+                            ::core::option::Option::None => {
+                                #flag_id = 0u8;
+                                #tag_id = 0i32;
+                                #( #outer_ids = #defaults; )*
+                            }
+                        }
+                    });
+                    slots.push(EncSlot {
+                        ident: flag_id,
+                        wire_ty: quote!(jni::sys::jboolean),
+                        descriptor: "Z".to_string(),
+                        is_object: false,
+                        default: quote!(0u8),
+                    });
+                }
+                slots.push(EncSlot {
+                    ident: tag_id,
+                    wire_ty: quote!(jni::sys::jint),
+                    descriptor: "I".to_string(),
+                    is_object: false,
+                    default: quote!(0i32),
+                });
+                for (i, sl) in all.iter().enumerate() {
+                    slots.push(EncSlot {
+                        ident: outer_ids[i].clone(),
+                        wire_ty: sl.wire_ty.clone(),
+                        descriptor: sl.descriptor.clone(),
+                        is_object: sl.is_object,
+                        default: sl.default.clone(),
+                    });
                 }
             }
             // Simple leaf: bind per the plan's wire form.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -148,6 +148,7 @@ pub(crate) fn synth_value_struct_leaves(
             identity: false,
             nullable: false,
             source: LeafSource::Field,
+            group: None,
         });
     }
     Some(leaves)

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -1,0 +1,332 @@
+//! Sum outputs: the leaf synthesis for a sum that IS a function's own return
+//! (or a callback argument), and the `match` that encodes it.
+//!
+//! A sum is the one decomposition that is not a deterministic product: only
+//! ONE alternative's leaves are live per value. Core models that with a
+//! synthesized [`LeafSource::SumTag`] selector plus per-leaf
+//! [`UnfoldLeaf::group`] membership
+//! ([`apply_sum_returns`](crate::api::core::unfold::apply_sum_returns)); this
+//! module is the JNI adapter's two ends of it — [`synth_sum_leaves`] builds the
+//! leaf list before `resolve`, [`encode_sum_leaves`] emits the single `match`
+//! that fills every slot at emit time.
+//!
+//! The wire layout is the same one a sum-typed **struct field** gets
+//! ([`PlanFieldKind::Sum`](super::super::PlanFieldKind::Sum)): a tag slot
+//! followed by one leaf group per variant, laid side by side, inert groups
+//! wire-defaulted. Only the delivery differs — a field's slots ride the
+//! parent's `fromParts`, a return's ride the hoisted builder singleton.
+
+use super::*;
+
+/// Leaf name of the synthesized selector. Distinct from every group slot by
+/// construction: a group slot always contains the `_` that separates its
+/// variant fragment from its property.
+pub(crate) const SUM_TAG_LEAF: &str = "tag";
+
+/// Synthesize the leaves of one `sealed_class`-declared sum: the
+/// [`LeafSource::SumTag`] selector followed by one
+/// [`LeafSource::VariantField`] leaf per payload field, in tag order, each
+/// carrying its variant's tag as its [`group`](UnfoldLeaf::group).
+///
+/// Runs BEFORE `resolve` (like
+/// [`synth_value_struct_leaves`](super::synth_value_struct_leaves)), so it may
+/// only read the declaration (`sum_cfg`) and the enum's syntax — never the
+/// converter tables. Every payload's own `out_ty` is registered as a required
+/// output by the core wiring, so a payload that cannot cross fails naming
+/// itself.
+///
+/// Slot names come from the same [`sum_slot_fragment`] / [`sum_field_prop_name`]
+/// pair the sealed-interface emitter and the struct-field bridge use, so a
+/// `variant!(V).name(...)` rename carries through to the builder's parameter
+/// names too.
+pub(crate) fn synth_sum_leaves(
+    ext: &JniGen,
+    sum_cfg: &SumConfig,
+    item_enum: &syn::ItemEnum,
+) -> Vec<crate::api::core::unfold::UnfoldLeaf> {
+    use crate::api::core::{
+        types_util::SumSpec,
+        unfold::{LeafSource, UnfoldLeaf},
+    };
+
+    let spec = SumSpec::from_item_enum(item_enum);
+    // The selector rides ahead of the groups it chooses between. Its `out_ty`
+    // documents the wire (`i32` → `jint` → Kotlin `Int`); nothing looks up a
+    // converter for it, because there is no value to convert — the emitter
+    // assigns the tag literal per arm.
+    let mut leaves = vec![UnfoldLeaf {
+        name: SUM_TAG_LEAF.to_string(),
+        path: Vec::new(),
+        out_ty: syn::parse_quote!(i32),
+        identity: false,
+        nullable: false,
+        source: LeafSource::SumTag,
+        group: None,
+    }];
+    for variant in &spec.variants {
+        let kotlin_name = ext.sum_variant_class_name(sum_cfg, &variant.ident);
+        for field in &variant.fields {
+            let prop = sum_field_prop_name(field);
+            leaves.push(UnfoldLeaf {
+                name: sum_slot_fragment(&kotlin_name, &prop),
+                path: Vec::new(),
+                out_ty: field.ty.clone(),
+                identity: false,
+                nullable: false,
+                source: LeafSource::VariantField {
+                    variant: variant.ident.clone(),
+                    member: field.member.clone(),
+                },
+                group: Some(variant.tag),
+            });
+        }
+    }
+    leaves
+}
+
+/// True when `plan` decomposes a sum — it carries the synthesized selector.
+/// The one place that question is asked, so every consumer agrees on it.
+pub(crate) fn is_sum_leaves(leaves: &[crate::api::core::unfold::UnfoldLeaf]) -> bool {
+    use crate::api::core::unfold::LeafSource;
+    leaves.iter().any(|l| l.source == LeafSource::SumTag)
+}
+
+/// Emit the Rust-side encode of a decomposed sum: ONE `match` over the value
+/// binding the tag and EVERY group's slots — the live group from its variant
+/// pattern's payload bindings, every other group from the same wire defaults an
+/// absent `Option<nested>` uses.
+///
+/// The signature mirrors [`encode_plan_leaves`](super::encode_plan_leaves), and
+/// the two are interchangeable at the call site: both bind `obj_idents` and
+/// return the per-leaf `jvalue` argument expressions in leaf order. What differs
+/// is that a leaf here is not an independent expression — its slot exists in
+/// every arm and only one arm computes it.
+pub(crate) fn encode_sum_leaves(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    plan: &crate::api::core::unfold::UnfoldPlan,
+    obj_idents: &[syn::Ident],
+    value: &TokenStream,
+    fail: &dyn Fn(TokenStream) -> TokenStream,
+) -> (TokenStream, Vec<TokenStream>) {
+    use crate::api::core::unfold::LeafSource;
+
+    let leaves = &plan.leaves;
+    // Qualified path of the source enum, for the arm patterns.
+    let ident = bare_path_ident(&plan.source).unwrap_or_else(|| {
+        panic!(
+            "jnigen sum unfold: source `{}` is not a path type",
+            TypeKey::from_type(&plan.source)
+        )
+    });
+    let module = ext.fn_module(registry, &ident);
+    let source: syn::Path = syn::parse_quote!(#module::#ident);
+
+    // Per-leaf slot shape: a primitive-wire leaf occupies a typed `jvalue`
+    // (its raw primitive rides the typed `run`), everything else a `JObject`.
+    // Derived from the SAME `leaf_is_prim` the argument expressions below and
+    // the interface descriptor use, so the three cannot disagree.
+    struct Slot {
+        prim: bool,
+        ty: TokenStream,
+        default: TokenStream,
+    }
+    let slots: Vec<Slot> = leaves
+        .iter()
+        .map(|leaf| {
+            if !leaf_is_prim(registry, leaf) {
+                return Slot {
+                    prim: false,
+                    ty: quote!(jni::objects::JObject),
+                    default: quote!(jni::objects::JObject::null()),
+                };
+            }
+            // The tag is synthesized, so it has no converter to read a wire
+            // from — it is a `jint` by definition.
+            let (sig, letter) = if leaf.source == LeafSource::SumTag {
+                ("I", format_ident!("i"))
+            } else {
+                let wire = registry
+                    .output_entry(&leaf.out_ty)
+                    .expect("leaf_is_prim implies a resolved output entry")
+                    .destination
+                    .clone();
+                let (sig, letter, _) =
+                    jni_field_access(&wire).expect("leaf_is_prim guarantees a primitive wire");
+                (sig, letter)
+            };
+            let zero = primitive_default_for_descriptor(sig);
+            Slot {
+                prim: true,
+                ty: quote!(jni::sys::jvalue),
+                default: quote!(jni::sys::jvalue { #letter: #zero }),
+            }
+        })
+        .collect();
+
+    let arg_exprs: Vec<TokenStream> = leaves
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| {
+            let id = &obj_idents[idx];
+            if slots[idx].prim {
+                quote!(#id)
+            } else {
+                quote!(jni::sys::jvalue { l: #id.as_raw() })
+            }
+        })
+        .collect();
+
+    // Declare every slot up front; each arm assigns all of them.
+    let decls: TokenStream = leaves
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| {
+            let id = &obj_idents[idx];
+            let ty = &slots[idx].ty;
+            quote! { let #id: #ty; }
+        })
+        .collect();
+
+    // One arm per variant, in tag order. `groups[tag]` are the leaf indices of
+    // that variant's payload, in declaration order — which is also the order
+    // its pattern binds them in.
+    let tag_idx = leaves
+        .iter()
+        .position(|l| l.source == LeafSource::SumTag)
+        .expect("a sum plan carries its selector leaf");
+    let tag_id = &obj_idents[tag_idx];
+    // A unit variant contributes no leaf, so the arm list is driven by the
+    // enum's own variants, not by the grouped leaves.
+    let (item_enum, _) = registry.enums.get(&ident).unwrap_or_else(|| {
+        panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
+    });
+    let spec = crate::api::core::types_util::SumSpec::from_item_enum(item_enum);
+
+    let arms: Vec<TokenStream> = spec
+        .variants
+        .iter()
+        .map(|variant| {
+            let group: Vec<usize> = leaves
+                .iter()
+                .enumerate()
+                .filter(|(_, l)| l.group == Some(variant.tag))
+                .map(|(i, _)| i)
+                .collect();
+            let binds: Vec<syn::Ident> = group
+                .iter()
+                .enumerate()
+                .map(|(k, _)| format_ident!("__sv{}", k))
+                .collect();
+            let vident = &variant.ident;
+            let pattern = match variant.fields.first().map(|f| &f.member) {
+                None => quote!(#source::#vident),
+                Some(syn::Member::Named(_)) => {
+                    let pairs = variant.fields.iter().zip(&binds).map(|(f, b)| {
+                        let syn::Member::Named(n) = &f.member else {
+                            unreachable!("variant field shapes are uniform")
+                        };
+                        quote!(#n: #b)
+                    });
+                    quote!(#source::#vident { #(#pairs),* })
+                }
+                Some(syn::Member::Unnamed(_)) => quote!(#source::#vident(#(#binds),*)),
+            };
+            // The live group: convert each payload through its own output
+            // converter, exactly as a struct field of the same type would be.
+            let live: TokenStream = group
+                .iter()
+                .zip(&binds)
+                .map(|(&idx, bind)| {
+                    encode_group_leaf(
+                        registry,
+                        &leaves[idx],
+                        &obj_idents[idx],
+                        slots[idx].prim,
+                        bind,
+                        fail,
+                    )
+                })
+                .collect();
+            // Every slot outside this arm's own group is inert.
+            let inert: TokenStream = (0..leaves.len())
+                .filter(|i| *i != tag_idx && !group.contains(i))
+                .map(|i| {
+                    let id = &obj_idents[i];
+                    let d = &slots[i].default;
+                    quote! { #id = #d; }
+                })
+                .collect();
+            let tag_lit = proc_macro2::Literal::i32_unsuffixed(variant.tag);
+            quote! {
+                #pattern => {
+                    #live
+                    #tag_id = jni::sys::jvalue { i: #tag_lit };
+                    #inert
+                }
+            }
+        })
+        .collect();
+
+    // A borrowed value is matched as-is; an owned one is matched by reference
+    // so each payload can be cloned out of it (the same reach a struct field
+    // leaf uses).
+    let matched = if plan.by_ref {
+        value.clone()
+    } else {
+        quote!(&#value)
+    };
+    let stmts = quote! {
+        #decls
+        match #matched { #(#arms)* }
+    };
+    (stmts, arg_exprs)
+}
+
+/// Encode ONE payload binding of a live variant arm into its slot. `bind` is
+/// the pattern variable holding `&Payload`; the value is cloned out of it, so a
+/// payload and a struct field of the same type reach their converter the same
+/// way.
+fn encode_group_leaf(
+    registry: &Registry<KotlinMeta>,
+    leaf: &crate::api::core::unfold::UnfoldLeaf,
+    obj_ident: &syn::Ident,
+    prim: bool,
+    bind: &syn::Ident,
+    fail: &dyn Fn(TokenStream) -> TokenStream,
+) -> TokenStream {
+    let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+        panic!(
+            "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
+            leaf.name,
+            TypeKey::from_type(&leaf.out_ty)
+        )
+    });
+    let conv = out_entry.function.sig.ident.clone();
+    let wire = out_entry.destination.clone();
+    let conv_fail = fail(quote!(__e.to_string()));
+    let enc = format_ident!("__enc_{}", obj_ident);
+    let encode = quote! {
+        let #enc = match #conv(&mut env, #bind.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                #conv_fail
+            }
+        };
+    };
+    if prim {
+        let letter = jni_field_access(&wire)
+            .expect("leaf_is_prim guarantees a primitive wire")
+            .1;
+        quote! {
+            #encode
+            #obj_ident = jni::sys::jvalue { #letter: #enc };
+        }
+    } else {
+        let cast = cast_wire_to_jobject(&enc, &wire, fail);
+        quote! {
+            #encode
+            #obj_ident = #cast;
+        }
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -207,7 +207,31 @@ fn factory_from_plan(
         } else {
             format!("{prefix}_{camel}")
         };
-        match &f.kind {
+        let (p, part) = factory_field(&f.kind, &base, imports)?;
+        params.extend(p);
+        parts.push(part);
+    }
+
+    let reconstruct = format!("{class_name}({})", parts.join(", "));
+    Some((params, reconstruct))
+}
+
+/// Declare the `fromParts` slots of ONE value position and the expression
+/// that rebuilds it — the Kotlin mirror of
+/// [`encode_field`](super::encode_field). A sum's payloads go through here
+/// too, so a payload and a struct field of the same type declare the same
+/// slot on both sides.
+fn factory_field(
+    kind: &PlanFieldKind,
+    base: &str,
+    imports: &mut BTreeSet<String>,
+) -> Option<(Vec<(String, kt::KtType)>, String)> {
+    let mut params: Vec<(String, kt::KtType)> = Vec::new();
+    let mut parts: Vec<String> = Vec::new();
+    let base = base.to_string();
+    {
+        let f_kind = kind;
+        match f_kind {
             // Projection leaf (handle / value class / blob).
             PlanFieldKind::Projection { proj, fqn, .. } => {
                 let short = register_fqn(fqn, imports);
@@ -229,6 +253,53 @@ fn factory_from_plan(
                 let short = register_fqn(kotlin.leaf_name()?, imports);
                 params.push((base.clone(), kt::KtType::int().nullable()));
                 parts.push(format!("{base}?.let {{ {short}.fromInt(it) }}"));
+            }
+            // Data-carrying enum — the tag slot plus every variant's group
+            // side by side, rebuilt by an inlined `when` (no JNI crossing,
+            // exactly like a nested data class).
+            PlanFieldKind::Sum {
+                kotlin_fqn,
+                optional,
+                variants,
+                ..
+            } => {
+                let iface_short = register_fqn(kotlin_fqn, imports);
+                let flag = format!("{base}__present");
+                if *optional {
+                    params.push((flag.clone(), kt::KtType::boolean()));
+                }
+                params.push((format!("{base}__tag"), kt::KtType::int()));
+
+                let mut arms: Vec<String> = Vec::new();
+                for (tag, v) in variants.iter().enumerate() {
+                    // Each group's slots are declared once, in variant order,
+                    // and are INERT whenever another variant is live — so the
+                    // nullability rule below applies to every group, not just
+                    // to an optional one.
+                    let mut fwd: Vec<String> = Vec::new();
+                    for pf in &v.fields {
+                        let slot = format!("{base}_{}", pf.slot);
+                        let (group_params, part) = factory_field(&pf.kind, &slot, imports)?;
+                        fwd.push(nullable_group_part(&mut params, group_params, part));
+                    }
+                    let ctor = if v.fields.is_empty() {
+                        format!("{iface_short}.{}", v.kotlin_name)
+                    } else {
+                        format!("{iface_short}.{}({})", v.kotlin_name, fwd.join(", "))
+                    };
+                    arms.push(format!("{tag} -> {ctor}"));
+                }
+                let when = format!(
+                    "when ({base}__tag) {{ {}; else -> throw IllegalArgumentException(\"{}: \
+                     invalid tag ${base}__tag\") }}",
+                    arms.join("; "),
+                    iface_short,
+                );
+                parts.push(if *optional {
+                    format!("if ({flag}) {when} else null")
+                } else {
+                    when
+                });
             }
             // Nested data-class field — inline its leaves and reconstruct via
             // the child's own `fromParts` (in bytecode, no JNI crossing).
@@ -293,8 +364,73 @@ fn factory_from_plan(
         }
     }
 
-    let reconstruct = format!("{class_name}({})", parts.join(", "));
-    Some((params, reconstruct))
+    debug_assert_eq!(
+        parts.len(),
+        1,
+        "factory_field must yield exactly one reconstruct expression"
+    );
+    Some((params, parts.remove(0)))
+}
+
+/// Declare one variant group's slots and return the expression that forwards
+/// them into the variant constructor.
+///
+/// A group is **inert** whenever another variant is live, and the Rust
+/// encoder fills an inert object slot with `JObject::null()`
+/// ([`primitive_default_for_descriptor`](super::primitive_default_for_descriptor)).
+/// A JVM `null` handed to a non-null Kotlin parameter throws inside the
+/// intrinsic null-check, before any generated code runs — so every
+/// object-shaped group slot must be declared nullable and forwarded `!!`
+/// inside its own (live) arm, where it is non-null again. Primitives take
+/// their `0`/`false` default and need no such treatment.
+///
+/// This is the N=1 `Option<nested>` rule (see the `Nested { optional }` arm)
+/// generalized to N groups; both call it so the two paths cannot drift.
+fn nullable_group_part(
+    params: &mut Vec<(String, kt::KtType)>,
+    group_params: Vec<(String, kt::KtType)>,
+    part: String,
+) -> String {
+    let mut part = part;
+    for (n, t) in group_params {
+        if is_kotlin_primitive_ty(&t) || t.is_nullable() {
+            params.push((n, t));
+        } else {
+            // The reconstruct expression references the slot by name; the
+            // live arm re-asserts non-nullness there.
+            part = replace_ident(&part, &n, &format!("{n}!!"));
+            params.push((n, t.nullable()));
+        }
+    }
+    part
+}
+
+/// Replace whole-identifier occurrences of `from` in a rendered Kotlin
+/// expression. Whole-identifier: a match must not be flanked by identifier
+/// characters, so rewriting `x` never touches `x_2` or `ax` — slot names of
+/// one group share a prefix (`exact_v0`, `exact_v01`), and a substring
+/// replace would corrupt them.
+fn replace_ident(haystack: &str, from: &str, to: &str) -> String {
+    let is_ident_char = |c: char| c == '_' || c.is_alphanumeric();
+    let mut out = String::with_capacity(haystack.len());
+    let mut rest = haystack;
+    while let Some(pos) = rest.find(from) {
+        let before_ok = rest[..pos]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_ident_char(c));
+        let after = &rest[pos + from.len()..];
+        let after_ok = after.chars().next().is_none_or(|c| !is_ident_char(c));
+        out.push_str(&rest[..pos]);
+        if before_ok && after_ok {
+            out.push_str(to);
+        } else {
+            out.push_str(from);
+        }
+        rest = after;
+    }
+    out.push_str(rest);
+    out
 }
 
 /// Render the Kotlin `close()` expression for a handle `receiver` through

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -135,13 +135,52 @@ pub(crate) struct TypedGroup {
     /// User-facing (typed) parameter type (the whole value, or a single leaf's
     /// typed view for a passthrough group).
     pub typed: kt::KtType,
-    /// `Some(class_short)` ⇒ reassemble this group's leaves via
-    /// `class_short.fromParts(leaves…)`; `None` ⇒ a single passthrough leaf
-    /// (the typed value IS the one raw param, optionally wrapped by its
+    /// `Some(expr)` ⇒ this group's raw leaves reassemble into ONE typed value
+    /// through `expr` — `Class.fromParts($0, $1, …)` for a fixed product, a
+    /// `when` over the tag for a sum. `None` ⇒ a single passthrough leaf (the
+    /// typed value IS the one raw param, optionally wrapped by its
     /// [`IfaceParam::wrap`]).
+    ///
+    /// Written with **positional placeholders** `$0`, `$1`, … over this group's
+    /// leaves rather than with their names: the signature-wide
+    /// [`dedup_names`] pass runs after a group is described, so a name captured
+    /// here could be stale by the time [`IfaceSpec::to_as_raw_fun`] renders it.
     pub reassemble: Option<String>,
+    /// FQNs the reassembly expression names in raw text (variant classes,
+    /// enums) and therefore needs imported where it is rendered.
+    pub imports: Vec<String>,
     /// Number of consecutive `params` (raw leaves) this group consumes.
     pub leaf_count: usize,
+}
+
+/// Substitute a [`TypedGroup::reassemble`] expression's `$k` placeholders with
+/// the group's actual parameter names. Scans left to right taking the longest
+/// digit run, so `$10` never resolves as `$1` followed by `0`.
+fn fill_placeholders(expr: &str, names: &[&str]) -> String {
+    let mut out = String::with_capacity(expr.len());
+    let mut rest = expr;
+    while let Some(pos) = rest.find('$') {
+        out.push_str(&rest[..pos]);
+        let digits: String = rest[pos + 1..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if digits.is_empty() {
+            out.push('$');
+            rest = &rest[pos + 1..];
+            continue;
+        }
+        let idx: usize = digits.parse().expect("digit run parses");
+        out.push_str(names.get(idx).copied().unwrap_or_else(|| {
+            panic!(
+                "reassembly placeholder ${idx} has no leaf in a {}-leaf group",
+                names.len()
+            )
+        }));
+        rest = &rest[pos + 1 + digits.len()..];
+    }
+    out.push_str(rest);
+    out
 }
 
 /// One generated `fun interface`: identity, Kotlin surface (typed + raw
@@ -422,8 +461,8 @@ impl IfaceSpec {
                     .map(|p| p.name.as_str())
                     .collect();
                 match &g.reassemble {
-                    Some(cls) => args.push(RunArg {
-                        expr: format!("{cls}.fromParts({})", names.join(", ")),
+                    Some(expr) => args.push(RunArg {
+                        expr: fill_placeholders(expr, &names),
                         owned: false,
                         nullable: false,
                     }),
@@ -646,16 +685,44 @@ fn plan_leaf_params(
     let names = plan_leaf_names(leaves);
     let mut out = Vec::with_capacity(leaves.len());
     for (name, leaf) in names.into_iter().zip(leaves.iter()) {
-        out.push(leaf_iface_param(
-            ext,
-            registry,
-            name,
-            &leaf.out_ty,
-            leaf.nullable,
-            true,
-        )?);
+        out.push(plan_leaf_param(ext, registry, name, leaf)?);
     }
     Some(out)
+}
+
+/// Both interface views of ONE decomposition leaf. The single entry point for a
+/// plan leaf, so the builder/folder/handler signatures and a callback's
+/// flattened `run` params classify it identically — the tag slot and the
+/// inert-group nullability rule below have to hold at every one of those sites,
+/// not just where the plan happens to be walked as a whole.
+fn plan_leaf_param(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    name: String,
+    leaf: &crate::api::core::unfold::UnfoldLeaf,
+) -> Option<IfaceParam> {
+    use crate::api::core::unfold::LeafSource;
+    // The sum selector has no converter behind it — it is a plain `Int` the
+    // emitter assigns per `match` arm.
+    if leaf.source == LeafSource::SumTag {
+        return Some(IfaceParam::same(name, kt::KtType::int()));
+    }
+    // A group slot is INERT whenever another variant is live, and the encoder
+    // fills an inert object slot with `JObject::null()`. A JVM null handed to a
+    // non-null Kotlin parameter throws inside the intrinsic null-check before
+    // any generated code runs, so every object-shaped group slot is nullable
+    // here and re-asserted (`!!`) inside its own live arm — the same rule
+    // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
+    // slots take their `0`/`false` default and stay unboxed.
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
+    leaf_iface_param(
+        ext,
+        registry,
+        name,
+        &leaf.out_ty,
+        leaf.nullable || inert_nullable,
+        true,
+    )
 }
 
 /// Both interface views of one delivered leaf.
@@ -941,6 +1008,36 @@ impl JniGen {
     }
 }
 
+/// The [`TypedGroup::reassemble`] expression (and its raw-text imports) for a
+/// **fixed-builder** decomposition's leaves — the one place the two shapes are
+/// distinguished, so the callback proxy and the `Vec` folder cannot pick
+/// different reassemblies for the same type.
+///
+/// A product reassembles through the class's own `fromParts`; a **sum** cannot
+/// — its `fromParts` is the Kotlin-facing convenience whose parameters are
+/// property types, not the wire — so it reassembles through the same inlined
+/// `when` over the tag that a sum-typed struct field gets.
+fn fixed_reassembly(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    source: &syn::Type,
+    leaves: &[crate::api::core::unfold::UnfoldLeaf],
+    class_fqn: &str,
+) -> (String, Vec<String>) {
+    let slots: Vec<String> = (0..leaves.len()).map(|i| format!("${i}")).collect();
+    if !is_sum_leaves(leaves) {
+        let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
+        return (
+            format!("{class_short}.fromParts({})", slots.join(", ")),
+            Vec::new(),
+        );
+    }
+    let params = plan_leaf_params(ext, registry, leaves).unwrap_or_default();
+    let mut imports: BTreeSet<String> = BTreeSet::new();
+    let (_, when) = ext.sum_reconstruct(registry, source, leaves, &params, &slots, &mut imports);
+    (when, imports.into_iter().collect())
+}
+
 /// Interface for an `impl Fn(args)` delivery: one `run` parameter per
 /// flattened leaf of each arg's callback plan (the arg whole when plan-less),
 /// returning `Unit`. Named `<ArgShorts>Callback` (`Fn()` → `VoidCallback`),
@@ -961,12 +1058,33 @@ pub(crate) fn callback_iface_spec(
         /// Whole-value typed view (`Some`) or `None` ⇒ use the leaf's own typed.
         typed: Option<kt::KtType>,
         reassemble: Option<String>,
+        imports: Vec<String>,
         leaf_count: usize,
     }
-    // (leaf name, out_ty, nullable, from_plan, owned_handle). `owned_handle`
-    // marks a plan-less opaque-handle arg delivered as a raw `jlong` and wrapped
-    // + closed Kotlin-side (Phase 3).
-    let mut leaf_tys: Vec<(String, syn::Type, bool, bool, bool)> = Vec::new();
+    /// One flattened `run` parameter before naming/dedup. A **plan** leaf keeps
+    /// the leaf itself, so it classifies through the shared
+    /// [`plan_leaf_param`] (tag slot, inert-group nullability) rather than a
+    /// second, weaker derivation here; a **whole** arg carries just its type,
+    /// and `owned_handle` marks a plan-less opaque handle delivered as a raw
+    /// `jlong` and wrapped + closed Kotlin-side (Phase 3).
+    enum LeafDesc {
+        Plan(String, crate::api::core::unfold::UnfoldLeaf),
+        Whole {
+            name: String,
+            ty: syn::Type,
+            nullable: bool,
+            owned_handle: bool,
+        },
+    }
+    impl LeafDesc {
+        fn name(&self) -> &str {
+            match self {
+                LeafDesc::Plan(n, _) => n,
+                LeafDesc::Whole { name, .. } => name,
+            }
+        }
+    }
+    let mut leaf_tys: Vec<LeafDesc> = Vec::new();
     let mut groups: Vec<GroupDesc> = Vec::new();
     let mut any_fixed = false;
 
@@ -983,7 +1101,7 @@ pub(crate) fn callback_iface_spec(
         if let Some(plan) = plan {
             let leaf_names = plan_leaf_names(&plan.leaves);
             for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
-                leaf_tys.push((n.clone(), l.out_ty.clone(), l.nullable, true, false));
+                leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
             }
             if plan.fixed_builder {
                 any_fixed = true;
@@ -992,11 +1110,13 @@ pub(crate) fn callback_iface_spec(
                     other => other.clone(),
                 };
                 let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
-                let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
+                let (reassemble, imports) =
+                    fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
-                    reassemble: Some(class_short),
+                    reassemble: Some(reassemble),
+                    imports,
                     leaf_count: plan.leaves.len(),
                 });
             } else {
@@ -1007,6 +1127,7 @@ pub(crate) fn callback_iface_spec(
                         name: n.clone(),
                         typed: None,
                         reassemble: None,
+                        imports: Vec::new(),
                         leaf_count: 1,
                     });
                 }
@@ -1019,36 +1140,37 @@ pub(crate) fn callback_iface_spec(
                 .and_then(|e| e.metadata.projection.as_ref())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
-            leaf_tys.push((
-                whole_value_name(t, i),
-                t.clone(),
-                is_option_type(t),
-                false,
+            leaf_tys.push(LeafDesc::Whole {
+                name: whole_value_name(t, i),
+                ty: t.clone(),
+                nullable: is_option_type(t),
                 owned_handle,
-            ));
+            });
             groups.push(GroupDesc {
                 name: whole_value_name(t, i),
                 typed: None,
                 reassemble: None,
+                imports: Vec::new(),
                 leaf_count: 1,
             });
         }
     }
-    let mut names: Vec<String> = leaf_tys.iter().map(|(n, ..)| n.clone()).collect();
+    let mut names: Vec<String> = leaf_tys.iter().map(|d| d.name().to_string()).collect();
     dedup_names(&mut names);
     let mut params = Vec::with_capacity(leaf_tys.len());
-    for (k, (_, out_ty, nullable, from_plan, owned_handle)) in leaf_tys.iter().enumerate() {
-        let param = if *owned_handle {
-            owned_handle_iface_param(ext, registry, names[k].clone(), out_ty, *nullable)?
-        } else {
-            leaf_iface_param(
-                ext,
-                registry,
-                names[k].clone(),
-                out_ty,
-                *nullable,
-                *from_plan,
-            )?
+    for (k, desc) in leaf_tys.iter().enumerate() {
+        let name = names[k].clone();
+        let param = match desc {
+            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, registry, name, leaf)?,
+            LeafDesc::Whole {
+                ty,
+                nullable,
+                owned_handle: true,
+                ..
+            } => owned_handle_iface_param(ext, registry, name, ty, *nullable)?,
+            LeafDesc::Whole { ty, nullable, .. } => {
+                leaf_iface_param(ext, registry, name, ty, *nullable, false)?
+            }
         };
         params.push(param);
     }
@@ -1066,6 +1188,7 @@ pub(crate) fn callback_iface_spec(
                 name: group_names[gi].clone(),
                 typed,
                 reassemble: g.reassemble.clone(),
+                imports: g.imports.clone(),
                 leaf_count: g.leaf_count,
             });
             at += g.leaf_count;
@@ -1222,18 +1345,20 @@ pub(crate) fn fixed_folder_typed_groups(
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans.get(decon)?;
     let fqn = ext.kotlin_fqn(&TypeKey::from_type(&spec.source))?;
-    let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
+    let (reassemble, imports) = fixed_reassembly(ext, registry, &spec.source, &spec.leaves, &fqn);
     Some(vec![
         TypedGroup {
             name: "acc".to_string(),
             typed: kt::KtType::var_("A"),
             reassemble: None,
+            imports: Vec::new(),
             leaf_count: 1,
         },
         TypedGroup {
             name: "element".to_string(),
             typed: kt::KtType::cls(fqn.to_string()),
-            reassemble: Some(class_short),
+            reassemble: Some(reassemble),
+            imports,
             leaf_count: spec.leaves.len(),
         },
     ])

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1136,8 +1136,19 @@ impl JniGen {
         enum FixedSingleton {
             StructBuilder(DeconId),
             StructFolder(DeconId),
+            /// A decomposed **sum**: the reassembly is a `when` over the tag
+            /// picking the live group, not a `fromParts` over a fixed product.
+            SumBuilder(DeconId),
+            SumFolder(DeconId),
             LeafFolder,
         }
+        // A decomposition is a sum's when it carries the synthesized selector.
+        let is_sum = |d: &DeconId| {
+            registry
+                .decon_plans
+                .get(d)
+                .is_some_and(|p| is_sum_leaves(&p.leaves))
+        };
 
         // Fixedness sets shared with the memo derivation (`iface.rs`): a
         // fixed DeconId gets a hoisted `__<Name>Builder` / folder-appender
@@ -1222,15 +1233,23 @@ impl JniGen {
                     SpecKey::Callback(_) => (false, None),
                     SpecKey::Builder(d) => (
                         false,
-                        fixed_decons
-                            .contains(d)
-                            .then(|| FixedSingleton::StructBuilder(d.clone())),
+                        fixed_decons.contains(d).then(|| {
+                            if is_sum(d) {
+                                FixedSingleton::SumBuilder(d.clone())
+                            } else {
+                                FixedSingleton::StructBuilder(d.clone())
+                            }
+                        }),
                     ),
                     SpecKey::Folder(d) => (
                         false,
-                        fixed_decons
-                            .contains(d)
-                            .then(|| FixedSingleton::StructFolder(d.clone())),
+                        fixed_decons.contains(d).then(|| {
+                            if is_sum(d) {
+                                FixedSingleton::SumFolder(d.clone())
+                            } else {
+                                FixedSingleton::StructFolder(d.clone())
+                            }
+                        }),
                     ),
                     SpecKey::WholeFolder(el_key) => (
                         false,
@@ -1254,6 +1273,14 @@ impl JniGen {
                             file = file.import(fqn.to_string());
                         }
                     }
+                    // A group's reassembly is raw text (`Reading.Exact(…)`,
+                    // `Priority.fromInt(…)`), so the classes it names by short
+                    // name need importing here.
+                    for g in &s.typed_groups {
+                        for fqn in &g.imports {
+                            file = file.import(fqn.clone());
+                        }
+                    }
                 }
                 if is_error {
                     file = file.decl(s.to_capture_decl());
@@ -1265,6 +1292,12 @@ impl JniGen {
                         }
                         FixedSingleton::StructFolder(decon) => {
                             self.value_struct_folder_singleton(registry, &s, &decon)
+                        }
+                        FixedSingleton::SumBuilder(decon) => {
+                            self.sum_builder_singleton(registry, &s, &decon)
+                        }
+                        FixedSingleton::SumFolder(decon) => {
+                            self.sum_folder_singleton(registry, &s, &decon)
                         }
                         FixedSingleton::LeafFolder => self.whole_value_folder_singleton(&s),
                     };
@@ -1369,6 +1402,211 @@ impl JniGen {
             name: holder,
             code: kt::Code::raw_reindent(&code),
         }
+    }
+
+    /// The hoisted **fixed builder** singleton for a decomposed **sum**: the
+    /// sum's dual of [`Self::value_struct_builder_singleton`], with a `when`
+    /// over the tag in place of a `fromParts` over a fixed product.
+    ///
+    /// The sealed interface's own `fromParts` is deliberately NOT the target
+    /// here. That factory is the Kotlin-facing convenience stage C emits — its
+    /// parameters are the variants' **property** types, not the wire, and its
+    /// object slots are non-null, which an inert group's `JObject::null()`
+    /// would trip on before any code runs. The reassembly the wire needs is the
+    /// same inlined `when` a sum-typed struct field already gets from
+    /// `factory_field`, so it is emitted here directly.
+    fn sum_builder_singleton(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        spec: &crate::api::lang::jnigen::jni::IfaceSpec,
+        decon: &crate::api::core::unfold::DeconId,
+    ) -> kt::KtDecl {
+        let plan = &registry.decon_plans[decon];
+        let mut imports: BTreeSet<String> = BTreeSet::new();
+        let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
+        let (iface_short, when) = self.sum_reconstruct(
+            registry,
+            &plan.source,
+            &plan.leaves,
+            &spec.params,
+            &names,
+            &mut imports,
+        );
+        let builder = spec.raw_name();
+        let val_name = format!("__{builder}");
+        let code = format!(
+            "internal val {val_name}: {builder}<{iface_short}> =\n    \
+             {builder} {{ {} ->\n    {when}\n}}",
+            names.join(", "),
+        );
+        let mut body = kt::Code::raw_reindent(&code);
+        for fqn in imports {
+            body = body.import(fqn);
+        }
+        kt::KtDecl::Raw {
+            name: val_name,
+            code: body,
+        }
+    }
+
+    /// The hoisted **folder-appender** singleton for a `Vec<sum>` element fold:
+    /// per element, pick the live alternative by tag and append it to the
+    /// accumulator `ArrayList`. The sum's dual of
+    /// [`Self::value_struct_folder_singleton`]; the folder's `run` params are
+    /// `[acc, tag, group-slots…]`, so the reassembly reads all but `acc`.
+    fn sum_folder_singleton(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        spec: &crate::api::lang::jnigen::jni::IfaceSpec,
+        decon: &crate::api::core::unfold::DeconId,
+    ) -> kt::KtDecl {
+        let plan = &registry.decon_plans[decon];
+        let mut imports: BTreeSet<String> = BTreeSet::new();
+        let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
+        let (iface_short, when) = self.sum_reconstruct(
+            registry,
+            &plan.source,
+            &plan.leaves,
+            &spec.params[1..],
+            &names[1..],
+            &mut imports,
+        );
+        let folder = spec.raw_name();
+        let holder = spec.singleton_holder_name();
+        let field = crate::api::lang::jnigen::jni::SINGLETON_FIELD;
+        let acc = &names[0];
+        let acc_ty = format!("ArrayList<{iface_short}>");
+        let code = format!(
+            "internal object {holder} {{\n    \
+             @JvmField\n    \
+             val {field}: {folder}<{acc_ty}> =\n        \
+             {folder} {{ {} -> {acc}.add({when}); {acc} }}\n\
+             }}",
+            names.join(", "),
+        );
+        let mut body = kt::Code::raw_reindent(&code);
+        for fqn in imports {
+            body = body.import(fqn);
+        }
+        kt::KtDecl::Raw {
+            name: holder,
+            code: body,
+        }
+    }
+
+    /// The wire-shaped reassembly of one decomposed sum: `(interface short
+    /// name, when-expression)`.
+    ///
+    /// `params` are the interface's `run` parameters **aligned with the plan's
+    /// leaves** (the selector first, then the groups) — so the caller strips a
+    /// folder's leading `acc`. Each group leaf's parameter is unwrapped into
+    /// its variant-constructor argument by [`Self::sum_ctor_arg`].
+    pub(crate) fn sum_reconstruct(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        source: &syn::Type,
+        leaves: &[crate::api::core::unfold::UnfoldLeaf],
+        params: &[crate::api::lang::jnigen::jni::IfaceParam],
+        names: &[String],
+        imports: &mut BTreeSet<String>,
+    ) -> (String, String) {
+        use crate::api::core::types_util::SumSpec;
+
+        let key = TypeKey::from_type(source);
+        let iface_fqn = self
+            .kotlin_fqn(&key)
+            .unwrap_or_else(|| panic!("sum builder: no Kotlin FQN for {key}"));
+        let iface_short = register_fqn(&iface_fqn, imports);
+        let ident = bare_path_ident(source)
+            .unwrap_or_else(|| panic!("sum builder: `{key}` is not a path type"));
+        let (item_enum, _) = registry
+            .enums
+            .get(&ident)
+            .unwrap_or_else(|| panic!("sum builder: no indexed enum `{ident}`"));
+        let sum_cfg = self.types[&key]
+            .sum_cfg
+            .as_ref()
+            .unwrap_or_else(|| panic!("sum builder: `{ident}` is not a sealed class"));
+        let spec = SumSpec::from_item_enum(item_enum);
+        let tag = &names[0];
+
+        let mut arms: Vec<String> = Vec::new();
+        for variant in &spec.variants {
+            let vname = self.sum_variant_class_name(sum_cfg, &variant.ident);
+            let args: Vec<String> = leaves
+                .iter()
+                .zip(params)
+                .zip(names)
+                .filter(|((l, _), _)| l.group == Some(variant.tag))
+                .map(|((l, p), n)| self.sum_ctor_arg(registry, l, p, n, imports))
+                .collect();
+            let ctor = if args.is_empty() {
+                format!("{iface_short}.{vname}")
+            } else {
+                format!("{iface_short}.{vname}({})", args.join(", "))
+            };
+            arms.push(format!("{} -> {ctor}", variant.tag));
+        }
+        let when = format!(
+            "when ({tag}) {{ {}; else -> throw IllegalArgumentException(\"{iface_short}: invalid \
+             tag ${tag}\") }}",
+            arms.join("; "),
+        );
+        (iface_short, when)
+    }
+
+    /// The variant-constructor argument for one group leaf: its `run`
+    /// parameter, un-inerted and wrapped back into the property type.
+    ///
+    /// Two independent transforms, in this order:
+    ///
+    /// 1. **Un-inert** — an object-shaped group slot is declared nullable
+    ///    (an inert group arrives as JVM null), so inside its own live arm it is
+    ///    re-asserted with `!!`. A payload that is *itself* optional
+    ///    (`Option<T>`) keeps its null: there the JVM null means `None`, and
+    ///    `!!` would turn a legitimately absent value into an exception.
+    /// 2. **Wrap** — the raw wire becomes the property: an enum discriminant
+    ///    through `fromInt`, a handle/blob/`ULong` through the interface's own
+    ///    [`WrapKind`](crate::api::lang::jnigen::jni::WrapKind), everything else
+    ///    verbatim.
+    fn sum_ctor_arg(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        leaf: &crate::api::core::unfold::UnfoldLeaf,
+        param: &crate::api::lang::jnigen::jni::IfaceParam,
+        name: &str,
+        imports: &mut BTreeSet<String>,
+    ) -> String {
+        let optional = is_option_type(&leaf.out_ty);
+        let arg = if param.raw.is_nullable() && !optional {
+            format!("{name}!!")
+        } else {
+            name.to_string()
+        };
+        // An enum payload rides its `jint` discriminant, so the interface types
+        // it `Int` and the wrap has to name the enum class itself — read off the
+        // same output-converter metadata `factory_field` reads for an enum
+        // struct field.
+        if self.is_kotlin_enum(&enum_probe_type(&leaf.out_ty)) {
+            let inner = option_inner_type(&leaf.out_ty).unwrap_or_else(|| leaf.out_ty.clone());
+            let name = registry
+                .output_entry(&inner)
+                .and_then(|e| e.metadata.kotlin_name.clone())
+                .and_then(|t| t.leaf_name().map(str::to_string))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "sum builder: enum payload `{}` has no Kotlin type on its output converter",
+                        leaf.name
+                    )
+                });
+            let short = register_fqn(&name, imports);
+            return if optional {
+                format!("{arg}?.let {{ {short}.fromInt(it) }}")
+            } else {
+                format!("{short}.fromInt({arg})")
+            };
+        }
+        param.wrap.wrap_expr(&arg, false)
     }
 
     /// The hoisted **folder-appender** singleton for a **whole single-leaf

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -921,12 +921,32 @@ impl JniGen {
                 field.ty.to_token_stream(),
             )
         });
-        // The input side must agree: Kotlin reads these very properties back
-        // when the value crosses the other way.
+        // The input side must agree on WHICH TYPE the property is — Kotlin
+        // reads these very properties back when the value crosses the other
+        // way, so a genuine disagreement (`String` in, `Long` out) is drift
+        // that belongs at the declaration.
+        //
+        // Nullability is deliberately excluded from the comparison: the two
+        // directions record it by different conventions. For `Option<T>` the
+        // output converter's name carries the `?` while the input converter's
+        // does not, because the input side expresses absence in the wire (a
+        // boxed value, a present flag, a niche) rather than in the type name.
+        // Comparing the rendered types would reject that legitimate shape —
+        // which is what an `Option<enum>` payload does.
         if let Some(inp) = registry.input_entry(&field.ty) {
-            if let Some(in_ty) = inp.metadata.kotlin_name.clone() {
+            if let (Some(in_ty), (Some(a), Some(b))) = (
+                inp.metadata.kotlin_name.clone(),
+                (
+                    inp.metadata
+                        .kotlin_name
+                        .as_ref()
+                        .and_then(|t| t.leaf_name())
+                        .map(str::to_string),
+                    ty.leaf_name().map(str::to_string),
+                ),
+            ) {
                 assert!(
-                    in_ty.to_string() == ty.to_string(),
+                    a == b,
                     "{}: the input and output converters for `{}` disagree on its Kotlin \
                      type (`{}` in, `{}` out) — a sealed class's properties are read by both \
                      directions, so they must map to one type",

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1175,8 +1175,10 @@ fn classify_params(
                     .leaves
                     .iter()
                     .filter_map(|leaf| {
-                        let tail = leaf.handle_target_tail.as_ref()?;
-                        let target = format!("{name}{tail}");
+                        // Through the leaf's own access template, so a
+                        // tag-gated variant handle locks the expression it
+                        // actually came from.
+                        let target = leaf.kt_handle_target(&name)?;
                         let consume_null = if leaf.handle_nullable {
                             format!("{target}?.markConsumed()")
                         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -328,10 +328,10 @@ pub(crate) fn classify_field(
 /// leaf group per variant, each payload classified through
 /// [`classify_field`].
 ///
-/// Recursion is bounded by the same depth guard the nested-struct path uses;
-/// a sum reaching its own type has no `jobject_input`-style escape hatch (the
-/// flatten plan is finite by construction), so it fails loudly here rather
-/// than expanding until the guard trips with an unhelpful message.
+/// Recursion is bounded by this function's own depth guard (see below) — a
+/// sum reaching its own type has no `jobject_input`-style escape hatch, since
+/// the flatten plan is finite by construction.
+///
 /// `None` propagates the resolver's **deferral** protocol: a payload whose
 /// converter has not resolved *yet* means "retry on the next fixed-point
 /// iteration", exactly as [`classify_field`] signals it for a struct field.
@@ -348,6 +348,19 @@ fn sum_plan_kind(
 ) -> Option<PlanFieldKind> {
     use crate::api::core::types_util::SumSpec;
 
+    // Sum expansion needs its OWN depth guard. A sum whose payload is a sum
+    // never passes through `build_struct_plan`, so that function's assert —
+    // the only one on this recursion before now — cannot see a chain made
+    // purely of sums. Rust's sizedness rules make an unindirected cycle
+    // impossible to declare, and every indirection either classifies as
+    // `Other` (`Box<E>` is not a bare ident) or is already rejected
+    // (`Vec<E>`), so this is defence in depth rather than a reachable path
+    // today. It costs one comparison and makes the bound true for every
+    // future shape instead of true-by-accident.
+    assert!(
+        depth <= 16,
+        "fromParts bridge: sealed-class expansion too deep at `{owner}` (recursive sum?)"
+    );
     let ident = bare_path_ident(ty).unwrap_or_else(|| {
         panic!("fromParts bridge: sealed-class field `{owner}` is not a path type")
     });

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -71,6 +71,26 @@ pub(crate) enum PlanFieldKind {
         child_fqn: Option<String>,
         plan: StructPlan,
     },
+    /// Data-carrying enum (`sealed_class`): an `Int` **tag** slot naming the
+    /// live alternative, followed by one **leaf group per variant** laid side
+    /// by side. Exactly one group is live; the rest are wire-defaulted and
+    /// the tag tells both sides which to read.
+    ///
+    /// This is [`Self::Nested`]'s `optional` gating with `N` groups instead
+    /// of one and an `Int` tag instead of a `Boolean` flag — a unit-only
+    /// enum would degenerate to "just a tag", which is why `enum_class`
+    /// keeps its own simpler path.
+    Sum {
+        /// Path to the source enum, for the encoder's match arms.
+        source: syn::Path,
+        /// Kotlin FQN of the sealed interface, for the factory's `when`.
+        kotlin_fqn: String,
+        /// `Option<E>` keeps its own `present` flag ahead of the tag; the tag
+        /// domain is never overloaded with an "absent" value.
+        optional: bool,
+        /// Variants in declaration order; index == tag.
+        variants: Vec<SumPlanVariant>,
+    },
     /// Simple leaf with its own output converter.
     Leaf {
         conv: syn::Ident,
@@ -84,6 +104,31 @@ pub(crate) enum PlanFieldKind {
         /// Kotlin-side `?` (an `Option` field whose wire is object-shaped).
         nullable: bool,
     },
+}
+
+/// One alternative of a [`PlanFieldKind::Sum`].
+pub(crate) struct SumPlanVariant {
+    /// Variant ident as declared in Rust — the encoder's match pattern.
+    pub rust_ident: syn::Ident,
+    /// Variant class name in Kotlin (after any `variant!(V).name(...)`).
+    pub kotlin_name: String,
+    /// This variant's payload, in declaration order. Empty for a unit
+    /// variant — the group that contributes nothing but its tag.
+    pub fields: Vec<SumPlanField>,
+}
+
+/// One payload field of a [`SumPlanVariant`]. Classified by exactly the same
+/// [`classify_field`] a struct field goes through, so a payload and a struct
+/// field of the same Rust type get the same slot, wire and Kotlin type.
+pub(crate) struct SumPlanField {
+    /// How the field is addressed in the encoder's match pattern.
+    pub member: syn::Member,
+    /// Slot-name fragment, `<variantCamel>_<prop>` (`exact_v0`). The Kotlin
+    /// property name it embeds is recomputed where needed from
+    /// [`sum_field_prop_name`], so there is one derivation rather than a
+    /// stored copy that could disagree with it.
+    pub slot: String,
+    pub kind: PlanFieldKind,
 }
 
 /// Classify `s`'s fields into the shared bridge plan. `None` aborts the
@@ -107,34 +152,77 @@ pub(crate) fn build_struct_plan(
     let mut fields: Vec<PlanField> = Vec::new();
     for field in &named.named {
         let fname = field.ident.as_ref()?.clone();
-        let effective_ty = field.ty.clone();
-        let field_entry = registry.output_entry(&effective_ty)?;
-        let conv = field_entry.function.sig.ident.clone();
+        let owner = format!("{}.{}", s.ident, fname);
+        let kind = classify_field(ext, registry, &field.ty, &owner, depth)?;
+        fields.push(PlanField { fname, kind });
+    }
+    Some(StructPlan { fields })
+}
 
+/// Classify ONE value position — a struct field or a sum's variant payload —
+/// into its bridge slot. Both callers go through here so a payload and a
+/// struct field of the same Rust type get the same slot, wire, descriptor and
+/// Kotlin type; the alternative (a second classification walk) is exactly the
+/// drift `StructPlan` exists to prevent.
+///
+/// `owner` is the dotted path used in diagnostics (`Config.mode`,
+/// `Reading::Exact.v0`).
+pub(crate) fn classify_field(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    ty: &syn::Type,
+    owner: &str,
+    depth: usize,
+) -> Option<PlanFieldKind> {
+    let effective_ty = ty.clone();
+
+    // A sum is classified FIRST, because it is the one kind with no converter
+    // of its own: it crosses as a tag plus one leaf group per variant, never
+    // as a single wire, which is why `sealed_class` types are declared
+    // boundary-only. Demanding an output entry before this point would send
+    // every sum-typed field down the `None` path and fail the whole parent's
+    // plan with an unresolved-converter error naming the wrong thing.
+    let bare = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
+    if matches!(ext.type_kind(registry, &bare), TypeKind::Sum) {
+        // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
+        // of nested data classes — the flattened bridge is fixed-layout by
+        // construction.
+        if pat_match_top(&effective_ty, "Vec") {
+            panic!(
+                "fromParts bridge: `Vec<{}>` sealed-class field (`{owner}`) is not supported \
+                 (variable arity)",
+                bare.to_token_stream(),
+            );
+        }
+        return Some(sum_plan_kind(
+            ext,
+            registry,
+            &bare,
+            owner,
+            option_inner_type(&effective_ty).is_some(),
+            depth,
+        ));
+    }
+
+    let field_entry = registry.output_entry(&effective_ty)?;
+    let conv = field_entry.function.sig.ident.clone();
+
+    {
         // Projection leaf (opaque handle / value blob).
         if let Some(proj) = field_entry.metadata.projection.clone() {
             if matches!(proj.strategy, FoldStrategy::Iterable(_)) {
                 panic!(
-                    "fromParts bridge: collection (`Vec<projection>`) field `{}.{}` is not \
-                     supported — add array codegen to lift this guard",
-                    s.ident, fname
+                    "fromParts bridge: collection (`Vec<projection>`) field `{owner}` is not \
+                     supported — add array codegen to lift this guard"
                 );
             }
             let fqn = projection_leaf_kt(ext, &proj)?.to_string();
-            fields.push(PlanField {
-                fname,
-                kind: PlanFieldKind::Projection { conv, proj, fqn },
-            });
-            continue;
+            return Some(PlanFieldKind::Projection { conv, proj, fqn });
         }
         // Bare enum leaf.
         if ext.is_kotlin_enum(&effective_ty) {
             let kotlin = field_entry.metadata.kotlin_name.clone()?;
-            fields.push(PlanField {
-                fname,
-                kind: PlanFieldKind::Enum { conv, kotlin },
-            });
-            continue;
+            return Some(PlanFieldKind::Enum { conv, kotlin });
         }
         // `Option<enum>` leaf.
         if let Some(inner) = option_inner_type(&effective_ty) {
@@ -144,38 +232,28 @@ pub(crate) fn build_struct_plan(
                     .metadata
                     .kotlin_name
                     .clone()?;
-                fields.push(PlanField {
-                    fname,
-                    kind: PlanFieldKind::OptionEnum { conv, kotlin },
-                });
-                continue;
+                return Some(PlanFieldKind::OptionEnum { conv, kotlin });
             }
         }
         // Nested plain data-class (optionally under `Option`).
-        let inner_ty = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
+        let inner_ty = bare.clone();
         if let TypeKind::DataStruct { st, cfg } = ext.type_kind(registry, &inner_ty) {
             if pat_match_top(&effective_ty, "Vec") {
                 panic!(
-                    "fromParts bridge: `Vec<{}>` data-class field (`{}.{}`) is not supported \
+                    "fromParts bridge: `Vec<{}>` data-class field (`{owner}`) is not supported \
                      (variable arity)",
                     inner_ty.to_token_stream(),
-                    s.ident,
-                    fname
                 );
             }
             let child_fqn = cfg
                 .and_then(|c| c.name_spec.as_ref())
                 .map(|s| ext.fqn_of(s));
             let plan = build_struct_plan(ext, registry, &st.clone(), depth + 1)?;
-            fields.push(PlanField {
-                fname,
-                kind: PlanFieldKind::Nested {
-                    optional: option_inner_type(&effective_ty).is_some(),
-                    child_fqn,
-                    plan,
-                },
+            return Some(PlanFieldKind::Nested {
+                optional: option_inner_type(&effective_ty).is_some(),
+                child_fqn,
+                plan,
             });
-            continue;
         }
         // Simple leaf: derive the slot descriptor and the Rust binding form
         // from the converter's wire — the one place this decision is made.
@@ -230,17 +308,122 @@ pub(crate) fn build_struct_plan(
             }
         };
         let nullable = is_option_type(&effective_ty) && !is_jni_primitive(&wire);
-        fields.push(PlanField {
-            fname,
-            kind: PlanFieldKind::Leaf {
-                conv,
-                wire: Box::new(wire),
-                form,
-                descriptor,
-                kotlin,
-                nullable,
-            },
-        });
+        Some(PlanFieldKind::Leaf {
+            conv,
+            wire: Box::new(wire),
+            form,
+            descriptor,
+            kotlin,
+            nullable,
+        })
     }
-    Some(StructPlan { fields })
+}
+
+/// Build the [`PlanFieldKind::Sum`] for a `sealed_class`-declared enum: one
+/// leaf group per variant, each payload classified through
+/// [`classify_field`].
+///
+/// Recursion is bounded by the same depth guard the nested-struct path uses;
+/// a sum reaching its own type has no `jobject_input`-style escape hatch (the
+/// flatten plan is finite by construction), so it fails loudly here rather
+/// than expanding until the guard trips with an unhelpful message.
+fn sum_plan_kind(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    ty: &syn::Type,
+    owner: &str,
+    optional: bool,
+    depth: usize,
+) -> PlanFieldKind {
+    use crate::api::core::types_util::SumSpec;
+
+    let ident = bare_path_ident(ty).unwrap_or_else(|| {
+        panic!("fromParts bridge: sealed-class field `{owner}` is not a path type")
+    });
+    let (item_enum, _) = registry.enums.get(&ident).unwrap_or_else(|| {
+        panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
+    });
+    let key = TypeKey::from_ident(&ident);
+    let cfg = ext
+        .types
+        .get(&key)
+        .unwrap_or_else(|| panic!("fromParts bridge: `{ident}` is not declared"));
+    let sum_cfg = cfg
+        .sum_cfg
+        .as_ref()
+        .unwrap_or_else(|| panic!("fromParts bridge: `{ident}` is not a sealed class"));
+    let kotlin_fqn = cfg
+        .name_spec
+        .as_ref()
+        .map(|s| ext.fqn_of(s))
+        .unwrap_or_else(|| panic!("fromParts bridge: sealed class `{ident}` has no Kotlin name"));
+
+    let spec = SumSpec::from_item_enum(item_enum);
+    let variants = spec
+        .variants
+        .iter()
+        .zip(&item_enum.variants)
+        .map(|(v, item_variant)| {
+            let kotlin_name = ext.sum_variant_class_name(sum_cfg, &v.ident);
+            let fields = v
+                .fields
+                .iter()
+                .zip(item_variant.fields.iter())
+                .map(|(f, item_field)| {
+                    let prop = sum_field_prop_name(f);
+                    let slot = sum_slot_fragment(&kotlin_name, &prop);
+                    let owner = format!("{ident}::{}.{prop}", v.ident);
+                    let kind = classify_field(ext, registry, &item_field.ty, &owner, depth + 1)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "fromParts bridge: sealed-class payload `{owner}` has no resolved \
+                                 output converter"
+                            )
+                        });
+                    SumPlanField {
+                        member: f.member.clone(),
+                        slot,
+                        kind,
+                    }
+                })
+                .collect();
+            SumPlanVariant {
+                rust_ident: v.ident.clone(),
+                kotlin_name,
+                fields,
+            }
+        })
+        .collect();
+
+    PlanFieldKind::Sum {
+        source: {
+            let module = ext.fn_module(registry, &ident);
+            syn::parse_quote!(#module::#ident)
+        },
+        kotlin_fqn,
+        optional,
+        variants,
+    }
+}
+
+/// Kotlin property name of one sum payload field — a named field keeps its
+/// camelCased name, a tuple field becomes `v0`, `v1`. Must agree with the
+/// sealed-interface emitter, which is why both call this.
+pub(crate) fn sum_field_prop_name(field: &crate::api::core::types_util::SumField) -> String {
+    match &field.member {
+        syn::Member::Named(id) => mangle_kotlin_ident(&kt_snake_to_camel(&id.to_string())),
+        syn::Member::Unnamed(i) => format!("v{}", i.index),
+    }
+}
+
+/// Slot-name fragment for one variant field: `<variantCamel>_<prop>`. Keyed
+/// on the **Kotlin** variant name so a `variant!(V).name(...)` rename carries
+/// through to the slots.
+pub(crate) fn sum_slot_fragment(kotlin_variant: &str, prop: &str) -> String {
+    let mut chars = kotlin_variant.chars();
+    let head: String = match chars.next() {
+        Some(c) => c.to_lowercase().collect(),
+        None => String::new(),
+    };
+    format!("{head}{}_{prop}", chars.as_str())
 }

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -199,14 +199,14 @@ pub(crate) fn classify_field(
                 core.to_token_stream(),
             );
         }
-        return Some(sum_plan_kind(
+        return sum_plan_kind(
             ext,
             registry,
             &bare,
             owner,
             option_inner_type(&effective_ty).is_some(),
             depth,
-        ));
+        );
     }
 
     let field_entry = registry.output_entry(&effective_ty)?;
@@ -332,6 +332,12 @@ pub(crate) fn classify_field(
 /// a sum reaching its own type has no `jobject_input`-style escape hatch (the
 /// flatten plan is finite by construction), so it fails loudly here rather
 /// than expanding until the guard trips with an unhelpful message.
+/// `None` propagates the resolver's **deferral** protocol: a payload whose
+/// converter has not resolved *yet* means "retry on the next fixed-point
+/// iteration", exactly as [`classify_field`] signals it for a struct field.
+/// Panicking there instead would turn a transient state into a build failure
+/// whenever a payload's converter happened to resolve later than this plan
+/// was first attempted.
 fn sum_plan_kind(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
@@ -339,7 +345,7 @@ fn sum_plan_kind(
     owner: &str,
     optional: bool,
     depth: usize,
-) -> PlanFieldKind {
+) -> Option<PlanFieldKind> {
     use crate::api::core::types_util::SumSpec;
 
     let ident = bare_path_ident(ty).unwrap_or_else(|| {
@@ -364,43 +370,31 @@ fn sum_plan_kind(
         .unwrap_or_else(|| panic!("fromParts bridge: sealed class `{ident}` has no Kotlin name"));
 
     let spec = SumSpec::from_item_enum(item_enum);
-    let variants = spec
-        .variants
-        .iter()
-        .zip(&item_enum.variants)
-        .map(|(v, item_variant)| {
-            let kotlin_name = ext.sum_variant_class_name(sum_cfg, &v.ident);
-            let fields = v
-                .fields
-                .iter()
-                .zip(item_variant.fields.iter())
-                .map(|(f, item_field)| {
-                    let prop = sum_field_prop_name(f);
-                    let slot = sum_slot_fragment(&kotlin_name, &prop);
-                    let owner = format!("{ident}::{}.{prop}", v.ident);
-                    let kind = classify_field(ext, registry, &item_field.ty, &owner, depth + 1)
-                        .unwrap_or_else(|| {
-                            panic!(
-                                "fromParts bridge: sealed-class payload `{owner}` has no resolved \
-                                 output converter"
-                            )
-                        });
-                    SumPlanField {
-                        member: f.member.clone(),
-                        slot,
-                        kind,
-                    }
-                })
-                .collect();
-            SumPlanVariant {
-                rust_ident: v.ident.clone(),
-                kotlin_name,
-                fields,
-            }
-        })
-        .collect();
+    let mut variants: Vec<SumPlanVariant> = Vec::new();
+    for (v, item_variant) in spec.variants.iter().zip(&item_enum.variants) {
+        let kotlin_name = ext.sum_variant_class_name(sum_cfg, &v.ident);
+        let mut fields: Vec<SumPlanField> = Vec::new();
+        for (f, item_field) in v.fields.iter().zip(item_variant.fields.iter()) {
+            let prop = sum_field_prop_name(f);
+            let slot = sum_slot_fragment(&kotlin_name, &prop);
+            let owner = format!("{ident}::{}.{prop}", v.ident);
+            // `?` — a payload whose converter has not resolved yet defers the
+            // whole plan to the next iteration, it does not fail the build.
+            let kind = classify_field(ext, registry, &item_field.ty, &owner, depth + 1)?;
+            fields.push(SumPlanField {
+                member: f.member.clone(),
+                slot,
+                kind,
+            });
+        }
+        variants.push(SumPlanVariant {
+            rust_ident: v.ident.clone(),
+            kotlin_name,
+            fields,
+        });
+    }
 
-    PlanFieldKind::Sum {
+    Some(PlanFieldKind::Sum {
         source: {
             let module = ext.fn_module(registry, &ident);
             syn::parse_quote!(#module::#ident)
@@ -408,7 +402,7 @@ fn sum_plan_kind(
         kotlin_fqn,
         optional,
         variants,
-    }
+    })
 }
 
 /// Kotlin property name of one sum payload field — a named field keeps its

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -182,16 +182,21 @@ pub(crate) fn classify_field(
     // boundary-only. Demanding an output entry before this point would send
     // every sum-typed field down the `None` path and fail the whole parent's
     // plan with an unresolved-converter error naming the wrong thing.
+    // `Vec` is peeled alongside `Option` here purely to CLASSIFY: `type_kind`
+    // answers about a bare ident, so it reports `Vec<Reading>` as `Other` and
+    // a rejection guarded on the unpeeled type could never fire. Peeling first
+    // is what makes the `Vec<sum>` error reachable at all.
     let bare = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
-    if matches!(ext.type_kind(registry, &bare), TypeKind::Sum) {
+    let core = vec_inner_type(&bare).unwrap_or_else(|| bare.clone());
+    if matches!(ext.type_kind(registry, &core), TypeKind::Sum) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by
         // construction.
-        if pat_match_top(&effective_ty, "Vec") {
+        if vec_inner_type(&bare).is_some() {
             panic!(
                 "fromParts bridge: `Vec<{}>` sealed-class field (`{owner}`) is not supported \
                  (variable arity)",
-                bare.to_token_stream(),
+                core.to_token_stream(),
             );
         }
         return Some(sum_plan_kind(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -939,3 +939,142 @@ fn sum_return_group_can_own_a_handle() {
         "the live arm wraps the pointer into its typed handle class:\n{kotlin}"
     );
 }
+
+/// TWO sums in one callback signature: each contributes its own selector, so
+/// the signature-wide dedup renames the second to `tag2` — and the reassembly
+/// expressions must follow it, including the `$tag` Kotlin string template in
+/// the invalid-tag message. That is why a group's reassembly is stored with
+/// positional placeholders and filled at render time rather than captured by
+/// name when the group is described.
+#[test]
+fn two_sum_callback_args_keep_their_own_selectors() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_pair(f: impl Fn(Reading, Lookup) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .class(crate::sealed_class!(Lookup))
+            .class(crate::ptr_class!(Probe))
+            .fun(crate::fun!(read_pair)),
+    );
+    let dir = unique_test_dir("jnigen_two_sum_cb");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // The user callback still sees two whole values.
+    assert!(
+        kotlin.contains("public fun run(reading: Reading, lookup: Lookup)"),
+        "{kotlin}"
+    );
+    // The raw twin carries both selectors, the second deduped.
+    assert!(
+        kotlin.contains("tag: Int,") && kotlin.contains("tag2: Int,"),
+        "each sum contributes its own selector:\n{kotlin}"
+    );
+    // Each `when` reads ITS OWN selector — in the dispatch and in the message.
+    assert!(
+        kotlin.contains("when (tag) { 0 -> Reading.Missing;")
+            && kotlin.contains(r#"IllegalArgumentException("Reading: invalid tag $tag")"#),
+        "{kotlin}"
+    );
+    assert!(
+        kotlin.contains("when (tag2) { 0 -> Lookup.Absent;")
+            && kotlin.contains(r#"IllegalArgumentException("Lookup: invalid tag $tag2")"#),
+        "the second sum's reassembly must follow its renamed selector, template \
+         included:\n{kotlin}"
+    );
+}
+
+/// A **slice of sums** as a callback argument has no lowering, and says so.
+///
+/// Folding a sequence of tag-gated groups into the foreign list needs the
+/// element folder that a `Vec<E>` *return* provides; without one the shape
+/// would resolve to nothing and surface as "`E` has no output converter",
+/// which names the sum rather than the position — misleading, because a sum
+/// has no whole-value converter by design. The declaration is rejected up
+/// front instead.
+#[test]
+fn slice_of_sum_callback_arg_is_rejected_with_its_reason() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_batch(f: impl Fn(&[Reading]) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .fun(crate::fun!(read_batch)),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("must be rejected")
+        .to_string();
+    assert!(
+        err.contains("read_batch") && err.contains("slice of a sealed_class"),
+        "the error must name the function and the unsupported position: {err}"
+    );
+    assert!(
+        err.contains("impl Fn(Reading)") && err.contains("Vec<Reading>"),
+        "…and point at the two shapes that do work: {err}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -571,3 +571,66 @@ fn sum_is_its_own_type_kind() {
     let cfg = jni.types.get(&TypeKey::from_type(&ty)).expect("declared");
     assert!(cfg.special_decl());
 }
+
+/// A `Vec` of tag-gated groups has variable arity, so it cannot ride the
+/// fixed-layout `fromParts` bridge — the same reason `Vec<data class>` is
+/// rejected. The guard has to peel `Vec` before asking `type_kind`, which
+/// answers about a bare ident and would otherwise report `Vec<Reading>` as
+/// `Other` and never reach this error.
+#[test]
+fn vec_of_sum_is_rejected_as_a_struct_field() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| {
+        let st: syn::ItemStruct = syn::parse_quote!(
+            pub struct Holder {
+                pub readings: #field_ty,
+            }
+        );
+        let f: syn::ItemFn = syn::parse_quote!(
+            pub fn holder_new() -> Holder {
+                unimplemented!()
+            }
+        );
+        let registry = Registry::<KotlinMeta>::from_items(vec![
+            (
+                syn::Item::Enum(syn::parse_quote!(
+                    pub enum Reading {
+                        Missing,
+                        Exact(i64),
+                    }
+                )),
+                loc.clone(),
+            ),
+            (syn::Item::Struct(st), loc.clone()),
+            (syn::Item::Fn(f), loc.clone()),
+        ])
+        .expect("index items");
+        let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .class(crate::data_class!(Holder))
+                .fun(crate::fun!(holder_new)),
+        );
+        let dir = unique_test_dir("sealed_vec_field");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+
+    for ty in [
+        syn::parse_quote!(Vec<Reading>),
+        syn::parse_quote!(Option<Vec<Reading>>),
+    ] {
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build(ty)))
+            .expect_err("Vec<sum> must be rejected");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(msg.contains("variable arity"), "{msg}");
+        assert!(msg.contains("Reading"), "{msg}");
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -634,3 +634,72 @@ fn vec_of_sum_is_rejected_as_a_struct_field() {
         assert!(msg.contains("Reading"), "{msg}");
     }
 }
+
+/// A sum that reaches its own type must fail deterministically, never run
+/// away. Rust's sizedness rules make an unindirected cycle impossible to
+/// declare, so the reachable shapes are the indirected ones — each of which
+/// must produce a clear outcome rather than a stack overflow.
+#[test]
+fn recursive_sum_shapes_fail_deterministically() {
+    let loc = myflat_loc();
+    let attempt = |variant: proc_macro2::TokenStream, tag: &str| -> Result<(), String> {
+        let e: syn::ItemEnum = syn::parse_quote!(
+            pub enum Node {
+                Leaf(i64),
+                #variant
+            }
+        );
+        let st: syn::ItemStruct = syn::parse_quote!(
+            pub struct Holder {
+                pub node: Node,
+            }
+        );
+        let f: syn::ItemFn = syn::parse_quote!(
+            pub fn holder_new() -> Holder {
+                unimplemented!()
+            }
+        );
+        let registry = Registry::<KotlinMeta>::from_items(vec![
+            (syn::Item::Enum(e), loc.clone()),
+            (syn::Item::Struct(st), loc.clone()),
+            (syn::Item::Fn(f), loc.clone()),
+        ])
+        .expect("index items");
+        let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+            crate::package!()
+                .class(crate::sealed_class!(Node))
+                .class(crate::data_class!(Holder))
+                .fun(crate::fun!(holder_new)),
+        );
+        let dir = unique_test_dir(tag);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            registry
+                .resolve(jni)
+                .map(|g| g.write_rust(dir.join("g.rs")))
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        }));
+        match outcome {
+            Ok(r) => r,
+            Err(p) => Err(p
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| p.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "panic".to_string())),
+        }
+    };
+
+    // `Vec<Node>` — variable arity, rejected with the intended message.
+    let msg = attempt(quote::quote!(Branch(Vec<Node>)), "rec_vec").expect_err("must fail");
+    assert!(msg.contains("variable arity"), "{msg}");
+
+    // `Box<Node>` — not a bare ident, so it never classifies as a sum; it
+    // fails as an unresolvable payload rather than recursing.
+    let msg = attempt(quote::quote!(Branch(Box<Node>)), "rec_box").expect_err("must fail");
+    assert!(
+        !msg.contains("too deep"),
+        "expected a resolution failure, not the depth guard: {msg}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -703,3 +703,239 @@ fn recursive_sum_shapes_fail_deterministically() {
         "expected a resolution failure, not the depth guard: {msg}"
     );
 }
+
+/// Build a binding whose declared functions return a sum in every position —
+/// bare, `Option`, `Vec`, and as a callback argument — plus one whose variant
+/// payload is an opaque handle. Returns `(generated Rust, generated Kotlin)`.
+fn sum_returns(tag: &str) -> (String, String) {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                    Labeled(String, Priority),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_maybe(which: i32) -> Option<Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_all(n: i32) -> Vec<Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn look_up(n: i64) -> Lookup {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_each(n: i32, sink: impl Fn(Reading) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::enum_class!(Priority))
+            .class(crate::sealed_class!(Reading))
+            .class(crate::sealed_class!(Lookup))
+            .class(crate::ptr_class!(Probe))
+            .fun(crate::fun!(read_one))
+            .fun(crate::fun!(read_maybe))
+            .fun(crate::fun!(read_all))
+            .fun(crate::fun!(look_up))
+            .fun(crate::fun!(read_each)),
+    );
+
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (rust, kotlin)
+}
+
+/// A sum in RETURN position crosses as its synthesized tag plus one leaf group
+/// per variant, laid side by side — the same wire layout a sum-typed struct
+/// field gets, but reassembled by a hoisted builder singleton because there is
+/// no parent `fromParts` to ride.
+///
+/// The builder's parameters are **wire** types (the enum payload is its `Int`
+/// discriminant), and every object-shaped group slot is nullable: an inert
+/// group is wire-defaulted to JVM null, which a non-null Kotlin parameter would
+/// reject in its intrinsic null check before any generated code ran.
+#[test]
+fn sum_return_builds_through_a_wire_shaped_singleton() {
+    let (_, kotlin) = sum_returns("jnigen_sum_return");
+
+    assert!(
+        kotlin.contains(
+            "public fun run(\n        tag: Int,\n        exact_v0: Long,\n        \
+             range_low: Long,\n        range_high: Long,\n        labeled_v0: String?,\n        \
+             labeled_v1: Int,\n    ): R"
+        ),
+        "builder must take the tag plus every group's WIRE slots, inert object \
+         slots nullable:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains(
+            "when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); \
+             2 -> Reading.Range(range_low, range_high); \
+             3 -> Reading.Labeled(labeled_v0!!, Priority.fromInt(labeled_v1)); \
+             else -> throw IllegalArgumentException(\"Reading: invalid tag $tag\") }"
+        ),
+        "the singleton picks the live group by tag, re-asserts the inert-nullable \
+         slot in its own arm, and rebuilds the enum payload from its \
+         discriminant:\n{kotlin}"
+    );
+    // An out-of-range tag is an error, never a variant.
+    assert!(kotlin.contains("Reading: invalid tag $tag"), "{kotlin}");
+}
+
+/// The sealed interface's own `fromParts` is the Kotlin-facing convenience
+/// stage C emits, NOT the wire target: its parameters are the variants'
+/// property types and its object slots are non-null. The return path therefore
+/// reassembles through its own singleton and leaves this factory alone —
+/// asserted here so the two do not silently converge.
+#[test]
+fn sum_from_parts_stays_the_property_typed_convenience() {
+    let (_, kotlin) = sum_returns("jnigen_sum_fromparts");
+    assert!(
+        kotlin.contains("labeled_v0: String,\n            labeled_v1: Priority,"),
+        "`fromParts` keeps property types and non-null object slots:\n{kotlin}"
+    );
+}
+
+/// The Rust side emits ONE `match` over the returned value: the live arm
+/// converts its own group's payloads and every other slot takes the wire
+/// default. No leaf is an independent expression — that is what a product
+/// decomposition does, and a sum is not one.
+#[test]
+fn sum_return_emits_one_match_with_wire_defaults() {
+    let (rust, _) = sum_returns("jnigen_sum_match");
+    let at = rust
+        .find("fn Java_io_test_jni_JNINative_readOne")
+        .expect("extern");
+    let body = &rust[at..at + 4000];
+    assert!(
+        body.contains("match &__out"),
+        "one match over the value:\n{body}"
+    );
+    assert!(
+        body.contains("myflat::Reading::Missing =>")
+            && body.contains("myflat::Reading::Range { low"),
+        "arms bind each variant's payload by pattern:\n{body}"
+    );
+    // The payload-less arm assigns the tag and defaults every group slot.
+    assert!(
+        body.contains("jni :: objects :: JObject :: null ()") || body.contains("JObject::null()"),
+        "an inert object slot is wire-defaulted to null:\n{body}"
+    );
+}
+
+/// `Option` and `Vec` layers ride the existing shape fold, so a sum needs
+/// nothing new for them: the optional nulls the whole result and the vector
+/// folds element by element, each element rebuilt by the same `when`.
+#[test]
+fn sum_return_composes_with_option_and_vec() {
+    let (_, kotlin) = sum_returns("jnigen_sum_layers");
+    assert!(
+        kotlin.contains(
+            "public fun readMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading?"
+        ),
+        "Option<sum> return is a nullable sum:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains(
+            "public fun readAll(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>"
+        ) && kotlin.contains("__ReadingFolderRawHolder.instance"),
+        "Vec<sum> folds through a hoisted appender singleton:\n{kotlin}"
+    );
+    // Callback argument: the user callback receives the whole reassembled sum
+    // while the raw twin still carries the decoupled slots.
+    assert!(
+        kotlin.contains(
+            "public fun interface ReadingCallback {\n    public fun run(reading: Reading)\n}"
+        ),
+        "the user callback sees the whole sum:\n{kotlin}"
+    );
+}
+
+/// A variant payload may be an opaque **handle**: it rides its raw `jlong`
+/// like any other handle leaf, so its slot stays a primitive (an inert group
+/// leaves the `0L` sentinel, never a fabricated handle object).
+#[test]
+fn sum_return_group_can_own_a_handle() {
+    let (_, kotlin) = sum_returns("jnigen_sum_handle");
+    assert!(
+        kotlin.contains("public fun run(tag: Int, found_v0: Long): R"),
+        "a handle payload's group slot is the raw pointer:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("1 -> Lookup.Found(Probe(found_v0))"),
+        "the live arm wraps the pointer into its typed handle class:\n{kotlin}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1029,6 +1029,62 @@ fn two_sum_callback_args_keep_their_own_selectors() {
     );
 }
 
+/// A sum in the **success position of a fallible return** has no lowering, and
+/// says so. `Result` returns deliberately keep their whole-value converter (so
+/// a fallible factory still hands back a handle), and a sum has no whole-value
+/// converter to keep — the decomposition lives on the builder-callback lane the
+/// `Result` path does not use.
+#[test]
+fn sum_in_result_ok_position_is_rejected_with_its_reason() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_try(n: i64) -> Result<Reading, Probe> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .class(crate::ptr_class!(Probe))
+            .fun(crate::fun!(read_try)),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("must be rejected")
+        .to_string();
+    assert!(
+        err.contains("read_try") && err.contains("success position of a fallible return"),
+        "the error must name the function and the unsupported position: {err}"
+    );
+    assert!(
+        err.contains("Return `Reading` directly"),
+        "…and say what to write instead: {err}"
+    );
+}
+
 /// A **slice of sums** as a callback argument has no lowering, and says so.
 ///
 /// Folding a sequence of tag-gated groups into the foreign list needs the

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -985,6 +985,42 @@ impl Prebindgen for JniGen {
         out
     }
 
+    /// Synthesize the tag-plus-groups decomposition of every `sealed_class`
+    /// type, so a function whose own return (or callback argument) IS the sum
+    /// delivers it as a tag plus one leaf group per variant — the same wire
+    /// layout a sum-typed struct field already gets, reassembled by the hoisted
+    /// builder singleton instead of by the parent's `fromParts`.
+    ///
+    /// Emitted for every declared sum, not only the ones currently returned: a
+    /// decomposition with no matching function wires no plan, and an unused
+    /// `DeconSpec` emits nothing.
+    fn sum_decons(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> Vec<crate::api::core::unfold::SumDecon> {
+        let mut keys: Vec<&TypeKey> = self.types.keys().collect();
+        keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        let mut out = Vec::new();
+        for key in keys {
+            let Some(sum_cfg) = self.types[key].sum_cfg.as_ref() else {
+                continue;
+            };
+            let source = key.to_type();
+            let Some(ident) = bare_path_ident(&source) else {
+                continue;
+            };
+            let Some((item_enum, _)) = registry.enums.get(&ident) else {
+                continue;
+            };
+            out.push(crate::api::core::unfold::SumDecon {
+                key: key.clone(),
+                source,
+                leaves: crate::api::lang::jnigen::jni::synth_sum_leaves(self, sum_cfg, item_enum),
+            });
+        }
+        out
+    }
+
     /// Nominate every **single-leaf** element type that appears in a `Vec<T>` /
     /// `Option<Vec<T>>` return or an `impl Fn(&[T])` callback arg, so
     /// [`crate::api::core::unfold::apply_leaf_vec_folds`] routes the collection

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1622,6 +1622,34 @@ impl JniGen {
             });
         }
         if let Some(name) = bare_path_ident(ty) {
+            // A `sealed_class` sum reached as a whole `JObject` — a field of a
+            // data class, or any position where the parent is already an
+            // object. Its own converter, so the parent's generic field branch
+            // delegates exactly as it does for a nested data class. (The
+            // OUTPUT direction has no counterpart: a sum crosses Rust →
+            // Kotlin flattened, always.)
+            if self.types.get(&key).is_some_and(|c| c.sum_cfg.is_some()) {
+                if let Some((e, _)) = registry.enums.get(&name) {
+                    let (wire, body) = sum_input_body(self, e, registry)?;
+                    // The wire's own null niche, exactly as a data class gets
+                    // — that is what lets `Option<sum>` fold with JVM null as
+                    // `None` instead of needing a boxed wrapper.
+                    let niches = default_niches_for_wire(&wire);
+                    let kotlin_name = self
+                        .types
+                        .get(&key)
+                        .and_then(|c| c.name_spec.as_ref())
+                        .map(|s| kt::KtType::cls(self.fqn_of(s)));
+                    return Some(ConverterImpl {
+                        subs: vec![],
+                        pre_stages: vec![],
+                        function: self.build_input_fn(ty, &wire, &body, None),
+                        destination: wire,
+                        niches,
+                        metadata: self.framework_meta(kotlin_name),
+                    });
+                }
+            }
             if let Some((s, _)) = registry.structs.get(&name) {
                 let (wire, body) = struct_input_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1236,17 +1236,44 @@ impl Prebindgen for JniGen {
                 }
             }
         }
-        // A **slice of sums** delivered to a callback (`impl Fn(&[E])`) has no
-        // lowering: the element fold would need the sum's folder-appender
-        // singleton, which is emitted per *return* position, so the shape
-        // resolves to nothing and would otherwise surface as "`E` has no
-        // output converter" — naming the sum rather than the position, since a
-        // sum has no whole-value converter by design. Reject it here, where the
-        // message can say what is actually unsupported.
+        // Two sum positions have no lowering. Both would otherwise fail as
+        // "`E` has no output converter", which names the sum rather than the
+        // position — actively misleading, because a sum has no whole-value
+        // converter BY DESIGN, so that message sends the reader looking for
+        // something that must not exist. Reject them here, where the message
+        // can say what is actually unsupported and what to write instead.
         for ident in self.declared_functions() {
             let Some((item_fn, _)) = registry.functions.get(&ident) else {
                 continue;
             };
+            // (1) A sum in the `Ok` position of a fallible return. A sum is
+            // delivered DECOMPOSED through a builder callback, and the
+            // `Result` lane has no builder: a `Result` return deliberately
+            // keeps its whole-value converter so a fallible factory still
+            // yields a handle (see `unfold::returns_type`).
+            if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
+                if let Some(ok) = crate::api::core::types_util::result_ok_type(ret) {
+                    let core = crate::api::core::types_util::peel_ref_option_vec(&ok);
+                    if matches!(self.type_kind(registry, &core), TypeKind::Sum) {
+                        return Err(format!(
+                            "fn `{ident}`: `Result<{}, _>` — a sealed_class value is not \
+                             supported in the success position of a fallible return. A sum \
+                             crosses decomposed (a tag plus one leaf group per variant) \
+                             through a builder callback, which the `Result` lane does not \
+                             have — a fallible return keeps its whole-value converter so a \
+                             factory can still hand back a handle. Return `{}` directly and \
+                             report failure through the error channel, or model the failure \
+                             as one of the sum's own variants",
+                            ok.to_token_stream(),
+                            ok.to_token_stream(),
+                        ));
+                    }
+                }
+            }
+            // (2) A **slice of sums** delivered to a callback
+            // (`impl Fn(&[E])`): the element fold would need the sum's
+            // folder-appender singleton, which is emitted per `Vec<E>` RETURN
+            // position, so the shape resolves to nothing.
             for input in &item_fn.sig.inputs {
                 let syn::FnArg::Typed(pt) = input else {
                     continue;

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1236,6 +1236,53 @@ impl Prebindgen for JniGen {
                 }
             }
         }
+        // A **slice of sums** delivered to a callback (`impl Fn(&[E])`) has no
+        // lowering: the element fold would need the sum's folder-appender
+        // singleton, which is emitted per *return* position, so the shape
+        // resolves to nothing and would otherwise surface as "`E` has no
+        // output converter" — naming the sum rather than the position, since a
+        // sum has no whole-value converter by design. Reject it here, where the
+        // message can say what is actually unsupported.
+        for ident in self.declared_functions() {
+            let Some((item_fn, _)) = registry.functions.get(&ident) else {
+                continue;
+            };
+            for input in &item_fn.sig.inputs {
+                let syn::FnArg::Typed(pt) = input else {
+                    continue;
+                };
+                let Some(args) = extract_fn_trait_args(&pt.ty) else {
+                    continue;
+                };
+                for arg in args {
+                    let after_ref = match &arg {
+                        syn::Type::Reference(r) => (*r.elem).clone(),
+                        other => other.clone(),
+                    };
+                    let syn::Type::Slice(s) = &after_ref else {
+                        continue;
+                    };
+                    let elem = match &*s.elem {
+                        syn::Type::Reference(r) => (*r.elem).clone(),
+                        other => other.clone(),
+                    };
+                    if matches!(self.type_kind(registry, &elem), TypeKind::Sum) {
+                        return Err(format!(
+                            "fn `{ident}`: `impl Fn(&[{}])` — a slice of a sealed_class value \
+                             is not supported as a callback argument. A sum crosses as a tag \
+                             plus one leaf group per variant, and folding a *sequence* of \
+                             those into the foreign list needs the element folder a `Vec<{}>` \
+                             RETURN provides; declare the callback over one value \
+                             (`impl Fn({})`) or return `Vec<{}>` instead",
+                            elem.to_token_stream(),
+                            elem.to_token_stream(),
+                            elem.to_token_stream(),
+                            elem.to_token_stream(),
+                        ));
+                    }
+                }
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Stage **D** of the sum-type work (umbrella #152, issue #149). Design: `docs/sum-types.md` §4.3–4.4.

Targets **#155 (stage C)**, its dependency.

## What works

A `sealed_class` sum is usable as a **data-class field**, both directions, exercised on a real JVM
(38 covertest sections).

**Rust → Kotlin: tag-gated variant groups.** An `Int` tag plus one leaf group per variant, inert groups
wire-defaulted, all riding the parent's single `fromParts` — no JVM object is built for the sum. The
committed golden:

```kotlin
public fun fromParts(
    id: Long,
    reading__tag: Int,
    reading_exact_v0: Long, reading_range_low: Long, reading_range_high: Long,
    reading_tagged_v0: String?, reading_tagged_v1: Int, reading_companion_v0: Long,
    fallback__present: Boolean, fallback__tag: Int, …,
    note: String,
): Observation = Observation(id, when (reading__tag) {
    0 -> Reading.Missing
    1 -> Reading.Exact(reading_exact_v0)
    …
    3 -> Reading.Tagged(reading_tagged_v0!!, Priority.fromInt(reading_tagged_v1))
    else -> throw IllegalArgumentException("Reading: invalid tag $reading__tag")
}, if (fallback__present) when (fallback__tag) { … } else null, note)
```

**Kotlin → Rust:** correct, via a whole-object converter (`instanceof` dispatch over the nested variant
classes), so the parent's generic field branch delegates exactly as it does for a nested data class.

## Structure

- `PlanFieldKind::Sum` + `SumPlanVariant`/`SumPlanField` join the shared `StructPlan`, so both emitters
  keep agreeing by construction.
- **`classify_field` extracted** from `build_struct_plan`: a sum's payload is classified by exactly the
  code a struct field of the same type goes through, not a parallel walk.
- **`encode_field` takes the value access explicitly** (`v.mode` at a field, a bound pattern variable
  inside a variant arm) — that is what lets the sum reuse it rather than duplicate it. `factory_field`
  is its Kotlin mirror.
- `nullable_group_part` holds the inert-slot rule, shared with the N=1 `Option<nested>` path.

## Three defects found while building, each fixed at its cause

1. **Inert object slots must be nullable.** An inert group's object slot is wire-defaulted to
   `JObject::null()`, and a JVM null in a non-null Kotlin parameter throws inside the intrinsic
   null-check *before any generated code runs*. Predicted when re-planning, confirmed in practice.
   Visible above as `reading_tagged_v0: String?` + `!!`.
2. **A sum must be classified before its converter is looked up** — it is the one kind with no converter
   of its own, so demanding an output entry first sent every sum field down the `None` path and failed
   the parent's plan naming the wrong thing.
3. **`synth_value_struct_leaves` silently treated a sum as a simple leaf**, synthesizing a leaf whose
   `out_ty` was the sum and then *requiring* an output converter that by design does not exist. It now
   joins the kinds that keep the whole-value path.

## The access-template refactor (`9038830`)

Landed as its own commit because it is pure — **committed generated output is byte-identical**.

`FlatLeaf::kt_access_tail` was a suffix (`{base}{tail}`), which cannot express a variant slot:
`(<base>.field as? Reading.Exact)?.v0 ?: 0L` puts the base in the middle. It gains a
`kt_access_prefix`, making the access a `prefix + base + tail` template; every existing leaf leaves the
prefix empty.

**The issue named only `kt_access_tail`, but `handle_target_tail` composes identically** and feeds handle
lock collection and `markConsumed()`. Left as a suffix it would silently lock and consume a *different*
expression than the slot reads — the worst failure shape available here, because it type-checks. Both now
go through `FlatLeaf::kt_handle_target`.

## The input path is now flattened too

A sum reached through a flattened data-class parameter crosses as a tag plus one group per variant, not
as one `JObject` per call:

```kotlin
CovNative.observationWhich(
    o.id,
    when (o.reading) { is …Reading.Missing -> 0; is …Reading.Exact -> 1; … },
    (o.reading as? …Reading.Exact)?.v0 ?: 0L,
    (o.reading as? …Reading.Tagged)?.v0,             // object slot stays nullable
    (o.reading as? …Reading.Tagged)?.v1?.value ?: 0, // enum reads its discriminant
    …)
```

`FlatFieldNode::Sum` carries the tag leaf, the optional `present` gate and one group per variant; the
Rust reconstruct is one `match` over the tag and **converts only the live arm's leaves**. An invalid tag
goes to `signal_binding_error` and returns — never a panic across the boundary (§3's locked rule),
verified from the JVM by calling the extern directly with tag 99, since the wrapper computes the tag
from an exhaustive `when` and cannot produce a bad one.

Two things the implementation settled:

- **An `enum_class` payload must read `.value`** — the slot's wire is the `jint` discriminant but the
  Kotlin property is the enum object. Without it the generated Kotlin does not typecheck. Caught by
  compiling the generated source, not by inspection.
- **A payload the flat form cannot express degrades rather than rejects.** A handle payload carries
  ownership and locking rules the tag-gated group does not model yet, so such a sum keeps crossing as
  one object through its own converter. Refusing would turn a binding that works today into a build
  error for a shape the generator already handles.

## Still open, deliberately

- **Handle payloads do not flatten** (they degrade, as above). Making them flatten means modelling
  ownership and `withSortedHandleLocks` collection through a tag gate — the `handle_target_tail` half of
  the access refactor is already in place for it. Worth its own change with its own coverage.
- **Lib tests for the two new plan builders.** Behaviour is covered by the JVM harness and by the
  `Vec<sum>` rejection test; the builders themselves have no unit tests.
- **A recursive-sum rejection test.** The depth guard exists; nothing asserts it.

## A correction to the plan in #149

The re-planned issue proposed splitting D by **direction** (output PR, then input PR). That seam does not
exist: a declared class is required in **both** directions (`class_decl` ⇒
`ensure_entry(Input/Output, …, true)`), so the moment a data class has a sum field its input converter
must resolve too — verified, and `.jobject_input()` does not help, since that flag chooses *which* input
shape, not whether one is needed. Hence one PR. I will correct that section of #149.

## Verification

356 lib tests; `./examples/regen-check.sh` clean; covertest JVM harness **PASS, 38 sections** (every
variant including the payload-less one, both `Option<sum>` states, the object-payload arm through the
optional, both sums live at once, and every alternative reconstructing the right Rust variant on the way
back in); `cargo fmt --check` and `clippy --all-targets --no-default-features --all-features --deny
warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

