### PR TITLE
cbindgen: derive tagged-union payload wires from the converter destination (#158)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -324,9 +324,34 @@ universal `.name()` override, and the `CurrentDecl` cursor for error messages (`
 ### 5.2 The mirror type
 
 `prereq_tagged_unions` mirrors `prereq_enums`
-(`prebindgen/src/api/lang/cbindgen/trait_impl.rs:650`), emitting a `#[repr(C)]` enum whose payload
-fields carry **wire** types chosen by the same `mirror_field_wire` policy `data_struct` uses
-(`trait_impl.rs:513`):
+(`prebindgen/src/api/lang/cbindgen/trait_impl.rs`), emitting a `#[repr(C)]` enum whose payload
+fields carry **wire** types chosen by `payload_field_wire`.
+
+A payload's wire is its **resolved converter destination** — the same source a `data_struct` field
+effectively uses — not the layout-preserving `mirror_field_wire` policy. That policy exists for
+`repr_c_struct`, where one whole-struct `Transmute` reinterprets the bytes, so it can only accept
+shapes that survive a reinterpret. **A tagged union is not reinterpreted; it is rebuilt arm by arm
+through per-field converters**, so its payloads are not constrained that way. What that admits:
+
+| Payload | Wire |
+|---|---|
+| scalar | itself |
+| `String` | `char *` (the one type whose two directions disagree — `*const` in, `*mut` out — so the field fixes the owning form and the arms convert by hand) |
+| declared `enum_type` | `MaybeUninit<mirror>`, validated on the way in (§5.3) |
+| `Box<T>` / `Option<Box<T>>`, `T` an `opaque_ptr` | `*mut t_t` |
+| nested `data_struct` | its mirror, **by value** |
+| bare `opaque_ptr` handle | `*mut t_t` |
+| converted leaf (`Duration` → `u64`) | the converter's destination |
+| `Vec<_>` | **rejected** — it needs two wires (pointer + length) and a union field carries one |
+
+The two directions must agree on the wire, since one field serves both; a disagreement is a
+generation error naming the payload, not a silent pick of one side. A payload with a **fallible
+output** converter is also refused: the union's encoder has no error channel, because Rust always
+writes a live arm.
+
+Because a payload can now reach its own converter, it is registered as a resolver dependency and the
+union's converter **defers** (returns `None`, which the resolver retries) until that converter has
+resolved. `subs` alone cannot order this — it only drives the post-resolution propagation pass.
 
 ```rust
 #[repr(C)]
@@ -364,6 +389,15 @@ A tagged union crosses **by value**, like a `data_struct`. If any variant's payl
 `z_<name>_drop(z_<name>_t *)` that frees the **active arm** — consistent with the existing typed
 per-pointer drops. Phase B requires it: an owning payload without a drop is a generation error, not a
 leak.
+
+Ownership follows from the wire, so a **nested `data_struct` payload** is owning when its own mirror
+has owning fields, even though the payload wire is a struct by value rather than a pointer. The drop
+reaches through the payload and releases each of them, nulling the slot so a second drop is a no-op.
+Without that a `String` or handle inside a struct payload would leak silently — which is exactly the
+shape zenoh-flat#30 needs (`ReplyResult`'s alternatives are structs whose fields are handles).
+
+The drop is also a second C entry point into the same bytes, so it validates the tag the same way
+`in_tagged_union` does (§5.3) and treats an out-of-range one as nothing to release.
 
 ## 6. What core owns
 

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -79,6 +79,22 @@ fn generate_ffi_bindings() -> PathBuf {
     cbindgen = cbindgen.tagged_union(pq!(Shape));
     cbindgen = cbindgen.data_struct(pq!(Drawing));
 
+    // #158 part 2: payload wires come from the resolved CONVERTER DESTINATION,
+    // not the layout-preserving mirror policy. `Note` exercises the two shapes
+    // that admits — a nested `data_struct` by value (`Caption`, owning a
+    // `char *` the union's drop must reach through and free) and a converted
+    // leaf (`Millis` → `u64`).
+    cbindgen = cbindgen.data_struct(pq!(Caption));
+    cbindgen = cbindgen.convert(
+        prebindgen::convert!(Millis)
+            .input(prebindgen::fun!(millis_from_raw))
+            .output(prebindgen::fun!(millis_to_raw)),
+    );
+    cbindgen = cbindgen
+        .ignore_function(pq!(millis_from_raw))
+        .ignore_function(pq!(millis_to_raw));
+    cbindgen = cbindgen.tagged_union(pq!(Note));
+
     // Multi-target cfg demonstration: `InsideFoo` (a fieldless enum whose
     // discriminants vary by `target_arch`) and `Foo` (a by-value data struct whose
     // field set varies by `target_arch` + feature). Declared unconditionally —
@@ -113,6 +129,10 @@ fn generate_ffi_bindings() -> PathBuf {
         // The union crossing IN on a fallible function: an out-of-range tag
         // reports through the same `char **e` as the domain error.
         pq!(shape_try_area),
+        // `Note`'s constructors: the nested-struct and converted-leaf payloads
+        // crossing OUT.
+        pq!(note_new_silent),
+        pq!(note_new_after),
     ] {
         cbindgen = cbindgen.function(function);
     }
@@ -137,6 +157,11 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(shape_get_label),
         pq!(drawing_new),
         pq!(drawing_get_shape),
+        // `Note` crossing IN (tag validated, so fallible without a `Result`),
+        // and its `&str`-taking constructor.
+        pq!(note_value),
+        pq!(note_new_titled),
+        pq!(caption_new),
         pq!(calculator_new_clone),
         pq!(calculator_get_value),
         pq!(calculator_get_count),

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -185,16 +185,56 @@ static void test_invalid_tag(void) {
     shape_drop(&bad);
 }
 
+/* Payload kinds the zero-copy mirror policy could not express (#158 part 2):
+ * a nested `data_struct` crossing BY VALUE, and a converted leaf whose wire is
+ * its conversion's destination rather than its own layout. Both directions,
+ * plus the union's drop reaching THROUGH the struct payload to free the
+ * `char *` it owns. */
+static void test_converter_derived_payloads(void) {
+    /* Unit arm. */
+    note_t silent = note_new_silent();
+    CHECK(silent.tag == Silent);
+    CHECK(note_value(silent) == 0);
+
+    /* Converted leaf: `Millis` crosses as the `uint64_t` its conversion
+     * produces, not as its own struct layout. */
+    note_t after = note_new_after(1500);
+    CHECK(after.tag == After);
+    CHECK(after.after == 1500);
+    CHECK(note_value(after) == 1500);
+
+    /* Nested data_struct by value: the whole record rides in the union arm. */
+    note_t titled = note_new_titled(7, "chapter one");
+    CHECK(titled.tag == Titled);
+    CHECK(titled.titled.id == 7);
+    CHECK(strcmp(titled.titled.text, "chapter one") == 0);
+    /* …and crosses back IN, rebuilt through the payload's own converter. */
+    CHECK(note_value(titled) == 7);
+
+    /* The union's drop reaches through the struct payload and frees its
+     * owning field, nulling the slot so a second drop is a no-op. */
+    note_drop(&titled);
+    CHECK(titled.titled.text == NULL);
+    note_drop(&titled);
+
+    /* Non-owning arms tolerate the drop and stay readable. */
+    note_drop(&after);
+    CHECK(note_value(after) == 1500);
+    note_drop(NULL);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
     test_drop();
     test_invalid_tag();
+    test_converter_derived_payloads();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
         return 1;
     }
-    printf("PASS - tagged union: every arm, every position, drop, invalid tag\n");
+    printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
+           "converter-derived payloads\n");
     return 0;
 }

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -49,6 +49,12 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct caption_t {
+    pub id: u64,
+    pub text: *mut ::core::ffi::c_char,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct drawing_t {
     pub id: u64,
     pub shape: ::core::mem::MaybeUninit<shape_t>,
@@ -75,6 +81,40 @@ pub enum operation_t {
     Sub = 1,
     Mul = 2,
     Div = 3,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum note_t {
+    Silent,
+    Titled(caption_t),
+    After(u64),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        note_t::Titled(__f0) => {
+            free((*__f0).text as *mut ::core::ffi::c_void);
+            (*__f0).text = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -134,6 +174,17 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+    example_flat::Caption {
+        id: v.id,
+        text: if v.text.is_null() {
+            ::std::string::String::new()
+        } else {
+            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
+        },
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
@@ -177,6 +228,38 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     }
     ::core::result::Result::Err(
         ::std::format!("invalid discriminant {} for `inside_foo_t`", __raw),
+    )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+    example_flat::millis_from_raw(v)
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Note(
+    v: ::core::mem::MaybeUninit<note_t>,
+) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+        return ::core::result::Result::Err(
+            ::std::format!("invalid tag {} for `note_t` (expected 0..3)", __tag),
+        );
+    }
+    let v = v.assume_init();
+    ::core::result::Result::Ok(
+        match v {
+            note_t::Silent => example_flat::Note::Silent,
+            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
+            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
+        },
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -359,6 +442,13 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+    caption_t {
+        id: v.id,
+        text: __cbg_alloc_cstr(v.text),
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
         id: v.id,
@@ -383,6 +473,20 @@ pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+    example_flat::millis_to_raw(&v)
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+    ::core::mem::MaybeUninit::new(
+        match v {
+            example_flat::Note::Silent => note_t::Silent,
+            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
+            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
+        },
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -646,6 +750,24 @@ pub unsafe extern "C" fn calculator_to_string(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn caption_new(
+    id: u64,
+    text: *const ::core::ffi::c_char,
+) -> caption_t {
+    let id = __cbg_in_u64(id);
+    let text = match __cbg_in___str(text) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::caption_new(id, text);
+    let __ret: caption_t;
+    __ret = __cbg_out_Caption(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
@@ -718,6 +840,57 @@ pub unsafe extern "C" fn inside_foo_value(
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
     __ret = __cbg_out_i32(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_after(
+    millis: u64,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let millis = __cbg_in_u64(millis);
+    let __v = example_flat::note_new_after(millis);
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
+    let __v = example_flat::note_new_silent();
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_titled(
+    id: u64,
+    text: *const ::core::ffi::c_char,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let id = __cbg_in_u64(id);
+    let text = match __cbg_in___str(text) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_new_titled(id, text);
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
+    let n = match __cbg_in_Note(n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_value(n);
+    let __ret: u64;
+    __ret = __cbg_out_u64(__v);
     __ret
 }
 #[no_mangle]

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -49,6 +49,12 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct caption_t {
+    pub id: u64,
+    pub text: *mut ::core::ffi::c_char,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct drawing_t {
     pub id: u64,
     pub shape: ::core::mem::MaybeUninit<shape_t>,
@@ -75,6 +81,40 @@ pub enum operation_t {
     Sub = 1,
     Mul = 2,
     Div = 3,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum note_t {
+    Silent,
+    Titled(caption_t),
+    After(u64),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        note_t::Titled(__f0) => {
+            free((*__f0).text as *mut ::core::ffi::c_void);
+            (*__f0).text = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -134,6 +174,17 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+    example_flat::Caption {
+        id: v.id,
+        text: if v.text.is_null() {
+            ::std::string::String::new()
+        } else {
+            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
+        },
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
@@ -177,6 +228,38 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     }
     ::core::result::Result::Err(
         ::std::format!("invalid discriminant {} for `inside_foo_t`", __raw),
+    )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+    example_flat::millis_from_raw(v)
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Note(
+    v: ::core::mem::MaybeUninit<note_t>,
+) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+        return ::core::result::Result::Err(
+            ::std::format!("invalid tag {} for `note_t` (expected 0..3)", __tag),
+        );
+    }
+    let v = v.assume_init();
+    ::core::result::Result::Ok(
+        match v {
+            note_t::Silent => example_flat::Note::Silent,
+            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
+            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
+        },
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -359,6 +442,13 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+    caption_t {
+        id: v.id,
+        text: __cbg_alloc_cstr(v.text),
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
         id: v.id,
@@ -383,6 +473,20 @@ pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+    example_flat::millis_to_raw(&v)
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+    ::core::mem::MaybeUninit::new(
+        match v {
+            example_flat::Note::Silent => note_t::Silent,
+            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
+            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
+        },
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -646,6 +750,24 @@ pub unsafe extern "C" fn calculator_to_string(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn caption_new(
+    id: u64,
+    text: *const ::core::ffi::c_char,
+) -> caption_t {
+    let id = __cbg_in_u64(id);
+    let text = match __cbg_in___str(text) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::caption_new(id, text);
+    let __ret: caption_t;
+    __ret = __cbg_out_Caption(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
@@ -718,6 +840,57 @@ pub unsafe extern "C" fn inside_foo_value(
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
     __ret = __cbg_out_i32(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_after(
+    millis: u64,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let millis = __cbg_in_u64(millis);
+    let __v = example_flat::note_new_after(millis);
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
+    let __v = example_flat::note_new_silent();
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_titled(
+    id: u64,
+    text: *const ::core::ffi::c_char,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let id = __cbg_in_u64(id);
+    let text = match __cbg_in___str(text) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_new_titled(id, text);
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
+    let n = match __cbg_in_Note(n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_value(n);
+    let __ret: u64;
+    __ret = __cbg_out_u64(__v);
     __ret
 }
 #[no_mangle]

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -28,6 +28,29 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+} caption_t;
+
+typedef enum note_t_Tag {
+  Silent,
+  Titled,
+  After,
+} note_t_Tag;
+
+typedef struct note_t {
+  note_t_Tag tag;
+  union {
+    struct {
+      struct caption_t titled;
+    };
+    struct {
+      uint64_t after;
+    };
+  };
+} note_t;
+
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -81,6 +104,8 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
+void note_drop(struct note_t *this_);
+
 void shape_drop(struct shape_t *this_);
 
 bool calculator_apply(struct calculator_t *c,
@@ -107,6 +132,8 @@ struct calculator_t *calculator_new_from_str(const char *s, char **e);
 
 char *calculator_to_string(const struct calculator_t *c);
 
+struct caption_t caption_new(uint64_t id, const char *text);
+
 struct shape_t drawing_get_shape(struct drawing_t d);
 
 struct drawing_t drawing_new(uint64_t id, struct shape_t shape);
@@ -118,6 +145,14 @@ struct foo_t foo_new(uint64_t id);
 enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
+
+struct note_t note_new_after(uint64_t millis);
+
+struct note_t note_new_silent(void);
+
+struct note_t note_new_titled(uint64_t id, const char *text);
+
+uint64_t note_value(struct note_t n);
 
 double shape_area(struct shape_t s);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -28,6 +28,29 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+} caption_t;
+
+typedef enum note_t_Tag {
+  Silent,
+  Titled,
+  After,
+} note_t_Tag;
+
+typedef struct note_t {
+  note_t_Tag tag;
+  union {
+    struct {
+      struct caption_t titled;
+    };
+    struct {
+      uint64_t after;
+    };
+  };
+} note_t;
+
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -81,6 +104,8 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
+void note_drop(struct note_t *this_);
+
 void shape_drop(struct shape_t *this_);
 
 bool calculator_apply(struct calculator_t *c,
@@ -107,6 +132,8 @@ struct calculator_t *calculator_new_from_str(const char *s, char **e);
 
 char *calculator_to_string(const struct calculator_t *c);
 
+struct caption_t caption_new(uint64_t id, const char *text);
+
 struct shape_t drawing_get_shape(struct drawing_t d);
 
 struct drawing_t drawing_new(uint64_t id, struct shape_t shape);
@@ -118,6 +145,14 @@ struct foo_t foo_new(uint64_t id);
 enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
+
+struct note_t note_new_after(uint64_t millis);
+
+struct note_t note_new_silent(void);
+
+struct note_t note_new_titled(uint64_t id, const char *text);
+
+uint64_t note_value(struct note_t n);
 
 double shape_area(struct shape_t s);
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -76,6 +76,89 @@ pub enum Shape {
     Labeled(String, Operation),
 }
 
+/// A by-value data struct used as a **union payload** — the shape zenoh-flat's
+/// `ReplyResult` needs, where an alternative carries a whole record rather than a
+/// scalar. Its `String` field owns memory, so the union's typed drop has to reach
+/// through the payload and release it.
+#[prebindgen]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Caption {
+    pub id: u64,
+    pub text: String,
+}
+
+/// Build a [`Caption`].
+#[prebindgen]
+pub fn caption_new(id: u64, text: &str) -> Caption {
+    Caption {
+        id,
+        text: text.to_string(),
+    }
+}
+
+/// A sum whose payloads are the shapes the zero-copy mirror policy could not
+/// express: a nested `data_struct` (by value, owning a `char *`) and a
+/// **converted leaf** whose wire is its converter's destination rather than its
+/// own layout.
+#[prebindgen]
+#[derive(Debug, Clone, PartialEq)]
+pub enum Note {
+    /// No payload — only the tag.
+    Silent,
+    /// A whole record by value, owning a `char *`.
+    Titled(Caption),
+    /// A converted leaf: `Millis` crosses as the `u64` its conversion produces.
+    After(Millis),
+}
+
+/// A newtype whose C wire is the `u64` its declared conversion produces — not
+/// its own layout. As a union payload it exercises the converter-destination
+/// rule directly.
+#[prebindgen]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Millis(pub u64);
+
+/// `Millis` from its raw value (the conversion's **input**).
+#[prebindgen]
+pub fn millis_from_raw(v: u64) -> Millis {
+    Millis(v)
+}
+
+/// `Millis` to its raw value (the conversion's **output**).
+#[prebindgen]
+pub fn millis_to_raw(v: &Millis) -> u64 {
+    v.0
+}
+
+/// A titled note (nested-struct payload).
+#[prebindgen]
+pub fn note_new_titled(id: u64, text: &str) -> Note {
+    Note::Titled(caption_new(id, text))
+}
+
+/// A delayed note (converted-leaf payload).
+#[prebindgen]
+pub fn note_new_after(millis: u64) -> Note {
+    Note::After(Millis(millis))
+}
+
+/// The silent note.
+#[prebindgen]
+pub fn note_new_silent() -> Note {
+    Note::Silent
+}
+
+/// Read a note back: its caption id, its delay, or 0 — the sum in **parameter**
+/// position, so both new payload kinds cross inbound as well as outbound.
+#[prebindgen]
+pub fn note_value(n: Note) -> u64 {
+    match n {
+        Note::Silent => 0,
+        Note::Titled(c) => c.id,
+        Note::After(Millis(m)) => m,
+    }
+}
+
 /// A by-value data struct carrying a sum as a **field** — the position that makes
 /// "exactly one of" compose with ordinary product data.
 #[prebindgen]

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -80,28 +80,33 @@ impl Cbindgen {
         &self,
         fty: &syn::Type,
         registry: &Registry<()>,
-    ) -> Option<syn::Type> {
+    ) -> Result<syn::Type, String> {
         // `String` is the one type whose two directions disagree on the wire
         // (`*const c_char` in, `*mut c_char` out), so the union field fixes the
         // OWNING form and the per-arm expressions convert by hand.
         if is_string(fty) {
-            return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
+            return Ok(syn::parse_quote!(*mut ::core::ffi::c_char));
         }
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
             let c = self.c_type_ident(fty);
-            return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
+            return Ok(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         // A `Vec` payload needs TWO C wires (pointer + length) and one union
         // field can carry only one, so its length would be silently dropped.
         // Rejected explicitly, because the converter-destination rule below
         // would otherwise hand back the pointer alone and look like it worked.
         if is_vec(fty) {
-            return None;
+            return Err(
+                "a `Vec` needs TWO C wires (pointer + length) and one union field carries only \
+                 one, so its length would be silently dropped — hand the sequence over through \
+                 a separate function, or wrap it in a declared `opaque_ptr` handle"
+                    .to_string(),
+            );
         }
         // Layout-identical shapes first (scalar, `Box<T>`/`Option<Box<T>>`
         // opaque pointer), so what already worked keeps its exact wire.
         if let Some(w) = self.mirror_field_wire(fty) {
-            return Some(w);
+            return Ok(w);
         }
         // Otherwise the payload's wire is its **resolved converter
         // destination** — the same source a `data_struct` field effectively
@@ -115,13 +120,34 @@ impl Cbindgen {
         // legitimately differ (a `String`'s const-ness above), which is why a
         // disagreement is `None` — a rejection naming the payload — rather
         // than a silent pick of one side.
-        let out = registry.output_entry(fty)?.destination.clone();
+        let out_entry = registry.output_entry(fty).ok_or_else(|| {
+            "no resolved OUTPUT converter — a payload crosses as its converter's destination, so \
+             it must be a scalar, a `String`, or a type this binding declares (`enum_type`, \
+             `data_struct`, `opaque_ptr`, or a `convert!` conversion)"
+                .to_string()
+        })?;
+        // Decided here rather than at the emit site, so every reason a payload
+        // can be refused is reported from ONE place, at the declaration.
+        if returns_result(&out_entry.function.sig.output) {
+            return Err(
+                "its OUTPUT converter is fallible, but a union is encoded without an error \
+                 channel — the encoder always writes a live arm, so there is nowhere for the \
+                 failure to go. Use an infallible conversion for this payload"
+                    .to_string(),
+            );
+        }
+        let out = out_entry.destination.clone();
         if let Some(inp) = registry.input_entry(fty) {
             if TypeKey::from_type(&inp.destination) != TypeKey::from_type(&out) {
-                return None;
+                return Err(format!(
+                    "its input and output converters disagree on the wire (`{}` in, `{}` out) \
+                     and one union field serves both directions",
+                    inp.destination.to_token_stream(),
+                    out.to_token_stream(),
+                ));
             }
         }
-        Some(out)
+        Ok(out)
     }
 
     /// Wire type of a `data_struct` field: the free [`c_field_wire`] policy

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -76,7 +76,14 @@ impl Cbindgen {
     /// enum with a discriminant no variant has would be UB). That is what makes
     /// the mirror's tag the *only* thing [`Cbindgen::in_tagged_union`] has to
     /// validate before `assume_init`.
-    pub(super) fn payload_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
+    pub(super) fn payload_field_wire(
+        &self,
+        fty: &syn::Type,
+        registry: &Registry<()>,
+    ) -> Option<syn::Type> {
+        // `String` is the one type whose two directions disagree on the wire
+        // (`*const c_char` in, `*mut c_char` out), so the union field fixes the
+        // OWNING form and the per-arm expressions convert by hand.
         if is_string(fty) {
             return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
         }
@@ -84,7 +91,37 @@ impl Cbindgen {
             let c = self.c_type_ident(fty);
             return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
-        self.mirror_field_wire(fty)
+        // A `Vec` payload needs TWO C wires (pointer + length) and one union
+        // field can carry only one, so its length would be silently dropped.
+        // Rejected explicitly, because the converter-destination rule below
+        // would otherwise hand back the pointer alone and look like it worked.
+        if is_vec(fty) {
+            return None;
+        }
+        // Layout-identical shapes first (scalar, `Box<T>`/`Option<Box<T>>`
+        // opaque pointer), so what already worked keeps its exact wire.
+        if let Some(w) = self.mirror_field_wire(fty) {
+            return Some(w);
+        }
+        // Otherwise the payload's wire is its **resolved converter
+        // destination** — the same source a `data_struct` field effectively
+        // uses. A union is rebuilt arm by arm through real per-field
+        // conversions, so its payloads are not constrained to the
+        // layout-preserving shapes a `repr_c_struct` mirror needs; this is
+        // what admits a nested `data_struct`, a bare `opaque_ptr` handle, and
+        // a converted leaf (`Duration` → `u64`).
+        //
+        // One field serves both directions, so they must agree on it. They can
+        // legitimately differ (a `String`'s const-ness above), which is why a
+        // disagreement is `None` — a rejection naming the payload — rather
+        // than a silent pick of one side.
+        let out = registry.output_entry(fty)?.destination.clone();
+        if let Some(inp) = registry.input_entry(fty) {
+            if TypeKey::from_type(&inp.destination) != TypeKey::from_type(&out) {
+                return None;
+            }
+        }
+        Some(out)
     }
 
     /// Wire type of a `data_struct` field: the free [`c_field_wire`] policy
@@ -112,8 +149,63 @@ impl Cbindgen {
     /// True when a payload wire hands owned memory to C — a `char *` block or
     /// an opaque pointer — and therefore has to be released by the union's
     /// typed drop.
-    pub(super) fn payload_wire_owns(wire: &syn::Type) -> bool {
-        matches!(wire, syn::Type::Ptr(_))
+    ///
+    /// A nested `data_struct` payload crosses BY VALUE, so the wire itself is
+    /// not a pointer, but its mirror's own fields may be: the union's drop
+    /// then has to reach through and release each of them (see
+    /// [`Cbindgen::payload_free_stmt`]). Without this a `String` or handle
+    /// inside a struct payload would leak, silently, for exactly the shape
+    /// zenoh-flat#30 needs.
+    pub(super) fn payload_wire_owns(
+        &self,
+        fty: &syn::Type,
+        wire: &syn::Type,
+        registry: &Registry<()>,
+    ) -> bool {
+        if matches!(wire, syn::Type::Ptr(_)) {
+            return true;
+        }
+        !self.owning_data_struct_fields(fty, registry).is_empty()
+    }
+
+    /// Whether a tagged-union payload crosses through a converter of its own,
+    /// rather than being its own wire. Everything except a scalar and the
+    /// hand-written `String` / opaque-pointer shapes does — a declared
+    /// `enum_type`, a nested `data_struct`, a bare `opaque_ptr` handle, a
+    /// converted leaf. Such a payload must be registered as a resolver
+    /// dependency so its converter exists by the time the union's own is
+    /// emitted; without that it silently degrades to a passthrough and the
+    /// generated code does not compile.
+    pub(super) fn payload_needs_converter(&self, fty: &syn::Type) -> bool {
+        if is_string(fty) || is_scalar(fty) || is_vec(fty) {
+            return false;
+        }
+        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+            return true;
+        }
+        // `Box<T>` / `Option<Box<T>>` opaque pointers are built inline from the
+        // handle's C ident, not through a converter call.
+        !matches!(self.mirror_field_wire(fty), Some(syn::Type::Ptr(_)))
+    }
+
+    /// The `(name, type)` of every field of a declared `data_struct` whose own
+    /// C wire owns memory. Empty when `fty` is not a declared data struct.
+    pub(super) fn owning_data_struct_fields(
+        &self,
+        fty: &syn::Type,
+        registry: &Registry<()>,
+    ) -> Vec<(syn::Ident, syn::Type)> {
+        if !self.data.contains_key(&TypeKey::from_type(fty)) {
+            return Vec::new();
+        }
+        self.struct_fields(registry, fty)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|(_, fty)| {
+                self.data_field_wire(fty)
+                    .is_some_and(|w| matches!(w, syn::Type::Ptr(_)))
+            })
+            .collect()
     }
 
     /// Whether any declared function returns a `Vec<_>` (possibly nested under

--- a/prebindgen/src/api/lang/cbindgen/tests/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/mod.rs
@@ -30,3 +30,17 @@ fn error_struct() -> syn::ItemStruct {
 fn catch<F: FnOnce()>(f: F) -> bool {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).is_err()
 }
+
+/// Like [`catch`], but returns the panic MESSAGE — for asserting that a
+/// rejection names the reason that actually applies, not merely that it
+/// rejected.
+fn catch_msg<F: FnOnce()>(f: F) -> String {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .err()
+        .and_then(|e| {
+            e.downcast_ref::<String>()
+                .cloned()
+                .or_else(|| e.downcast_ref::<&str>().map(|s| s.to_string()))
+        })
+        .expect("expected a panic carrying a message")
+}

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -441,3 +441,126 @@ fn null_opaque_payload_is_reported_not_materialised() {
         "{src}"
     );
 }
+
+/// A payload's wire is its **resolved converter destination**, not the
+/// layout-preserving `repr_c_struct` mirror policy (#158 part 2). That is what
+/// admits a nested `data_struct` by value and a converted leaf whose wire is
+/// its conversion's destination — the shapes zenoh-flat#30's `ReplyResult`
+/// needs, and which the mirror policy rejected outright.
+#[test]
+fn payload_wires_come_from_the_converter_destination() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Caption {
+                    pub id: u64,
+                    pub text: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Millis(pub u64);
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Note {
+                    Silent,
+                    Titled(Caption),
+                    After(Millis),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn millis_from_raw(v: u64) -> Millis {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn millis_to_raw(v: &Millis) -> u64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn note_new() -> Note {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn note_value(n: Note) -> u64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<()>::from_items(items).expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .data_struct(syn::parse_quote!(Caption))
+        .convert(
+            crate::convert!(Millis)
+                .input(crate::fun!(millis_from_raw))
+                .output(crate::fun!(millis_to_raw)),
+        )
+        .ignore_function(syn::parse_quote!(millis_from_raw))
+        .ignore_function(syn::parse_quote!(millis_to_raw))
+        .tagged_union(syn::parse_quote!(Note))
+        .function(syn::parse_quote!(note_new))
+        .function(syn::parse_quote!(note_value))
+        .panic();
+
+    let src = write(cbindgen, registry, "payload_converter_wires");
+    let compact: String = src.split_whitespace().collect();
+
+    // The mirror: a nested data struct rides BY VALUE as its own mirror, and a
+    // converted leaf rides as the wire its conversion produces.
+    assert!(compact.contains("Titled(caption_t),"), "{src}");
+    assert!(compact.contains("After(u64),"), "{src}");
+    // Both directions route through the payload's own converter.
+    assert!(
+        compact.contains("note_t::Titled(__cbg_out_Caption(__f0))"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("note_t::After(__cbg_out_Millis(__f0))"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("example_flat::Note::Titled(__cbg_in_Caption(__f0))"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("example_flat::Note::After(__cbg_in_Millis(__f0))"),
+        "{src}"
+    );
+    // The struct payload owns a `char *`, so the union's drop reaches THROUGH
+    // the by-value payload to release it and nulls the slot.
+    assert!(
+        compact.contains("free((*__f0).textas*mut::core::ffi::c_void);"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("(*__f0).text=::core::ptr::null_mut();"),
+        "{src}"
+    );
+}

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -351,6 +351,62 @@ fn declarators_do_not_accept_each_others_shape() {
     assert!(catch(unit_as_union));
 }
 
+/// Each way a payload can be refused reports ITS OWN reason. The wire policy
+/// has four of them, and a message that lists all four on every failure — or,
+/// worse, names the wrong one — is what makes a rejection hard to act on. A
+/// `Vec` payload is the case that proves it: it HAS an output converter and
+/// its directions agree, so a message about missing or mismatched converters
+/// would be flatly wrong.
+#[test]
+fn each_payload_rejection_names_its_own_reason() {
+    let loc = SourceLocation::default();
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn odd_new() -> Odd {
+            unimplemented!()
+        }
+    );
+
+    // (1) `Vec` — two wires needed, one field available.
+    let vec_case = || {
+        let e: syn::ItemEnum = syn::parse_quote!(
+            pub enum Odd {
+                Nothing,
+                Many(Vec<u8>),
+            }
+        );
+        let registry = Registry::<()>::from_items([
+            (syn::Item::Enum(e), loc.clone()),
+            (syn::Item::Fn(make.clone()), loc.clone()),
+        ])
+        .expect("index items");
+        let cbindgen = Cbindgen::new()
+            .source_module(syn::parse_quote!(example_flat))
+            .free_memory_function("example_free")
+            .mangle_type_name(|base| format!("{base}_t"))
+            .tagged_union(syn::parse_quote!(Odd))
+            .function(syn::parse_quote!(odd_new));
+        let _ = write(cbindgen, registry, "reject_vec_payload");
+    };
+    let msg = catch_msg(vec_case);
+    assert!(
+        msg.contains("Odd::Many"),
+        "names the offending payload: {msg}"
+    );
+    assert!(
+        msg.contains("TWO C wires") && msg.contains("pointer + length"),
+        "…and why a Vec cannot cross, not a converter complaint: {msg}"
+    );
+    assert!(
+        !msg.contains("no resolved OUTPUT converter"),
+        "a Vec HAS an output converter — that reason would be wrong: {msg}"
+    );
+
+    // The other three reasons (no output converter, wire mismatch, fallible
+    // output converter) are guards: an undeclared payload type fails at
+    // RESOLVE, before `prereq_tagged_unions` runs, so nothing reaches them
+    // from a fixture. Their messages are specific, but unexercised.
+}
+
 /// A payload type outside the supported wire set is a generation error naming
 /// the offending variant field, not a silently wrong wire.
 #[test]

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -883,18 +883,17 @@ impl Cbindgen {
         registry: &Registry<()>,
     ) -> syn::Type {
         self.payload_field_wire(&field.ty, registry)
-            .unwrap_or_else(|| {
+            .unwrap_or_else(|reason| {
                 panic!(
-                    "Cbindgen::tagged_union: payload `{}::{}{}` has unsupported type `{}` \
-                 — it has no resolved output converter, or its input and output \
-                 converters disagree on the wire (one union field serves both)",
+                    "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
                     type_short(ty),
                     variant,
                     match &field.ident {
                         Some(n) => format!(".{n}"),
                         None => String::new(),
                     },
-                    field.ty.to_token_stream()
+                    field.ty.to_token_stream(),
+                    reason,
                 )
             })
     }
@@ -1273,20 +1272,13 @@ impl Cbindgen {
         if is_scalar(fty) {
             return quote!(#b);
         }
-        // The output counterpart of the input dispatch above. A FALLIBLE output
-        // converter is refused rather than silently unwrapped: the union's own
-        // encoder has no error channel (Rust always writes a live arm), so
-        // there is nowhere honest for the failure to go.
+        // The output counterpart of the input dispatch above. Acceptance —
+        // including the refusal of a FALLIBLE output converter, which a union
+        // cannot report through — is decided once in `payload_field_wire`, so
+        // this site only emits the call.
         match registry.output_entry(fty) {
             Some(entry) => {
                 let conv = entry.function.sig.ident.clone();
-                assert!(
-                    !returns_result(&entry.function.sig.output),
-                    "Cbindgen::tagged_union: payload `{}` has a FALLIBLE output converter, but \
-                     a union is encoded without an error channel — the encoder always writes a \
-                     live arm. Use an infallible conversion for this payload",
-                    fty.to_token_stream()
-                );
                 quote!(#conv(#b))
             }
             None => quote!(#b),

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -794,7 +794,7 @@ impl Cbindgen {
                 let wires: Vec<syn::Type> = v
                     .fields
                     .iter()
-                    .map(|f| self.payload_wire_of(&ty, vident, f))
+                    .map(|f| self.payload_wire_of(&ty, vident, f, registry))
                     .collect();
                 match &v.fields {
                     syn::Fields::Unit => variant_defs.push(quote!(#vident)),
@@ -816,7 +816,7 @@ impl Cbindgen {
                     .iter()
                     .zip(&wires)
                     .enumerate()
-                    .filter(|(_, (_, w))| Cbindgen::payload_wire_owns(w))
+                    .filter(|(_, (f, w))| self.payload_wire_owns(&f.ty, w, registry))
                     .map(|(i, (f, w))| (i, f, w))
                     .collect();
                 if owning.is_empty() {
@@ -828,7 +828,7 @@ impl Cbindgen {
                 let pattern = variant_pattern(&cname, vident, &v.fields, &binds);
                 let frees = owning.iter().map(|(i, f, _)| {
                     let b = &binds[*i];
-                    self.payload_free_stmt(&f.ty, b)
+                    self.payload_free_stmt(&f.ty, b, registry)
                 });
                 drop_arms.push(quote!(#pattern => { #(#frees)* }));
             }
@@ -880,21 +880,23 @@ impl Cbindgen {
         ty: &syn::Type,
         variant: &syn::Ident,
         field: &syn::Field,
+        registry: &Registry<()>,
     ) -> syn::Type {
-        self.payload_field_wire(&field.ty).unwrap_or_else(|| {
-            panic!(
-                "Cbindgen::tagged_union: payload `{}::{}{}` has unsupported type `{}` \
-                 (expected a scalar, a `String`, a declared `enum_type`, or an opaque \
-                 pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
-                type_short(ty),
-                variant,
-                match &field.ident {
-                    Some(n) => format!(".{n}"),
-                    None => String::new(),
-                },
-                field.ty.to_token_stream()
-            )
-        })
+        self.payload_field_wire(&field.ty, registry)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Cbindgen::tagged_union: payload `{}::{}{}` has unsupported type `{}` \
+                 — it has no resolved output converter, or its input and output \
+                 converters disagree on the wire (one union field serves both)",
+                    type_short(ty),
+                    variant,
+                    match &field.ident {
+                        Some(n) => format!(".{n}"),
+                        None => String::new(),
+                    },
+                    field.ty.to_token_stream()
+                )
+            })
     }
 
     /// Release one owning payload slot held behind `binding` (a `&mut` to the
@@ -902,20 +904,48 @@ impl Cbindgen {
     /// the same union is a no-op. A `char *` block goes back to the C
     /// allocator; an opaque pointer is re-boxed and dropped, running the Rust
     /// destructor.
-    fn payload_free_stmt(&self, fty: &syn::Type, binding: &syn::Ident) -> TokenStream {
+    fn payload_free_stmt(
+        &self,
+        fty: &syn::Type,
+        binding: &syn::Ident,
+        registry: &Registry<()>,
+    ) -> TokenStream {
         if is_string(fty) {
             return quote!(
                 free(*#binding as *mut ::core::ffi::c_void);
                 *#binding = ::core::ptr::null_mut();
             );
         }
-        let inner = opaque_ptr_payload_inner(fty).unwrap_or_else(|| {
-            panic!(
-                "Cbindgen::tagged_union: owning payload `{}` is neither a `String` nor an \
-                 opaque pointer",
-                fty.to_token_stream()
-            )
-        });
+        // A nested `data_struct` payload crosses BY VALUE, so the arm binds the
+        // mirror itself and what has to be released is each of its OWNING
+        // fields — reached through the binding and nulled in place, exactly as
+        // a directly-owning payload is. This is the shape zenoh-flat#30 needs
+        // (`ReplyResult`'s alternatives are structs whose fields are handles),
+        // and without it those fields would leak silently.
+        let owning = self.owning_data_struct_fields(fty, registry);
+        if !owning.is_empty() {
+            let frees = owning.iter().map(|(fname, fty)| {
+                if is_string(fty) {
+                    quote!(
+                        free((*#binding).#fname as *mut ::core::ffi::c_void);
+                        (*#binding).#fname = ::core::ptr::null_mut();
+                    )
+                } else {
+                    let inner = opaque_ptr_payload_inner(fty).unwrap_or_else(|| fty.clone());
+                    let src_inner = self.src_ty(&inner);
+                    quote!(
+                        if !(*#binding).#fname.is_null() {
+                            drop(::std::boxed::Box::from_raw(
+                                (*#binding).#fname as *mut #src_inner,
+                            ));
+                            (*#binding).#fname = ::core::ptr::null_mut();
+                        }
+                    )
+                }
+            });
+            return quote!(#(#frees)*);
+        }
+        let inner = opaque_ptr_payload_inner(fty).unwrap_or_else(|| fty.clone());
         let src_inner = self.src_ty(&inner);
         quote!(
             if !(*#binding).is_null() {
@@ -956,6 +986,19 @@ impl Cbindgen {
         let name = Self::in_name(ty);
         let cname = self.c_type_ident(ty);
         let src = self.src_ty(ty);
+        // A payload that crosses through its own converter needs that converter
+        // to exist before this one can call it. `subs` only drives the
+        // post-resolution propagation pass, so it cannot order the build —
+        // returning `None` here is the resolver's DEFERRAL protocol, and it
+        // retries at the next fixed point. Without this the payload silently
+        // degrades to a passthrough and the generated code does not compile.
+        for v in &e.variants {
+            for f in &v.fields {
+                if self.payload_needs_converter(&f.ty) && r.input_entry(&f.ty).is_none() {
+                    return None;
+                }
+            }
+        }
         let mut subs: Vec<syn::Type> = Vec::new();
         let arms: Vec<TokenStream> = e
             .variants
@@ -971,12 +1014,16 @@ impl Cbindgen {
                     .iter()
                     .zip(&binds)
                     .map(|(f, b)| {
-                        // Payload fields with their own converter (a declared
-                        // `enum_type`) contribute a resolver dependency.
-                        if self.enums.contains_key(&TypeKey::from_type(&f.ty)) {
+                        // Every payload that crosses through a converter of its
+                        // own — a declared `enum_type`, a nested `data_struct`,
+                        // an opaque handle, a converted leaf — is a resolver
+                        // dependency, so its converter exists before this one is
+                        // emitted. Without it the payload silently falls back to
+                        // a passthrough and the generated code does not compile.
+                        if self.payload_needs_converter(&f.ty) {
                             subs.push(f.ty.clone());
                         }
-                        self.payload_in_expr(&f.ty, b)
+                        self.payload_in_expr(&f.ty, b, r)
                     })
                     .collect();
                 let to = variant_ctor(&src, vident, &v.fields, &exprs);
@@ -1069,6 +1116,14 @@ impl Cbindgen {
         let name = Self::out_name(ty);
         let cname = self.c_type_ident(ty);
         let src = self.src_ty(ty);
+        // Deferral, as in `in_tagged_union` — the output counterpart.
+        for v in &e.variants {
+            for f in &v.fields {
+                if self.payload_needs_converter(&f.ty) && r.output_entry(&f.ty).is_none() {
+                    return None;
+                }
+            }
+        }
         let mut subs: Vec<syn::Type> = Vec::new();
         let arms: Vec<TokenStream> = e
             .variants
@@ -1084,10 +1139,10 @@ impl Cbindgen {
                     .iter()
                     .zip(&binds)
                     .map(|(f, b)| {
-                        if self.enums.contains_key(&TypeKey::from_type(&f.ty)) {
+                        if self.payload_needs_converter(&f.ty) {
                             subs.push(f.ty.clone());
                         }
-                        self.payload_out_expr(&f.ty, b)
+                        self.payload_out_expr(&f.ty, b, r)
                     })
                     .collect();
                 let to = variant_ctor(&cname_ty(&cname), vident, &v.fields, &exprs);
@@ -1116,7 +1171,12 @@ impl Cbindgen {
     /// One payload field, C wire → Rust value. Mirrors the `data_struct`
     /// input policy, plus the opaque-pointer and declared-enum cases the
     /// mirror wire allows.
-    fn payload_in_expr(&self, fty: &syn::Type, b: &syn::Ident) -> TokenStream {
+    fn payload_in_expr(
+        &self,
+        fty: &syn::Type,
+        b: &syn::Ident,
+        registry: &Registry<()>,
+    ) -> TokenStream {
         if is_string(fty) {
             return quote!(if #b.is_null() {
                 ::std::string::String::new()
@@ -1161,12 +1221,35 @@ impl Cbindgen {
                 })
             };
         }
-        quote!(#b)
+        // A scalar is its own wire and needs no call.
+        if is_scalar(fty) {
+            return quote!(#b);
+        }
+        // Everything else rides its own resolved input converter — the wire
+        // came from that converter's destination, so the two cannot disagree.
+        // A fallible one propagates with `?`, which the union's own `Result`
+        // already provides.
+        match registry.input_entry(fty) {
+            Some(entry) => {
+                let conv = &entry.function.sig.ident;
+                if returns_result(&entry.function.sig.output) {
+                    quote!(#conv(#b)?)
+                } else {
+                    quote!(#conv(#b))
+                }
+            }
+            None => quote!(#b),
+        }
     }
 
     /// One payload field, Rust value → C wire. The `String` arm allocates the
     /// `char *` block the union's typed drop later frees.
-    fn payload_out_expr(&self, fty: &syn::Type, b: &syn::Ident) -> TokenStream {
+    fn payload_out_expr(
+        &self,
+        fty: &syn::Type,
+        b: &syn::Ident,
+        registry: &Registry<()>,
+    ) -> TokenStream {
         if is_string(fty) {
             return quote!(__cbg_alloc_cstr(#b));
         }
@@ -1187,7 +1270,27 @@ impl Cbindgen {
                 quote!(::std::boxed::Box::into_raw(#b) as *mut #c)
             };
         }
-        quote!(#b)
+        if is_scalar(fty) {
+            return quote!(#b);
+        }
+        // The output counterpart of the input dispatch above. A FALLIBLE output
+        // converter is refused rather than silently unwrapped: the union's own
+        // encoder has no error channel (Rust always writes a live arm), so
+        // there is nowhere honest for the failure to go.
+        match registry.output_entry(fty) {
+            Some(entry) => {
+                let conv = entry.function.sig.ident.clone();
+                assert!(
+                    !returns_result(&entry.function.sig.output),
+                    "Cbindgen::tagged_union: payload `{}` has a FALLIBLE output converter, but \
+                     a union is encoded without an error channel — the encoder always writes a \
+                     live arm. Use an infallible conversion for this payload",
+                    fty.to_token_stream()
+                );
+                quote!(#conv(#b))
+            }
+            None => quote!(#b),
+        }
     }
 
     /// Callback closure structs: one `#[repr(C)]` `{ context, call, drop }`


### PR DESCRIPTION
Part 2 of #158 — the half stage B could not express. Part of the sum-type umbrella #152.

**Base:** `sum-types-b-cbindgen` (#154), since it builds directly on the tagged-union lowering.

## The problem

`payload_field_wire` delegated to `mirror_field_wire` — the **layout-preserving** policy that exists for `repr_c_struct`, where one whole-struct `Transmute` reinterprets the bytes, so it can only accept shapes that survive a reinterpret. But a tagged union **is not reinterpreted**: it is rebuilt arm by arm through per-field converters, so its payloads were never constrained that way. The design said so; the code inherited the wrong policy.

## The change

A payload's wire is now its **resolved converter destination** — the same source a `data_struct` field effectively uses. That admits the three shapes §5 promises and the mirror policy rejected:

| Payload | Before | Now |
|---|---|---|
| nested `data_struct` | rejected | its mirror, **by value** |
| bare `opaque_ptr` handle (not `Box<T>`) | rejected | `*mut t_t` |
| converted leaf (`Millis` → `u64`) | rejected | the converter's destination |

The mirror policy is still consulted **first**, so scalars and boxed opaque pointers keep their exact wire and every committed golden for them is unchanged. This PR only *adds* acceptance.

### Three rules the new freedom needs

- **One field, both directions** — they must agree on the wire, since a single union field serves both. A disagreement is a generation error naming the payload, not a silent pick of one side. `String` is the exception that proves it (`*const` in, `*mut` out), so it keeps its hand-written form.
- **No fallible output converter** — a union's encoder has no error channel (Rust always writes a live arm), so such a payload is refused rather than silently unwrapped.
- **`Vec` is rejected explicitly** — it needs two wires (pointer + length) and a union field carries one. Without the guard the destination rule would hand back the pointer alone, drop the length, and look like it worked. This is what the existing `unsupported_payload_is_a_generation_error` test caught when I first wired it up.

### Two mechanical consequences

- **Deferral.** A payload can now reach its own converter, so it is registered as a resolver dependency *and* the union's converter returns `None` until that converter has resolved — the resolver's retry protocol. `subs` alone cannot order this; it only drives the post-resolution propagation pass. Without the deferral the payload silently degraded to a passthrough and the generated code did not compile (`expected Caption, found caption_t`).
- **Ownership follows from the wire.** A nested `data_struct` payload is owning when *its own mirror* has owning fields, even though the payload wire is a struct by value rather than a pointer. The typed drop reaches through and releases each, nulling the slot:

```rust
note_t::Titled(__f0) => {
    free((*__f0).text as *mut ::core::ffi::c_void);
    (*__f0).text = ::core::ptr::null_mut();
}
```

  Without this a `String` or handle inside a struct payload leaks silently — **which is exactly the shape zenoh-flat#30 needs**, since `ReplyResult`'s alternatives are structs whose fields are handles.

## What it renders

```c
typedef struct caption_t { uint64_t id; char *text; } caption_t;

typedef struct note_t {
  note_t_Tag tag;
  union {
    struct { struct caption_t titled; };   /* nested struct, by value */
    struct { uint64_t after; };            /* converted leaf */
  };
} note_t;

void note_drop(struct note_t *this_);
```

## Coverage

- `example-flat` gains `Note` — a payload-less arm, a nested `Caption` owning a `char *`, and a converted `Millis` — crossing **out** and back **in**.
- `c/smoke.c` reads every arm, checks the converted leaf really is a `uint64_t` on the wire, and asserts the drop frees the nested `char *` and nulls it so a second drop is a no-op. **Verified leak-free under ASan/LeakSanitizer**, not just "it printed PASS".
- A lib test pinning the mirror's wires (`Titled(caption_t)`, `After(u64)`), both directions' converter calls, and the reach-through free.
- `cargo test --all --all-features` (381 lib tests), `regen-check.sh` clean, `fmt --check`, `clippy --deny warnings`; both arch goldens regenerated.

## Not in this PR

**Instance 3 of #158 — `repr_c_struct` mirror enum fields.** It needs a different shape: that mirror is reinterpreted wholesale by `Transmute`, so there is no converter for a per-field validation to hook into, and `MaybeUninit` in the mirror would not help because the reinterpret is the problem. Pre-existing, blocks nothing here, left on the issue.

With this merged, #158's stated scope — part 1 (both instances) and part 2 — is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
