### PR TITLE
Stage 0: close the remaining boundary safety gaps (#189)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,3 +75,15 @@ jobs:
     - name: Run covertest-kotlin assert harness
       working-directory: examples/covertest-kotlin
       run: ./gradlew run --console=plain
+
+  smoke-asan:
+    # C-runtime coverage: the ownership contract the generated layer promises,
+    # checked by a leak detector rather than by reading `smoke.c`. Its own job
+    # so a leak is reported as a leak, not buried in the covertest log.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      run: rustup toolchain install stable && rustup default stable
+    - name: Run the C smoke test under ASan/LSan/UBSan
+      run: ./examples/smoke-asan.sh

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -464,6 +464,9 @@ public fun summaryPrefer(
     fallback1: Summary?,
     onError: JniErrorHandler<Long>,
 ): Long {
+    if ((primary1?.ptr ?: 0L) != 0L && (primary1?.ptr ?: 0L) == (fallback1?.ptr ?: 0L)) return onError.run(
+        "Aliasing arguments: 'primary1' and 'fallback1' are the same native resource; a consumed handle may not be passed twice in one call.",
+    )
     if (primary1?.isClosed() == true) return onError.run("Operation on a closed native handle.")
     if (fallback1?.isClosed() == true) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
@@ -559,6 +562,9 @@ public fun <R> summaryMerge(
     onError: JniErrorHandler<R>,
     build: SummaryBuilder<R>,
 ): R {
+    if ((primary1?.ptr ?: 0L) != 0L && (primary1?.ptr ?: 0L) == (fallback1?.ptr ?: 0L)) return onError.run(
+        "Aliasing arguments: 'primary1' and 'fallback1' are the same native resource; a consumed handle may not be passed twice in one call.",
+    )
     if (primary1?.isClosed() == true) return onError.run("Operation on a closed native handle.")
     if (fallback1?.isClosed() == true) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -844,6 +844,32 @@ fun main() {
             } == (3L to 42.0),
         )                                                                          // handle / handle
 
+        // #189 ALIAS PREFLIGHT: two consumed handle params of one class can be
+        // handed the SAME resource, which would consume one allocation twice.
+        // The wrapper compares `ptr` before the lock and before any conversion,
+        // so the rejection reaches `onError` and the handle is untouched —
+        // still open, still usable, and still ours to close. A check inside the
+        // converter could not offer that: by then the first argument is gone.
+        run {
+            val shared = Summary.of(5L, 55.0, boom)
+            var aliasMessage: String? = null
+            val rejected = summaryPrefer(shared, shared) { je ->
+                aliasMessage = je
+                -1L
+            }
+            check(rejected == -1L)
+            check(aliasMessage?.contains("Aliasing arguments") == true) {
+                "expected an alias rejection, got: $aliasMessage"
+            }
+            // Nothing was consumed: the handle survives and still reads.
+            check(!shared.isClosed())
+            check(shared.total(boom) == 55.0)
+
+            // No false positives — two DISTINCT handles of the same class go
+            // through untouched.
+            check(summaryPrefer(shared, Summary.of(3L, 99.0, boom), boom) == 0L)
+        }
+
         // Optional combined-selector expansion: `Option<&Summary>` under the
         // dual-arm type default. The selector also encodes absence (-1 = None);
         // the borrow-identity arm CLONES, so the handle survives the call.

--- a/examples/example-cbindgen/CMakeLists.txt
+++ b/examples/example-cbindgen/CMakeLists.txt
@@ -103,3 +103,11 @@ add_custom_target(run_smoke
   DEPENDS example_smoke
   VERBATIM
 )
+
+# The same smoke test under ASan/LSan/UBSan — the form CI runs, and the one that
+# can fail on a leak rather than printing PASS while leaking. Kept as a script
+# rather than a CMake option so CI does not need CMake at all.
+add_custom_target(run_smoke_asan
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../smoke-asan.sh"
+  VERBATIM
+)

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -161,6 +161,7 @@ fn generate_ffi_bindings() -> PathBuf {
         // `Note` crossing IN (tag validated, so fallible without a `Result`),
         // and its `&str`-taking constructor.
         pq!(note_value),
+        pq!(note_emphatic),
         pq!(note_new_titled),
         pq!(note_new_sketched),
         pq!(caption_new),

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -118,6 +118,12 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(calculator_new),
         pq!(calculator_new_from_str),
         pq!(calculator_apply),
+        // Two consumed handles of one type, and one consumed beside one
+        // borrowed: the two shapes the alias preflight covers. Both return
+        // `Result`, so the rejection reaches the caller through `char **e`
+        // rather than aborting.
+        pq!(calculator_merge),
+        pq!(calculator_absorb),
         pq!(foo_new),
         pq!(foo_get_id),
         pq!(inside_foo_default),

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -22,9 +22,17 @@
  *     through its `char **e`, and `shape_drop` ignores it. Constructing that
  *     value is the point of the check — it is not a Rust `shape_t` at all;
  *   - the same rule one level down, on a `bool` payload (`note_t`'s `Flagged`
- *     arm): a byte outside `{0,1}` is normalised, not materialised.
+ *     arm): a byte outside `{0,1}` is normalised, not materialised;
+ *   - and one level below THAT, on a `bool` field of a `data_struct` payload
+ *     (`caption_t`'s `emphatic`) — which is what makes the invariant
+ *     transitive rather than true only of the tag and the direct payloads.
  *
  * Exits non-zero on the first failed check.
+ *
+ * This file is also the repo's ownership contract in executable form — every
+ * arm C receives is C's to release — so it is run under ASan/LSan/UBSan by
+ * `examples/smoke-asan.sh` in CI. A missing `*_drop` or `example_free` here is
+ * a failure, not a silent PASS.
  */
 #include <math.h>
 #include <stdio.h>
@@ -206,12 +214,14 @@ static void test_converter_derived_payloads(void) {
     CHECK(note_value(after) == 1500);
 
     /* Nested data_struct by value: the whole record rides in the union arm. */
-    note_t titled = note_new_titled(7, "chapter one");
+    note_t titled = note_new_titled(7, "chapter one", true);
     CHECK(titled.tag == Titled);
     CHECK(titled.titled.id == 7);
     CHECK(strcmp(titled.titled.text, "chapter one") == 0);
+    CHECK(titled.titled.emphatic == true);
     /* …and crosses back IN, rebuilt through the payload's own converter. */
     CHECK(note_value(titled) == 7);
+    CHECK(note_emphatic(titled) == true);
 
     /* The union's drop reaches through the struct payload and frees its
      * owning field, nulling the slot so a second drop is a no-op. */
@@ -252,6 +262,27 @@ static void test_out_of_domain_bool_payload(void) {
     note_drop(&off);
 }
 
+/* The same rule one level DOWN, on a `bool` field of a `data_struct` payload
+ * (#170 instance 2). This is what makes the union's "no invalid value is ever
+ * materialised" invariant transitive: the nested record is rebuilt through
+ * per-field wires, so each restricted-validity field has to be normalised on
+ * its own, not just the tag and the direct payloads. */
+static void test_out_of_domain_bool_data_struct_field(void) {
+    static const unsigned char bytes[] = {0, 1, 2, 0xff};
+    static const bool expected[] = {false, true, true, true};
+
+    for (size_t i = 0; i < sizeof bytes / sizeof bytes[0]; i++) {
+        note_t titled = note_new_titled(7, "chapter one", false);
+        memcpy(&titled.titled.emphatic, &bytes[i], 1);
+
+        CHECK(note_emphatic(titled) == expected[i]);
+        /* The rest of the record still decodes normally around it. */
+        CHECK(note_value(titled) == 7);
+
+        note_drop(&titled);
+    }
+}
+
 /* A union nested inside a struct payload. `note_t`'s `Sketched` arm carries a
  * `drawing_t` BY VALUE, whose own `shape` field is another union with an owning
  * arm — a `char *` two levels down that nothing else can reach: a union arm is
@@ -282,6 +313,7 @@ int main(void) {
     test_invalid_tag();
     test_converter_derived_payloads();
     test_out_of_domain_bool_payload();
+    test_out_of_domain_bool_data_struct_field();
     test_nested_union_payload();
 
     if (failures != 0) {
@@ -289,7 +321,7 @@ int main(void) {
         return 1;
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
-           "converter-derived payloads, out-of-domain bool payload, "
-           "nested union payload\n");
+           "converter-derived payloads, out-of-domain bool payload and "
+           "data-struct field, nested union payload\n");
     return 0;
 }

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -306,6 +306,40 @@ static void test_nested_union_payload(void) {
     shape_drop(&sketched.sketched.shape);
 }
 
+/* #189's alias preflight, under the leak detector that makes it meaningful.
+ * `calculator_merge(x, x)` would hand one allocation to two `Box::from_raw`
+ * calls — a double free ASan reports immediately. The generated wrapper
+ * compares the pointers before either conversion runs, so the call is rejected
+ * and the handle is untouched: still live, still ours to drop exactly once. */
+static void test_alias_preflight(void) {
+    char *e = NULL;
+    calculator_t *c = calculator_new();
+
+    CHECK(calculator_merge(c, c, &e) == NULL);
+    CHECK(e != NULL);
+    CHECK(strstr(e, "aliasing arguments") != NULL);
+    example_free(e);
+    e = NULL;
+
+    /* Nothing was consumed — the handle still works and is dropped once. */
+    CHECK(calculator_get_value(c) == 0.0);
+
+    /* The mixed consume/borrow shape is rejected by the same rule. */
+    double out = -1.0;
+    CHECK(!calculator_absorb(c, c, &out, &e));
+    CHECK(e != NULL);
+    CHECK(out == -1.0);
+    example_free(e);
+    e = NULL;
+
+    /* Two DISTINCT handles still work — the preflight adds no false positive.
+     * Both are consumed by the merge; the result is the only thing to drop. */
+    calculator_t *merged = calculator_merge(c, calculator_new(), &e);
+    CHECK(merged != NULL);
+    CHECK(e == NULL);
+    calculator_drop(merged);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
@@ -315,6 +349,7 @@ int main(void) {
     test_out_of_domain_bool_payload();
     test_out_of_domain_bool_data_struct_field();
     test_nested_union_payload();
+    test_alias_preflight();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
@@ -322,6 +357,6 @@ int main(void) {
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
            "converter-derived payloads, out-of-domain bool payload and "
-           "data-struct field, nested union payload\n");
+           "data-struct field, nested union payload, alias preflight\n");
     return 0;
 }

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -576,6 +576,66 @@ pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_absorb(
+    a: *mut calculator_t,
+    b: *const calculator_t,
+    out: *mut f64,
+    e: *mut *mut ::core::ffi::c_char,
+) -> bool {
+    if !(a as *const ()).is_null() && (a as *const ()) == (b as *const ()) {
+        let __msg = ::std::string::String::from(
+            "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
+        );
+        if !e.is_null() {
+            *e = __cbg_out_Error(
+                <example_flat::Error as ::core::convert::From<
+                    ::std::string::String,
+                >>::from(__msg),
+            );
+        }
+        return false;
+    }
+    let a = match __cbg_in_Calculator(a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return false;
+        }
+    };
+    let b = match __cbg_in___Calculator(b) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return false;
+        }
+    };
+    match example_flat::calculator_absorb(a, b) {
+        ::core::result::Result::Ok(__v) => {
+            *out = __cbg_out_f64(__v);
+            true
+        }
+        ::core::result::Result::Err(__err) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(__err);
+            }
+            false
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_apply(
     c: *mut calculator_t,
     op: ::core::mem::MaybeUninit<operation_t>,
@@ -700,6 +760,66 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_merge(
+    a: *mut calculator_t,
+    b: *mut calculator_t,
+    e: *mut *mut ::core::ffi::c_char,
+) -> *mut calculator_t {
+    if !(a as *const ()).is_null() && (a as *const ()) == (b as *const ()) {
+        let __msg = ::std::string::String::from(
+            "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
+        );
+        if !e.is_null() {
+            *e = __cbg_out_Error(
+                <example_flat::Error as ::core::convert::From<
+                    ::std::string::String,
+                >>::from(__msg),
+            );
+        }
+        return ::core::ptr::null_mut();
+    }
+    let a = match __cbg_in_Calculator(a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return ::core::ptr::null_mut();
+        }
+    };
+    let b = match __cbg_in_Calculator(b) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return ::core::ptr::null_mut();
+        }
+    };
+    match example_flat::calculator_merge(a, b) {
+        ::core::result::Result::Ok(__v) => {
+            let __ret: *mut calculator_t;
+            __ret = __cbg_out_Calculator(__v);
+            __ret
+        }
+        ::core::result::Result::Err(__err) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(__err);
+            }
+            ::core::ptr::null_mut()
+        }
+    }
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -52,6 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct caption_t {
     pub id: u64,
     pub text: *mut ::core::ffi::c_char,
+    pub emphatic: ::core::mem::MaybeUninit<bool>,
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -187,6 +188,7 @@ pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
         } else {
             ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
         },
