### PR TITLE
cbindgen: free a tagged union nested inside a struct payload (#152 review)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -418,6 +418,15 @@ reaches through the payload and releases each of them, nulling the slot so a sec
 Without that a `String` or handle inside a struct payload would leak silently — which is exactly the
 shape zenoh-flat#30 needs (`ReplyResult`'s alternatives are structs whose fields are handles).
 
+That reach is **recursive one level further**: a struct payload's own field may itself be a declared
+`tagged_union` with an owning arm, whose wire is again a by-value mirror rather than a pointer. The
+outer drop delegates to *that* union's typed drop, which nulls what it frees, so idempotence
+composes. Nothing else can reach it — at top level the data-struct contract is that C releases each
+owning field itself, but a union arm is not a top-level struct field. One predicate
+(`tagged_union_has_drop`) serves as both the drop's emission condition and the containing struct's
+test for whether to call it, so a nested union cannot be freed through a symbol that was never
+emitted.
+
 The drop is also a second C entry point into the same bytes, so it validates the tag the same way
 `in_tagged_union` does (§5.3) and treats an out-of-range one as nothing to release.
 

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -162,6 +162,7 @@ fn generate_ffi_bindings() -> PathBuf {
         // and its `&str`-taking constructor.
         pq!(note_value),
         pq!(note_new_titled),
+        pq!(note_new_sketched),
         pq!(caption_new),
         pq!(calculator_new_clone),
         pq!(calculator_get_value),

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -252,6 +252,29 @@ static void test_out_of_domain_bool_payload(void) {
     note_drop(&off);
 }
 
+/* A union nested inside a struct payload. `note_t`'s `Sketched` arm carries a
+ * `drawing_t` BY VALUE, whose own `shape` field is another union with an owning
+ * arm — a `char *` two levels down that nothing else can reach: a union arm is
+ * not a top-level struct field the C caller releases by hand. `note_drop` has to
+ * reach through the record and call the nested union's own typed drop. */
+static void test_nested_union_payload(void) {
+    note_t sketched = note_new_sketched(3, "outline");
+    CHECK(sketched.tag == Sketched);
+    CHECK(sketched.sketched.id == 3);
+    CHECK(sketched.sketched.shape.tag == Labeled);
+    CHECK(strcmp(sketched.sketched.shape.labeled._0, "outline") == 0);
+
+    /* …and crosses back IN, rebuilt through both levels of converter. */
+    CHECK(note_value(sketched) == 3);
+
+    /* The outer drop reaches the inner union's active arm and nulls it, so a
+     * second drop of either is a no-op. */
+    note_drop(&sketched);
+    CHECK(sketched.sketched.shape.labeled._0 == NULL);
+    note_drop(&sketched);
+    shape_drop(&sketched.sketched.shape);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
@@ -259,12 +282,14 @@ int main(void) {
     test_invalid_tag();
     test_converter_derived_payloads();
     test_out_of_domain_bool_payload();
+    test_nested_union_payload();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
         return 1;
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
-           "converter-derived payloads, out-of-domain bool payload\n");
+           "converter-derived payloads, out-of-domain bool payload, "
+           "nested union payload\n");
     return 0;
 }

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -89,6 +89,7 @@ pub enum note_t {
     Titled(caption_t),
     After(u64),
     Flagged(::core::mem::MaybeUninit<bool>),
+    Sketched(drawing_t),
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
@@ -106,13 +107,16 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         (*this_).as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
         return;
     }
     match (*this_).assume_init_mut() {
         note_t::Titled(__f0) => {
             free((*__f0).text as *mut ::core::ffi::c_void);
             (*__f0).text = ::core::ptr::null_mut();
+        }
+        note_t::Sketched(__f0) => {
+            shape_drop(&mut (*__f0).shape);
         }
         _ => {}
     }
@@ -249,9 +253,9 @@ pub(crate) unsafe fn __cbg_in_Note(
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         v.as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
         return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..4)", __tag),
+            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
         );
     }
     let v = v.assume_init();
@@ -264,6 +268,9 @@ pub(crate) unsafe fn __cbg_in_Note(
                 example_flat::Note::Flagged(
                     ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
                 )
+            }
+            note_t::Sketched(__f0) => {
+                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
             }
         },
     )
@@ -497,6 +504,9 @@ pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<
             example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
             example_flat::Note::Flagged(__f0) => {
                 note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            }
