### PR TITLE
jnigen: reject an undecomposed sum in a Result error position (#162)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1138,6 +1138,57 @@ fn undeclared_sum_in_result_error_position_is_rejected() {
     );
 }
 
+/// A WRAPPED error type (`Result<_, Option<Sum>>`) is where the diagnostic's
+/// two type spellings diverge, so it pins which is which: the `Display` bound
+/// and the `expand_return!` key are the WHOLE error type (that is what
+/// `__e.to_string()` runs on, and what the deconstructor auto-apply matches),
+/// while only the "is declared `sealed_class!`" clause names the peeled sum.
+/// Getting these backwards would hand the author advice that cannot work.
+#[test]
+fn the_diagnostic_names_the_whole_error_type_where_it_must() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_try(n: i64) -> Result<i64, Option<Reading>> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .fun(crate::fun!(read_try)),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("must be rejected")
+        .to_string();
+    let compact: String = err.split_whitespace().collect();
+
+    // The whole `E` — the position, the `Display` bound, and the fix.
+    assert!(compact.contains("`Result<_,Option<Reading>>`"), "{err}");
+    assert!(compact.contains("`Option<Reading>:Display`"), "{err}");
+    assert!(compact.contains("expand_return!(Option<Reading>)"), "{err}");
+    // …and the peeled sum only where the declaration lives.
+    assert!(
+        compact.contains("`Reading`isdeclared`sealed_class!`"),
+        "{err}"
+    );
+}
+
 /// The counterpart: a sum error type WITH a type-level deconstructor is the
 /// supported shape and must keep resolving — the diagnostic above must not
 /// become a blanket ban on sums in the error position.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1085,6 +1085,106 @@ fn sum_in_result_ok_position_is_rejected_with_its_reason() {
     );
 }
 
+/// A sum in the **error** position of a `Result`, with nothing declared to
+/// decompose it. Unlike the other two rejected positions this one RESOLVES —
+/// it takes the generic undecomposed-`E` path and routes the `Err` to the
+/// plain binding-error channel as `e.to_string()`. Kotlin would receive a
+/// `String` from a hierarchy the author explicitly declared, and the generated
+/// crate would quietly require `E: Display`, failing downstream in generated
+/// code. Emitting something misleading is worse than not emitting.
+#[test]
+fn undeclared_sum_in_result_error_position_is_rejected() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_try(n: i64) -> Result<i64, Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::sealed_class!(Reading))
+            .fun(crate::fun!(read_try)),
+    );
+    let err = registry
+        .resolve(jni)
+        .expect_err("must be rejected")
+        .to_string();
+    assert!(
+        err.contains("read_try") && err.contains("Result<_, Reading>"),
+        "the error must name the function and the position: {err}"
+    );
+    assert!(
+        err.contains("e.to_string()") && err.contains("Display"),
+        "…and both consequences of the silent path: {err}"
+    );
+    assert!(
+        err.contains("expand_return!(Reading)"),
+        "…and what to write instead: {err}"
+    );
+}
+
+/// The counterpart: a sum error type WITH a type-level deconstructor is the
+/// supported shape and must keep resolving — the diagnostic above must not
+/// become a blanket ban on sums in the error position.
+#[test]
+fn declared_sum_in_result_error_position_resolves() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn reading_code(v: &Reading) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_try(n: i64) -> Result<i64, Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .expand(crate::expand_return!(Reading).field(crate::fun!(reading_code)))
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .fun(crate::fun!(read_try)),
+        );
+    registry
+        .resolve(jni)
+        .expect("a declared error deconstructor is the supported shape");
+}
+
 /// A **slice of sums** as a callback argument has no lowering, and says so.
 ///
 /// Folding a sequence of tag-gated groups into the foreign list needs the

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1303,9 +1303,18 @@ impl Prebindgen for JniGen {
                              deliver, so the error crosses through the typed domain-handler \
                              channel; or, if a text message really is what you want, drop the \
                              `sealed_class!` declaration for this type",
+                            // `Result<_, E>` and the `expand_return!` key are
+                            // the WHOLE error type: the `Display` bound falls
+                            // on it (the generated code calls `__e.to_string()`
+                            // on the `Err` value), and the auto-apply matches a
+                            // deconstructor by that same whole type. Only the
+                            // "is declared `sealed_class!`" clause names the
+                            // peeled sum, since that is what carries the
+                            // declaration. Identical for a bare `E`; they
+                            // diverge once it is wrapped.
                             err_ty.to_token_stream(),
                             core.to_token_stream(),
-                            core.to_token_stream(),
+                            err_ty.to_token_stream(),
                             err_ty.to_token_stream(),
                         ));
                     }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1236,7 +1236,8 @@ impl Prebindgen for JniGen {
                 }
             }
         }
-        // Two sum positions have no lowering. Both would otherwise fail as
+        // Three sum positions in a declared signature are wrong. Two have no
+        // lowering at all and would otherwise fail as
         // "`E` has no output converter", which names the sum rather than the
         // position — actively misleading, because a sum has no whole-value
         // converter BY DESIGN, so that message sends the reader looking for
@@ -1270,7 +1271,47 @@ impl Prebindgen for JniGen {
                     }
                 }
             }
