### PR TITLE
Stage E — core + jnigen: sum-typed returns and callback arguments (#150)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -15,9 +15,9 @@ A source crate cannot currently express "exactly one of these alternatives". Bot
 payload variants outright:
 
 - `lang::Cbindgen` — `assert_unit_variants` guards the mirror emission and both converters
-  (`src/api/lang/cbindgen/trait_impl.rs:231`, `:660`, `:1159`).
+  (`prebindgen/src/api/lang/cbindgen/trait_impl.rs:231`, `:660`, `:1159`).
 - `lang::JniGen` — `enum_class!`'s contract is "the enum must be unit-variant only"
-  (`src/api/lang/jnigen/jni/decl.rs:739-748`).
+  (`prebindgen/src/api/lang/jnigen/jni/decl.rs:739-748`).
 
 So authors encode sums as products and demote the invariant to prose. Two live examples in
 zenoh-flat:
@@ -71,14 +71,15 @@ Two facts make this cheap to build:
 
 1. **The type graph already walks variant payloads.** `Registry::scan_enum` and
    `Registry::immediate_edges` register every variant field type in both directions
-   (`src/api/core/registry.rs:1177-1189`, `:1285-1292`), so payload converters resolve with no core
-   change.
+   (`prebindgen/src/api/core/registry.rs:1177-1189`, `:1285-1292`), so payload converters
+   resolve with no core change.
 2. **Both directions already gate leaf groups — with `N = 1`.** An `Option<Struct>` input crosses as
    a synthetic `present: Boolean` plus field slots that are wire-defaulted when absent
-   (`FlatLeaf::is_present_flag`, `src/api/lang/jnigen/jni/emit/flat_input.rs:306`); an
+   (`FlatLeaf::is_present_flag`, `prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs:306`); an
    `Option<nested>` output does the same in the `fromParts` bridge
-   (`PlanFieldKind::Nested { optional }`, `src/api/lang/jnigen/jni/struct_plan.rs:66`). A sum is that
-   mechanism with an `Int` tag instead of a `Boolean` flag and `N` groups instead of one.
+   (`PlanFieldKind::Nested { optional }`,
+   `prebindgen/src/api/lang/jnigen/jni/struct_plan.rs:66`). A sum is that mechanism with an `Int`
+   tag instead of a `Boolean` flag and `N` groups instead of one.
 
 ### Chosen lowering: flattened, always
 
@@ -88,16 +89,16 @@ Rust-side. Rejected alternative: give the sum an ordinary terminal converter wit
 in every position immediately, but it reintroduces the per-crossing JVM object and per-field JNI
 reflection that this codebase deliberately removed (the `fromParts` flattening was worth 2.4×,
 leaf folds 3–8×), and it would force an exemption to the rule that a data class flattens *completely*
-or generation fails (`src/api/lang/jnigen/jni/decl.rs:814-819`). `ReplyStruct` is on the
+or generation fails (`prebindgen/src/api/lang/jnigen/jni/decl.rs:814-819`). `ReplyStruct` is on the
 per-message path, so the slow shape would not have survived anyway.
 
 ## 3. Locked decisions
 
 | Decision | Rule |
 |---|---|
-| **Tag numbering** | Declaration order, `0..N-1`. Payload enums carry no `repr` — a `repr` is a wire detail the neutral tier must not name. Unit enums keep explicit-discriminant support through `enum_discriminant_values` (`src/api/lang/jnigen/util.rs:98`), which **moves into core** so both adapters share one implementation instead of two. |
-| **Leaf naming** | Variant field leaf = `<variant_snake>_<field>`, matching the existing nested-prefix convention (`payload_id` for the nested field `payload.id`). Tuple field ⇒ `<variant_snake>_0`. The synthetic tag leaf = `<field>__tag`, using the same double-underscore marker as the existing `<field>__present` gate. Core `DeconSpec` leaf names keep their `__` chain separator. |
-| **Kotlin surface** | `sealed interface E` with the variant classes **nested inside it** — `data class PeriodicQueries(val period: Long) : E`, `data object Heartbeat : E` — so variant names cannot collide package-wide. Tuple payload fields are named `v0`, `v1`, …. A `fromParts(tag, …)` companion on the interface reassembles from the tag + slots. |
+| **Tag numbering** | Declaration order, `0..N-1`. Payload enums carry no `repr` — a `repr` is a wire detail the neutral tier must not name. Unit enums keep explicit-discriminant support through `enum_discriminant_values` (`prebindgen/src/api/lang/jnigen/util.rs:98`), which **moves into core** so both adapters share one implementation instead of two. |
+| **Leaf naming** | A variant field's **wire slot** = `<variantCamel>_<property>` (`range_low`, `exact_v0`), matching the existing nested-prefix convention (`payload_id` for the nested field `payload.id`). It is keyed on the **Kotlin** variant name, so a `variant!(V).name(...)` rename carries through to the slots. Under a parent field the slot is prefixed with it (`mode_periodicQueries_period`) and the synthetic tag leaf is `<field>__tag`, using the same double-underscore marker as the existing `<field>__present` gate; standing alone (a sum in return position) the tag leaf is just `tag`. Core's neutral `SumField::name` (`<variant_snake>_<field>`, tuple ⇒ `<variant_snake>_0`) is a language-agnostic label an adapter may ignore — the JNI wire slot is the rule above. Core `DeconSpec` leaf names keep their `__` chain separator. |
+| **Kotlin surface** | `sealed interface E` with the variant classes **nested inside it** — `data class PeriodicQueries(val period: Long) : E`, `data object Heartbeat : E` — so variant names cannot collide package-wide. A named payload field keeps its camelCased name; tuple payload fields are named `v0`, `v1`, … (so a tuple variant `Exact(i64)` surfaces as `data class Exact(val v0: Long)` with the slot `exact_v0`). A `fromParts(tag, …)` companion on the interface reassembles from the tag + slots. |
 | **Unit-only enums** | Unchanged path. Handing a payload enum to `enum_class!` / `.enum_type()` is a **hard error** naming `sealed_class!` / `.tagged_union()` — no silent upgrade, matching the "invalid = ERROR" declaration policy. |
 | **Handle payloads** | Allowed. `ReplyResult` (flat #30) needs them: `SampleStruct` carries `KeyExpr`, `ZBytes`, `Encoding`. A tag-gated handle leaf reuses `FlatLeaf::handle_nullable`, which already means "gated by an optional ancestor" (`flat_input.rs:315-317`), and joins the existing N-ary `withSortedHandleLocks` collection unchanged. |
 | **Optionality** | `Option<E>` keeps its own present-flag gate; the tag domain is never overloaded with a `-1 = absent`. Optionality and choice are independent facts and stay independent leaves. |
@@ -110,8 +111,8 @@ Running example:
 
 ```rust
 pub enum RecoveryMode {
-    PeriodicQueries(Duration),   // tag 0
-    Heartbeat,                   // tag 1
+    PeriodicQueries { period: Duration },   // tag 0
+    Heartbeat,                              // tag 1
 }
 pub struct RecoveryConfig {
     pub mode: Option<RecoveryMode>,
@@ -123,10 +124,14 @@ pub struct RecoveryConfig {
 
 ```rust
 .package(package!("io.zenoh.jni")
-    .class(sealed_class!(RecoveryMode)
-        .variant(variant!(PeriodicQueries).name("Periodic")))   // optional per-variant rename
+    .class(sealed_class!(RecoveryMode))
     .class(data_class!(RecoveryConfig)))
 ```
+
+A per-variant `.variant(variant!(V).name("…"))` renames the emitted class **and every slot derived
+from it**, so the surface stays self-consistent; the running example below keeps the source names so
+each snippet reads as one contract. `examples/covertest-kotlin` exercises the rename
+(`variant!(Labeled).name("Tagged")` ⇒ the class `Tagged` and the slots `tagged_v0` / `tagged_v1`).
 
 `sealed_class!(E)` is a fifth class kind beside `ptr_class!` / `data_class!` / `enum_class!` /
 `value_class!`: one simple argument, sub-builder, `.name()`, per-variant `.variant(variant!(V))`, and
@@ -180,15 +185,15 @@ public data class RecoveryConfig(val mode: RecoveryMode?, val retentionPeriod: L
 ### 4.3 Output path (Rust → Kotlin)
 
 `PlanFieldKind::Sum { tag_slot, variants }` joins the shared bridge plan
-(`src/api/lang/jnigen/jni/struct_plan.rs`). The Rust encoder emits **one `match`** binding the tag
-and every slot, inert slots filled by the existing `primitive_default_for_descriptor`
-(`src/api/lang/jnigen/jni/emit/struct_out.rs:51`):
+(`prebindgen/src/api/lang/jnigen/jni/struct_plan.rs`). The Rust encoder emits **one `match`**
+binding the tag and every slot, inert slots filled by the existing
+`primitive_default_for_descriptor` (`prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs:51`):
 
 ```rust
 let (mode__present, mode__tag, mode_periodic_queries_period) = match &v.mode {
     None => (false, 0i32, 0i64),
-    Some(RecoveryMode::PeriodicQueries(p)) => (true, 0i32, __out_Duration(p.clone())),
-    Some(RecoveryMode::Heartbeat)          => (true, 1i32, 0i64),
+    Some(RecoveryMode::PeriodicQueries { period }) => (true, 0i32, __out_Duration(period.clone())),
+    Some(RecoveryMode::Heartbeat)                 => (true, 1i32, 0i64),
 };
 ```
 
@@ -198,9 +203,10 @@ for the sum, and both sides enumerate the same slots in the same order because b
 
 ### 4.4 Input path (Kotlin → Rust)
 
-`FlatFieldNode::Sum` joins `Value` / `Nested` (`src/api/lang/jnigen/jni/emit/flat_input.rs:349`), and
-`FlatInputPlan.root` generalizes from `FlatStructNode` to a struct-or-sum root so a **sum-typed
-parameter** flattens too. Extern signature:
+`FlatFieldNode::Sum` joins `Value` / `Nested`
+(`prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs:349`), and `FlatInputPlan.root` generalizes
+from `FlatStructNode` to a struct-or-sum root so a **sum-typed parameter** flattens too. Extern
+signature:
 
 ```kotlin
 external fun sessionDeclareAdvancedSubscriber(
@@ -220,7 +226,7 @@ Rust reconstruct, with an invalid tag going to the binding-error channel rather 
 ```rust
 let mode = if mode_present {
     Some(match mode_tag {
-        0 => RecoveryMode::PeriodicQueries(__in_Duration(mode_periodic_queries_period)),
+        0 => RecoveryMode::PeriodicQueries { period: __in_Duration(mode_periodic_queries_period) },
         1 => RecoveryMode::Heartbeat,
         t => return __jni_err(env, error_sink, format!("RecoveryMode: invalid tag {t}")),
     })
@@ -249,11 +255,12 @@ recoveryModeTag = when (recovery?.mode) {
 
 A sum returned by a function (or delivered as a callback argument) is the one position that needs
 core work, because `api/core/unfold.rs` is a deterministic **product** — "every record always runs
-and contributes its leaf … there is no selector" (`src/api/core/unfold.rs:8-11`). It gains one:
+and contributes its leaf … there is no selector" (`prebindgen/src/api/core/unfold.rs:8-11`). It
+gains one:
 
 - `LeafSource::VariantField { variant, member }` beside `Accessor` / `Field`
-  (`src/api/core/unfold/plan.rs`), so a leaf can be reached through a variant pattern rather
-  than a field chain, plus `LeafSource::SumTag` for the synthesized selector.
+  (`prebindgen/src/api/core/unfold/plan.rs`), so a leaf can be reached through a variant pattern
+  rather than a field chain, plus `LeafSource::SumTag` for the synthesized selector.
 - Per-leaf group membership (`UnfoldLeaf::group`), so the Rust emitter emits one `match` over
   the value instead of independent per-leaf expressions. The tag leaf is the one leaf with **no
   converter** (`UnfoldLeaf::has_converter()`): it is assigned per arm, so requiring an output
@@ -266,7 +273,7 @@ and contributes its leaf … there is no selector" (`src/api/core/unfold.rs:8-11
   bare type.
 
 `Option` / `Vec` layers need nothing new — they ride the existing `Shape` fold
-(`src/api/core/shape.rs`), same as for a data class.
+(`prebindgen/src/api/core/shape.rs`), same as for a data class.
 
 **The wire target is the hoisted builder singleton, not `Sum.fromParts`.** §4.2's `fromParts` is the
 Kotlin-facing convenience: its parameters are the variants' **property** types (`Priority`, not the
@@ -309,16 +316,17 @@ Generation errors, each naming the offending path:
 
 ### 5.1 Declaration
 
-`.tagged_union(ty)` beside `.enum_type(ty)` (`src/api/lang/cbindgen/builder.rs:398`), wired into the
-same three places every declarator touches: the already-declared guard (`:306`), the universal
-`.name()` override, and the `CurrentDecl` cursor for error messages (`:701`). `.enum_type()` on a
-payload enum errors with a pointer to it.
+`.tagged_union(ty)` beside `.enum_type(ty)` (`prebindgen/src/api/lang/cbindgen/builder.rs:398`),
+wired into the same three places every declarator touches: the already-declared guard (`:306`), the
+universal `.name()` override, and the `CurrentDecl` cursor for error messages (`:701`).
+`.enum_type()` on a payload enum errors with a pointer to it.
 
 ### 5.2 The mirror type
 
-`prereq_tagged_unions` mirrors `prereq_enums` (`src/api/lang/cbindgen/trait_impl.rs:650`), emitting a
-`#[repr(C)]` enum whose payload fields carry **wire** types chosen by the same `mirror_field_wire`
-policy `data_struct` uses (`trait_impl.rs:513`):
+`prereq_tagged_unions` mirrors `prereq_enums`
+(`prebindgen/src/api/lang/cbindgen/trait_impl.rs:650`), emitting a `#[repr(C)]` enum whose payload
+fields carry **wire** types chosen by the same `mirror_field_wire` policy `data_struct` uses
+(`trait_impl.rs:513`):
 
 ```rust
 #[repr(C)]
@@ -343,7 +351,7 @@ reusing the per-field converters the resolver already produced:
 pub(crate) fn __in_z_recovery_mode_t(v: z_recovery_mode_t) -> RecoveryMode {
     match v {
         z_recovery_mode_t::PeriodicQueries { period } =>
-            RecoveryMode::PeriodicQueries(__in_Duration(period)),
+            RecoveryMode::PeriodicQueries { period: __in_Duration(period) },
         z_recovery_mode_t::Heartbeat => RecoveryMode::Heartbeat,
     }
 }
@@ -361,15 +369,15 @@ leak.
 
 | Piece | Home |
 |---|---|
-| `EnumShape::{Unit, Sum}` classifier — the single definition of "is this enum C-like" | `src/api/core/types_util.rs` |
-| `SumSpec { key, source, variants: Vec<SumVariant> }`, `SumVariant { ident, tag, fields }`, `SumField { member, name, ty }` — the neutral description both adapters read | `src/api/core/types_util.rs` |
-| `enum_discriminant_values`, moved out of `jnigen/util.rs` | `src/api/core/types_util.rs` |
-| The unfold selector (`LeafSource::VariantField`, tag leaf, group membership, `apply_sum_returns`) | `src/api/core/unfold.rs` |
+| `EnumShape::{Unit, Sum}` classifier — the single definition of "is this enum C-like" | `prebindgen/src/api/core/types_util.rs` |
+| `SumSpec { key, source, variants: Vec<SumVariant> }`, `SumVariant { ident, tag, fields }`, `SumField { member, name, ty }` — the neutral description both adapters read | `prebindgen/src/api/core/types_util.rs` |
+| `enum_discriminant_values`, moved out of `jnigen/util.rs` | `prebindgen/src/api/core/types_util.rs` |
+| The unfold selector (`LeafSource::VariantField`, tag leaf, group membership, `apply_sum_returns`) | `prebindgen/src/api/core/unfold.rs` |
 
 Everything else is adapter-local. Payload **wire** choice stays per-adapter, exactly as `ValueDecon`
 leaves are adapter-built today (`Prebindgen::value_struct_decons`,
-`src/api/core/prebindgen.rs:218`) — core describes the sum, adapters decide what its leaves look like
-on the wire.
+`prebindgen/src/api/core/prebindgen.rs:218`) — core describes the sum, adapters decide what its
+leaves look like on the wire.
 
 ## 7. Test obligations
 
@@ -405,7 +413,7 @@ do not count.
 |---|---|---|---|
 | **A** | [#146](https://github.com/milyin/prebindgen/issues/146) | core: `EnumShape` classifier, `SumSpec`, `enum_discriminant_values` moved into core, the three `assert_unit_variants` sites and `enum_class!`'s contract replaced by classifier-driven errors. No behavior change for existing enums. | — |
 | **B** | [#147](https://github.com/milyin/prebindgen/issues/147) | cbindgen: `.tagged_union()`, `prereq_tagged_unions`, `in_/out_tagged_union`, the payload-ownership drop rule, goldens + C smoke test. | A |
-| **C** | [#148](https://github.com/milyin/prebindgen/issues/148) | jnigen: `sealed_class!` + `variant!`, `TypeKind::Sum`, `TypeConfig.sum_cfg`, the sealed-interface emitter (sibling of `write_enum_classes`, `src/api/lang/jnigen/jni/kotlin_emit.rs:555`). | A |
+| **C** | [#148](https://github.com/milyin/prebindgen/issues/148) | jnigen: `sealed_class!` + `variant!`, `TypeKind::Sum`, `TypeConfig.sum_cfg`, the sealed-interface emitter (sibling of `write_enum_classes`, `prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs:555`). | A |
 | **D** | [#149](https://github.com/milyin/prebindgen/issues/149) | jnigen: tag-gated groups on both flatten paths — `FlatFieldNode::Sum`, the struct-or-sum root, the `kt_access` expression-template refactor, `PlanFieldKind::Sum`. Unblocks flat #31 + #11, and flat #30 in its struct-field form (`ReplyStruct { result: ReplyResult, … }`). | C |
 | **E** | [#150](https://github.com/milyin/prebindgen/issues/150) | core + jnigen: sum-typed returns and callback arguments — the unfold selector. Needed when a function's **own** return (or a callback argument) is the sum, e.g. a `reply_get_result(&Reply) -> ReplyResult` accessor mirroring base's `Reply::result()`. | D |
 

--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -252,16 +252,49 @@ core work, because `api/core/unfold.rs` is a deterministic **product** — "ever
 and contributes its leaf … there is no selector" (`src/api/core/unfold.rs:8-11`). It gains one:
 
 - `LeafSource::VariantField { variant, member }` beside `Accessor` / `Field`
-  (`src/api/core/unfold/plan.rs:63-78`), so a leaf can be reached through a variant pattern rather
-  than a field chain.
-- Per-leaf group membership plus a synthesized tag leaf, so the Rust emitter emits one `match` over
-  the value instead of independent per-leaf expressions.
-- `apply_sum_returns`, modeled on `apply_value_structs` (`src/api/core/unfold.rs:455`): for every
-  declared function returning a declared sum (`E` / `&E` / `Option<E>` / `Vec<E>`), build a
-  `fixed_builder` `UnfoldPlan` whose foreign builder is the sealed interface's `fromParts`.
+  (`src/api/core/unfold/plan.rs`), so a leaf can be reached through a variant pattern rather
+  than a field chain, plus `LeafSource::SumTag` for the synthesized selector.
+- Per-leaf group membership (`UnfoldLeaf::group`), so the Rust emitter emits one `match` over
+  the value instead of independent per-leaf expressions. The tag leaf is the one leaf with **no
+  converter** (`UnfoldLeaf::has_converter()`): it is assigned per arm, so requiring an output
+  converter for it would make every sum depend on an unrelated `i32` crossing existing.
+- `apply_sum_returns`, modeled on `apply_value_structs`: for every declared function returning a
+  declared sum (`E` / `&E` / `Option<E>` / `Vec<E>`) and every `impl Fn(E)` / `impl Fn(&E)`
+  callback parameter, build a `fixed_builder` `UnfoldPlan` over the tag + groups. It also drops the
+  declared return's scan-time output requirement at **every layer** (`E`, `Option<E>`, `Vec<E>`) —
+  a sum has no whole-value converter by construction, and the boundary-only pass only reaches the
+  bare type.
 
 `Option` / `Vec` layers need nothing new — they ride the existing `Shape` fold
 (`src/api/core/shape.rs`), same as for a data class.
+
+**The wire target is the hoisted builder singleton, not `Sum.fromParts`.** §4.2's `fromParts` is the
+Kotlin-facing convenience: its parameters are the variants' **property** types (`Priority`, not the
+`Int` discriminant) and its object slots are non-null, which an inert group's `JObject::null()`
+would trip on inside the JVM's intrinsic null check before any generated code ran. So the return
+path reassembles through the same inlined `when` over the tag that a sum-typed struct field already
+gets, emitted into the hoisted `__<Name>Builder` / folder-appender singleton (and into the `asRaw`
+proxy for a callback argument). Both come from one derivation, so the two positions cannot drift:
+
+```kotlin
+internal val __ReadingBuilder: ReadingBuilder<Reading> =
+    ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 ->
+        when (tag) {
+            0 -> Reading.Missing
+            1 -> Reading.Exact(exact_v0)
+            2 -> Reading.Range(range_low, range_high)
+            3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1))
+            4 -> Reading.Companion(companion_v0)
+            else -> throw IllegalArgumentException("Reading: invalid tag $tag")
+        }
+    }
+```
+
+The `!!` is §4.4's inert-slot rule at the interface boundary: an object-shaped group slot is
+declared nullable (`tagged_v0: String?`) because an inert group is wire-defaulted to JVM null, and
+re-asserted inside its own live arm. Primitive slots keep their `0`/`false` default unboxed — a
+handle payload rides its raw `jlong`, so an inert handle group is the `0L` sentinel that is simply
+never wrapped.
 
 ### 4.6 Rejections
 
@@ -375,3 +408,8 @@ do not count.
 | **C** | [#148](https://github.com/milyin/prebindgen/issues/148) | jnigen: `sealed_class!` + `variant!`, `TypeKind::Sum`, `TypeConfig.sum_cfg`, the sealed-interface emitter (sibling of `write_enum_classes`, `src/api/lang/jnigen/jni/kotlin_emit.rs:555`). | A |
 | **D** | [#149](https://github.com/milyin/prebindgen/issues/149) | jnigen: tag-gated groups on both flatten paths — `FlatFieldNode::Sum`, the struct-or-sum root, the `kt_access` expression-template refactor, `PlanFieldKind::Sum`. Unblocks flat #31 + #11, and flat #30 in its struct-field form (`ReplyStruct { result: ReplyResult, … }`). | C |
 | **E** | [#150](https://github.com/milyin/prebindgen/issues/150) | core + jnigen: sum-typed returns and callback arguments — the unfold selector. Needed when a function's **own** return (or a callback argument) is the sum, e.g. a `reply_get_result(&Reply) -> ReplyResult` accessor mirroring base's `Reply::result()`. | D |
+
+A sum nested as a **data-class field** keeps the whole-value `fromParts` path (stage D's
+`PlanFieldKind::Sum`); the fixed-builder leaf synthesis for value structs still declines a sum
+field. Flattening that too is a wire-width/allocation optimization of an already-correct path, not
+a capability, so it is deliberately not part of stage E.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -236,6 +236,10 @@ fn main() {
                 // .name("Tagged")` exercises the per-variant rename (which
                 // also renames its `fromParts` slots).
                 .class(sealed_class!(Reading).variant(variant!(Labeled).name("Tagged")))
+                // `Lookup` is the sum in RETURN position whose groups own
+                // resources: one alternative carries an opaque handle, one
+                // carries nothing at all.
+                .class(sealed_class!(Lookup))
                 // `Observation` carries that sum as a data-class FIELD —
                 // required (`reading`) and optional (`fallback`) — beside
                 // ordinary flattened leaves, so the tag-gated groups must
@@ -455,6 +459,16 @@ fn main() {
                 .fun(fun!(observation_which))
                 .fun(fun!(tagged_new))
                 .fun(fun!(tagged_rank))
+                // A sum as the function's OWN return (and callback argument):
+                // the tag + groups ride the hoisted builder / folder singleton
+                // instead of a parent's `fromParts`. All four positions —
+                // bare, `Option`, `Vec`, callback — plus a group owning a
+                // native handle.
+                .fun(fun!(reading_of))
+                .fun(fun!(reading_maybe))
+                .fun(fun!(reading_series))
+                .fun(fun!(reading_each))
+                .fun(fun!(lookup_of))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -59,6 +59,8 @@ Base package: `io.prebindgen.covertest`
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
+- `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
+  - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
 - `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation>): Observation`
 - `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`
@@ -68,6 +70,13 @@ Base package: `io.prebindgen.covertest`
 - `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int`
 - `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority>): Priority`
 - `priority_weight` — `fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int`
+- `reading_each` — `fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>)`
+- `reading_maybe` — `fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading?`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `reading_of` — `fun readingOf(which: Int, onError: JniErrorHandler<Reading>): Reading`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
   - shaped by: return `Stamp` decomposed → [] (Callback delivery)
@@ -151,6 +160,7 @@ Base package: `io.prebindgen.covertest`
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
+- `Lookup`: sealed_class → `io.prebindgen.covertest.model.Lookup` (wire `?`)
 - `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `ObjectBoundary16`: data_class → `io.prebindgen.covertest.model.ObjectBoundary16` (wire `jni :: objects :: JObject`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -746,6 +746,8 @@ internal object CovNative {
 
     external fun labelReverse(l: String, errorSink: Any): String
 
+    external fun lookupOf(count: Long, total: Double, build: Any, errorSink: Any): Any?
+
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
 
     external fun objectBoundaryValue(value: ObjectBoundary, errorSink: Any): Long
@@ -804,6 +806,14 @@ internal object CovNative {
     external fun priorityOr(pPresent: Boolean, pValue: Int, fallback: Int, errorSink: Any): Int
 
     external fun priorityWeight(p: Int, errorSink: Any): Int
+
+    external fun readingEach(n: Int, sink: Any, errorSink: Any)
+
+    external fun readingMaybe(which: Int, build: Any, errorSink: Any): Any?
+
+    external fun readingOf(which: Int, build: Any, errorSink: Any): Any?
+
+    external fun readingSeries(n: Int, acc: Any?, fold: Any, errorSink: Any): Any?
 
     external fun stampNanos(s: ByteArray, errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -7,6 +7,7 @@ import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.__u64FolderRawHolder
+import io.prebindgen.covertest.analytics.Summary
 import io.prebindgen.covertest.asRaw
 import io.prebindgen.covertest.u64Callback
 
@@ -29,6 +30,40 @@ public enum class Priority(public override val value: Int) : PriorityKind, Ranke
     public companion object {
         @JvmStatic
         public fun fromInt(value: Int): Priority = entries.first { it.value == value }
+    }
+}
+
+/**
+ * A sum whose alternatives are a **payload-less** variant and one carrying an
+ * opaque **handle** — the shape a real lookup/reply result takes, and the one
+ * that proves a tag-gated group can own a native resource: the live group
+ * hands over a fresh handle, the inert group's slot stays a null pointer that
+ * is never wrapped.
+ *
+ * JVM-side surface for the native Rust `Lookup` sum: exactly one alternative is live.
+ */
+public sealed interface Lookup {
+    /** Nothing matched — only the tag is live. */
+    public data object Absent : Lookup
+
+    /** What matched, as a handle the caller owns (and must close). */
+    public data class Found(public val v0: Summary) : Lookup
+
+    /**
+     * Why the lookup could not run — a `String` beside the handle group, so an
+     * inert object slot is exercised alongside an inert primitive one.
+     */
+    public data class Failed(public val v0: String) : Lookup
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(tag: Int, found_v0: Summary, failed_v0: String): Lookup =
+            when (tag) {
+                0 -> Absent
+                1 -> Found(found_v0)
+                2 -> Failed(failed_v0)
+                else -> throw IllegalArgumentException("Lookup: invalid tag $tag")
+            }
     }
 }
 
@@ -673,6 +708,36 @@ public value class Stamp(public val bytes: ByteArray) {
     }
 }
 
+public fun interface ReadingCallback {
+    public fun run(reading: Reading)
+}
+
+public fun interface ReadingCallbackRaw {
+    public fun run(
+        tag: Int,
+        exact_v0: Long,
+        range_low: Long,
+        range_high: Long,
+        tagged_v0: String?,
+        tagged_v1: Int,
+        companion_v0: Long,
+    )
+}
+
+public fun ReadingCallback.asRaw(): ReadingCallbackRaw =
+    ReadingCallbackRaw {
+        tag,
+        exact_v0,
+        range_low,
+        range_high,
+        tagged_v0,
+        tagged_v1,
+        companion_v0 ->
+        run(
+            when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+        )
+    }
+
 public fun interface DurationBoundaryBuilder<out R> {
     public fun run(delay: ULong?): R
 }
@@ -691,6 +756,48 @@ public fun <R> DurationBoundaryBuilder<R>.asRaw(): DurationBoundaryBuilderRaw<R>
 
 internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
 DurationBoundaryBuilderRaw { delay -> DurationBoundary.fromParts(delay) }
+
+public fun interface LookupBuilder<out R> {
+    public fun run(tag: Int, found_v0: Summary, failed_v0: String?): R
+}
+
+public fun interface LookupBuilderRaw<out R> {
+    public fun run(tag: Int, found_v0: Long, failed_v0: String?): R
+}
+
+public fun <R> LookupBuilder<R>.asRaw(): LookupBuilderRaw<R> =
+    LookupBuilderRaw<R> {
+        tag,
+        found_v0,
+        failed_v0 ->
+        run(
+            tag,
+            Summary(found_v0),
+            failed_v0
+        )
+    }
+
+internal val __LookupBuilderRaw: LookupBuilderRaw<Lookup> =
+LookupBuilderRaw { tag, found_v0, failed_v0 ->
+    when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
+}
+
+public fun interface ReadingBuilder<out R> {
+    public fun run(
+        tag: Int,
+        exact_v0: Long,
+        range_low: Long,
+        range_high: Long,
+        tagged_v0: String?,
+        tagged_v1: Int,
+        companion_v0: Long,
+    ): R
+}
+
+internal val __ReadingBuilder: ReadingBuilder<Reading> =
+ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 ->
+    when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+}
 
 public fun interface UnsignedBuilder<out R> {
     public fun run(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?): R
@@ -718,6 +825,45 @@ public fun <R> UnsignedBuilder<R>.asRaw(): UnsignedBuilderRaw<R> =
 
 internal val __UnsignedBuilderRaw: UnsignedBuilderRaw<Unsigned> =
 UnsignedBuilderRaw { byte, short, int, long, maybeLong -> Unsigned.fromParts(byte, short, int, long, maybeLong) }
+
+public fun interface ReadingFolder<A> {
+    public fun run(acc: A, element: Reading): A
+}
+
+public fun interface ReadingFolderRaw<A> {
+    public fun run(
+        acc: A,
+        tag: Int,
+        exact_v0: Long,
+        range_low: Long,
+        range_high: Long,
+        tagged_v0: String?,
+        tagged_v1: Int,
+        companion_v0: Long,
+    ): A
+}
+
+public fun <A> ReadingFolder<A>.asRaw(): ReadingFolderRaw<A> =
+    ReadingFolderRaw<A> {
+        acc,
+        tag,
+        exact_v0,
+        range_low,
+        range_high,
+        tagged_v0,
+        tagged_v1,
+        companion_v0 ->
+        run(
+            acc,
+            when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+        )
+    }
+
+internal object __ReadingFolderRawHolder {
+    @JvmField
+    val instance: ReadingFolderRaw<ArrayList<Reading>> =
+    ReadingFolderRaw { acc, tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 -> acc.add(when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }); acc }
+}
 
 public fun interface StampFolder<A> {
     public fun run(acc: A, element: Stamp): A
@@ -1060,6 +1206,78 @@ public fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int {
     val __ret = CovNative.taggedRank(t.id, t.marker, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
+}
+
+/**
+ * The selected alternative as the function's **own return** — a sum in
+ * return position, where nothing but the value's own tag says which group is
+ * live. Unlike a struct field (whose slots ride the parent's `fromParts`),
+ * there is no surrounding product to carry the tag, so the decomposition
+ * itself has to.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun readingOf(which: Int, onError: JniErrorHandler<Reading>): Reading {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.readingOf(which, __ReadingBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Reading
+}
+
+/**
+ * `Option<sum>` return: `which < 0` yields `None`. Optionality and choice stay
+ * independent — the present layer nulls the whole result rather than becoming
+ * an extra tag value.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.readingMaybe(which, __ReadingBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Reading?
+}
+
+/**
+ * `Vec<sum>` return: alternatives `0..n`, each folded into the foreign list
+ * element by element.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading> {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.readingSeries(
+        n,
+        ArrayList<Reading>(),
+        __ReadingFolderRawHolder.instance,
+        __bcap,
+    )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as List<Reading>
+}
+
+/** A sum as a **callback argument**: alternatives `0..n` delivered in turn. */
+public fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.readingEach(n, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Build a [`Lookup`]: `count < 0` is a failure, `count == 0` is absent,
+ * anything else is found.
+ *
+ * The Rust `Lookup` result is delivered decomposed: the builder callback receives (`tag`, `found_v0`, `failed_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.lookupOf(count, total, __LookupBuilderRaw, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Lookup
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -34,6 +34,7 @@ import io.prebindgen.covertest.model.ObjectBoundary63
 import io.prebindgen.covertest.model.ObjectBoundary64
 import io.prebindgen.covertest.model.ObjectBoundaryLeaf
 import io.prebindgen.covertest.model.Priority
+import io.prebindgen.covertest.model.Lookup
 import io.prebindgen.covertest.model.Reading
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Unsigned
@@ -55,6 +56,11 @@ import io.prebindgen.covertest.model.objectBoundaryValue
 import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.observationWhich
+import io.prebindgen.covertest.model.lookupOf
+import io.prebindgen.covertest.model.readingEach
+import io.prebindgen.covertest.model.readingMaybe
+import io.prebindgen.covertest.model.readingOf
+import io.prebindgen.covertest.model.readingSeries
 import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.Tagged
 import io.prebindgen.covertest.model.taggedNew
@@ -392,6 +398,73 @@ fun main() {
         check(invalidTag != null && invalidTag!!.contains("Reading: invalid tag")) {
             "expected the binding-error channel to carry the invalid tag, got: $invalidTag"
         }
+    }
+
+    // ── a sum as the function's OWN return / callback argument ────────────────
+    // Nothing surrounds the value here, so the decomposition carries its own
+    // tag: the wrapper hands the native side a hoisted builder (or folder)
+    // singleton, and the live group is picked by a `when` over that tag. Still
+    // no JVM object built on the Rust side — only the tag and the raw slots
+    // cross.
+    section("sum in return position (tag + groups through a fixed builder)") {
+        // Bare `E` return: every variant shape survives, including the
+        // payload-less one and the ones whose groups carry object slots.
+        check(readingOf(0, boom) == Reading.Missing)
+        check(readingOf(1, boom) == Reading.Exact(42L))
+        check(readingOf(2, boom) == Reading.Range(1L, 9L))
+        check(readingOf(3, boom) == Reading.Tagged("warm", Priority.HIGH))
+        check(readingOf(4, boom) == Reading.Companion(5L))
+        // The payload-less alternative is still the singleton `data object` —
+        // the tag alone rebuilt it, no group was read.
+        check(readingOf(0, boom) === Reading.Missing)
+
+        // `Option<E>` return: the present layer nulls the whole result and is
+        // independent of the tag (which is 0 — `Missing` — in the null case,
+        // and must not be mistaken for one).
+        check(readingMaybe(-1, boom) == null)
+        check(readingMaybe(0, boom) == Reading.Missing)
+        check(readingMaybe(3, boom) == Reading.Tagged("warm", Priority.HIGH))
+
+        // `Vec<E>` return: each element's tag + groups cross raw and the
+        // folder singleton appends the rebuilt alternative.
+        check(readingSeries(0, boom).isEmpty())
+        check(
+            readingSeries(5, boom) == listOf(
+                Reading.Missing,
+                Reading.Exact(42L),
+                Reading.Range(1L, 9L),
+                Reading.Tagged("warm", Priority.HIGH),
+                Reading.Companion(5L),
+            )
+        )
+
+        // Callback argument: the user callback receives the whole reassembled
+        // sum while the wire still carries decoupled slots.
+        val seen = ArrayList<Reading>()
+        readingEach(5, { r -> seen.add(r) }, boom)
+        check(seen == readingSeries(5, boom))
+    }
+
+    // ── a tag-gated group that owns a native resource ─────────────────────────
+    // `Lookup.Found` carries an opaque handle: the live group hands over a
+    // freshly boxed pointer the caller owns, while an inert handle slot stays
+    // the `0L` sentinel that is never wrapped (wrapping it would fabricate a
+    // handle to nothing). `Failed`'s `String` group proves an inert OBJECT slot
+    // arrives as JVM null and so must be nullable in the raw builder.
+    section("sum return with a handle payload") {
+        check(lookupOf(0L, 0.0, boom) === Lookup.Absent)
+
+        val failed = lookupOf(-1L, 0.0, boom)
+        check(failed is Lookup.Failed && (failed as Lookup.Failed).v0 == "negative count")
+
+        val found = lookupOf(3L, 7.5, boom)
+        check(found is Lookup.Found)
+        val summary = (found as Lookup.Found).v0
+        // The handle is live and owns its own copy of the native object.
+        check(summary.count(boom) == 3L)
+        check(summary.total(boom) == 7.5)
+        summary.close()
+        check(summary.isClosed())
     }
 
     // ── a sum whose payload is NOT leaf-shaped ────────────────────────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -835,6 +835,117 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
+    Ok({
+        let __obj = v;
+        (|| -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Lookup: null value where a variant was required".to_string(),
+                    ),
+                );
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Absent")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Lookup", ": instanceof ",
+                        "io/prebindgen/covertest/model/Lookup$Absent", ": {}"), e
+                    ),
+                ))?
+            {
+                return ::core::result::Result::Ok(perftest_flat::Lookup::Absent);
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Found")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Lookup", ": instanceof ",
+                        "io/prebindgen/covertest/model/Lookup$Found", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(
+                        __obj,
+                        "v0",
+                        "Lio/prebindgen/covertest/analytics/Summary;",
+                    )
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Lookup.Found.v0: {}", e)))?;
+                let __p_v0_raw: jni::sys::jlong = if __p_v0_obj.is_null() {
+                    0
+                } else {
+                    env.call_method(&__p_v0_obj, "peek", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Lookup.Found.v0: {}", e)))?
+                };
+                if __p_v0_raw == 0 || (__p_v0_raw & 1) == 1 {
+                    return ::core::result::Result::Err(
+                        <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from("Operation on a closed native handle.".to_string()),
+                    );
+                }
+                let __p_v0: perftest_flat::Summary = unsafe {
+                    *std::boxed::Box::from_raw(__p_v0_raw as *mut perftest_flat::Summary)
+                };
+                return ::core::result::Result::Ok(perftest_flat::Lookup::Found(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Failed")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Lookup", ": instanceof ",
+                        "io/prebindgen/covertest/model/Lookup$Failed", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Lookup.Failed.v0: {}", e)))?;
+                let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
+                let __p_v0 = JString_to_String_c7f3ca43(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Lookup::Failed(__p_v0));
+            }
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from("Lookup: value is not one of its declared variants".to_string()),
+            )
+        })()?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Marker_3dc81334<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -2370,6 +2481,242 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
                 Ok(())
             })()
                 .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(& Payload)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Reading) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Reading)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(IJJJLjava/lang/String;IJ)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Reading)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Reading| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Reading)", e)))?;
+                env.push_local_frame(20)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Reading)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __cb0_obj0: jni::sys::jvalue;
+                    let __cb0_obj1: jni::sys::jvalue;
+                    let __cb0_obj2: jni::sys::jvalue;
+                    let __cb0_obj3: jni::sys::jvalue;
+                    let __cb0_obj4: jni::objects::JObject;
+                    let __cb0_obj5: jni::sys::jvalue;
+                    let __cb0_obj6: jni::sys::jvalue;
+                    match &__cb_arg0 {
+                        perftest_flat::Reading::Missing => {
+                            __cb0_obj0 = jni::sys::jvalue { i: 0 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Exact(__sv0) => {
+                            let __enc___cb0_obj1 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj1 = jni::sys::jvalue {
+                                j: __enc___cb0_obj1,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 1 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                            let __enc___cb0_obj2 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj2 = jni::sys::jvalue {
+                                j: __enc___cb0_obj2,
+                            };
+                            let __enc___cb0_obj3 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv1.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj3 = jni::sys::jvalue {
+                                j: __enc___cb0_obj3,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 2 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                            let __enc___cb0_obj4 = match String_to_JString_c7f3ca43(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj4 = __enc___cb0_obj4.into();
+                            let __enc___cb0_obj5 = match Priority_to_jint_447102d2(
+                                &mut env,
+                                __sv1.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj5 = jni::sys::jvalue {
+                                i: __enc___cb0_obj5,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 3 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                        perftest_flat::Reading::Companion(__sv0) => {
+                            let __enc___cb0_obj6 = match i64_to_jlong_fbf9a9bc(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj6 = jni::sys::jvalue {
+                                j: __enc___cb0_obj6,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 4 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj4 = jni::objects::JObject::null();
+                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
+                        }
+                    }
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                __cb0_obj2,
+                                __cb0_obj3,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj4.as_raw(),
+                                },
+                                __cb0_obj5,
+                                __cb0_obj6,
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Reading)"));
         })
     })
 }
@@ -8677,6 +9024,140 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_lookupOf<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    count: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/LookupBuilderRaw";
+    const __CB_DESCR: &str = "(IJLjava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::lookup_of(count, total);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    let __obj2: jni::objects::JObject;
+    match &__out {
+        perftest_flat::Lookup::Absent => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::objects::JObject::null();
+        }
+        perftest_flat::Lookup::Found(__sv0) => {
+            let __enc___obj1 = match Summary_to_jlong_3cb103b9(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+            __obj2 = jni::objects::JObject::null();
+        }
+        perftest_flat::Lookup::Failed(__sv0) => {
+            let __enc___obj2 = match String_to_JString_c7f3ca43(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = __enc___obj2.into();
+            __obj0 = jni::sys::jvalue { i: 2 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                jni::sys::jvalue {
+                    l: __obj2.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -9797,6 +10278,760 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityWeight<'
             0 as jni::sys::jint
         }
     }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jint,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jint_to_i32_a3e3b6ef(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::reading_each(n, sink);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingMaybe<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
+    const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::reading_maybe(which);
+    match __out {
+        ::core::option::Option::Some(__inner) => {
+            let __obj0: jni::sys::jvalue;
+            let __obj1: jni::sys::jvalue;
+            let __obj2: jni::sys::jvalue;
+            let __obj3: jni::sys::jvalue;
+            let __obj4: jni::objects::JObject;
+            let __obj5: jni::sys::jvalue;
+            let __obj6: jni::sys::jvalue;
+            match &__inner {
+                perftest_flat::Reading::Missing => {
+                    __obj0 = jni::sys::jvalue { i: 0 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Exact(__sv0) => {
+                    let __enc___obj1 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj1 = jni::sys::jvalue {
+                        j: __enc___obj1,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 1 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                    let __enc___obj2 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj2 = jni::sys::jvalue {
+                        j: __enc___obj2,
+                    };
+                    let __enc___obj3 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv1.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj3 = jni::sys::jvalue {
+                        j: __enc___obj3,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 2 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                    let __enc___obj4 = match String_to_JString_c7f3ca43(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj4 = __enc___obj4.into();
+                    let __enc___obj5 = match Priority_to_jint_447102d2(
+                        &mut env,
+                        __sv1.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj5 = jni::sys::jvalue {
+                        i: __enc___obj5,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 3 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Companion(__sv0) => {
+                    let __enc___obj6 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj6 = jni::sys::jvalue {
+                        j: __enc___obj6,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 4 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                }
+            }
+            match __CB_MID
+                .call_object(
+                    &mut env,
+                    __CB_FQN,
+                    "run",
+                    __CB_DESCR,
+                    &__builder,
+                    &[
+                        __obj0,
+                        __obj1,
+                        __obj2,
+                        __obj3,
+                        jni::sys::jvalue {
+                            l: __obj4.as_raw(),
+                        },
+                        __obj5,
+                        __obj6,
+                    ],
+                )
+            {
+                ::core::result::Result::Ok(__o) => __o,
+                ::core::result::Result::Err(__e) => {
+                    let _ = env.exception_describe();
+                    let __e2 = <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string());
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e2.to_string(),
+                    );
+                    jni::objects::JObject::null().into()
+                }
+            }
+        }
+        ::core::option::Option::None => jni::objects::JObject::null().into(),
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingOf<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
+    const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::reading_of(which);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    let __obj2: jni::sys::jvalue;
+    let __obj3: jni::sys::jvalue;
+    let __obj4: jni::objects::JObject;
+    let __obj5: jni::sys::jvalue;
+    let __obj6: jni::sys::jvalue;
+    match &__out {
+        perftest_flat::Reading::Missing => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Exact(__sv0) => {
+            let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+            let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = jni::sys::jvalue {
+                j: __enc___obj2,
+            };
+            let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj3 = jni::sys::jvalue {
+                j: __enc___obj3,
+            };
+            __obj0 = jni::sys::jvalue { i: 2 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+            let __enc___obj4 = match String_to_JString_c7f3ca43(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj4 = __enc___obj4.into();
+            let __enc___obj5 = match Priority_to_jint_447102d2(&mut env, __sv1.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj5 = jni::sys::jvalue {
+                i: __enc___obj5,
+            };
+            __obj0 = jni::sys::jvalue { i: 3 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Companion(__sv0) => {
+            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj6 = jni::sys::jvalue {
+                j: __enc___obj6,
+            };
+            __obj0 = jni::sys::jvalue { i: 4 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                __obj3,
+                jni::sys::jvalue {
+                    l: __obj4.as_raw(),
+                },
+                __obj5,
+                __obj6,
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingSeries<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jint,
+    __acc: jni::objects::JObject<'a>,
+    __fold: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jint_to_i32_a3e3b6ef(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingFolderRaw";
+    const __CB_DESCR: &str = "(Ljava/lang/Object;IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __vec = perftest_flat::reading_series(n);
+    let mut __acc = __acc;
+    for __elem in __vec.into_iter() {
+        let __obj0: jni::sys::jvalue;
+        let __obj1: jni::sys::jvalue;
+        let __obj2: jni::sys::jvalue;
+        let __obj3: jni::sys::jvalue;
+        let __obj4: jni::objects::JObject;
+        let __obj5: jni::sys::jvalue;
+        let __obj6: jni::sys::jvalue;
+        match &__elem {
+            perftest_flat::Reading::Missing => {
+                __obj0 = jni::sys::jvalue { i: 0 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Exact(__sv0) => {
+                let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj1 = jni::sys::jvalue {
+                    j: __enc___obj1,
+                };
+                __obj0 = jni::sys::jvalue { i: 1 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj2 = jni::sys::jvalue {
+                    j: __enc___obj2,
+                };
+                let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj3 = jni::sys::jvalue {
+                    j: __enc___obj3,
+                };
+                __obj0 = jni::sys::jvalue { i: 2 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                let __enc___obj4 = match String_to_JString_c7f3ca43(
+                    &mut env,
+                    __sv0.clone(),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj4 = __enc___obj4.into();
+                let __enc___obj5 = match Priority_to_jint_447102d2(
+                    &mut env,
+                    __sv1.clone(),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj5 = jni::sys::jvalue {
+                    i: __enc___obj5,
+                };
+                __obj0 = jni::sys::jvalue { i: 3 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj6 = jni::sys::jvalue { j: 0i64 };
+            }
+            perftest_flat::Reading::Companion(__sv0) => {
+                let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                __obj6 = jni::sys::jvalue {
+                    j: __enc___obj6,
+                };
+                __obj0 = jni::sys::jvalue { i: 4 };
+                __obj1 = jni::sys::jvalue { j: 0i64 };
+                __obj2 = jni::sys::jvalue { j: 0i64 };
+                __obj3 = jni::sys::jvalue { j: 0i64 };
+                __obj4 = jni::objects::JObject::null();
+                __obj5 = jni::sys::jvalue { i: 0i32 };
+            }
+        }
+        __acc = match __CB_MID
+            .call_object(
+                &mut env,
+                __CB_FQN,
+                "run",
+                __CB_DESCR,
+                &__fold,
+                &[
+                    jni::sys::jvalue {
+                        l: __acc.as_raw(),
+                    },
+                    __obj0,
+                    __obj1,
+                    __obj2,
+                    __obj3,
+                    jni::sys::jvalue {
+                        l: __obj4.as_raw(),
+                    },
+                    __obj5,
+                    __obj6,
+                ],
+            )
+        {
+            ::core::result::Result::Ok(__o) => __o,
+            ::core::result::Result::Err(__e) => {
+                let _ = env.exception_describe();
+                let __e2 = <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string());
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e2.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+    }
+    __acc
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -193,6 +193,67 @@ pub fn tagged_rank(t: Tagged) -> i32 {
     }
 }
 
+/// The selected alternative as the function's **own return** — a sum in
+/// return position, where nothing but the value's own tag says which group is
+/// live. Unlike a struct field (whose slots ride the parent's `fromParts`),
+/// there is no surrounding product to carry the tag, so the decomposition
+/// itself has to.
+#[prebindgen]
+pub fn reading_of(which: i32) -> Reading {
+    reading_for(which)
+}
+
+/// `Option<sum>` return: `which < 0` yields `None`. Optionality and choice stay
+/// independent — the present layer nulls the whole result rather than becoming
+/// an extra tag value.
+#[prebindgen]
+pub fn reading_maybe(which: i32) -> Option<Reading> {
+    (which >= 0).then(|| reading_for(which))
+}
+
+/// `Vec<sum>` return: alternatives `0..n`, each folded into the foreign list
+/// element by element.
+#[prebindgen]
+pub fn reading_series(n: i32) -> Vec<Reading> {
+    (0..n).map(reading_for).collect()
+}
+
+/// A sum as a **callback argument**: alternatives `0..n` delivered in turn.
+#[prebindgen]
+pub fn reading_each(n: i32, sink: impl Fn(Reading) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(reading_for(i));
+    }
+}
+
+/// A sum whose alternatives are a **payload-less** variant and one carrying an
+/// opaque **handle** — the shape a real lookup/reply result takes, and the one
+/// that proves a tag-gated group can own a native resource: the live group
+/// hands over a fresh handle, the inert group's slot stays a null pointer that
+/// is never wrapped.
+#[prebindgen]
+#[derive(Clone)]
+pub enum Lookup {
+    /// Nothing matched — only the tag is live.
+    Absent,
+    /// What matched, as a handle the caller owns (and must close).
+    Found(Summary),
+    /// Why the lookup could not run — a `String` beside the handle group, so an
+    /// inert object slot is exercised alongside an inert primitive one.
+    Failed(String),
+}
+
+/// Build a [`Lookup`]: `count < 0` is a failure, `count == 0` is absent,
+/// anything else is found.
+#[prebindgen]
+pub fn lookup_of(count: i64, total: f64) -> Lookup {
+    match count {
+        c if c < 0 => Lookup::Failed("negative count".to_string()),
+        0 => Lookup::Absent,
+        c => Lookup::Found(summary_new(c, total)),
+    }
+}
+
 /// Which alternative an [`Observation`]'s `reading` holds, by declaration
 /// order — the sum crossing back **in** as part of a data-class parameter.
 #[prebindgen]

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -222,6 +222,24 @@ pub trait Prebindgen {
         Vec::new()
     }
 
+    /// Synthesized **sum** decompositions for this adapter — the
+    /// selector-carrying sibling of [`Self::value_struct_decons`]. Each names a
+    /// data-carrying enum, its synthesized tag leaf and one leaf group per
+    /// alternative. Consulted by `write_rust` right after
+    /// [`Self::value_struct_decons`]: each is wired by
+    /// [`crate::api::core::unfold::apply_sum_returns`] into a fixed-builder
+    /// [`crate::api::core::unfold::UnfoldPlan`] for every function whose own
+    /// return (or callback argument) IS the sum, so the value crosses as a tag
+    /// plus tag-gated groups and the foreign side picks the live alternative.
+    ///
+    /// Default: empty.
+    fn sum_decons(
+        &self,
+        _registry: &Registry<Self::Metadata>,
+    ) -> Vec<crate::api::core::unfold::SumDecon> {
+        Vec::new()
+    }
+
     /// Element types the adapter nominates for a **whole-element leaf fold**: a
     /// `Vec<T>` / `Option<Vec<T>>` return (or `impl Fn(&[T])` callback arg) whose
     /// element `T` is a single boundary leaf (e.g. a String, a value blob, an

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1386,6 +1386,13 @@ impl<M> Registry<M> {
         if !value_decons.is_empty() {
             crate::api::core::unfold::apply_value_structs(self, value_decons, &declared.functions)?;
         }
+        // Synthesized sum decompositions: the same fixed-builder wiring for a
+        // value whose alternatives are chosen at runtime (tag + one leaf group
+        // per variant) rather than being a fixed product.
+        let sum_decons = ext.sum_decons(self);
+        if !sum_decons.is_empty() {
+            crate::api::core::unfold::apply_sum_returns(self, sum_decons, &declared.functions)?;
+        }
         // Single-leaf `Vec<T>`/`&[T]` whole-element folds — the dual of the
         // `data_class` folds above, for String / value-blob / handle elements
         // (so the list is built on the foreign side, not via a Rust ArrayList).

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -458,89 +458,178 @@ pub fn apply_value_structs<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
     for vd in &decons {
-        let decon = DeconId::Default(vd.key.to_string());
-        require_unique_leaf_names(&vd.source, &vd.leaves)?;
-        registry
-            .decon_plans
-            .entry(decon.clone())
-            .or_insert_with(|| DeconSpec {
-                source: vd.source.clone(),
-                leaves: vd.leaves.clone(),
-            });
+        let decon = wire_fixed_decon(registry, &vd.key, &vd.source, &vd.leaves)?;
 
         // Output position: a declared fn returning the struct
         // (`T` / `&T` / `Option<T|&T>` / `Vec<T|&T>`) decomposes into a
         // fixed-builder plan. (`Result<T, E>` is left to the whole-value
         // converter — the synthesizer covers the infallible returns.)
-        for func in declared_fns {
-            let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
-                continue;
-            };
-            let ret = fn_return(&item_fn);
-            if !returns_type(&ret, &vd.key) || registry.unfold_plans.contains_key(func) {
-                continue;
-            }
-            // Shape over the field decomposition: peel an outer `Option`, then a
-            // `Vec`, then a leading `&`. `Vec<T|&T>` ⇒ Iterable (a **fixed
-            // folder**: each element's field leaves cross raw and the foreign
-            // folder rebuilds it via `fromParts` + appends, so no Java object is
-            // built on the Rust side); `Option<…>` wraps the inner shape in
-            // Optional (`None` ⇒ a null result). `element: None` keeps the
-            // decomposed-leaf path. The element/inner borrow-ness sets `by_ref`
-            // (the field reach clones either way).
-            let (optional, after_opt) = match option_inner_type(&ret) {
-                Some(inner) => (true, inner),
-                None => (false, ret.clone()),
-            };
-            let (iterable, core) = match vec_inner_type(&after_opt) {
-                Some(inner) => (true, inner),
-                None => (false, after_opt),
-            };
-            let by_ref = matches!(&core, syn::Type::Reference(_));
-            let inner_shape = if iterable {
-                UnfoldShape::Iterable(Box::new(UnfoldShape::Base))
-            } else {
-                UnfoldShape::Base
-            };
-            let shape = if optional {
-                UnfoldShape::Optional((), Box::new(inner_shape))
-            } else {
-                inner_shape
-            };
-            for leaf in &vd.leaves {
-                registry.require_output(&leaf.out_ty, &loc);
-            }
-            let plan = UnfoldPlan {
-                source: vd.source.clone(),
-                decon: Some(decon.clone()),
-                by_ref,
-                shape,
-                leaves: vd.leaves.clone(),
-                element: None,
-                delivery: Delivery::Callback,
-                convert_out_ty: None,
-                fixed_builder: true,
-            };
-            registry.unfold_plans.insert(func.clone(), plan);
-        }
+        wire_fixed_returns(registry, vd, &decon, declared_fns, false);
 
         // Callback-argument position: an `impl Fn(&T)` / `impl Fn(T)` parameter
         // of a declared fn delivers the flattened leaves to the foreign
         // callback, which reassembles the whole value via the data class's
         // `fromParts` before invoking the user's typed callback (the group
         // reassembly lives in the JNI adapter's `asRaw` proxy).
-        apply_value_struct_callbacks(registry, vd, &decon, declared_fns)?;
+        wire_fixed_callbacks(registry, vd, &decon, declared_fns)?;
     }
     Ok(())
 }
 
+/// A synthesized **sum** decomposition, produced by the language adapter (which
+/// knows how each payload encodes) and fed to [`apply_sum_returns`] — the
+/// selector-carrying sibling of [`ValueDecon`].
+///
+/// Its [`leaves`](Self::leaves) are a [`LeafSource::SumTag`] selector followed
+/// by one **group** per alternative ([`LeafSource::VariantField`] leaves
+/// carrying [`UnfoldLeaf::group`]). Exactly one group is live per value; the
+/// emitter reads the whole list as ONE `match` over the value, filling every
+/// inert slot with its wire default. The foreign side picks the live group by
+/// the tag and rebuilds the alternative, so no object is built on the Rust
+/// side.
+pub struct SumDecon {
+    /// Canonical key of the sum type (the `DeconId::Default` key).
+    pub key: TypeKey,
+    /// The enum type (owned) the leaves decompose.
+    pub source: syn::Type,
+    /// The tag leaf followed by every variant's group, in tag order.
+    pub leaves: Vec<UnfoldLeaf>,
+}
+
+/// Wire the synthesized **sum** decompositions into the registry — the
+/// [`apply_value_structs`] analog for a value whose alternatives are chosen at
+/// runtime instead of being a fixed product.
+///
+/// For every declared function returning the sum (`E` / `&E` / `Option<E>` /
+/// `Vec<E>`) and every `impl Fn(E)` / `impl Fn(&E)` callback parameter, builds a
+/// **fixed-builder** [`UnfoldPlan`] over the tag + group leaves, registering
+/// each leaf's `out_ty` as a required output.
+///
+/// A sum has no converter of its own (it is boundary-only: a tag plus groups is
+/// not a single wire), so the declared return's scan-time output requirement —
+/// including the `Option<E>` / `Vec<E>` layers, which the boundary-only pass
+/// does not reach — is dropped here as the plan takes over.
+///
+/// Runs in `write_rust` right after [`apply_value_structs`] and before `resolve`.
+pub fn apply_sum_returns<M>(
+    registry: &mut Registry<M>,
+    decons: Vec<SumDecon>,
+    declared_fns: &std::collections::HashSet<syn::Ident>,
+) -> Result<(), UnfoldError> {
+    for sd in &decons {
+        let decon = wire_fixed_decon(registry, &sd.key, &sd.source, &sd.leaves)?;
+        let vd = ValueDecon {
+            key: sd.key.clone(),
+            source: sd.source.clone(),
+            leaves: sd.leaves.clone(),
+        };
+        wire_fixed_returns(registry, &vd, &decon, declared_fns, true);
+        wire_fixed_callbacks(registry, &vd, &decon, declared_fns)?;
+    }
+    Ok(())
+}
+
+/// Register the declaration-canonical [`DeconSpec`] of a synthesized
+/// decomposition (first writer wins) and return its identity.
+fn wire_fixed_decon<M>(
+    registry: &mut Registry<M>,
+    key: &TypeKey,
+    source: &syn::Type,
+    leaves: &[UnfoldLeaf],
+) -> Result<DeconId, UnfoldError> {
+    let decon = DeconId::Default(key.to_string());
+    require_unique_leaf_names(source, leaves)?;
+    registry
+        .decon_plans
+        .entry(decon.clone())
+        .or_insert_with(|| DeconSpec {
+            source: source.clone(),
+            leaves: leaves.to_vec(),
+        });
+    Ok(decon)
+}
+
+/// Build the fixed-builder output plan for every declared fn returning the
+/// decomposed type (`T` / `&T` / `Option<T|&T>` / `Vec<T|&T>`). `no_converter`
+/// marks a type that has no whole-value converter at all (a sum), so the
+/// declared return's scan-time output requirement is dropped as the plan
+/// replaces it.
+fn wire_fixed_returns<M>(
+    registry: &mut Registry<M>,
+    vd: &ValueDecon,
+    decon: &DeconId,
+    declared_fns: &std::collections::HashSet<syn::Ident>,
+    no_converter: bool,
+) {
+    for func in declared_fns {
+        let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
+            continue;
+        };
+        let ret = fn_return(&item_fn);
+        if !returns_type(&ret, &vd.key) || registry.unfold_plans.contains_key(func) {
+            continue;
+        }
+        // Shape over the leaf decomposition: peel an outer `Option`, then a
+        // `Vec`, then a leading `&`. `Vec<T|&T>` ⇒ Iterable (a **fixed
+        // folder**: each element's leaves cross raw and the foreign folder
+        // rebuilds it + appends, so no Java object is built on the Rust
+        // side); `Option<…>` wraps the inner shape in Optional (`None` ⇒ a
+        // null result). `element: None` keeps the decomposed-leaf path. The
+        // element/inner borrow-ness sets `by_ref` (the reach clones either
+        // way).
+        let (optional, after_opt) = match option_inner_type(&ret) {
+            Some(inner) => (true, inner),
+            None => (false, ret.clone()),
+        };
+        let (iterable, core) = match vec_inner_type(&after_opt) {
+            Some(inner) => (true, inner),
+            None => (false, after_opt.clone()),
+        };
+        let by_ref = matches!(&core, syn::Type::Reference(_));
+        let inner_shape = if iterable {
+            UnfoldShape::Iterable(Box::new(UnfoldShape::Base))
+        } else {
+            UnfoldShape::Base
+        };
+        let shape = if optional {
+            UnfoldShape::Optional((), Box::new(inner_shape))
+        } else {
+            inner_shape
+        };
+        if no_converter {
+            // The plan delivers the return leaf-by-leaf, so no converter is
+            // needed for the declared return — and for a sum none can exist.
+            // Drop the scan-time registrations of every layer (the boundary-only
+            // pass only reaches the bare type), so the missing converters are not
+            // flagged as unresolved-required.
+            registry.unrequire_output(&ret);
+            registry.unrequire_output(&after_opt);
+        }
+        for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
+            registry.require_output(&leaf.out_ty, &loc);
+        }
+        let plan = UnfoldPlan {
+            source: vd.source.clone(),
+            decon: Some(decon.clone()),
+            by_ref,
+            shape,
+            leaves: vd.leaves.clone(),
+            element: None,
+            delivery: Delivery::Callback,
+            convert_out_ty: None,
+            fixed_builder: true,
+        };
+        registry.unfold_plans.insert(func.clone(), plan);
+    }
+}
+
 /// Build a fixed-builder callback-arg plan for every `impl Fn(&T)` /
-/// `impl Fn(T)` parameter (of a declared fn) whose value is the value struct
-/// `vd`. The foreign callback receives the flattened leaves (reassembled there
-/// via the data class's `fromParts`) instead of a whole value built on the Rust
-/// side. Separate from the output-position wiring so the callback path (which
-/// needs the foreign-side group-reassembly adapter) can be enabled on its own.
-fn apply_value_struct_callbacks<M>(
+/// `impl Fn(T)` parameter (of a declared fn) whose value is the decomposed type
+/// `vd`. The foreign callback receives the flattened leaves (reassembled there)
+/// instead of a whole value built on the Rust side. Separate from the
+/// output-position wiring so the callback path (which needs the foreign-side
+/// group-reassembly adapter) can be enabled on its own.
+fn wire_fixed_callbacks<M>(
     registry: &mut Registry<M>,
     vd: &ValueDecon,
     decon: &DeconId,
@@ -582,7 +671,7 @@ fn apply_value_struct_callbacks<M>(
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                for leaf in &vd.leaves {
+                for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
                     registry.require_output(&leaf.out_ty, &loc);
                 }
                 let plan = UnfoldPlan {
@@ -1147,6 +1236,7 @@ fn flatten<M>(
                     identity: true,
                     nullable,
                     source: LeafSource::Accessor,
+                    group: None,
                 });
             }
             DeconRecord::Acc { name, .. } | DeconRecord::LocalAcc { name, .. } => {
@@ -1244,6 +1334,7 @@ fn flatten<M>(
                         identity,
                         nullable,
                         source: LeafSource::Accessor,
+                        group: None,
                     });
                 }
             }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -59,7 +59,7 @@ pub struct DeconSpec {
 }
 
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum LeafSource {
     /// The path is a chain of `#[prebindgen]` **accessor functions**:
     /// `source_module::f(&value)`, composing nested accessors. Nesting steps
@@ -74,6 +74,27 @@ pub enum LeafSource {
     /// fields cross as decoupled leaves and the foreign side reassembles the
     /// object (so no Java object is built on the Rust side).
     Field,
+    /// The **synthesized selector** of a decomposed sum: an `i32` naming which
+    /// alternative is live. It is not read off the value at all — the emitter
+    /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
+    /// the groups it selects between (see
+    /// [`crate::api::core::unfold::apply_sum_returns`]).
+    SumTag,
+    /// A payload field of ONE alternative of a decomposed sum, reached through
+    /// a **variant pattern** rather than an accessor chain or a field chain:
+    /// the emitter binds `member` inside `variant`'s `match` arm. The leaf is
+    /// live only when [`UnfoldLeaf::group`] equals the value's tag; in every
+    /// other arm its slot carries the wire default.
+    ///
+    /// This is the selector [`Accessor`](Self::Accessor) and
+    /// [`Field`](Self::Field) deliberately lack — both are deterministic
+    /// products, every record contributing unconditionally.
+    VariantField {
+        /// The variant's ident as declared in the source enum.
+        variant: syn::Ident,
+        /// How the payload field is addressed in the arm's pattern.
+        member: syn::Member,
+    },
 }
 
 /// A resolved output expansion for one function.
@@ -146,6 +167,28 @@ pub struct UnfoldLeaf {
     /// `match Some/None`.
     pub nullable: bool,
     /// How [`Self::path`] is reached from the value — an accessor-fn chain
-    /// (default) or a struct-field chain (synthesized `data_class`).
+    /// (default), a struct-field chain (synthesized `data_class`), or a
+    /// variant pattern binding (decomposed sum).
     pub source: LeafSource,
+    /// **Group membership**: `Some(tag)` marks the leaf as belonging to the
+    /// leaf group of the sum alternative with that tag — live only when the
+    /// value's [`LeafSource::SumTag`] leaf equals `tag`, wire-defaulted
+    /// otherwise. `None` for an unconditional (product) leaf, including the
+    /// tag leaf itself, which selects between groups rather than joining one.
+    ///
+    /// Grouping is what turns a leaf list into a `match`: leaves sharing a
+    /// group are emitted together in one arm instead of as independent
+    /// per-leaf expressions.
+    pub group: Option<i32>,
+}
+
+impl UnfoldLeaf {
+    /// Whether this leaf's [`out_ty`](Self::out_ty) needs a resolved **output
+    /// converter**. False only for the synthesized [`LeafSource::SumTag`]
+    /// selector: it is assigned per `match` arm, never converted, so requiring
+    /// a converter for it would make every sum depend on an unrelated `i32`
+    /// crossing existing in the binding.
+    pub fn has_converter(&self) -> bool {
+        self.source != LeafSource::SumTag
+    }
 }

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1072,6 +1072,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Field,
+        group: None,
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
@@ -1124,6 +1125,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Field,
+        group: None,
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
@@ -1650,4 +1652,134 @@ fn duplicate_declarations_collected() {
         text.contains("duplicate output expansion for `z_session_key`"),
         "{text}"
     );
+}
+
+/// The tag + group leaves a sum decomposition is made of. Mirrors what the
+/// JNI adapter synthesizes: a selector followed by one group per alternative.
+fn reading_sum_decon() -> SumDecon {
+    let tag = UnfoldLeaf {
+        name: "tag".to_string(),
+        path: vec![],
+        out_ty: syn::parse_quote!(i32),
+        identity: false,
+        nullable: false,
+        source: LeafSource::SumTag,
+        group: None,
+    };
+    let field = |name: &str, variant: &str, idx: u32, ty: syn::Type, group: i32| UnfoldLeaf {
+        name: name.to_string(),
+        path: vec![],
+        out_ty: ty,
+        identity: false,
+        nullable: false,
+        source: LeafSource::VariantField {
+            variant: ident(variant),
+            member: syn::Member::Unnamed(syn::Index::from(idx as usize)),
+        },
+        group: Some(group),
+    };
+    SumDecon {
+        key: TypeKey::from_type(&syn::parse_quote!(Reading)),
+        source: syn::parse_quote!(Reading),
+        leaves: vec![
+            tag,
+            // group 0 (`Missing`) is empty — a unit variant contributes only
+            // its tag.
+            field("exact_v0", "Exact", 0, syn::parse_quote!(i64), 1),
+        ],
+    }
+}
+
+/// A sum returned by a function decomposes into a **fixed-builder** plan over
+/// its tag and groups — the same delivery a by-value `data_class` gets, with
+/// the selector added. The declared return's own output requirement is dropped:
+/// a sum has no whole-value converter by construction, so leaving it required
+/// would fail the resolve on a converter that must not exist.
+#[test]
+fn sum_return_is_a_fixed_builder_plan() {
+    let mut reg = reg_with(&["fn read_one(which: i32) -> Reading { todo!() }"]);
+    let declared: std::collections::HashSet<syn::Ident> =
+        ["read_one"].iter().map(|s| ident(s)).collect();
+    apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
+
+    let plan = reg.unfold_plans.get(&ident("read_one")).expect("plan");
+    assert!(plan.fixed_builder, "sum ⇒ fixed builder");
+    assert_eq!(plan.delivery, Delivery::Callback);
+    assert!(matches!(plan.shape, UnfoldShape::Base));
+    assert!(!plan.by_ref);
+    assert_eq!(plan.leaves.len(), 2, "the tag plus one group leaf");
+    assert_eq!(plan.leaves[0].source, LeafSource::SumTag);
+    assert_eq!(plan.leaves[0].group, None, "the selector joins no group");
+    assert_eq!(
+        plan.leaves[1].group,
+        Some(1),
+        "the group is its variant's tag"
+    );
+    assert!(matches!(
+        &plan.leaves[1].source,
+        LeafSource::VariantField { variant, .. } if variant == "Exact"
+    ));
+    // The selector is synthesized, so it must not drag an `i32` output
+    // requirement into a binding that has no `i32` crossing of its own.
+    assert!(!plan.leaves[0].has_converter());
+    assert!(plan.leaves[1].has_converter());
+    assert!(
+        !reg.required_outputs_scan
+            .contains(&TypeKey::from_type(&syn::parse_quote!(Reading))),
+        "a sum has no whole-value converter, so its return must not require one"
+    );
+}
+
+/// `Option` and `Vec` layers ride the existing shape fold — a sum needs
+/// nothing new for them — and each layer's own scan-time output requirement is
+/// dropped along with the bare type's.
+#[test]
+fn sum_return_layers_ride_the_shape_fold() {
+    let mut reg = reg_with(&[
+        "fn read_maybe(w: i32) -> Option<Reading> { todo!() }",
+        "fn read_all(n: i32) -> Vec<Reading> { todo!() }",
+    ]);
+    let declared: std::collections::HashSet<syn::Ident> = ["read_maybe", "read_all"]
+        .iter()
+        .map(|s| ident(s))
+        .collect();
+    apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
+
+    let opt = reg.unfold_plans.get(&ident("read_maybe")).expect("plan");
+    assert!(matches!(&opt.shape,
+        UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Base)));
+    let vec_plan = reg.unfold_plans.get(&ident("read_all")).expect("plan");
+    assert!(matches!(&vec_plan.shape,
+        UnfoldShape::Iterable(inner) if matches!(**inner, UnfoldShape::Base)));
+    assert!(vec_plan.element.is_none(), "decomposed-leaf fold");
+    for ty in ["Option<Reading>", "Vec<Reading>", "Reading"] {
+        let ty: syn::Type = syn::parse_str(ty).unwrap();
+        assert!(
+            !reg.required_outputs_scan.contains(&TypeKey::from_type(&ty)),
+            "no layer of a sum return may require a whole-value converter: {}",
+            ty.to_token_stream()
+        );
+    }
+}
+
+/// An `impl Fn(E)` callback argument decomposes the same way a return does —
+/// the plan is keyed by the arg type, so the trampoline delivers the tag and
+/// groups instead of a whole value built on the Rust side.
+#[test]
+fn sum_callback_arg_is_a_fixed_builder_plan() {
+    let mut reg = reg_with(&[
+        "fn read_each(n: i32, f: impl Fn(Reading) + Send + Sync + 'static) { todo!() }",
+    ]);
+    let declared: std::collections::HashSet<syn::Ident> =
+        ["read_each"].iter().map(|s| ident(s)).collect();
+    apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
+
+    let key = TypeKey::from_type(&syn::parse_quote!(Reading));
+    let plan = reg
+        .callback_arg_plans
+        .get(&key)
+        .expect("callback-arg plan keyed by the arg type");
+    assert!(plan.fixed_builder);
+    assert!(matches!(plan.shape, UnfoldShape::Base));
+    assert_eq!(plan.leaves[0].source, LeafSource::SumTag);
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -75,7 +75,8 @@ pub(crate) fn callback_input(
             .filter(|p| super::render::is_iterable_fold(&p.shape))
         {
             // Every leaf converter must already be resolved (deferral safety).
-            for leaf in &plan.leaves {
+            // A synthesized leaf (a sum's tag) has no converter to wait for.
+            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
                 registry.output_entry(&leaf.out_ty)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
@@ -164,8 +165,11 @@ pub(crate) fn callback_input(
         if let Some(plan) = registry.callback_arg_plans.get(&TypeKey::from_type(arg_ty)) {
             // Deferral safety: every leaf converter (and identity-leaf
             // projection) must already be resolved — return None so the rank
-            // resolver retries this converter later otherwise.
-            for leaf in &plan.leaves {
+            // resolver retries this converter later otherwise. A synthesized
+            // leaf (a sum's tag) has no converter to wait for: requiring one
+            // would make the trampoline wait forever on an `i32` crossing the
+            // binding may not have.
+            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
                 let e = registry.output_entry(&leaf.out_ty)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -372,6 +372,13 @@ pub(crate) fn encode_plan_leaves(
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
+    // A decomposed **sum** is the one plan whose leaves are not independent:
+    // only one group is live per value, so the whole list is emitted as ONE
+    // `match` rather than per-leaf expressions. Same contract, different
+    // emitter — see [`encode_sum_leaves`].
+    if is_sum_leaves(&plan.leaves) {
+        return encode_sum_leaves(ext, registry, plan, obj_idents, value, fail);
+    }
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
@@ -634,7 +641,7 @@ pub(crate) fn encode_plan_leaves(
         // Rust expression to `body`.
         use crate::api::core::unfold::LeafSource;
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
-            match leaf.source {
+            match &leaf.source {
                 LeafSource::Accessor => reach_leaf(
                     &qualify,
                     &leaf.path,
@@ -649,6 +656,13 @@ pub(crate) fn encode_plan_leaves(
                     let segs = &leaf.path;
                     body(quote!(#value #(.#segs)*.clone()))
                 }
+                // Group leaves never reach this walk: a plan carrying them is
+                // routed to `encode_sum_leaves` at the top of this function,
+                // because a variant payload has no path — it is bound by a
+                // `match` arm.
+                LeafSource::SumTag | LeafSource::VariantField { .. } => unreachable!(
+                    "sum leaves are encoded by `encode_sum_leaves`, not reached by path"
+                ),
             }
         };
 
@@ -705,10 +719,24 @@ pub(crate) fn leaf_is_prim(
     registry: &Registry<KotlinMeta>,
     leaf: &crate::api::core::unfold::UnfoldLeaf,
 ) -> bool {
+    // The synthesized sum selector is a `jint` by definition — it is assigned,
+    // never converted, so it has no output entry to read a wire from and must
+    // not be made to depend on one resolving.
+    if leaf.source == crate::api::core::unfold::LeafSource::SumTag {
+        return true;
+    }
     if leaf.nullable {
         return false;
     }
-    let Some(entry) = registry.output_entry(&leaf.out_ty) else {
+    leaf_ty_is_prim(registry, &leaf.out_ty)
+}
+
+/// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw
+/// primitive** slot? Split out so the interface derivation can ask the question
+/// about a leaf whose own `nullable` flag it is in the middle of computing (an
+/// inert sum group slot).
+pub(crate) fn leaf_ty_is_prim(registry: &Registry<KotlinMeta>, out_ty: &syn::Type) -> bool {
+    let Some(entry) = registry.output_entry(out_ty) else {
         return false;
     };
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -404,6 +404,30 @@ fn read_kotlin_property(
             let fqn = handle_field_fqn(ext, proj).replace('.', "/");
             let sig = format!("L{fqn};");
             let obj = format_ident!("{}_obj", bind);
+            // A required (non-`Option`) handle payload is OWNED by the variant
+            // it builds, so it is decoded by CONSUMING the native object
+            // (`Box::from_raw`) — the mirror of the output side's
+            // `Box::into_raw`. The borrow converter would yield
+            // `OwnedObject<T>`, which cannot populate an owned field. Same rule
+            // (and same reasoning) as an owned handle field of a data class;
+            // `Option<_>` keeps the niche-aware converter (jlong 0 ⇒ `None`).
+            let closed_msg = "Operation on a closed native handle.";
+            let decode = if option_inner_type(ty).is_some() {
+                quote! { let #bind = #conv(env, &#raw)?; }
+            } else {
+                quote! {
+                    if #raw == 0 || (#raw & 1) == 1 {
+                        return ::core::result::Result::Err(
+                            <__JniErr as ::core::convert::From<String>>::from(
+                                #closed_msg.to_string(),
+                            ),
+                        );
+                    }
+                    let #bind: #ty = unsafe {
+                        *std::boxed::Box::from_raw(#raw as *mut #ty)
+                    };
+                }
+            };
             return Some((
                 quote! {
                     let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
@@ -416,7 +440,7 @@ fn read_kotlin_property(
                             .and_then(|val| val.j())
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
                     };
-                    let #bind = #conv(env, &#raw)?;
+                    #decode
                 },
                 quote!(#bind),
             ));

--- a/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
@@ -15,6 +15,7 @@ mod delivery;
 mod flat_input;
 mod names;
 mod struct_out;
+mod sum_out;
 mod vec_build;
 mod wrapper;
 
@@ -24,5 +25,6 @@ pub(crate) use delivery::*;
 pub(crate) use flat_input::*;
 pub(crate) use names::*;
 pub(crate) use struct_out::*;
+pub(crate) use sum_out::*;
 pub(crate) use vec_build::*;
 pub(crate) use wrapper::*;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -148,6 +148,7 @@ pub(crate) fn synth_value_struct_leaves(
             identity: false,
             nullable: false,
             source: LeafSource::Field,
+            group: None,
         });
     }
     Some(leaves)

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -1,0 +1,332 @@
+//! Sum outputs: the leaf synthesis for a sum that IS a function's own return
+//! (or a callback argument), and the `match` that encodes it.
+//!
+//! A sum is the one decomposition that is not a deterministic product: only
+//! ONE alternative's leaves are live per value. Core models that with a
+//! synthesized [`LeafSource::SumTag`] selector plus per-leaf
+//! [`UnfoldLeaf::group`] membership
+//! ([`apply_sum_returns`](crate::api::core::unfold::apply_sum_returns)); this
+//! module is the JNI adapter's two ends of it — [`synth_sum_leaves`] builds the
+//! leaf list before `resolve`, [`encode_sum_leaves`] emits the single `match`
+//! that fills every slot at emit time.
+//!
+//! The wire layout is the same one a sum-typed **struct field** gets
+//! ([`PlanFieldKind::Sum`](super::super::PlanFieldKind::Sum)): a tag slot
+//! followed by one leaf group per variant, laid side by side, inert groups
+//! wire-defaulted. Only the delivery differs — a field's slots ride the
+//! parent's `fromParts`, a return's ride the hoisted builder singleton.
+
+use super::*;
+
+/// Leaf name of the synthesized selector. Distinct from every group slot by
+/// construction: a group slot always contains the `_` that separates its
+/// variant fragment from its property.
+pub(crate) const SUM_TAG_LEAF: &str = "tag";
+
+/// Synthesize the leaves of one `sealed_class`-declared sum: the
+/// [`LeafSource::SumTag`] selector followed by one
+/// [`LeafSource::VariantField`] leaf per payload field, in tag order, each
+/// carrying its variant's tag as its [`group`](UnfoldLeaf::group).
+///
+/// Runs BEFORE `resolve` (like
+/// [`synth_value_struct_leaves`](super::synth_value_struct_leaves)), so it may
+/// only read the declaration (`sum_cfg`) and the enum's syntax — never the
+/// converter tables. Every payload's own `out_ty` is registered as a required
+/// output by the core wiring, so a payload that cannot cross fails naming
+/// itself.
+///
+/// Slot names come from the same [`sum_slot_fragment`] / [`sum_field_prop_name`]
+/// pair the sealed-interface emitter and the struct-field bridge use, so a
+/// `variant!(V).name(...)` rename carries through to the builder's parameter
+/// names too.
+pub(crate) fn synth_sum_leaves(
+    ext: &JniGen,
+    sum_cfg: &SumConfig,
+    item_enum: &syn::ItemEnum,
+) -> Vec<crate::api::core::unfold::UnfoldLeaf> {
+    use crate::api::core::{
+        types_util::SumSpec,
+        unfold::{LeafSource, UnfoldLeaf},
+    };
+
+    let spec = SumSpec::from_item_enum(item_enum);
+    // The selector rides ahead of the groups it chooses between. Its `out_ty`
+    // documents the wire (`i32` → `jint` → Kotlin `Int`); nothing looks up a
+    // converter for it, because there is no value to convert — the emitter
+    // assigns the tag literal per arm.
+    let mut leaves = vec![UnfoldLeaf {
+        name: SUM_TAG_LEAF.to_string(),
+        path: Vec::new(),
+        out_ty: syn::parse_quote!(i32),
+        identity: false,
+        nullable: false,
+        source: LeafSource::SumTag,
+        group: None,
+    }];
+    for variant in &spec.variants {
+        let kotlin_name = ext.sum_variant_class_name(sum_cfg, &variant.ident);
+        for field in &variant.fields {
+            let prop = sum_field_prop_name(field);
+            leaves.push(UnfoldLeaf {
+                name: sum_slot_fragment(&kotlin_name, &prop),
+                path: Vec::new(),
+                out_ty: field.ty.clone(),
+                identity: false,
+                nullable: false,
+                source: LeafSource::VariantField {
+                    variant: variant.ident.clone(),
+                    member: field.member.clone(),
+                },
+                group: Some(variant.tag),
+            });
+        }
+    }
+    leaves
+}
+
+/// True when `plan` decomposes a sum — it carries the synthesized selector.
+/// The one place that question is asked, so every consumer agrees on it.
+pub(crate) fn is_sum_leaves(leaves: &[crate::api::core::unfold::UnfoldLeaf]) -> bool {
+    use crate::api::core::unfold::LeafSource;
+    leaves.iter().any(|l| l.source == LeafSource::SumTag)
+}
+
+/// Emit the Rust-side encode of a decomposed sum: ONE `match` over the value
+/// binding the tag and EVERY group's slots — the live group from its variant
+/// pattern's payload bindings, every other group from the same wire defaults an
+/// absent `Option<nested>` uses.
+///
+/// The signature mirrors [`encode_plan_leaves`](super::encode_plan_leaves), and
+/// the two are interchangeable at the call site: both bind `obj_idents` and
+/// return the per-leaf `jvalue` argument expressions in leaf order. What differs
+/// is that a leaf here is not an independent expression — its slot exists in
+/// every arm and only one arm computes it.
+pub(crate) fn encode_sum_leaves(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    plan: &crate::api::core::unfold::UnfoldPlan,
+    obj_idents: &[syn::Ident],
+    value: &TokenStream,
+    fail: &dyn Fn(TokenStream) -> TokenStream,
+) -> (TokenStream, Vec<TokenStream>) {
+    use crate::api::core::unfold::LeafSource;
+
+    let leaves = &plan.leaves;
+    // Qualified path of the source enum, for the arm patterns.
+    let ident = bare_path_ident(&plan.source).unwrap_or_else(|| {
+        panic!(
+            "jnigen sum unfold: source `{}` is not a path type",
+            TypeKey::from_type(&plan.source)
+        )
+    });
+    let module = ext.fn_module(registry, &ident);
+    let source: syn::Path = syn::parse_quote!(#module::#ident);
+
+    // Per-leaf slot shape: a primitive-wire leaf occupies a typed `jvalue`
+    // (its raw primitive rides the typed `run`), everything else a `JObject`.
+    // Derived from the SAME `leaf_is_prim` the argument expressions below and
+    // the interface descriptor use, so the three cannot disagree.
+    struct Slot {
+        prim: bool,
+        ty: TokenStream,
+        default: TokenStream,
+    }
+    let slots: Vec<Slot> = leaves
+        .iter()
+        .map(|leaf| {
+            if !leaf_is_prim(registry, leaf) {
+                return Slot {
+                    prim: false,
+                    ty: quote!(jni::objects::JObject),
+                    default: quote!(jni::objects::JObject::null()),
+                };
+            }
+            // The tag is synthesized, so it has no converter to read a wire
+            // from — it is a `jint` by definition.
+            let (sig, letter) = if leaf.source == LeafSource::SumTag {
+                ("I", format_ident!("i"))
+            } else {
+                let wire = registry
+                    .output_entry(&leaf.out_ty)
+                    .expect("leaf_is_prim implies a resolved output entry")
+                    .destination
+                    .clone();
+                let (sig, letter, _) =
+                    jni_field_access(&wire).expect("leaf_is_prim guarantees a primitive wire");
+                (sig, letter)
+            };
+            let zero = primitive_default_for_descriptor(sig);
+            Slot {
+                prim: true,
+                ty: quote!(jni::sys::jvalue),
+                default: quote!(jni::sys::jvalue { #letter: #zero }),
+            }
+        })
+        .collect();
+
+    let arg_exprs: Vec<TokenStream> = leaves
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| {
+            let id = &obj_idents[idx];
+            if slots[idx].prim {
+                quote!(#id)
+            } else {
+                quote!(jni::sys::jvalue { l: #id.as_raw() })
+            }
+        })
+        .collect();
+
+    // Declare every slot up front; each arm assigns all of them.
+    let decls: TokenStream = leaves
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| {
+            let id = &obj_idents[idx];
+            let ty = &slots[idx].ty;
+            quote! { let #id: #ty; }
+        })
+        .collect();
+
+    // One arm per variant, in tag order. `groups[tag]` are the leaf indices of
+    // that variant's payload, in declaration order — which is also the order
+    // its pattern binds them in.
+    let tag_idx = leaves
+        .iter()
+        .position(|l| l.source == LeafSource::SumTag)
+        .expect("a sum plan carries its selector leaf");
+    let tag_id = &obj_idents[tag_idx];
+    // A unit variant contributes no leaf, so the arm list is driven by the
+    // enum's own variants, not by the grouped leaves.
+    let (item_enum, _) = registry.enums.get(&ident).unwrap_or_else(|| {
+        panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
+    });
+    let spec = crate::api::core::types_util::SumSpec::from_item_enum(item_enum);
+
+    let arms: Vec<TokenStream> = spec
+        .variants
+        .iter()
+        .map(|variant| {
+            let group: Vec<usize> = leaves
+                .iter()
+                .enumerate()
+                .filter(|(_, l)| l.group == Some(variant.tag))
+                .map(|(i, _)| i)
+                .collect();
+            let binds: Vec<syn::Ident> = group
+                .iter()
+                .enumerate()
+                .map(|(k, _)| format_ident!("__sv{}", k))
+                .collect();
+            let vident = &variant.ident;
+            let pattern = match variant.fields.first().map(|f| &f.member) {
+                None => quote!(#source::#vident),
+                Some(syn::Member::Named(_)) => {
+                    let pairs = variant.fields.iter().zip(&binds).map(|(f, b)| {
+                        let syn::Member::Named(n) = &f.member else {
+                            unreachable!("variant field shapes are uniform")
+                        };
+                        quote!(#n: #b)
+                    });
+                    quote!(#source::#vident { #(#pairs),* })
+                }
+                Some(syn::Member::Unnamed(_)) => quote!(#source::#vident(#(#binds),*)),
+            };
+            // The live group: convert each payload through its own output
+            // converter, exactly as a struct field of the same type would be.
+            let live: TokenStream = group
+                .iter()
+                .zip(&binds)
+                .map(|(&idx, bind)| {
+                    encode_group_leaf(
+                        registry,
+                        &leaves[idx],
+                        &obj_idents[idx],
+                        slots[idx].prim,
+                        bind,
+                        fail,
+                    )
+                })
+                .collect();
+            // Every slot outside this arm's own group is inert.
+            let inert: TokenStream = (0..leaves.len())
+                .filter(|i| *i != tag_idx && !group.contains(i))
+                .map(|i| {
+                    let id = &obj_idents[i];
+                    let d = &slots[i].default;
+                    quote! { #id = #d; }
+                })
+                .collect();
+            let tag_lit = proc_macro2::Literal::i32_unsuffixed(variant.tag);
+            quote! {
+                #pattern => {
+                    #live
+                    #tag_id = jni::sys::jvalue { i: #tag_lit };
+                    #inert
+                }
+            }
+        })
+        .collect();
+
+    // A borrowed value is matched as-is; an owned one is matched by reference
+    // so each payload can be cloned out of it (the same reach a struct field
+    // leaf uses).
+    let matched = if plan.by_ref {
+        value.clone()
+    } else {
+        quote!(&#value)
+    };
+    let stmts = quote! {
+        #decls
+        match #matched { #(#arms)* }
+    };
+    (stmts, arg_exprs)
+}
+
+/// Encode ONE payload binding of a live variant arm into its slot. `bind` is
+/// the pattern variable holding `&Payload`; the value is cloned out of it, so a
+/// payload and a struct field of the same type reach their converter the same
+/// way.
+fn encode_group_leaf(
+    registry: &Registry<KotlinMeta>,
+    leaf: &crate::api::core::unfold::UnfoldLeaf,
+    obj_ident: &syn::Ident,
+    prim: bool,
+    bind: &syn::Ident,
+    fail: &dyn Fn(TokenStream) -> TokenStream,
+) -> TokenStream {
+    let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+        panic!(
+            "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
+            leaf.name,
+            TypeKey::from_type(&leaf.out_ty)
+        )
+    });
+    let conv = out_entry.function.sig.ident.clone();
+    let wire = out_entry.destination.clone();
+    let conv_fail = fail(quote!(__e.to_string()));
+    let enc = format_ident!("__enc_{}", obj_ident);
+    let encode = quote! {
+        let #enc = match #conv(&mut env, #bind.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                #conv_fail
+            }
+        };
+    };
+    if prim {
+        let letter = jni_field_access(&wire)
+            .expect("leaf_is_prim guarantees a primitive wire")
+            .1;
+        quote! {
+            #encode
+            #obj_ident = jni::sys::jvalue { #letter: #enc };
+        }
+    } else {
+        let cast = cast_wire_to_jobject(&enc, &wire, fail);
+        quote! {
+            #encode
+            #obj_ident = #cast;
+        }
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -135,13 +135,52 @@ pub(crate) struct TypedGroup {
     /// User-facing (typed) parameter type (the whole value, or a single leaf's
     /// typed view for a passthrough group).
     pub typed: kt::KtType,
-    /// `Some(class_short)` ⇒ reassemble this group's leaves via
-    /// `class_short.fromParts(leaves…)`; `None` ⇒ a single passthrough leaf
-    /// (the typed value IS the one raw param, optionally wrapped by its
+    /// `Some(expr)` ⇒ this group's raw leaves reassemble into ONE typed value
+    /// through `expr` — `Class.fromParts($0, $1, …)` for a fixed product, a
+    /// `when` over the tag for a sum. `None` ⇒ a single passthrough leaf (the
+    /// typed value IS the one raw param, optionally wrapped by its
     /// [`IfaceParam::wrap`]).
+    ///
+    /// Written with **positional placeholders** `$0`, `$1`, … over this group's
+    /// leaves rather than with their names: the signature-wide
+    /// [`dedup_names`] pass runs after a group is described, so a name captured
+    /// here could be stale by the time [`IfaceSpec::to_as_raw_fun`] renders it.
     pub reassemble: Option<String>,
+    /// FQNs the reassembly expression names in raw text (variant classes,
+    /// enums) and therefore needs imported where it is rendered.
+    pub imports: Vec<String>,
     /// Number of consecutive `params` (raw leaves) this group consumes.
     pub leaf_count: usize,
+}
+
+/// Substitute a [`TypedGroup::reassemble`] expression's `$k` placeholders with
+/// the group's actual parameter names. Scans left to right taking the longest
+/// digit run, so `$10` never resolves as `$1` followed by `0`.
+fn fill_placeholders(expr: &str, names: &[&str]) -> String {
+    let mut out = String::with_capacity(expr.len());
+    let mut rest = expr;
+    while let Some(pos) = rest.find('$') {
+        out.push_str(&rest[..pos]);
+        let digits: String = rest[pos + 1..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if digits.is_empty() {
+            out.push('$');
+            rest = &rest[pos + 1..];
+            continue;
+        }
+        let idx: usize = digits.parse().expect("digit run parses");
+        out.push_str(names.get(idx).copied().unwrap_or_else(|| {
+            panic!(
+                "reassembly placeholder ${idx} has no leaf in a {}-leaf group",
+                names.len()
+            )
+        }));
+        rest = &rest[pos + 1 + digits.len()..];
+    }
+    out.push_str(rest);
+    out
 }
 
 /// One generated `fun interface`: identity, Kotlin surface (typed + raw
@@ -422,8 +461,8 @@ impl IfaceSpec {
                     .map(|p| p.name.as_str())
                     .collect();
                 match &g.reassemble {
-                    Some(cls) => args.push(RunArg {
-                        expr: format!("{cls}.fromParts({})", names.join(", ")),
+                    Some(expr) => args.push(RunArg {
+                        expr: fill_placeholders(expr, &names),
                         owned: false,
                         nullable: false,
                     }),
@@ -646,16 +685,44 @@ fn plan_leaf_params(
     let names = plan_leaf_names(leaves);
     let mut out = Vec::with_capacity(leaves.len());
     for (name, leaf) in names.into_iter().zip(leaves.iter()) {
-        out.push(leaf_iface_param(
-            ext,
-            registry,
-            name,
-            &leaf.out_ty,
-            leaf.nullable,
-            true,
-        )?);
+        out.push(plan_leaf_param(ext, registry, name, leaf)?);
     }
     Some(out)
+}
+
+/// Both interface views of ONE decomposition leaf. The single entry point for a
+/// plan leaf, so the builder/folder/handler signatures and a callback's
+/// flattened `run` params classify it identically — the tag slot and the
+/// inert-group nullability rule below have to hold at every one of those sites,
+/// not just where the plan happens to be walked as a whole.
+fn plan_leaf_param(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    name: String,
+    leaf: &crate::api::core::unfold::UnfoldLeaf,
+) -> Option<IfaceParam> {
+    use crate::api::core::unfold::LeafSource;
+    // The sum selector has no converter behind it — it is a plain `Int` the
+    // emitter assigns per `match` arm.
+    if leaf.source == LeafSource::SumTag {
+        return Some(IfaceParam::same(name, kt::KtType::int()));
+    }
+    // A group slot is INERT whenever another variant is live, and the encoder
+    // fills an inert object slot with `JObject::null()`. A JVM null handed to a
+    // non-null Kotlin parameter throws inside the intrinsic null-check before
+    // any generated code runs, so every object-shaped group slot is nullable
+    // here and re-asserted (`!!`) inside its own live arm — the same rule
+    // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
+    // slots take their `0`/`false` default and stay unboxed.
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
+    leaf_iface_param(
+        ext,
+        registry,
+        name,
+        &leaf.out_ty,
+        leaf.nullable || inert_nullable,
+        true,
+    )
 }
 
 /// Both interface views of one delivered leaf.
@@ -941,6 +1008,36 @@ impl JniGen {
     }
 }
 
+/// The [`TypedGroup::reassemble`] expression (and its raw-text imports) for a
+/// **fixed-builder** decomposition's leaves — the one place the two shapes are
+/// distinguished, so the callback proxy and the `Vec` folder cannot pick
+/// different reassemblies for the same type.
+///
+/// A product reassembles through the class's own `fromParts`; a **sum** cannot
+/// — its `fromParts` is the Kotlin-facing convenience whose parameters are
+/// property types, not the wire — so it reassembles through the same inlined
+/// `when` over the tag that a sum-typed struct field gets.
+fn fixed_reassembly(
+    ext: &JniGen,
+    registry: &Registry<KotlinMeta>,
+    source: &syn::Type,
+    leaves: &[crate::api::core::unfold::UnfoldLeaf],
+    class_fqn: &str,
+) -> (String, Vec<String>) {
+    let slots: Vec<String> = (0..leaves.len()).map(|i| format!("${i}")).collect();
+    if !is_sum_leaves(leaves) {
+        let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
+        return (
+            format!("{class_short}.fromParts({})", slots.join(", ")),
+            Vec::new(),
+        );
+    }
+    let params = plan_leaf_params(ext, registry, leaves).unwrap_or_default();
+    let mut imports: BTreeSet<String> = BTreeSet::new();
+    let (_, when) = ext.sum_reconstruct(registry, source, leaves, &params, &slots, &mut imports);
+    (when, imports.into_iter().collect())
+}
+
 /// Interface for an `impl Fn(args)` delivery: one `run` parameter per
 /// flattened leaf of each arg's callback plan (the arg whole when plan-less),
 /// returning `Unit`. Named `<ArgShorts>Callback` (`Fn()` → `VoidCallback`),
@@ -961,12 +1058,33 @@ pub(crate) fn callback_iface_spec(
         /// Whole-value typed view (`Some`) or `None` ⇒ use the leaf's own typed.
         typed: Option<kt::KtType>,
         reassemble: Option<String>,
+        imports: Vec<String>,
         leaf_count: usize,
     }
-    // (leaf name, out_ty, nullable, from_plan, owned_handle). `owned_handle`
-    // marks a plan-less opaque-handle arg delivered as a raw `jlong` and wrapped
-    // + closed Kotlin-side (Phase 3).
-    let mut leaf_tys: Vec<(String, syn::Type, bool, bool, bool)> = Vec::new();
+    /// One flattened `run` parameter before naming/dedup. A **plan** leaf keeps
+    /// the leaf itself, so it classifies through the shared
+    /// [`plan_leaf_param`] (tag slot, inert-group nullability) rather than a
+    /// second, weaker derivation here; a **whole** arg carries just its type,
+    /// and `owned_handle` marks a plan-less opaque handle delivered as a raw
+    /// `jlong` and wrapped + closed Kotlin-side (Phase 3).
+    enum LeafDesc {
+        Plan(String, crate::api::core::unfold::UnfoldLeaf),
+        Whole {
+            name: String,
+            ty: syn::Type,
+            nullable: bool,
+            owned_handle: bool,
+        },
+    }
+    impl LeafDesc {
+        fn name(&self) -> &str {
+            match self {
+                LeafDesc::Plan(n, _) => n,
+                LeafDesc::Whole { name, .. } => name,
+            }
+        }
+    }
+    let mut leaf_tys: Vec<LeafDesc> = Vec::new();
     let mut groups: Vec<GroupDesc> = Vec::new();
     let mut any_fixed = false;
 
@@ -983,7 +1101,7 @@ pub(crate) fn callback_iface_spec(
         if let Some(plan) = plan {
             let leaf_names = plan_leaf_names(&plan.leaves);
             for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
-                leaf_tys.push((n.clone(), l.out_ty.clone(), l.nullable, true, false));
+                leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
             }
             if plan.fixed_builder {
                 any_fixed = true;
@@ -992,11 +1110,13 @@ pub(crate) fn callback_iface_spec(
                     other => other.clone(),
                 };
                 let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
-                let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
+                let (reassemble, imports) =
+                    fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
-                    reassemble: Some(class_short),
+                    reassemble: Some(reassemble),
+                    imports,
                     leaf_count: plan.leaves.len(),
                 });
             } else {
@@ -1007,6 +1127,7 @@ pub(crate) fn callback_iface_spec(
                         name: n.clone(),
                         typed: None,
                         reassemble: None,
+                        imports: Vec::new(),
                         leaf_count: 1,
                     });
                 }
@@ -1019,36 +1140,37 @@ pub(crate) fn callback_iface_spec(
                 .and_then(|e| e.metadata.projection.as_ref())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
-            leaf_tys.push((
-                whole_value_name(t, i),
-                t.clone(),
-                is_option_type(t),
-                false,
+            leaf_tys.push(LeafDesc::Whole {
+                name: whole_value_name(t, i),
+                ty: t.clone(),
+                nullable: is_option_type(t),
                 owned_handle,
-            ));
+            });
             groups.push(GroupDesc {
                 name: whole_value_name(t, i),
                 typed: None,
                 reassemble: None,
+                imports: Vec::new(),
                 leaf_count: 1,
             });
         }
     }
-    let mut names: Vec<String> = leaf_tys.iter().map(|(n, ..)| n.clone()).collect();
+    let mut names: Vec<String> = leaf_tys.iter().map(|d| d.name().to_string()).collect();
     dedup_names(&mut names);
     let mut params = Vec::with_capacity(leaf_tys.len());
-    for (k, (_, out_ty, nullable, from_plan, owned_handle)) in leaf_tys.iter().enumerate() {
-        let param = if *owned_handle {
-            owned_handle_iface_param(ext, registry, names[k].clone(), out_ty, *nullable)?
-        } else {
-            leaf_iface_param(
-                ext,
-                registry,
-                names[k].clone(),
-                out_ty,
-                *nullable,
-                *from_plan,
-            )?
+    for (k, desc) in leaf_tys.iter().enumerate() {
+        let name = names[k].clone();
+        let param = match desc {
+            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, registry, name, leaf)?,
+            LeafDesc::Whole {
+                ty,
+                nullable,
+                owned_handle: true,
+                ..
+            } => owned_handle_iface_param(ext, registry, name, ty, *nullable)?,
+            LeafDesc::Whole { ty, nullable, .. } => {
+                leaf_iface_param(ext, registry, name, ty, *nullable, false)?
+            }
         };
         params.push(param);
     }
@@ -1066,6 +1188,7 @@ pub(crate) fn callback_iface_spec(
                 name: group_names[gi].clone(),
                 typed,
                 reassemble: g.reassemble.clone(),
+                imports: g.imports.clone(),
                 leaf_count: g.leaf_count,
             });
             at += g.leaf_count;
@@ -1222,18 +1345,20 @@ pub(crate) fn fixed_folder_typed_groups(
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans.get(decon)?;
     let fqn = ext.kotlin_fqn(&TypeKey::from_type(&spec.source))?;
-    let class_short = fqn.rsplit('.').next().unwrap_or(&fqn).to_string();
+    let (reassemble, imports) = fixed_reassembly(ext, registry, &spec.source, &spec.leaves, &fqn);
     Some(vec![
         TypedGroup {
             name: "acc".to_string(),
             typed: kt::KtType::var_("A"),
             reassemble: None,
+            imports: Vec::new(),
             leaf_count: 1,
         },
         TypedGroup {
             name: "element".to_string(),
             typed: kt::KtType::cls(fqn.to_string()),
-            reassemble: Some(class_short),
+            reassemble: Some(reassemble),
+            imports,
             leaf_count: spec.leaves.len(),
         },
     ])

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1136,8 +1136,19 @@ impl JniGen {
         enum FixedSingleton {
             StructBuilder(DeconId),
             StructFolder(DeconId),
+            /// A decomposed **sum**: the reassembly is a `when` over the tag
+            /// picking the live group, not a `fromParts` over a fixed product.
+            SumBuilder(DeconId),
+            SumFolder(DeconId),
             LeafFolder,
         }
+        // A decomposition is a sum's when it carries the synthesized selector.
+        let is_sum = |d: &DeconId| {
+            registry
+                .decon_plans
+                .get(d)
+                .is_some_and(|p| is_sum_leaves(&p.leaves))
+        };
 
         // Fixedness sets shared with the memo derivation (`iface.rs`): a
         // fixed DeconId gets a hoisted `__<Name>Builder` / folder-appender
@@ -1222,15 +1233,23 @@ impl JniGen {
                     SpecKey::Callback(_) => (false, None),
                     SpecKey::Builder(d) => (
                         false,
-                        fixed_decons
-                            .contains(d)
-                            .then(|| FixedSingleton::StructBuilder(d.clone())),
+                        fixed_decons.contains(d).then(|| {
+                            if is_sum(d) {
+                                FixedSingleton::SumBuilder(d.clone())
+                            } else {
+                                FixedSingleton::StructBuilder(d.clone())
+                            }
+                        }),
                     ),
                     SpecKey::Folder(d) => (
                         false,
-                        fixed_decons
-                            .contains(d)
-                            .then(|| FixedSingleton::StructFolder(d.clone())),
+                        fixed_decons.contains(d).then(|| {
+                            if is_sum(d) {
+                                FixedSingleton::SumFolder(d.clone())
+                            } else {
+                                FixedSingleton::StructFolder(d.clone())
+                            }
+                        }),
                     ),
                     SpecKey::WholeFolder(el_key) => (
                         false,
@@ -1254,6 +1273,14 @@ impl JniGen {
                             file = file.import(fqn.to_string());
                         }
                     }
+                    // A group's reassembly is raw text (`Reading.Exact(…)`,
+                    // `Priority.fromInt(…)`), so the classes it names by short
+                    // name need importing here.
+                    for g in &s.typed_groups {
+                        for fqn in &g.imports {
+                            file = file.import(fqn.clone());
+                        }
+                    }
                 }
                 if is_error {
                     file = file.decl(s.to_capture_decl());
@@ -1265,6 +1292,12 @@ impl JniGen {
                         }
                         FixedSingleton::StructFolder(decon) => {
                             self.value_struct_folder_singleton(registry, &s, &decon)
+                        }
+                        FixedSingleton::SumBuilder(decon) => {
+                            self.sum_builder_singleton(registry, &s, &decon)
+                        }
+                        FixedSingleton::SumFolder(decon) => {
+                            self.sum_folder_singleton(registry, &s, &decon)
                         }
                         FixedSingleton::LeafFolder => self.whole_value_folder_singleton(&s),
                     };
@@ -1369,6 +1402,211 @@ impl JniGen {
             name: holder,
             code: kt::Code::raw_reindent(&code),
         }
+    }
+
+    /// The hoisted **fixed builder** singleton for a decomposed **sum**: the
+    /// sum's dual of [`Self::value_struct_builder_singleton`], with a `when`
+    /// over the tag in place of a `fromParts` over a fixed product.
+    ///
+    /// The sealed interface's own `fromParts` is deliberately NOT the target
+    /// here. That factory is the Kotlin-facing convenience stage C emits — its
+    /// parameters are the variants' **property** types, not the wire, and its
+    /// object slots are non-null, which an inert group's `JObject::null()`
+    /// would trip on before any code runs. The reassembly the wire needs is the
+    /// same inlined `when` a sum-typed struct field already gets from
+    /// `factory_field`, so it is emitted here directly.
+    fn sum_builder_singleton(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        spec: &crate::api::lang::jnigen::jni::IfaceSpec,
+        decon: &crate::api::core::unfold::DeconId,
+    ) -> kt::KtDecl {
+        let plan = &registry.decon_plans[decon];
+        let mut imports: BTreeSet<String> = BTreeSet::new();
+        let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
+        let (iface_short, when) = self.sum_reconstruct(
+            registry,
+            &plan.source,
+            &plan.leaves,
+            &spec.params,
+            &names,
+            &mut imports,
+        );
+        let builder = spec.raw_name();
+        let val_name = format!("__{builder}");
+        let code = format!(
+            "internal val {val_name}: {builder}<{iface_short}> =\n    \
+             {builder} {{ {} ->\n    {when}\n}}",
+            names.join(", "),
+        );
+        let mut body = kt::Code::raw_reindent(&code);
+        for fqn in imports {
+            body = body.import(fqn);
+        }
+        kt::KtDecl::Raw {
+            name: val_name,
+            code: body,
+        }
+    }
+
+    /// The hoisted **folder-appender** singleton for a `Vec<sum>` element fold:
+    /// per element, pick the live alternative by tag and append it to the
+    /// accumulator `ArrayList`. The sum's dual of
+    /// [`Self::value_struct_folder_singleton`]; the folder's `run` params are
+    /// `[acc, tag, group-slots…]`, so the reassembly reads all but `acc`.
+    fn sum_folder_singleton(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        spec: &crate::api::lang::jnigen::jni::IfaceSpec,
+        decon: &crate::api::core::unfold::DeconId,
+    ) -> kt::KtDecl {
+        let plan = &registry.decon_plans[decon];
+        let mut imports: BTreeSet<String> = BTreeSet::new();
+        let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
+        let (iface_short, when) = self.sum_reconstruct(
+            registry,
+            &plan.source,
+            &plan.leaves,
+            &spec.params[1..],
+            &names[1..],
+            &mut imports,
+        );
+        let folder = spec.raw_name();
+        let holder = spec.singleton_holder_name();
+        let field = crate::api::lang::jnigen::jni::SINGLETON_FIELD;
+        let acc = &names[0];
+        let acc_ty = format!("ArrayList<{iface_short}>");
+        let code = format!(
+            "internal object {holder} {{\n    \
+             @JvmField\n    \
+             val {field}: {folder}<{acc_ty}> =\n        \
+             {folder} {{ {} -> {acc}.add({when}); {acc} }}\n\
+             }}",
+            names.join(", "),
+        );
+        let mut body = kt::Code::raw_reindent(&code);
+        for fqn in imports {
+            body = body.import(fqn);
+        }
+        kt::KtDecl::Raw {
+            name: holder,
+            code: body,
+        }
+    }
+
+    /// The wire-shaped reassembly of one decomposed sum: `(interface short
+    /// name, when-expression)`.
+    ///
+    /// `params` are the interface's `run` parameters **aligned with the plan's
+    /// leaves** (the selector first, then the groups) — so the caller strips a
+    /// folder's leading `acc`. Each group leaf's parameter is unwrapped into
+    /// its variant-constructor argument by [`Self::sum_ctor_arg`].
+    pub(crate) fn sum_reconstruct(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        source: &syn::Type,
+        leaves: &[crate::api::core::unfold::UnfoldLeaf],
+        params: &[crate::api::lang::jnigen::jni::IfaceParam],
+        names: &[String],
+        imports: &mut BTreeSet<String>,
+    ) -> (String, String) {
+        use crate::api::core::types_util::SumSpec;
+
+        let key = TypeKey::from_type(source);
+        let iface_fqn = self
+            .kotlin_fqn(&key)
+            .unwrap_or_else(|| panic!("sum builder: no Kotlin FQN for {key}"));
+        let iface_short = register_fqn(&iface_fqn, imports);
+        let ident = bare_path_ident(source)
+            .unwrap_or_else(|| panic!("sum builder: `{key}` is not a path type"));
+        let (item_enum, _) = registry
+            .enums
+            .get(&ident)
+            .unwrap_or_else(|| panic!("sum builder: no indexed enum `{ident}`"));
+        let sum_cfg = self.types[&key]
+            .sum_cfg
+            .as_ref()
+            .unwrap_or_else(|| panic!("sum builder: `{ident}` is not a sealed class"));
+        let spec = SumSpec::from_item_enum(item_enum);
+        let tag = &names[0];
+
+        let mut arms: Vec<String> = Vec::new();
+        for variant in &spec.variants {
+            let vname = self.sum_variant_class_name(sum_cfg, &variant.ident);
+            let args: Vec<String> = leaves
+                .iter()
+                .zip(params)
+                .zip(names)
+                .filter(|((l, _), _)| l.group == Some(variant.tag))
+                .map(|((l, p), n)| self.sum_ctor_arg(registry, l, p, n, imports))
+                .collect();
+            let ctor = if args.is_empty() {
+                format!("{iface_short}.{vname}")
+            } else {
+                format!("{iface_short}.{vname}({})", args.join(", "))
+            };
+            arms.push(format!("{} -> {ctor}", variant.tag));
+        }
+        let when = format!(
+            "when ({tag}) {{ {}; else -> throw IllegalArgumentException(\"{iface_short}: invalid \
+             tag ${tag}\") }}",
+            arms.join("; "),
+        );
+        (iface_short, when)
+    }
+
+    /// The variant-constructor argument for one group leaf: its `run`
+    /// parameter, un-inerted and wrapped back into the property type.
+    ///
+    /// Two independent transforms, in this order:
+    ///
+    /// 1. **Un-inert** — an object-shaped group slot is declared nullable
+    ///    (an inert group arrives as JVM null), so inside its own live arm it is
+    ///    re-asserted with `!!`. A payload that is *itself* optional
+    ///    (`Option<T>`) keeps its null: there the JVM null means `None`, and
+    ///    `!!` would turn a legitimately absent value into an exception.
+    /// 2. **Wrap** — the raw wire becomes the property: an enum discriminant
+    ///    through `fromInt`, a handle/blob/`ULong` through the interface's own
+    ///    [`WrapKind`](crate::api::lang::jnigen::jni::WrapKind), everything else
+    ///    verbatim.
+    fn sum_ctor_arg(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        leaf: &crate::api::core::unfold::UnfoldLeaf,
+        param: &crate::api::lang::jnigen::jni::IfaceParam,
+        name: &str,
+        imports: &mut BTreeSet<String>,
+    ) -> String {
+        let optional = is_option_type(&leaf.out_ty);
+        let arg = if param.raw.is_nullable() && !optional {
+            format!("{name}!!")
+        } else {
+            name.to_string()
+        };
+        // An enum payload rides its `jint` discriminant, so the interface types
+        // it `Int` and the wrap has to name the enum class itself — read off the
+        // same output-converter metadata `factory_field` reads for an enum
+        // struct field.
+        if self.is_kotlin_enum(&enum_probe_type(&leaf.out_ty)) {
+            let inner = option_inner_type(&leaf.out_ty).unwrap_or_else(|| leaf.out_ty.clone());
+            let name = registry
+                .output_entry(&inner)
+                .and_then(|e| e.metadata.kotlin_name.clone())
+                .and_then(|t| t.leaf_name().map(str::to_string))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "sum builder: enum payload `{}` has no Kotlin type on its output converter",
+                        leaf.name
+                    )
+                });
+            let short = register_fqn(&name, imports);
+            return if optional {
+                format!("{arg}?.let {{ {short}.fromInt(it) }}")
+            } else {
+                format!("{short}.fromInt({arg})")
+            };
+        }
+        param.wrap.wrap_expr(&arg, false)
     }
 
     /// The hoisted **folder-appender** singleton for a **whole single-leaf

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -939,3 +939,142 @@ fn sum_return_group_can_own_a_handle() {
         "the live arm wraps the pointer into its typed handle class:\n{kotlin}"
     );
 }
+
+/// TWO sums in one callback signature: each contributes its own selector, so
+/// the signature-wide dedup renames the second to `tag2` — and the reassembly
+/// expressions must follow it, including the `$tag` Kotlin string template in
+/// the invalid-tag message. That is why a group's reassembly is stored with
+/// positional placeholders and filled at render time rather than captured by
+/// name when the group is described.
+#[test]
+fn two_sum_callback_args_keep_their_own_selectors() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_pair(f: impl Fn(Reading, Lookup) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .class(crate::sealed_class!(Lookup))
+            .class(crate::ptr_class!(Probe))
+            .fun(crate::fun!(read_pair)),
+    );
+    let dir = unique_test_dir("jnigen_two_sum_cb");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // The user callback still sees two whole values.
+    assert!(
+        kotlin.contains("public fun run(reading: Reading, lookup: Lookup)"),
+        "{kotlin}"
+    );
+    // The raw twin carries both selectors, the second deduped.
+    assert!(
+        kotlin.contains("tag: Int,") && kotlin.contains("tag2: Int,"),
+        "each sum contributes its own selector:\n{kotlin}"
+    );
+    // Each `when` reads ITS OWN selector — in the dispatch and in the message.
+    assert!(
+        kotlin.contains("when (tag) { 0 -> Reading.Missing;")
+            && kotlin.contains(r#"IllegalArgumentException("Reading: invalid tag $tag")"#),
+        "{kotlin}"
+    );
+    assert!(
+        kotlin.contains("when (tag2) { 0 -> Lookup.Absent;")
+            && kotlin.contains(r#"IllegalArgumentException("Lookup: invalid tag $tag2")"#),
+        "the second sum's reassembly must follow its renamed selector, template \
+         included:\n{kotlin}"
+    );
+}
+
+/// A **slice of sums** as a callback argument has no lowering, and says so.
+///
+/// Folding a sequence of tag-gated groups into the foreign list needs the
+/// element folder that a `Vec<E>` *return* provides; without one the shape
+/// would resolve to nothing and surface as "`E` has no output converter",
+/// which names the sum rather than the position — misleading, because a sum
+/// has no whole-value converter by design. The declaration is rejected up
+/// front instead.
+#[test]
+fn slice_of_sum_callback_arg_is_rejected_with_its_reason() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_batch(f: impl Fn(&[Reading]) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .fun(crate::fun!(read_batch)),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("must be rejected")
+        .to_string();
+    assert!(
+        err.contains("read_batch") && err.contains("slice of a sealed_class"),
+        "the error must name the function and the unsupported position: {err}"
+    );
+    assert!(
+        err.contains("impl Fn(Reading)") && err.contains("Vec<Reading>"),
+        "…and point at the two shapes that do work: {err}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -703,3 +703,239 @@ fn recursive_sum_shapes_fail_deterministically() {
         "expected a resolution failure, not the depth guard: {msg}"
     );
 }
+
+/// Build a binding whose declared functions return a sum in every position —
+/// bare, `Option`, `Vec`, and as a callback argument — plus one whose variant
+/// payload is an opaque handle. Returns `(generated Rust, generated Kotlin)`.
+fn sum_returns(tag: &str) -> (String, String) {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                    Labeled(String, Priority),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_maybe(which: i32) -> Option<Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_all(n: i32) -> Vec<Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn look_up(n: i64) -> Lookup {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_each(n: i32, sink: impl Fn(Reading) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::enum_class!(Priority))
+            .class(crate::sealed_class!(Reading))
+            .class(crate::sealed_class!(Lookup))
+            .class(crate::ptr_class!(Probe))
+            .fun(crate::fun!(read_one))
+            .fun(crate::fun!(read_maybe))
+            .fun(crate::fun!(read_all))
+            .fun(crate::fun!(look_up))
+            .fun(crate::fun!(read_each)),
+    );
+
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).unwrap();
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (rust, kotlin)
+}
+
+/// A sum in RETURN position crosses as its synthesized tag plus one leaf group
+/// per variant, laid side by side — the same wire layout a sum-typed struct
+/// field gets, but reassembled by a hoisted builder singleton because there is
+/// no parent `fromParts` to ride.
+///
+/// The builder's parameters are **wire** types (the enum payload is its `Int`
+/// discriminant), and every object-shaped group slot is nullable: an inert
+/// group is wire-defaulted to JVM null, which a non-null Kotlin parameter would
+/// reject in its intrinsic null check before any generated code ran.
+#[test]
+fn sum_return_builds_through_a_wire_shaped_singleton() {
+    let (_, kotlin) = sum_returns("jnigen_sum_return");
+
+    assert!(
+        kotlin.contains(
+            "public fun run(\n        tag: Int,\n        exact_v0: Long,\n        \
+             range_low: Long,\n        range_high: Long,\n        labeled_v0: String?,\n        \
+             labeled_v1: Int,\n    ): R"
+        ),
+        "builder must take the tag plus every group's WIRE slots, inert object \
+         slots nullable:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains(
+            "when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); \
+             2 -> Reading.Range(range_low, range_high); \
+             3 -> Reading.Labeled(labeled_v0!!, Priority.fromInt(labeled_v1)); \
+             else -> throw IllegalArgumentException(\"Reading: invalid tag $tag\") }"
+        ),
+        "the singleton picks the live group by tag, re-asserts the inert-nullable \
+         slot in its own arm, and rebuilds the enum payload from its \
+         discriminant:\n{kotlin}"
+    );
+    // An out-of-range tag is an error, never a variant.
+    assert!(kotlin.contains("Reading: invalid tag $tag"), "{kotlin}");
+}
+
+/// The sealed interface's own `fromParts` is the Kotlin-facing convenience
+/// stage C emits, NOT the wire target: its parameters are the variants'
+/// property types and its object slots are non-null. The return path therefore
+/// reassembles through its own singleton and leaves this factory alone —
+/// asserted here so the two do not silently converge.
+#[test]
+fn sum_from_parts_stays_the_property_typed_convenience() {
+    let (_, kotlin) = sum_returns("jnigen_sum_fromparts");
+    assert!(
+        kotlin.contains("labeled_v0: String,\n            labeled_v1: Priority,"),
+        "`fromParts` keeps property types and non-null object slots:\n{kotlin}"
+    );
+}
+
+/// The Rust side emits ONE `match` over the returned value: the live arm
+/// converts its own group's payloads and every other slot takes the wire
+/// default. No leaf is an independent expression — that is what a product
+/// decomposition does, and a sum is not one.
+#[test]
+fn sum_return_emits_one_match_with_wire_defaults() {
+    let (rust, _) = sum_returns("jnigen_sum_match");
+    let at = rust
+        .find("fn Java_io_test_jni_JNINative_readOne")
+        .expect("extern");
+    let body = &rust[at..at + 4000];
+    assert!(
+        body.contains("match &__out"),
+        "one match over the value:\n{body}"
+    );
+    assert!(
+        body.contains("myflat::Reading::Missing =>")
+            && body.contains("myflat::Reading::Range { low"),
+        "arms bind each variant's payload by pattern:\n{body}"
+    );
+    // The payload-less arm assigns the tag and defaults every group slot.
+    assert!(
+        body.contains("jni :: objects :: JObject :: null ()") || body.contains("JObject::null()"),
+        "an inert object slot is wire-defaulted to null:\n{body}"
+    );
+}
+
+/// `Option` and `Vec` layers ride the existing shape fold, so a sum needs
+/// nothing new for them: the optional nulls the whole result and the vector
+/// folds element by element, each element rebuilt by the same `when`.
+#[test]
+fn sum_return_composes_with_option_and_vec() {
+    let (_, kotlin) = sum_returns("jnigen_sum_layers");
+    assert!(
+        kotlin.contains(
+            "public fun readMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading?"
+        ),
+        "Option<sum> return is a nullable sum:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains(
+            "public fun readAll(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>"
+        ) && kotlin.contains("__ReadingFolderRawHolder.instance"),
+        "Vec<sum> folds through a hoisted appender singleton:\n{kotlin}"
+    );
+    // Callback argument: the user callback receives the whole reassembled sum
+    // while the raw twin still carries the decoupled slots.
+    assert!(
+        kotlin.contains(
+            "public fun interface ReadingCallback {\n    public fun run(reading: Reading)\n}"
+        ),
+        "the user callback sees the whole sum:\n{kotlin}"
+    );
+}
+
+/// A variant payload may be an opaque **handle**: it rides its raw `jlong`
+/// like any other handle leaf, so its slot stays a primitive (an inert group
+/// leaves the `0L` sentinel, never a fabricated handle object).
+#[test]
+fn sum_return_group_can_own_a_handle() {
+    let (_, kotlin) = sum_returns("jnigen_sum_handle");
+    assert!(
+        kotlin.contains("public fun run(tag: Int, found_v0: Long): R"),
+        "a handle payload's group slot is the raw pointer:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("1 -> Lookup.Found(Probe(found_v0))"),
+        "the live arm wraps the pointer into its typed handle class:\n{kotlin}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1029,6 +1029,62 @@ fn two_sum_callback_args_keep_their_own_selectors() {
     );
 }
 
+/// A sum in the **success position of a fallible return** has no lowering, and
+/// says so. `Result` returns deliberately keep their whole-value converter (so
+/// a fallible factory still hands back a handle), and a sum has no whole-value
+/// converter to keep — the decomposition lives on the builder-callback lane the
+/// `Result` path does not use.
+#[test]
+fn sum_in_result_ok_position_is_rejected_with_its_reason() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_try(n: i64) -> Result<Reading, Probe> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .class(crate::ptr_class!(Probe))
+            .fun(crate::fun!(read_try)),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("must be rejected")
+        .to_string();
+    assert!(
+        err.contains("read_try") && err.contains("success position of a fallible return"),
+        "the error must name the function and the unsupported position: {err}"
+    );
+    assert!(
+        err.contains("Return `Reading` directly"),
+        "…and say what to write instead: {err}"
+    );
+}
+
 /// A **slice of sums** as a callback argument has no lowering, and says so.
 ///
 /// Folding a sequence of tag-gated groups into the foreign list needs the

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -985,6 +985,42 @@ impl Prebindgen for JniGen {
         out
     }
 
+    /// Synthesize the tag-plus-groups decomposition of every `sealed_class`
+    /// type, so a function whose own return (or callback argument) IS the sum
+    /// delivers it as a tag plus one leaf group per variant — the same wire
+    /// layout a sum-typed struct field already gets, reassembled by the hoisted
+    /// builder singleton instead of by the parent's `fromParts`.
+    ///
+    /// Emitted for every declared sum, not only the ones currently returned: a
+    /// decomposition with no matching function wires no plan, and an unused
+    /// `DeconSpec` emits nothing.
+    fn sum_decons(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> Vec<crate::api::core::unfold::SumDecon> {
+        let mut keys: Vec<&TypeKey> = self.types.keys().collect();
+        keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        let mut out = Vec::new();
+        for key in keys {
+            let Some(sum_cfg) = self.types[key].sum_cfg.as_ref() else {
+                continue;
+            };
+            let source = key.to_type();
+            let Some(ident) = bare_path_ident(&source) else {
+                continue;
+            };
+            let Some((item_enum, _)) = registry.enums.get(&ident) else {
+                continue;
+            };
+            out.push(crate::api::core::unfold::SumDecon {
+                key: key.clone(),
+                source,
+                leaves: crate::api::lang::jnigen::jni::synth_sum_leaves(self, sum_cfg, item_enum),
+            });
+        }
+        out
+    }
+
     /// Nominate every **single-leaf** element type that appears in a `Vec<T>` /
     /// `Option<Vec<T>>` return or an `impl Fn(&[T])` callback arg, so
     /// [`crate::api::core::unfold::apply_leaf_vec_folds`] routes the collection

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1236,17 +1236,44 @@ impl Prebindgen for JniGen {
                 }
             }
         }
-        // A **slice of sums** delivered to a callback (`impl Fn(&[E])`) has no
-        // lowering: the element fold would need the sum's folder-appender
-        // singleton, which is emitted per *return* position, so the shape
-        // resolves to nothing and would otherwise surface as "`E` has no
-        // output converter" — naming the sum rather than the position, since a
-        // sum has no whole-value converter by design. Reject it here, where the
-        // message can say what is actually unsupported.
+        // Two sum positions have no lowering. Both would otherwise fail as
+        // "`E` has no output converter", which names the sum rather than the
+        // position — actively misleading, because a sum has no whole-value
+        // converter BY DESIGN, so that message sends the reader looking for
+        // something that must not exist. Reject them here, where the message
+        // can say what is actually unsupported and what to write instead.
         for ident in self.declared_functions() {
             let Some((item_fn, _)) = registry.functions.get(&ident) else {
                 continue;
             };
+            // (1) A sum in the `Ok` position of a fallible return. A sum is
+            // delivered DECOMPOSED through a builder callback, and the
+            // `Result` lane has no builder: a `Result` return deliberately
+            // keeps its whole-value converter so a fallible factory still
+            // yields a handle (see `unfold::returns_type`).
+            if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
+                if let Some(ok) = crate::api::core::types_util::result_ok_type(ret) {
+                    let core = crate::api::core::types_util::peel_ref_option_vec(&ok);
+                    if matches!(self.type_kind(registry, &core), TypeKind::Sum) {
+                        return Err(format!(
+                            "fn `{ident}`: `Result<{}, _>` — a sealed_class value is not \
+                             supported in the success position of a fallible return. A sum \
+                             crosses decomposed (a tag plus one leaf group per variant) \
+                             through a builder callback, which the `Result` lane does not \
+                             have — a fallible return keeps its whole-value converter so a \
+                             factory can still hand back a handle. Return `{}` directly and \
+                             report failure through the error channel, or model the failure \
+                             as one of the sum's own variants",
+                            ok.to_token_stream(),
+                            ok.to_token_stream(),
+                        ));
+                    }
+                }
+            }
+            // (2) A **slice of sums** delivered to a callback
+            // (`impl Fn(&[E])`): the element fold would need the sum's
+            // folder-appender singleton, which is emitted per `Vec<E>` RETURN
+            // position, so the shape resolves to nothing.
             for input in &item_fn.sig.inputs {
                 let syn::FnArg::Typed(pt) = input else {
                     continue;

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1236,6 +1236,53 @@ impl Prebindgen for JniGen {
                 }
             }
         }
+        // A **slice of sums** delivered to a callback (`impl Fn(&[E])`) has no
+        // lowering: the element fold would need the sum's folder-appender
+        // singleton, which is emitted per *return* position, so the shape
+        // resolves to nothing and would otherwise surface as "`E` has no
+        // output converter" — naming the sum rather than the position, since a
+        // sum has no whole-value converter by design. Reject it here, where the
+        // message can say what is actually unsupported.
+        for ident in self.declared_functions() {
+            let Some((item_fn, _)) = registry.functions.get(&ident) else {
+                continue;
+            };
+            for input in &item_fn.sig.inputs {
+                let syn::FnArg::Typed(pt) = input else {
+                    continue;
+                };
+                let Some(args) = extract_fn_trait_args(&pt.ty) else {
+                    continue;
+                };
+                for arg in args {
+                    let after_ref = match &arg {
+                        syn::Type::Reference(r) => (*r.elem).clone(),
+                        other => other.clone(),
+                    };
+                    let syn::Type::Slice(s) = &after_ref else {
+                        continue;
+                    };
+                    let elem = match &*s.elem {
+                        syn::Type::Reference(r) => (*r.elem).clone(),
+                        other => other.clone(),
+                    };
+                    if matches!(self.type_kind(registry, &elem), TypeKind::Sum) {
+                        return Err(format!(
+                            "fn `{ident}`: `impl Fn(&[{}])` — a slice of a sealed_class value \
+                             is not supported as a callback argument. A sum crosses as a tag \
+                             plus one leaf group per variant, and folding a *sequence* of \
+                             those into the foreign list needs the element folder a `Vec<{}>` \
+                             RETURN provides; declare the callback over one value \
+                             (`impl Fn({})`) or return `Vec<{}>` instead",
+                            elem.to_token_stream(),
+                            elem.to_token_stream(),
+                            elem.to_token_stream(),
+                            elem.to_token_stream(),
+                        ));
+                    }
+                }
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Stage **E** of the sum-type work (#150), the last position. Design: `docs/sum-types.md` §4.5.

Based on `sum-types-d-sums` (#157), following the stack the earlier stages use — #153 on `sum-types`, #154/#155 on A, #157 on C — so this diff is stage E alone rather than A+C+D+E.

## The gap

After #149 a sum crosses as a parameter and as a data-class field. What was left is the sum being the function's **own** return, because `api/core/unfold` decomposes a value as a deterministic product:

> A **deconstructor** … is a **deterministic product**: every record always runs and contributes its leaf — there is no selector (unlike a *constructor*, whose selector picks one variant).

Every leaf is an independent expression evaluated unconditionally, so no leaf list could say "these leaves only exist in arm 1". This gives `unfold` the dual of `expand`'s runtime variant selector.

## Core

- `LeafSource::SumTag` — the synthesized `i32` selector. It has no path (the emitter assigns it per `match` arm) and, uniquely, **no converter** (`UnfoldLeaf::has_converter()`): requiring an output converter for it would make every sum depend on an unrelated `i32` crossing existing somewhere in the binding. That is not hypothetical — it is what made the first library test hang on deferral.
- `LeafSource::VariantField { variant, member }` — a payload reached through a variant pattern rather than an accessor or field chain.
- `UnfoldLeaf::group` — membership, which is what lets an emitter read the leaf list as ONE `match` with wire-defaulted inert slots.
- `apply_sum_returns`, sharing the fixed-builder plumbing with `apply_value_structs` (extracted into `wire_fixed_decon` / `wire_fixed_returns` / `wire_fixed_callbacks`). It also drops the declared return's scan-time output requirement at **every** layer (`E`, `Option<E>`, `Vec<E>`) — a sum has no whole-value converter by construction, and the boundary-only pass only reaches the bare type.

`Option` / `Vec` need nothing new; they ride the existing `Shape` fold.

## The decision the handoff asked for

> So E must either reshape `Sum.fromParts` to the wire contract, or emit a separate wire-shaped builder and leave the convenience factory alone.

**The wire target is the hoisted builder singleton; `fromParts` is left alone.** Stage C's factory is the Kotlin-facing convenience — property-typed parameters (`Priority`, not the `Int` discriminant) and non-null object slots that an inert group's `JObject::null()` would trip on inside the JVM's intrinsic null check. The return path instead reassembles through the same inlined `when` over the tag that a sum-typed struct field already gets:

```kotlin
internal val __ReadingBuilder: ReadingBuilder<Reading> =
    ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 ->
        when (tag) {
            0 -> Reading.Missing
            1 -> Reading.Exact(exact_v0)
            2 -> Reading.Range(range_low, range_high)
            3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1))
            4 -> Reading.Companion(companion_v0)
            else -> throw IllegalArgumentException("Reading: invalid tag $tag")
        }
    }
```

One reassembly style for both positions, no NPE or type-mismatch hazard, and `Test.kt`'s existing `fromParts` assertions keep working. A test asserts the two do **not** silently converge.

The Rust side is one `match`, the live arm converting its own group and everything else taking the wire default:

```rust
let __obj0: jni::sys::jvalue;  // tag
let __obj1: jni::sys::jvalue;  // Found's handle
let __obj2: jni::objects::JObject;  // Failed's String
match &__out {
    Lookup::Absent => { __obj0 = jvalue { i: 0 }; __obj1 = jvalue { j: 0i64 }; __obj2 = JObject::null(); }
    Lookup::Found(__sv0)  => { let __enc = Summary_to_jlong(&mut env, __sv0.clone())?; … }
    Lookup::Failed(__sv0) => { … }
}
```

## Two bugs found on the way

- **The callback path derived its `run` params separately** from `plan_leaf_params`, so `ReadingCallbackRaw` declared `tagged_v0: String` where the encoder sends null. `plan_leaf_param` is now the single classification of a decomposition leaf, shared by builder/folder/handler signatures and a callback's flattened params, so the tag slot and the inert-group nullability rule cannot hold at one site and not another.
- **A required handle payload decoded through the borrow converter** (`OwnedObject<T>`), which cannot populate an owned field — the generated decoder did not compile. Now consumes via `Box::from_raw`, matching the rule the struct-field path already uses. Its own commit (2f3f920), since it is a stage-D gap this stage merely surfaced.

Also: `TypedGroup::reassemble` generalizes from a class short name to a reassembly **expression** with positional `$k` placeholders, so a sum's `when` can serve the same role as a product's `fromParts` — and neither is broken by the signature-wide name dedup that runs *after* a group is described.

## Coverage

`perftest-flat` gains `reading_of` / `reading_maybe` / `reading_series` / `reading_each` — the four positions (bare, `Option`, `Vec`, callback) — plus a `Lookup` sum whose alternatives are a payload-less variant, an opaque **handle** payload, and a `String`. That last one is the demanding shape: a live group hands over a native resource the caller owns and closes, while an inert group's object slot stays JVM null and its handle slot stays the `0L` sentinel that is simply never wrapped.

`covertest-kotlin` asserts all of it on a real JVM (two new sections). Library tests: three in `core/unfold` (plan shape, layer composition, callback arg) and five in `jnigen/tests/sealed.rs` (wire-shaped singleton, `fromParts` left alone, the single `match`, `Option`/`Vec`/callback, handle payload).

## Deliberately out of scope

`synth_value_struct_leaves` still declines a sum **field**. That path works today via the whole-value `fromParts` bridge (#149), so flattening it too is a wire-width/allocation optimization of an already-correct path, not a capability. Recorded in `docs/sum-types.md` §9.

## Verification

- `cargo test --all` and `cargo test --all --all-features` — green
- `cargo fmt --check` and `clippy --all-targets --no-default-features --all-features --deny warnings` — clean
- `examples/regen-check.sh` — byte-identical (`example-cbindgen` and `perftest-kotlin` goldens untouched; the `--all-features` cbindgen pollution the handoff warns about was reset before committing)
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 41 sections

Depends on: #157 (stage D). Unblocks zenoh-flat #30's accessor form — a `reply_get_result(&Reply) -> ReplyResult` returning a sum whose payloads are nested data classes with gated handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
