### PR TITLE
ci: run on every pull request, not only those targeting main (#152 review)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,23 @@
 name: Rust
 
+# A stacked feature branch is reviewed as a chain of PRs targeting the branch
+# below it, not `main`. With a `branches: [main]` filter on `pull_request` none
+# of those PRs ran CI, so an umbrella branch could accumulate a whole feature
+# and meet clippy / fmt / the golden-diff check for the first time only at the
+# merge to `main`. The filter is therefore on `push` only (where it keeps the
+# duplicate run off feature branches); every PR runs, whatever it targets.
+# `workflow_dispatch` allows a manual run on a long-lived integration branch.
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
+
+# Every PR running means a push to a branch with an open PR would otherwise
+# queue a second identical run; keep only the newest per ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +48,10 @@ jobs:
 
     - name: Build
       run: cargo build
+    # `--all-features` is NOT optional here: the whole `lang::Cbindgen` suite is
+    # behind `unstable-cbindgen`, so a bare `cargo test` silently skips ~60
+    # tests. Both lines are kept — the first proves the default feature set
+    # still builds and passes on its own.
     - name: Run tests
       run: |
         cargo test


### PR DESCRIPTION
Fixes finding **3** of the review on #152 — the CI blind spot the PR body itself flagged.

## The problem

`rust.yml` filtered `pull_request` on `branches: [ "main" ]`. A stacked feature branch is reviewed as a chain of PRs targeting the branch *below* it, so **none of #152's five stage PRs ran CI**. `sum-types` accumulated ~14 k lines and would have met clippy, `fmt --check`, `regen-check.sh` and the JVM covertest as a whole for the first time at the merge to `main`.

## The change

- the branch filter applies to `push` only — where it still keeps a duplicate run off feature branches;
- `pull_request` has no filter: every PR runs, whatever it targets;
- `workflow_dispatch` for a manual run on a long-lived integration branch (e.g. `sum-types` itself, before it merges);
- a `concurrency` group cancels superseded runs per ref, since a push to a branch with an open PR would now otherwise queue two identical runs.

## On `--all-features`

The review asked for confirmation, and the answer is that the workflow **already** runs `cargo test --all --all-features`. Measured on this branch:

| Command | Tests |
|---|---|
| `cargo test -p prebindgen` | 327 |
| `cargo test -p prebindgen --all-features` | 388 |

The 61-test gap is the entire `lang::Cbindgen` suite, behind `unstable-cbindgen` — including `tagged_unions.rs`, the centrepiece of stage B. Both lines are kept (the bare one proves the default feature set stands on its own), with a comment saying why the second may not be dropped.

## Note

This PR targets `sum-types` like the other review fixes, so the widened trigger takes effect for the rest of the stack immediately — this PR is itself the first one to run under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)