+            example_flat::Note::Sketched(__f0) => {
+                note_t::Sketched(__cbg_out_Drawing(__f0))
             }
         },
     )
@@ -881,6 +891,24 @@ pub unsafe extern "C" fn note_new_flagged(
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_sketched(
+    id: u64,
+    label: *const ::core::ffi::c_char,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let id = __cbg_in_u64(id);
+    let label = match __cbg_in___str(label) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
     __ret = __cbg_out_Note(__v);
     __ret

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -89,6 +89,7 @@ pub enum note_t {
     Titled(caption_t),
     After(u64),
     Flagged(::core::mem::MaybeUninit<bool>),
+    Sketched(drawing_t),
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
@@ -106,13 +107,16 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         (*this_).as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
         return;
     }
     match (*this_).assume_init_mut() {
         note_t::Titled(__f0) => {
             free((*__f0).text as *mut ::core::ffi::c_void);
             (*__f0).text = ::core::ptr::null_mut();
+        }
+        note_t::Sketched(__f0) => {
+            shape_drop(&mut (*__f0).shape);
         }
         _ => {}
     }
@@ -249,9 +253,9 @@ pub(crate) unsafe fn __cbg_in_Note(
     let __tag: ::core::ffi::c_int = ::core::ptr::read(
         v.as_ptr() as *const ::core::ffi::c_int,
     );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
         return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..4)", __tag),
+            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
         );
     }
     let v = v.assume_init();
@@ -264,6 +268,9 @@ pub(crate) unsafe fn __cbg_in_Note(
                 example_flat::Note::Flagged(
                     ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
                 )
+            }
+            note_t::Sketched(__f0) => {
+                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
             }
         },
     )
@@ -497,6 +504,9 @@ pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<
             example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
             example_flat::Note::Flagged(__f0) => {
                 note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            }
+            example_flat::Note::Sketched(__f0) => {
+                note_t::Sketched(__cbg_out_Drawing(__f0))
             }
         },
     )
