### PR TITLE
cbindgen: normalise a `bool` tagged-union payload instead of materialising it (#152 review)

### DIFF
--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -129,10 +129,11 @@ fn generate_ffi_bindings() -> PathBuf {
         // The union crossing IN on a fallible function: an out-of-range tag
         // reports through the same `char **e` as the domain error.
         pq!(shape_try_area),
-        // `Note`'s constructors: the nested-struct and converted-leaf payloads
-        // crossing OUT.
+        // `Note`'s constructors: the nested-struct, converted-leaf and `bool`
+        // payloads crossing OUT.
         pq!(note_new_silent),
         pq!(note_new_after),
+        pq!(note_new_flagged),
     ] {
         cbindgen = cbindgen.function(function);
     }

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -20,7 +20,9 @@
  *   - a tag NO variant has. A C caller can always write one, so the binding
  *     validates it before a Rust enum exists: `shape_try_area` reports it
  *     through its `char **e`, and `shape_drop` ignores it. Constructing that
- *     value is the point of the check — it is not a Rust `shape_t` at all.
+ *     value is the point of the check — it is not a Rust `shape_t` at all;
+ *   - the same rule one level down, on a `bool` payload (`note_t`'s `Flagged`
+ *     arm): a byte outside `{0,1}` is normalised, not materialised.
  *
  * Exits non-zero on the first failed check.
  */
@@ -223,18 +225,46 @@ static void test_converter_derived_payloads(void) {
     note_drop(NULL);
 }
 
+/* A `bool` payload. `bool` is the one scalar whose domain is restricted, and C
+ * can put any byte in the slot — `memcpy` from a `char`, a union, a struct read
+ * off the wire. Rust may not HOLD such a byte in a `bool`, so the payload
+ * crosses behind `MaybeUninit` (spelled `bool` in the header, unchanged) and the
+ * byte is normalised C-style on the way in: nonzero is true. */
+static void test_out_of_domain_bool_payload(void) {
+    note_t on = note_new_flagged(true);
+    CHECK(on.tag == Flagged);
+    CHECK(note_value(on) == 1);
+
+    note_t off = note_new_flagged(false);
+    CHECK(off.tag == Flagged);
+    CHECK(note_value(off) == 0);
+
+    /* A byte no Rust `bool` may hold, written the way a C caller can. */
+    unsigned char junk = 2;
+    memcpy(&off.flagged, &junk, sizeof junk);
+    CHECK(note_value(off) == 1);
+
+    junk = 0xff;
+    memcpy(&off.flagged, &junk, sizeof junk);
+    CHECK(note_value(off) == 1);
+
+    /* A bool owns nothing: the drop is a no-op on this arm. */
+    note_drop(&off);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
     test_drop();
     test_invalid_tag();
     test_converter_derived_payloads();
+    test_out_of_domain_bool_payload();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
         return 1;
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
-           "converter-derived payloads\n");
+           "converter-derived payloads, out-of-domain bool payload\n");
     return 0;
 }

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -88,6 +88,7 @@ pub enum note_t {
     Silent,
     Titled(caption_t),
     After(u64),
+    Flagged(::core::mem::MaybeUninit<bool>),
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
@@ -105,7 +106,7 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         (*this_).as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
         return;
     }
     match (*this_).assume_init_mut() {
@@ -248,9 +249,9 @@ pub(crate) unsafe fn __cbg_in_Note(
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         v.as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
         return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..3)", __tag),
+            ::std::format!("invalid tag {} for `note_t` (expected 0..4)", __tag),
         );
     }
     let v = v.assume_init();
@@ -259,6 +260,11 @@ pub(crate) unsafe fn __cbg_in_Note(
             note_t::Silent => example_flat::Note::Silent,
             note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
             note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
+            note_t::Flagged(__f0) => {
+                example_flat::Note::Flagged(
+                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
+                )
+            }
         },
     )
 }
@@ -399,6 +405,10 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_bool(v: bool) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -485,6 +495,9 @@ pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
             example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
