### PR TITLE
Stage T: the Tier 0 semantic shape tier (#190)

### DIFF
--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -26,6 +26,7 @@ pub mod niches;
 pub mod prebindgen;
 pub mod registry;
 pub(crate) mod resolve;
+pub mod semantic;
 pub mod shape;
 pub mod types_util;
 pub mod unfold;

--- a/prebindgen/src/api/core/semantic.rs
+++ b/prebindgen/src/api/core/semantic.rs
@@ -357,7 +357,21 @@ impl ShapeGraph {
 
     /// Peel the source's use qualifier off `ty` and intern what remains.
     fn intern_use<M>(&mut self, ty: &syn::Type, registry: &Registry<M>) -> SemanticUse {
-        let (source, inner) = peel_source_use(ty);
+        // Transparent wrappers are stripped on **both** sides of the peel, not
+        // just one:
+        //
+        //   `&Box<T>`  needs the strip AFTER  — peel yields `Box<T>`;
+        //   `Box<&T>`  needs the strip BEFORE — otherwise the `&` is still
+        //              there when the key is formed, and the reference ends up
+        //              *inside* the interned node instead of on the edge.
+        //
+        // That second case is what makes the order load-bearing rather than
+        // cosmetic: a node keyed `& T` contradicts this tier's own rule that a
+        // use qualifier lives on the edge, and `build` would classify it as a
+        // `Leaf` — silently losing the structure of a declared `T`.
+        let outer = strip_transparent(ty);
+        let (source, inner) = peel_source_use(&outer);
+        let inner = strip_transparent(&inner);
         SemanticUse {
             shape: self.intern(&inner, registry),
             source,
@@ -371,10 +385,16 @@ impl ShapeGraph {
     /// makes a recursive type terminate: the recursive occurrence finds the
     /// reserved id in `by_key` and becomes a back-edge instead of recursing
     /// forever.
+    /// `ty` must already be normalized by [`Self::intern_use`] — no use
+    /// qualifier and no transparent wrapper — so an interning key can never
+    /// contain a reference.
     fn intern<M>(&mut self, ty: &syn::Type, registry: &Registry<M>) -> ShapeId {
-        // `Box` is heap indirection, not structure — see the module docs.
-        let ty = strip_transparent(ty);
-        let key = TypeKey::from_type(&ty);
+        debug_assert!(
+            !matches!(ty, syn::Type::Reference(_)),
+            "intern received an unpeeled reference `{}` — the use qualifier belongs on the edge",
+            quote::ToTokens::to_token_stream(ty)
+        );
+        let key = TypeKey::from_type(ty);
         if let Some(id) = self.by_key.get(&key) {
             return *id;
         }
@@ -385,7 +405,7 @@ impl ShapeGraph {
         self.keys.push(key.clone());
         self.by_key.insert(key.clone(), id);
 
-        let built = self.build(&ty, &key, registry);
+        let built = self.build(ty, &key, registry);
         self.nodes[id.0] = built;
         id
     }

--- a/prebindgen/src/api/core/semantic.rs
+++ b/prebindgen/src/api/core/semantic.rs
@@ -40,6 +40,22 @@
 //!   at the source it is exactly a two-alternative sum, and modelling it as an
 //!   opaque leaf would hide `T` and `E` from the tier whose job is structure.
 //!
+//! # What is deliberately *not* decomposed
+//!
+//! A [`Leaf`](SemanticShape::Leaf) says "this tier does not decompose it", and
+//! two cases take that answer on purpose, because the alternative is a node
+//! that looks decomposed and is wrong:
+//!
+//! - **A type-or-const-generic declared item** ([`generic_over_types`]).
+//!   `struct Wrap<T> { value: T }` interned as `Wrap<u8>` would otherwise be a
+//!   product keyed `Wrap<u8>` whose field is still the *parameter* `T`.
+//!   Instantiating the root's arguments is the other half of the answer and
+//!   lands the day an adapter needs it.
+//! - **A foreign-qualified path** ([`source_item_ident`]). Ingest normalizes
+//!   every captured source spelling to a bare ident, so anything still
+//!   qualified is not the registry's own item — matching on the tail would give
+//!   `foreign::Rec` the local `Rec`'s fields under the key `foreign::Rec`.
+//!
 //! # Cycles are represented, never cut
 //!
 //! `Node { children: Vec<Node> }` interns to a finite graph with a back-edge,
@@ -451,13 +467,19 @@ impl ShapeGraph {
             };
         }
 
-        // A declared struct or enum, looked up by its bare ident because that
-        // is how the registry indexes source items — the graph's own key stays
-        // the full `TypeKey` either way.
-        let Some(ident) = super::types_util::path_tail_ident(ty) else {
+        // A declared struct or enum — but only through a **canonical source
+        // path**. See `source_item_ident`: matching on the tail ident alone
+        // would give `foreign::Rec` the local `Rec`'s fields while keeping
+        // `foreign::Rec` as its key, which contradicts both the full-`TypeKey`
+        // rule and `normalize_type`'s own statement that an unknown crate path
+        // is never reduced because its spelling is its identity.
+        let Some(ident) = source_item_ident(ty) else {
             return SemanticShape::Leaf(key.clone());
         };
         if let Some((item, _)) = registry.structs.get(&ident) {
+            if generic_over_types(&item.generics) {
+                return SemanticShape::Leaf(key.clone());
+            }
             let item = item.clone();
             return SemanticShape::Product {
                 key: key.clone(),
@@ -465,6 +487,9 @@ impl ShapeGraph {
             };
         }
         if let Some((item, _)) = registry.enums.get(&ident) {
+            if generic_over_types(&item.generics) {
+                return SemanticShape::Leaf(key.clone());
+            }
             let item = item.clone();
             return SemanticShape::Choice {
                 key: key.clone(),
@@ -554,6 +579,69 @@ impl ShapeGraph {
             },
         }
     }
+}
+
+/// The ident of a **canonical source-item path**, or `None` for anything that
+/// is not one.
+///
+/// The registry indexes source items by bare ident, and ingest normalizes every
+/// captured spelling to that form (`crate::Foo`, `myflat::Foo` → `Foo`). So a
+/// path that is still qualified after normalization denotes something the
+/// registry does *not* own — `normalize_type` says exactly this about unknown
+/// crate paths: they are never reduced, because `a::KeyExpr` and `b::KeyExpr`
+/// may be genuinely distinct types and their spelling is their identity.
+///
+/// Matching on the tail ident instead would hand `foreign::Rec` the local
+/// `Rec`'s fields while keeping `foreign::Rec` as the node's key — a product
+/// assembled from an unrelated item, and the full-`TypeKey` invariant broken
+/// from the other direction.
+///
+/// Lifetime arguments are allowed (`Ref<'a>` is still `Ref`): a lifetime cannot
+/// appear in a field's *type structure*, so decomposition stays sound. Type and
+/// const arguments are not — see [`generic_over_types`].
+fn source_item_ident(ty: &syn::Type) -> Option<syn::Ident> {
+    let syn::Type::Path(tp) = ty else { return None };
+    if tp.qself.is_some() || tp.path.leading_colon.is_some() || tp.path.segments.len() != 1 {
+        return None;
+    }
+    let seg = tp.path.segments.first()?;
+    match &seg.arguments {
+        syn::PathArguments::None => Some(seg.ident.clone()),
+        syn::PathArguments::AngleBracketed(ab) => ab
+            .args
+            .iter()
+            .all(|a| matches!(a, syn::GenericArgument::Lifetime(_)))
+            .then(|| seg.ident.clone()),
+        syn::PathArguments::Parenthesized(_) => None,
+    }
+}
+
+/// Whether a declared item is parameterized by **types or consts** — in which
+/// case this tier refuses to decompose it.
+///
+/// `struct Wrap<T> { value: T }` interned as `Wrap<u8>` would otherwise become a
+/// product keyed `Wrap<u8>` whose field is still the *parameter* `T`, not `u8`:
+/// a node that looks decomposed and is wrong, which is worse than one that
+/// admits it does not know. Recursive generic types compound it, since the
+/// back-edge would point at the uninstantiated body rather than the concrete
+/// root.
+///
+/// Substituting the root's arguments is the other half of the answer and is
+/// deliberately **not** attempted here: doing it properly means defaults,
+/// const generics, partial application and nested parameter references, and a
+/// half-done substitution reintroduces exactly the silently-wrong node this
+/// guard exists to prevent. A [`Leaf`](SemanticShape::Leaf) is the honest
+/// answer — "this tier does not decompose it" — and an adapter that meets one
+/// rejects it as unsupported instead of mis-planning it. The day an adapter
+/// needs generic source items, instantiation lands here with its own tests.
+///
+/// Lifetime parameters do not count: they cannot appear in a field's type
+/// structure.
+fn generic_over_types(generics: &syn::Generics) -> bool {
+    generics
+        .params
+        .iter()
+        .any(|p| matches!(p, syn::GenericParam::Type(_) | syn::GenericParam::Const(_)))
 }
 
 /// Split `ty` into how it is held and what is held.

--- a/prebindgen/src/api/core/semantic.rs
+++ b/prebindgen/src/api/core/semantic.rs
@@ -1,0 +1,592 @@
+//! Tier 0 — the language-neutral **semantic shape** of a boundary value.
+//!
+//! One interned graph describing what the *source Rust type says*, shared by
+//! every adapter. Stage 1 (`lang::Cbindgen`) and Stage 3 (`lang::JniGen`) both
+//! build their own Tier 1 plans **over** this tier; without a single owner each
+//! would grow a private copy of the same traversal, which is the failure mode
+//! [#187](https://github.com/milyin/prebindgen/issues/187) exists to prevent.
+//!
+//! # What this tier may say
+//!
+//! Structure and use. A struct is a [`SemanticShape::Product`], an enum is a
+//! [`SemanticShape::Choice`], `Option` and the sequence types are layers, and
+//! **every child edge is use-qualified** — [`SemanticUse`] records whether the
+//! parent holds that child by value, by shared reference, or by exclusive
+//! reference.
+//!
+//! That last part is the reason a root-only crossing context is not enough:
+//! `Vec<&T>` is a container held by value whose *elements* are shared-borrowed,
+//! and there is nowhere to write that down without an edge qualifier.
+//!
+//! # What this tier may not say
+//!
+//! > Tier 0 may not name a JVM descriptor, a C ABI type, a Kotlin class, or a
+//! > delivery protocol.
+//!
+//! [`SourceUse`] records what the source type says; what that obliges either
+//! side to *release* is a Tier 1 decision. The module-boundary test in
+//! `semantic/tests.rs` checks this mechanically against this file's own text,
+//! because Rust's module system cannot express "no adapter concept is
+//! reachable from here".
+//!
+//! Two consequences worth stating, since both look like omissions:
+//!
+//! - **`Box<T>` is transparent.** A `Box` is heap indirection, which is a
+//!   representation fact — whether it becomes a pointer on the wire is Tier 1's
+//!   call. It is also what makes `Option<Box<Node>>` a legal recursion rather
+//!   than an infinitely-sized type.
+//! - **`Result<T, E>` is an ordinary [`Choice`](SemanticShape::Choice).** Both
+//!   adapters route it to an error channel, but *that* is the Tier 1 decision;
+//!   at the source it is exactly a two-alternative sum, and modelling it as an
+//!   opaque leaf would hide `T` and `E` from the tier whose job is structure.
+//!
+//! # Cycles are represented, never cut
+//!
+//! `Node { children: Vec<Node> }` interns to a finite graph with a back-edge,
+//! because interning happens **before** a node's children are built. Where a
+//! cycle may be cut — and what that costs on the wire — is Tier 1 policy, so
+//! this tier offers no stopping-rule hook; a hook here would be the same policy
+//! leak the tier boundary exists to prevent. [`ShapeGraph::is_recursive`] is a
+//! *query* over the finished graph, not a knob.
+
+// This tier lands before either adapter reads it: Stage 1 (#192) and Stage 3
+// (#193) are its consumers, and #187's whole point is that neither of them owns
+// it. So the graph is exercised by its own tests and nothing else yet — the
+// same gap `SumSpec` carries for the same reason, and it goes away with the
+// first adapter that plans over a shape.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use super::{
+    registry::{Registry, TypeKey},
+    types_util::{EnumShape, SumSpec},
+};
+
+/// Interned identity of a node in a [`ShapeGraph`].
+///
+/// Ids are only meaningful within the graph that issued them. Two graphs may
+/// hand out the same numeric id for unrelated shapes, so an id is never
+/// compared across graphs — the accessors all take `&self` for that reason.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ShapeId(usize);
+
+impl ShapeId {
+    /// The raw index, for diagnostics and test assertions.
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// How a parent holds a child — the edge qualifier that makes `Vec<&T>`
+/// expressible.
+///
+/// This records the **source** relationship only. That a `SharedRef` element
+/// cannot be handed to a consuming converter, or that a `Value` element obliges
+/// the receiver to release it, are Tier 1 conclusions drawn *from* this, not
+/// facts stored here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SourceUse {
+    /// Held by value — `T`.
+    Value,
+    /// Shared borrow — `&T`.
+    SharedRef,
+    /// Exclusive borrow — `&mut T`.
+    ExclusiveRef,
+}
+
+/// Which sequence spelling a [`SemanticShape::Sequence`] layer came from.
+///
+/// Kept distinct because the three differ in what the *source* says about
+/// ownership of the backing storage, which is an input to Tier 1's decision
+/// even though the decision itself is not made here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SequenceKind {
+    /// `Vec<T>` — owned, growable.
+    Vec,
+    /// `[T]`, reached through `&[T]` — borrowed storage.
+    Slice,
+    /// `Cow<'_, [T]>` — borrowed or owned, decided at runtime.
+    CowSlice,
+}
+
+/// A use-qualified edge to a child shape.
+///
+/// Every child edge in this tier is one of these; there is no unqualified
+/// `ShapeId` reference in a node, so a traversal cannot silently lose the
+/// distinction between `Vec<T>` and `Vec<&T>`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SemanticUse {
+    /// The child node.
+    pub shape: ShapeId,
+    /// How the parent holds it.
+    pub source: SourceUse,
+}
+
+/// One field of a [`Product`](SemanticShape::Product), or one payload slot of a
+/// [`VariantUse`].
+#[derive(Clone, Debug)]
+pub struct FieldUse {
+    /// How the field is *addressed*: `Named(ident)` for a record field,
+    /// `Unnamed(index)` for a tuple slot.
+    ///
+    /// Retained as a [`syn::Member`] rather than degraded to a string on
+    /// purpose. A `Member` distinguishes `.0` from `."0"` and survives
+    /// round-tripping into generated code; rebuilding an access from a string
+    /// is [#186](https://github.com/milyin/prebindgen/issues/186)'s textual
+    /// problem one tier lower, and the point of doing Tier 0 at all is not to
+    /// recreate it.
+    pub member: syn::Member,
+    /// A human-readable name for diagnostics and for adapters that need a
+    /// flattened leaf name. **Not** an identity — two fields may share one, and
+    /// nothing may key on it.
+    pub diagnostic_name: String,
+    /// The field's shape and how this parent holds it.
+    pub uses: SemanticUse,
+}
+
+/// One alternative of a [`Choice`](SemanticShape::Choice).
+#[derive(Clone, Debug)]
+pub struct VariantUse {
+    /// The variant ident **as declared in the source**, independent of any
+    /// destination-language naming. An adapter that renames a variant records
+    /// that in its own tier; this stays the Rust spelling, so a construction
+    /// path built from it is always valid.
+    pub ident: syn::Ident,
+    /// Declaration-order tag, `0..N-1`. A payload enum's alternatives are
+    /// identified by this, never by a `#[repr]` discriminant.
+    pub tag: i32,
+    /// The alternative's payload in declaration order. **Empty for a unit
+    /// variant** — the group that contributes nothing but its tag.
+    pub fields: Vec<FieldUse>,
+}
+
+/// The language-neutral shape of one type.
+///
+/// Interned in a [`ShapeGraph`]; children are reached through [`SemanticUse`]
+/// edges rather than by containment, so a recursive type is a finite graph.
+#[derive(Clone, Debug)]
+pub enum SemanticShape {
+    /// A type with no structure this tier decomposes: a scalar, a `String`, a
+    /// callback, or any type the registry did not index as a struct or enum.
+    ///
+    /// "Leaf" is a statement about *this graph's* knowledge, not about the
+    /// type — an opaque handle and an `i32` are both leaves here, and what
+    /// separates them is a Tier 1 declaration.
+    Leaf(TypeKey),
+    /// A struct: all of these fields, together.
+    Product {
+        /// Canonical key of the struct type.
+        key: TypeKey,
+        /// Fields in declaration order.
+        fields: Vec<FieldUse>,
+    },
+    /// An enum: exactly one of these alternatives.
+    ///
+    /// **Every enum is a `Choice`, unit-only included** — a unit enum is the
+    /// degenerate sum whose every variant group is empty, which is exactly the
+    /// tag-only lowering. An adapter may collapse an all-empty choice to a
+    /// tag-only leaf; this tier does not, because "is it a sum" and "does it
+    /// carry payloads" are different questions and only the second is
+    /// [`EnumShape`]'s.
+    Choice {
+        /// Canonical key of the enum type.
+        key: TypeKey,
+        /// Alternatives in declaration order.
+        variants: Vec<VariantUse>,
+    },
+    /// An `Option<…>` layer.
+    Optional(SemanticUse),
+    /// A `Vec<…>` / `[…]` / `Cow<'_, […]>` layer.
+    Sequence {
+        /// Which spelling it came from.
+        kind: SequenceKind,
+        /// The element edge — this is where `Vec<&T>` records that its elements
+        /// are shared-borrowed while the container is held by value.
+        elem: SemanticUse,
+    },
+}
+
+impl SemanticShape {
+    /// Every child edge, in a single uniform accessor, so a traversal cannot
+    /// forget a variant.
+    pub fn children(&self) -> Vec<SemanticUse> {
+        match self {
+            SemanticShape::Leaf(_) => Vec::new(),
+            SemanticShape::Product { fields, .. } => fields.iter().map(|f| f.uses).collect(),
+            SemanticShape::Choice { variants, .. } => variants
+                .iter()
+                .flat_map(|v| v.fields.iter().map(|f| f.uses))
+                .collect(),
+            SemanticShape::Optional(u) => vec![*u],
+            SemanticShape::Sequence { elem, .. } => vec![*elem],
+        }
+    }
+
+    /// [`EnumShape`] as a **classifier over** a `Choice` — not a second
+    /// modelling of one. `None` for anything that is not a choice.
+    ///
+    /// The distinction exists because the *declarators* differ: `enum_class!` /
+    /// `.enum_type()` accept only the degenerate case, and handing them a
+    /// payload enum is an error naming the sum declarator. It is not a second
+    /// shape.
+    pub fn enum_shape(&self) -> Option<EnumShape> {
+        match self {
+            SemanticShape::Choice { variants, .. } => {
+                Some(if variants.iter().all(|v| v.fields.is_empty()) {
+                    EnumShape::Unit
+                } else {
+                    EnumShape::Sum
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// An interned graph of [`SemanticShape`]s.
+///
+/// Interning is keyed by the **full [`TypeKey`]**, never by a bare identifier.
+/// That is the structural fix for
+/// [#136](https://github.com/milyin/prebindgen/issues/136): a bare-ident cycle
+/// stack conflates two distinct types that happen to share a short name, and no
+/// amount of care at the use site recovers the difference once the key has
+/// thrown it away.
+#[derive(Debug, Default)]
+pub struct ShapeGraph {
+    nodes: Vec<SemanticShape>,
+    by_key: HashMap<TypeKey, ShapeId>,
+    /// Reverse index, so a layer node can report the spelling it came from.
+    keys: Vec<TypeKey>,
+}
+
+impl ShapeGraph {
+    /// An empty graph.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Intern the shape of `ty` **as a root**, returning its use-qualified
+    /// edge. A root is use-qualified like any other edge: a `&T` parameter is a
+    /// shared-ref use of `T`, not a distinct shape.
+    pub fn intern_root<M>(&mut self, ty: &syn::Type, registry: &Registry<M>) -> SemanticUse {
+        self.intern_use(ty, registry)
+    }
+
+    /// The node behind an id.
+    pub fn get(&self, id: ShapeId) -> &SemanticShape {
+        &self.nodes[id.0]
+    }
+
+    /// The key a node was interned under.
+    pub fn key(&self, id: ShapeId) -> &TypeKey {
+        &self.keys[id.0]
+    }
+
+    /// The id already interned for `key`, if any.
+    pub fn id_of(&self, key: &TypeKey) -> Option<ShapeId> {
+        self.by_key.get(key).copied()
+    }
+
+    /// Number of interned nodes — the finiteness a recursion test asserts.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the graph is empty.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Every interned id, in interning order.
+    pub fn ids(&self) -> impl Iterator<Item = ShapeId> {
+        (0..self.nodes.len()).map(ShapeId)
+    }
+
+    /// Project the `Optional` / `Sequence` layers above `id` onto the existing
+    /// [`Shape`](super::shape::Shape) stack, stopping at the first node that is
+    /// not a layer.
+    ///
+    /// This is the answer to "does `Shape<N>` survive Tier 0": **it survives as
+    /// a derived view, not as a second model.** `Shape<N>`'s `N` is the
+    /// null-representation choice, which is a wire fact and belongs to Tier 1;
+    /// the *layer stack itself* is semantic and is now owned here. So the
+    /// engines that fold over layers keep their algebra and stop deriving the
+    /// stack themselves.
+    pub fn wrapper_projection(&self, id: ShapeId) -> super::shape::Shape {
+        match self.get(id) {
+            SemanticShape::Optional(inner) => {
+                super::shape::Shape::optional((), self.wrapper_projection(inner.shape))
+            }
+            SemanticShape::Sequence { elem, .. } => {
+                super::shape::Shape::iterable(self.wrapper_projection(elem.shape))
+            }
+            _ => super::shape::Shape::Base,
+        }
+    }
+
+    /// The node the layer stack above `id` bottoms out at — the leaf, product
+    /// or choice [`Self::wrapper_projection`] stopped at.
+    pub fn base_of(&self, id: ShapeId) -> ShapeId {
+        match self.get(id) {
+            SemanticShape::Optional(inner) => self.base_of(inner.shape),
+            SemanticShape::Sequence { elem, .. } => self.base_of(elem.shape),
+            _ => id,
+        }
+    }
+
+    /// Whether `id` is reachable from itself — i.e. it participates in a cycle.
+    ///
+    /// A **query** over the finished graph, not a stopping rule. Which cycles
+    /// may be cut, and how, is Tier 1 policy; offering that decision here would
+    /// be the policy leak this tier exists to prevent.
+    pub fn is_recursive(&self, id: ShapeId) -> bool {
+        let mut seen = vec![false; self.nodes.len()];
+        let mut stack: Vec<ShapeId> = self.get(id).children().iter().map(|u| u.shape).collect();
+        while let Some(next) = stack.pop() {
+            if next == id {
+                return true;
+            }
+            if std::mem::replace(&mut seen[next.0], true) {
+                continue;
+            }
+            stack.extend(self.get(next).children().iter().map(|u| u.shape));
+        }
+        false
+    }
+
+    /// Peel the source's use qualifier off `ty` and intern what remains.
+    fn intern_use<M>(&mut self, ty: &syn::Type, registry: &Registry<M>) -> SemanticUse {
+        let (source, inner) = peel_source_use(ty);
+        SemanticUse {
+            shape: self.intern(&inner, registry),
+            source,
+        }
+    }
+
+    /// Intern `ty`'s shape, reusing an existing node when its key is already
+    /// present.
+    ///
+    /// The id is reserved **before** the children are built, which is what
+    /// makes a recursive type terminate: the recursive occurrence finds the
+    /// reserved id in `by_key` and becomes a back-edge instead of recursing
+    /// forever.
+    fn intern<M>(&mut self, ty: &syn::Type, registry: &Registry<M>) -> ShapeId {
+        // `Box` is heap indirection, not structure — see the module docs.
+        let ty = strip_transparent(ty);
+        let key = TypeKey::from_type(&ty);
+        if let Some(id) = self.by_key.get(&key) {
+            return *id;
+        }
+        let id = ShapeId(self.nodes.len());
+        // Placeholder, so the key is claimed before `build` can recurse into
+        // it. Overwritten unconditionally below.
+        self.nodes.push(SemanticShape::Leaf(key.clone()));
+        self.keys.push(key.clone());
+        self.by_key.insert(key.clone(), id);
+
+        let built = self.build(&ty, &key, registry);
+        self.nodes[id.0] = built;
+        id
+    }
+
+    /// Classify one type into a node, interning its children.
+    fn build<M>(&mut self, ty: &syn::Type, key: &TypeKey, registry: &Registry<M>) -> SemanticShape {
+        use super::types_util::{first_type_arg, is_option_type, is_vec_type, result_parts};
+
+        if is_option_type(ty) {
+            if let Some(inner) = first_type_arg(ty) {
+                return SemanticShape::Optional(self.intern_use(&inner, registry));
+            }
+        }
+        if is_vec_type(ty) {
+            if let Some(inner) = first_type_arg(ty) {
+                return SemanticShape::Sequence {
+                    kind: SequenceKind::Vec,
+                    elem: self.intern_use(&inner, registry),
+                };
+            }
+        }
+        if let syn::Type::Slice(s) = ty {
+            return SemanticShape::Sequence {
+                kind: SequenceKind::Slice,
+                elem: self.intern_use(&s.elem, registry),
+            };
+        }
+        if let Some(inner) = cow_slice_elem(ty) {
+            return SemanticShape::Sequence {
+                kind: SequenceKind::CowSlice,
+                elem: self.intern_use(&inner, registry),
+            };
+        }
+        // `Result<T, E>` is a two-alternative sum at the source. Whether it
+        // becomes an error channel is Tier 1's decision, not this tier's.
+        if let Some((ok, err)) = result_parts(ty) {
+            return SemanticShape::Choice {
+                key: key.clone(),
+                variants: vec![
+                    self.synthetic_variant("Ok", 0, &ok, registry),
+                    self.synthetic_variant("Err", 1, &err, registry),
+                ],
+            };
+        }
+
+        // A declared struct or enum, looked up by its bare ident because that
+        // is how the registry indexes source items — the graph's own key stays
+        // the full `TypeKey` either way.
+        let Some(ident) = super::types_util::path_tail_ident(ty) else {
+            return SemanticShape::Leaf(key.clone());
+        };
+        if let Some((item, _)) = registry.structs.get(&ident) {
+            let item = item.clone();
+            return SemanticShape::Product {
+                key: key.clone(),
+                fields: self.product_fields(&item, registry),
+            };
+        }
+        if let Some((item, _)) = registry.enums.get(&ident) {
+            let item = item.clone();
+            return SemanticShape::Choice {
+                key: key.clone(),
+                variants: self.choice_variants(&item, registry),
+            };
+        }
+        SemanticShape::Leaf(key.clone())
+    }
+
+    /// The fields of a declared struct, in declaration order.
+    fn product_fields<M>(
+        &mut self,
+        item: &syn::ItemStruct,
+        registry: &Registry<M>,
+    ) -> Vec<FieldUse> {
+        item.fields
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let (member, diagnostic_name) = match &f.ident {
+                    Some(id) => (syn::Member::Named(id.clone()), id.to_string()),
+                    None => (syn::Member::Unnamed(syn::Index::from(i)), i.to_string()),
+                };
+                FieldUse {
+                    member,
+                    diagnostic_name,
+                    uses: self.intern_use(&f.ty, registry),
+                }
+            })
+            .collect()
+    }
+
+    /// The alternatives of a declared enum.
+    ///
+    /// Built **through [`SumSpec`]**, which is this tier's `Choice`
+    /// constructor rather than a parallel description of the same enum: it
+    /// already assigns declaration-order tags, retains `syn::Member`, and
+    /// derives the nested-prefix leaf names, and having two places compute
+    /// those is the duplication Tier 0 exists to remove.
+    fn choice_variants<M>(
+        &mut self,
+        item: &syn::ItemEnum,
+        registry: &Registry<M>,
+    ) -> Vec<VariantUse> {
+        let spec = SumSpec::from_item_enum(item);
+        spec.variants
+            .iter()
+            .map(|v| VariantUse {
+                ident: v.ident.clone(),
+                tag: v.tag,
+                fields: v
+                    .fields
+                    .iter()
+                    .map(|f| FieldUse {
+                        member: f.member.clone(),
+                        diagnostic_name: f.name.clone(),
+                        uses: self.intern_use(&f.ty, registry),
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    /// One alternative of a sum that has no `syn::ItemEnum` behind it (today,
+    /// `Result`'s two arms), carrying a single unnamed payload.
+    fn synthetic_variant<M>(
+        &mut self,
+        ident: &str,
+        tag: i32,
+        payload: &syn::Type,
+        registry: &Registry<M>,
+    ) -> VariantUse {
+        let uses = self.intern_use(payload, registry);
+        VariantUse {
+            ident: syn::Ident::new(ident, proc_macro2::Span::call_site()),
+            tag,
+            // A unit payload carries nothing, so the alternative is a unit
+            // variant — the same shape a fieldless declared variant has.
+            fields: if super::types_util::is_unit(payload) {
+                Vec::new()
+            } else {
+                vec![FieldUse {
+                    member: syn::Member::Unnamed(syn::Index::from(0usize)),
+                    diagnostic_name: super::types_util::pascal_to_snake(ident),
+                    uses,
+                }]
+            },
+        }
+    }
+}
+
+/// Split `ty` into how it is held and what is held.
+///
+/// `&[T]` peels to `(SharedRef, [T])`, so the borrow lands on the edge and the
+/// slice becomes an ordinary sequence node — which is what lets `&[T]` and
+/// `Vec<T>` share one traversal.
+fn peel_source_use(ty: &syn::Type) -> (SourceUse, syn::Type) {
+    match ty {
+        syn::Type::Reference(r) => {
+            let source = if r.mutability.is_some() {
+                SourceUse::ExclusiveRef
+            } else {
+                SourceUse::SharedRef
+            };
+            (source, (*r.elem).clone())
+        }
+        other => (SourceUse::Value, other.clone()),
+    }
+}
+
+/// Peel wrappers that carry no semantic structure. `Box<T>` is heap
+/// indirection — a representation fact Tier 1 decides about — and treating it
+/// as transparent is also what makes `Option<Box<Node>>` a legal recursion.
+fn strip_transparent(ty: &syn::Type) -> syn::Type {
+    if super::types_util::path_tail_ident(ty)
+        .map(|i| i == "Box")
+        .unwrap_or(false)
+    {
+        if let Some(inner) = super::types_util::first_type_arg(ty) {
+            return strip_transparent(&inner);
+        }
+    }
+    ty.clone()
+}
+
+/// The element of a `Cow<'_, [E]>`, if `ty` is one.
+fn cow_slice_elem(ty: &syn::Type) -> Option<syn::Type> {
+    let syn::Type::Path(tp) = ty else {
+        return None;
+    };
+    let seg = tp.path.segments.last()?;
+    if seg.ident != "Cow" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        syn::GenericArgument::Type(syn::Type::Slice(slice)) => Some((*slice.elem).clone()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/prebindgen/src/api/core/semantic/tests.rs
+++ b/prebindgen/src/api/core/semantic/tests.rs
@@ -1,0 +1,504 @@
+use super::*;
+use crate::{api::core::registry::Registry, SourceLocation};
+
+/// Build a registry from `syn` item sources, then intern one root type.
+fn graph_of(items: &[&str], root: &str) -> (ShapeGraph, SemanticUse) {
+    let loc = SourceLocation::default();
+    let parsed: Vec<(syn::Item, SourceLocation)> = items
+        .iter()
+        .map(|s| {
+            (
+                syn::parse_str::<syn::Item>(s).expect("test item"),
+                loc.clone(),
+            )
+        })
+        .collect();
+    let registry = Registry::<()>::from_items(parsed).expect("index items");
+    let ty: syn::Type = syn::parse_str(root).expect("test type");
+    let mut graph = ShapeGraph::new();
+    let root_use = graph.intern_root(&ty, &registry);
+    (graph, root_use)
+}
+
+fn key(s: &str) -> TypeKey {
+    TypeKey::parse(s).expect("test key")
+}
+
+// ── structure ───────────────────────────────────────────────────────────
+
+/// A struct is a `Product` whose fields keep their `syn::Member` addressing —
+/// named stays named, tuple stays indexed — and each field edge records how the
+/// struct holds it.
+#[test]
+fn struct_is_a_product_keeping_member_addressing() {
+    let (g, root) = graph_of(
+        &["pub struct Rec { pub id: u64, pub label: String }"],
+        "Rec",
+    );
+    assert_eq!(root.source, SourceUse::Value);
+    let SemanticShape::Product { key: k, fields } = g.get(root.shape) else {
+        panic!("expected a product, got {:?}", g.get(root.shape));
+    };
+    assert_eq!(k, &key("Rec"));
+    assert_eq!(fields.len(), 2);
+    assert!(matches!(&fields[0].member, syn::Member::Named(i) if i == "id"));
+    assert!(matches!(&fields[1].member, syn::Member::Named(i) if i == "label"));
+    assert_eq!(fields[0].diagnostic_name, "id");
+
+    let (g2, root2) = graph_of(&["pub struct Pair(pub u64, pub u64);"], "Pair");
+    let SemanticShape::Product { fields, .. } = g2.get(root2.shape) else {
+        panic!("expected a product");
+    };
+    assert!(matches!(&fields[0].member, syn::Member::Unnamed(i) if i.index == 0));
+    assert!(matches!(&fields[1].member, syn::Member::Unnamed(i) if i.index == 1));
+}
+
+/// **Every enum is a `Choice`, unit-only included.** A unit enum is the
+/// degenerate sum whose variant groups are all empty — that is exactly the
+/// tag-only lowering, and collapsing it here would be an adapter's decision
+/// taken one tier too early.
+#[test]
+fn every_enum_is_a_choice_including_unit_only() {
+    let (g, root) = graph_of(&["pub enum Op { Add, Sub, Mul }"], "Op");
+    let SemanticShape::Choice { key: k, variants } = g.get(root.shape) else {
+        panic!(
+            "a unit enum must still be a Choice, got {:?}",
+            g.get(root.shape)
+        );
+    };
+    assert_eq!(k, &key("Op"));
+    assert_eq!(variants.len(), 3);
+    assert!(variants.iter().all(|v| v.fields.is_empty()));
+    assert_eq!(
+        variants.iter().map(|v| v.tag).collect::<Vec<_>>(),
+        vec![0, 1, 2]
+    );
+    // The classifier rides ON the choice rather than replacing it.
+    assert_eq!(g.get(root.shape).enum_shape(), Some(EnumShape::Unit));
+}
+
+/// A payload enum is the same node kind with non-empty groups, and the
+/// classifier is the only thing that changes.
+#[test]
+fn payload_enum_is_the_same_node_kind() {
+    let (g, root) = graph_of(
+        &["pub enum Shape { Empty, Circle(f64), Rect { w: f64, h: f64 } }"],
+        "Shape",
+    );
+    let SemanticShape::Choice { variants, .. } = g.get(root.shape) else {
+        panic!("expected a choice");
+    };
+    assert_eq!(g.get(root.shape).enum_shape(), Some(EnumShape::Sum));
+    assert!(variants[0].fields.is_empty());
+    assert!(matches!(&variants[1].fields[0].member, syn::Member::Unnamed(i) if i.index == 0));
+    assert!(matches!(&variants[2].fields[0].member, syn::Member::Named(i) if i == "w"));
+    // The variant ident stays the SOURCE spelling, independent of any
+    // destination-language rename.
+    assert_eq!(variants[2].ident, "Rect");
+    // …and the nested-prefix leaf name comes from `SumSpec`, this tier's
+    // Choice constructor, rather than being derived a second time here.
+    assert_eq!(variants[2].fields[0].diagnostic_name, "rect_w");
+}
+
+// ── use-qualified edges ─────────────────────────────────────────────────
+
+/// The reason edges are use-qualified at all: `Vec<&T>` is a container held by
+/// value whose *elements* are shared-borrowed. A root-only crossing context
+/// cannot say this — it has exactly one slot for a qualifier and two things to
+/// qualify.
+#[test]
+fn vec_of_shared_refs_qualifies_container_and_element_separately() {
+    let (g, root) = graph_of(&["pub struct Rec { pub id: u64 }"], "Vec<&Rec>");
+    assert_eq!(root.source, SourceUse::Value);
+    let SemanticShape::Sequence { kind, elem } = g.get(root.shape) else {
+        panic!("expected a sequence");
+    };
+    assert_eq!(*kind, SequenceKind::Vec);
+    assert_eq!(elem.source, SourceUse::SharedRef);
+    assert!(matches!(g.get(elem.shape), SemanticShape::Product { .. }));
+}
+
+/// The three source use qualifiers, at the root.
+#[test]
+fn root_use_records_the_source_qualifier() {
+    for (spelling, want) in [
+        ("Rec", SourceUse::Value),
+        ("&Rec", SourceUse::SharedRef),
+        ("&mut Rec", SourceUse::ExclusiveRef),
+    ] {
+        let (g, root) = graph_of(&["pub struct Rec { pub id: u64 }"], spelling);
+        assert_eq!(root.source, want, "for `{spelling}`");
+        // All three name the SAME shape — the qualifier is on the edge, not a
+        // distinct node, so `&Rec` and `Rec` share one interned product.
+        assert_eq!(g.key(root.shape), &key("Rec"));
+    }
+}
+
+/// `&[T]` peels its borrow onto the edge and becomes an ordinary sequence node,
+/// so `&[T]`, `Vec<T>` and `Cow<'_, [T]>` share one traversal and differ only
+/// by `SequenceKind`.
+#[test]
+fn sequence_kinds_are_distinguished_but_share_a_node_kind() {
+    for (spelling, want_kind, want_use) in [
+        ("Vec<u8>", SequenceKind::Vec, SourceUse::Value),
+        ("&[u8]", SequenceKind::Slice, SourceUse::SharedRef),
+        ("Cow<'a, [u8]>", SequenceKind::CowSlice, SourceUse::Value),
+    ] {
+        let (g, root) = graph_of(&[], spelling);
+        assert_eq!(root.source, want_use, "for `{spelling}`");
+        let SemanticShape::Sequence { kind, elem } = g.get(root.shape) else {
+            panic!(
+                "`{spelling}` must be a sequence, got {:?}",
+                g.get(root.shape)
+            );
+        };
+        assert_eq!(*kind, want_kind, "for `{spelling}`");
+        assert_eq!(elem.source, SourceUse::Value);
+    }
+}
+
+/// `Option<T>` is a layer, not a property of the thing it wraps.
+#[test]
+fn option_is_a_layer() {
+    let (g, root) = graph_of(&["pub struct Rec { pub id: u64 }"], "Option<&Rec>");
+    let SemanticShape::Optional(inner) = g.get(root.shape) else {
+        panic!("expected an optional");
+    };
+    assert_eq!(inner.source, SourceUse::SharedRef);
+    assert!(matches!(g.get(inner.shape), SemanticShape::Product { .. }));
+}
+
+/// `Box<T>` is heap indirection, which is a representation fact — so it is
+/// transparent here and `Box<Rec>` interns to the same node `Rec` does.
+#[test]
+fn box_is_transparent() {
+    let (g, root) = graph_of(&["pub struct Rec { pub id: u64 }"], "Option<Box<Rec>>");
+    let SemanticShape::Optional(inner) = g.get(root.shape) else {
+        panic!("expected an optional");
+    };
+    assert_eq!(g.key(inner.shape), &key("Rec"));
+}
+
+/// `Result<T, E>` is a two-alternative sum at the source. Both adapters route
+/// it to an error channel, but that is a Tier 1 decision — modelling it as an
+/// opaque leaf would hide `T` and `E` from the tier whose job is structure.
+#[test]
+fn result_is_an_ordinary_choice() {
+    let (g, root) = graph_of(
+        &[
+            "pub struct Rec { pub id: u64 }",
+            "pub struct Error { pub m: String }",
+        ],
+        "Result<Rec, Error>",
+    );
+    let SemanticShape::Choice { variants, .. } = g.get(root.shape) else {
+        panic!("expected a choice, got {:?}", g.get(root.shape));
+    };
+    assert_eq!(variants.len(), 2);
+    assert_eq!(variants[0].ident, "Ok");
+    assert_eq!(variants[1].ident, "Err");
+    assert_eq!(g.key(variants[0].fields[0].uses.shape), &key("Rec"));
+    assert_eq!(g.key(variants[1].fields[0].uses.shape), &key("Error"));
+
+    // `Result<(), E>` has a unit Ok arm: a group that contributes nothing.
+    let (g2, root2) = graph_of(&["pub struct Error { pub m: String }"], "Result<(), Error>");
+    let SemanticShape::Choice { variants, .. } = g2.get(root2.shape) else {
+        panic!("expected a choice");
+    };
+    assert!(variants[0].fields.is_empty());
+    assert_eq!(variants[1].fields.len(), 1);
+}
+
+// ── interning and cycles ────────────────────────────────────────────────
+
+/// Interning is keyed by the **full `TypeKey`**, never a bare ident — the
+/// structural fix for #136.
+///
+/// This is a unit test on the graph, and deliberately not described as
+/// end-to-end coverage of #136's collision: the source namespace is flat and
+/// `check_no_duplicate` rejects duplicate idents across kinds, so two distinct
+/// declared types sharing a short name cannot reach the capture pipeline at
+/// all. What is asserted here is that the graph tells apart types that share a
+/// tail ident — generic instantiations are the reachable form of that.
+#[test]
+fn interning_keys_on_the_full_type_key_not_a_bare_ident() {
+    let (g, _) = graph_of(&[], "Vec<Vec<u8>>");
+    // `Vec<Vec<u8>>`, `Vec<u8>` and `u8` are three nodes: keying on the tail
+    // ident `Vec` would have collapsed the outer two into one and produced a
+    // self-loop instead of a two-level sequence.
+    assert!(g.id_of(&key("Vec<Vec<u8>>")).is_some());
+    assert!(g.id_of(&key("Vec<u8>")).is_some());
+    assert!(g.id_of(&key("u8")).is_some());
+    assert_ne!(
+        g.id_of(&key("Vec<Vec<u8>>")).unwrap(),
+        g.id_of(&key("Vec<u8>")).unwrap()
+    );
+    assert_eq!(g.len(), 3);
+
+    // Every id's key round-trips: nothing was interned under a shortened name.
+    for id in g.ids() {
+        assert_eq!(g.id_of(g.key(id)), Some(id));
+    }
+}
+
+/// One type interned twice is one node, whatever route reached it.
+#[test]
+fn a_repeated_type_interns_once() {
+    let (g, root) = graph_of(
+        &[
+            "pub struct Rec { pub a: Leaf, pub b: Leaf, pub c: Vec<Leaf> }",
+            "pub struct Leaf { pub v: u64 }",
+        ],
+        "Rec",
+    );
+    let SemanticShape::Product { fields, .. } = g.get(root.shape) else {
+        panic!("expected a product");
+    };
+    assert_eq!(fields[0].uses.shape, fields[1].uses.shape);
+    let SemanticShape::Sequence { elem, .. } = g.get(fields[2].uses.shape) else {
+        panic!("expected a sequence");
+    };
+    assert_eq!(elem.shape, fields[0].uses.shape);
+}
+
+/// Self-recursion interns **finitely**, with a `ShapeId` back-edge to the
+/// `Node` node itself — asserted structurally, not inferred from "it
+/// terminated".
+#[test]
+fn self_recursion_interns_finitely_with_a_back_edge() {
+    let (g, root) = graph_of(
+        &["pub struct Node { pub id: u64, pub children: Vec<Node> }"],
+        "Node",
+    );
+    let node_id = root.shape;
+    let SemanticShape::Product { fields, .. } = g.get(node_id) else {
+        panic!("expected a product");
+    };
+    let SemanticShape::Sequence { elem, .. } = g.get(fields[1].uses.shape) else {
+        panic!("expected a sequence");
+    };
+    // The back-edge is exactly the `Node` id, not a fresh copy of it.
+    assert_eq!(elem.shape, node_id);
+    assert_eq!(elem.source, SourceUse::Value);
+    // Node, u64, Vec<Node> — and nothing else.
+    assert_eq!(g.len(), 3);
+    assert!(g.is_recursive(node_id));
+    assert!(!g.is_recursive(g.id_of(&key("u64")).unwrap()));
+}
+
+/// Mutual recursion through legal indirection yields **two nodes and two
+/// back-edges**, not divergence.
+///
+/// `A { b: B }` / `B { a: A }` is infinitely sized and is not Rust, so the
+/// fixture goes through `Vec`, which is the indirection a captured source crate
+/// can actually declare.
+#[test]
+fn mutual_recursion_yields_two_nodes_and_two_back_edges() {
+    let (g, root) = graph_of(
+        &[
+            "pub struct A { pub bs: Vec<B> }",
+            "pub struct B { pub as_: Vec<A> }",
+        ],
+        "A",
+    );
+    let a_id = root.shape;
+    let b_id = g.id_of(&key("B")).expect("B interned");
+    assert_ne!(a_id, b_id);
+
+    let elem_of = |id: ShapeId| {
+        let SemanticShape::Product { fields, .. } = g.get(id) else {
+            panic!("expected a product");
+        };
+        let SemanticShape::Sequence { elem, .. } = g.get(fields[0].uses.shape) else {
+            panic!("expected a sequence");
+        };
+        *elem
+    };
+    // A → Vec<B> → B, and B → Vec<A> → A: both back-edges land on the exact
+    // expected ids.
+    assert_eq!(elem_of(a_id).shape, b_id);
+    assert_eq!(elem_of(b_id).shape, a_id);
+
+    // A, Vec<B>, B, Vec<A> — four nodes, finite.
+    assert_eq!(g.len(), 4);
+    assert!(g.is_recursive(a_id));
+    assert!(g.is_recursive(b_id));
+}
+
+/// Recursion reached through a borrow keeps the borrow on the edge, so a cycle
+/// does not silently become a by-value one.
+#[test]
+fn a_back_edge_keeps_its_use_qualifier() {
+    let (g, root) = graph_of(
+        &["pub struct Node { pub kids: Vec<&'static Node> }"],
+        "Node",
+    );
+    let SemanticShape::Product { fields, .. } = g.get(root.shape) else {
+        panic!("expected a product");
+    };
+    let SemanticShape::Sequence { elem, .. } = g.get(fields[0].uses.shape) else {
+        panic!("expected a sequence");
+    };
+    assert_eq!(elem.shape, root.shape);
+    assert_eq!(elem.source, SourceUse::SharedRef);
+}
+
+/// An enum can recur too, and the cycle runs through a variant payload.
+#[test]
+fn recursive_choice_interns_finitely() {
+    let (g, root) = graph_of(&["pub enum Tree { Leaf(u64), Branch(Vec<Tree>) }"], "Tree");
+    let SemanticShape::Choice { variants, .. } = g.get(root.shape) else {
+        panic!("expected a choice");
+    };
+    let SemanticShape::Sequence { elem, .. } = g.get(variants[1].fields[0].uses.shape) else {
+        panic!("expected a sequence");
+    };
+    assert_eq!(elem.shape, root.shape);
+    assert!(g.is_recursive(root.shape));
+}
+
+/// An unindexed type is a `Leaf` — a statement about this graph's knowledge,
+/// not about the type. What separates an opaque handle from an `i32` is a
+/// Tier 1 declaration.
+#[test]
+fn unindexed_types_and_scalars_are_leaves() {
+    let (g, root) = graph_of(&[], "Undeclared");
+    assert!(matches!(g.get(root.shape), SemanticShape::Leaf(k) if k == &key("Undeclared")));
+    let (g2, root2) = graph_of(&[], "i32");
+    assert!(matches!(g2.get(root2.shape), SemanticShape::Leaf(_)));
+}
+
+/// `children()` is the one uniform edge accessor, so a traversal cannot forget
+/// a variant.
+#[test]
+fn children_covers_every_node_kind() {
+    let (g, root) = graph_of(
+        &[
+            "pub struct Rec { pub a: u64, pub b: Option<Vec<Op>> }",
+            "pub enum Op { Add, Pair(u64, u64) }",
+        ],
+        "Rec",
+    );
+    // Product: one edge per field.
+    assert_eq!(g.get(root.shape).children().len(), 2);
+    // Choice: one edge per payload slot, flattened across variants.
+    let op = g.id_of(&key("Op")).expect("Op interned");
+    assert_eq!(g.get(op).children().len(), 2);
+    // Leaf: none. Layers: exactly one.
+    let u64_id = g.id_of(&key("u64")).unwrap();
+    assert!(g.get(u64_id).children().is_empty());
+    assert_eq!(g.get(g.id_of(&key("Vec<Op>")).unwrap()).children().len(), 1);
+    assert_eq!(
+        g.get(g.id_of(&key("Option<Vec<Op>>")).unwrap())
+            .children()
+            .len(),
+        1
+    );
+}
+
+// ── the tier boundary ───────────────────────────────────────────────────
+
+/// **Tier 0 may not name a JVM descriptor, a C ABI type, a Kotlin class, or a
+/// delivery protocol.**
+///
+/// Rust's module system cannot express "no adapter concept is reachable from
+/// here" — `semantic.rs` could import from `api::lang` and still compile. So
+/// the boundary is checked against the module's own text, which is crude but is
+/// the only form of this check that can actually fail.
+#[test]
+fn no_adapter_policy_is_reachable_from_tier_0() {
+    let src = include_str!("../semantic.rs");
+    // Strip comments: the module *documents* what it may not name, and those
+    // sentences are the point rather than a violation.
+    let code: String = src
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !t.starts_with("//")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    for forbidden in [
+        // adapters and their modules
+        "lang::",
+        "jnigen",
+        "cbindgen",
+        "JniGen",
+        "Cbindgen",
+        // JVM / JNI vocabulary
+        "jlong",
+        "jint",
+        "JObject",
+        "JNIEnv",
+        "descriptor",
+        "Kotlin",
+        "kt_",
+        // C ABI vocabulary
+        "c_char",
+        "c_int",
+        "repr(C)",
+        "MaybeUninit",
+        "extern \"C\"",
+        // delivery / wire policy
+        "Wire",
+        "wire",
+        "Delivery",
+        "delivery",
+    ] {
+        assert!(
+            !code.contains(forbidden),
+            "Tier 0 must not name adapter policy, found `{forbidden}` in semantic.rs"
+        );
+    }
+
+    // …and its imports stay inside core.
+    for line in code.lines().filter(|l| l.trim_start().starts_with("use ")) {
+        assert!(
+            line.contains("std::")
+                || line.contains("super::")
+                || line.contains("syn")
+                || line.contains("crate::api::core"),
+            "Tier 0 import escapes core: {line}"
+        );
+    }
+}
+
+// ── the `Shape<N>` decision ─────────────────────────────────────────────
+
+/// `Shape<N>` survives Tier 0 as a **derived view**, not a second model: the
+/// layer stack is semantic and is owned here, while `N` — the
+/// null-representation choice — is a wire fact that belongs to Tier 1.
+///
+/// So the engines that fold over layers keep their algebra and stop deriving
+/// the stack themselves.
+#[test]
+fn wrapper_projection_derives_the_shape_stack() {
+    use crate::api::core::shape::Shape;
+
+    let (g, root) = graph_of(
+        &["pub struct Rec { pub id: u64 }"],
+        "Option<Vec<Option<Rec>>>",
+    );
+    let projected = g.wrapper_projection(root.shape);
+    // Outside in: Optional, Iterable, Optional, then the base.
+    let Shape::Optional((), l1) = &projected else {
+        panic!("expected an optional, got {projected:?}");
+    };
+    let Shape::Iterable(l2) = &**l1 else {
+        panic!("expected an iterable");
+    };
+    let Shape::Optional((), l3) = &**l2 else {
+        panic!("expected an optional");
+    };
+    assert!(matches!(**l3, Shape::Base));
+    assert!(projected.has_iterable_layer());
+
+    // …and the base the stack bottoms out at is the product itself.
+    assert_eq!(g.key(g.base_of(root.shape)), &key("Rec"));
+
+    // A shape with no layers projects to a bare base.
+    let (g2, root2) = graph_of(&["pub struct Rec { pub id: u64 }"], "&Rec");
+    assert!(matches!(g2.wrapper_projection(root2.shape), Shape::Base));
+    assert_eq!(g2.base_of(root2.shape), root2.shape);
+}

--- a/prebindgen/src/api/core/semantic/tests.rs
+++ b/prebindgen/src/api/core/semantic/tests.rs
@@ -179,6 +179,88 @@ fn box_is_transparent() {
     assert_eq!(g.key(inner.shape), &key("Rec"));
 }
 
+/// A transparent wrapper is stripped on **both** sides of the use peel.
+///
+/// `&Box<T>` needs the strip after the peel; `Box<&T>` needs it before —
+/// otherwise the `&` is still present when the interning key is formed, the
+/// reference lands *inside* the node instead of on the edge, and `build`
+/// classifies it as a `Leaf`, silently losing the structure of a declared `T`.
+/// Both spellings must name the same node as a bare `T` and differ only in
+/// their edge qualifier.
+#[test]
+fn transparent_wrappers_are_stripped_on_both_sides_of_the_peel() {
+    for (spelling, want_use) in [
+        ("Box<Rec>", SourceUse::Value),
+        ("&Box<Rec>", SourceUse::SharedRef),
+        ("&mut Box<Rec>", SourceUse::ExclusiveRef),
+        ("Box<&Rec>", SourceUse::SharedRef),
+        ("Box<&mut Rec>", SourceUse::ExclusiveRef),
+        ("Box<Box<&Rec>>", SourceUse::SharedRef),
+    ] {
+        let (g, root) = graph_of(&["pub struct Rec { pub id: u64 }"], spelling);
+        assert_eq!(root.source, want_use, "edge qualifier for `{spelling}`");
+        // The node is `Rec` itself — not `& Rec`, and not a `Leaf`.
+        assert_eq!(g.key(root.shape), &key("Rec"), "node key for `{spelling}`");
+        assert!(
+            matches!(g.get(root.shape), SemanticShape::Product { .. }),
+            "`{spelling}` must keep the product's structure, got {:?}",
+            g.get(root.shape)
+        );
+    }
+
+    // …and the same one level down, where the wrapper sits on a field.
+    let (g, root) = graph_of(
+        &[
+            "pub struct Holder { pub a: Box<&'static Rec>, pub b: Vec<Box<&'static Rec>> }",
+            "pub struct Rec { pub id: u64 }",
+        ],
+        "Holder",
+    );
+    let SemanticShape::Product { fields, .. } = g.get(root.shape) else {
+        panic!("expected a product");
+    };
+    assert_eq!(fields[0].uses.source, SourceUse::SharedRef);
+    assert_eq!(g.key(fields[0].uses.shape), &key("Rec"));
+    let SemanticShape::Sequence { elem, .. } = g.get(fields[1].uses.shape) else {
+        panic!("expected a sequence");
+    };
+    assert_eq!(elem.source, SourceUse::SharedRef);
+    assert_eq!(elem.shape, fields[0].uses.shape);
+}
+
+/// **No node is a reference.** A use qualifier lives on the edge, so a node
+/// keyed `& T` would be this tier contradicting its own rule — that is exactly
+/// the `Box<&T>` defect above, where the `&` survived into the key.
+///
+/// Note what this does *not* say: a **layer's** key legitimately contains its
+/// element's spelling, so `Option<&Rec>` is a perfectly good key. It has to be
+/// — `Option<Rec>` and `Option<&Rec>` are different layers (their element edges
+/// differ) and must not collide. The invariant is about the node's own head,
+/// not about the characters in its key.
+#[test]
+fn no_node_is_itself_a_reference() {
+    let (g, _) = graph_of(
+        &[
+            "pub struct Holder { pub a: Box<&'static Rec>, pub b: &'static [Rec], \
+              pub c: Option<&'static Rec>, pub d: Vec<&'static Rec> }",
+            "pub struct Rec { pub id: u64 }",
+        ],
+        "Holder",
+    );
+    for id in g.ids() {
+        let k = g.key(id).as_str();
+        assert!(
+            !k.trim_start().starts_with('&'),
+            "node {id:?} is itself a reference (`{k}`) — the qualifier belongs on the edge"
+        );
+    }
+    // The layer keys that legitimately mention a reference are still there, and
+    // still distinct from their by-value counterparts.
+    assert!(g.id_of(&key("Option<&'static Rec>")).is_some());
+    assert!(g.id_of(&key("Vec<&'static Rec>")).is_some());
+    assert!(g.id_of(&key("Option<Rec>")).is_none());
+}
+
 /// `Result<T, E>` is a two-alternative sum at the source. Both adapters route
 /// it to an error channel, but that is a Tier 1 decision — modelling it as an
 /// opaque leaf would hide `T` and `E` from the tier whose job is structure.
@@ -398,6 +480,104 @@ fn children_covers_every_node_kind() {
 
 // ── the tier boundary ───────────────────────────────────────────────────
 
+/// Strip Rust comments — both `//` line comments and `/* … */` blocks —
+/// while leaving **string literals intact**.
+///
+/// The module documents what it may not name, so its own prose about
+/// `descriptor` and `Kotlin` is the point rather than a violation. String
+/// literals are deliberately *not* stripped: Tier 0 naming adapter vocabulary
+/// inside a panic message would be a real violation, so the scan should still
+/// see it. The scanner tracks strings only so that a `/*` or `//` appearing
+/// inside one does not open a phantom comment.
+///
+/// Char literals are not tracked: `'` is overwhelmingly a lifetime in this
+/// file, and a naive char-literal state would swallow code from `'a` to the
+/// next quote. The cost of that omission is a `//` inside a char literal being
+/// treated as a comment, which nothing in this crate writes.
+fn code_without_comments(src: &str) -> String {
+    #[derive(Clone, Copy, PartialEq)]
+    enum St {
+        Code,
+        Line,
+        Block,
+        Str,
+        StrEsc,
+    }
+    let mut out = String::with_capacity(src.len());
+    let mut st = St::Code;
+    let mut chars = src.chars().peekable();
+    while let Some(c) = chars.next() {
+        match st {
+            St::Code => match (c, chars.peek()) {
+                ('/', Some('/')) => {
+                    chars.next();
+                    st = St::Line;
+                }
+                ('/', Some('*')) => {
+                    chars.next();
+                    st = St::Block;
+                }
+                ('"', _) => {
+                    st = St::Str;
+                    out.push(c);
+                }
+                _ => out.push(c),
+            },
+            St::Line => {
+                if c == '\n' {
+                    st = St::Code;
+                    out.push(c);
+                }
+            }
+            St::Block => {
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    st = St::Code;
+                } else if c == '\n' {
+                    // Keep line structure so the import scan below still works.
+                    out.push(c);
+                }
+            }
+            St::Str => {
+                out.push(c);
+                st = match c {
+                    '\\' => St::StrEsc,
+                    '"' => St::Code,
+                    _ => St::Str,
+                };
+            }
+            St::StrEsc => {
+                out.push(c);
+                st = St::Str;
+            }
+        }
+    }
+    out
+}
+
+/// The stripper itself, since the boundary test is only as good as it is.
+#[test]
+fn comment_stripping_handles_blocks_and_leaves_strings_alone() {
+    let src = r#"
+// line comment mentioning jlong
+/* block comment
+   mentioning Kotlin */
+let a = "a string with jlong in it";
+let b = "not a // comment"; /* trailing */ let c = 1;
+"#;
+    let code = code_without_comments(src);
+    // Both comment forms are gone…
+    assert!(!code.contains("line comment"), "{code}");
+    assert!(!code.contains("block comment"), "{code}");
+    assert!(!code.contains("mentioning"), "{code}");
+    assert!(!code.contains("trailing"), "{code}");
+    // …string literals survive, including one containing `//`…
+    assert!(code.contains(r#""a string with jlong in it""#), "{code}");
+    assert!(code.contains(r#""not a // comment""#), "{code}");
+    // …and code after a block comment on the same line is kept.
+    assert!(code.contains("let c = 1;"), "{code}");
+}
+
 /// **Tier 0 may not name a JVM descriptor, a C ABI type, a Kotlin class, or a
 /// delivery protocol.**
 ///
@@ -405,19 +585,13 @@ fn children_covers_every_node_kind() {
 /// here" — `semantic.rs` could import from `api::lang` and still compile. So
 /// the boundary is checked against the module's own text, which is crude but is
 /// the only form of this check that can actually fail.
+///
+/// Comments are stripped by [`code_without_comments`], which handles both
+/// comment forms and leaves string literals in the scan — a message naming
+/// adapter vocabulary would be a real violation.
 #[test]
 fn no_adapter_policy_is_reachable_from_tier_0() {
-    let src = include_str!("../semantic.rs");
-    // Strip comments: the module *documents* what it may not name, and those
-    // sentences are the point rather than a violation.
-    let code: String = src
-        .lines()
-        .filter(|l| {
-            let t = l.trim_start();
-            !t.starts_with("//")
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let code = code_without_comments(include_str!("../semantic.rs"));
 
     for forbidden in [
         // adapters and their modules

--- a/prebindgen/src/api/core/semantic/tests.rs
+++ b/prebindgen/src/api/core/semantic/tests.rs
@@ -261,6 +261,93 @@ fn no_node_is_itself_a_reference() {
     assert!(g.id_of(&key("Option<Rec>")).is_none());
 }
 
+/// A **generic declared type is a `Leaf`**, not a product assembled from its
+/// uninstantiated body.
+///
+/// `struct Wrap<T> { value: T }` interned as `Wrap<u8>` would otherwise become a
+/// product keyed `Wrap<u8>` whose field is the *parameter* `T` — a node that
+/// looks decomposed and is wrong, which is worse than one that admits it does
+/// not know. Substituting the root's arguments is a separate piece of work with
+/// its own edge cases (defaults, const generics, partial application); until an
+/// adapter needs it, refusing is the honest answer.
+#[test]
+fn generic_declared_types_are_leaves_not_uninstantiated_products() {
+    let items = &[
+        "pub struct Wrap<T> { pub value: T }",
+        "pub enum Either<A, B> { Left(A), Right(B) }",
+        "pub struct Sized2<const N: usize> { pub v: [u8; N] }",
+        "pub struct Rec { pub id: u64 }",
+    ];
+    for spelling in [
+        "Wrap<u8>",
+        "Wrap<Rec>",
+        "Wrap",
+        "Either<u8, Rec>",
+        "Sized2<4>",
+    ] {
+        let (g, root) = graph_of(items, spelling);
+        assert!(
+            matches!(g.get(root.shape), SemanticShape::Leaf(_)),
+            "`{spelling}` must be a Leaf, got {:?}",
+            g.get(root.shape)
+        );
+        // Crucially: the parameter never appears as a node of its own.
+        assert!(
+            g.id_of(&key("T")).is_none() && g.id_of(&key("A")).is_none(),
+            "`{spelling}` leaked a type parameter into the graph"
+        );
+    }
+
+    // A **lifetime**-only generic is still decomposed: a lifetime cannot appear
+    // in a field's type structure, so nothing is left uninstantiated.
+    let (g, root) = graph_of(
+        &[
+            "pub struct Ref<'a> { pub inner: &'a Rec }",
+            "pub struct Rec { pub id: u64 }",
+        ],
+        "Ref<'a>",
+    );
+    let SemanticShape::Product { fields, .. } = g.get(root.shape) else {
+        panic!(
+            "a lifetime-only generic must still decompose, got {:?}",
+            g.get(root.shape)
+        );
+    };
+    assert_eq!(fields[0].uses.source, SourceUse::SharedRef);
+    assert_eq!(g.key(fields[0].uses.shape), &key("Rec"));
+}
+
+/// A **foreign-qualified type is a `Leaf`**, even when the registry happens to
+/// hold a local item with the same tail ident.
+///
+/// Matching on the tail alone would give `foreign::Rec` the local `Rec`'s
+/// fields while keeping `foreign::Rec` as the node's key — a product assembled
+/// from an unrelated item. `normalize_type` says the same thing from the other
+/// side: an unknown crate path is never reduced, because `a::KeyExpr` and
+/// `b::KeyExpr` may be genuinely distinct types and their spelling is their
+/// identity.
+#[test]
+fn foreign_qualified_types_do_not_inherit_a_local_item() {
+    let items = &["pub struct Rec { pub id: u64, pub label: String }"];
+
+    // The local one decomposes…
+    let (g, root) = graph_of(items, "Rec");
+    assert!(matches!(g.get(root.shape), SemanticShape::Product { .. }));
+
+    // …and every qualified spelling that is NOT the registry's own item does
+    // not, however suggestive its tail ident is.
+    for spelling in ["foreign::Rec", "a::b::Rec", "::other::Rec"] {
+        let (g, root) = graph_of(items, spelling);
+        assert!(
+            matches!(g.get(root.shape), SemanticShape::Leaf(_)),
+            "`{spelling}` must be a Leaf, got {:?}",
+            g.get(root.shape)
+        );
+        // …and it keeps its own identity rather than collapsing onto `Rec`.
+        assert_ne!(g.key(root.shape), &key("Rec"), "for `{spelling}`");
+    }
+}
+
 /// `Result<T, E>` is a two-alternative sum at the source. Both adapters route
 /// it to an error channel, but that is a Tier 1 decision — modelling it as an
 /// opaque leaf would hide `T` and `E` from the tier whose job is structure.

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -2,6 +2,12 @@
 //! short-name helpers every pipeline stage needs. One definition here
 //! replaces the per-module copies that used to live in `core::unfold`,
 //! `core::expand`, and the jnigen adapter.
+//!
+//! `is_vec_type`, `is_unit` and `first_type_arg` used to be gated behind
+//! `unstable-cbindgen`, because the C adapter was their only caller.
+//! [`semantic`](super::semantic) — Tier 0 — needs them now, and core may not
+//! depend on an adapter's feature flag: that is the same tier boundary the
+//! module-boundary test enforces from the other direction.
 
 use proc_macro2::Span;
 use quote::ToTokens;
@@ -363,19 +369,18 @@ pub fn is_option_type(ty: &syn::Type) -> bool {
 }
 
 /// True when `ty` is `Vec<…>` (by last path segment).
-#[cfg(feature = "unstable-cbindgen")]
 pub fn is_vec_type(ty: &syn::Type) -> bool {
     path_tail_is(ty, "Vec")
 }
 
-/// True when `ty` is `Result<…>` (by last path segment).
+/// True when `ty` is `Result<…>` (by last path segment). Still adapter-only —
+/// Tier 0 goes through [`result_parts`], which needs the arms anyway.
 #[cfg(feature = "unstable-cbindgen")]
 pub fn is_result_type(ty: &syn::Type) -> bool {
     path_tail_is(ty, "Result")
 }
 
 /// True when `ty` is the unit type `()`.
-#[cfg(feature = "unstable-cbindgen")]
 pub fn is_unit(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty())
 }
@@ -412,7 +417,6 @@ pub fn result_err_type(ty: &syn::Type) -> Option<syn::Type> {
 /// First angle-bracketed **type** argument of a path type (`T` of `Option<T>`
 /// / `Vec<T>` / `Result<T, _>`), skipping lifetime/const args. `None` when
 /// there is no type argument.
-#[cfg(feature = "unstable-cbindgen")]
 pub fn first_type_arg(ty: &syn::Type) -> Option<syn::Type> {
     let syn::Type::Path(tp) = ty else { return None };
     let seg = tp.path.segments.last()?;

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -532,10 +532,13 @@ pub fn first_payload_variant(e: &syn::ItemEnum) -> Option<&syn::Variant> {
 /// them in memory as a `#[repr(C)]` union). Nothing here names a wire
 /// detail — in particular a payload enum carries no `repr`, so tags are
 /// declaration order and never an explicit discriminant.
-/// The neutral description lands before either lowering, so both adapters
-/// read one definition instead of growing a private one each; the
-/// `dead_code` allow covers that gap and goes away with the first adapter
-/// that reads a sum.
+///
+/// As of Stage T (#190) this is the **`Choice` constructor** for the Tier 0
+/// semantic tier rather than a parallel description of the same enum:
+/// [`ShapeGraph`](crate::api::core::semantic::ShapeGraph) builds
+/// [`SemanticShape::Choice`](crate::api::core::semantic::SemanticShape::Choice)
+/// through it, so declaration-order tags, `syn::Member` addressing and the
+/// nested-prefix leaf names are computed in exactly one place.
 #[allow(dead_code)]
 pub struct SumSpec {
     /// Canonical key of the enum type.


### PR DESCRIPTION
Stage T of #187 — closes #190, and **closes #136**. Targets `boundary-planning` (#202), not `main`.

One interned graph describing what the *source Rust type says*, owned by an explicit milestone. Stages 1 (#192) and 3 (#193) both consume it; without this stage neither owns it and both would grow a private copy of the same traversal — the precise failure #187 exists to prevent.

## What landed

`api/core/semantic.rs` — `SemanticShape` interned in a `ShapeGraph`:

| Node | Carries |
|---|---|
| `Leaf(TypeKey)` | a type this tier does not decompose — a statement about *the graph's knowledge*, not about the type |
| `Product { key, fields }` | a struct |
| `Choice { key, variants }` | an enum — **every** enum, unit-only included |
| `Optional(SemanticUse)` | an `Option` layer |
| `Sequence { kind, elem }` | `Vec` / `[T]` / `Cow<'_, [T]>` |

**Every child edge is use-qualified.** `SemanticUse { shape, source }` with `SourceUse = Value | SharedRef | ExclusiveRef` is what makes `Vec<&T>` expressible — container held by value, elements shared-borrowed — which a root-only crossing context cannot say, having one slot for a qualifier and two things to qualify. There is no unqualified `ShapeId` in a node, so a traversal cannot silently lose the distinction.

`FieldUse` retains `syn::Member` plus a separate `diagnostic_name` that nothing may key on; `VariantUse` retains the source `syn::Ident` independent of destination-language naming. Degrading either to a string would rebuild #186's textual-access problem one tier lower, which is the opposite of the point.

`SumSpec` **becomes the `Choice` constructor** rather than a parallel description: declaration-order tags, `syn::Member` addressing and the nested-prefix leaf names are now computed in exactly one place. `EnumShape` survives as a classifier *over* a choice (`SemanticShape::enum_shape`), not a second modelling of one.

## Cycles are represented, never cut

The id is reserved **before** children are built, so a recursive occurrence finds it in the intern map and becomes a back-edge. There is no stopping-rule hook: where a cycle may be cut is Tier 1 policy, and a hook here would be the same policy leak the tier boundary exists to prevent. `is_recursive` is a query over the finished graph, not a knob.

## Two decisions the issue left open

Both resolved toward the tier boundary, and both are stated in the module docs because they look like omissions otherwise:

- **`Shape<N>` survives as a derived view**, not a second model. `ShapeGraph::wrapper_projection` derives the layer stack onto the existing `Shape`; `N` — the null representation — stays a wire fact for Tier 1. The engines that fold over layers keep their algebra and stop deriving the stack themselves.
- **`Box<T>` is transparent, `Result<T, E>` is an ordinary `Choice`.** A `Box` is heap indirection — a representation fact, and what makes `Option<Box<Node>>` a legal recursion rather than an infinitely-sized type. A `Result` is a two-alternative sum at the source; that both adapters route it to an error channel is Tier 1's decision, and modelling it as an opaque leaf would hide `T` and `E` from the tier whose job is structure.

## On #136

Closed **structurally**, by delivering its first suggested fix: interning keys on the full `TypeKey`, never a bare ident.

What is deliberately *not* done is correcting the bare-ident cycle stack in `jni/emit/flat_input.rs` pointwise — Stage 3 deletes `FlatLeaf` outright, and touching emission here would break this stage's byte-identical exit.

What is deliberately *not claimed* is end-to-end coverage of #136's collision. The source namespace is flat and `check_no_duplicate` rejects duplicate idents across kinds, so two distinct declared types sharing a short name cannot reach the capture pipeline at all — #136 says as much itself. The test is scoped as a unit test on the graph, with generic instantiations (`Vec<Vec<u8>>` vs `Vec<u8>`) as the reachable form of the same distinction, and its doc comment says so rather than overselling it.

## Exit

- **Must not move — all generated artifacts.** ✅ `examples/regen-check.sh` byte-identical. This stage adds a tier; it does not reroute emission, and nothing outside `api/core` changed.
- **Asserted — no adapter policy is reachable from Tier 0.** ✅ A module-boundary test over the module's own text: adapter modules, JVM vocabulary (`jlong`, `JNIEnv`, `descriptor`, `Kotlin`), C ABI vocabulary (`c_char`, `repr(C)`, `MaybeUninit`) and delivery/wire vocabulary are all rejected, and imports are checked to stay inside `core`. Rust's module system cannot express this — `semantic.rs` could import `api::lang` and still compile — so the check is textual, which is crude but is the only form that can actually fail. **Verified it does fail** on an injected `jlong`.
- **Asserted — cycles are tested here, not assumed.** ✅ All three the issue names:
  - self-recursion (`Node { children: Vec<Node> }`) interns finitely, with the back-edge asserted to be **exactly** the `Node` `ShapeId` and the graph asserted at 3 nodes — not inferred from "it terminated";
  - mutual recursion through legal indirection (`A { bs: Vec<B> }` / `B { as_: Vec<A> }`) yields two nodes and two back-edges, both checked structurally;
  - the defensive full-`TypeKey` interning invariant, scoped as described above.

  Plus: a back-edge keeps its use qualifier (`Vec<&Node>` stays `SharedRef`), and a recursive `Choice` terminates through a variant payload.

19 tests total, covering every node kind, all three `SourceUse` values, all three `SequenceKind`s, the uniform `children()` accessor, and the `Shape` projection.

## Verification

```
cargo test --all --all-features             ok (425 lib tests)
cargo clippy --all-targets … -D warnings    ok
cargo fmt --check                           ok
examples/regen-check.sh                     PASS (byte-identical)
```

## Note for reviewers

The module carries `#![allow(dead_code)]`. That is the same gap `SumSpec` has carried since #146, for the same reason and with the same expiry: this tier lands before either adapter reads it, and the allow goes away with the first adapter that plans over a shape. If you'd rather it be gated some other way, say so — it is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)