+        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -412,8 +414,8 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_bool(v: bool) -> bool {
-    v
+pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
@@ -463,6 +465,7 @@ pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
         id: v.id,
         text: __cbg_alloc_cstr(v.text),
+        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -776,6 +779,7 @@ pub unsafe extern "C" fn calculator_to_string(
 pub unsafe extern "C" fn caption_new(
     id: u64,
     text: *const ::core::ffi::c_char,
+    emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
     let id = __cbg_in_u64(id);
     let text = match __cbg_in___str(text) {
@@ -784,7 +788,8 @@ pub unsafe extern "C" fn caption_new(
             panic!("{}", __msg);
         }
     };
-    let __v = example_flat::caption_new(id, text);
+    let emphatic = __cbg_in_bool(emphatic);
+    let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
     __ret = __cbg_out_Caption(__v);
     __ret
@@ -867,6 +872,20 @@ pub unsafe extern "C" fn inside_foo_value(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
+    let n = match __cbg_in_Note(n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_emphatic(n);
+    let __ret: bool;
+    __ret = __cbg_out_bool(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
@@ -879,7 +898,7 @@ pub unsafe extern "C" fn note_new_after(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_new_flagged(
-    flag: bool,
+    flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
     let flag = __cbg_in_bool(flag);
     let __v = example_flat::note_new_flagged(flag);
@@ -918,6 +937,7 @@ pub unsafe extern "C" fn note_new_sketched(
 pub unsafe extern "C" fn note_new_titled(
     id: u64,
     text: *const ::core::ffi::c_char,
+    emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
     let id = __cbg_in_u64(id);
     let text = match __cbg_in___str(text) {
@@ -926,7 +946,8 @@ pub unsafe extern "C" fn note_new_titled(
             panic!("{}", __msg);
         }
     };
-    let __v = example_flat::note_new_titled(id, text);
+    let emphatic = __cbg_in_bool(emphatic);
+    let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
     __ret = __cbg_out_Note(__v);
     __ret

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -576,6 +576,66 @@ pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_absorb(
+    a: *mut calculator_t,
+    b: *const calculator_t,
+    out: *mut f64,
+    e: *mut *mut ::core::ffi::c_char,
+) -> bool {
+    if !(a as *const ()).is_null() && (a as *const ()) == (b as *const ()) {
+        let __msg = ::std::string::String::from(
+            "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
+        );
+        if !e.is_null() {
+            *e = __cbg_out_Error(
+                <example_flat::Error as ::core::convert::From<
+                    ::std::string::String,
+                >>::from(__msg),
+            );
+        }
+        return false;
+    }
+    let a = match __cbg_in_Calculator(a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return false;
+        }
+    };
+    let b = match __cbg_in___Calculator(b) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return false;
+        }
+    };
+    match example_flat::calculator_absorb(a, b) {
+        ::core::result::Result::Ok(__v) => {
+            *out = __cbg_out_f64(__v);
+            true
+        }
+        ::core::result::Result::Err(__err) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(__err);
+            }
+            false
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_apply(
     c: *mut calculator_t,
     op: ::core::mem::MaybeUninit<operation_t>,
@@ -700,6 +760,66 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_merge(
+    a: *mut calculator_t,
+    b: *mut calculator_t,
+    e: *mut *mut ::core::ffi::c_char,
+) -> *mut calculator_t {
+    if !(a as *const ()).is_null() && (a as *const ()) == (b as *const ()) {
+        let __msg = ::std::string::String::from(
+            "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
+        );
+        if !e.is_null() {
+            *e = __cbg_out_Error(
+                <example_flat::Error as ::core::convert::From<
+                    ::std::string::String,
+                >>::from(__msg),
+            );
+        }
+        return ::core::ptr::null_mut();
+    }
+    let a = match __cbg_in_Calculator(a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return ::core::ptr::null_mut();
+        }
+    };
+    let b = match __cbg_in_Calculator(b) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(
+                    <example_flat::Error as ::core::convert::From<
+                        ::std::string::String,
+                    >>::from(__msg),
+                );
+            }
+            return ::core::ptr::null_mut();
+        }
+    };
+    match example_flat::calculator_merge(a, b) {
+        ::core::result::Result::Ok(__v) => {
+            let __ret: *mut calculator_t;
+            __ret = __cbg_out_Calculator(__v);
+            __ret
+        }
+        ::core::result::Result::Err(__err) => {
+            if !e.is_null() {
+                *e = __cbg_out_Error(__err);
+            }
+            ::core::ptr::null_mut()
+        }
+    }
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -52,6 +52,7 @@ pub unsafe extern "C" fn calculator_drop(this_: *mut calculator_t) {
 pub struct caption_t {
     pub id: u64,
     pub text: *mut ::core::ffi::c_char,
+    pub emphatic: ::core::mem::MaybeUninit<bool>,
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -187,6 +188,7 @@ pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
         } else {
             ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
         },
+        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -412,8 +414,8 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_bool(v: bool) -> bool {
-    v
+pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
@@ -463,6 +465,7 @@ pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
         id: v.id,
         text: __cbg_alloc_cstr(v.text),
+        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -776,6 +779,7 @@ pub unsafe extern "C" fn calculator_to_string(
 pub unsafe extern "C" fn caption_new(
     id: u64,
     text: *const ::core::ffi::c_char,
+    emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
     let id = __cbg_in_u64(id);
     let text = match __cbg_in___str(text) {
@@ -784,7 +788,8 @@ pub unsafe extern "C" fn caption_new(
             panic!("{}", __msg);
         }
     };
-    let __v = example_flat::caption_new(id, text);
+    let emphatic = __cbg_in_bool(emphatic);
+    let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
     __ret = __cbg_out_Caption(__v);
     __ret
@@ -867,6 +872,20 @@ pub unsafe extern "C" fn inside_foo_value(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
+    let n = match __cbg_in_Note(n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let __v = example_flat::note_emphatic(n);
+    let __ret: bool;
+    __ret = __cbg_out_bool(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
@@ -879,7 +898,7 @@ pub unsafe extern "C" fn note_new_after(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_new_flagged(
-    flag: bool,
+    flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
     let flag = __cbg_in_bool(flag);
     let __v = example_flat::note_new_flagged(flag);
@@ -918,6 +937,7 @@ pub unsafe extern "C" fn note_new_sketched(
 pub unsafe extern "C" fn note_new_titled(
     id: u64,
     text: *const ::core::ffi::c_char,
+    emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
     let id = __cbg_in_u64(id);
     let text = match __cbg_in___str(text) {
@@ -926,7 +946,8 @@ pub unsafe extern "C" fn note_new_titled(
             panic!("{}", __msg);
         }
     };
-    let __v = example_flat::note_new_titled(id, text);
+    let emphatic = __cbg_in_bool(emphatic);
+    let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
     __ret = __cbg_out_Note(__v);
     __ret

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -117,6 +117,8 @@ void note_drop(struct note_t *this_);
 
 void shape_drop(struct shape_t *this_);
 
+bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
+
 bool calculator_apply(struct calculator_t *c,
                       enum operation_t op,
                       double operand,
@@ -132,6 +134,8 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 double calculator_get_value(const struct calculator_t *c);
 
 bool calculator_is(const struct calculator_t *c, double value);
+
+struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 
 struct calculator_t *calculator_new(void);
 

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -31,6 +31,7 @@ typedef struct calculator_t {
 typedef struct caption_t {
   uint64_t id;
   char *text;
+  bool emphatic;
 } caption_t;
 
 typedef enum shape_t_Tag {
@@ -140,7 +141,7 @@ struct calculator_t *calculator_new_from_str(const char *s, char **e);
 
 char *calculator_to_string(const struct calculator_t *c);
 
-struct caption_t caption_new(uint64_t id, const char *text);
+struct caption_t caption_new(uint64_t id, const char *text, bool emphatic);
 
 struct shape_t drawing_get_shape(struct drawing_t d);
 
@@ -154,6 +155,8 @@ enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
 
+bool note_emphatic(struct note_t n);
+
 struct note_t note_new_after(uint64_t millis);
 
 struct note_t note_new_flagged(bool flag);
@@ -162,7 +165,7 @@ struct note_t note_new_silent(void);
 
 struct note_t note_new_sketched(uint64_t id, const char *label);
 
-struct note_t note_new_titled(uint64_t id, const char *text);
+struct note_t note_new_titled(uint64_t id, const char *text, bool emphatic);
 
 uint64_t note_value(struct note_t n);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -117,6 +117,8 @@ void note_drop(struct note_t *this_);
 
 void shape_drop(struct shape_t *this_);
 
+bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
+
 bool calculator_apply(struct calculator_t *c,
                       enum operation_t op,
                       double operand,
@@ -132,6 +134,8 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 double calculator_get_value(const struct calculator_t *c);
 
 bool calculator_is(const struct calculator_t *c, double value);
+
+struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 
 struct calculator_t *calculator_new(void);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -31,6 +31,7 @@ typedef struct calculator_t {
 typedef struct caption_t {
   uint64_t id;
   char *text;
+  bool emphatic;
 } caption_t;
 
 typedef enum shape_t_Tag {
@@ -140,7 +141,7 @@ struct calculator_t *calculator_new_from_str(const char *s, char **e);
 
 char *calculator_to_string(const struct calculator_t *c);
 
-struct caption_t caption_new(uint64_t id, const char *text);
+struct caption_t caption_new(uint64_t id, const char *text, bool emphatic);
 
 struct shape_t drawing_get_shape(struct drawing_t d);
 
@@ -154,6 +155,8 @@ enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
 
+bool note_emphatic(struct note_t n);
+
 struct note_t note_new_after(uint64_t millis);
 
 struct note_t note_new_flagged(bool flag);
@@ -162,7 +165,7 @@ struct note_t note_new_silent(void);
 
 struct note_t note_new_sketched(uint64_t id, const char *label);
 
-struct note_t note_new_titled(uint64_t id, const char *text);
+struct note_t note_new_titled(uint64_t id, const char *text, bool emphatic);
 
 uint64_t note_value(struct note_t n);
 

--- a/examples/example-cbindgen/src/boundary_tests.rs
+++ b/examples/example-cbindgen/src/boundary_tests.rs
@@ -20,9 +20,9 @@ use core::{
 };
 
 use crate::{
-    calculator_apply, calculator_drop, calculator_get_value, calculator_new, caption_t,
-    example_free, inside_foo_default, inside_foo_value, note_drop, note_emphatic, note_new_flagged,
-    note_new_titled, note_t, note_value, operation_t,
+    calculator_absorb, calculator_apply, calculator_drop, calculator_get_value, calculator_merge,
+    calculator_new, caption_t, example_free, inside_foo_default, inside_foo_value, note_drop,
+    note_emphatic, note_new_flagged, note_new_titled, note_t, note_value, operation_t,
 };
 
 /// The wire value a C caller passing `value` produces — including a `value`
@@ -220,5 +220,105 @@ fn enum_round_trips_through_the_validating_wire() {
     unsafe {
         let v = inside_foo_default();
         assert_eq!(inside_foo_value(MaybeUninit::new(v)), v as i32);
+    }
+}
+
+/// #189's alias preflight, in the shape it exists for: two **consumed** handles
+/// of one type. `calculator_merge(x, x)` would reconstruct one allocation twice
+/// — the second `Box::from_raw` on a pointer the first already owns.
+///
+/// Rejected *before* either conversion runs, so the handle is untouched and
+/// still usable afterwards. That is the observable that distinguishes a
+/// preflight from a check inside the converter: by then the first argument has
+/// already been consumed and there is nothing left to keep.
+#[test]
+fn aliased_consumed_handles_are_rejected_before_any_conversion() {
+    unsafe {
+        let c = calculator_new();
+        let mut err: *mut c_char = ptr::null_mut();
+
+        assert!(calculator_merge(c, c, &mut err).is_null());
+        assert!(!err.is_null());
+        let msg = CStr::from_ptr(err).to_string_lossy().into_owned();
+        assert!(msg.contains("aliasing arguments"), "{msg}");
+        assert!(msg.contains("Calculator"), "{msg}");
+        example_free(err.cast::<c_void>());
+
+        // Nothing was consumed: the handle is still live and still owns its
+        // value. (Under ASan a consumed-then-reused handle is a use-after-free;
+        // here it is simply the argument we passed.)
+        assert_eq!(calculator_get_value(c), 0.0);
+        calculator_drop(c);
+    }
+}
+
+/// The mixed case: one **consumed** handle beside one **borrowed** handle. The
+/// borrow dangles the moment the consume takes ownership, so it is rejected by
+/// the same rule — which is why the generation predicate is "at least one
+/// consume or exclusive borrow, and any other access in the same domain"
+/// rather than "two or more consumed parameters".
+#[test]
+fn consumed_and_borrowed_alias_is_rejected() {
+    unsafe {
+        let c = calculator_new();
+        let mut out = -1.0f64;
+        let mut err: *mut c_char = ptr::null_mut();
+
+        assert!(!calculator_absorb(c, c, &mut out, &mut err));
+        assert!(!err.is_null());
+        let msg = CStr::from_ptr(err).to_string_lossy().into_owned();
+        assert!(msg.contains("aliasing arguments"), "{msg}");
+        // The call had no effect at all.
+        assert_eq!(out, -1.0);
+        example_free(err.cast::<c_void>());
+
+        assert_eq!(calculator_get_value(c), 0.0);
+        calculator_drop(c);
+    }
+}
+
+/// No false positives: two **distinct** resources of the same type still work,
+/// in both the consume/consume and the consume/borrow shape. A preflight that
+/// rejected these would have removed working surface, which is exactly what
+/// #189 rules out.
+#[test]
+fn distinct_handles_are_not_treated_as_aliases() {
+    unsafe {
+        let mut err: *mut c_char = ptr::null_mut();
+
+        let a = calculator_new();
+        let b = calculator_new();
+        assert!(calculator_apply(
+            a,
+            MaybeUninit::new(operation_t::Add),
+            2.0,
+            &mut 0.0,
+            &mut err
+        ));
+        assert!(calculator_apply(
+            b,
+            MaybeUninit::new(operation_t::Add),
+            5.0,
+            &mut 0.0,
+            &mut err
+        ));
+
+        // consume/borrow with distinct resources.
+        let mut out = -1.0f64;
+        assert!(calculator_absorb(a, b, &mut out, &mut err));
+        assert!(err.is_null());
+        assert_eq!(out, 7.0);
+
+        // consume/consume with distinct resources. `a` is gone (absorbed), so
+        // build two more.
+        let c = calculator_new();
+        let d = calculator_new();
+        let merged = calculator_merge(c, d, &mut err);
+        assert!(!merged.is_null());
+        assert!(err.is_null());
+        assert_eq!(calculator_get_value(merged), 0.0);
+
+        calculator_drop(merged);
+        calculator_drop(b);
     }
 }

--- a/examples/example-cbindgen/src/boundary_tests.rs
+++ b/examples/example-cbindgen/src/boundary_tests.rs
@@ -20,8 +20,9 @@ use core::{
 };
 
 use crate::{
-    calculator_apply, calculator_drop, calculator_get_value, calculator_new, example_free,
-    inside_foo_default, inside_foo_value, note_new_flagged, note_t, note_value, operation_t,
+    calculator_apply, calculator_drop, calculator_get_value, calculator_new, caption_t,
+    example_free, inside_foo_default, inside_foo_value, note_drop, note_emphatic, note_new_flagged,
+    note_new_titled, note_t, note_value, operation_t,
 };
 
 /// The wire value a C caller passing `value` produces — including a `value`
@@ -147,14 +148,67 @@ unsafe fn raw_flagged(byte: u8) -> MaybeUninit<note_t> {
 fn out_of_domain_bool_payload_is_normalised_not_materialised() {
     unsafe {
         // Rust's own `true`/`false` round trip.
-        assert_eq!(note_value(note_new_flagged(true)), 1);
-        assert_eq!(note_value(note_new_flagged(false)), 0);
+        assert_eq!(note_value(note_new_flagged(MaybeUninit::new(true))), 1);
+        assert_eq!(note_value(note_new_flagged(MaybeUninit::new(false))), 0);
         // The hand-written wire agrees with the generated encoder.
         assert_eq!(note_value(raw_flagged(0)), 0);
         assert_eq!(note_value(raw_flagged(1)), 1);
         // Bytes no Rust `bool` may hold: accepted, normalised to `true`.
         assert_eq!(note_value(raw_flagged(2)), 1);
         assert_eq!(note_value(raw_flagged(0xff)), 1);
+    }
+}
+
+/// The wire a C caller produces for a plain `bool` **parameter** with `byte` in
+/// the slot — including a byte no Rust `bool` may hold.
+unsafe fn raw_bool_arg(byte: u8) -> MaybeUninit<bool> {
+    let mut slot = MaybeUninit::<bool>::uninit();
+    ptr::write(slot.as_mut_ptr().cast::<u8>(), byte);
+    slot
+}
+
+/// #170 instance 1 — the broadest one: a plain `bool` **parameter**. It shares
+/// the payload's wire and normalising read, so the byte a caller supplies never
+/// becomes a Rust `bool` unchecked. The C prototype is untouched: cbindgen
+/// renders `MaybeUninit<bool>` as `bool`, so this is still `note_new_flagged(bool)`
+/// in the header.
+#[test]
+fn out_of_domain_bool_parameter_is_normalised_not_materialised() {
+    unsafe {
+        assert_eq!(note_value(note_new_flagged(raw_bool_arg(0))), 0);
+        assert_eq!(note_value(note_new_flagged(raw_bool_arg(1))), 1);
+        assert_eq!(note_value(note_new_flagged(raw_bool_arg(2))), 1);
+        assert_eq!(note_value(note_new_flagged(raw_bool_arg(0xff))), 1);
+    }
+}
+
+/// #170 instance 2 — a `bool` field of a `data_struct`, reached through a
+/// tagged-union payload. `caption_t` is built by the generated encoder and then
+/// its `emphatic` slot is overwritten the way a C caller can (a `memcpy`, a
+/// union, a struct read off the wire); the decode has to normalise it one level
+/// down, inside `__cbg_in_Caption`. This is what makes the union's "no invalid
+/// value is ever materialised" invariant transitive.
+#[test]
+fn out_of_domain_bool_data_struct_field_is_normalised_not_materialised() {
+    unsafe {
+        let text = c"chapter one";
+        for (byte, expected) in [(0u8, false), (1, true), (2, true), (0xff, true)] {
+            let mut note = note_new_titled(7, text.as_ptr(), raw_bool_arg(0));
+            // Overwrite the payload's `bool` field in place, through raw bytes.
+            // The payload begins at the union's alignment (see `raw_flagged`).
+            let caption = note
+                .as_mut_ptr()
+                .cast::<u8>()
+                .add(align_of::<note_t>())
+                .cast::<caption_t>();
+            ptr::write(ptr::addr_of_mut!((*caption).emphatic).cast::<u8>(), byte);
+
+            // A union crosses BY VALUE, so the callee copies the label out and
+            // the block stays ours — the same contract `smoke.c` relies on.
+            assert_eq!(note_emphatic(ptr::read(&note)), expected, "byte {byte:#x}");
+            assert_eq!(note_value(ptr::read(&note)), 7);
+            note_drop(&mut note);
+        }
     }
 }
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -321,6 +321,32 @@ pub fn calculator_new_clone(c: &Calculator) -> Calculator {
     }
 }
 
+/// Fold one accumulator into another, consuming **both**.
+///
+/// Two consumed handles of the same type is a supported shape, and it is the
+/// aliasing hazard: called as `calculator_merge(x, x)` a C caller would have
+/// one allocation reconstructed twice, so the generated wrapper runs a
+/// pointer-identity **preflight** before either conversion and reports the
+/// alias through this `Result`'s error channel.
+#[prebindgen]
+pub fn calculator_merge(a: Calculator, b: Calculator) -> Result<Calculator, Error> {
+    let mut history = a.history;
+    history.extend(b.history);
+    Ok(Calculator {
+        value: a.value + b.value,
+        history,
+    })
+}
+
+/// Consume one accumulator while **borrowing** another — the mixed case the
+/// "two or more consumed parameters" reading of the rule would have skipped.
+/// The borrow dangles the moment the consume takes ownership, so the same
+/// preflight covers it.
+#[prebindgen]
+pub fn calculator_absorb(a: Calculator, b: &Calculator) -> Result<f64, Error> {
+    Ok(a.value + b.value)
+}
+
 /// Apply `op` with `operand`, updating the accumulator and returning the new
 /// value. Division by zero returns an error (its fallible `&mut` input routes
 /// through the error channel of the `Result`).

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -80,19 +80,27 @@ pub enum Shape {
 /// `ReplyResult` needs, where an alternative carries a whole record rather than a
 /// scalar. Its `String` field owns memory, so the union's typed drop has to reach
 /// through the payload and release it.
+///
+/// The `bool` field is the second half of #170: a `data_struct` field crosses by
+/// value through a per-field wire, so a byte C wrote has to be normalised there
+/// too — and because this struct is also a union payload, that is what makes the
+/// tagged union's "no invalid value is ever materialised" invariant hold
+/// *transitively*, one level down.
 #[prebindgen]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Caption {
     pub id: u64,
     pub text: String,
+    pub emphatic: bool,
 }
 
 /// Build a [`Caption`].
 #[prebindgen]
-pub fn caption_new(id: u64, text: &str) -> Caption {
+pub fn caption_new(id: u64, text: &str, emphatic: bool) -> Caption {
     Caption {
         id,
         text: text.to_string(),
+        emphatic,
     }
 }
 
@@ -141,8 +149,8 @@ pub fn millis_to_raw(v: &Millis) -> u64 {
 
 /// A titled note (nested-struct payload).
 #[prebindgen]
-pub fn note_new_titled(id: u64, text: &str) -> Note {
-    Note::Titled(caption_new(id, text))
+pub fn note_new_titled(id: u64, text: &str, emphatic: bool) -> Note {
+    Note::Titled(caption_new(id, text, emphatic))
 }
 
 /// A delayed note (converted-leaf payload).
@@ -183,6 +191,17 @@ pub fn note_value(n: Note) -> u64 {
         Note::After(Millis(m)) => m,
         Note::Flagged(f) => f as u64,
         Note::Sketched(d) => d.id,
+    }
+}
+
+/// Whether a titled note's caption is emphatic. The observable of #170's
+/// second instance: the `bool` rides in as a `data_struct` field of a union
+/// payload, two per-field wires down from the C caller's bytes.
+#[prebindgen]
+pub fn note_emphatic(n: Note) -> bool {
+    match n {
+        Note::Titled(c) => c.emphatic,
+        _ => false,
     }
 }
 

--- a/examples/perftest-c/build.rs
+++ b/examples/perftest-c/build.rs
@@ -73,7 +73,16 @@ fn generate_ffi_bindings() -> PathBuf {
     // consume (`storage_put_by_take`) reads the value out through a `*mut payload_t` and
     // nulls the moved-out `label` in place, making the caller's later free a no-op (no
     // `.owned()` modifier, no `Default` requirement — the `label` is nullable).
-    cbindgen = cbindgen.repr_c_struct(pq!(Payload));
+    //
+    // `.assume_c_field_validity()` acknowledges the one gap the mirror policy
+    // cannot close: `Payload::flag` is a `bool`, and the whole-struct
+    // reinterpret gives no hook to normalise a byte outside `{0, 1}` that a C
+    // caller wrote (#170 instance 3). This benchmark's C side writes the field
+    // through `_Bool`, so it is in-domain by construction; a real binding should
+    // prefer a `data_struct` field, which normalises per field.
+    cbindgen = cbindgen
+        .repr_c_struct(pq!(Payload))
+        .assume_c_field_validity();
 
     // The `&Payload` callback signature -> a `closure_payload_t` closure struct
     // whose `call` takes a `const payload_t *` (zero-copy borrow). `.base_name`

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -333,8 +333,8 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_bool(v: bool) -> bool {
-    v
+pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_payload_t(

--- a/examples/smoke-asan.sh
+++ b/examples/smoke-asan.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Run the C smoke test against the generated `example_flat` ABI under
+# AddressSanitizer + LeakSanitizer + UndefinedBehaviorSanitizer.
+#
+# `c/smoke.c` is the test that exists to prove the ownership contract — every
+# arm C receives is C's to release, and the typed drops release exactly the live
+# one. Running it without a leak detector meant it could violate that contract
+# and still print PASS, which is what happened (#154 review). This is the gate
+# that keeps it honest.
+#
+# What is and is not instrumented: the Rust cdylib is built by a stable
+# toolchain and is therefore NOT compiled with `-Zsanitizer=address`, so ASan's
+# redzone checks apply to the C side only. LeakSanitizer, however, interposes
+# `malloc` for the whole process, and Rust's default allocator on Linux is the
+# system allocator — so a block the generated Rust layer hands out and nobody
+# frees IS reported, with the generated file and line in the stack. That is the
+# property this gate is for.
+#
+# Usage:
+#   examples/smoke-asan.sh
+#
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+cc="${CC:-cc}"
+out_dir="${TMPDIR:-/tmp}/prebindgen-smoke-asan.$$"
+mkdir -p "$out_dir"
+trap 'rm -rf "$out_dir"' EXIT
+
+arch="$(uname -m)"
+case "$arch" in
+    x86_64 | amd64) header_arch=x86_64 ;;
+    aarch64 | arm64) header_arch=aarch64 ;;
+    *)
+        echo "no committed example_flat header for architecture '$arch'" >&2
+        exit 1
+        ;;
+esac
+
+echo "== cargo build -p example-cbindgen (cdylib + regenerated header)"
+cargo build -p example-cbindgen
+
+lib_dir="$repo_root/target/debug"
+case "$(uname -s)" in
+    Darwin) dylib="$lib_dir/libexample_cbindgen.dylib" ;;
+    *) dylib="$lib_dir/libexample_cbindgen.so" ;;
+esac
+if [[ ! -f "$dylib" ]]; then
+    echo "expected cdylib at $dylib" >&2
+    exit 1
+fi
+
+# `-fno-sanitize-recover=all` turns every UBSan finding into a non-zero exit;
+# without it an unaligned load or a signed overflow only prints and continues.
+sanitizers=(
+    -fsanitize=address,undefined
+    -fno-sanitize-recover=all
+    -fno-omit-frame-pointer
+)
+
+echo "== compiling c/smoke.c for $header_arch under ASan/LSan/UBSan"
+"$cc" "${sanitizers[@]}" -g -O1 -std=c11 -Wall -Wextra -Werror \
+    -I "$repo_root/examples/example-cbindgen/include" \
+    "$repo_root/examples/example-cbindgen/c/smoke.c" \
+    -o "$out_dir/smoke" \
+    -L "$lib_dir" -lexample_cbindgen -lm \
+    -Wl,-rpath,"$lib_dir"
+
+echo "== running"
+ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1" \
+    UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" \
+    "$out_dir/smoke"
+
+echo "PASS - C smoke test clean under ASan/LSan/UBSan"

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -243,6 +243,7 @@ impl Cbindgen {
                 opaque: opaque_ty,
                 kind,
                 generate_mirror: false,
+                assume_c_field_validity: false,
                 cfg: TypeCfg::default(),
             },
         );
@@ -289,10 +290,51 @@ impl Cbindgen {
                 opaque: syn::parse_quote!(#mirror),
                 kind: OpaqueKind::Data,
                 generate_mirror: true,
+                assume_c_field_validity: false,
                 cfg: TypeCfg::default(),
             },
         );
         self.current = Some(CurrentDecl::ValueOpaque(key));
+        self
+    }
+
+    /// Accept a [`Self::repr_c_struct`] whose mirror has **restricted-validity**
+    /// fields, taking responsibility for their bytes.
+    ///
+    /// A `repr_c_struct` crosses IN by one whole-struct reinterpret, so there is
+    /// no per-field hook where a C-supplied byte could be normalised or checked
+    /// before the source struct exists. A field whose Rust type accepts only
+    /// *some* bit patterns — `bool` (`0`/`1`) or a declared [`Self::enum_type`]
+    /// (the declared discriminants) — is therefore undefined behaviour the
+    /// moment C writes anything else into the mirror and hands it back. The
+    /// generator rejects such a declaration by default (#170 instance 3, #158
+    /// instance 3); the real fix is a raw-wire lowering, which does not exist
+    /// yet.
+    ///
+    /// This modifier is the acknowledgement, not a fix: it says the C side of
+    /// this binding is trusted to write only in-domain bytes into those fields.
+    /// It exists so that the audit rejects **silently unsound new declarations**
+    /// without removing bindings that already ship. Chain it directly after the
+    /// [`Self::repr_c_struct`] it applies to; the panic message names every
+    /// field it would cover.
+    ///
+    /// Prefer, in order: move the field into a [`Self::data_struct`] (per-field
+    /// wires, so `bool` normalises), pass it as a separate scalar parameter, or
+    /// widen it to an integer the whole domain of which is valid.
+    pub fn assume_c_field_validity(mut self) -> Self {
+        match self.current.clone() {
+            Some(CurrentDecl::ValueOpaque(key)) => {
+                self.value_opaque
+                    .get_mut(&key)
+                    .expect("entry vanished")
+                    .assume_c_field_validity = true;
+            }
+            other => panic!(
+                "Cbindgen::assume_c_field_validity must follow a `repr_c_struct` declaration, \
+                 not {}",
+                describe_current(&other)
+            ),
+        }
         self
     }
 

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -863,6 +863,115 @@ impl Cbindgen {
             .is_some_and(|entry| returns_result(&entry.function.sig.output))
     }
 
+    /// How one parameter *uses* the resource it names — the axis the alias rule
+    /// is stated on. `None` ⇒ the parameter names no single owned resource (a
+    /// scalar, a string, a slice block, an undeclared type), so it cannot alias
+    /// one.
+    ///
+    /// `T` and `Option<T>` share a resource domain: both arrive as the same
+    /// handle pointer, and comparing the syntactic parameter type instead would
+    /// miss `f(x: ZThing, y: Option<ZThing>)` called with the same handle
+    /// twice.
+    fn alias_slot(&self, ty: &syn::Type) -> Option<(TypeKey, AliasAccess)> {
+        let inner = if is_option(ty) {
+            first_type_arg(ty)?
+        } else {
+            ty.clone()
+        };
+        let declared =
+            |key: &TypeKey| self.opaque.contains_key(key) || self.value_opaque.contains_key(key);
+        if let syn::Type::Reference(r) = &inner {
+            // `&mut MaybeUninit<T>` borrows T's slot exclusively just as
+            // `&mut T` does; the wire is the same pointer.
+            let elem = (*r.elem).clone();
+            let elem = maybe_uninit_inner(&elem).unwrap_or(elem);
+            let key = TypeKey::from_type(&elem);
+            if !declared(&key) {
+                return None;
+            }
+            return Some((
+                key,
+                if r.mutability.is_some() {
+                    AliasAccess::Exclusive
+                } else {
+                    AliasAccess::Shared
+                },
+            ));
+        }
+        let key = TypeKey::from_type(&inner);
+        declared(&key).then_some((key, AliasAccess::Consume))
+    }
+
+    /// The runtime **alias preflight**: reject a call whose arguments name the
+    /// same resource in a combination that would reconstruct or invalidate it
+    /// twice, *before* any conversion runs.
+    ///
+    /// `z_combine(primary: ZThing, fallback: ZThing)` is a supported
+    /// declaration; called as `z_combine(x, x)` it reaches `Box::from_raw`
+    /// twice on one allocation. So is `f(a: ZThing, b: &ZThing)` — the borrow
+    /// dangles the moment the consume takes ownership — and `f(a: &mut T, b:
+    /// &T)`, where the exclusive reference is not exclusive at all. Rejecting
+    /// the *declaration* is not an option: these are shapes that ship today, so
+    /// removing them would be a regression that a later stage would have to
+    /// undo.
+    ///
+    /// Emitted whenever a call has **at least one `Consume` or
+    /// `ExclusiveBorrow`** and **any other active access in the same resource
+    /// domain**. Stated that way rather than as "two or more consumed
+    /// parameters", which would skip exactly the two mixed cases above.
+    ///
+    /// A NULL pointer names no resource — two NULLs are not an alias — and is
+    /// rejected by each converter's own null check, so the comparison skips it.
+    ///
+    /// Shared/shared is *not* rejected: two `&T` to one resource is legal Rust
+    /// and legal C.
+    pub(super) fn alias_preflight(&self, f: &syn::ItemFn, route: &ErrRoute) -> Option<TokenStream> {
+        let mut slots: Vec<(syn::Ident, TypeKey, AliasAccess)> = Vec::new();
+        for input in &f.sig.inputs {
+            let syn::FnArg::Typed(pt) = input else {
+                continue;
+            };
+            let syn::Pat::Ident(pat_id) = &*pt.pat else {
+                continue;
+            };
+            if let Some((key, access)) = self.alias_slot(&pt.ty) {
+                slots.push((pat_id.ident.clone(), key, access));
+            }
+        }
+
+        let on_err = route_message(route);
+        let mut checks: Vec<TokenStream> = Vec::new();
+        for i in 0..slots.len() {
+            for j in (i + 1)..slots.len() {
+                let (a, a_key, a_access) = &slots[i];
+                let (b, b_key, b_access) = &slots[j];
+                if a_key != b_key {
+                    continue;
+                }
+                // At least one side must be exclusive about the resource.
+                if matches!(a_access, AliasAccess::Shared)
+                    && matches!(b_access, AliasAccess::Shared)
+                {
+                    continue;
+                }
+                let msg = format!(
+                    "aliasing arguments: `{a}` ({}) and `{b}` ({}) are the same `{}` — a \
+                     consumed or exclusively-borrowed resource may not be named twice in one call",
+                    a_access.describe(),
+                    b_access.describe(),
+                    a_key.as_str(),
+                );
+                checks.push(quote!(
+                    if !(#a as *const ()).is_null() && (#a as *const ()) == (#b as *const ()) {
+                        let __msg = ::std::string::String::from(#msg);
+                        #on_err
+                    }
+                ));
+            }
+        }
+        (!checks.is_empty()).then(|| quote!(#(#checks)*))
+    }
+
     /// Build the wire param list, per-input decode statements, and call-site
     /// argument expressions. Fallible inputs (converter returns `Result<_,
     /// String>`) route their `Err(msg)` per `route`; infallible inputs decode
@@ -875,7 +984,10 @@ impl Cbindgen {
         route: &ErrRoute,
     ) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {
         let mut params = Vec::new();
-        let mut decodes = Vec::new();
+        // The alias preflight runs BEFORE every decode, which is the whole
+        // point: by the time the first converter has run, one of the aliased
+        // arguments has already been consumed.
+        let mut decodes: Vec<TokenStream> = self.alias_preflight(f, route).into_iter().collect();
         let mut call_args = Vec::new();
 
         for input in &f.sig.inputs {
@@ -946,19 +1058,7 @@ impl Cbindgen {
             params.push(quote!(#ident: #wire));
 
             if returns_result(&entry.function.sig.output) {
-                let on_err = match route {
-                    ErrRoute::Result {
-                        e_conv,
-                        e_ty_src,
-                        fail_return,
-                    } => quote!(
-                        if !e.is_null() {
-                            *e = #e_conv(<#e_ty_src as ::core::convert::From<::std::string::String>>::from(__msg));
-                        }
-                        return #fail_return;
-                    ),
-                    ErrRoute::Panic => quote!(panic!("{}", __msg);),
-                };
+                let on_err = route_message(route);
                 decodes.push(quote!(
                     let #ident = match #conv(#ident) {
                         ::core::result::Result::Ok(__v) => __v,

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -77,9 +77,9 @@ impl Cbindgen {
     /// they do too. That is what makes the mirror's tag the *only* thing
     /// [`Cbindgen::in_tagged_union`] has to validate before `assume_init`.
     ///
-    /// (A `bool` reached through a nested `data_struct` payload is **not**
-    /// covered here — see #170. That is the pre-existing `c_field_wire` policy,
-    /// which a plain `bool` parameter shares.)
+    /// A `bool` reached through a nested `data_struct` payload is covered by
+    /// the same [`bool_wire`] policy, which [`c_field_wire`] and the plain
+    /// `bool` parameter now share (#170).
     pub(super) fn payload_field_wire(
         &self,
         fty: &syn::Type,
@@ -98,11 +98,9 @@ impl Cbindgen {
         // `bool` is the one scalar with a restricted domain: `2` is a byte a C
         // caller can write into the union and NOT a Rust `bool`, so holding it
         // in the mirror is the same UB an out-of-range discriminant is. Same
-        // remedy, and invisible in C for the same reason (cbindgen simplifies
-        // `MaybeUninit<T>` to `T`); the byte is normalised C-style — nonzero is
-        // true — in `payload_in_expr`.
+        // remedy everywhere C writes a `bool` — see `bool_wire`.
         if is_bool(fty) {
-            return Ok(syn::parse_quote!(::core::mem::MaybeUninit<bool>));
+            return Ok(bool_wire());
         }
         // A `Vec` payload needs TWO C wires (pointer + length) and one union
         // field can carry only one, so its length would be silently dropped.
@@ -325,6 +323,12 @@ impl Cbindgen {
     /// [`Cbindgen::opaque_ptr`]) becomes `*mut t_t`. The whole-struct `Transmute`
     /// (size/align-equal, asserted) then reinterprets each source field's bits into
     /// this wire. `None` ⇒ the field type is unsupported in a `repr_c_struct`.
+    ///
+    /// Note what this policy cannot express: the wire *is* the source field's
+    /// type, so a field whose Rust type has restricted validity is reinterpreted
+    /// from C's bytes with no chance to check them. That gap is audited
+    /// separately by [`Self::restricted_validity_field`] — this function keeps
+    /// answering what the layout is.
     pub(super) fn mirror_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
         if is_scalar(fty) {
             return Some(fty.clone());
@@ -347,6 +351,73 @@ impl Cbindgen {
             }
         }
         None
+    }
+
+    /// Why a `repr_c_struct` mirror field is **not** safe to reinterpret from
+    /// C-supplied bytes, or `None` when every bit pattern of its wire is a valid
+    /// value of the source field's type.
+    ///
+    /// Integers, floats and raw pointers hold any bits legally (holding a
+    /// garbage pointer is sound; dereferencing it is the caller's contract).
+    /// Two Rust types do not: `bool`, whose domain is `0`/`1` (#170 instance 3),
+    /// and a declared `enum_type`, whose domain is the declared discriminants
+    /// (#158 instance 3).
+    ///
+    /// The other positions these types cross — a parameter, a `data_struct`
+    /// field, a tagged-union payload — all go through a *per-value* converter,
+    /// so each has a hook: `bool` normalises through [`bool_wire`], an enum
+    /// validates its discriminant in `in_enum`. A `repr_c_struct` has no such
+    /// hook: one whole-struct `Transmute` reinterprets the mirror into the
+    /// source type, and by the time any generated code could look, the invalid
+    /// value already exists. Wrapping the mirror field in `MaybeUninit` moves
+    /// the problem rather than solving it — the transmute's *output* still has
+    /// the real field.
+    pub(super) fn restricted_validity_field(&self, fty: &syn::Type) -> Option<&'static str> {
+        if is_bool(fty) {
+            return Some("`bool` — only `0` and `1` are valid");
+        }
+        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+            return Some("a declared `enum_type` — only its declared discriminants are valid");
+        }
+        None
+    }
+
+    /// The audit of [`Self::restricted_validity_field`] over one
+    /// `repr_c_struct`'s mirror: the offending `(field, reason)` pairs, in
+    /// declaration order. Empty ⇒ the whole mirror is safe to reinterpret.
+    pub(super) fn restricted_validity_fields(
+        &self,
+        registry: &Registry<()>,
+        ty: &syn::Type,
+    ) -> Vec<(syn::Ident, &'static str)> {
+        self.struct_fields(registry, ty)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(fname, fty)| {
+                self.restricted_validity_field(&fty)
+                    .map(|reason| (fname, reason))
+            })
+            .collect()
+    }
+
+    /// Whether C can hand this type's mirror **back** to Rust. Only then can a
+    /// caller-written byte reach a reinterpret, so only then does
+    /// [`Self::restricted_validity_fields`] describe a live hazard.
+    ///
+    /// Every inbound position keys its own converter, so the four spellings are
+    /// checked directly rather than inferred from the base type's entry.
+    pub(super) fn crosses_in_by_reinterpret(
+        &self,
+        registry: &Registry<()>,
+        ty: &syn::Type,
+    ) -> bool {
+        let forms: [syn::Type; 4] = [
+            ty.clone(),
+            syn::parse_quote!(&#ty),
+            syn::parse_quote!(&mut #ty),
+            syn::parse_quote!(&[#ty]),
+        ];
+        forms.iter().any(|f| registry.input_entry(f).is_some())
     }
 
     /// Exported `#[no_mangle]` symbol for a declared function:

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -400,26 +400,6 @@ impl Cbindgen {
             .collect()
     }
 
-    /// Whether C can hand this type's mirror **back** to Rust. Only then can a
-    /// caller-written byte reach a reinterpret, so only then does
-    /// [`Self::restricted_validity_fields`] describe a live hazard.
-    ///
-    /// Every inbound position keys its own converter, so the four spellings are
-    /// checked directly rather than inferred from the base type's entry.
-    pub(super) fn crosses_in_by_reinterpret(
-        &self,
-        registry: &Registry<()>,
-        ty: &syn::Type,
-    ) -> bool {
-        let forms: [syn::Type; 4] = [
-            ty.clone(),
-            syn::parse_quote!(&#ty),
-            syn::parse_quote!(&mut #ty),
-            syn::parse_quote!(&[#ty]),
-        ];
-        forms.iter().any(|f| registry.input_entry(f).is_some())
-    }
-
     /// Exported `#[no_mangle]` symbol for a declared function:
     /// [`Self::mangle_function`] over the base — a `.base_name(...)` override when
     /// set, else the Rust fn ident — or that base verbatim when no mangler is set.

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -166,6 +166,11 @@ struct ValueOpaqueCfg {
     /// [`Cbindgen::repr_c_struct`]; `false` for `opaque_data_struct` /
     /// `opaque_owned_struct` (counterpart defined elsewhere).
     generate_mirror: bool,
+    /// Opt-out of the restricted-validity field audit (#170 instance 3, #158
+    /// instance 3). Set by [`Cbindgen::assume_c_field_validity`]. See
+    /// [`Cbindgen::restricted_validity_field`] for what the audit rejects and
+    /// why the escape hatch exists.
+    assume_c_field_validity: bool,
     /// Name config (`.base_name()` override; default naming via the manglers).
     cfg: TypeCfg,
 }
@@ -486,6 +491,41 @@ fn is_bool(ty: &syn::Type) -> bool {
     type_path_tail(ty).map(|i| i == "bool").unwrap_or(false)
 }
 
+/// The C wire for a `bool` in any position C can write: `MaybeUninit<bool>`.
+///
+/// `bool` is the one FFI-safe scalar with a restricted domain — only `0` and
+/// `1` are valid — so a byte a C caller supplies may not be **held** in a Rust
+/// `bool` at all, let alone read from one. `MaybeUninit<bool>` holds any byte
+/// legally, has `bool`'s size and alignment (so a layout-preserving mirror
+/// still transmutes), and is invisible in the header: cbindgen simplifies
+/// `MaybeUninit<T>` to `T`, so the C prototype keeps saying `bool`.
+///
+/// The counterpart read is [`bool_in_expr`]. Together they are the single
+/// policy for #170; every position that lets C hand over a `bool` — a
+/// parameter, a `data_struct` field, a tagged-union payload — uses this pair
+/// and nothing else.
+fn bool_wire() -> syn::Type {
+    syn::parse_quote!(::core::mem::MaybeUninit<bool>)
+}
+
+/// Read a [`bool_wire`] slot the way C converts to `_Bool`: nonzero is true.
+///
+/// `access` must evaluate to a `MaybeUninit<bool>` place. The byte is read out
+/// as a `u8` — legal for any bit pattern — so no invalid `bool` ever exists.
+/// Unlike an enum discriminant there is nothing to reject: every byte has an
+/// unambiguous C meaning.
+///
+/// The read is `unsafe`; every caller emits it inside an `unsafe fn` body.
+fn bool_in_expr(access: TokenStream) -> TokenStream {
+    quote!(::core::ptr::read(#access.as_ptr() as *const u8) != 0)
+}
+
+/// Wrap a Rust `bool` for a [`bool_wire`] slot. Rust only ever writes `0`/`1`,
+/// so the outbound direction is a pure wrap.
+fn bool_out_expr(value: TokenStream) -> TokenStream {
+    quote!(::core::mem::MaybeUninit::new(#value))
+}
+
 /// Whether `ty` is an FFI-safe scalar primitive that passes through unchanged
 /// (`bool`, the fixed-width / pointer-width integers, and floats).
 fn is_scalar(ty: &syn::Type) -> bool {
@@ -628,11 +668,17 @@ fn route_result(call: TokenStream, route: &ErrRoute<'_>) -> TokenStream {
     }
 }
 
-/// C-ABI wire type for a struct field. `String` → `*mut c_char`; FFI-safe
-/// scalars pass through. `None` for anything else (unsupported this increment).
+/// C-ABI wire type for a struct field. `String` → `*mut c_char`; `bool` →
+/// [`bool_wire`]; the remaining FFI-safe scalars pass through. `None` for
+/// anything else (unsupported this increment).
 fn c_field_wire(ty: &syn::Type) -> Option<syn::Type> {
     if is_string(ty) {
         return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
+    }
+    // #170 instance 2: the field arrives from C by value, so it may not be a
+    // Rust `bool` until the byte has been normalised.
+    if is_bool(ty) {
+        return Some(bool_wire());
     }
     if is_scalar(ty) {
         return Some(ty.clone());

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -233,6 +233,54 @@ enum ErrRoute<'a> {
     Panic,
 }
 
+/// Emit the statements that report `__msg` — a `String` already in scope — per
+/// `route`, and leave the wrapper.
+///
+/// Shared by the per-input decode failure and by the alias preflight, so the
+/// two cannot drift on how a binding error reaches the caller.
+fn route_message(route: &ErrRoute<'_>) -> TokenStream {
+    match route {
+        ErrRoute::Result {
+            e_conv,
+            e_ty_src,
+            fail_return,
+        } => quote!(
+            if !e.is_null() {
+                *e = #e_conv(
+                    <#e_ty_src as ::core::convert::From<::std::string::String>>::from(__msg),
+                );
+            }
+            return #fail_return;
+        ),
+        ErrRoute::Panic => quote!(panic!("{}", __msg);),
+    }
+}
+
+/// How a parameter uses the resource it names — the axis
+/// [`Cbindgen::alias_preflight`] states its rule on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AliasAccess {
+    /// Taken by value: the callee owns it afterwards, and the C-side handle is
+    /// dead.
+    Consume,
+    /// `&mut T`: exclusive for the duration of the call.
+    Exclusive,
+    /// `&T`: shared, and the only access that may legally coexist with another
+    /// of its own kind.
+    Shared,
+}
+
+impl AliasAccess {
+    /// The word used for this access in a preflight rejection message.
+    fn describe(self) -> &'static str {
+        match self {
+            AliasAccess::Consume => "consumed",
+            AliasAccess::Exclusive => "exclusively borrowed",
+            AliasAccess::Shared => "borrowed",
+        }
+    }
+}
+
 /// C / cbindgen language adapter. Build it with [`Cbindgen::new`], declare the
 /// items to convert with the fluent methods, then drive it through
 /// [`Registry::resolve`](crate::core::Registry::resolve) →

--- a/prebindgen/src/api/lang/cbindgen/selector.rs
+++ b/prebindgen/src/api/lang/cbindgen/selector.rs
@@ -18,6 +18,7 @@ impl Cbindgen {
             .or_else(|| self.in_tagged_union(ty, registry))
             .or_else(|| self.in_string(ty))
             .or_else(|| self.in_str(ty))
+            .or_else(|| self.in_bool(ty))
             .or_else(|| self.in_scalar(ty))
             .or_else(|| self.in_wrappers(ty, registry))
     }

--- a/prebindgen/src/api/lang/cbindgen/tests/aliasing.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/aliasing.rs
@@ -1,0 +1,157 @@
+//! The runtime alias preflight (#189): which calls get one, which do not, and
+//! what it compares.
+//!
+//! Two arguments of one call can name the same resource — `z_combine(x, x)`
+//! reconstructs one allocation twice. Rejecting the *declaration* would remove
+//! shapes that ship today, so the generator emits a pointer-identity check
+//! instead, ahead of every conversion. The runtime behaviour is pinned by
+//! `example-cbindgen`'s `boundary_tests`; these tests pin **when** the check is
+//! emitted, which is the part a refactor can silently change.
+
+use super::*;
+
+/// The fixture: one opaque handle plus whichever function under test.
+fn build(fns: &[&str]) -> String {
+    let loc = SourceLocation::default();
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Thing {
+                    pub v: u64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Other {
+                    pub v: u64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (syn::Item::Struct(error_struct()), loc.clone()),
+    ];
+    let mut idents: Vec<syn::Ident> = Vec::new();
+    for src in fns {
+        let f: syn::ItemFn = syn::parse_str(src).expect("test fn");
+        idents.push(f.sig.ident.clone());
+        items.push((syn::Item::Fn(f), loc.clone()));
+    }
+    let registry = Registry::<()>::from_items(items).expect("index items");
+
+    let mut cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(myflat))
+        .free_memory_function("my_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .mangle_function(|n| n.to_string())
+        .opaque_ptr(syn::parse_quote!(Thing))
+        .opaque_ptr(syn::parse_quote!(Other))
+        .data_struct(syn::parse_quote!(Error))
+        .error();
+    for id in idents {
+        cbindgen = cbindgen.function(syn::parse_quote!(#id)).panic();
+    }
+    write(cbindgen, registry, "cbindgen_aliasing")
+}
+
+/// The generation predicate, cell by cell. Emitted when the call has **at least
+/// one `Consume` or `ExclusiveBorrow`** *and* **any other active access in the
+/// same resource domain** — which is deliberately wider than "two or more
+/// consumed parameters", the reading that would have skipped the two mixed
+/// rows below.
+#[test]
+fn preflight_is_emitted_exactly_for_the_predicate() {
+    for (src, want) in [
+        // consume × consume
+        (
+            "pub fn f(a: Thing, b: Thing) -> Result<u64, Error> { unimplemented!() }",
+            true,
+        ),
+        // consume × shared borrow — the borrow dangles when the consume takes
+        // ownership.
+        (
+            "pub fn f(a: Thing, b: &Thing) -> Result<u64, Error> { unimplemented!() }",
+            true,
+        ),
+        // exclusive borrow × shared borrow — the `&mut` is not exclusive at all.
+        (
+            "pub fn f(a: &mut Thing, b: &Thing) -> Result<u64, Error> { unimplemented!() }",
+            true,
+        ),
+        // exclusive × exclusive
+        (
+            "pub fn f(a: &mut Thing, b: &mut Thing) -> Result<u64, Error> { unimplemented!() }",
+            true,
+        ),
+        // shared × shared — legal Rust, legal C, no preflight.
+        (
+            "pub fn f(a: &Thing, b: &Thing) -> Result<u64, Error> { unimplemented!() }",
+            false,
+        ),
+        // one resource only.
+        (
+            "pub fn f(a: Thing, b: u64) -> Result<u64, Error> { unimplemented!() }",
+            false,
+        ),
+        // two consumes of DIFFERENT domains — distinct allocations, nothing to
+        // compare.
+        (
+            "pub fn f(a: Thing, b: Other) -> Result<u64, Error> { unimplemented!() }",
+            false,
+        ),
+    ] {
+        let src_gen = build(&[src]);
+        assert_eq!(
+            src_gen.contains("aliasing arguments"),
+            want,
+            "preflight emission wrong for `{src}`:\n{src_gen}"
+        );
+    }
+}
+
+/// `T` and `Option<T>` are the same resource domain: both arrive as the same
+/// handle pointer. Comparing the syntactic parameter type instead would let
+/// `f(x, Some(x))` through — the exact miss #187's review called out.
+#[test]
+fn option_and_bare_share_a_resource_domain() {
+    let src =
+        build(&["pub fn f(a: Thing, b: Option<Thing>) -> Result<u64, Error> { unimplemented!() }"]);
+    assert!(src.contains("aliasing arguments"), "{src}");
+    let compact: String = src.split_whitespace().collect();
+    assert!(
+        compact.contains("if!(aas*const()).is_null()&&(aas*const())==(bas*const())"),
+        "{src}"
+    );
+}
+
+/// The preflight runs **before** the first conversion — not inside one, and not
+/// between them. By the time a converter has run, one of the aliased arguments
+/// has already been consumed and there is nothing left to reject.
+#[test]
+fn preflight_precedes_every_conversion() {
+    let src = build(&["pub fn f(a: Thing, b: Thing) -> Result<u64, Error> { unimplemented!() }"]);
+    let alias_at = src.find("aliasing arguments").expect("preflight emitted");
+    let first_conv = src
+        .find("__cbg_in_Thing(a)")
+        .expect("input conversion emitted");
+    assert!(
+        alias_at < first_conv,
+        "preflight must precede the first conversion:\n{src}"
+    );
+}
+
+/// Three resources of one domain produce all three pairwise checks — the rule
+/// is over pairs, not over "the first two handles".
+#[test]
+fn every_qualifying_pair_is_checked() {
+    let src = build(&[
+        "pub fn f(a: Thing, b: &Thing, c: &Thing) -> Result<u64, Error> { unimplemented!() }",
+    ]);
+    let compact: String = src.split_whitespace().collect();
+    // a×b and a×c qualify (a consumes); b×c is borrow/borrow and does not.
+    assert!(compact.contains("(aas*const())==(bas*const())"), "{src}");
+    assert!(compact.contains("(aas*const())==(cas*const())"), "{src}");
+    assert!(!compact.contains("(bas*const())==(cas*const())"), "{src}");
+}

--- a/prebindgen/src/api/lang/cbindgen/tests/boundary_invariants.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/boundary_invariants.rs
@@ -1,0 +1,378 @@
+//! Generator-level boundary invariants, asserted against the *generated code*
+//! rather than against any one declaration's expected text.
+//!
+//! Every other test in this module pins what one shape lowers to. These two pin
+//! what **no** shape may lower to, over a corpus that declares one of every
+//! supported category at once — so a new position added to the adapter is
+//! covered the moment it appears in that corpus, without anyone remembering to
+//! extend a checklist.
+//!
+//! - **No C extern input materialises a restricted-validity Rust type directly
+//!   from caller bytes** (#170, #158). A C caller can put any bit pattern in an
+//!   inbound slot, so a slot whose Rust type accepts only *some* patterns —
+//!   `bool`, a declared `enum_type` — is undefined behaviour before any
+//!   generated code runs. Such a slot must cross behind `MaybeUninit`, which
+//!   holds any byte legally and is spelled the same in C.
+//! - **No raw pointer is turned into a `Box` or a reference without a null
+//!   check first** (#154 review).
+
+use quote::ToTokens;
+
+use super::*;
+
+/// One source item set + declaration set exercising every input category the
+/// adapter supports, so the invariants below run over a realistic surface
+/// rather than a single shape.
+///
+/// Deliberately absent: a `repr_c_struct` with a restricted-validity field.
+/// That is the one position with no per-value hook, and it is rejected at
+/// declaration time unless the binding acknowledges it with
+/// `.assume_c_field_validity()` — see `restricted_validity_*` in `structs.rs`.
+/// Keeping it out of this corpus is what lets these invariants be absolute.
+fn every_input_category() -> String {
+    let loc = SourceLocation::default();
+
+    let items: Vec<syn::Item> = vec![
+        syn::parse_quote!(
+            pub enum Operation {
+                Add = 0,
+                Sub = 1,
+            }
+        ),
+        syn::parse_quote!(
+            pub enum Shape {
+                Empty,
+                Circle(f64),
+                Rect { width: f64, height: f64 },
+                Labeled(String, Operation),
+                Flagged(bool),
+                Captioned(Caption),
+            }
+        ),
+        syn::parse_quote!(
+            pub struct Caption {
+                pub id: u64,
+                pub text: String,
+                pub emphatic: bool,
+            }
+        ),
+        syn::parse_quote!(
+            pub struct Handle {
+                pub inner: u64,
+            }
+        ),
+        // Every input position, one function each.
+        syn::parse_quote!(
+            pub fn take_scalars(a: i32, b: f64, c: bool) -> bool {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_enum(op: Operation) -> i32 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_union(s: Shape) -> f64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_data_struct(c: Caption) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_handle(h: Handle) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn borrow_handle(h: &Handle) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn borrow_handle_mut(h: &mut Handle) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_optional_handle(h: Option<Handle>) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_str(s: &str) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_string(s: String) -> u64 {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn take_scalar_slice(xs: &[u8]) -> u64 {
+                unimplemented!()
+            }
+        ),
+        // Every output position that has a matching input wire, so the file
+        // also contains the encoders the invariants must not trip over.
+        syn::parse_quote!(
+            pub fn make_union(flag: bool) -> Shape {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn make_caption(emphatic: bool) -> Caption {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn make_handle() -> Handle {
+                unimplemented!()
+            }
+        ),
+        syn::parse_quote!(
+            pub fn each_handle(f: impl Fn(&Handle) + Send + Sync + 'static) {
+                unimplemented!()
+            }
+        ),
+    ];
+
+    let registry = Registry::<()>::from_items(items.into_iter().map(|i| (i, loc.clone())))
+        .expect("index items");
+
+    let mut cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .mangle_callback(|bases| format!("closure_{}_t", bases.join("_")))
+        .mangle_function(|n| n.to_string())
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .enum_type(syn::parse_quote!(Operation))
+        .tagged_union(syn::parse_quote!(Shape))
+        .data_struct(syn::parse_quote!(Caption))
+        .callback(syn::parse_quote!(impl Fn(&Handle) + Send + Sync + 'static));
+
+    for f in [
+        "take_scalars",
+        "take_enum",
+        "take_union",
+        "take_data_struct",
+        "take_handle",
+        "borrow_handle",
+        "borrow_handle_mut",
+        "take_optional_handle",
+        "take_str",
+        "take_string",
+        "take_scalar_slice",
+        "make_union",
+        "make_caption",
+        "make_handle",
+        "each_handle",
+    ] {
+        let ident = format_ident!("{f}");
+        cbindgen = cbindgen.function(syn::parse_quote!(#ident)).panic();
+    }
+
+    write(cbindgen, registry, "boundary_invariants")
+}
+
+/// The generated `#[repr(C)]` mirror structs, by name — needed to follow a
+/// by-value struct parameter down into its fields.
+fn mirror_structs(file: &syn::File) -> HashMap<String, syn::ItemStruct> {
+    file.items
+        .iter()
+        .filter_map(|i| match i {
+            syn::Item::Struct(s) => Some((s.ident.to_string(), s.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The generated `#[repr(C)]` mirror enums, by name. A mirror enum is a
+/// restricted-validity type in exactly the way the source enum is: only its
+/// declared discriminants are valid, and a C caller writes an `int`.
+fn mirror_enums(file: &syn::File) -> HashSet<String> {
+    file.items
+        .iter()
+        .filter_map(|i| match i {
+            syn::Item::Enum(e) => Some(e.ident.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Why `ty`, appearing in an **inbound** slot, would materialise a value whose
+/// Rust type rejects some of the bit patterns C can write — or `None` when
+/// every pattern is valid.
+///
+/// `MaybeUninit<T>` terminates the walk: that is the wire whose whole point is
+/// to hold C's bytes without interpreting them, and whatever is inside it is
+/// the generated converter's problem, checked by the converter's own tests.
+/// Raw pointers terminate too — holding a garbage pointer is sound; whether it
+/// may be dereferenced is the second invariant's business.
+fn restricted_inbound(
+    ty: &syn::Type,
+    structs: &HashMap<String, syn::ItemStruct>,
+    enums: &HashSet<String>,
+    seen: &mut HashSet<String>,
+) -> Option<String> {
+    let name = ty.to_token_stream().to_string();
+    if matches!(ty, syn::Type::Ptr(_)) {
+        return None;
+    }
+    if let syn::Type::Reference(r) = ty {
+        return restricted_inbound(&r.elem, structs, enums, seen);
+    }
+    let tail = type_path_tail(ty)?.to_string();
+    if tail == "MaybeUninit" {
+        return None;
+    }
+    if tail == "bool" {
+        return Some(format!("`{name}` is a `bool` (only `0`/`1` are valid)"));
+    }
+    if enums.contains(&tail) {
+        return Some(format!(
+            "`{name}` is a mirror enum (only its declared discriminants are valid)"
+        ));
+    }
+    if let Some(s) = structs.get(&tail) {
+        // A by-value mirror struct is only as safe as its fields.
+        if !seen.insert(tail.clone()) {
+            return None;
+        }
+        for f in &s.fields {
+            if let Some(why) = restricted_inbound(&f.ty, structs, enums, seen) {
+                let fname = f
+                    .ident
+                    .as_ref()
+                    .map(|i| i.to_string())
+                    .unwrap_or_else(|| "_".to_string());
+                return Some(format!("`{name}`'s field `{fname}`: {why}"));
+            }
+        }
+    }
+    None
+}
+
+/// Every generated function that C can call or that decodes C's bytes: the
+/// `#[no_mangle] extern "C"` wrappers and destructors, plus the `__cbg_in_*`
+/// input converters they call.
+fn inbound_fns(file: &syn::File) -> Vec<syn::ItemFn> {
+    file.items
+        .iter()
+        .filter_map(|i| match i {
+            syn::Item::Fn(f) => Some(f.clone()),
+            _ => None,
+        })
+        .filter(|f| f.sig.abi.is_some() || f.sig.ident.to_string().starts_with("__cbg_in_"))
+        .collect()
+}
+
+/// #170 / #158, as a property of the generator rather than of one declaration:
+/// **no inbound slot may have a Rust type that rejects bit patterns C can
+/// write.** Restricted-validity values cross behind `MaybeUninit` and are
+/// normalised (`bool`) or validated (an enum discriminant) before the Rust
+/// value exists.
+///
+/// Returns are exempt by construction — Rust writes them, so they are valid by
+/// definition, and that is why `-> bool` is still a bare `bool`.
+#[test]
+fn no_c_extern_input_materialises_a_restricted_validity_type() {
+    let src = every_input_category();
+    let file: syn::File = syn::parse_file(&src).expect("generated file parses");
+    let structs = mirror_structs(&file);
+    let enums = mirror_enums(&file);
+
+    let mut violations: Vec<String> = Vec::new();
+    for f in inbound_fns(&file) {
+        for input in &f.sig.inputs {
+            let syn::FnArg::Typed(pt) = input else {
+                continue;
+            };
+            let mut seen = HashSet::new();
+            if let Some(why) = restricted_inbound(&pt.ty, &structs, &enums, &mut seen) {
+                violations.push(format!(
+                    "  {}({}): {why}",
+                    f.sig.ident,
+                    pt.pat.to_token_stream(),
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "inbound slots materialise restricted-validity Rust types from caller bytes:\n{}\n\n{src}",
+        violations.join("\n"),
+    );
+
+    // The corpus has to actually contain the shapes this is checking, or an
+    // empty violation list would mean nothing. `bool` must reach the boundary
+    // as a parameter, as a data-struct field and as a union payload; an enum
+    // must reach it by value.
+    let compact: String = src.split_whitespace().collect();
+    for expected in [
+        "c:::core::mem::MaybeUninit<bool>",           // parameter
+        "pubemphatic:::core::mem::MaybeUninit<bool>", // data_struct field
+        "Flagged(::core::mem::MaybeUninit<bool>)",    // union payload
+        "op:::core::mem::MaybeUninit<operation_t>",   // enum by value
+        "s:::core::mem::MaybeUninit<shape_t>",        // union by value
+    ] {
+        assert!(
+            compact.contains(expected),
+            "corpus no longer covers `{expected}` — the invariant above would pass vacuously\n{src}"
+        );
+    }
+}
+
+/// #154's review finding, as a property: **a raw pointer is never turned into a
+/// `Box` or a reference without being null-checked first.**
+///
+/// Checked per function body, which is the granularity the generator emits at:
+/// every converter that reconstitutes an owned `Box`, or reborrows C's memory,
+/// null-checks in the same body — either returning a named error on its
+/// `Result` path or treating NULL as the empty/`None` case.
+#[test]
+fn no_raw_pointer_is_dereferenced_without_a_null_check() {
+    let src = every_input_category();
+    let file: syn::File = syn::parse_file(&src).expect("generated file parses");
+
+    let mut violations: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+    for f in file.items.iter().filter_map(|i| match i {
+        syn::Item::Fn(f) => Some(f),
+        _ => None,
+    }) {
+        let body: String = f.block.to_token_stream().to_string();
+        let compact: String = body.split_whitespace().collect();
+        // `from_raw_parts` is the slice lowering, which reconstitutes memory
+        // from a pointer just as `Box::from_raw` does — same rule.
+        let reconstitutes = compact.contains("::from_raw(")
+            || compact.contains("::from_raw_parts(")
+            || compact.contains("&*(")
+            || compact.contains("&mut*(");
+        if !reconstitutes {
+            continue;
+        }
+        checked += 1;
+        if !compact.contains(".is_null()") {
+            violations.push(format!("  {}", f.sig.ident));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "these generated fns reconstitute memory from a raw pointer with no null check:\n{}\n\n{src}",
+        violations.join("\n"),
+    );
+    // Same discrimination guard: an empty corpus would pass silently.
+    assert!(
+        checked >= 5,
+        "expected the corpus to exercise several pointer-reconstituting fns, saw {checked}\n{src}"
+    );
+}

--- a/prebindgen/src/api/lang/cbindgen/tests/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{api::test_util::unique_test_dir, SourceLocation};
 
+mod boundary_invariants;
 mod builder;
 mod callbacks;
 mod errors;

--- a/prebindgen/src/api/lang/cbindgen/tests/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{api::test_util::unique_test_dir, SourceLocation};
 
+mod aliasing;
 mod boundary_invariants;
 mod builder;
 mod callbacks;

--- a/prebindgen/src/api/lang/cbindgen/tests/structs.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/structs.rs
@@ -485,3 +485,159 @@ fn repr_c_struct_mut_ref_and_maybe_uninit_out_param() {
         "{src}"
     );
 }
+
+/// The one position with no per-value hook (#170 instance 3, #158 instance 3):
+/// a `repr_c_struct` mirror is reinterpreted **wholesale** by one `Transmute`,
+/// so a field whose Rust type accepts only some bit patterns is undefined
+/// behaviour the moment C writes another one and hands the struct back. Every
+/// other position — a parameter, a `data_struct` field, a union payload — goes
+/// through a per-value converter and has somewhere to normalise or validate.
+///
+/// Rejected at declaration time, with the offending field named.
+#[test]
+fn repr_c_struct_restricted_validity_field_is_rejected() {
+    for (field, want) in [
+        (quote::quote!(pub flag: bool), "`flag`: `bool`"),
+        (
+            quote::quote!(pub op: Operation),
+            "`op`: a declared `enum_type`",
+        ),
+    ] {
+        let msg = catch_msg(|| {
+            let loc = SourceLocation::default();
+            let st: syn::ItemStruct = syn::parse_quote!(
+                #[repr(C)]
+                pub struct Rec {
+                    pub id: u64,
+                    #field,
+                }
+            );
+            let take: syn::ItemFn = syn::parse_quote!(
+                pub fn rec_take(r: Rec) -> u64 {
+                    unimplemented!()
+                }
+            );
+            let registry = Registry::<()>::from_items([
+                (syn::Item::Struct(st), loc.clone()),
+                (
+                    syn::Item::Enum(syn::parse_quote!(
+                        pub enum Operation {
+                            Add = 0,
+                            Sub = 1,
+                        }
+                    )),
+                    loc.clone(),
+                ),
+                (syn::Item::Fn(take), loc.clone()),
+            ])
+            .expect("index items");
+
+            let cbindgen = Cbindgen::new()
+                .source_module(syn::parse_quote!(zenoh_flat))
+                .mangle_type_name(|base| format!("{base}_t"))
+                .mangle_destructor(|base| format!("{base}_drop"))
+                .mangle_function(|n| n.to_string())
+                .enum_type(syn::parse_quote!(Operation))
+                .repr_c_struct(syn::parse_quote!(Rec))
+                .function(syn::parse_quote!(rec_take))
+                .panic();
+
+            let _ = write(cbindgen, registry, "repr_c_struct_restricted");
+        });
+        assert!(msg.contains(want), "{msg}");
+        assert!(msg.contains("assume_c_field_validity"), "{msg}");
+    }
+}
+
+/// The escape hatch: `.assume_c_field_validity()` says this binding's C side is
+/// trusted to write only in-domain bytes. It is an acknowledgement, not a fix —
+/// the mirror still holds the field verbatim — and it exists so the audit can
+/// reject silently-unsound **new** declarations without removing bindings that
+/// already ship.
+#[test]
+fn repr_c_struct_restricted_validity_field_accepted_when_acknowledged() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        #[repr(C)]
+        pub struct Rec {
+            pub id: u64,
+            pub flag: bool,
+        }
+    );
+    let take: syn::ItemFn = syn::parse_quote!(
+        pub fn rec_take(r: Rec) -> u64 {
+            unimplemented!()
+        }
+    );
+    let registry = Registry::<()>::from_items([
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Fn(take), loc.clone()),
+    ])
+    .expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .mangle_function(|n| n.to_string())
+        .repr_c_struct(syn::parse_quote!(Rec))
+        .assume_c_field_validity()
+        .function(syn::parse_quote!(rec_take))
+        .panic();
+
+    let src = write(cbindgen, registry, "repr_c_struct_acknowledged");
+    let compact: String = src.split_whitespace().collect();
+    assert!(compact.contains("pubflag:bool"), "{src}");
+}
+
+/// The audit does **not** narrow itself to mirrors C hands back, even though
+/// only those are reachable: a declared type resolves both directions whether
+/// or not either is called, so "does it cross in" has no truthful answer at
+/// this point in the pipeline (the reachability accounting #194/#196 replace).
+/// Over-reporting is the safe direction — this pins that an output-only mirror
+/// is rejected too, and takes the acknowledgement like any other.
+#[test]
+fn repr_c_struct_restricted_validity_field_audited_even_when_output_only() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        #[repr(C)]
+        pub struct Rec {
+            pub id: u64,
+            pub flag: bool,
+        }
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn rec_make() -> Rec {
+            unimplemented!()
+        }
+    );
+    let registry = || {
+        Registry::<()>::from_items([
+            (syn::Item::Struct(st.clone()), loc.clone()),
+            (syn::Item::Fn(make.clone()), loc.clone()),
+        ])
+        .expect("index items")
+    };
+
+    let declare = |acknowledged: bool| {
+        let mut c = Cbindgen::new()
+            .source_module(syn::parse_quote!(zenoh_flat))
+            .mangle_type_name(|base| format!("{base}_t"))
+            .mangle_destructor(|base| format!("{base}_drop"))
+            .mangle_function(|n| n.to_string())
+            .repr_c_struct(syn::parse_quote!(Rec));
+        if acknowledged {
+            c = c.assume_c_field_validity();
+        }
+        c.function(syn::parse_quote!(rec_make))
+    };
+
+    let msg = catch_msg(|| {
+        let _ = write(declare(false), registry(), "repr_c_struct_out_only");
+    });
+    assert!(msg.contains("`flag`: `bool`"), "{msg}");
+
+    let src = write(declare(true), registry(), "repr_c_struct_out_only_ack");
+    let compact: String = src.split_whitespace().collect();
+    assert!(compact.contains("pubflag:bool"), "{src}");
+}

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -626,27 +626,31 @@ impl Cbindgen {
                 // Restricted-validity audit (#170 instance 3, #158 instance 3):
                 // a mirror is reinterpreted whole, so a field whose Rust type
                 // rejects some bit patterns is UB the moment C writes one and
-                // hands the struct back. Only inbound mirrors can be reached
-                // that way, so a write-only mirror is left alone.
+                // hands the struct back.
+                //
+                // Not narrowed to inbound mirrors, though only those are
+                // reachable: converter reachability is not derived from use
+                // today (a declared type resolves BOTH directions whether or
+                // not either is called — the accounting #194/#196 replace), so
+                // "does it cross in" has no truthful answer here. Over-
+                // reporting is the safe direction, and the acknowledgement
+                // below is the escape for a genuinely write-only mirror.
                 let restricted = self.restricted_validity_fields(registry, &ty);
-                if !restricted.is_empty()
-                    && !cfg.assume_c_field_validity
-                    && self.crosses_in_by_reinterpret(registry, &ty)
-                {
+                if !restricted.is_empty() && !cfg.assume_c_field_validity {
                     let listed: Vec<String> = restricted
                         .iter()
                         .map(|(fname, reason)| format!("  `{fname}`: {reason}"))
                         .collect();
                     panic!(
-                        "Cbindgen::repr_c_struct: `{}` crosses IN from C by whole-struct \
+                        "Cbindgen::repr_c_struct: `{}` crosses C's memory by whole-struct \
                          reinterpret, but these fields have restricted-validity Rust types:\n\
                          {}\n\
                          A C caller can write a byte outside those domains, and the reinterpret \
                          materialises it with no hook to normalise or validate it first (#170, \
                          #158). Move the field to a `data_struct` (per-field wires), pass it as \
                          a separate parameter, or widen it to an integer. If this binding's C \
-                         side is trusted to write only in-domain bytes, acknowledge it with \
-                         `.assume_c_field_validity()`.",
+                         side is trusted to write only in-domain bytes — or never hands the \
+                         mirror back at all — acknowledge it with `.assume_c_field_validity()`.",
                         type_short(&ty),
                         listed.join("\n"),
                     );

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -73,6 +73,12 @@ impl Cbindgen {
                 subs.push(fty.clone());
                 fallible = true;
                 inits.push(quote!(#fname: #conv(v.#fname)?));
+            } else if is_bool(fty) {
+                // #170 instance 2: the field's wire is `MaybeUninit<bool>`, so
+                // the byte C wrote is normalised here — a Rust `bool` never
+                // holds it unchecked.
+                let read = bool_in_expr(quote!(v.#fname));
+                inits.push(quote!(#fname: #read));
             } else {
                 inits.push(quote!(#fname: v.#fname));
             }
@@ -378,9 +384,39 @@ impl Cbindgen {
         })
     }
 
-    /// FFI-safe scalar (`bool`, integers, floats): identity pass-through.
+    /// `bool` input: the one scalar that is **not** a pass-through (#170).
+    ///
+    /// A `bool` parameter is the broadest place C hands over a byte that no
+    /// Rust `bool` may hold, so it crosses as [`bool_wire`] and is normalised
+    /// by [`bool_in_expr`] before a `bool` exists. The C prototype is
+    /// unchanged — cbindgen simplifies `MaybeUninit<T>` to `T`.
+    pub(crate) fn in_bool(&self, ty: &syn::Type) -> Option<ConverterImpl<()>> {
+        if !is_bool(ty) {
+            return None;
+        }
+        let name = Self::in_name(ty);
+        let wire = bool_wire();
+        let read = bool_in_expr(quote!(v));
+        let function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) unsafe fn #name(v: #wire) -> bool {
+                #read
+            }
+        );
+        Some(ConverterImpl {
+            subs: vec![],
+            destination: wire,
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
+    /// FFI-safe scalar (integers, floats): identity pass-through. `bool` is
+    /// claimed earlier by [`Self::in_bool`] and never reaches here.
     pub(crate) fn in_scalar(&self, ty: &syn::Type) -> Option<ConverterImpl<()>> {
-        if !is_scalar(ty) {
+        if !is_scalar(ty) || is_bool(ty) {
             return None;
         }
         let name = Self::in_name(ty);
@@ -587,6 +623,34 @@ impl Cbindgen {
                         type_short(&ty)
                     )
                 });
+                // Restricted-validity audit (#170 instance 3, #158 instance 3):
+                // a mirror is reinterpreted whole, so a field whose Rust type
+                // rejects some bit patterns is UB the moment C writes one and
+                // hands the struct back. Only inbound mirrors can be reached
+                // that way, so a write-only mirror is left alone.
+                let restricted = self.restricted_validity_fields(registry, &ty);
+                if !restricted.is_empty()
+                    && !cfg.assume_c_field_validity
+                    && self.crosses_in_by_reinterpret(registry, &ty)
+                {
+                    let listed: Vec<String> = restricted
+                        .iter()
+                        .map(|(fname, reason)| format!("  `{fname}`: {reason}"))
+                        .collect();
+                    panic!(
+                        "Cbindgen::repr_c_struct: `{}` crosses IN from C by whole-struct \
+                         reinterpret, but these fields have restricted-validity Rust types:\n\
+                         {}\n\
+                         A C caller can write a byte outside those domains, and the reinterpret \
+                         materialises it with no hook to normalise or validate it first (#170, \
+                         #158). Move the field to a `data_struct` (per-field wires), pass it as \
+                         a separate parameter, or widen it to an integer. If this binding's C \
+                         side is trusted to write only in-domain bytes, acknowledge it with \
+                         `.assume_c_field_validity()`.",
+                        type_short(&ty),
+                        listed.join("\n"),
+                    );
+                }
                 let field_defs: Vec<TokenStream> = fields
                     .iter()
                     .map(|(fname, fty)| {
@@ -1233,13 +1297,10 @@ impl Cbindgen {
                 })
             };
         }
-        // A `bool` payload rides as `MaybeUninit<bool>` (see
-        // `payload_field_wire`), so the byte C wrote is read out as a `u8` —
-        // legal for any bit pattern — and normalised the way C converts to
-        // `_Bool`: nonzero is true. No rejection: unlike a tag, every byte here
-        // has an unambiguous meaning.
+        // A `bool` payload rides as `MaybeUninit<bool>` (see `bool_wire`), so
+        // the byte C wrote is normalised rather than materialised.
         if is_bool(fty) {
-            return quote!(::core::ptr::read(#b.as_ptr() as *const u8) != 0);
+            return bool_in_expr(quote!(#b));
         }
         // A scalar is its own wire and needs no call.
         if is_scalar(fty) {
@@ -1293,7 +1354,7 @@ impl Cbindgen {
         // The counterpart of the normalising read above: Rust always writes a
         // valid `0`/`1`, so this only wraps.
         if is_bool(fty) {
-            return quote!(::core::mem::MaybeUninit::new(#b));
+            return bool_out_expr(quote!(#b));
         }
         if is_scalar(fty) {
             return quote!(#b);
@@ -1750,6 +1811,9 @@ impl Cbindgen {
                     let conv = Self::out_name(fty);
                     subs.push(fty.clone());
                     inits.push(quote!(#fname: #conv(v.#fname)));
+                } else if is_bool(fty) {
+                    let wrap = bool_out_expr(quote!(v.#fname));
+                    inits.push(quote!(#fname: #wrap));
                 } else {
                     inits.push(quote!(#fname: v.#fname));
                 }
@@ -1967,6 +2031,22 @@ impl Cbindgen {
         if rf.mutability.is_none() {
             if let syn::Type::Slice(s) = &*rf.elem {
                 let e = (*s.elem).clone();
+                // #170, the slice instance. The two-param lowering builds the
+                // `&[E]` zero-copy from C's own block, so there is nowhere to
+                // normalise the bytes: `&[bool]` would materialise every
+                // element's restricted domain at once. `MaybeUninit<bool>` is
+                // not a fix here — the callee wants `&[bool]`, and rebuilding
+                // the block would silently drop the zero-copy contract this
+                // path exists for. Rejected until a raw-wire lowering exists.
+                if is_bool(&e) {
+                    panic!(
+                        "Cbindgen: `&[bool]` cannot cross IN from C. A `bool` slice is \
+                         reinterpreted zero-copy from the caller's block, so a byte outside \
+                         `{{0, 1}}` would become a Rust `bool` with no chance to normalise it \
+                         (#170). Take the flags as an integer slice, or wrap them in a declared \
+                         `opaque_ptr` handle."
+                    );
+                }
                 if is_scalar(&e) {
                     let name =
                         format_ident!("__cbg_inmark_slice_{}", sanitize(&TypeKey::from_type(&e)));

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -656,6 +656,12 @@ struct Opaque {
     consume_null: Option<String>,
     /// `true` for `Option<&T>` — nullable param, branches before lock.
     nullable: bool,
+    /// The **resource domain**: the handle's Kotlin type name with nullability
+    /// dropped, so `T` and `T?` land in one domain and two unrelated handle
+    /// classes do not. Used only by [`render_alias_preflight`], to keep it from
+    /// comparing a `Storage` against a `Summary` — pointers that can never be
+    /// equal. `None` ⇒ unknown, so compare against everything (fail-safe).
+    domain: Option<String>,
 }
 
 /// Peel `&` / `Option<…>` / `Option<&…>` layers and return the inner type's
@@ -1175,6 +1181,12 @@ fn classify_params(
                             target,
                             consume_null: Some(consume_null),
                             nullable: leaf.handle_nullable,
+                            // A flattened leaf carries no Kotlin class name of
+                            // its own, so its domain is unknown and it compares
+                            // against every other handle — the fail-safe
+                            // direction (an extra `ptr` comparison, never a
+                            // missed alias).
+                            domain: None,
                         })
                     })
                     .collect();
@@ -1592,6 +1604,7 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
                 target,
                 consume_null,
                 nullable,
+                domain: p.kt_type.simple_name().map(str::to_string),
             }]
         })
         .collect()
@@ -1678,6 +1691,73 @@ fn error_sink_parts(
         binding_call_arg: "__bcap.ze0".to_string(),
         domain,
     })
+}
+
+/// Pre-lock **alias preflight**: reject a call whose handle arguments name the
+/// same native resource in a combination that would consume or invalidate it
+/// twice — before the lock, and before any conversion.
+///
+/// `zCombine(primary: ZThing, fallback: ZThing)` is a supported declaration;
+/// called as `zCombine(x, x)` it hands one allocation to two consuming
+/// converters. `zAbsorb(a: ZThing, b: ZThing?)` mixing a consume with a borrow
+/// is the same defect: the borrow dangles the moment the consume takes
+/// ownership. Emitted whenever the call has **at least one consumed handle**
+/// and **any other handle**.
+///
+/// Comparison is on `ptr`, the resource's own address, not on the declared
+/// Kotlin type — which is what makes `T` and `T?` (and a handle nested inside a
+/// flattened `data_class`) compare in the same domain without enumerating the
+/// spellings. Two distinct live handles cannot share an address, so this has no
+/// false positives; `0L` names no resource and is skipped.
+///
+/// A binding failure, so it routes through the same channel a closed handle
+/// does — a function-level return, never a throw.
+fn render_alias_preflight(opaques: &[Opaque], binding_param: &str, is_unit: bool) -> kt::Code {
+    let mut guards = kt::Code::new();
+    if opaques.len() < 2 || !opaques.iter().any(|o| o.consume_null.is_some()) {
+        return guards;
+    }
+    let ptr_of = |o: &Opaque| {
+        if o.nullable {
+            format!("({t}?.ptr ?: 0L)", t = o.target)
+        } else {
+            format!("{t}.ptr", t = o.target)
+        }
+    };
+    for i in 0..opaques.len() {
+        for j in (i + 1)..opaques.len() {
+            let (a, b) = (&opaques[i], &opaques[j]);
+            // Two borrows of one resource are legal; at least one side must be
+            // taking it away.
+            if a.consume_null.is_none() && b.consume_null.is_none() {
+                continue;
+            }
+            // Two handles of different classes are different allocations, so
+            // their pointers can never be equal — checking them would be dead
+            // code in every wrapper that mixes handle types. An unknown domain
+            // compares against everything.
+            if let (Some(da), Some(db)) = (&a.domain, &b.domain) {
+                if da != db {
+                    continue;
+                }
+            }
+            let (pa, pb) = (ptr_of(a), ptr_of(b));
+            let msg = format!(
+                "\"Aliasing arguments: '{}' and '{}' are the same native resource; a consumed \
+                 handle may not be passed twice in one call.\"",
+                a.name, b.name,
+            );
+            let cond = format!("{pa} != 0L && {pa} == {pb}");
+            guards = if is_unit {
+                guards.wline(format!(
+                    "if ({cond}) {{ {binding_param}.run({msg}); return }}"
+                ))
+            } else {
+                guards.wline(format!("if ({cond}) return {binding_param}.run({msg})"))
+            };
+        }
+    }
+    guards
 }
 
 /// Pre-lock closed-handle guards: a racy-but-safe `isClosed()` check before
@@ -1860,10 +1940,12 @@ fn render_body(
     // The capture is a per-thread reusable holder (zero allocation): the
     // extern writes its `@JvmField` slots via `run`, the wrapper reads
     // them after the (synchronous) call. `acquire()` resets the slots.
-    let mut b = render_prelock_guards(opaques, &sink.binding_param, is_unit).line(format!(
-        "val __bcap = {}.acquire()",
-        sink.binding_capture_short
-    ));
+    let mut b = render_alias_preflight(opaques, &sink.binding_param, is_unit)
+        .push(render_prelock_guards(opaques, &sink.binding_param, is_unit))
+        .line(format!(
+            "val __bcap = {}.acquire()",
+            sink.binding_capture_short
+        ));
     if let Some(d) = &sink.domain {
         b = b.line(format!("val __dcap = {}.acquire()", d.capture_short));
     }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/aliasing.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/aliasing.rs
@@ -1,0 +1,140 @@
+//! The Kotlin-side alias preflight (#189) — the JNI counterpart of the C one
+//! in `lang::cbindgen::tests::aliasing`.
+//!
+//! Two typed handles a caller passes to one wrapper can be the same object, or
+//! two objects over one native allocation. `zCombine(x, x)` then hands that
+//! allocation to two consuming converters. Rejecting the declaration is not an
+//! option — it is a supported shape today — so the wrapper compares `ptr`
+//! before the lock and before any conversion, and routes the rejection through
+//! the same binding-error channel a closed handle uses.
+
+use super::*;
+
+/// One `ptr_class` handle (plus a second, unrelated one) and whichever
+/// functions are under test.
+fn build(fns: &[&str], tag: &str) -> String {
+    let loc = myflat_loc();
+    let mut items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThing {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOther {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let mut decls = crate::package!("ops")
+        .class(crate::ptr_class!(ZThing))
+        .class(crate::ptr_class!(ZOther));
+    for src in fns {
+        let f: syn::ItemFn = syn::parse_str(src).expect("test fn");
+        let id = f.sig.ident.clone();
+        decls = decls.fun(crate::lang::FunctionDecl::new(id));
+        items.push((syn::Item::Fn(f), loc.clone()));
+    }
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(decls);
+    super::flatten::write_all(registry.resolve(jni).expect("resolve"), tag)
+}
+
+/// The generation predicate on the Kotlin side. JniGen has no exclusive-borrow
+/// mode of its own — `&T` and `&mut T` both reach Kotlin as a locked borrow —
+/// so the rule reduces to "at least one consumed handle, and any other handle
+/// in the same domain".
+#[test]
+fn preflight_is_emitted_exactly_for_the_predicate() {
+    for (src, want, tag) in [
+        // consume × consume
+        (
+            "pub fn z_op(a: ZThing, b: ZThing) -> i64 { unimplemented!() }",
+            true,
+            "jni_alias_cc",
+        ),
+        // consume × borrow
+        (
+            "pub fn z_op(a: ZThing, b: &ZThing) -> i64 { unimplemented!() }",
+            true,
+            "jni_alias_cb",
+        ),
+        // borrow × borrow — legal, no preflight.
+        (
+            "pub fn z_op(a: &ZThing, b: &ZThing) -> i64 { unimplemented!() }",
+            false,
+            "jni_alias_bb",
+        ),
+        // one handle only.
+        (
+            "pub fn z_op(a: ZThing, b: i64) -> i64 { unimplemented!() }",
+            false,
+            "jni_alias_one",
+        ),
+        // two consumes of DIFFERENT classes — distinct allocations, so their
+        // pointers can never be equal and the check would be dead code.
+        (
+            "pub fn z_op(a: ZThing, b: ZOther) -> i64 { unimplemented!() }",
+            false,
+            "jni_alias_xtype",
+        ),
+    ] {
+        let out = build(&[src], tag);
+        assert_eq!(
+            out.contains("Aliasing arguments"),
+            want,
+            "preflight emission wrong for `{src}`:\n{out}"
+        );
+    }
+}
+
+/// `T` and `Option<T>` are one resource domain. The comparison is on `ptr` —
+/// the resource's own address — precisely so the two spellings do not have to
+/// be enumerated, and so a caller passing the same handle as `a` and as
+/// `Some(a)` is caught.
+#[test]
+fn option_and_bare_share_a_resource_domain() {
+    let out = build(
+        &["pub fn z_op(a: ZThing, b: Option<ZThing>) -> i64 { unimplemented!() }"],
+        "jni_alias_option",
+    );
+    let all: String = out.split_whitespace().collect();
+    assert!(out.contains("Aliasing arguments"), "{out}");
+    assert!(all.contains("a.ptr!=0L&&a.ptr==(b?.ptr?:0L)"), "{out}");
+}
+
+/// The preflight runs **before** the lock, before the closed-handle guard's
+/// neighbours, and before the native call — i.e. before anything has consumed
+/// or converted an argument.
+#[test]
+fn preflight_precedes_the_lock_and_the_call() {
+    let all = build(
+        &["pub fn z_op(a: ZThing, b: ZThing) -> i64 { unimplemented!() }"],
+        "jni_alias_order",
+    );
+    // `write_all` concatenates every emitted file, and the runtime support file
+    // mentions the lock helper too — so the ordering is read inside the wrapper.
+    let start = all.find("public fun zOp(").expect("wrapper emitted");
+    let out = &all[start..];
+    let alias_at = out.find("Aliasing arguments").expect("preflight emitted");
+    let lock_at = out
+        .find("withSortedHandleLocks")
+        .expect("lock scaffold emitted");
+    assert!(
+        alias_at < lock_at,
+        "preflight must precede the lock:\n{out}"
+    );
+    let call_at = out.find("markConsumed").expect("consume emitted");
+    assert!(
+        alias_at < call_at,
+        "preflight must precede the consume:\n{out}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -1340,7 +1340,7 @@ fn split_fixture(extra: &[&str]) -> Registry<KotlinMeta> {
     Registry::<KotlinMeta>::from_items(items).expect("index items")
 }
 
-fn write_all(gen: crate::api::core::Generation<JniGen>, tag: &str) -> String {
+pub(super) fn write_all(gen: crate::api::core::Generation<JniGen>, tag: &str) -> String {
     let dir = unique_test_dir(tag);
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -23,6 +23,7 @@ fn myflat_loc() -> crate::SourceLocation {
     }
 }
 
+mod aliasing;
 mod callbacks;
 mod config;
 mod consts;


### PR DESCRIPTION
Stage 0 of #187 — closes #189, and #170.

**Goal:** no known UB at the boundary while the refactor is in flight. Tactical by design: none of this is expected to survive Stage 1 unchanged, and that is the accepted trade against carrying known UB for the duration.

Four commits, one per bullet group; each is reviewable on its own.

## What changed

### 1. `bool` normalisation (#170) — `415993b`

`bool` is the one FFI-safe scalar with a restricted domain, so `is_scalar` letting it "pass through unchanged" meant a C caller could hand over a byte outside `{0, 1}` and have it materialised as a Rust `bool` — UB before any generated code runs. #171 fixed the union-payload half; this closes the rest.

One policy — `bool_wire` / `bool_in_expr` / `bool_out_expr` in `cbindgen/mod.rs` — used by every position C can write:

| Instance | Site | Status |
|---|---|---|
| plain `bool` parameter | `in_scalar` split into `in_bool` + `in_scalar` | fixed |
| `data_struct` field | `c_field_wire`, `in_data_struct`, `out_data_struct` | fixed |
| tagged-union payload | rebased onto the shared helpers | already fixed (#171) |
| `&[bool]` | rejected — see below | rejected |
| `repr_c_struct` mirror field | audited — see below | audited |

`&[bool]` is rejected rather than fixed: the slice is reinterpreted zero-copy from the caller's own block, so there is no per-element hook, and rebuilding it would silently drop the zero-copy contract that path exists for.

### 2. `repr_c_struct` restricted-validity audit (#170 instance 3, #158 instance 3) — `415993b`

A `repr_c_struct` mirror is reinterpreted **wholesale** by one `Transmute`, so a `bool` or declared-`enum_type` field is UB the moment C writes an out-of-domain byte and hands the struct back — and unlike every other position there is no per-value hook to normalise or validate it. The real fix is the raw-wire lowering Stage 1 brings.

Such a declaration is now **rejected**, with a message naming every offending field, unless the binding acknowledges it with the new `.assume_c_field_validity()`. `perftest-c`'s `Payload::flag` is the only shipping instance and takes the acknowledgement — rejecting it outright would have moved a C header, which this stage's exit forbids.

Deliberately **not** narrowed to inbound mirrors, even though only those are reachable: a declared type resolves both directions whether or not either is called, so "does it cross in" has no truthful answer until #194/#196 replace that accounting. Over-reporting is the safe direction; there is a test pinning that choice.

### 3. `Box::from_raw` and the generator invariant test — `337cf0c`

Every `Box::from_raw` / reference reconstitution is already null-checked (the #154 review findings landed in earlier PRs). What was missing is anything keeping it true, so both properties are now asserted **at generator level**, against generated code, over a corpus that declares one of every supported input category:

- no inbound slot materialises a restricted-validity Rust type — walked through by-value mirror structs into their fields, with `MaybeUninit` and raw pointers terminating the walk;
- no raw pointer becomes a `Box` or a reference without a null check in the same body.

Both carry a discrimination guard asserting the corpus still contains the shapes they check, so neither can start passing vacuously. Verified by weakening `bool_wire()` to a bare `bool`: the first test then names all six offending slots.

### 4. ASan/LSan/UBSan gate — `4f09a3a`

`c/smoke.c` is the repo's ownership contract in executable form; run without a leak detector it could violate that contract and still print PASS. `examples/smoke-asan.sh` builds it with `-fsanitize=address,undefined -fno-sanitize-recover=all` and runs it with `detect_leaks=1`, as its own CI job.

The Rust cdylib is not itself instrumented (stable toolchain), but LSan interposes `malloc` process-wide and Rust's default allocator on Linux is the system allocator — so a block the generated layer hands out and nobody frees **is** reported. Verified by deleting one `example_free` call: LSan names `__cbg_alloc_cstr` at `example_flat_x86_64.rs:10`.

The two leak sites #189 cites are already gone; the current file is clean.

### 5. Alias preflight — `0998064`

Two arguments of one call can name the same resource: `z_combine(x, x)` hands one allocation to two consuming converters, `f(a: T, b: &T)` dangles the borrow the moment the consume takes ownership, `f(a: &mut T, b: &T)` has an exclusive reference that is not exclusive. **Rejection is not an option** — these ship today, and Stage 3 would have to restore them — so the generator emits a runtime pointer-identity check.

Generation predicate, as #189 states it: **at least one `Consume` or `ExclusiveBorrow`, and any other active access in the same resource domain.** Wider than "two or more consumed parameters", which skips both mixed rows.

- **C** compares the wire pointers cast to `*const ()`, ahead of every decode, reporting through the wrapper's own error route — the same `route_message` a fallible input decode uses, factored out so the two cannot drift.
- **Kotlin** compares `NativeHandle.ptr` before the lock and before any conversion, routing to the binding-error channel a closed handle already uses.

Comparison is by **underlying resource domain**, not syntactic parameter type, so `f(x, Some(x))` is caught: C peels `Option`/`&`/`&mut`/`MaybeUninit` to the declared type's key; Kotlin compares the address itself, narrowed to same-class pairs only to keep provably-unequal comparisons out of the output.

All four of #189's assertions are covered:

| Assertion | Where |
|---|---|
| rejected **before** any conversion | `boundary_tests` calls `calculator_merge(c, c)` / `calculator_absorb(c, c)`, then asserts `c` is still live and readable — something a check inside the converter could not offer |
| distinct resources still work | same file, both shapes |
| `T` vs `Option<T>` by resource domain | one test per adapter |
| the test discriminates | the generator tests assert the predicate cell by cell, including the four rows that must emit **nothing** |

Also under the leak detector (`smoke.c` exercises the rejected aliased call and drops the surviving handle exactly once, so letting the call through would surface as an ASan double-free) and on a real JVM (`covertest-kotlin` passes one `Summary` twice to `summaryPrefer` and asserts the handle survives).

## Exit criteria

- **Must not move — C headers.** ✅ The `bool` fix moves generated Rust only: cbindgen simplifies `MaybeUninit<T>` to `T`, so `note_new_flagged(bool flag)` is unchanged. The header diff is **purely additive**, from test surface deliberately added below.
- **Reviewed diff — generated Rust for `bool` inputs** (cause: normalisation inserted). ✅ `__cbg_in_bool` now takes `MaybeUninit<bool>` and reads the byte as a `u8`; `caption_t.emphatic` likewise.
- **Reviewed diff — `smoke.c`** (cause: leak fixes). ✅ No leaks to fix; the diff is the new coverage plus the sanitizer note.
- **Reviewed diff — generated Rust and Kotlin wrappers for every call meeting the preflight predicate** (cause: alias preflight inserted). ✅ Exactly four: `calculator_merge` / `calculator_absorb` (new, C) and `summaryPrefer` / `summaryMerge` (Kotlin).
- **Asserted — the invariant test and the leak detector both run in CI and both pass.** ✅ New `smoke-asan` job; the invariant tests ride the existing `cargo test --all --all-features`.

## Test surface added (the only non-generated header movement)

- `example-flat`: `Caption` gains a `bool` field — #170's "nested `data_struct` payload with a `bool` field", the case that kept the tagged union's no-invalid-value invariant from being transitively true — plus `note_emphatic` to observe it, and `calculator_merge` / `calculator_absorb` for the two alias shapes.
- `boundary_tests` (in-process, against the real extern surface): out-of-domain bytes fed to a plain parameter and to a `data_struct` field; the three alias cases.

## Verification

```
cargo test                                   ok
cargo test --all --all-features              ok
cargo clippy --all-targets … -D warnings     ok
cargo fmt --check                            ok
examples/regen-check.sh                      PASS (byte-identical)
examples/smoke-asan.sh                       PASS (ASan/LSan/UBSan clean)
covertest-kotlin ./gradlew run               PASS - 44 sections
```

Both committed architectures were regenerated (`x86_64` and `aarch64`, the latter via `--target aarch64-unknown-linux-gnu`; the build script runs before the cross-link fails).

## Known gap, stated plainly

`perftest-c`'s `Payload::flag` remains an unvalidated `bool` inside a `repr_c_struct` mirror. It is now **acknowledged at the declaration site** rather than invisible in the generator, which is what "audit/reject until raw-wire lowering exists" buys; the fix itself belongs to Stage 1 (#192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)