### PR TITLE
jnigen: store a type's declared kind as a sum, not five flags (#180)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -8,29 +8,61 @@
 
 use super::*;
 
-/// Which of the five class declarators a type is registered under. A type
-/// gets exactly one: two declarators would emit two Kotlin declarations for
-/// the same FQN and leave the type table ambiguous about the kind, so the
-/// second is a hard error (see [`JniGen::assert_class_kind`]). Reopening the
-/// *same* declarator stays legal — its options merge.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DeclaredKind {
-    Ptr,
-    Enum,
-    Sealed,
-    Data,
-    Value,
-}
-
 impl DeclaredKind {
     /// The declaring macro's name, for the conflict message.
-    fn macro_name(self) -> &'static str {
+    pub(crate) fn macro_name(&self) -> &'static str {
         match self {
-            DeclaredKind::Ptr => "ptr_class",
-            DeclaredKind::Enum => "enum_class",
-            DeclaredKind::Sealed => "sealed_class",
+            DeclaredKind::Ptr(_) => "ptr_class",
+            DeclaredKind::Enum(_) => "enum_class",
+            DeclaredKind::Sealed(_) => "sealed_class",
             DeclaredKind::Data => "data_class",
             DeclaredKind::Value => "value_class",
+        }
+    }
+
+    /// Fold a **reopened** declaration of the same kind into this one, or
+    /// reject a *different* kind. Both halves of "a type gets exactly one
+    /// class declarator" live here, once, for every kind:
+    ///
+    /// * a different variant is rejected — two declarators would emit two
+    ///   Kotlin declarations for the same FQN and leave the type table
+    ///   ambiguous about the kind. The check is one discriminant comparison,
+    ///   kind-agnostic and symmetric in declaration order, so a new kind is
+    ///   covered by it without touching this function;
+    /// * the same variant merges that kind's own payload, each rule written
+    ///   next to the payload it merges.
+    ///
+    /// `type_name` is the short Rust name of the type being declared, for the
+    /// message.
+    fn merge(&mut self, incoming: DeclaredKind, type_name: &str) {
+        assert!(
+            std::mem::discriminant(&*self) == std::mem::discriminant(&incoming),
+            "`{}` is already declared with `{}!(...)`; it cannot also be declared with \
+             `{}!(...)` — a type gets exactly one class declarator",
+            type_name,
+            self.macro_name(),
+            incoming.macro_name(),
+        );
+        match (self, incoming) {
+            // `.gc_managed()` is sticky-OR: once any declaration asks for
+            // Cleaner-backed release, the handle keeps it.
+            (DeclaredKind::Ptr(have), DeclaredKind::Ptr(add)) => {
+                have.gc_managed |= add.gc_managed;
+            }
+            // Per-variant last-wins: a second `sealed_class!(E)` adding one
+            // `.variant(...)` must not drop the renames the first one set.
+            (DeclaredKind::Sealed(have), DeclaredKind::Sealed(add)) => {
+                have.variant_names.extend(add.variant_names);
+            }
+            // Kinds with no payload of their own: nothing to merge.
+            (DeclaredKind::Enum(_), _) | (DeclaredKind::Data, _) | (DeclaredKind::Value, _) => {}
+            // The discriminants were just checked equal, so no mixed pair
+            // reaches this arm — landing here means a kind carrying options
+            // was added above without a merge rule.
+            (existing, _) => unreachable!(
+                "`{}!(...)` has no merge rule for a reopened declaration",
+                existing.macro_name()
+            ),
         }
     }
 }
@@ -67,10 +99,7 @@ impl JniGen {
     /// wire (JNI `external fun`).
     pub(crate) fn is_kotlin_enum(&self, ty: &syn::Type) -> bool {
         let key = TypeKey::from_type(ty);
-        self.types
-            .get(&key)
-            .and_then(|c| c.enum_cfg.as_ref())
-            .is_some()
+        self.types.get(&key).is_some_and(|c| c.is_enum_class())
     }
 }
 
@@ -322,51 +351,22 @@ impl JniGen {
         }
     }
 
-    /// The class declarator a type is already registered under, read back
-    /// from the marker its acceptor set. A data class has no marker of its
-    /// own — it is precisely a declared class that is none of the special
-    /// kinds — so it is recognized by [`TypeConfig::class_decl`] alone, which
-    /// makes this total over the five declarators.
-    fn declared_kind(&self, key: &TypeKey) -> Option<DeclaredKind> {
-        let cfg = self.types.get(key)?;
-        if cfg.opaque.is_some() {
-            return Some(DeclaredKind::Ptr);
-        }
-        if cfg.enum_cfg.is_some() {
-            return Some(DeclaredKind::Enum);
-        }
-        if cfg.sum_cfg.is_some() {
-            return Some(DeclaredKind::Sealed);
-        }
-        if cfg.value_blob {
-            return Some(DeclaredKind::Value);
-        }
-        cfg.class_decl.then_some(DeclaredKind::Data)
-    }
-
-    /// One type gets exactly **one** class declarator. Reopening the same
-    /// declarator is supported (options merge); a second, different one is a
-    /// hard error — it would emit two Kotlin declarations for the same FQN
-    /// and leave the type table with an ambiguous kind. Called by every
-    /// acceptor before it registers anything, so the rule holds symmetrically
-    /// for all five and does not depend on declaration order.
-    fn assert_class_kind(&self, key: &TypeKey, incoming: DeclaredKind) {
-        if let Some(existing) = self.declared_kind(key) {
-            assert!(
-                existing == incoming,
-                "`{}` is already declared with `{}!(...)`; it cannot also be declared with \
-                 `{}!(...)` — a type gets exactly one class declarator",
-                rust_short_name(key),
-                existing.macro_name(),
-                incoming.macro_name(),
-            );
-        }
-    }
-
-    /// Store one class declaration's raw [`NameSpec`] in the type table.
+    /// Register one class declaration: its [`DeclaredKind`] (kind + that
+    /// kind's own options) and its raw [`NameSpec`]. The single entry point
+    /// into [`Self::types`] — every acceptor goes through it, so the
+    /// one-declarator-per-type rule is enforced for all kinds by
+    /// [`DeclaredKind::merge`] and cannot be forgotten by a new one.
     /// No FQN is derived here — names materialize at read time via
     /// [`JniGen::fqn_of`], against whatever the settings are then.
