### PR TITLE
covertest: an Option<enum> payload in a RETURNED sum (#152 review finding 4)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -459,6 +459,10 @@ fn main() {
                 .fun(fun!(observation_which))
                 .fun(fun!(tagged_new))
                 .fun(fun!(tagged_rank))
+                // The same `Option<enum>` payload in RETURN position — the
+                // `synth_sum_leaves` path, which the struct field above does
+                // not reach (it degrades to the whole-object crossing).
+                .fun(fun!(marker_of))
                 // A sum as the function's OWN return (and callback argument):
                 // the tag + groups ride the hoisted builder / folder singleton
                 // instead of a parent's `fromParts`. All four positions —

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -67,6 +67,8 @@ Base package: `io.prebindgen.covertest`
 - `lookup_each` — `fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>)`
 - `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
   - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)
+- `marker_of` — `fun markerOf(which: Int, onError: JniErrorHandler<Marker>): Marker`
+  - shaped by: return `Marker` decomposed → [tag, ranked_v0] (Callback delivery)
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
 - `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation>): Observation`
 - `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -710,6 +710,8 @@ internal object CovNative {
 
     external fun lookupOf(count: Long, total: Double, build: Any, errorSink: Any): Any?
 
+    external fun markerOf(which: Int, build: Any, errorSink: Any): Any?
+
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
 
     external fun objectBoundaryValue(value: ObjectBoundary, errorSink: Any): Long

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -774,6 +774,15 @@ LookupBuilderRaw { tag, found_v0, failed_v0 ->
     when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
 }
 
+public fun interface MarkerBuilder<out R> {
+    public fun run(tag: Int, ranked_v0: Int?): R
+}
+
+internal val __MarkerBuilder: MarkerBuilder<Marker> =
+MarkerBuilder { tag, ranked_v0 ->
+    when (tag) { 0 -> Marker.None_; 1 -> Marker.Ranked(ranked_v0?.let { Priority.fromInt(it) }); else -> throw IllegalArgumentException("Marker: invalid tag $tag") }
+}
+
 public fun interface ReadingBuilder<out R> {
     public fun run(
         tag: Int,
@@ -1144,6 +1153,28 @@ public fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int {
     val __ret = CovNative.taggedRank(t.id, t.marker, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
+}
+
+/**
+ * The same `Option<enum>` payload with the sum in **return** position rather
+ * than as a struct field. Only this reaches `synth_sum_leaves`, which hardcodes
+ * `nullable: false` on every group leaf and lets `plan_leaf_param` widen from
+ * the inert side; a struct field takes `PlanFieldKind::Sum` and, for this
+ * payload, degrades to the whole-object crossing instead.
+ *
+ * Two nullabilities meet in one slot and must not collapse into each other:
+ * the payload's own `None`, and the slot being inert because the other variant
+ * is live. Both arrive as a JVM null, so `Ranked(null)` and `None_` are only
+ * told apart by the tag.
+ *
+ * The Rust `Marker` result is delivered decomposed: the builder callback receives (`tag`, `ranked_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun markerOf(which: Int, onError: JniErrorHandler<Marker>): Marker {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.markerOf(which, __MarkerBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Marker
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -67,6 +67,7 @@ import io.prebindgen.covertest.model.readingOf
 import io.prebindgen.covertest.model.readingSeries
 import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.Tagged
+import io.prebindgen.covertest.model.markerOf
 import io.prebindgen.covertest.model.taggedNew
 import io.prebindgen.covertest.model.taggedRank
 import io.prebindgen.covertest.model.payloadPriority
@@ -556,6 +557,30 @@ fun main() {
         check(taggedRank(Tagged(1L, Marker.None_), boom) == -1)
         check(taggedRank(Tagged(1L, Marker.Ranked(null)), boom) == 0)
         check(taggedRank(Tagged(1L, Marker.Ranked(Priority.HIGH)), boom) == 10)
+    }
+
+    // ── the same Option<enum> payload in RETURN position ──────────────────────
+    // The field above degrades to the whole-object crossing, so it never reaches
+    // `synth_sum_leaves` — which hardcodes `nullable: false` on every group leaf
+    // and lets `plan_leaf_param` widen from the inert side. Two nullabilities
+    // meet in this one slot and must not collapse into each other: the payload's
+    // own `None`, and the slot being inert because the OTHER variant is live.
+    // Both arrive as a JVM null, so only the tag tells `Ranked(null)` from
+    // `None_`.
+    section("Option<enum> payload in a returned sum") {
+        check(markerOf(0, boom) === Marker.None_)
+
+        val absent = markerOf(1, boom)
+        check(absent is Marker.Ranked && absent.v0 == null)
+
+        val present = markerOf(2, boom)
+        check(present is Marker.Ranked && present.v0 == Priority.HIGH)
+
+        // The two nulls are distinguishable in both directions: each value the
+        // return path built crosses back in and reads as itself.
+        check(taggedRank(Tagged(1L, markerOf(0, boom)), boom) == -1)
+        check(taggedRank(Tagged(1L, markerOf(1, boom)), boom) == 0)
+        check(taggedRank(Tagged(1L, markerOf(2, boom)), boom) == 10)
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -9890,6 +9890,100 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_lookupOf<'a>(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_markerOf<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/MarkerBuilder";
+    const __CB_DESCR: &str = "(ILjava/lang/Integer;)Ljava/lang/Object;";
+    let __out = perftest_flat::marker_of(which);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::objects::JObject;
+    match &__out {
+        perftest_flat::Marker::None_ => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::objects::JObject::null();
+        }
+        perftest_flat::Marker::Ranked(__sv0) => {
+            let __enc___obj1 = match Option_Priority_to_JObject_ad5cbb32(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = __enc___obj1;
+            __obj0 = jni::sys::jvalue { i: 1 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                jni::sys::jvalue {
+                    l: __obj1.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_millisAdd<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -182,6 +182,25 @@ pub fn tagged_new(which: i32) -> Tagged {
     }
 }
 
+/// The same `Option<enum>` payload with the sum in **return** position rather
+/// than as a struct field. Only this reaches `synth_sum_leaves`, which hardcodes
+/// `nullable: false` on every group leaf and lets `plan_leaf_param` widen from
+/// the inert side; a struct field takes `PlanFieldKind::Sum` and, for this
+/// payload, degrades to the whole-object crossing instead.
+///
+/// Two nullabilities meet in one slot and must not collapse into each other:
+/// the payload's own `None`, and the slot being inert because the other variant
+/// is live. Both arrive as a JVM null, so `Ranked(null)` and `None_` are only
+/// told apart by the tag.
+#[prebindgen]
+pub fn marker_of(which: i32) -> Marker {
+    match which {
+        0 => Marker::None_,
+        1 => Marker::Ranked(None),
+        _ => Marker::Ranked(Some(Priority::High)),
+    }
+}
+
 /// Read it back — the whole-object sum decode, including the `Option<enum>`
 /// payload, crossing Kotlin → Rust.
 #[prebindgen]


### PR DESCRIPTION
Fixes finding **4** of the review on #152 — the untested position, closed with coverage rather than added to the #161 list.

## What was untested

`synth_sum_leaves` hardcodes `nullable: false` on every group leaf, and `plan_leaf_param` then computes nullability as `leaf.nullable || inert_nullable`. The covertest exercised `Option<Priority>` only through `Marker` as a **struct field** — `PlanFieldKind::Sum`, which for this payload degrades to the whole-object crossing and so never reaches `synth_sum_leaves` at all. The return-position behaviour was inferred to be correct, not observed.

## What it now asserts

`marker_of(which) -> Marker` puts the same payload in return position. The property under test is that **two nullabilities meet in one slot and must not collapse into each other**:

- the payload's own `None` (`Ranked(None)`), and
- the slot being inert because the *other* variant is live (`None_`).

Both arrive as a JVM null, so only the tag distinguishes them:

```kotlin
check(markerOf(0, boom) === Marker.None_)
val absent = markerOf(1, boom);  check(absent is Marker.Ranked && absent.v0 == null)
val present = markerOf(2, boom); check(present is Marker.Ranked && present.v0 == Priority.HIGH)
```

Each returned value then crosses back **in** through `taggedRank`, so the distinction is shown to survive the round trip.

## What the generator does (now pinned, previously inferred)

The review's conclusion was right. The builder slot is boxed:

```kotlin
public fun interface MarkerBuilder<out R> { public fun run(tag: Int, ranked_v0: Int?): R }
internal val __MarkerBuilder: MarkerBuilder<Marker> = MarkerBuilder { tag, ranked_v0 ->
    when (tag) { 0 -> Marker.None_; 1 -> Marker.Ranked(ranked_v0?.let { Priority.fromInt(it) }); … }
}
```

with the inert default `JObject::null()` on the Rust side — the `Option<Priority>` payload rides `Option_Priority_to_JObject`, an object leaf, so the widening is consistent in both places.

## Verified

- **JVM covertest: 44 sections pass**, including `ok - Option<enum> payload in a returned sum`
- `cargo test --all --all-features` (388 lib), `cargo fmt --check`, `clippy -D warnings` — clean
- `examples/regen-check.sh` — `PASS - regen check clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)