@@ -881,6 +891,24 @@ pub unsafe extern "C" fn note_new_flagged(
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
+    let __ret: ::core::mem::MaybeUninit<note_t>;
+    __ret = __cbg_out_Note(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_new_sketched(
+    id: u64,
+    label: *const ::core::ffi::c_char,
+) -> ::core::mem::MaybeUninit<note_t> {
+    let id = __cbg_in_u64(id);
+    let label = match __cbg_in___str(label) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
     __ret = __cbg_out_Note(__v);
     __ret

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -33,28 +33,6 @@ typedef struct caption_t {
   char *text;
 } caption_t;
 
-typedef enum note_t_Tag {
-  Silent,
-  Titled,
-  After,
-  Flagged,
-} note_t_Tag;
-
-typedef struct note_t {
-  note_t_Tag tag;
-  union {
-    struct {
-      struct caption_t titled;
-    };
-    struct {
-      uint64_t after;
-    };
-    struct {
-      bool flagged;
-    };
-  };
-} note_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -83,16 +61,42 @@ typedef struct shape_t {
   };
 } shape_t;
 
+typedef struct drawing_t {
+  uint64_t id;
+  struct shape_t shape;
+} drawing_t;
+
+typedef enum note_t_Tag {
+  Silent,
+  Titled,
+  After,
+  Flagged,
+  Sketched,
+} note_t_Tag;
+
+typedef struct note_t {
+  note_t_Tag tag;
+  union {
+    struct {
+      struct caption_t titled;
+    };
+    struct {
+      uint64_t after;
+    };
+    struct {
+      bool flagged;
+    };
+    struct {
+      struct drawing_t sketched;
+    };
+  };
+} note_t;
+
 typedef struct closure_value_t {
   void *context;
   void (*call)(double, void*);
   void (*drop)(void*);
 } closure_value_t;
-
-typedef struct drawing_t {
-  uint64_t id;
-  struct shape_t shape;
-} drawing_t;
 
 typedef struct foo_t {
   uint64_t id;
@@ -155,6 +159,8 @@ struct note_t note_new_after(uint64_t millis);
 struct note_t note_new_flagged(bool flag);
 
 struct note_t note_new_silent(void);
+
+struct note_t note_new_sketched(uint64_t id, const char *label);
 
 struct note_t note_new_titled(uint64_t id, const char *text);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -33,28 +33,6 @@ typedef struct caption_t {
   char *text;
 } caption_t;
 
-typedef enum note_t_Tag {
-  Silent,
-  Titled,
-  After,
-  Flagged,
-} note_t_Tag;
-
-typedef struct note_t {
-  note_t_Tag tag;
-  union {
-    struct {
-      struct caption_t titled;
-    };
-    struct {
-      uint64_t after;
-    };
-    struct {
-      bool flagged;
-    };
-  };
-} note_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -83,16 +61,42 @@ typedef struct shape_t {
   };
 } shape_t;
 
+typedef struct drawing_t {
+  uint64_t id;
+  struct shape_t shape;
+} drawing_t;
+
+typedef enum note_t_Tag {
+  Silent,
+  Titled,
+  After,
+  Flagged,
+  Sketched,
+} note_t_Tag;
+
+typedef struct note_t {
+  note_t_Tag tag;
+  union {
+    struct {
+      struct caption_t titled;
+    };
+    struct {
+      uint64_t after;
+    };
+    struct {
+      bool flagged;
+    };
+    struct {
+      struct drawing_t sketched;
+    };
+  };
+} note_t;
+
 typedef struct closure_value_t {
   void *context;
   void (*call)(double, void*);
   void (*drop)(void*);
 } closure_value_t;
-
-typedef struct drawing_t {
-  uint64_t id;
-  struct shape_t shape;
-} drawing_t;
 
 typedef struct foo_t {
   uint64_t id;
@@ -155,6 +159,8 @@ struct note_t note_new_after(uint64_t millis);
 struct note_t note_new_flagged(bool flag);
 
 struct note_t note_new_silent(void);
+
+struct note_t note_new_sketched(uint64_t id, const char *label);
 
 struct note_t note_new_titled(uint64_t id, const char *text);
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -113,6 +113,11 @@ pub enum Note {
     /// so it crosses behind `MaybeUninit` like a declared enum does and a byte
     /// C wrote is normalised, never materialised as a Rust `bool`.
     Flagged(bool),
+    /// A record whose own field is ANOTHER union with an owning arm. The
+    /// payload crosses by value, so `note_drop` has to reach through it and
+    /// release the nested union's active arm — nothing else can: a union arm
+    /// is not a top-level struct field the C caller drops by hand.
+    Sketched(Drawing),
 }
 
 /// A newtype whose C wire is the `u64` its declared conversion produces — not
@@ -158,6 +163,16 @@ pub fn note_new_flagged(flag: bool) -> Note {
     Note::Flagged(flag)
 }
 
+/// A sketched note: a record payload whose own `shape` field is another union,
+/// with an arm that owns a `char *`.
+#[prebindgen]
+pub fn note_new_sketched(id: u64, label: &str) -> Note {
+    Note::Sketched(Drawing {
+        id,
+        shape: Shape::Labeled(label.to_string(), Operation::Add),
+    })
+}
+
 /// Read a note back: its caption id, its delay, or 0 — the sum in **parameter**
 /// position, so both new payload kinds cross inbound as well as outbound.
 #[prebindgen]
@@ -167,6 +182,7 @@ pub fn note_value(n: Note) -> u64 {
         Note::Titled(c) => c.id,
         Note::After(Millis(m)) => m,
         Note::Flagged(f) => f as u64,
+        Note::Sketched(d) => d.id,
     }
 }
 

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -240,11 +240,45 @@ impl Cbindgen {
         self.struct_fields(registry, fty)
             .unwrap_or_default()
             .into_iter()
-            .filter(|(_, fty)| {
-                self.data_field_wire(fty)
-                    .is_some_and(|w| matches!(w, syn::Type::Ptr(_)))
-            })
+            .filter(|(_, fty)| self.data_field_owns(fty, registry))
             .collect()
+    }
+
+    /// Whether one `data_struct` **field** hands owned memory to C: its own wire
+    /// is a pointer (`String` → `char *`), or it is a declared
+    /// [`Cbindgen::tagged_union`] with an owning arm — which crosses by value,
+    /// so the pointer it owns is one level further down.
+    fn data_field_owns(&self, fty: &syn::Type, registry: &Registry<()>) -> bool {
+        if matches!(self.data_field_wire(fty), Some(syn::Type::Ptr(_))) {
+            return true;
+        }
+        self.tagged_union_has_drop(fty, registry)
+    }
+
+    /// Whether a declared `tagged_union` gets a typed `<base>_drop` — i.e. it is
+    /// produced at all, and some arm's payload owns memory.
+    ///
+    /// This is the emission condition of that drop
+    /// ([`Cbindgen::prereq_tagged_unions`]) *and* the test for whether a
+    /// containing struct has to call it, so a union nested inside a payload
+    /// cannot be freed through a symbol that was never emitted. `false` for
+    /// anything that is not a declared tagged union.
+    pub(super) fn tagged_union_has_drop(&self, fty: &syn::Type, registry: &Registry<()>) -> bool {
+        if !self.tagged_unions.contains_key(&TypeKey::from_type(fty))
+            || registry.output_entry(fty).is_none()
+        {
+            return false;
+        }
+        self.enum_variants(registry, fty)
+            .unwrap_or_default()
+            .iter()
+            .flat_map(|v| v.fields.iter())
+            .any(|f| match self.payload_field_wire(&f.ty, registry) {
+                // A rejected payload is reported from the emission site, which
+                // panics before any of this matters.
+                Err(_) => false,
+                Ok(wire) => self.payload_wire_owns(&f.ty, &wire, registry),
+            })
     }
 
     /// Whether any declared function returns a `Vec<_>` (possibly nested under

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -261,6 +261,74 @@ fn tagged_union_as_data_struct_field() {
     assert!(compact.contains("shape:__cbg_out_Shape(v.shape),"), "{src}");
 }
 
+/// A union nested inside a **struct payload** of another union. The record
+/// crosses by value, so the pointer it owns is two levels down — and nothing
+/// else can release it: a union arm is not a top-level struct field the C caller
+/// drops by hand. The outer drop therefore reaches through the payload and calls
+/// the inner union's own typed drop, which nulls what it frees and so keeps the
+/// whole thing idempotent.
+#[test]
+fn a_union_nested_in_a_struct_payload_is_freed() {
+    let loc = SourceLocation::default();
+    let drawing: syn::ItemStruct = syn::parse_quote!(
+        pub struct Drawing {
+            pub id: u64,
+            pub shape: Shape,
+        }
+    );
+    let note: syn::ItemEnum = syn::parse_quote!(
+        pub enum Note {
+            Silent,
+            Sketched(Drawing),
+        }
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn note_new() -> Note {
+            unimplemented!()
+        }
+    );
+    let shape_new: syn::ItemFn = syn::parse_quote!(
+        pub fn shape_new() -> Shape {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Enum(shape_enum()), loc.clone()),
+        (syn::Item::Enum(operation_enum()), loc.clone()),
+        (syn::Item::Struct(drawing), loc.clone()),
+        (syn::Item::Enum(note), loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+        (syn::Item::Fn(shape_new), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .enum_type(syn::parse_quote!(Operation))
+        .tagged_union(syn::parse_quote!(Shape))
+        .data_struct(syn::parse_quote!(Drawing))
+        .tagged_union(syn::parse_quote!(Note))
+        .function(syn::parse_quote!(note_new))
+        .function(syn::parse_quote!(shape_new));
+
+    let src = write(cbindgen, registry, "nested_union_payload");
+    let compact: String = src.split_whitespace().collect();
+
+    // The outer union owns something only THROUGH the record, so it gets a drop
+    // at all — and that drop delegates to the inner union's.
+    assert!(
+        compact.contains("fnnote_drop(this_:*mut::core::mem::MaybeUninit<note_t>)"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("note_t::Sketched(__f0)=>{shape_drop(&mut(*__f0).shape);}"),
+        "{src}"
+    );
+}
+
 /// A data struct of plain fields keeps its **infallible** decode — only a
 /// union field makes the struct's own conversion able to fail.
 #[test]

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -841,7 +841,11 @@ impl Cbindgen {
                 }
             ));
 
-            if registry.output_entry(&ty).is_some() && !drop_arms.is_empty() {
+            // The same predicate a CONTAINING struct uses to decide whether to
+            // call this drop, so a nested union can never be freed through a
+            // symbol that was not emitted.
+            if self.tagged_union_has_drop(&ty, registry) {
+                debug_assert!(!drop_arms.is_empty(), "has_drop implies an owning arm");
                 let drop_ident = self.destructor_symbol(&ty);
                 // The drop is a second C entry point into the same bytes, so it
                 // owes the same tag check as the input converter — `&mut *this_`
@@ -929,16 +933,25 @@ impl Cbindgen {
                         free((*#binding).#fname as *mut ::core::ffi::c_void);
                         (*#binding).#fname = ::core::ptr::null_mut();
                     )
+                } else if self.tagged_union_has_drop(fty, registry) {
+                    // The field is ANOTHER union, crossing by value. Its own
+                    // typed drop releases whichever arm is live and nulls the
+                    // slot, so this stays idempotent like every other arm here
+                    // — and the owning pointer is reached even though it is two
+                    // levels down. Nothing else can reach it: a union arm is not
+                    // a top-level struct field the C caller releases by hand.
+                    let drop_ident = self.destructor_symbol(fty);
+                    quote!(#drop_ident(&mut (*#binding).#fname);)
                 } else {
-                    let inner = opaque_ptr_payload_inner(fty).unwrap_or_else(|| fty.clone());
-                    let src_inner = self.src_ty(&inner);
-                    quote!(
-                        if !(*#binding).#fname.is_null() {
-                            drop(::std::boxed::Box::from_raw(
-                                (*#binding).#fname as *mut #src_inner,
-                            ));
-                            (*#binding).#fname = ::core::ptr::null_mut();
-                        }
+                    // `owning_data_struct_fields` yields exactly the two shapes
+                    // above (`data_field_owns`), so this is unreachable — and a
+                    // silent fall-through here would be a leak, which is the
+                    // defect this whole path exists to prevent.
+                    panic!(
+                        "Cbindgen: data-struct field `{}` of type `{}` is owning but has no \
+                         release form (expected a `String` or a declared `tagged_union`)",
+                        fname,
+                        fty.to_token_stream(),
                     )
                 }
             });


### PR DESCRIPTION
Fixes finding **5** of the review on #152 (and the dead-branch note in the same finding).

## The leak

`owning_data_struct_fields` selected fields whose `data_field_wire` is `Type::Ptr`. A `tagged_union` field's wire is `MaybeUninit<mirror>` — not a pointer — so if a struct payload of a union itself carries a union with an owning arm, `payload_free_stmt` walked straight past it and the `char *` leaked.

At **top level** this is consistent with the documented data-struct contract: the struct has no destructor and C releases each owning field itself. But a union arm is *not* a top-level struct field. Once the struct is buried in a union payload, nothing else can reach two levels down — the outer drop is the only entry point that exists.

## The fix

An owning `data_struct` field is now one of two things, stated once in `data_field_owns`:

1. its own wire is a pointer (`String` → `char *`), or
2. it is a declared `tagged_union` with an owning arm — crossing by value, with the pointer one level further down.

For (2) the outer drop delegates to the inner union's own typed drop, which nulls what it frees, so idempotence composes:

```rust
note_t::Sketched(__f0) => { shape_drop(&mut (*__f0).shape); }
```

`tagged_union_has_drop` is now the **single** predicate for "this union has a `<base>_drop`", used both as that drop's emission condition and as a containing struct's test for whether to call it — so a nested union can never be freed through a symbol that was never emitted.

## The dead branch, also from finding 5

`payload_free_stmt`'s struct-field loop had an `else` that did `Box::from_raw` on an "opaque field", unreachable because `c_field_wire` yields `Ptr` only for `String`. It is now a `panic!` naming the field: `owning_data_struct_fields` yields exactly the two shapes above, and a silent fall-through there would be precisely the leak this path exists to prevent.

## Coverage

- `example-flat` gains `Note::Sketched(Drawing)` — a record payload whose own `shape` field is a union with an owning arm — plus `note_new_sketched`;
- `c/smoke.c` builds one, reads the `char *` two levels down, calls `note_drop`, and checks the inner slot is nulled and a second drop of either level is a no-op;
- `a_union_nested_in_a_struct_payload_is_freed` pins the generated delegation.

## Verified

- `cargo test --all --all-features` — 389 lib + all example suites pass
- `cargo fmt --check`, `clippy --all-targets --no-default-features --all-features -D warnings` — clean
- `examples/regen-check.sh` — `PASS - regen check clean` (both arch headers regenerated)
- `cmake --build … --target run_smoke` — `PASS - tagged union: … converter-derived payloads, nested union payload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)