-    fn register_class_name(&mut self, key: &TypeKey, spec: NameSpec) {
+    ///
+    /// Returns the stored config so the caller can fold in its cross-kind
+    /// options (`jobject_input`, interfaces).
+    fn register_class(
+        &mut self,
+        key: &TypeKey,
+        kind: DeclaredKind,
+        spec: NameSpec,
+    ) -> &mut TypeConfig {
         // Early failure for a bad per-decl `.name()`: the FQN itself is only
         // derived at write time, but a dotted relative name is a declaration
         // mistake and should surface in the declaring call (the same check
@@ -383,9 +383,16 @@ impl JniGen {
                 n
             );
         }
-        let entry = self.types.entry(key.clone()).or_default();
-        entry.class_decl = true;
-        entry.name_spec = Some(spec);
+        let short = rust_short_name(key);
+        match self.types.entry(key.clone()) {
+            std::collections::hash_map::Entry::Occupied(e) => {
+                let cfg = e.into_mut();
+                cfg.kind.merge(kind, &short);
+                cfg.name_spec = Some(spec);
+                cfg
+            }
+            std::collections::hash_map::Entry::Vacant(e) => e.insert(TypeConfig::new(kind, spec)),
+        }
     }
 
     /// Merge a decl's interface options into the type's [`TypeConfig`]
