### PR TITLE
jnigen: a fixed builder emits no dead typed interface (#160)

### DIFF
--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -419,27 +419,9 @@ public fun interface PayloadBuilder<out R> {
 internal val __PayloadBuilder: PayloadBuilder<Payload> =
 PayloadBuilder { id, seq, value, flag, label -> Payload.fromParts(id, seq, value, flag, label) }
 
-public fun interface PayloadFolder<A> {
-    public fun run(acc: A, element: Payload): A
-}
-
 public fun interface PayloadFolderRaw<A> {
     public fun run(acc: A, id: Long, seq: Int, value: Double, flag: Boolean, label: String?): A
 }
-
-public fun <A> PayloadFolder<A>.asRaw(): PayloadFolderRaw<A> =
-    PayloadFolderRaw<A> {
-        acc,
-        id,
-        seq,
-        value,
-        flag,
-        label ->
-        run(
-            acc,
-            Payload.fromParts(id, seq, value, flag, label)
-        )
-    }
 
 internal object __PayloadFolderRawHolder {
     @JvmField
@@ -447,23 +429,9 @@ internal object __PayloadFolderRawHolder {
     PayloadFolderRaw { acc, id, seq, value, flag, label -> acc.add(Payload.fromParts(id, seq, value, flag, label)); acc }
 }
 
-public fun interface StorageFolder<A> {
-    public fun run(acc: A, element: Storage): A
-}
-
 public fun interface StorageFolderRaw<A> {
     public fun run(acc: A, element: Long): A
 }
-
-public fun <A> StorageFolder<A>.asRaw(): StorageFolderRaw<A> =
-    StorageFolderRaw<A> {
-        acc,
-        element ->
-        run(
-            acc,
-            Storage(element)
-        )
-    }
 
 internal object __StorageFolderRawHolder {
     @JvmField
@@ -481,23 +449,9 @@ internal object __StringFolderHolder {
     StringFolder { acc, element -> acc.add(element); acc }
 }
 
-public fun interface u64Folder<A> {
-    public fun run(acc: A, element: ULong): A
-}
-
 public fun interface u64FolderRaw<A> {
     public fun run(acc: A, element: Long): A
 }
-
-public fun <A> u64Folder<A>.asRaw(): u64FolderRaw<A> =
-    u64FolderRaw<A> {
-        acc,
-        element ->
-        run(
-            acc,
-            element.toULong()
-        )
-    }
 
 internal object __u64FolderRawHolder {
     @JvmField

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -738,44 +738,16 @@ public fun ReadingCallback.asRaw(): ReadingCallbackRaw =
         )
     }
 
-public fun interface DurationBoundaryBuilder<out R> {
-    public fun run(delay: ULong?): R
-}
-
 public fun interface DurationBoundaryBuilderRaw<out R> {
     public fun run(delay: Long): R
 }
 
-public fun <R> DurationBoundaryBuilder<R>.asRaw(): DurationBoundaryBuilderRaw<R> =
-    DurationBoundaryBuilderRaw<R> {
-        delay ->
-        run(
-            if (delay == -1L) null else delay.toULong()
-        )
-    }
-
 internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
 DurationBoundaryBuilderRaw { delay -> DurationBoundary.fromParts(delay) }
-
-public fun interface LookupBuilder<out R> {
-    public fun run(tag: Int, found_v0: Summary, failed_v0: String?): R
-}
 
 public fun interface LookupBuilderRaw<out R> {
     public fun run(tag: Int, found_v0: Long, failed_v0: String?): R
 }
-
-public fun <R> LookupBuilder<R>.asRaw(): LookupBuilderRaw<R> =
-    LookupBuilderRaw<R> {
-        tag,
-        found_v0,
-        failed_v0 ->
-        run(
-            tag,
-            Summary(found_v0),
-            failed_v0
-        )
-    }
 
 internal val __LookupBuilderRaw: LookupBuilderRaw<Lookup> =
 LookupBuilderRaw { tag, found_v0, failed_v0 ->
@@ -799,36 +771,12 @@ ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, com
     when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
 }
 
-public fun interface UnsignedBuilder<out R> {
-    public fun run(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?): R
-}
-
 public fun interface UnsignedBuilderRaw<out R> {
     public fun run(byte: Int, short: Int, int: Long, long: Long, maybeLong: Long?): R
 }
 
-public fun <R> UnsignedBuilder<R>.asRaw(): UnsignedBuilderRaw<R> =
-    UnsignedBuilderRaw<R> {
-        byte,
-        short,
-        int,
-        long,
-        maybeLong ->
-        run(
-            byte,
-            short,
-            int,
-            long.toULong(),
-            maybeLong?.toULong()
-        )
-    }
-
 internal val __UnsignedBuilderRaw: UnsignedBuilderRaw<Unsigned> =
 UnsignedBuilderRaw { byte, short, int, long, maybeLong -> Unsigned.fromParts(byte, short, int, long, maybeLong) }
-
-public fun interface ReadingFolder<A> {
-    public fun run(acc: A, element: Reading): A
-}
 
 public fun interface ReadingFolderRaw<A> {
     public fun run(
@@ -843,45 +791,15 @@ public fun interface ReadingFolderRaw<A> {
     ): A
 }
 
-public fun <A> ReadingFolder<A>.asRaw(): ReadingFolderRaw<A> =
-    ReadingFolderRaw<A> {
-        acc,
-        tag,
-        exact_v0,
-        range_low,
-        range_high,
-        tagged_v0,
-        tagged_v1,
-        companion_v0 ->
-        run(
-            acc,
-            when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
-        )
-    }
-
 internal object __ReadingFolderRawHolder {
     @JvmField
     val instance: ReadingFolderRaw<ArrayList<Reading>> =
     ReadingFolderRaw { acc, tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 -> acc.add(when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }); acc }
 }
 
-public fun interface StampFolder<A> {
-    public fun run(acc: A, element: Stamp): A
-}
-
 public fun interface StampFolderRaw<A> {
     public fun run(acc: A, element: ByteArray): A
 }
-
-public fun <A> StampFolder<A>.asRaw(): StampFolderRaw<A> =
-    StampFolderRaw<A> {
-        acc,
-        element ->
-        run(
-            acc,
-            Stamp(element)
-        )
-    }
 
 internal object __StampFolderRawHolder {
     @JvmField

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -610,27 +610,9 @@ public fun interface PayloadBuilder<out R> {
 internal val __PayloadBuilder: PayloadBuilder<Payload> =
 PayloadBuilder { id, seq, value, flag, label -> Payload.fromParts(id, seq, value, flag, label) }
 
-public fun interface PayloadFolder<A> {
-    public fun run(acc: A, element: Payload): A
-}
-
 public fun interface PayloadFolderRaw<A> {
     public fun run(acc: A, id: Long, seq: Int, value: Double, flag: Boolean, label: String?): A
 }
-
-public fun <A> PayloadFolder<A>.asRaw(): PayloadFolderRaw<A> =
-    PayloadFolderRaw<A> {
-        acc,
-        id,
-        seq,
-        value,
-        flag,
-        label ->
-        run(
-            acc,
-            Payload.fromParts(id, seq, value, flag, label)
-        )
-    }
 
 internal object __PayloadFolderRawHolder {
     @JvmField

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -918,13 +918,36 @@ impl SpecKey {
 pub(crate) fn fixed_decon_ids(
     registry: &Registry<KotlinMeta>,
 ) -> std::collections::HashSet<DeconId> {
-    registry
+    let fixed: std::collections::HashSet<DeconId> = registry
         .unfold_plans
         .values()
         .chain(registry.callback_arg_plans.values())
         .filter(|p| p.fixed_builder)
         .filter_map(|p| p.decon.clone())
-        .collect()
+        .collect();
+    // Fixedness must be UNIFORM per identity, and two consumers now depend on
+    // that: the memo swaps in the fixed typed-group view for the whole
+    // identity, and the emitter suppresses the typed interface entirely when
+    // the singleton is its only implementation. A mixed identity would give a
+    // non-fixed wrapper a `build`/`fold` param whose interface was shaped —
+    // or removed — for the fixed case.
+    //
+    // It holds by construction: `apply_value_structs` / `apply_sum_returns` run
+    // AFTER `unfold::apply` and wire every reachable position of a type at
+    // once, so a `DeconId::Default` is all-fixed or all-not; a `DeconId::PerFn`
+    // is unique to one function and so trivially uniform. Asserted rather than
+    // assumed, so a future wiring change fails here instead of emitting a
+    // wrapper that references an interface which no longer exists.
+    debug_assert!(
+        !registry
+            .unfold_plans
+            .values()
+            .chain(registry.callback_arg_plans.values())
+            .any(|p| !p.fixed_builder && p.decon.as_ref().is_some_and(|d| fixed.contains(d))),
+        "fixed and non-fixed plans share one DeconId — the typed interface \
+         cannot be shaped (or suppressed) for both"
+    );
+    fixed
 }
 
 /// Element type keys whose whole-element fold is fixed (a synthesized

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1262,12 +1262,33 @@ impl JniGen {
                 self.iface_spec(registry, &u).map(|s| (s, is_error, fixed))
             })
             .map(|(s, is_error, fixed)| {
+                // A **fixed** builder/folder has no user-facing side: the only
+                // implementation is the hoisted singleton emitted below, which
+                // implements the RAW twin, and the wrapper passes that singleton
+                // to the native call. So the typed interface and its `asRaw`
+                // proxy would be dead public API — and for a sum actively
+                // misleading, since `asRaw` wraps every group's slots as if all
+                // were live when exactly one ever is (issue #160). Emit neither.
+                //
+                // Only when there IS a twin: with no twin, `raw_name() == name`,
+                // so `to_decl()` *is* the interface the singleton implements and
+                // JNI calls.
+                let typed_is_dead = fixed.is_some() && s.needs_raw();
+                let mut file = kt::KtFile::new(s.package.clone());
+                if !typed_is_dead {
+                    file = file.decl(s.to_decl());
+                }
                 // Typed (user-facing) interface; when any leaf's raw view
                 // differs, also the JNI-called raw twin and the `asRaw()`
                 // proxy adapter that wraps raw leaves into typed objects.
-                let mut file = kt::KtFile::new(s.package.clone()).decl(s.to_decl());
                 if s.needs_raw() {
-                    file = file.decl(s.to_raw_decl()).decl(s.to_as_raw_fun());
+                    file = file.decl(s.to_raw_decl());
+                    if !typed_is_dead {
+                        file = file.decl(s.to_as_raw_fun());
+                    }
+                    // Kept even when the proxy is suppressed: a hoisted
+                    // singleton names the same classes by short name from its
+                    // own raw text (`Class.fromParts(…)`, a `wrap` expression).
                     for p in &s.params {
                         if let Some(fqn) = p.wrap.class_fqn() {
                             file = file.import(fqn.to_string());

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -855,6 +855,51 @@ fn sum_return_builds_through_a_wire_shaped_singleton() {
     assert!(kotlin.contains("Reading: invalid tag $tag"), "{kotlin}");
 }
 
+/// A **fixed** builder is implemented only by its hoisted singleton, so the
+/// typed `fun interface` and the `asRaw` proxy that would adapt to it are dead
+/// public API — and for a sum with a handle payload they are actively wrong:
+/// `asRaw` would wrap every group's slot as if all were live, turning an inert
+/// group's `0L` sentinel into a handle to nothing. Neither is emitted (#160);
+/// the raw twin the singleton implements is.
+///
+/// Uses the handle-payload fixture because that is the shape with a raw twin
+/// at all — when a builder's leaves need no wrapping, `raw_name() == name` and
+/// the single interface IS the one JNI calls, so there is nothing dead to drop.
+#[test]
+fn a_fixed_builder_emits_no_dead_typed_twin() {
+    let (_, kotlin) = sum_returns("jnigen_sum_no_dead_twin");
+
+    // The twin the singleton implements and JNI calls.
+    assert!(
+        kotlin.contains("public fun interface LookupBuilderRaw<out R>"),
+        "the raw twin is what exists:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("internal val __LookupBuilderRaw: LookupBuilderRaw<Lookup>"),
+        "the singleton implements it:\n{kotlin}"
+    );
+    // The dead surface: the typed declaration and the proxy adapting to it.
+    assert!(
+        !kotlin.contains("public fun interface LookupBuilder<out R>"),
+        "no typed twin for a fixed builder:\n{kotlin}"
+    );
+    assert!(
+        !kotlin.contains("LookupBuilder<R>.asRaw()"),
+        "and so no proxy that would wrap an inert group's sentinel:\n{kotlin}"
+    );
+
+    // A CALLBACK interface is the opposite case and keeps both: the user
+    // implements the typed one, and `asRaw` is how the raw leaves reach it.
+    assert!(
+        kotlin.contains("public fun interface ReadingCallback"),
+        "a callback keeps its typed interface — the user implements it:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("ReadingCallback.asRaw()"),
+        "and keeps the proxy that feeds it:\n{kotlin}"
+    );
+}
+
 /// The sealed interface's own `fromParts` is the Kotlin-facing convenience
 /// stage C emits, NOT the wire target: its parameters are the variants'
 /// property types and its object slots are non-null. The return path therefore

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -365,9 +365,14 @@ fn vec_of_handle_output_folds_kotlin_side() {
         .join("\n");
     let kc: String = kotlin.split_whitespace().collect();
 
-    // A `ZThingFolder<A>` interface is generated, and the wrapper returns a typed
-    // list, allocating the `ArrayList<ZThing>` accumulator on the Kotlin side.
-    assert!(kc.contains("interfaceZThingFolder<A>"), "{kotlin}");
+    // A `ZThingFolderRaw<A>` interface is generated, and the wrapper returns a
+    // typed list, allocating the `ArrayList<ZThing>` accumulator on the Kotlin
+    // side. The fold is FIXED (the hoisted singleton below is its only
+    // implementation), so no typed twin or `asRaw` proxy is emitted — that
+    // surface would be dead public API (#160).
+    assert!(kc.contains("interfaceZThingFolderRaw<A>"), "{kotlin}");
+    assert!(!kc.contains("interfaceZThingFolder<A>"), "{kotlin}");
+    assert!(!kc.contains("ZThingFolder<A>.asRaw"), "{kotlin}");
     assert!(kc.contains("List<ZThing>"), "{kotlin}");
     assert!(kc.contains("ArrayList<ZThing>()"), "{kotlin}");
     // The folder singleton wraps each raw `jlong` element into the typed handle


### PR DESCRIPTION
Closes #160. Part of the sum-type umbrella #152.

**Base:** `sum-types-a-core` (#153), not `sum-types` — that branch is the docs commit alone and has no jnigen sum support, so this could not build there. It still reaches `main` through the umbrella.

## The problem

A **fixed-builder** decomposition — a by-value `data_class`, a `Vec` element fold, or (since #150) a sum — emitted both a typed `fun interface` and the raw twin JNI actually calls. Only the twin is ever implemented: by the hoisted singleton, which the wrapper passes to the native call. The typed declaration and its `asRaw` proxy were public API nothing could reach.

For a sum they were also **wrong**, which is what makes this more than tidying:

```kotlin
public fun interface LookupBuilder<out R> {
    public fun run(tag: Int, found_v0: Summary, failed_v0: String?): R
}
public fun <R> LookupBuilder<R>.asRaw(): LookupBuilderRaw<R> =
    LookupBuilderRaw<R> { tag, found_v0, failed_v0 -> run(tag, Summary(found_v0), failed_v0) }
```

`Summary(found_v0)` wraps whatever is in that slot — but exactly one group is ever live, so for any other tag it wraps the `0L` sentinel: **a handle to nothing**. The signature reads as if all three slots are simultaneously meaningful.

## The change

Take the first option from the issue — suppress rather than mark `internal` — gated on *fixed AND has a twin*.

That second condition is the subtle part: with no twin `raw_name() == name`, so the single interface **is** the one the singleton implements and JNI calls. Nothing is dead and nothing is dropped. `ReadingBuilder` in the tests is exactly that case, which is why the new test uses the handle-payload fixture instead — it is the shape that has a twin at all.

Param and group imports are kept either way: a hoisted singleton names those classes by short name from its own raw text (`Class.fromParts(…)`, a `wrap` expression), so dropping them with the proxy would break the singleton.

### One scope difference from the issue

The issue named `SpecKey::Builder` / `SpecKey::Folder`. A fixed **`WholeFolder`** turned out to be the same shape — `whole_value_folder_singleton` also implements `raw_name()`, and nothing references the typed one — so it is included. Leaving it out would have knowingly kept shipping the surface this PR exists to remove. Verified rather than assumed: the only references to `ZThingFolderRaw` in the generated output are the singleton and the wrapper's native call.

A **callback** keeps both, as the issue says it should: the user implements the typed interface and `asRaw` is how raw leaves reach it. Pinned in the new test.

## Effect

**146 lines of generated Kotlin removed, none added** — `LookupBuilder`, `DurationBoundaryBuilder`, `UnsignedBuilder`, `PayloadFolder` and their proxies. Nothing referenced any of the dropped names.

## Verification

- `covertest-kotlin` JVM harness: **all 41 sections pass**, unchanged — the strongest evidence the removed surface was dead.
- `cargo test --all --all-features` (371 lib tests), `regen-check.sh` clean after regeneration, `cargo fmt --check`, `clippy --all-targets --no-default-features --all-features --deny warnings` clean.
- New test asserts both halves: twin + singleton present, typed declaration and proxy absent, callback keeping its pair. The existing `Vec<handle>` fold test now asserts the raw twin it actually emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
