### PR TITLE
jnigen: move the replace_ident tests to the end of fold.rs

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -436,43 +436,6 @@ fn replace_ident(haystack: &str, from: &str, to: &str) -> String {
     out
 }
 
-#[cfg(test)]
-mod replace_ident_tests {
-    use super::replace_ident;
-
-    /// The property the function exists for: a slot name is rewritten only as a
-    /// whole identifier, so the `!!` never lands on a longer name that merely
-    /// starts (or ends) with it.
-    #[test]
-    fn only_whole_identifiers_are_rewritten() {
-        assert_eq!(replace_ident("x", "x", "x!!"), "x!!");
-        assert_eq!(replace_ident("x_2", "x", "x!!"), "x_2");
-        assert_eq!(replace_ident("ax", "x", "x!!"), "ax");
-        assert_eq!(
-            replace_ident("Reading.Exact(exact_v0)", "exact_v0", "exact_v0!!"),
-            "Reading.Exact(exact_v0!!)"
-        );
-        // A prefix of a longer slot name of the same group is left alone.
-        assert_eq!(
-            replace_ident("f(exact_v0, exact_v01)", "exact_v0", "exact_v0!!"),
-            "f(exact_v0!!, exact_v01)"
-        );
-    }
-
-    /// A rejected occurrence must not consume the context of the next one: with
-    /// the left character re-sliced out of the remaining input, `"axx"` rewrote
-    /// its second `x` — the first having been dropped from `rest` along with the
-    /// `a` that disqualified it.
-    #[test]
-    fn a_rejected_match_keeps_its_left_context() {
-        assert_eq!(replace_ident("axx", "x", "x!!"), "axx");
-        assert_eq!(replace_ident("xxx", "x", "x!!"), "xxx");
-        assert_eq!(replace_ident("x ax", "x", "x!!"), "x!! ax");
-        // Every occurrence of a genuinely standalone identifier is rewritten.
-        assert_eq!(replace_ident("x + x", "x", "x!!"), "x!! + x!!");
-    }
-}
-
 /// Render the Kotlin `close()` expression for a handle `receiver` through
 /// the folded [`FoldStrategy`] layers. Fresh lambda variable per nesting
 /// level avoids `it` shadowing; the common single-layer cases are
@@ -682,5 +645,42 @@ pub(crate) fn register_fqn(fqn: &str, used: &mut BTreeSet<String>) -> String {
         fqn.rsplit('.').next().unwrap_or(fqn).to_string()
     } else {
         fqn.to_string()
+    }
+}
+
+#[cfg(test)]
+mod replace_ident_tests {
+    use super::replace_ident;
+
+    /// The property the function exists for: a slot name is rewritten only as a
+    /// whole identifier, so the `!!` never lands on a longer name that merely
+    /// starts (or ends) with it.
+    #[test]
+    fn only_whole_identifiers_are_rewritten() {
+        assert_eq!(replace_ident("x", "x", "x!!"), "x!!");
+        assert_eq!(replace_ident("x_2", "x", "x!!"), "x_2");
+        assert_eq!(replace_ident("ax", "x", "x!!"), "ax");
+        assert_eq!(
+            replace_ident("Reading.Exact(exact_v0)", "exact_v0", "exact_v0!!"),
+            "Reading.Exact(exact_v0!!)"
+        );
+        // A prefix of a longer slot name of the same group is left alone.
+        assert_eq!(
+            replace_ident("f(exact_v0, exact_v01)", "exact_v0", "exact_v0!!"),
+            "f(exact_v0!!, exact_v01)"
+        );
+    }
+
+    /// A rejected occurrence must not consume the context of the next one: with
+    /// the left character re-sliced out of the remaining input, `"axx"` rewrote
+    /// its second `x` — the first having been dropped from `rest` along with the
+    /// `a` that disqualified it.
+    #[test]
+    fn a_rejected_match_keeps_its_left_context() {
+        assert_eq!(replace_ident("axx", "x", "x!!"), "axx");
+        assert_eq!(replace_ident("xxx", "x", "x!!"), "xxx");
+        assert_eq!(replace_ident("x ax", "x", "x!!"), "x!! ax");
+        // Every occurrence of a genuinely standalone identifier is rewritten.
+        assert_eq!(replace_ident("x + x", "x", "x!!"), "x!! + x!!");
     }
 }


### PR DESCRIPTION
Fixes the clippy failure on #152 (both `build (stable)` and `build (1.85.0)`, run 30200032585):

```
error: items after a test module
   --> prebindgen/src/api/lang/jnigen/jni/fold.rs:440:1
440 | mod replace_ident_tests {
    = note: `-D clippy::items-after-test-module` implied by `-D warnings`
```

The inline test module added in #172 sits mid-file, with six more `pub(crate)` items
after it. Every other in-file test module in the crate is at the end of its file, so
the module moves there rather than the lint being allowed. The tests and
`replace_ident` itself are unchanged — a pure relocation.

Verified locally: `cargo clippy --all-targets --no-default-features --all-features -- --deny warnings`
clean, `cargo +nightly fmt --check` clean, 329 lib tests pass (including both
`replace_ident_tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)