@@ -396,7 +403,7 @@ impl JniGen {
         let cfg = self
             .types
             .get_mut(key)
-            .expect("register_class_name created the entry");
+            .expect("register_class created the entry");
         cfg.interface_enabled |= iface.enabled;
         if iface.name_override.is_some() {
             cfg.interface_name_override = iface.name_override;
@@ -411,9 +418,11 @@ impl JniGen {
     fn accept_ptr_class(&mut self, subpackage: &str, decl: PtrClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.assert_class_kind(&key, DeclaredKind::Ptr);
-        self.register_class_name(
+        self.register_class(
             &key,
+            DeclaredKind::Ptr(OpaqueConfig {
+                gc_managed: decl.gc_managed,
+            }),
             NameSpec {
                 subpackage: subpackage.to_string(),
                 short,
@@ -421,13 +430,6 @@ impl JniGen {
                 kind: NameKind::Ptr,
             },
         );
-        let opaque = self
-            .types
-            .get_mut(&key)
-            .expect("register_class_name created the entry")
-            .opaque
-            .get_or_insert_with(OpaqueConfig::default);
-        opaque.gc_managed |= decl.gc_managed;
         self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
     }
@@ -435,9 +437,9 @@ impl JniGen {
     fn accept_enum_class(&mut self, subpackage: &str, decl: EnumClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.assert_class_kind(&key, DeclaredKind::Enum);
-        self.register_class_name(
+        self.register_class(
             &key,
+            DeclaredKind::Enum(EnumConfig::default()),
             NameSpec {
                 subpackage: subpackage.to_string(),
                 short,
@@ -445,10 +447,6 @@ impl JniGen {
                 kind: NameKind::Enum,
             },
         );
-        self.types
-            .get_mut(&key)
-            .expect("register_class_name created the entry")
-            .enum_cfg = Some(EnumConfig::default());
         self.store_iface_opts(&key, decl.iface);
     }
 
@@ -459,9 +457,17 @@ impl JniGen {
     fn accept_sealed_class(&mut self, subpackage: &str, decl: SealedClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.assert_class_kind(&key, DeclaredKind::Sealed);
-        self.register_class_name(
+        // Reopened decls merge — `DeclaredKind::merge` owns that rule for
+        // every kind, so this acceptor only builds its own payload.
+        let mut sum = SumConfig::default();
+        for v in decl.variants {
+            if let Some(name) = v.name_override {
+                sum.variant_names.insert(v.rust_ident, name);
+            }
+        }
+        self.register_class(
             &key,
+            DeclaredKind::Sealed(sum),
             NameSpec {
                 subpackage: subpackage.to_string(),
                 short,
@@ -469,20 +475,6 @@ impl JniGen {
                 kind: NameKind::Enum,
             },
         );
-        // Reopened decls MERGE, like every other class kind: a second
-        // `sealed_class!(E)` adding one `.variant(...)` must not drop the
-        // renames the first one set. Per variant it is last-wins.
-        let sum = self
-            .types
-            .get_mut(&key)
-            .expect("register_class_name created the entry")
-            .sum_cfg
-            .get_or_insert_with(SumConfig::default);
-        for v in decl.variants {
-            if let Some(name) = v.name_override {
-                sum.variant_names.insert(v.rust_ident, name);
-            }
-        }
         self.store_iface_opts(&key, decl.iface);
     }
 
@@ -502,12 +494,8 @@ impl JniGen {
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.assert_class_kind(&key, DeclaredKind::Data);
         let spec = Self::data_value_name_spec(subpackage, short, decl.name_override);
-        self.register_class_name(&key, spec);
-        self.types
-            .get_mut(&key)
-            .expect("register_class_name created the entry")
+        self.register_class(&key, DeclaredKind::Data, spec)
             .jobject_input |= decl.jobject_input;
         self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
@@ -516,13 +504,8 @@ impl JniGen {
     fn accept_value_class(&mut self, subpackage: &str, decl: ValueClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        self.assert_class_kind(&key, DeclaredKind::Value);
         let spec = Self::data_value_name_spec(subpackage, short, decl.name_override);
-        self.register_class_name(&key, spec);
-        self.types
-            .get_mut(&key)
-            .expect("register_class_name created the entry")
-            .value_blob = true;
+        self.register_class(&key, DeclaredKind::Value, spec);
         self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
     }
@@ -693,14 +676,15 @@ impl JniGen {
         })
     }
 
-    /// Whether `key` was declared as a class in some package (any of the four
-    /// class kinds). A boundary decl on a type without a class declaration
-    /// makes it **rust-side-only**: the value is always built from
-    /// ingredients / decomposed into fields at the boundary and never
-    /// materializes in Kotlin — so the `_self` arms are structurally
-    /// impossible for it.
+    /// Whether `key` was declared as a class in some package (any
+    /// [`DeclaredKind`]). Presence in [`Self::types`] *is* the answer —
+    /// [`Self::register_class`] is the table's only writer. A boundary decl on
+    /// a type without a class declaration makes it **rust-side-only**: the
+    /// value is always built from ingredients / decomposed into fields at the
+    /// boundary and never materializes in Kotlin — so the `_self` arms are
+    /// structurally impossible for it.
     fn is_class_declared(&self, key: &TypeKey) -> bool {
-        self.types.get(key).is_some_and(|c| c.class_decl)
+        self.types.contains_key(key)
     }
 
     /// Lower the raw [`ExpandParamDecl`]s into the core's immutable
@@ -985,9 +969,7 @@ impl JniGen {
         };
         let inner_key = TypeKey::from_type(&r.elem);
         assert!(
-            self.types
-                .get(&inner_key)
-                .is_some_and(|c| c.opaque.is_some()),
+            self.types.get(&inner_key).is_some_and(|c| c.is_opaque()),
             "expand_return!({}).field(… .name(\"{name}\")): an `Option<&T>` binding-local field \
              delivers a nullable typed HANDLE, so `T` must be a declared ptr_class — `{}` is \
              not; return an owned `Option<{}>` instead",

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -5,14 +5,14 @@
 use super::*;
 
 /// The adapter-declared kind of a **bare** (already `Option`/`&`-stripped)
-/// Rust type, in fixed precedence: opaque handle → enum class → sealed class
-/// → value blob → registered source struct → everything else.
+/// Rust type: the declared [`DeclaredKind`] when the type is declared to this
+/// adapter, else a registered source struct, else everything else.
 ///
-/// The four special kinds are mutually exclusive by builder enforcement;
-/// the precedence order only pins down behavior if that invariant is ever
-/// violated. `DataStruct` is any struct captured from the source crate —
-/// `cfg` tells whether it was also declared to the builder (a `data_class`
-/// candidate) or is merely known to the registry.
+/// The four special kinds cannot overlap — a type stores exactly one
+/// [`DeclaredKind`], so this is a lookup, not a precedence chain.
+/// `DataStruct` is any struct captured from the source crate — `cfg` tells
+/// whether it was also declared to the builder (a `data_class` candidate) or
+/// is merely known to the registry.
 pub(crate) enum TypeKind<'r, 'c> {
     /// Declared via `ptr_class` — jlong wire, typed-handle Kotlin class.
     Handle,
@@ -39,10 +39,7 @@ impl TypeConfig {
     /// `enum_class` / `sealed_class` / `value_class`) — types with their own
     /// dedicated Kotlin emitters, never flattened as data classes.
     pub(crate) fn special_decl(&self) -> bool {
-        self.opaque.is_some()
-            || self.enum_cfg.is_some()
-            || self.sum_cfg.is_some()
-            || self.value_blob
+        !matches!(self.kind, DeclaredKind::Data)
     }
 }
 
@@ -57,17 +54,15 @@ impl JniGen {
     ) -> TypeKind<'r, 'c> {
         let cfg = self.types.get(&TypeKey::from_type(bare));
         if let Some(c) = cfg {
-            if c.opaque.is_some() {
-                return TypeKind::Handle;
-            }
-            if c.enum_cfg.is_some() {
-                return TypeKind::Enum;
-            }
-            if c.sum_cfg.is_some() {
-                return TypeKind::Sum;
-            }
-            if c.value_blob {
-                return TypeKind::ValueBlob;
+            match c.kind {
+                DeclaredKind::Ptr(_) => return TypeKind::Handle,
+                DeclaredKind::Enum(_) => return TypeKind::Enum,
+                DeclaredKind::Sealed(_) => return TypeKind::Sum,
+                DeclaredKind::Value => return TypeKind::ValueBlob,
+                // A data class is exactly a declared source struct — fall
+                // through to the registry probe below, which supplies the
+                // `syn::ItemStruct` its emitters flatten.
+                DeclaredKind::Data => {}
             }
         }
         if let Some(name) = bare_path_ident(bare) {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -294,7 +294,7 @@ pub(crate) fn sum_input_body(
 
     let key = TypeKey::from_ident(&e.ident);
     let cfg = ext.types.get(&key)?;
-    let sum_cfg = cfg.sum_cfg.as_ref()?;
+    let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
     let iface_path = iface_fqn.replace('.', "/");
     let source_module = ext.fn_module(registry, &e.ident);
@@ -833,7 +833,7 @@ fn build_flat_sum_field(
     let ident = bare_path_ident(sum_ty)?;
     let (item_enum, _) = registry.enums.get(&ident)?;
     let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
-    let sum_cfg = cfg.sum_cfg.as_ref()?;
+    let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
     let spec = SumSpec::from_item_enum(item_enum);
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -157,7 +157,7 @@ pub(crate) fn option_inner_ref_mutability(ty: &syn::Type) -> Option<bool> {
 /// knows which inline field to unwrap (`<name>.bytes`).
 pub(crate) fn value_projection_field_for_leaf(ext: &JniGen, leaf_key: &TypeKey) -> Option<String> {
     let cfg = ext.types.get(leaf_key)?;
-    if cfg.value_blob {
+    if cfg.is_value_blob() {
         return Some("bytes".to_string());
     }
     None

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -58,11 +58,7 @@ pub(crate) fn reject_handle_constant_type(ext: &JniGen, ty: &syn::Type, what: &s
         break;
     }
     let key = TypeKey::from_type(&ty);
-    let is_handle = ext
-        .types
-        .get(&key)
-        .and_then(|cfg| cfg.opaque.as_ref())
-        .is_some();
+    let is_handle = ext.types.get(&key).is_some_and(|cfg| cfg.is_opaque());
     assert!(
         !is_handle,
         "{what} `{name}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -402,7 +402,7 @@ impl JniGen {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
             let cfg = &self.types[key];
-            if !cfg.value_blob {
+            if !cfg.is_value_blob() {
                 continue;
             }
             let fqn = cfg
@@ -512,7 +512,7 @@ impl JniGen {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
             let cfg = &self.types[key];
-            if cfg.opaque.is_none() {
+            if !cfg.is_opaque() {
                 continue;
             }
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
@@ -594,7 +594,7 @@ impl JniGen {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
             let cfg = &self.types[key];
-            if cfg.enum_cfg.is_none() {
+            if !cfg.is_enum_class() {
                 continue;
             }
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
@@ -655,7 +655,7 @@ impl JniGen {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
             let cfg = &self.types[key];
-            let Some(sum_cfg) = cfg.sum_cfg.as_ref() else {
+            let Some(sum_cfg) = cfg.sum() else {
                 continue;
             };
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
@@ -1545,8 +1545,7 @@ impl JniGen {
             .get(&ident)
             .unwrap_or_else(|| panic!("sum builder: no indexed enum `{ident}`"));
         let sum_cfg = self.types[&key]
-            .sum_cfg
-            .as_ref()
+            .sum()
             .unwrap_or_else(|| panic!("sum builder: `{ident}` is not a sealed class"));
         let spec = SumSpec::from_item_enum(item_enum);
         let tag = &names[0];

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -68,18 +68,18 @@ pub(crate) use crate::api::{
 // Structured type-conversion configuration
 // ──────────────────────────────────────────────────────────────────────
 
-/// Per-opaque-handle configuration (driven by `JniGen::ptr_class`).
+/// Options of a type declared with `ptr_class!` — the payload of
+/// [`DeclaredKind::Ptr`], which is what marks the type as an opaque handle.
+/// The unified Kotlin emitter writes a typed-handle `.kt` file (and the Rust
+/// side its `freePtr` destructor) for every such type.
 ///
 /// The typed-handle Kotlin FQN (e.g. `"io.zenoh.jni.JNISession"`) lives
-/// in the surrounding [`TypeConfig::kotlin_name`] slot — FQN-consumers
+/// in the surrounding [`TypeConfig::name_spec`] slot — FQN-consumers
 /// (typed-handle class emission, `instanceof` dispatch,
 /// return-value constructor wrap) read it from there. The
 /// value-context Kotlin name for the same type (`"Long"`) is produced
 /// independently by the rank-0 opaque handler in [`KotlinMeta`], so
 /// the two roles don't collide despite sharing the `TypeConfig`.
-/// Presence marker: a type registered via `JniGen::ptr_class`. The unified
-/// Kotlin emitter writes a typed-handle `.kt` file (and the Rust side its
-/// `freePtr` destructor) for every opaque type.
 #[derive(Clone, Default)]
 pub(crate) struct OpaqueConfig {
     /// `ptr_class!(X).gc_managed()`: the typed handle stores its pointer in
@@ -89,22 +89,24 @@ pub(crate) struct OpaqueConfig {
     pub gc_managed: bool,
 }
 
-/// Per-enum configuration (driven by `JniGen::enum_class`).
+/// Options of a type declared with `enum_class!` — the payload of
+/// [`DeclaredKind::Enum`], which is what marks a `#[prebindgen]`-scanned
+/// `enum` as a Kotlin enum class. There are none yet: the declaration itself
+/// carries all the information, so this is the empty slot future enum options
+/// go in.
 ///
-/// Marks a `#[prebindgen]`-scanned `enum` as a Kotlin enum class — the
-/// rank-0 converter arms emit `jint ↔ Rust enum` bodies (via `TryFrom<i32>`
-/// for input and `as jni::sys::jint` for output), and the Kotlin emitter
-/// writes an `enum class` file with SCREAMING_SNAKE_CASE variants and a
-/// discriminant-keyed `fromInt(...)` companion. The Kotlin FQN lives in
-/// the surrounding [`TypeConfig::kotlin_name`] slot, same as
+/// The rank-0 converter arms emit `jint ↔ Rust enum` bodies (via
+/// `TryFrom<i32>` for input and `as jni::sys::jint` for output), and the
+/// Kotlin emitter writes an `enum class` file with SCREAMING_SNAKE_CASE
+/// variants and a discriminant-keyed `fromInt(...)` companion. The Kotlin FQN
+/// lives in the surrounding [`TypeConfig::name_spec`] slot, same as
 /// [`OpaqueConfig`].
-/// Presence marker: a type registered via `JniGen::enum_class`. The unified
-/// Kotlin emitter writes an `enum class` `.kt` file for every declared enum.
 #[derive(Clone, Default)]
 pub(crate) struct EnumConfig {}
 
-/// Presence marker + per-variant naming of a type registered via
-/// `sealed_class!`: a `#[prebindgen]` **data-carrying** enum mirrored as a
+/// Per-variant naming of a type declared with `sealed_class!` — the payload
+/// of [`DeclaredKind::Sealed`], which is what marks a `#[prebindgen]`
+/// **data-carrying** enum as mirrored by a
 /// Kotlin `sealed interface`. The tag/leaf-group structure itself is read
 /// from the source enum through the neutral
 /// [`SumSpec`](crate::api::core::types_util::SumSpec) — only what the
@@ -141,11 +143,56 @@ impl FunctionEntry {
     }
 }
 
+/// Which of the five class declarators a type is registered under, **with
+/// that declarator's own options**. A type gets exactly one — this is a sum,
+/// not a set of independent markers: two declarators would emit two Kotlin
+/// declarations for the same FQN, so the second is a hard error (see
+/// [`DeclaredKind::merge`]). Reopening the *same* declarator stays legal —
+/// `merge` folds the incoming payload into the stored one.
+///
+/// Adding a sixth class kind is one variant here plus its emitter: there is
+/// no flag to add and no precedence chain to extend, because every consumer
+/// reads this one field (via [`TypeConfig`]'s accessors, [`JniGen::type_kind`],
+/// or a direct match).
+#[derive(Clone)]
+pub(crate) enum DeclaredKind {
+    /// `ptr_class!` — an opaque-handle type: jlong wire,
+    /// `Box::into_raw`/`Box::from_raw` conventions, instanceof dispatch, and
+    /// Kotlin typed-handle class emission.
+    Ptr(OpaqueConfig),
+    /// `enum_class!` — a `#[prebindgen]` fieldless enum mirrored as a Kotlin
+    /// `enum class`: jint wire (input + output via `TryFrom<i32>` / `as
+    /// jint`) and a generated `.kt` file.
+    Enum(EnumConfig),
+    /// `sealed_class!` — a `#[prebindgen]` data-carrying enum mirrored as a
+    /// Kotlin `sealed interface`: a tag plus one leaf group per variant.
+    Sealed(SumConfig),
+    /// `data_class!` — a `#[prebindgen]` struct mirrored as a Kotlin `data
+    /// class`, flattened field-by-field at the boundary. The kind with no
+    /// options of its own.
+    Data,
+    /// `value_class!` — a `Copy` Rust type passed **by value as its raw
+    /// memory blob** in a `JByteArray` (wire), the value-level peer of an
+    /// opaque handle's `jlong`. Surfaces as a `@JvmInline value class`
+    /// erased to `ByteArray`.
+    Value,
+}
+
 /// All configuration the structured builder accumulates for one
-/// canonical Rust type key. Every field is `None` by default;
-/// builder methods populate the ones they care about.
-#[derive(Clone, Default)]
+/// canonical Rust type key. The declared kind is mandatory (an entry exists
+/// only because some declarator created it); the remaining, cross-kind
+/// options default to unset and are populated by the decl that carries them.
+#[derive(Clone)]
 pub(crate) struct TypeConfig {
+    /// The class declarator this type is registered under, carrying that
+    /// kind's own options. Every entry in [`JniGen::types`] has one: entries
+    /// are created only by a class declarator (see
+    /// `JniGen::register_class`), which is why presence in the table *is*
+    /// "declared as a class" — declared classes are required in **both**
+    /// directions at scan (their converters always resolve both ways),
+    /// unlike a wrapper registration, which is required per **usage**
+    /// direction.
+    pub kind: DeclaredKind,
     /// Raw naming spec of the type as declared — verbatim Kotlin type or
     /// settings-derived class name. Required for any type emitted in
     /// Kotlin; the concrete FQN (`Sample` → `"io.zenoh.jni.Sample"`,
@@ -153,41 +200,10 @@ pub(crate) struct TypeConfig {
     /// [`JniGen::fqn_of`], which is what makes the `set_*` settings
     /// order-independent w.r.t. declarations.
     pub name_spec: Option<NameSpec>,
-    /// If `Some`, this is an opaque-handle type — gets jlong wire,
-    /// `Box::into_raw`/`Box::from_raw` conventions, instanceof
-    /// dispatch, and Kotlin typed-handle class emission.
-    pub opaque: Option<OpaqueConfig>,
-    /// If `Some`, this is a `#[prebindgen]` enum mirrored as a Kotlin
-    /// `enum class` — gets jint wire (input + output via `TryFrom<i32>`
-    /// / `as jint`) and a generated `.kt` file. Class kinds are mutually
-    /// exclusive — see the note on [`Self::class_decl`].
-    pub enum_cfg: Option<EnumConfig>,
-    /// If `Some`, this is a `#[prebindgen]` data-carrying enum mirrored as a
-    /// Kotlin `sealed interface` — a tag plus one leaf group per variant.
-    pub sum_cfg: Option<SumConfig>,
-    /// Set by [`JniGen::value_class`]: this is a `Copy` Rust type passed
-    /// **by value as its raw memory blob** in a `JByteArray` (wire), the
-    /// value-level peer of an opaque handle's `jlong`. No Kotlin class, no
-    /// projection — it surfaces as `ByteArray`.
-    pub value_blob: bool,
     /// Explicit opt-in for a `data_class` to cross Kotlin → Rust as one
     /// `JObject`. Unmarked data classes are required to flatten completely;
     /// this flag is sticky across reopened declarations.
     pub jobject_input: bool,
-    /// Set by the five class declarators (`ptr_class` / `enum_class` /
-    /// `sealed_class` / `data_class` / `value_class`), NOT by wrapper
-    /// registration. Declared classes are required in **both** directions at
-    /// scan (their converters always resolve both ways); a wrapper-only entry
-    /// is required per **usage** direction, so an output-only wrapper needs no
-    /// input twin.
-    ///
-    /// A type gets exactly **one** of the five: the kind markers above are
-    /// mutually exclusive, enforced in one place for all of them by
-    /// `JniGen::assert_class_kind`. Reopening the *same* declarator is legal
-    /// and merges its options. This flag is also what identifies a **data
-    /// class** — the declarator with no marker of its own is precisely a
-    /// declared class that is none of the special kinds.
-    pub class_decl: bool,
     /// Emit the generated interface mirroring the class's public instance
     /// surface, and make the class implement it with `override` on every
     /// class-body member (`.interface()` / implied by `.interface_name()`).
@@ -200,6 +216,53 @@ pub(crate) struct TypeConfig {
     /// nominally; the class body and lifecycle members are unaffected.
     /// Orthogonal to [`Self::interface_enabled`].
     pub interfaces: Vec<String>,
+}
+
+impl TypeConfig {
+    /// A freshly declared type: the declarator's kind and naming spec, every
+    /// cross-kind option unset. Reopening the same declarator goes through
+    /// [`DeclaredKind::merge`] instead.
+    pub(crate) fn new(kind: DeclaredKind, name_spec: NameSpec) -> Self {
+        Self {
+            kind,
+            name_spec: Some(name_spec),
+            jobject_input: false,
+            interface_enabled: false,
+            interface_name_override: None,
+            interfaces: Vec::new(),
+        }
+    }
+
+    /// The opaque-handle options if this type is a `ptr_class`, else `None`.
+    pub(crate) fn opaque(&self) -> Option<&OpaqueConfig> {
+        match &self.kind {
+            DeclaredKind::Ptr(o) => Some(o),
+            _ => None,
+        }
+    }
+
+    /// `true` if this type is a `ptr_class`-declared opaque handle.
+    pub(crate) fn is_opaque(&self) -> bool {
+        matches!(self.kind, DeclaredKind::Ptr(_))
+    }
+
+    /// `true` if this type is an `enum_class`-declared Kotlin `enum class`.
+    pub(crate) fn is_enum_class(&self) -> bool {
+        matches!(self.kind, DeclaredKind::Enum(_))
+    }
+
+    /// The sum options if this type is a `sealed_class`, else `None`.
+    pub(crate) fn sum(&self) -> Option<&SumConfig> {
+        match &self.kind {
+            DeclaredKind::Sealed(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// `true` if this type is a `value_class`-declared `Copy` value blob.
+    pub(crate) fn is_value_blob(&self) -> bool {
+        matches!(self.kind, DeclaredKind::Value)
+    }
 }
 
 /// Free-standing functions emitted into a synthetic package-level wrapper
@@ -378,9 +441,11 @@ pub struct JniGen {
     pub(crate) interface_name_mangle: Option<NameMangle>,
 
     /// Structured per-type configuration keyed by canonical Rust type.
-    /// One entry per `Rust type ↔ JNI/Kotlin` rule; populated when accepting
-    /// a `ClassDecl`. Holds opaque-handle
-    /// config, enum config, and the raw [`NameSpec`] (Kotlin FQNs are
+    /// One entry per declared class; populated when accepting a `ClassDecl`,
+    /// through the table's single writer `JniGen::register_class` — so
+    /// presence here *is* "declared as a class", and each entry's
+    /// [`TypeConfig::kind`] is the one representation of which declarator it
+    /// came from. Also holds the raw [`NameSpec`] (Kotlin FQNs are
     /// derived from it on read via [`JniGen::kotlin_fqn`] /
     /// [`JniGen::fqn_of`]); the converter bodies themselves live in
     /// [`Self::input_wrappers`] / [`Self::output_wrappers`]. The rank-0

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -38,7 +38,7 @@ impl JniGen {
     /// JVM, so two distinct such classes share one method descriptor.
     pub(crate) fn is_value_blob_kotlin(&self, simple: &str) -> bool {
         self.types.values().any(|c| {
-            c.value_blob
+            c.is_value_blob()
                 && c.name_spec
                     .as_ref()
                     .map(|s| self.fqn_of(s))

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -265,7 +265,7 @@ pub(crate) fn build_typed_handle(
     let gc_managed = ext
         .types
         .get(key)
-        .and_then(|cfg| cfg.opaque.as_ref())
+        .and_then(|cfg| cfg.opaque())
         .is_some_and(|o| o.gc_managed);
     let base_short = if gc_managed {
         "GcNativeHandle"

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -249,19 +249,7 @@ impl JniGen {
         let Some(cfg) = self.types.get(key) else {
             return "undeclared";
         };
-        if cfg.opaque.is_some() {
-            "ptr_class"
-        } else if cfg.enum_cfg.is_some() {
-            "enum_class"
-        } else if cfg.sum_cfg.is_some() {
-            "sealed_class"
-        } else if cfg.value_blob {
-            "value_class"
-        } else if cfg.class_decl {
-            "data_class"
-        } else {
-            "wrapper"
-        }
+        cfg.kind.macro_name()
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -457,8 +457,7 @@ fn sum_plan_kind(
         .get(&key)
         .unwrap_or_else(|| panic!("fromParts bridge: `{ident}` is not declared"));
     let sum_cfg = cfg
-        .sum_cfg
-        .as_ref()
+        .sum()
         .unwrap_or_else(|| panic!("fromParts bridge: `{ident}` is not a sealed class"));
     let kotlin_fqn = cfg
         .name_spec

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -122,7 +122,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
         // mismatch: inferred type is E.Missing but E.E was expected").
         // Verified against kotlinc. So this one is a declaration error, and
         // the message names both ways to disambiguate.
-        if let Some(sum_cfg) = cfg.sum_cfg.as_ref() {
+        if let Some(sum_cfg) = cfg.sum() {
             let mut seen: BTreeMap<String, String> = BTreeMap::from([(
                 short.to_string(),
                 format!("sealed class `{key}` itself (its variants' supertype)"),

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -264,6 +264,53 @@ fn reopened_sealed_class_merges_variant_names() {
     assert!(c.contains("1->One(one_v0)"), "{kt}");
 }
 
+/// The stored kind's payload merges on reopen, and `.gc_managed()` is
+/// sticky-OR: a plain `ptr_class!(T)` reopening a `.gc_managed()` one must not
+/// demote the handle. Peer of [`reopened_sealed_class_merges_variant_names`]
+/// for the other options-carrying kind — both rules live in
+/// `DeclaredKind::merge`, so this pins the order-independence they share.
+#[test]
+fn reopened_ptr_class_keeps_gc_managed() {
+    let loc = myflat_loc();
+    let items = || {
+        vec![(
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Session {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        )]
+    };
+    let gc_managed_of = |first: crate::lang::PtrClassDecl, second: crate::lang::PtrClassDecl| {
+        let registry = Registry::<KotlinMeta>::from_items(items()).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(crate::package!().class(first).class(second));
+        drop(registry);
+        let key = TypeKey::from_type(&syn::parse_quote!(Session));
+        jni.types
+            .get(&key)
+            .expect("declared")
+            .opaque()
+            .expect("ptr_class")
+            .gc_managed
+    };
+
+    assert!(gc_managed_of(
+        crate::ptr_class!(Session).gc_managed(),
+        crate::ptr_class!(Session),
+    ));
+    assert!(gc_managed_of(
+        crate::ptr_class!(Session),
+        crate::ptr_class!(Session).gc_managed(),
+    ));
+    assert!(!gc_managed_of(
+        crate::ptr_class!(Session),
+        crate::ptr_class!(Session),
+    ));
+}
+
 /// A type gets exactly **one** class declarator. Two different ones would
 /// emit two Kotlin declarations for the same FQN, so the second is a hard
 /// error — symmetrically, whichever order they come in.
@@ -300,8 +347,8 @@ fn a_type_gets_one_class_declarator() {
     };
 
     // Every conflicting pair among the five declarators is rejected, in both
-    // orders — the check runs before any registration, so it does not depend
-    // on which came first.
+    // orders — the second declaration is matched against the kind the first
+    // one stored, so it does not depend on which came first.
     type MakeDecl = fn() -> crate::lang::ClassDecl;
     let pairs: Vec<(MakeDecl, MakeDecl)> = vec![
         (

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -306,7 +306,7 @@ impl JniGen {
             // `name_spec` for FQN-consumers, but the value-context
             // name is `"Long"` (set on the rank-0 handler's metadata).
             // Don't let that FQN leak into a wrapper's metadata.
-            if cfg.opaque.is_none() {
+            if !cfg.is_opaque() {
                 if let Some(spec) = &cfg.name_spec {
                     return Some(kt::KtType::cls(self.fqn_of(spec)));
                 }
@@ -527,7 +527,7 @@ pub(crate) fn build_handle_destructor_items(
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
     for (key, cfg) in &ext.types {
-        if cfg.opaque.is_none() {
+        if !cfg.is_opaque() {
             continue;
         }
         // Skip handles the (feature-aware) scan never references — their
@@ -877,7 +877,7 @@ impl JniGen {
             // that the Kotlin folder wraps into its typed handle class. Enums
             // and multi-field data classes are not leaf-folded — data classes go
             // through `value_struct_decons`.
-            Some(cfg) => cfg.value_blob || cfg.opaque.is_some(),
+            Some(cfg) => cfg.is_value_blob() || cfg.is_opaque(),
             // Undeclared: `String` is JObject-shaped; `u64` is the built-in
             // scalar projection whose raw jlong leaf the Kotlin folder wraps
             // into `ULong`. Other primitive collections retain their existing
@@ -1002,7 +1002,7 @@ impl Prebindgen for JniGen {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         let mut out = Vec::new();
         for key in keys {
-            let Some(sum_cfg) = self.types[key].sum_cfg.as_ref() else {
+            let Some(sum_cfg) = self.types[key].sum() else {
                 continue;
             };
             let source = key.to_type();
@@ -1128,19 +1128,17 @@ impl Prebindgen for JniGen {
             .collect()
     }
 
-    /// Every type registered via one of the four **class declarators**
-    /// (`.ptr_class` / `.enum_class` / `.data_class` / `.value_class`).
-    /// These are the only structs/enums the per-item emitter walks, and the
-    /// scan requires them in BOTH directions (their converters always resolve
-    /// both ways). Wrapper-only registrations are deliberately excluded: a
+    /// Every type registered via one of the **class declarators**
+    /// (`ptr_class!` / `enum_class!` / `sealed_class!` / `data_class!` /
+    /// `value_class!`) — i.e. every entry in the type table, whose only
+    /// writer is `JniGen::register_class`. These are the only structs/enums
+    /// the per-item emitter walks, and the scan requires them in BOTH
+    /// directions (their converters always resolve both ways). Wrapper
+    /// registrations live in their own tables and are deliberately excluded: a
     /// wrapper type is required per **usage** direction, so an output-only
     /// wrapper needs no input twin.
     fn declared_types(&self) -> std::collections::HashSet<TypeKey> {
-        self.types
-            .iter()
-            .filter(|(_, c)| c.class_decl)
-            .map(|(k, _)| k.clone())
-            .collect()
+        self.types.keys().cloned().collect()
     }
 
     /// Union of every `.constant(...)` list across all
@@ -1453,7 +1451,7 @@ impl Prebindgen for JniGen {
             .chain(
                 self.types
                     .iter()
-                    .filter(|(_, c)| c.sum_cfg.is_some())
+                    .filter(|(_, c)| c.sum().is_some())
                     .map(|(k, _)| k.clone()),
             )
             .collect()
@@ -1502,7 +1500,7 @@ impl Prebindgen for JniGen {
         // converter use. The bare type name is qualified against
         // its origin module by `post_process_item` like every other body.
         for (key, cfg) in &self.types {
-            if cfg.value_blob {
+            if cfg.is_value_blob() {
                 let ty = key.to_type();
                 items.push(syn::parse_quote!(
                     const _: () = {
@@ -1631,7 +1629,7 @@ impl JniGen {
         // registered rank-0 wrappers, then built-ins).
         let key = TypeKey::from_type(ty);
         if let Some(cfg) = self.types.get(&key) {
-            if cfg.opaque.is_some() {
+            if cfg.is_opaque() {
                 return Some(self.opaque_handle_input(ty));
             }
         }
@@ -1642,7 +1640,7 @@ impl JniGen {
         // handlers. `T: Copy` ⇒ reading the value out is sound (no double
         // drop); the `Copy` bound itself is enforced by the assertion in
         // `prerequisites`.
-        if self.types.get(&key).map(|c| c.value_blob).unwrap_or(false) {
+        if self.types.get(&key).is_some_and(|c| c.is_value_blob()) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JByteArray);
             let body: syn::Expr = syn::parse_quote!({
                 let __bytes = env.convert_byte_array(v).map_err(|e| {
@@ -1685,7 +1683,7 @@ impl JniGen {
         // intentional. The rank-0 enum arm produces a terminal converter
         // (jint → Rust enum) with the configured Kotlin FQN in metadata.
         if let Some(cfg) = self.types.get(&key) {
-            if cfg.enum_cfg.is_some() {
+            if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
                     if let Some((e, _)) = registry.enums.get(&name) {
                         let (wire, body) = enum_input_body(self, registry, e);
@@ -1788,7 +1786,7 @@ impl JniGen {
             // delegates exactly as it does for a nested data class. (The
             // OUTPUT direction has no counterpart: a sum crosses Rust →
             // Kotlin flattened, always.)
-            if self.types.get(&key).is_some_and(|c| c.sum_cfg.is_some()) {
+            if self.types.get(&key).is_some_and(|c| c.sum().is_some()) {
                 if let Some((e, _)) = registry.enums.get(&name) {
                     let (wire, body) = sum_input_body(self, e, registry)?;
                     // The wire's own null niche, exactly as a data class gets
@@ -1873,7 +1871,7 @@ impl JniGen {
         // unified user-registered wrapper table, then built-ins).
         let key = TypeKey::from_type(ty);
         if let Some(cfg) = self.types.get(&key) {
-            if cfg.opaque.is_some() {
+            if cfg.is_opaque() {
                 return Some(self.opaque_handle_output(ty));
             }
         }
@@ -1883,7 +1881,7 @@ impl JniGen {
         // bytes and letting it drop normally is sound. Wire is `JByteArray`
         // (jobject-shaped), so `Vec<T>` / `Option<T>` compose through the
         // existing handlers — `Vec<value-blob>` surfaces as `List<ByteArray>`.
-        if self.types.get(&key).map(|c| c.value_blob).unwrap_or(false) {
+        if self.types.get(&key).is_some_and(|c| c.is_value_blob()) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JByteArray);
             let body: syn::Expr = syn::parse_quote!({
                 let __bytes: &[u8] = unsafe {
@@ -1923,7 +1921,7 @@ impl JniGen {
         // `#[repr(i32)]` (or any repr that supports the cast) on the
         // declared enum so the discriminant value round-trips identically.
         if let Some(cfg) = self.types.get(&key) {
-            if cfg.enum_cfg.is_some() {
+            if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
                     if let Some((e, _)) = registry.enums.get(&name) {
                         let (wire, body) = enum_output_body(self, e);
@@ -2068,8 +2066,7 @@ impl JniGen {
                 && self
                     .types
                     .get(&TypeKey::from_type(t1))
-                    .map(|c| c.opaque.is_some())
-                    .unwrap_or(false)
+                    .is_some_and(|c| c.is_opaque())
             {
                 let mut ref_ty = r.clone();
                 *ref_ty.elem = t1.clone();


### PR DESCRIPTION
Closes #180.

## Problem

`TypeConfig` stored what is logically **one mutually-exclusive choice** as five independent fields:

```rust
pub opaque: Option<OpaqueConfig>,   // ptr_class
pub enum_cfg: Option<EnumConfig>,   // enum_class
pub sum_cfg: Option<SumConfig>,     // sealed_class
pub value_blob: bool,               // value_class
pub class_decl: bool,               // data_class (= declared, none of the above)
```

The sum existed (`DeclaredKind`) but was *derived*: `declared_kind()` and `type_kind()` each walked the same precedence chain, exclusivity was a runtime `assert_class_kind` every acceptor had to remember to call, and the precedence order existed only to pin down behavior if that invariant were violated — papering over a state that should not be representable.

## Change

The stored state is the sum. `DeclaredKind` moves next to `TypeConfig` and carries each kind's payload:

```rust
pub(crate) enum DeclaredKind {
    Ptr(OpaqueConfig),
    Enum(EnumConfig),
    Sealed(SumConfig),
    Data,
    Value,
}
```

`TypeConfig.kind` is mandatory; the five flags are gone. Consequently:

- **One acceptor path.** `declared_kind` / `assert_class_kind` / `register_class_name` collapse into a single table writer, `JniGen::register_class(key, kind, spec)`, which every acceptor goes through.
- **Exclusivity is written once.** `DeclaredKind::merge` holds both halves of "a type gets exactly one class declarator": a different kind is rejected by one discriminant comparison — kind-agnostic and symmetric in declaration order, so a new kind is covered without touching it — and the same kind merges its own payload (`gc_managed` sticky-OR, `variant_names` per-variant last-wins), each rule written next to the payload it merges. A payload-carrying kind added without a merge rule hits an `unreachable!` rather than silently dropping options (the #155 finding).
- **Both precedence chains become field reads.** `type_kind()` is a match on `cfg.kind` with the `Data` arm falling through to the registry-struct probe; `special_decl()` is one `matches!`. The caveat comment about a violated invariant is gone.
- **`class_kind_name()` is `kind.macro_name()`** — 12 lines to 1, and its unreachable `"wrapper"` arm with it.
- `register_class` being the table's only writer makes presence in `types` *be* "declared as a class": `is_class_declared` is `contains_key`, `declared_types` is `keys()`.

Adding a sixth class kind is now one variant plus its emitter — no new flag, no new precedence arm.

## Verification

- 331 lib + 11 integration tests pass; clippy clean; `cargo fmt --check` clean; no new rustdoc link warnings.
- **Behavior-preserving end-to-end**: regenerated `zenoh-flat-jni` from this branch and from its merge base, and diffed every artifact — `src/generated_bindings.rs`, all of `kotlin/generated/**`, and `kotlin/REPORT.md` are byte-for-byte identical.
- New test `reopened_ptr_class_keeps_gc_managed` pins the reopen-merge of the other options-carrying kind, the peer of the existing `reopened_sealed_class_merges_variant_names`. The existing `a_type_gets_one_class_declarator` continues to cover the conflicting pairs in both orders, including the `sealed_class!` + `value_class!` pair the flag-based check originally let through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