-            // (2) A **slice of sums** delivered to a callback
+            // (2) A sum in the **error** position of a `Result` with no
+            // deconstructor declared for it. Unlike the other two this one
+            // RESOLVES — it takes the generic undecomposed-`E` path, where the
+            // `Err` is routed to the plain binding-error channel as
+            // `e.to_string()`. So the author declares a sealed hierarchy and
+            // Kotlin silently receives a `String`, and the generated crate
+            // quietly acquires an `E: Display` bound that fails downstream in
+            // generated code rather than at the declaration. Emitting
+            // something misleading is worse than not emitting: say so here.
+            //
+            // An error plan can only come from a TYPE-level `expand_return!`
+            // (auto-applied to every fn with that `E`); a per-fn
+            // `.expand_return(...)` always targets the Output position. So the
+            // declaration set is the whole story, and this stays a pre-resolve
+            // check.
+            if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
+                if let Some(err_ty) = crate::api::core::types_util::result_err_type(ret) {
+                    let core = crate::api::core::types_util::peel_ref_option_vec(&err_ty);
+                    let declared = self
+                        .return_expand_decls
+                        .iter()
+                        .any(|d| d.key == TypeKey::from_type(&err_ty));
+                    if !declared && matches!(self.type_kind(registry, &core), TypeKind::Sum) {
+                        return Err(format!(
+                            "fn `{ident}`: `Result<_, {}>` — `{}` is declared `sealed_class!`, \
+                             but nothing decomposes it in the error position, so it would be \
+                             delivered as `e.to_string()` on the plain binding-error channel \
+                             rather than as the sealed hierarchy (and would silently require \
+                             `{}: Display`). Declare `expand_return!({})` with the fields to \
+                             deliver, so the error crosses through the typed domain-handler \
+                             channel; or, if a text message really is what you want, drop the \
+                             `sealed_class!` declaration for this type",
+                            err_ty.to_token_stream(),
+                            core.to_token_stream(),
+                            core.to_token_stream(),
+                            err_ty.to_token_stream(),
+                        ));
+                    }
+                }
+            }
+            // (3) A **slice of sums** delivered to a callback
             // (`impl Fn(&[E])`): the element fold would need the sum's
             // folder-appender singleton, which is emitted per `Vec<E>` RETURN
             // position, so the shape resolves to nothing.


### PR DESCRIPTION
Addresses #162 (the diagnostic half). Part of the sum-type umbrella #152.

**Base:** `sum-types-a-core` (#153) — `sum-types` is the docs commit alone and has no jnigen sum support, so this could not build there. Still reaches `main` through the umbrella.

## The problem

`fn f(..) -> Result<T, Sum>` where `Sum` is `sealed_class!`-declared but has no deconstructor **resolves**, and that is precisely the problem. It takes the generic undecomposed-`E` path, so the `Err` goes to the plain binding-error channel as text:

```rust
Err(__e) => {
    signal_binding_error(&mut env, &__error_sink, …, &__e.to_string());
    return 0 as jni::sys::jlong;
}
```

Two things go quietly wrong:

1. Kotlin receives a `String` on `onBindingError`, not the sealed hierarchy the author explicitly declared. Nothing warns.
2. The generated crate acquires an `E: Display` bound. A source enum without it fails to compile **downstream**, with rustc pointing at generated code rather than at the declaration that caused it.

Neither is sum-specific — it is what any undeclared `E` gets, which is why it emits rather than failing. But declaring a sealed hierarchy and silently getting text back is the quiet mismatch the "invalid = ERROR" declaration policy exists to prevent. It is the third `Result` interaction and the only one that emitted something misleading rather than erroring.

## The change

The issue's **first** option (diagnose), which it ranks as the cheap fix that stops the silent case. The error names the function, the position, both consequences, and the two things an author can write instead:

```
fn `read_try`: `Result<_, Reading>` — `Reading` is declared `sealed_class!`, but nothing
decomposes it in the error position, so it would be delivered as `e.to_string()` on the
plain binding-error channel rather than as the sealed hierarchy (and would silently require
`Reading: Display`). Declare `expand_return!(Reading)` with the fields to deliver, so the
error crosses through the typed domain-handler channel; or, if a text message really is what
you want, drop the `sealed_class!` declaration for this type
```

It joins the two existing rejections in the same `validate` walk, so all three unsupported sum positions now fail the same way — by name, at the declaration.

**Why it stays pre-resolve:** the declaration set is the whole story. An error plan can only come from a **type-level** `expand_return!` (auto-applied to every fn with that `E`), because a per-fn `.expand_return(...)` always targets the Output position — `build_deconstructors` pushes `DeconTarget::Output` unconditionally for `fn_return_expands`. So no resolve-time state is needed to know whether the sum will be decomposed.

## Coverage

- The rejection: asserts it names the function, the position, both consequences, and the fix.
- **Its counterpart** — a sum error type *with* a type-level deconstructor still resolves. Without this the diagnostic could silently become a blanket ban on sums in the error position, which is the opposite of what #162 wants.

`cargo test --all --all-features` (373 lib tests), `regen-check.sh` clean (no generated output moves — this only rejects), `cargo fmt --check`, `clippy --deny warnings` clean.

## Left open on #162

The **real feature**: giving the domain-error channel (`registry.error_plans` / `error_handler_iface_spec`) the same tag + groups treatment #150 gave the output channel. The error handler is already builder-shaped (`run(leaves…): R`), so the leaf machinery should carry over; what is missing is the selector on that lane. `ReplyResult`-shaped error types are exactly what a sum is for, so this is worth doing — it is just a materially larger change than the diagnostic, and the diagnostic is what stops the silent case today. Keeping #162 open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
