### PR TITLE
jnigen: derive data-class property types from the struct plan (#156)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -85,8 +85,10 @@ pub(crate) fn build_data_class(
     // disagree with its own factory parameter (#156).
     let plan = build_struct_plan(ext, registry, item_struct, 0).unwrap_or_else(|| {
         panic!(
-            "data class `{}`: could not classify every field for the fromParts bridge — each \
-             field needs a resolved OUTPUT converter (it declares the slot the encoder fills)",
+            "data class `{}`: could not classify every field for the fromParts bridge. Each \
+             field needs a resolved OUTPUT converter (that direction declares the slot the \
+             encoder fills) AND the Kotlin metadata that converter carries — a `kotlin_name`, \
+             or a registered class for a projection leaf",
             item_struct.ident
         )
     });

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -79,12 +79,24 @@ pub(crate) fn build_data_class(
         }
     };
 
+    // The class declaration is derived from the SAME plan the `fromParts`
+    // factory and the Rust encoder walk. Deriving it separately — a third
+    // classification with its own rules — is what let a property's type
+    // disagree with its own factory parameter (#156).
+    let plan = build_struct_plan(ext, registry, item_struct, 0).unwrap_or_else(|| {
+        panic!(
+            "data class `{}`: could not classify every field for the fromParts bridge — each \
+             field needs a resolved OUTPUT converter (it declares the slot the encoder fills)",
+            item_struct.ident
+        )
+    });
+
     let mut ctor_params: Vec<kt::KtCtorParam> = Vec::new();
     // Track per-field destructible (name, folded close strategy) so the
     // bottom emitter can produce a matching `close()` body for each.
     let mut destructible_fields: Vec<(String, crate::api::lang::jnigen::jni::FoldStrategy)> =
         Vec::new();
