### PR TITLE
jnigen: pin the two untested sum positions (#161)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -303,6 +303,28 @@ re-asserted inside its own live arm. Primitive slots keep their `0`/`false` defa
 handle payload rides its raw `jlong`, so an inert handle group is the `0L` sentinel that is simply
 never wrapped.
 
+**Who closes a handle payload: the receiver, in both positions.** A sum payload is a plan **leaf**,
+so it takes `WrapKind::Handle` — the generated code wraps the pointer into its typed handle class
+and stops there. It does *not* take the `WrapKind::HandleOwned` contract that a plan-less
+`impl Fn(Handle)` argument gets, where the proxy also `close()`s the handle in a `finally`
+(close-unless-taken). So:
+
+- a **returned** sum hands over a handle the caller owns and must `close()`;
+- a sum delivered to a **callback** does the same — the handle is live for the duration of `run` and
+  stays live after it returns, and closing it is the receiver's job.
+
+The two positions agree, which is the point: the reassembly comes from one derivation, so the
+ownership contract cannot differ between them. Both are exercised on the JVM in
+`examples/covertest-kotlin` ("sum return with a handle payload", "sum with a handle payload
+delivered to a callback"), the latter asserting the handle is usable inside `run` and still
+closeable afterwards.
+
+**A borrowed sum return (`&E`, `Option<&E>`) crosses like an owned one.** `unfold::returns_type`
+peels the leading `&` and `wire_fixed_returns` records `by_ref`, so the encoder matches *through*
+the reference instead of moving the value out of its owner; each live group clones what it needs.
+Kotlin therefore receives an ordinary value with no borrow to track and nothing to close — the
+borrow never crosses the boundary — and the owner is unchanged and can be read again.
+
 ### 4.6 Rejections
 
 Generation errors, each naming the offending path:

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -469,6 +469,13 @@ fn main() {
                 .fun(fun!(reading_series))
                 .fun(fun!(reading_each))
                 .fun(fun!(lookup_of))
+                // #161: the two positions the four above do not reach — a
+                // handle-carrying sum arriving through a CALLBACK, and a sum
+                // returned BORROWED (`&E` / `Option<&E>`).
+                .fun(fun!(lookup_each))
+                .fun(fun!(archive_set_reading))
+                .fun(fun!(archive_reading))
+                .fun(fun!(archive_reading_maybe))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -52,6 +52,11 @@ Base package: `io.prebindgen.covertest`
 - `annotated_payload_value` — `fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>): Double`
 - `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority?`
 - `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long?`
+- `archive_reading` — `fun archiveReading(a: SummaryVault, onError: JniErrorHandler<Reading>): Reading`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `archive_reading_maybe` — `fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading?`
+  - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `archive_set_reading` — `fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandler<Unit>)`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
@@ -59,6 +64,7 @@ Base package: `io.prebindgen.covertest`
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
+- `lookup_each` — `fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>)`
 - `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
   - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -711,6 +711,12 @@ internal object CovNative {
 
     external fun archiveNew(errorSink: Any): Long
 
+    external fun archiveReading(a: Long, build: Any, errorSink: Any): Any?
+
+    external fun archiveReadingMaybe(a: Long, build: Any, errorSink: Any): Any?
+
+    external fun archiveSetReading(a: Long, which: Int, errorSink: Any)
+
     external fun archiveStore(
         a: Long,
         sSel: Int,
@@ -745,6 +751,8 @@ internal object CovNative {
     external fun escape_probe_value(p: Long, errorSink: Any): Long
 
     external fun labelReverse(l: String, errorSink: Any): String
+
+    external fun lookupEach(n: Long, total: Double, sink: Any, errorSink: Any)
 
     external fun lookupOf(count: Long, total: Double, build: Any, errorSink: Any): Any?
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -8,8 +8,10 @@ import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.__u64FolderRawHolder
 import io.prebindgen.covertest.analytics.Summary
+import io.prebindgen.covertest.analytics.SummaryVault
 import io.prebindgen.covertest.asRaw
 import io.prebindgen.covertest.u64Callback
+import io.prebindgen.covertest.withSortedHandleLocks
 
 public interface PriorityKind {
     val value: Int
@@ -708,6 +710,24 @@ public value class Stamp(public val bytes: ByteArray) {
     }
 }
 
+public fun interface LookupCallback {
+    public fun run(lookup: Lookup)
+}
+
+public fun interface LookupCallbackRaw {
+    public fun run(tag: Int, found_v0: Long, failed_v0: String?)
+}
+
+public fun LookupCallback.asRaw(): LookupCallbackRaw =
+    LookupCallbackRaw {
+        tag,
+        found_v0,
+        failed_v0 ->
+        run(
+            when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
+        )
+    }
+
 public fun interface ReadingCallback {
     public fun run(reading: Reading)
 }
@@ -1278,6 +1298,76 @@ public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>
     val __ret = CovNative.lookupOf(count, total, __LookupBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as Lookup
+}
+
+/**
+ * A handle-carrying sum as a **callback argument** — the same `Lookup` that
+ * [`lookup_of`] returns, arriving through `impl Fn` instead. Alternatives are
+ * delivered in turn (`Failed`, `Absent`, `Found`, then `Found` again), so a
+ * live group hands a native resource to the callback while the inert groups'
+ * slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
+ * but not closed by the proxy: it is the callback body's to close, exactly as
+ * for a returned sum.
+ */
+public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.lookupEach(n, total, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Store the `which` alternative as the archive's own reading, and the same one
+ * as its optional fallback. A **negative** `which` clears the fallback and
+ * resets the reading to the first alternative, so the two borrow shapes can be
+ * exercised independently: `&Reading` always has a value, `Option<&Reading>`
+ * does not.
+ */
+public fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandler<Unit>) {
+    if (a.isClosed()) { onError.run("Operation on a closed native handle."); return }
+    val __bcap = JniErrorHandlerCapture.acquire()
+    withSortedHandleLocks(a) {
+        val a_ptr = a.ptr
+        CovNative.archiveSetReading(a_ptr, which, __bcap)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * A sum returned **borrowed** (`&Reading`). The value stays owned by the
+ * archive; the binding decomposes it in place — the encoder matches through
+ * the reference instead of consuming — and the caller gets an ordinary
+ * Kotlin value with no borrow to track.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun archiveReading(a: SummaryVault, onError: JniErrorHandler<Reading>): Reading {
+    if (a.isClosed()) return onError.run("Operation on a closed native handle.")
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = withSortedHandleLocks(a) {
+        val a_ptr = a.ptr
+        CovNative.archiveReading(a_ptr, __ReadingBuilder, __bcap)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Reading
+}
+
+/**
+ * The optional layer over the same borrow (`Option<&Reading>`): `None` nulls
+ * the whole result, exactly as for an owned `Option<Reading>`.
+ *
+ * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading? {
+    if (a.isClosed()) return onError.run("Operation on a closed native handle.")
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = withSortedHandleLocks(a) {
+        val a_ptr = a.ptr
+        CovNative.archiveReadingMaybe(a_ptr, __ReadingBuilder, __bcap)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Reading?
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1303,9 +1303,10 @@ public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>
 /**
  * A handle-carrying sum as a **callback argument** — the same `Lookup` that
  * [`lookup_of`] returns, arriving through `impl Fn` instead. Alternatives are
- * delivered in turn (`Failed`, `Absent`, `Found`, then `Found` again), so a
- * live group hands a native resource to the callback while the inert groups'
- * slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
+ * delivered in `count` order starting at `-1`, so `n >= 3` covers all three:
+ * `Failed` (`i = 0`), `Absent` (`i = 1`), then `Found` with an increasing
+ * count. A live group hands a native resource to the callback while the inert
+ * groups' slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
  * but not closed by the proxy: it is the callback body's to close, exactly as
  * for a returned sum.
  */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -56,7 +56,11 @@ import io.prebindgen.covertest.model.objectBoundaryValue
 import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.observationWhich
+import io.prebindgen.covertest.model.lookupEach
 import io.prebindgen.covertest.model.lookupOf
+import io.prebindgen.covertest.model.archiveReading
+import io.prebindgen.covertest.model.archiveReadingMaybe
+import io.prebindgen.covertest.model.archiveSetReading
 import io.prebindgen.covertest.model.readingEach
 import io.prebindgen.covertest.model.readingMaybe
 import io.prebindgen.covertest.model.readingOf
@@ -465,6 +469,75 @@ fun main() {
         check(summary.total(boom) == 7.5)
         summary.close()
         check(summary.isClosed())
+    }
+
+    // The same handle-carrying sum arriving through a CALLBACK rather than as a
+    // return. A sum payload is a plan LEAF, so the generated proxy WRAPS the
+    // pointer but does not `close()` it — unlike a plan-less `impl Fn(Handle)`
+    // arg, which closes in a `finally`. So the handle is live for as long as the
+    // receiver keeps it and is the caller's to close, exactly as for a returned
+    // sum. That contract is what this pins (#161).
+    section("sum with a handle payload delivered to a callback") {
+        val seen = mutableListOf<String>()
+        val kept = mutableListOf<Summary>()
+        lookupEach(3L, 2.5, { lookup ->
+            when (lookup) {
+                is Lookup.Failed -> seen.add("failed:${lookup.v0}")
+                Lookup.Absent -> seen.add("absent")
+                is Lookup.Found -> {
+                    val s = lookup.v0
+                    // Live INSIDE the callback: the live group's handle is a real
+                    // native object, not the inert `0L` sentinel.
+                    check(!s.isClosed())
+                    check(s.total(boom) == 2.5)
+                    seen.add("found:${s.count(boom)}")
+                    kept.add(s)
+                }
+            }
+        }, boom)
+        check(seen == listOf("failed:negative count", "absent", "found:1"))
+
+        // Still live AFTER the call returns — the proxy did not close it — and
+        // closeable by the receiver that kept it.
+        check(kept.size == 1)
+        val s = kept[0]
+        check(!s.isClosed())
+        check(s.count(boom) == 1L)
+        s.close()
+        check(s.isClosed())
+    }
+
+    // A sum returned BORROWED (`&Reading` / `Option<&Reading>`). The value stays
+    // owned by the archive; the encoder matches THROUGH the reference and clones
+    // what each live group needs, so Kotlin gets an ordinary value with no
+    // borrow to track and the owner can be read again afterwards (#161).
+    section("borrowed sum returns") {
+        val vault = archiveNew(boom)
+
+        // Every alternative, read back through `&Reading`.
+        archiveSetReading(vault, 0, boom)
+        check(archiveReading(vault, boom) === Reading.Missing)
+        archiveSetReading(vault, 1, boom)
+        check((archiveReading(vault, boom) as Reading.Exact).v0 == 42L)
+        archiveSetReading(vault, 2, boom)
+        val range = archiveReading(vault, boom) as Reading.Range
+        check(range.low == 1L && range.high == 9L)
+        archiveSetReading(vault, 3, boom)
+        val tagged = archiveReading(vault, boom) as Reading.Tagged
+        check(tagged.v0 == "warm" && tagged.v1 == Priority.HIGH)
+
+        // Borrowing does not consume: the same archive answers again, and the
+        // value it still owns is unchanged.
+        check((archiveReading(vault, boom) as Reading.Tagged).v0 == "warm")
+
+        // `Option<&Reading>`: the present layer nulls the whole result, staying
+        // independent of the tag.
+        check(archiveReadingMaybe(vault, boom) != null)
+        archiveSetReading(vault, -1, boom)
+        check(archiveReadingMaybe(vault, boom) == null)
+        check(archiveReading(vault, boom) === Reading.Missing)
+
+        vault.close()
     }
 
     // ── a sum whose payload is NOT leaf-shaped ────────────────────────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2046,6 +2046,144 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_impl_Fn_Lookup_Send_Sync_static_4a65bc23<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Lookup) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Lookup)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(IJLjava/lang/String;)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Lookup)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Lookup| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Lookup)", e)))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Lookup)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __cb0_obj0: jni::sys::jvalue;
+                    let __cb0_obj1: jni::sys::jvalue;
+                    let __cb0_obj2: jni::objects::JObject;
+                    match &__cb_arg0 {
+                        perftest_flat::Lookup::Absent => {
+                            __cb0_obj0 = jni::sys::jvalue { i: 0 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj2 = jni::objects::JObject::null();
+                        }
+                        perftest_flat::Lookup::Found(__sv0) => {
+                            let __enc___cb0_obj1 = match Summary_to_jlong_3cb103b9(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj1 = jni::sys::jvalue {
+                                j: __enc___cb0_obj1,
+                            };
+                            __cb0_obj0 = jni::sys::jvalue { i: 1 };
+                            __cb0_obj2 = jni::objects::JObject::null();
+                        }
+                        perftest_flat::Lookup::Failed(__sv0) => {
+                            let __enc___cb0_obj2 = match String_to_JString_c7f3ca43(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj2 = __enc___cb0_obj2.into();
+                            __cb0_obj0 = jni::sys::jvalue { i: 2 };
+                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
+                        }
+                    }
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj2.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Lookup)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_95073668<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -8371,6 +8509,525 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveNew<'a>(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveReading<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    a: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let a = match jlong_to_Archive_cd73502c(&mut env, &a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
+    const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::archive_reading(&a);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    let __obj2: jni::sys::jvalue;
+    let __obj3: jni::sys::jvalue;
+    let __obj4: jni::objects::JObject;
+    let __obj5: jni::sys::jvalue;
+    let __obj6: jni::sys::jvalue;
+    match __out {
+        perftest_flat::Reading::Missing => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Exact(__sv0) => {
+            let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+            let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = jni::sys::jvalue {
+                j: __enc___obj2,
+            };
+            let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj3 = jni::sys::jvalue {
+                j: __enc___obj3,
+            };
+            __obj0 = jni::sys::jvalue { i: 2 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+            let __enc___obj4 = match String_to_JString_c7f3ca43(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj4 = __enc___obj4.into();
+            let __enc___obj5 = match Priority_to_jint_447102d2(&mut env, __sv1.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj5 = jni::sys::jvalue {
+                i: __enc___obj5,
+            };
+            __obj0 = jni::sys::jvalue { i: 3 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Companion(__sv0) => {
+            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj6 = jni::sys::jvalue {
+                j: __enc___obj6,
+            };
+            __obj0 = jni::sys::jvalue { i: 4 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { i: 0i32 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                __obj3,
+                jni::sys::jvalue {
+                    l: __obj4.as_raw(),
+                },
+                __obj5,
+                __obj6,
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveReadingMaybe<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    a: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let a = match jlong_to_Archive_cd73502c(&mut env, &a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
+    const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::archive_reading_maybe(&a);
+    match __out {
+        ::core::option::Option::Some(__inner) => {
+            let __obj0: jni::sys::jvalue;
+            let __obj1: jni::sys::jvalue;
+            let __obj2: jni::sys::jvalue;
+            let __obj3: jni::sys::jvalue;
+            let __obj4: jni::objects::JObject;
+            let __obj5: jni::sys::jvalue;
+            let __obj6: jni::sys::jvalue;
+            match __inner {
+                perftest_flat::Reading::Missing => {
+                    __obj0 = jni::sys::jvalue { i: 0 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Exact(__sv0) => {
+                    let __enc___obj1 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj1 = jni::sys::jvalue {
+                        j: __enc___obj1,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 1 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                    let __enc___obj2 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj2 = jni::sys::jvalue {
+                        j: __enc___obj2,
+                    };
+                    let __enc___obj3 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv1.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj3 = jni::sys::jvalue {
+                        j: __enc___obj3,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 2 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                    let __enc___obj4 = match String_to_JString_c7f3ca43(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj4 = __enc___obj4.into();
+                    let __enc___obj5 = match Priority_to_jint_447102d2(
+                        &mut env,
+                        __sv1.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj5 = jni::sys::jvalue {
+                        i: __enc___obj5,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 3 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj6 = jni::sys::jvalue { j: 0i64 };
+                }
+                perftest_flat::Reading::Companion(__sv0) => {
+                    let __enc___obj6 = match i64_to_jlong_fbf9a9bc(
+                        &mut env,
+                        __sv0.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __obj6 = jni::sys::jvalue {
+                        j: __enc___obj6,
+                    };
+                    __obj0 = jni::sys::jvalue { i: 4 };
+                    __obj1 = jni::sys::jvalue { j: 0i64 };
+                    __obj2 = jni::sys::jvalue { j: 0i64 };
+                    __obj3 = jni::sys::jvalue { j: 0i64 };
+                    __obj4 = jni::objects::JObject::null();
+                    __obj5 = jni::sys::jvalue { i: 0i32 };
+                }
+            }
+            match __CB_MID
+                .call_object(
+                    &mut env,
+                    __CB_FQN,
+                    "run",
+                    __CB_DESCR,
+                    &__builder,
+                    &[
+                        __obj0,
+                        __obj1,
+                        __obj2,
+                        __obj3,
+                        jni::sys::jvalue {
+                            l: __obj4.as_raw(),
+                        },
+                        __obj5,
+                        __obj6,
+                    ],
+                )
+            {
+                ::core::result::Result::Ok(__o) => __o,
+                ::core::result::Result::Err(__e) => {
+                    let _ = env.exception_describe();
+                    let __e2 = <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string());
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e2.to_string(),
+                    );
+                    jni::objects::JObject::null().into()
+                }
+            }
+        }
+        ::core::option::Option::None => jni::objects::JObject::null().into(),
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveSetReading<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    a: jni::sys::jlong,
+    which: jni::sys::jint,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let mut a = match jlong_to_Archive_cd73502c(&mut env, &a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::archive_set_reading(&mut a, which);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -9019,6 +9676,81 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
                 &__e.to_string(),
             );
             jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_lookupEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match JObject_to_impl_Fn_Lookup_Send_Sync_static_4a65bc23(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::lookup_each(n, total, sink);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -256,9 +256,10 @@ pub fn lookup_of(count: i64, total: f64) -> Lookup {
 
 /// A handle-carrying sum as a **callback argument** — the same `Lookup` that
 /// [`lookup_of`] returns, arriving through `impl Fn` instead. Alternatives are
-/// delivered in turn (`Failed`, `Absent`, `Found`, then `Found` again), so a
-/// live group hands a native resource to the callback while the inert groups'
-/// slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
+/// delivered in `count` order starting at `-1`, so `n >= 3` covers all three:
+/// `Failed` (`i = 0`), `Absent` (`i = 1`), then `Found` with an increasing
+/// count. A live group hands a native resource to the callback while the inert
+/// groups' slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
 /// but not closed by the proxy: it is the callback body's to close, exactly as
 /// for a returned sum.
 #[prebindgen]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -254,6 +254,20 @@ pub fn lookup_of(count: i64, total: f64) -> Lookup {
     }
 }
 
+/// A handle-carrying sum as a **callback argument** — the same `Lookup` that
+/// [`lookup_of`] returns, arriving through `impl Fn` instead. Alternatives are
+/// delivered in turn (`Failed`, `Absent`, `Found`, then `Found` again), so a
+/// live group hands a native resource to the callback while the inert groups'
+/// slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
+/// but not closed by the proxy: it is the callback body's to close, exactly as
+/// for a returned sum.
+#[prebindgen]
+pub fn lookup_each(n: i64, total: f64, sink: impl Fn(Lookup) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(lookup_of(i - 1, total));
+    }
+}
+
 /// Which alternative an [`Observation`]'s `reading` holds, by declaration
 /// order — the sum crossing back **in** as part of a data-class parameter.
 #[prebindgen]
@@ -1047,9 +1061,24 @@ pub fn storage_emit(n: i64, h: &StorageHandler) {
 /// **borrowed** — the shape zenoh-flat's `z_*` accessors use for the C tier's
 /// zero-copy borrows — which the JVM binding lowers by **cloning** into a fresh
 /// owned handle (the JVM keeps its handle past the call).
-#[derive(Default)]
 pub struct Archive {
     latest: Option<Summary>,
+    /// A sum the archive OWNS, so it can hand one back **borrowed** (`&Reading`)
+    /// — the return shape whose encoder must match on the value behind the
+    /// reference rather than moving it.
+    reading: Reading,
+    /// The same, optional, for the `Option<&Reading>` shape.
+    fallback: Option<Reading>,
+}
+
+impl Default for Archive {
+    fn default() -> Self {
+        Self {
+            latest: None,
+            reading: Reading::Missing,
+            fallback: None,
+        }
+    }
 }
 
 /// Create an empty archive.
@@ -1062,6 +1091,33 @@ pub fn archive_new() -> Archive {
 #[prebindgen]
 pub fn archive_store(a: &mut Archive, s: Summary) {
     a.latest = Some(s);
+}
+
+/// Store the `which` alternative as the archive's own reading, and the same one
+/// as its optional fallback. A **negative** `which` clears the fallback and
+/// resets the reading to the first alternative, so the two borrow shapes can be
+/// exercised independently: `&Reading` always has a value, `Option<&Reading>`
+/// does not.
+#[prebindgen]
+pub fn archive_set_reading(a: &mut Archive, which: i32) {
+    a.reading = reading_for(which.max(0));
+    a.fallback = (which >= 0).then(|| reading_for(which));
+}
+
+/// A sum returned **borrowed** (`&Reading`). The value stays owned by the
+/// archive; the binding decomposes it in place — the encoder matches through
+/// the reference instead of consuming — and the caller gets an ordinary
+/// Kotlin value with no borrow to track.
+#[prebindgen]
+pub fn archive_reading(a: &Archive) -> &Reading {
+    &a.reading
+}
+
+/// The optional layer over the same borrow (`Option<&Reading>`): `None` nulls
+/// the whole result, exactly as for an owned `Option<Reading>`.
+#[prebindgen]
+pub fn archive_reading_maybe(a: &Archive) -> Option<&Reading> {
+    a.fallback.as_ref()
 }
 
 /// The stored summary, borrowed (`Option<&Summary>` **return** — `None` when

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -787,6 +787,22 @@ fn sum_returns(tag: &str) -> (String, String) {
             )),
             loc.clone(),
         ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_borrowed(p: &Probe) -> &Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_borrowed_maybe(p: &Probe) -> Option<&Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
     ];
     let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
@@ -799,7 +815,9 @@ fn sum_returns(tag: &str) -> (String, String) {
             .fun(crate::fun!(read_maybe))
             .fun(crate::fun!(read_all))
             .fun(crate::fun!(look_up))
-            .fun(crate::fun!(read_each)),
+            .fun(crate::fun!(read_each))
+            .fun(crate::fun!(read_borrowed))
+            .fun(crate::fun!(read_borrowed_maybe)),
     );
 
     let dir = unique_test_dir(tag);
@@ -893,6 +911,54 @@ fn sum_return_emits_one_match_with_wire_defaults() {
     assert!(
         body.contains("jni :: objects :: JObject :: null ()") || body.contains("JObject::null()"),
         "an inert object slot is wire-defaulted to null:\n{body}"
+    );
+}
+
+/// A sum returned **borrowed** (`&E`, `Option<&E>`). `unfold::returns_type`
+/// peels the leading `&` and `wire_fixed_returns` records `by_ref`, so the
+/// encoder matches THROUGH the reference rather than moving the value out of
+/// the owner. Each live group then clones what it needs, and Kotlin receives an
+/// ordinary value with no borrow to track — the borrow never crosses (#161).
+#[test]
+fn borrowed_sum_return_matches_through_the_reference() {
+    let (rust, kotlin) = sum_returns("jnigen_sum_borrowed");
+
+    for extern_fn in ["readBorrowed", "readBorrowedMaybe"] {
+        let at = rust
+            .find(&format!("fn Java_io_test_jni_JNINative_{extern_fn}"))
+            .unwrap_or_else(|| panic!("{extern_fn} extern missing:\n{rust}"));
+        let body = &rust[at..at + 4000];
+        // The value is borrowed from its owner, and the match is over that
+        // borrow — never `match __out` on a moved value.
+        assert!(
+            body.contains("match __out") || body.contains("match &__out"),
+            "{extern_fn}: one match over the borrowed value:\n{body}"
+        );
+        assert!(
+            body.contains("myflat::Reading::Missing =>"),
+            "{extern_fn}: arms bind each variant through the reference:\n{body}"
+        );
+        // A payload reached through a borrow cannot be moved out, so the live
+        // group clones it.
+        assert!(
+            body.contains(".clone()"),
+            "{extern_fn}: a borrowed group's payload is cloned, not moved:\n{body}"
+        );
+    }
+
+    // Kotlin sees a plain value / nullable value — a borrowed sum is not a
+    // handle, so there is nothing to close and no lifetime to track.
+    assert!(
+        kotlin.contains(
+            "public fun readBorrowed(p: Probe, onError: JniErrorHandler<Reading>): Reading"
+        ),
+        "a borrowed sum arrives as an ordinary value:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains(
+            "public fun readBorrowedMaybe(p: Probe, onError: JniErrorHandler<Reading?>): Reading?"
+        ),
+        "and the optional layer only nulls the whole result:\n{kotlin}"
     );
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -928,11 +928,18 @@ fn borrowed_sum_return_matches_through_the_reference() {
             .find(&format!("fn Java_io_test_jni_JNINative_{extern_fn}"))
             .unwrap_or_else(|| panic!("{extern_fn} extern missing:\n{rust}"));
         let body = &rust[at..at + 4000];
-        // The value is borrowed from its owner, and the match is over that
-        // borrow — never `match __out` on a moved value.
+        // The value is borrowed from its owner, so the encoder matches the
+        // binding DIRECTLY — `by_ref` is already reflected in `__out`'s type.
+        // Asserted exactly: a bare `contains("match __out")` would also accept
+        // `match __out2`, and accepting `match &__out` as an alternative would
+        // let a regression to double-referencing the borrow pass silently.
         assert!(
-            body.contains("match __out") || body.contains("match &__out"),
+            body.contains("match __out {"),
             "{extern_fn}: one match over the borrowed value:\n{body}"
+        );
+        assert!(
+            !body.contains("match &__out"),
+            "{extern_fn}: a borrowed return must not take a second reference:\n{body}"
         );
         assert!(
             body.contains("myflat::Reading::Missing =>"),


### PR DESCRIPTION
Closes #161. Part of the sum-type umbrella #152.

**Base:** `sum-types-a-core` (#153) — `sum-types` is the docs commit alone and has no jnigen sum support. Still reaches `main` through the umbrella.

Both positions resolved and emitted already; nothing exercised them, so their behaviour was inferred. Now observed on a real JVM, and the contracts they imply are written down.

## 1. A handle payload delivered through a callback

The issue's inference was right, and the generated proxy shows it plainly:

```kotlin
public fun LookupCallback.asRaw(): LookupCallbackRaw =
    LookupCallbackRaw { tag, found_v0, failed_v0 ->
        run(when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); … })
    }
```

Wrapped, not closed — no `finally`. A sum payload is a plan **leaf**, so it takes `WrapKind::Handle`, not the `WrapKind::HandleOwned` close-unless-taken contract a plan-less `impl Fn(Handle)` argument gets. The receiver owns the handle, exactly as for a returned sum.

`perftest-flat` gains `lookup_each`, delivering `Failed` / `Absent` / `Found` in turn. The covertest section asserts the live group's handle is usable **inside** `run`, still live **after** the call returns, and closeable by the receiver that kept it — and that the inert groups' slots never surface as handles.

### On the open question

> Worth checking at the same time whether the transient/`HandleOwned` contract is the better default here: a callback argument is conventionally borrowed for the duration of the call.

**Keeping `Handle`.** Switching would make a sum payload's ownership depend on *where the sum appears* — owned when returned, borrowed when delivered to a callback. Right now both positions reassemble from one derivation, which is what guarantees they cannot disagree; making them differ deliberately would give that up for a convention the sum lowering does not otherwise follow. Happy to revisit if you'd rather have the borrow semantics.

## 2. Borrowed sum returns (`&E`, `Option<&E>`)

`Archive` gains a `Reading` it owns plus an optional one, with `archive_reading` / `archive_reading_maybe` handing them back borrowed. Confirmed generated shape:

```rust
let __out = perftest_flat::archive_reading(&a);
match __out {
    perftest_flat::Reading::Missing => { … }
    perftest_flat::Reading::Exact(__sv0) => { … __sv0.clone() … }
```

The encoder matches **through** the reference rather than moving the value out of its owner, and each live group clones what it needs. Kotlin gets an ordinary value with no borrow to track and nothing to close — the borrow never crosses. The covertest section reads every alternative, then reads the same archive **again** to show borrowing did not consume it, and checks that `Option<&E>` nulls the whole result independently of the tag.

The issue notes a borrowed sum has no obvious owner for a handle payload; `Reading`'s payloads are leaves, and the handle-payload case is covered on the owned path (`Lookup`), so that doubly-untested combination is still not exercised — worth its own case if it ever has a natural signature.

## Coverage

- **`covertest-kotlin`: 43 sections, all green on the JVM** (was 41).
- A lib test asserting the borrowed encoder's match-through-reference and clone for both `&E` and `Option<&E>`, plus the plain-value Kotlin signatures.
- `docs/sum-types.md` §4.5 gains both rules — who closes a handle payload (the receiver, in both positions, and *why* they agree) and what a borrowed return costs (nothing).

`cargo test --all --all-features`, `regen-check.sh` clean, `cargo fmt --check`, `clippy --deny warnings` clean.

## One fixture note

`archive_set_reading` treats a negative `which` as "clear the fallback, reset the reading to the first alternative", so `&Reading` (always present) and `Option<&Reading>` (sometimes absent) can be driven independently from one setter. My first version reused `reading_for(which)` directly and I had assumed `-1` meant `Missing` — it falls to the `_` arm and yields `Companion`, which the JVM run caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