+            example_flat::Note::Flagged(__f0) => {
+                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            }
         },
     )
 }
@@ -849,6 +862,17 @@ pub unsafe extern "C" fn note_new_after(
 ) -> ::core::mem::MaybeUninit<note_t> {
     let millis = __cbg_in_u64(millis);
     let __v = example_flat::note_new_after(millis);
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_flagged(
+    flag: bool,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let flag = __cbg_in_bool(flag);
+    let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
     __ret = __cbg_out_Note(__v);
     __ret

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -88,6 +88,7 @@ pub enum note_t {
     Silent,
     Titled(caption_t),
     After(u64),
+    Flagged(::core::mem::MaybeUninit<bool>),
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
@@ -105,7 +106,7 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         (*this_).as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
         return;
     }
     match (*this_).assume_init_mut() {
@@ -248,9 +249,9 @@ pub(crate) unsafe fn __cbg_in_Note(
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         v.as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 3i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
         return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..3)", __tag),
+            ::std::format!("invalid tag {} for `note_t` (expected 0..4)", __tag),
         );
     }
     let v = v.assume_init();
@@ -259,6 +260,11 @@ pub(crate) unsafe fn __cbg_in_Note(
             note_t::Silent => example_flat::Note::Silent,
             note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
             note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
+            note_t::Flagged(__f0) => {
+                example_flat::Note::Flagged(
+                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
+                )
+            }
         },
     )
 }
@@ -399,6 +405,10 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_bool(v: bool) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -485,6 +495,9 @@ pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
             example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
+            example_flat::Note::Flagged(__f0) => {
+                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            }
         },
     )
 }
@@ -849,6 +862,17 @@ pub unsafe extern "C" fn note_new_after(
 ) -> ::core::mem::MaybeUninit<note_t> {
     let millis = __cbg_in_u64(millis);
     let __v = example_flat::note_new_after(millis);
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_flagged(
+    flag: bool,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let flag = __cbg_in_bool(flag);
+    let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
     __ret = __cbg_out_Note(__v);
     __ret

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -37,6 +37,7 @@ typedef enum note_t_Tag {
   Silent,
   Titled,
   After,
+  Flagged,
 } note_t_Tag;
 
 typedef struct note_t {
@@ -47,6 +48,9 @@ typedef struct note_t {
     };
     struct {
       uint64_t after;
+    };
+    struct {
+      bool flagged;
     };
   };
 } note_t;
@@ -147,6 +151,8 @@ enum inside_foo_t inside_foo_default(void);
 int32_t inside_foo_value(enum inside_foo_t x);
 
 struct note_t note_new_after(uint64_t millis);
+
+struct note_t note_new_flagged(bool flag);
 
 struct note_t note_new_silent(void);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -37,6 +37,7 @@ typedef enum note_t_Tag {
   Silent,
   Titled,
   After,
+  Flagged,
 } note_t_Tag;
 
 typedef struct note_t {
@@ -47,6 +48,9 @@ typedef struct note_t {
     };
     struct {
       uint64_t after;
+    };
+    struct {
+      bool flagged;
     };
   };
 } note_t;
@@ -147,6 +151,8 @@ enum inside_foo_t inside_foo_default(void);
 int32_t inside_foo_value(enum inside_foo_t x);
 
 struct note_t note_new_after(uint64_t millis);
+
+struct note_t note_new_flagged(bool flag);
 
 struct note_t note_new_silent(void);
 

--- a/examples/example-cbindgen/src/boundary_tests.rs
+++ b/examples/example-cbindgen/src/boundary_tests.rs
@@ -15,13 +15,13 @@
 
 use core::{
     ffi::{c_char, c_int, c_void, CStr},
-    mem::MaybeUninit,
+    mem::{align_of, MaybeUninit},
     ptr,
 };
 
 use crate::{
     calculator_apply, calculator_drop, calculator_get_value, calculator_new, example_free,
-    inside_foo_default, inside_foo_value, operation_t,
+    inside_foo_default, inside_foo_value, note_new_flagged, note_t, note_value, operation_t,
 };
 
 /// The wire value a C caller passing `value` produces — including a `value`