-    for field in fields_named {
+    for (field, pf) in fields_named.iter().zip(&plan.fields) {
         let field_ident = field.ident.as_ref().unwrap_or_else(|| {
             panic!(
                 "render_data_class_source: struct `{}` has an unnamed field in named-fields context",
@@ -92,76 +104,42 @@ pub(crate) fn build_data_class(
             )
         });
         let kotlin_field_name = mangle_kotlin_ident(&kt_snake_to_camel(&field_ident.to_string()));
+        let owner = format!("{}.{}", item_struct.ident, field_ident);
 
-        // Projection field (opaque handle or value class): the typed Kotlin
-        // type (`ZKeyExpr?`, `List<ZKeyExpr>`, `ZenohId`, `List<ZenohId>`, …)
-        // is derived from the folded `Projection` the type-unfolding mechanism
-        // propagated onto this field's converter metadata, instead of a
-        // syntactic `Option<T>` peel. Closeable `close()` emission applies
-        // only to `Handle` kind (and only when owned); value classes are
-        // erased to their inner wire, so they never close.
-        let field_projection = registry
-            .output_entry(&field.ty)
-            .and_then(|e| e.metadata.projection.clone())
-            .or_else(|| {
-                registry
-                    .input_entry(&field.ty)
-                    .and_then(|e| e.metadata.projection.clone())
-            });
-        if let Some(h) = field_projection {
-            let leaf = projection_leaf_kt(ext, &h).unwrap_or_else(|| {
-                panic!(
-                    "render_data_class_source: projection field `{}.{}` leaf `{}` has no \
-                         Kotlin FQN registered (ptr_class / value_class)",
-                    item_struct.ident, field_ident, h.leaf_key
-                )
-            });
-            ctor_params.push(
-                kt::KtCtorParam::new(&kotlin_field_name, handle_kt_type(&h.strategy, &leaf)).val(),
-            );
-            if matches!(
-                h.kind,
-                crate::api::lang::jnigen::jni::ProjectionKind::Handle
-            ) && h.owned
+        // The declaration reads ONE direction — output — because that is the
+        // direction that declares the `fromParts` slots the encoder fills, and
+        // it is the direction both plans already use exclusively
+        // (`build_struct_plan` output-only, `flat_input.rs` input-only). A
+        // property whose type came from whichever direction happened to
+        // resolve, while its wire came from the other, is how the declaration
+        // drifted from the plans.
+        //
+        // A projection visible only on the INPUT side is exactly that drift
+        // made reachable: the old walk emitted a typed handle property (plus
+        // `AutoCloseable`) while the plan classified the same field as an
+        // ordinary leaf, so the property and its own factory parameter
+        // disagreed. Reject it at the declaration instead.
+        if !matches!(pf.kind, PlanFieldKind::Projection { .. }) {
+            if let Some(proj) = registry
+                .input_entry(&field.ty)
+                .and_then(|e| e.metadata.projection.clone())
             {
-                destructible_fields.push((kotlin_field_name, h.strategy));
+                panic!(
+                    "data class field `{owner}`: the INPUT converter projects this field as `{:?}` \
+                     but the OUTPUT converter does not, so the property type and its own \
+                     `fromParts` parameter would disagree. The output direction declares the \
+                     bridge, so give the field an output converter with the same projection — or \
+                     drop the input-side projection",
+                    proj.kind
+                );
             }
-            continue;
         }
 
-        let kotlin_ty = registry
-            .output_entry(&field.ty)
-            .and_then(|e| e.metadata.kotlin_name.clone())
-            .or_else(|| registry.input_entry(&field.ty).and_then(|e| e.metadata.kotlin_name.clone()))
-            .unwrap_or_else(|| {
-                panic!(
-                    "render_data_class_source: field `{}.{}` has no Kotlin type mapping; register converters before declaring data_class",
-                    item_struct.ident,
-                    field_ident
-                )
-            });
-        let ty = kotlin_ty;
-        // `Option<T>` whose wire is a JNI primitive (jlong/jint/jboolean/…)
-        // and that *isn't* an opaque handle (handled above) is encoded by
-        // the struct emitter as the bare primitive with a sentinel for
-        // `None` (0 / 0.0 / false). The Kotlin field must match that JVM
-        // slot: declare it non-nullable so the constructor signature
-        // stays primitive (`J` vs `Ljava/lang/Long;`). Nullable boxing
-        // for non-handle primitives would require generator-side changes
-        // in `struct_output_body` to `Long.valueOf(...)`.
-        let wire = registry
-            .output_entry(&field.ty)
-            .map(|e| e.destination.clone());
-        let primitive_wire = wire
-            .as_ref()
-            .map(crate::api::lang::jnigen::jni::is_jni_primitive)
-            .unwrap_or(false);
-        let ty = if is_option_type(&field.ty) && !primitive_wire {
-            ty.nullable()
-        } else {
-            ty
-        };
-        ctor_params.push(kt::KtCtorParam::new(&kotlin_field_name, ty).val());
+        ctor_params
+            .push(kt::KtCtorParam::new(&kotlin_field_name, pf.kind.property_type(&owner)).val());
+        if let Some(strategy) = pf.kind.destructible() {
+            destructible_fields.push((kotlin_field_name, strategy));
+        }
     }
 
     // `fromParts` companion factory — recursively flattened the same way as the

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -353,7 +353,8 @@ impl PlanFieldKind {
             } => {
                 let fqn = child_fqn.as_ref().unwrap_or_else(|| {
                     panic!(
-                        "data class property `{owner}`: nested data-class field has no registered                          Kotlin class — declare the child type in a package"
+                        "data class property `{owner}`: nested data-class field has no \
+                         registered Kotlin class — declare the child type in a package"
                     )
                 });
                 let t = kt::KtType::cls(fqn);

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -324,6 +324,89 @@ pub(crate) fn classify_field(
     }
 }
 
+impl PlanFieldKind {
+    /// The Kotlin type of the `data class` **constructor property** this field
+    /// becomes.
+    ///
+    /// The class declaration, the `fromParts` factory and the Rust encoder are
+    /// three views of one classification, so all three read it from here — the
+    /// module docs' "agree by construction instead of by hand-synchronized
+    /// parallel walks" applied to the declaration too (#156). Deriving it
+    /// separately is what let a property's type disagree with its own
+    /// factory parameter.
+    ///
+    /// `owner` is the dotted path used in diagnostics.
+    pub(crate) fn property_type(&self, owner: &str) -> kt::KtType {
+        match self {
+            // A projection's typed surface is its folded shape over the leaf
+            // class (`ZKeyExpr?`, `List<ZKeyExpr>`, `ULong`), which the plan
+            // already resolved into `fqn`.
+            PlanFieldKind::Projection { proj, fqn, .. } => {
+                handle_kt_type(&proj.strategy, &kt::KtType::cls(fqn))
+            }
+            PlanFieldKind::Enum { kotlin, .. } => kotlin.clone(),
+            PlanFieldKind::OptionEnum { kotlin, .. } => kotlin.clone().nullable(),
+            PlanFieldKind::Nested {
+                optional,
+                child_fqn,
+                ..
+            } => {
+                let fqn = child_fqn.as_ref().unwrap_or_else(|| {
+                    panic!(
+                        "data class property `{owner}`: nested data-class field has no registered                          Kotlin class — declare the child type in a package"
+                    )
+                });
+                let t = kt::KtType::cls(fqn);
+                if *optional {
+                    t.nullable()
+                } else {
+                    t
+                }
+            }
+            PlanFieldKind::Sum {
+                kotlin_fqn,
+                optional,
+                ..
+            } => {
+                let t = kt::KtType::cls(kotlin_fqn);
+                if *optional {
+                    t.nullable()
+                } else {
+                    t
+                }
+            }
+            // `nullable` is the plan's own rule — an `Option` field whose wire
+            // is object-shaped. An `Option` over a PRIMITIVE wire stays
+            // non-null, because the encoder passes the bare primitive with a
+            // sentinel and the JVM slot must match (`J`, not `Ljava/lang/Long;`).
+            PlanFieldKind::Leaf {
+                kotlin, nullable, ..
+            } => {
+                if *nullable {
+                    kotlin.clone().nullable()
+                } else {
+                    kotlin.clone()
+                }
+            }
+        }
+    }
+
+    /// The close strategy when this field owns a native handle, so the class
+    /// implements `AutoCloseable` and `close()` walks it. Only an **owned**
+    /// `Handle` projection qualifies: a value blob is erased to its inner wire
+    /// and owns nothing, and a borrowed handle is not this object's to release.
+    pub(crate) fn destructible(&self) -> Option<FoldStrategy> {
+        match self {
+            PlanFieldKind::Projection { proj, .. }
+                if matches!(proj.kind, ProjectionKind::Handle) && proj.owned =>
+            {
+                Some(proj.strategy.clone())
+            }
+            _ => None,
+        }
+    }
+}
+
 /// Build the [`PlanFieldKind::Sum`] for a `sealed_class`-declared enum: one
 /// leaf group per variant, each payload classified through
 /// [`classify_field`].

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1328,3 +1328,105 @@ fn unsigned_scalars_use_lossless_kotlin_surface_and_raw_jni_wires() {
     assert!(kc.contains("fununsignedResult(value:ULong"), "{kotlin}");
     assert!(kc.contains("):ULong"), "{kotlin}");
 }
+
+/// A data class's constructor property types come from the SAME
+/// [`build_struct_plan`] its `fromParts` factory walks, so a property and its
+/// own factory parameter cannot disagree (#156). Pinned across the field kinds
+/// the plan distinguishes: a handle projection, a nested data class, a bare
+/// enum, and an `Option` leaf over an object-shaped wire.
+#[test]
+fn data_class_properties_match_their_from_parts_params() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Child {
+                    pub n: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Level {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Handle {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Bag {
+                    pub handle: Handle,
+                    pub child: Child,
+                    pub level: Level,
+                    pub note: Option<String>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bag_make() -> Bag {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bag_take(b: Bag) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::ptr_class!(Handle))
+            .class(crate::data_class!(Child))
+            .class(crate::enum_class!(Level))
+            .class(crate::data_class!(Bag))
+            .fun(crate::fun!(bag_make))
+            .fun(crate::fun!(bag_take)),
+    );
+
+    let dir = unique_test_dir("jnigen_data_class_props");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = registry.resolve(jni).expect("resolve");
+    let kotlin = generation
+        .write_kotlin(&dir.join("kotlin"))
+        .unwrap()
+        .iter()
+        .map(|path| std::fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    // The declaration: each property takes the plan's type for its kind.
+    assert!(kc.contains("valhandle:Handle"), "{kotlin}");
+    assert!(kc.contains("valchild:Child"), "{kotlin}");
+    assert!(kc.contains("vallevel:Level"), "{kotlin}");
+    assert!(kc.contains("valnote:String?"), "{kotlin}");
+    // An owned handle property makes the class closeable.
+    assert!(kc.contains("AutoCloseable"), "{kotlin}");
+    assert!(kc.contains("funclose()"), "{kotlin}");
+    // …and the factory reassembles into exactly those properties: the nested
+    // child is inlined as its own leaves, the handle arrives as a raw pointer
+    // and the enum as its discriminant, then each is rebuilt.
+    assert!(kc.contains("Bag(Handle(handle)"), "{kotlin}");
+    assert!(kc.contains("Child.fromParts(child_n)"), "{kotlin}");
+    assert!(kc.contains("Level.fromInt(level)"), "{kotlin}");
+}


### PR DESCRIPTION
Closes #156. Part of the sum-type umbrella #152.

**Base:** `sum-types-a-core` (#153) — the class emitter this touches was reshaped by #155, and `sum-types` is the docs commit alone. Still reaches `main` through the umbrella.

## The problem

`build_data_class` derived a data class's **constructor property types** with its own walk, while the `fromParts` factory those same properties feed was built from `build_struct_plan`. Two derivations of one fact — and `struct_plan.rs` exists precisely so both sides "agree by construction instead of by hand-synchronized parallel walks". The class *declaration* was a third walk that did not use it.

The second rule was also laxer, and mixed directions: the property's Kotlin type and projection fell back output → input, while the nullability decision shaping the *same* property read the output entry only. A property's type, its nullability and its wire slot are one decision.

## The change

The declaration now reads the plan:

```rust
let plan = build_struct_plan(ext, registry, item_struct, 0)…;
for (field, pf) in fields_named.iter().zip(&plan.fields) {
    ctor_params.push(KtCtorParam::new(&name, pf.kind.property_type(&owner)).val());
    if let Some(strategy) = pf.kind.destructible() { … }
}
```

Two accessors on `PlanFieldKind` in `struct_plan.rs` — the module that owns the classification:

- **`property_type()`** — the Kotlin type per kind: a projection's folded shape over its resolved leaf FQN, a nested class's registered FQN, an enum's `kotlin`, `Option<enum>` nullable, and a leaf's `kotlin` + the plan's own `nullable` (an `Option` over an object-shaped wire; an `Option` over a *primitive* wire stays non-null, because the encoder passes the bare primitive with a sentinel and the JVM slot must match `J`, not `Ljava/lang/Long;`).
- **`destructible()`** — the close strategy, `Some` only for an **owned** `Handle` projection. A value blob is erased to its inner wire and owns nothing; a borrowed handle is not this object's to release. Previously the same condition, now stated once beside the classification.

The output→input fallbacks are gone. Output is authoritative because it declares the `fromParts` slots the encoder fills, and it is the direction both plans already use exclusively (`build_struct_plan` output-only, `flat_input.rs` input-only) — so only this walk could disagree with them.

Net: **−68/+47 lines in `render.rs`**, with the classification moved to where it belongs.

## The rejections — and an honest caveat

Two guards are added at the drift points the issue names: a field with no resolved output converter is an error naming the class and the direction, and an input-only projection is an error naming the field and both sides.

**Neither is exercised, because I could not construct either through the public declaration API.** A declared `ptr_class` ends up with an output entry regardless of whether the source crate ever produces one, so "no output converter" never fires; and I found no declaration that yields a projection on the input entry but not the output entry. I wrote both tests, could not make them reach the guards, and deleted them rather than contort a fixture into asserting something it wasn't really testing.

So: the guards are cheap insurance at the exact point the drift would occur, and the issue asks for them — but treat them as unproven, not as verified behaviour. If you know a declaration shape that reaches either, I'll add the test.

The issue's own assessment matches this: *"For a plain leaf the fallback is likely dead… This has not been observed in an in-repo binding; it is reachable by construction, and nothing currently rejects it."*

## What IS tested

The regression test the issue asks for — a property's type and its own `fromParts` parameter type agree — across every field kind the plan distinguishes: an owned handle projection, a nested data class, a bare enum, and an `Option` leaf over an object wire. It asserts the declaration (`val handle: Handle`, `val child: Child`, `val level: Level`, `val note: String?`, `AutoCloseable` + `close()`) and the factory that feeds it (`Bag(Handle(handle), Child.fromParts(child_n), Level.fromInt(level), note)`) in one place.

## Verification

- **All in-repo generated Kotlin regenerates byte-identical** — `regen-check.sh` clean. The strictness is free here, as it was for sums in #155.
- `cargo test --all --all-features`, `cargo fmt --check`, `clippy --all-targets --no-default-features --all-features --deny warnings` clean.
- **`regen-check.sh --with-zenoh-flat-jni`: `ok: zenoh-flat-jni generated output is byte-identical`.** This is the check the issue specifically asks for, since the fallback's leniency might have been load-bearing for a consumer not visible from this repo. It is not.

  Note for anyone reproducing it: `zenoh-flat` and `zenoh-flat-jni` mains are currently out of sync (zenoh-flat renamed `config_new_from_json` → `..._json5` and 11 other items that the JNI binding still declares), so a fresh clone of both fails at resolve before any of this code runs. I pinned `zenoh-flat` to `70ba62a`, the commit matching zenoh-flat-jni's HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