@@ -116,6 +116,45 @@ fn negative_operation_discriminant_is_rejected() {
 
         example_free(err.cast::<c_void>());
         calculator_drop(c);
+    }
+}
+
+/// The wire a C caller produces by writing raw union bytes: tag `Flagged` with
+/// `byte` in the payload slot.
+///
+/// A `#[repr(C)]` enum with payload variants is laid out as a leading `int`
+/// discriminant followed by the variant union, padded to the union's alignment
+/// — so the payload begins at the whole type's alignment. The `0`/`1` cases in
+/// the test below pin that offset against the generated encoder.
+unsafe fn raw_flagged(byte: u8) -> MaybeUninit<note_t> {
+    const FLAGGED_TAG: c_int = 3;
+    let mut slot = MaybeUninit::<note_t>::zeroed();
+    ptr::write(slot.as_mut_ptr().cast::<c_int>(), FLAGGED_TAG);
+    ptr::write(
+        slot.as_mut_ptr().cast::<u8>().add(align_of::<note_t>()),
+        byte,
+    );
+    slot
+}
+
+/// `bool` is the one scalar whose domain is restricted (`0`/`1`), so a `bool`
+/// payload crosses behind `MaybeUninit` like a declared enum does: the byte C
+/// wrote is read as a `u8` and normalised the way C converts to `_Bool`, never
+/// materialised as a Rust `bool`. Written against a bare `bool` payload wire the
+/// `2` case below would have been undefined behaviour at `assume_init` — before
+/// any `match` — which is the point.
+#[test]
+fn out_of_domain_bool_payload_is_normalised_not_materialised() {
+    unsafe {
+        // Rust's own `true`/`false` round trip.
+        assert_eq!(note_value(note_new_flagged(true)), 1);
+        assert_eq!(note_value(note_new_flagged(false)), 0);
+        // The hand-written wire agrees with the generated encoder.
+        assert_eq!(note_value(raw_flagged(0)), 0);
+        assert_eq!(note_value(raw_flagged(1)), 1);
+        // Bytes no Rust `bool` may hold: accepted, normalised to `true`.
+        assert_eq!(note_value(raw_flagged(2)), 1);
+        assert_eq!(note_value(raw_flagged(0xff)), 1);
     }
 }
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -109,6 +109,10 @@ pub enum Note {
     Titled(Caption),
     /// A converted leaf: `Millis` crosses as the `u64` its conversion produces.
     After(Millis),
+    /// A `bool` payload — the one scalar whose domain is restricted (`0`/`1`),
+    /// so it crosses behind `MaybeUninit` like a declared enum does and a byte
+    /// C wrote is normalised, never materialised as a Rust `bool`.
+    Flagged(bool),
 }
 
 /// A newtype whose C wire is the `u64` its declared conversion produces — not
@@ -148,6 +152,12 @@ pub fn note_new_silent() -> Note {
     Note::Silent
 }
 
+/// A flagged note (`bool` payload).
+#[prebindgen]
+pub fn note_new_flagged(flag: bool) -> Note {
+    Note::Flagged(flag)
+}
+
 /// Read a note back: its caption id, its delay, or 0 — the sum in **parameter**
 /// position, so both new payload kinds cross inbound as well as outbound.
 #[prebindgen]
@@ -156,6 +166,7 @@ pub fn note_value(n: Note) -> u64 {
         Note::Silent => 0,
         Note::Titled(c) => c.id,
         Note::After(Millis(m)) => m,
+        Note::Flagged(f) => f as u64,
     }
 }
 

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -70,12 +70,16 @@ impl Cbindgen {
     /// so each wire here is produced by a real per-field conversion. That is
     /// what lets `String` join the set.
     ///
-    /// Every wire this returns is **bit-pattern-agnostic**: scalars and raw
-    /// pointers hold any bits legally, and a declared `enum_type` payload is
-    /// wrapped in [`::core::mem::MaybeUninit`] so it does too (holding a Rust
-    /// enum with a discriminant no variant has would be UB). That is what makes
-    /// the mirror's tag the *only* thing [`Cbindgen::in_tagged_union`] has to
-    /// validate before `assume_init`.
+    /// Every wire this returns is **bit-pattern-agnostic**: integers, floats and
+    /// raw pointers hold any bits legally, and the two Rust types that do *not*
+    /// — a declared `enum_type` (a discriminant no variant has) and `bool`
+    /// (anything but `0`/`1`) — are wrapped in [`::core::mem::MaybeUninit`] so
+    /// they do too. That is what makes the mirror's tag the *only* thing
+    /// [`Cbindgen::in_tagged_union`] has to validate before `assume_init`.
+    ///
+    /// (A `bool` reached through a nested `data_struct` payload is **not**
+    /// covered here — see #170. That is the pre-existing `c_field_wire` policy,
+    /// which a plain `bool` parameter shares.)
     pub(super) fn payload_field_wire(
         &self,
         fty: &syn::Type,
@@ -90,6 +94,15 @@ impl Cbindgen {
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
             let c = self.c_type_ident(fty);
             return Ok(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
+        }
+        // `bool` is the one scalar with a restricted domain: `2` is a byte a C
+        // caller can write into the union and NOT a Rust `bool`, so holding it
+        // in the mirror is the same UB an out-of-range discriminant is. Same
+        // remedy, and invisible in C for the same reason (cbindgen simplifies
+        // `MaybeUninit<T>` to `T`); the byte is normalised C-style — nonzero is
+        // true — in `payload_in_expr`.
+        if is_bool(fty) {
+            return Ok(syn::parse_quote!(::core::mem::MaybeUninit<bool>));
         }
         // A `Vec` payload needs TWO C wires (pointer + length) and one union
         // field can carry only one, so its length would be silently dropped.

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -480,6 +480,12 @@ fn maybe_uninit_inner(ty: &syn::Type) -> Option<syn::Type> {
     None
 }
 
+/// Whether `ty` is `bool` — the one scalar whose domain is restricted (`0`/`1`),
+/// so C-supplied bytes may not be held in it without being normalised first.
+fn is_bool(ty: &syn::Type) -> bool {
+    type_path_tail(ty).map(|i| i == "bool").unwrap_or(false)
+}
+
 /// Whether `ty` is an FFI-safe scalar primitive that passes through unchanged
 /// (`bool`, the fixed-width / pointer-width integers, and floats).
 fn is_scalar(ty: &syn::Type) -> bool {

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -620,3 +620,71 @@ fn payload_wires_come_from_the_converter_destination() {
         "{src}"
     );
 }
+
+/// A `bool` payload is the one scalar whose domain is restricted, so it rides
+/// as `MaybeUninit<bool>` like a declared enum does — otherwise the union's
+/// `assume_init` would materialise a `bool` from whatever byte C wrote, which is
+/// the same UB the tag check exists to prevent. On the way in the byte is read
+/// as a `u8` and normalised C-style (nonzero is true); on the way out Rust's
+/// own `0`/`1` is only wrapped. The C spelling is unchanged: cbindgen
+/// simplifies `MaybeUninit<T>` to `T`.
+#[test]
+fn bool_payload_is_normalised_not_materialised() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Flagged {
+                    Off,
+                    On(bool),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn flagged_new() -> Flagged {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn flagged_value(f: Flagged) -> bool {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<()>::from_items(items).expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .tagged_union(syn::parse_quote!(Flagged))
+        .function(syn::parse_quote!(flagged_new))
+        .function(syn::parse_quote!(flagged_value))
+        .panic();
+
+    let src = write(cbindgen, registry, "bool_payload");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("On(::core::mem::MaybeUninit<bool>),"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("example_flat::Flagged::On(::core::ptr::read(__f0.as_ptr()as*constu8)!=0"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("flagged_t::On(::core::mem::MaybeUninit::new(__f0))"),
+        "{src}"
+    );
+    // A bool owns nothing, so the union still gets no typed drop.
+    assert!(!compact.contains("flagged_drop"), "{src}");
+}

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1220,6 +1220,14 @@ impl Cbindgen {
                 })
             };
         }
+        // A `bool` payload rides as `MaybeUninit<bool>` (see
+        // `payload_field_wire`), so the byte C wrote is read out as a `u8` —
+        // legal for any bit pattern — and normalised the way C converts to
+        // `_Bool`: nonzero is true. No rejection: unlike a tag, every byte here
+        // has an unambiguous meaning.
+        if is_bool(fty) {
+            return quote!(::core::ptr::read(#b.as_ptr() as *const u8) != 0);
+        }
         // A scalar is its own wire and needs no call.
         if is_scalar(fty) {
             return quote!(#b);
@@ -1268,6 +1276,11 @@ impl Cbindgen {
             } else {
                 quote!(::std::boxed::Box::into_raw(#b) as *mut #c)
             };
+        }
+        // The counterpart of the normalising read above: Rust always writes a
+        // valid `0`/`1`, so this only wraps.
+        if is_bool(fty) {
+            return quote!(::core::mem::MaybeUninit::new(#b));
         }
         if is_scalar(fty) {
             return quote!(#b);


### PR DESCRIPTION
Fixes finding **1** of the review on #152 — the one place where a documented soundness invariant was actually false.

## The defect

`payload_field_wire` documents that *every* wire it returns is bit-pattern-agnostic, and `in_tagged_union` relies on exactly that to justify `v.assume_init()` after validating only the tag. But `is_scalar` includes `bool`, so a `bool` payload went through as its own wire:

```rust
pub enum Flagged { Off, On(bool) }
```
→ mirror `On(bool)`, converter `let v = v.assume_init();`

A C caller writing `2` into that union byte produces a value no Rust `bool` may hold — UB at `assume_init`, before any `match`. That is precisely the failure mode #158 closes one level up.

## The fix

`bool` joins the declared-`enum_type` case:

- wire is `::core::mem::MaybeUninit<bool>`;
- **in**: the byte is read as a `u8` (legal for any bit pattern) and normalised the way C converts to `_Bool` — nonzero is true. No rejection: unlike a tag, every byte here has an unambiguous meaning;
- **out**: Rust always writes a valid `0`/`1`, so it only wraps.

**The C header does not move.** cbindgen simplifies `MaybeUninit<T>` to `T`, so the slot is still spelled `bool` — the committed goldens show `bool flagged;` in the union arm.

## Coverage

Per the every-feature rule:

| Level | What |
|---|---|
| lib test | `bool_payload_is_normalised_not_materialised` — the wire and both converter directions |
| example | `example-flat` gains `Note::Flagged(bool)` + `note_new_flagged`, so the shape rides the committed goldens (both arches regenerated) |
| Rust boundary test | writes `2` and `0xff` into the payload slot through the raw bytes, exactly as a C caller can |
| C smoke test | the same from C, via `memcpy` into `note_t.flagged` |

## Verified

- `cargo test --all --all-features` — 389 lib + all example suites pass
- `cargo fmt --check`, `clippy --all-targets --no-default-features --all-features -D warnings` — clean
- `examples/regen-check.sh` — `PASS - regen check clean`
- `cmake --build … --target run_smoke` — `PASS - tagged union: … converter-derived payloads, out-of-domain bool payload`

## Out of scope, tracked

A `bool` reached through a **nested `data_struct` payload**, a plain `bool` **parameter**, and a `repr_c_struct` mirror field are the same defect on the pre-existing `c_field_wire`/scalar-passthrough policy, none of them introduced by the sum-type work. Filed as #170; the doc comment on `payload_field_wire` now says so rather than over-claiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)