### PR TITLE
Stage 5A: Kotlin expression AST infrastructure (KtExpr) (#186)

### DIFF
--- a/prebindgen/src/api/gen/kotlin/expr.rs
+++ b/prebindgen/src/api/gen/kotlin/expr.rs
@@ -136,9 +136,52 @@ impl std::fmt::Display for KtNameError {
 
 impl std::error::Error for KtNameError {}
 
+/// Kotlin's **hard keywords** — the ones that are never valid as a bare
+/// identifier, in any position.
+///
+/// Soft and modifier keywords (`data`, `value`, `by`, `where`, …) are
+/// deliberately absent: they are contextual and *are* legal identifiers, so
+/// rejecting them would refuse names Kotlin accepts.
+pub(crate) const KOTLIN_HARD_KEYWORDS: &[&str] = &[
+    "as",
+    "break",
+    "class",
+    "continue",
+    "do",
+    "else",
+    "false",
+    "for",
+    "fun",
+    "if",
+    "in",
+    "interface",
+    "is",
+    "null",
+    "object",
+    "package",
+    "return",
+    "super",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typealias",
+    "typeof",
+    "val",
+    "var",
+    "when",
+    "while",
+];
+
+/// Whether `s` is a Kotlin hard keyword.
+pub(crate) fn is_hard_keyword(s: &str) -> bool {
+    KOTLIN_HARD_KEYWORDS.contains(&s)
+}
+
 impl KtName {
     /// Validate and build. Each dot-separated segment must be a Kotlin
-    /// identifier: a letter or `_` followed by letters, digits or `_`.
+    /// identifier: a letter or `_` followed by letters, digits or `_`, and not
+    /// a [hard keyword](KOTLIN_HARD_KEYWORDS).
     ///
     /// This is what stops a producer smuggling an expression through a name —
     /// without it, `Name("a.b() ?: c")` would render as arbitrary source and
@@ -165,6 +208,14 @@ impl KtName {
             }
             if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
                 return reject("segment may only contain letters, digits and `_`");
+            }
+            // A hard keyword renders as uncompilable Kotlin. Rejected rather
+            // than backtick-escaped: nothing in this generator needs a
+            // keyword-named class or member, and silently rewriting a name
+            // would make the emitted spelling differ from the one asked for —
+            // which for a `Fixed` binder is exactly what must not happen.
+            if is_hard_keyword(seg) {
+                return reject("segment is a Kotlin hard keyword");
             }
         }
         Ok(KtName(s))
@@ -215,6 +266,14 @@ pub enum KtExpr {
     Local(BindingId),
     /// A **free** name: class, member, or type reference.
     Name(KtName),
+    /// `this` — the enclosing receiver.
+    ///
+    /// A node of its own rather than a `Name`, because `this` is a hard keyword
+    /// and `KtName` rejects those. That rejection is the point: it forced the
+    /// one expression that legitimately spells a keyword to become structure
+    /// instead of slipping through the free-name set. The generator needs it
+    /// for a promoted receiver, where the access base is `this`.
+    This,
     Literal(KtLiteral),
     /// `recv.name` / `recv?.name`.
     Field {
@@ -404,6 +463,7 @@ impl ExprArena {
             }
             KtExpr::Local(_)
             | KtExpr::Name(_)
+            | KtExpr::This
             | KtExpr::Literal(_)
             | KtExpr::Hole
             | KtExpr::Raw(_) => {}
@@ -446,7 +506,9 @@ impl ExprArena {
         };
         match expr {
             KtExpr::Local(id) => KtExpr::Local(lookup(id)),
-            KtExpr::Name(_) | KtExpr::Literal(_) | KtExpr::Hole | KtExpr::Raw(_) => expr.clone(),
+            KtExpr::Name(_) | KtExpr::This | KtExpr::Literal(_) | KtExpr::Hole | KtExpr::Raw(_) => {
+                expr.clone()
+            }
             KtExpr::Field { recv, name, safe } => KtExpr::Field {
                 recv: Box::new(self.rewrite_ids(recv, map)),
                 name: name.clone(),
@@ -524,9 +586,12 @@ pub fn map_expr(expr: &KtExpr, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> 
         return replacement;
     }
     match expr {
-        KtExpr::Local(_) | KtExpr::Name(_) | KtExpr::Literal(_) | KtExpr::Hole | KtExpr::Raw(_) => {
-            expr.clone()
-        }
+        KtExpr::Local(_)
+        | KtExpr::Name(_)
+        | KtExpr::This
+        | KtExpr::Literal(_)
+        | KtExpr::Hole
+        | KtExpr::Raw(_) => expr.clone(),
         KtExpr::Field { recv, name, safe } => KtExpr::Field {
             recv: Box::new(map_expr(recv, f)),
             name: name.clone(),
@@ -663,6 +728,10 @@ impl KtExpr {
     }
     pub fn name(n: impl Into<String>) -> Self {
         KtExpr::Name(KtName::expect(n))
+    }
+    /// `this`.
+    pub fn this() -> Self {
+        KtExpr::This
     }
     pub fn null() -> Self {
         KtExpr::Literal(KtLiteral::Null)

--- a/prebindgen/src/api/gen/kotlin/expr.rs
+++ b/prebindgen/src/api/gen/kotlin/expr.rs
@@ -384,10 +384,38 @@ pub enum KtPattern {
 ///
 /// Ids start at zero per arena, so two independently built arenas collide —
 /// see the module docs for why that is the point.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ExprArena {
     id: ArenaId,
     binders: Vec<Binder>,
+    /// A **clone** cannot allocate. See the `Clone` impl below.
+    sealed: bool,
+}
+
+/// Cloning keeps the [`ArenaId`], because the trees already built against this
+/// arena keep referring to it — a clone with a fresh id would orphan every
+/// `Local` in them.
+///
+/// That is exactly why the clone is **sealed**: two arenas sharing an id and
+/// both still allocating would hand out identical
+/// `BindingId { arena, index }` values for different binders, and the
+/// provenance check would wave the collision straight through. A sealed arena
+/// can be read, rendered and grafted *from*; it just cannot mint anything new,
+/// so the id/index pair stays unique to one binder for the arena's whole
+/// lifetime.
+///
+/// The model clones arenas constantly — `Ast<T>`, `ExprSlot`, `KtFun` all derive
+/// `Clone` — and none of those clones binds afterwards, so sealing costs
+/// nothing in practice and closes the hole by construction. To extend a cloned
+/// tree, `graft` it into a fresh arena, which alpha-remaps.
+impl Clone for ExprArena {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            binders: self.binders.clone(),
+            sealed: true,
+        }
+    }
 }
 
 impl Default for ExprArena {
@@ -401,6 +429,7 @@ impl ExprArena {
         Self {
             id: ArenaId::next(),
             binders: Vec::new(),
+            sealed: false,
         }
     }
 
@@ -443,6 +472,12 @@ impl ExprArena {
     }
 
     fn push(&mut self, spelling: Spelling) -> BindingId {
+        assert!(
+            !self.sealed,
+            "ExprArena: this arena is a clone and cannot allocate — two arenas sharing an \
+             `ArenaId` would mint identical `BindingId`s for different binders, which is the \
+             collision provenance exists to catch. Graft the tree into a fresh arena instead."
+        );
         let id = BindingId {
             arena: self.id,
             index: self.binders.len() as u32,

--- a/prebindgen/src/api/gen/kotlin/expr.rs
+++ b/prebindgen/src/api/gen/kotlin/expr.rs
@@ -322,7 +322,14 @@ pub enum KtExpr {
         /// `?.name(…)`.
         safe: bool,
         /// A trailing lambda argument, rendered outside the parentheses.
-        trailing_lambda: Option<Box<KtExpr>>,
+        ///
+        /// Typed as a [`KtLambda`], not a `KtExpr`: Kotlin's trailing-argument
+        /// syntax accepts only a lambda, so
+        /// `consume().with_trailing_lambda(int(1))` would render `consume() 1`.
+        /// Constraining the field means direct variant construction cannot
+        /// produce that either, which an assert in the helper alone would not
+        /// prevent.
+        trailing_lambda: Option<Box<KtLambda>>,
     },
     /// `expr as ty` / `expr as? ty`.
     As {
@@ -333,10 +340,7 @@ pub enum KtExpr {
     /// `lhs ?: rhs`.
     Elvis(Box<KtExpr>, Box<KtExpr>),
     /// `{ params -> body }`.
-    Lambda {
-        params: Vec<BindingId>,
-        body: Vec<KtStmt>,
-    },
+    Lambda(KtLambda),
     /// `when (subject) { arms }`.
     When {
         subject: Box<KtExpr>,
@@ -351,6 +355,33 @@ pub enum KtExpr {
     /// TEMPORARY escape hatch. Crate-private, every construction site tracked
     /// in #199, whose exit deletes this variant.
     Raw(String),
+}
+
+/// A lambda: its parameter binders and its body.
+///
+/// A type of its own so Kotlin's **trailing-argument** position can be typed as
+/// one. `Call::trailing_lambda` used to be an `Option<Box<KtExpr>>`, which let
+/// `consume().with_trailing_lambda(int(1))` render `consume() 1` — invalid
+/// Kotlin that only an assert would have caught, and only on the path through
+/// the helper.
+#[derive(Clone, Debug, PartialEq)]
+pub struct KtLambda {
+    pub params: Vec<BindingId>,
+    pub body: Vec<KtStmt>,
+}
+
+impl KtLambda {
+    pub fn new(params: impl IntoIterator<Item = BindingId>, body: Vec<KtStmt>) -> Self {
+        Self {
+            params: params.into_iter().collect(),
+            body,
+        }
+    }
+
+    /// A single-expression body.
+    pub fn expr(params: impl IntoIterator<Item = BindingId>, body: KtExpr) -> Self {
+        Self::new(params, vec![KtStmt::Expr(body)])
+    }
 }
 
 /// A statement inside a lambda or block body.
@@ -534,15 +565,7 @@ impl ExprArena {
         map: &mut HashMap<BindingId, BindingId>,
     ) {
         match expr {
-            KtExpr::Lambda { params, body } => {
-                for p in params {
-                    let fresh = self.push(from.binder(*p).spelling.clone());
-                    map.insert(*p, fresh);
-                }
-                for s in body {
-                    self.remap_stmt_introductions(from, s, map);
-                }
-            }
+            KtExpr::Lambda(l) => self.remap_lambda_introductions(from, l, map),
             KtExpr::Field { recv, .. } => self.remap_introductions(from, recv, map),
             KtExpr::Call {
                 recv,
@@ -557,7 +580,7 @@ impl ExprArena {
                     self.remap_introductions(from, a, map);
                 }
                 if let Some(l) = trailing_lambda {
-                    self.remap_introductions(from, l, map);
+                    self.remap_lambda_introductions(from, l, map);
                 }
             }
             KtExpr::As { expr, .. } => self.remap_introductions(from, expr, map),
@@ -580,6 +603,21 @@ impl ExprArena {
             | KtExpr::Literal(_)
             | KtExpr::Hole
             | KtExpr::Raw(_) => {}
+        }
+    }
+
+    fn remap_lambda_introductions(
+        &mut self,
+        from: &ExprArena,
+        l: &KtLambda,
+        map: &mut HashMap<BindingId, BindingId>,
+    ) {
+        for p in &l.params {
+            let fresh = self.push(from.binder(*p).spelling.clone());
+            map.insert(*p, fresh);
+        }
+        for s in &l.body {
+            self.remap_stmt_introductions(from, s, map);
         }
     }
 
@@ -640,7 +678,7 @@ impl ExprArena {
                 safe: *safe,
                 trailing_lambda: trailing_lambda
                     .as_ref()
-                    .map(|l| Box::new(self.rewrite_ids(l, map))),
+                    .map(|l| Box::new(self.rewrite_lambda_ids(l, map))),
             },
             KtExpr::As { expr, ty, safe } => KtExpr::As {
                 expr: Box::new(self.rewrite_ids(expr, map)),
@@ -651,10 +689,14 @@ impl ExprArena {
                 Box::new(self.rewrite_ids(a, map)),
                 Box::new(self.rewrite_ids(b, map)),
             ),
-            KtExpr::Lambda { params, body } => KtExpr::Lambda {
-                params: params.iter().map(lookup).collect(),
-                body: body.iter().map(|s| self.rewrite_stmt_ids(s, map)).collect(),
-            },
+            KtExpr::Lambda(l) => KtExpr::Lambda(KtLambda {
+                params: l.params.iter().map(lookup).collect(),
+                body: l
+                    .body
+                    .iter()
+                    .map(|s| self.rewrite_stmt_ids(s, map))
+                    .collect(),
+            }),
             KtExpr::When { subject, arms } => KtExpr::When {
                 subject: Box::new(self.rewrite_ids(subject, map)),
                 arms: arms
@@ -668,6 +710,21 @@ impl ExprArena {
                     })
                     .collect(),
             },
+        }
+    }
+
+    fn rewrite_lambda_ids(&self, l: &KtLambda, map: &HashMap<BindingId, BindingId>) -> KtLambda {
+        let lookup = |id: &BindingId| {
+            *map.get(id)
+                .expect("a lambda's own binders are introduced by its tree")
+        };
+        KtLambda {
+            params: l.params.iter().map(lookup).collect(),
+            body: l
+                .body
+                .iter()
+                .map(|s| self.rewrite_stmt_ids(s, map))
+                .collect(),
         }
     }
 
@@ -721,7 +778,7 @@ pub fn map_expr(expr: &KtExpr, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> 
             name: name.clone(),
             args: args.iter().map(|a| map_expr(a, f)).collect(),
             safe: *safe,
-            trailing_lambda: trailing_lambda.as_ref().map(|l| Box::new(map_expr(l, f))),
+            trailing_lambda: trailing_lambda.as_ref().map(|l| Box::new(map_lambda(l, f))),
         },
         KtExpr::As { expr, ty, safe } => KtExpr::As {
             expr: Box::new(map_expr(expr, f)),
@@ -729,10 +786,7 @@ pub fn map_expr(expr: &KtExpr, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> 
             safe: *safe,
         },
         KtExpr::Elvis(a, b) => KtExpr::Elvis(Box::new(map_expr(a, f)), Box::new(map_expr(b, f))),
-        KtExpr::Lambda { params, body } => KtExpr::Lambda {
-            params: params.clone(),
-            body: body.iter().map(|s| map_stmt(s, f)).collect(),
-        },
+        KtExpr::Lambda(l) => KtExpr::Lambda(map_lambda(l, f)),
         KtExpr::When { subject, arms } => KtExpr::When {
             subject: Box::new(map_expr(subject, f)),
             arms: arms
@@ -746,6 +800,14 @@ pub fn map_expr(expr: &KtExpr, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> 
                 })
                 .collect(),
         },
+    }
+}
+
+/// [`map_expr`] over a lambda.
+pub fn map_lambda(l: &KtLambda, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> KtLambda {
+    KtLambda {
+        params: l.params.clone(),
+        body: l.body.iter().map(|s| map_stmt(s, f)).collect(),
     }
 }
 
@@ -923,7 +985,7 @@ impl KtExpr {
         }
     }
     /// Attach a trailing lambda: `f(a) { … }`.
-    pub fn with_trailing_lambda(mut self, lambda: KtExpr) -> Self {
+    pub fn with_trailing_lambda(mut self, lambda: KtLambda) -> Self {
         match &mut self {
             KtExpr::Call {
                 trailing_lambda, ..
@@ -954,10 +1016,7 @@ impl KtExpr {
     }
     /// `{ params -> body }`.
     pub fn lambda(params: impl IntoIterator<Item = BindingId>, body: Vec<KtStmt>) -> Self {
-        KtExpr::Lambda {
-            params: params.into_iter().collect(),
-            body,
-        }
+        KtExpr::Lambda(KtLambda::new(params, body))
     }
     /// A single-expression lambda body.
     pub fn lambda1(params: impl IntoIterator<Item = BindingId>, body: KtExpr) -> Self {

--- a/prebindgen/src/api/gen/kotlin/expr.rs
+++ b/prebindgen/src/api/gen/kotlin/expr.rs
@@ -51,17 +51,42 @@ use std::collections::{BTreeSet, HashMap};
 
 use super::types::KtType;
 
-/// Identity of a binder within one [`ExprArena`].
-///
-/// Never compared across arenas — [`ExprArena::graft`] remaps rather than
-/// trusting that two arenas agree.
+/// Identity of the arena a [`BindingId`] belongs to. Globally generative, so
+/// two arenas are always distinguishable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BindingId(u32);
+pub struct ArenaId(u64);
+
+impl ArenaId {
+    fn next() -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        ArenaId(NEXT.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// Identity of a binder: **which arena** it came from, plus its index there.
+///
+/// The arena tag is what makes a cross-arena mistake detectable rather than
+/// silent. Indices still start at zero per arena — so two independently built
+/// trees still collide on `index`, and [`ExprArena::graft`]'s alpha-remap stays
+/// load-bearing and exercised — but a `Local` from another arena can no longer
+/// resolve against a host binder that happens to share its index. Composition
+/// ([`fill_hole`], [`substitute`], [`Ast::in_scope`]) asserts provenance, so
+/// the failure is a named panic at the seam instead of silent capture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BindingId {
+    arena: ArenaId,
+    index: u32,
+}
 
 impl BindingId {
-    /// The raw index, for diagnostics and test assertions.
+    /// The raw index within its arena, for diagnostics and test assertions.
     pub fn index(self) -> u32 {
-        self.0
+        self.index
+    }
+    /// The arena this binder belongs to.
+    pub fn arena(self) -> ArenaId {
+        self.arena
     }
 }
 
@@ -93,7 +118,9 @@ impl NameHint {
             .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
             .collect();
         let cleaned = cleaned.trim_start_matches(|c: char| c.is_ascii_digit());
-        NameHint(if cleaned.is_empty() {
+        // An all-underscore hint would render as Kotlin's discard placeholder,
+        // which is not a referenceable binder.
+        NameHint(if cleaned.is_empty() || cleaned.chars().all(|c| c == '_') {
             "tmp".to_string()
         } else {
             cleaned.to_string()
@@ -216,6 +243,12 @@ impl KtName {
             // which for a `Fixed` binder is exactly what must not happen.
             if is_hard_keyword(seg) {
                 return reject("segment is a Kotlin hard keyword");
+            }
+            // Kotlin treats a bare `_` as an ignoring placeholder, not an
+            // identifier — `val _ = x` is a discard and `_` is not referenceable.
+            // `_x` and `x_` are fine; only an all-underscore segment is not.
+            if seg.chars().all(|c| c == '_') {
+                return reject("segment is only underscores, which Kotlin reads as a placeholder");
             }
         }
         Ok(KtName(s))
@@ -351,14 +384,50 @@ pub enum KtPattern {
 ///
 /// Ids start at zero per arena, so two independently built arenas collide —
 /// see the module docs for why that is the point.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ExprArena {
+    id: ArenaId,
     binders: Vec<Binder>,
+}
+
+impl Default for ExprArena {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ExprArena {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            id: ArenaId::next(),
+            binders: Vec::new(),
+        }
+    }
+
+    /// This arena's identity.
+    pub fn id(&self) -> ArenaId {
+        self.id
+    }
+
+    /// Panic unless every `Local` in `expr` belongs to this arena.
+    ///
+    /// The guard behind every composition entry point. Without it, inserting a
+    /// tree built elsewhere lets `Local(index 0)` resolve against *this*
+    /// arena's binder 0 — the structural capture `graft` exists to prevent,
+    /// arriving through `fill_hole` or `substitute` instead.
+    pub fn assert_owns(&self, expr: &KtExpr, what: &str) {
+        map_expr(expr, &mut |e| {
+            if let KtExpr::Local(id) = e {
+                assert!(
+                    id.arena == self.id,
+                    "{what}: `Local` from arena {:?} used with arena {:?} — graft the tree in \
+                     with `ExprArena::graft`, which alpha-remaps, instead of cloning it across",
+                    id.arena,
+                    self.id
+                );
+            }
+            None
+        });
     }
 
     /// A binder whose spelling is **public API** and must survive rendering
@@ -374,14 +443,23 @@ impl ExprArena {
     }
 
     fn push(&mut self, spelling: Spelling) -> BindingId {
-        let id = BindingId(self.binders.len() as u32);
+        let id = BindingId {
+            arena: self.id,
+            index: self.binders.len() as u32,
+        };
         self.binders.push(Binder { id, spelling });
         id
     }
 
-    /// The binder behind an id.
+    /// The binder behind an id. Panics if the id is from another arena.
     pub fn binder(&self, id: BindingId) -> &Binder {
-        &self.binders[id.0 as usize]
+        assert!(
+            id.arena == self.id,
+            "BindingId from arena {:?} looked up in arena {:?}",
+            id.arena,
+            self.id
+        );
+        &self.binders[id.index as usize]
     }
 
     /// Number of binders — the count a remap test compares against.
@@ -500,7 +578,7 @@ impl ExprArena {
                 panic!(
                     "ExprArena::graft: `Local({})` refers to a binder the grafted tree does not \
                      introduce — it was built against a scope that is not being grafted with it",
-                    id.0
+                    id.index
                 )
             })
         };
@@ -660,7 +738,12 @@ pub fn map_stmt(stmt: &KtStmt, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> 
 /// (`(<base>.field as? Reading.Exact)?.v0 ?: 0L`) is just a tree with a hole,
 /// and filling it is a rewrite rather than three string concatenations that
 /// each have to remember the other two.
-pub fn fill_hole(template: &KtExpr, value: &KtExpr) -> KtExpr {
+pub fn fill_hole(arena: &ExprArena, template: &KtExpr, value: &KtExpr) -> KtExpr {
+    // Both sides must belong to `arena`: filling a hole with a tree built
+    // elsewhere would let its `Local`s resolve against this arena's binders.
+    // Cross-arena composition goes through `ExprArena::graft`, which remaps.
+    arena.assert_owns(template, "fill_hole(template)");
+    arena.assert_owns(value, "fill_hole(value)");
     map_expr(template, &mut |e| match e {
         KtExpr::Hole => Some(value.clone()),
         _ => None,
@@ -686,7 +769,13 @@ pub fn has_hole(expr: &KtExpr) -> bool {
 /// binder that happens to *print* the same name cannot rebind it — the renderer
 /// allocates the printed names afterwards, and it knows which id each one
 /// belongs to.
-pub fn substitute(expr: &KtExpr, target: BindingId, value: &KtExpr) -> KtExpr {
+pub fn substitute(arena: &ExprArena, expr: &KtExpr, target: BindingId, value: &KtExpr) -> KtExpr {
+    arena.assert_owns(expr, "substitute(expr)");
+    arena.assert_owns(value, "substitute(value)");
+    assert!(
+        target.arena == arena.id(),
+        "substitute: target binder is from another arena"
+    );
     map_expr(expr, &mut |e| match e {
         KtExpr::Local(id) if *id == target => Some(value.clone()),
         _ => None,

--- a/prebindgen/src/api/gen/kotlin/expr.rs
+++ b/prebindgen/src/api/gen/kotlin/expr.rs
@@ -1,0 +1,778 @@
+//! Kotlin **expression** AST — [`KtExpr`], [`KtStmt`], [`KtPattern`] — and the
+//! [`ExprArena`] that owns their binders.
+//!
+//! Kotlin emission has been half AST and half string concatenation: declarations
+//! go through [`super::model`], expressions were `String`s assembled by hand.
+//! Every defect class that produced — `replace_ident`'s left-context bug
+//! (#172), hand-numbered `e0`/`e1` lambda variables to dodge `it` shadowing,
+//! `kt_access_prefix` + base + `kt_access_tail` as a textual template — is
+//! invisible until Gradle compiles the output, and a wrong-but-valid expression
+//! is not caught even then.
+//!
+//! This module is **infrastructure only**. No call site is migrated here: Stage
+//! 3 (#193) rewrites the emitters that produce plan-carried expressions, and
+//! #199 (Stage 5B) migrates the rest and deletes the escape hatches.
+//!
+//! # Binder identity is structural, not textual
+//!
+//! Everything that *binds* — lambda parameters, function and constructor
+//! parameters, local `val`s — carries a [`BindingId`] and is referenced through
+//! [`KtExpr::Local`]. [`KtName`] is a **free-name** set only: classes, members,
+//! type references. That split is the whole point: an expression referencing
+//! `Name("x")` inserted under a lambda that prints `x` would be captured, and
+//! deciding which textual `x` belongs to which binder is exactly the reasoning
+//! `replace_ident` gets wrong.
+//!
+//! Naming is renderer-controlled only for [`Spelling::Fresh`]. A function or
+//! constructor parameter is [`Spelling::Fixed`]: those names are Kotlin's
+//! named-argument surface, callable from user code, and renaming one would
+//! silently break every `foo(bar = …)` call site.
+//!
+//! # Grafting alpha-remaps
+//!
+//! [`BindingId`]s are allocated per [`ExprArena`] starting at zero, so two
+//! independently built trees **do** collide — and [`ExprArena::graft`] remaps
+//! the incoming tree's ids as it copies them in.
+//!
+//! That allocation scheme is deliberate. Globally-generative ids would make
+//! collision impossible by construction, which sounds safer but leaves the
+//! remap unexercised and unfalsifiable: the test that proves grafting cannot
+//! capture would pass whether or not the remap existed. Making collisions the
+//! normal case makes the remap load-bearing.
+
+// This tier lands before its consumers: Stage 3 (#193) rewrites the emitters
+// that produce plan-carried expressions, and #199 migrates the rest. Until
+// then the AST is exercised by its own tests and by nothing else — the same gap
+// `SumSpec` and Tier 0 carry, and it closes with the first emitter that builds
+// a tree instead of a string.
+#![allow(dead_code)]
+
+use std::collections::{BTreeSet, HashMap};
+
+use super::types::KtType;
+
+/// Identity of a binder within one [`ExprArena`].
+///
+/// Never compared across arenas — [`ExprArena::graft`] remaps rather than
+/// trusting that two arenas agree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BindingId(u32);
+
+impl BindingId {
+    /// The raw index, for diagnostics and test assertions.
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// How a binder is spelled in the rendered source.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Spelling {
+    /// **Public API**: function and constructor parameter names, which are
+    /// Kotlin's named-argument surface. Preserved byte-identically — the
+    /// renderer may not rename these, and a `Fresh` binder may not shadow one.
+    Fixed(KtName),
+    /// Renderer-allocated: lambda parameters, locals, temporaries. The hint is
+    /// a preference, not a promise.
+    Fresh(NameHint),
+}
+
+/// A preferred base name for a [`Spelling::Fresh`] binder. The renderer appends
+/// a disambiguating suffix when the hint is taken.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NameHint(String);
+
+impl NameHint {
+    /// A hint. Non-identifier characters are dropped rather than rejected — a
+    /// hint is advisory, and the renderer is what guarantees the emitted name
+    /// is legal.
+    pub fn new(s: impl AsRef<str>) -> Self {
+        let cleaned: String = s
+            .as_ref()
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        let cleaned = cleaned.trim_start_matches(|c: char| c.is_ascii_digit());
+        NameHint(if cleaned.is_empty() {
+            "tmp".to_string()
+        } else {
+            cleaned.to_string()
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A binder: its identity plus how it is spelled.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Binder {
+    pub id: BindingId,
+    pub spelling: Spelling,
+}
+
+/// A **free** Kotlin name — a class, member, or type reference. Never a binder;
+/// binders are [`BindingId`]s.
+///
+/// Validated at construction, so a malformed identifier is rejected here rather
+/// than discovered by Gradle. A dotted name is an FQN and registers an import
+/// when rendered, the same way [`KtType`] does.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KtName(String);
+
+/// Why a [`KtName`] was rejected.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KtNameError {
+    pub input: String,
+    pub reason: &'static str,
+}
+
+impl std::fmt::Display for KtNameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid Kotlin name `{}`: {}", self.input, self.reason)
+    }
+}
+
+impl std::error::Error for KtNameError {}
+
+impl KtName {
+    /// Validate and build. Each dot-separated segment must be a Kotlin
+    /// identifier: a letter or `_` followed by letters, digits or `_`.
+    ///
+    /// This is what stops a producer smuggling an expression through a name —
+    /// without it, `Name("a.b() ?: c")` would render as arbitrary source and
+    /// make #199's "no string-built expressions" exit unfalsifiable.
+    pub fn new(s: impl Into<String>) -> Result<Self, KtNameError> {
+        let s = s.into();
+        let reject = |reason| {
+            Err(KtNameError {
+                input: s.clone(),
+                reason,
+            })
+        };
+        if s.is_empty() {
+            return reject("empty");
+        }
+        for seg in s.split('.') {
+            if seg.is_empty() {
+                return reject("empty path segment");
+            }
+            let mut chars = seg.chars();
+            let first = chars.next().expect("segment is non-empty");
+            if !(first.is_ascii_alphabetic() || first == '_') {
+                return reject("segment must start with a letter or `_`");
+            }
+            if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                return reject("segment may only contain letters, digits and `_`");
+            }
+        }
+        Ok(KtName(s))
+    }
+
+    /// Build, panicking on a malformed name. For generator-internal names that
+    /// are structurally guaranteed valid; a malformed one is a generator bug,
+    /// not a user error.
+    pub fn expect(s: impl Into<String>) -> Self {
+        Self::new(s).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this is a dotted FQN (and therefore importable).
+    pub fn is_qualified(&self) -> bool {
+        self.0.contains('.')
+    }
+
+    /// The last segment — what a qualified name renders as once imported.
+    pub fn simple(&self) -> &str {
+        self.0.rsplit('.').next().unwrap_or(&self.0)
+    }
+}
+
+/// A Kotlin literal. Typed, so a string literal is escaped **by the renderer**
+/// rather than pre-escaped by whoever built it.
+#[derive(Clone, Debug, PartialEq)]
+pub enum KtLiteral {
+    Null,
+    Bool(bool),
+    Int(i32),
+    Long(i64),
+    Double(f64),
+    Str(String),
+}
+
+/// A Kotlin expression.
+///
+/// Every variant is structured. The single exception, [`KtExpr::Raw`], is
+/// crate-private and deliberately conspicuous: counting its construction sites
+/// is the mechanical check behind #199's global exit.
+#[derive(Clone, Debug, PartialEq)]
+pub enum KtExpr {
+    /// Reference to a binder introduced in this tree.
+    Local(BindingId),
+    /// A **free** name: class, member, or type reference.
+    Name(KtName),
+    Literal(KtLiteral),
+    /// `recv.name` / `recv?.name`.
+    Field {
+        recv: Box<KtExpr>,
+        name: KtName,
+        safe: bool,
+    },
+    /// `recv.name(args)` / `name(args)` when `recv` is `None`.
+    Call {
+        recv: Option<Box<KtExpr>>,
+        name: KtName,
+        args: Vec<KtExpr>,
+        /// `?.name(…)`.
+        safe: bool,
+        /// A trailing lambda argument, rendered outside the parentheses.
+        trailing_lambda: Option<Box<KtExpr>>,
+    },
+    /// `expr as ty` / `expr as? ty`.
+    As {
+        expr: Box<KtExpr>,
+        ty: KtType,
+        safe: bool,
+    },
+    /// `lhs ?: rhs`.
+    Elvis(Box<KtExpr>, Box<KtExpr>),
+    /// `{ params -> body }`.
+    Lambda {
+        params: Vec<BindingId>,
+        body: Vec<KtStmt>,
+    },
+    /// `when (subject) { arms }`.
+    When {
+        subject: Box<KtExpr>,
+        arms: Vec<(KtPattern, KtExpr)>,
+    },
+    /// The placeholder [`fill_hole`] replaces — the tree operation that
+    /// `kt_access_prefix` + base + `kt_access_tail` was simulating.
+    ///
+    /// Never renders. A tree still containing one is a generator bug, so the
+    /// renderer panics rather than emitting something plausible.
+    Hole,
+    /// TEMPORARY escape hatch. Crate-private, every construction site tracked
+    /// in #199, whose exit deletes this variant.
+    Raw(String),
+}
+
+/// A statement inside a lambda or block body.
+#[derive(Clone, Debug, PartialEq)]
+pub enum KtStmt {
+    /// `val <binder> = <expr>` (or `var`).
+    Let {
+        binder: BindingId,
+        mutable: bool,
+        value: KtExpr,
+    },
+    /// A bare expression statement — and, in final position, a lambda's or
+    /// expression-body's result.
+    Expr(KtExpr),
+    /// `return <expr>` / `return`.
+    Return(Option<KtExpr>),
+}
+
+/// A `when` arm pattern.
+#[derive(Clone, Debug, PartialEq)]
+pub enum KtPattern {
+    /// `is <ty> ->`.
+    Is(KtType),
+    /// A constant: `<expr> ->`.
+    Value(KtExpr),
+    /// `else ->`.
+    Else,
+}
+
+/// Owns the binders of one or more expression trees.
+///
+/// Ids start at zero per arena, so two independently built arenas collide —
+/// see the module docs for why that is the point.
+#[derive(Clone, Debug, Default)]
+pub struct ExprArena {
+    binders: Vec<Binder>,
+}
+
+impl ExprArena {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A binder whose spelling is **public API** and must survive rendering
+    /// byte-identically: a function or constructor parameter.
+    pub fn bind_fixed(&mut self, name: KtName) -> BindingId {
+        self.push(Spelling::Fixed(name))
+    }
+
+    /// A binder the renderer may name: a lambda parameter, a local, a
+    /// temporary.
+    pub fn bind_fresh(&mut self, hint: impl AsRef<str>) -> BindingId {
+        self.push(Spelling::Fresh(NameHint::new(hint)))
+    }
+
+    fn push(&mut self, spelling: Spelling) -> BindingId {
+        let id = BindingId(self.binders.len() as u32);
+        self.binders.push(Binder { id, spelling });
+        id
+    }
+
+    /// The binder behind an id.
+    pub fn binder(&self, id: BindingId) -> &Binder {
+        &self.binders[id.0 as usize]
+    }
+
+    /// Number of binders — the count a remap test compares against.
+    pub fn len(&self) -> usize {
+        self.binders.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.binders.is_empty()
+    }
+
+    /// Copy a tree built in `from` into this arena, **alpha-remapping** every
+    /// binder it introduces and every reference to one.
+    ///
+    /// Without this, grafting two trees that each allocated `BindingId(0)`
+    /// would silently merge two unrelated binders — structural capture that
+    /// scope-aware *rendering* cannot detect, because at render time the two
+    /// are indistinguishable.
+    ///
+    /// A `Local` referring to a binder the incoming tree does not itself
+    /// introduce is a dangling reference and is rejected: it can only mean the
+    /// tree was built against a scope that is not being grafted with it.
+    pub fn graft(&mut self, from: &ExprArena, expr: &KtExpr) -> KtExpr {
+        let mut map = HashMap::new();
+        // Introduce first, so a `Local` appearing before its binder in
+        // traversal order (a lambda body referring to its own parameter) still
+        // resolves.
+        self.remap_introductions(from, expr, &mut map);
+        self.rewrite_ids(expr, &map)
+    }
+
+    /// Allocate a fresh id in `self` for every binder `expr` introduces.
+    fn remap_introductions(
+        &mut self,
+        from: &ExprArena,
+        expr: &KtExpr,
+        map: &mut HashMap<BindingId, BindingId>,
+    ) {
+        match expr {
+            KtExpr::Lambda { params, body } => {
+                for p in params {
+                    let fresh = self.push(from.binder(*p).spelling.clone());
+                    map.insert(*p, fresh);
+                }
+                for s in body {
+                    self.remap_stmt_introductions(from, s, map);
+                }
+            }
+            KtExpr::Field { recv, .. } => self.remap_introductions(from, recv, map),
+            KtExpr::Call {
+                recv,
+                args,
+                trailing_lambda,
+                ..
+            } => {
+                if let Some(r) = recv {
+                    self.remap_introductions(from, r, map);
+                }
+                for a in args {
+                    self.remap_introductions(from, a, map);
+                }
+                if let Some(l) = trailing_lambda {
+                    self.remap_introductions(from, l, map);
+                }
+            }
+            KtExpr::As { expr, .. } => self.remap_introductions(from, expr, map),
+            KtExpr::Elvis(a, b) => {
+                self.remap_introductions(from, a, map);
+                self.remap_introductions(from, b, map);
+            }
+            KtExpr::When { subject, arms } => {
+                self.remap_introductions(from, subject, map);
+                for (p, e) in arms {
+                    if let KtPattern::Value(v) = p {
+                        self.remap_introductions(from, v, map);
+                    }
+                    self.remap_introductions(from, e, map);
+                }
+            }
+            KtExpr::Local(_)
+            | KtExpr::Name(_)
+            | KtExpr::Literal(_)
+            | KtExpr::Hole
+            | KtExpr::Raw(_) => {}
+        }
+    }
+
+    fn remap_stmt_introductions(
+        &mut self,
+        from: &ExprArena,
+        stmt: &KtStmt,
+        map: &mut HashMap<BindingId, BindingId>,
+    ) {
+        match stmt {
+            KtStmt::Let { binder, value, .. } => {
+                self.remap_introductions(from, value, map);
+                let fresh = self.push(from.binder(*binder).spelling.clone());
+                map.insert(*binder, fresh);
+            }
+            KtStmt::Expr(e) => self.remap_introductions(from, e, map),
+            KtStmt::Return(Some(e)) => self.remap_introductions(from, e, map),
+            KtStmt::Return(None) => {}
+        }
+    }
+
+    /// Rewrite **both** references and binding positions.
+    ///
+    /// `map_expr` alone is not enough: it rewrites `Local`s but copies a
+    /// `Lambda`'s `params` and a `Let`'s `binder` through unchanged, which
+    /// would leave the incoming tree binding the host's ids — precisely the
+    /// capture the remap exists to prevent.
+    fn rewrite_ids(&self, expr: &KtExpr, map: &HashMap<BindingId, BindingId>) -> KtExpr {
+        let lookup = |id: &BindingId| {
+            *map.get(id).unwrap_or_else(|| {
+                panic!(
+                    "ExprArena::graft: `Local({})` refers to a binder the grafted tree does not \
+                     introduce — it was built against a scope that is not being grafted with it",
+                    id.0
+                )
+            })
+        };
+        match expr {
+            KtExpr::Local(id) => KtExpr::Local(lookup(id)),
+            KtExpr::Name(_) | KtExpr::Literal(_) | KtExpr::Hole | KtExpr::Raw(_) => expr.clone(),
+            KtExpr::Field { recv, name, safe } => KtExpr::Field {
+                recv: Box::new(self.rewrite_ids(recv, map)),
+                name: name.clone(),
+                safe: *safe,
+            },
+            KtExpr::Call {
+                recv,
+                name,
+                args,
+                safe,
+                trailing_lambda,
+            } => KtExpr::Call {
+                recv: recv.as_ref().map(|r| Box::new(self.rewrite_ids(r, map))),
+                name: name.clone(),
+                args: args.iter().map(|a| self.rewrite_ids(a, map)).collect(),
+                safe: *safe,
+                trailing_lambda: trailing_lambda
+                    .as_ref()
+                    .map(|l| Box::new(self.rewrite_ids(l, map))),
+            },
+            KtExpr::As { expr, ty, safe } => KtExpr::As {
+                expr: Box::new(self.rewrite_ids(expr, map)),
+                ty: ty.clone(),
+                safe: *safe,
+            },
+            KtExpr::Elvis(a, b) => KtExpr::Elvis(
+                Box::new(self.rewrite_ids(a, map)),
+                Box::new(self.rewrite_ids(b, map)),
+            ),
+            KtExpr::Lambda { params, body } => KtExpr::Lambda {
+                params: params.iter().map(lookup).collect(),
+                body: body.iter().map(|s| self.rewrite_stmt_ids(s, map)).collect(),
+            },
+            KtExpr::When { subject, arms } => KtExpr::When {
+                subject: Box::new(self.rewrite_ids(subject, map)),
+                arms: arms
+                    .iter()
+                    .map(|(p, e)| {
+                        let p = match p {
+                            KtPattern::Value(v) => KtPattern::Value(self.rewrite_ids(v, map)),
+                            other => other.clone(),
+                        };
+                        (p, self.rewrite_ids(e, map))
+                    })
+                    .collect(),
+            },
+        }
+    }
+
+    fn rewrite_stmt_ids(&self, stmt: &KtStmt, map: &HashMap<BindingId, BindingId>) -> KtStmt {
+        match stmt {
+            KtStmt::Let {
+                binder,
+                mutable,
+                value,
+            } => KtStmt::Let {
+                binder: *map
+                    .get(binder)
+                    .expect("a Let's binder is introduced by its own tree"),
+                mutable: *mutable,
+                value: self.rewrite_ids(value, map),
+            },
+            KtStmt::Expr(e) => KtStmt::Expr(self.rewrite_ids(e, map)),
+            KtStmt::Return(e) => KtStmt::Return(e.as_ref().map(|e| self.rewrite_ids(e, map))),
+        }
+    }
+}
+
+/// Rewrite a tree bottom-up, replacing any node `f` answers `Some` for.
+///
+/// The one traversal every tree operation goes through, so a variant added
+/// later cannot be silently skipped by half of them.
+pub fn map_expr(expr: &KtExpr, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> KtExpr {
+    if let Some(replacement) = f(expr) {
+        return replacement;
+    }
+    match expr {
+        KtExpr::Local(_) | KtExpr::Name(_) | KtExpr::Literal(_) | KtExpr::Hole | KtExpr::Raw(_) => {
+            expr.clone()
+        }
+        KtExpr::Field { recv, name, safe } => KtExpr::Field {
+            recv: Box::new(map_expr(recv, f)),
+            name: name.clone(),
+            safe: *safe,
+        },
+        KtExpr::Call {
+            recv,
+            name,
+            args,
+            safe,
+            trailing_lambda,
+        } => KtExpr::Call {
+            recv: recv.as_ref().map(|r| Box::new(map_expr(r, f))),
+            name: name.clone(),
+            args: args.iter().map(|a| map_expr(a, f)).collect(),
+            safe: *safe,
+            trailing_lambda: trailing_lambda.as_ref().map(|l| Box::new(map_expr(l, f))),
+        },
+        KtExpr::As { expr, ty, safe } => KtExpr::As {
+            expr: Box::new(map_expr(expr, f)),
+            ty: ty.clone(),
+            safe: *safe,
+        },
+        KtExpr::Elvis(a, b) => KtExpr::Elvis(Box::new(map_expr(a, f)), Box::new(map_expr(b, f))),
+        KtExpr::Lambda { params, body } => KtExpr::Lambda {
+            params: params.clone(),
+            body: body.iter().map(|s| map_stmt(s, f)).collect(),
+        },
+        KtExpr::When { subject, arms } => KtExpr::When {
+            subject: Box::new(map_expr(subject, f)),
+            arms: arms
+                .iter()
+                .map(|(p, e)| {
+                    let p = match p {
+                        KtPattern::Value(v) => KtPattern::Value(map_expr(v, f)),
+                        other => other.clone(),
+                    };
+                    (p, map_expr(e, f))
+                })
+                .collect(),
+        },
+    }
+}
+
+/// [`map_expr`] over a statement.
+pub fn map_stmt(stmt: &KtStmt, f: &mut dyn FnMut(&KtExpr) -> Option<KtExpr>) -> KtStmt {
+    match stmt {
+        KtStmt::Let {
+            binder,
+            mutable,
+            value,
+        } => KtStmt::Let {
+            binder: *binder,
+            mutable: *mutable,
+            value: map_expr(value, f),
+        },
+        KtStmt::Expr(e) => KtStmt::Expr(map_expr(e, f)),
+        KtStmt::Return(e) => KtStmt::Return(e.as_ref().map(|e| map_expr(e, f))),
+    }
+}
+
+/// Fill every [`KtExpr::Hole`] in `template` with `value`.
+///
+/// This is the tree operation the `kt_access_prefix` + base + `kt_access_tail`
+/// triple was simulating: a template with the base in the middle
+/// (`(<base>.field as? Reading.Exact)?.v0 ?: 0L`) is just a tree with a hole,
+/// and filling it is a rewrite rather than three string concatenations that
+/// each have to remember the other two.
+pub fn fill_hole(template: &KtExpr, value: &KtExpr) -> KtExpr {
+    map_expr(template, &mut |e| match e {
+        KtExpr::Hole => Some(value.clone()),
+        _ => None,
+    })
+}
+
+/// Whether a tree still contains an unfilled [`KtExpr::Hole`].
+pub fn has_hole(expr: &KtExpr) -> bool {
+    let mut found = false;
+    map_expr(expr, &mut |e| {
+        if matches!(e, KtExpr::Hole) {
+            found = true;
+        }
+        None
+    });
+    found
+}
+
+/// Replace every `Local(target)` in `expr` with `value`.
+///
+/// The replacement for `replace_ident`. Capture is structurally impossible: a
+/// reference is a [`BindingId`], not a spelling, so inserting a tree under a
+/// binder that happens to *print* the same name cannot rebind it — the renderer
+/// allocates the printed names afterwards, and it knows which id each one
+/// belongs to.
+pub fn substitute(expr: &KtExpr, target: BindingId, value: &KtExpr) -> KtExpr {
+    map_expr(expr, &mut |e| match e {
+        KtExpr::Local(id) if *id == target => Some(value.clone()),
+        _ => None,
+    })
+}
+
+/// Every free [`KtName`] reachable in a tree.
+///
+/// Two uses: the import set a rendered unit reports, and the reservation the
+/// renderer makes before allocating printable names — a machine-allocated
+/// binder may not shadow a name the tree references.
+pub fn free_names(expr: &KtExpr) -> BTreeSet<KtName> {
+    let mut out = BTreeSet::new();
+    map_expr(expr, &mut |e| {
+        match e {
+            KtExpr::Name(n) => {
+                out.insert(n.clone());
+            }
+            KtExpr::Field { name, .. } | KtExpr::Call { name, .. } => {
+                out.insert(name.clone());
+            }
+            _ => {}
+        }
+        None
+    });
+    out
+}
+
+// ── convenience constructors ────────────────────────────────────────────
+//
+// Every one of these builds a structured node; none of them accepts free-form
+// expression text. That is what makes #199's exit checkable: the only way to
+// get a string into a tree is `KtExpr::Raw`, and its construction sites are
+// counted.
+
+impl KtExpr {
+    pub fn local(id: BindingId) -> Self {
+        KtExpr::Local(id)
+    }
+    pub fn name(n: impl Into<String>) -> Self {
+        KtExpr::Name(KtName::expect(n))
+    }
+    pub fn null() -> Self {
+        KtExpr::Literal(KtLiteral::Null)
+    }
+    pub fn bool_(v: bool) -> Self {
+        KtExpr::Literal(KtLiteral::Bool(v))
+    }
+    pub fn int(v: i32) -> Self {
+        KtExpr::Literal(KtLiteral::Int(v))
+    }
+    pub fn long(v: i64) -> Self {
+        KtExpr::Literal(KtLiteral::Long(v))
+    }
+    pub fn str_(v: impl Into<String>) -> Self {
+        KtExpr::Literal(KtLiteral::Str(v.into()))
+    }
+    /// `self.name`.
+    pub fn field(self, name: impl Into<String>) -> Self {
+        KtExpr::Field {
+            recv: Box::new(self),
+            name: KtName::expect(name),
+            safe: false,
+        }
+    }
+    /// `self?.name`.
+    pub fn safe_field(self, name: impl Into<String>) -> Self {
+        KtExpr::Field {
+            recv: Box::new(self),
+            name: KtName::expect(name),
+            safe: true,
+        }
+    }
+    /// `self.name(args)`.
+    pub fn call(self, name: impl Into<String>, args: impl IntoIterator<Item = KtExpr>) -> Self {
+        KtExpr::Call {
+            recv: Some(Box::new(self)),
+            name: KtName::expect(name),
+            args: args.into_iter().collect(),
+            safe: false,
+            trailing_lambda: None,
+        }
+    }
+    /// `self?.name(args)`.
+    pub fn safe_call(
+        self,
+        name: impl Into<String>,
+        args: impl IntoIterator<Item = KtExpr>,
+    ) -> Self {
+        KtExpr::Call {
+            recv: Some(Box::new(self)),
+            name: KtName::expect(name),
+            args: args.into_iter().collect(),
+            safe: true,
+            trailing_lambda: None,
+        }
+    }
+    /// `name(args)` — an unqualified call.
+    pub fn free_call(name: impl Into<String>, args: impl IntoIterator<Item = KtExpr>) -> Self {
+        KtExpr::Call {
+            recv: None,
+            name: KtName::expect(name),
+            args: args.into_iter().collect(),
+            safe: false,
+            trailing_lambda: None,
+        }
+    }
+    /// Attach a trailing lambda: `f(a) { … }`.
+    pub fn with_trailing_lambda(mut self, lambda: KtExpr) -> Self {
+        match &mut self {
+            KtExpr::Call {
+                trailing_lambda, ..
+            } => *trailing_lambda = Some(Box::new(lambda)),
+            other => panic!("a trailing lambda needs a call, got {other:?}"),
+        }
+        self
+    }
+    /// `self as ty`.
+    pub fn cast(self, ty: KtType) -> Self {
+        KtExpr::As {
+            expr: Box::new(self),
+            ty,
+            safe: false,
+        }
+    }
+    /// `self as? ty`.
+    pub fn safe_cast(self, ty: KtType) -> Self {
+        KtExpr::As {
+            expr: Box::new(self),
+            ty,
+            safe: true,
+        }
+    }
+    /// `self ?: other`.
+    pub fn elvis(self, other: KtExpr) -> Self {
+        KtExpr::Elvis(Box::new(self), Box::new(other))
+    }
+    /// `{ params -> body }`.
+    pub fn lambda(params: impl IntoIterator<Item = BindingId>, body: Vec<KtStmt>) -> Self {
+        KtExpr::Lambda {
+            params: params.into_iter().collect(),
+            body,
+        }
+    }
+    /// A single-expression lambda body.
+    pub fn lambda1(params: impl IntoIterator<Item = BindingId>, body: KtExpr) -> Self {
+        Self::lambda(params, vec![KtStmt::Expr(body)])
+    }
+}
+
+pub mod render;
+
+#[cfg(test)]
+mod tests;

--- a/prebindgen/src/api/gen/kotlin/expr/render.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/render.rs
@@ -18,8 +18,8 @@
 use std::collections::HashSet;
 
 use super::{
-    super::types::ImportSet, free_names, BindingId, ExprArena, KtExpr, KtLiteral, KtName,
-    KtPattern, KtStmt, Spelling,
+    super::types::ImportSet, free_names, is_hard_keyword, BindingId, ExprArena, KtExpr, KtLiteral,
+    KtName, KtPattern, KtStmt, Spelling,
 };
 
 /// Binding strength of an expression, high binds tighter. Only the operators
@@ -45,7 +45,7 @@ fn prec(e: &KtExpr) -> Prec {
         // A `when` and a lambda are brace-delimited, so they are self-bracketing
         // in every position we emit them.
         KtExpr::Lambda { .. } | KtExpr::When { .. } => Prec::Atom,
-        KtExpr::Local(_) | KtExpr::Name(_) | KtExpr::Literal(_) => Prec::Atom,
+        KtExpr::Local(_) | KtExpr::Name(_) | KtExpr::This | KtExpr::Literal(_) => Prec::Atom,
         KtExpr::Hole | KtExpr::Raw(_) => Prec::Atom,
     }
 }
@@ -106,9 +106,15 @@ impl<'a> Scope<'a> {
         }
     }
 
-    /// `hint`, else `hint2`, `hint3`, … — the first spelling not already taken.
+    /// `hint`, else `hint2`, `hint3`, … — the first spelling that is neither
+    /// taken nor a Kotlin hard keyword.
+    ///
+    /// A hint is advisory and arrives from a leaf name or a field name, so it
+    /// can easily be `when` or `object`; emitting that bare would be
+    /// uncompilable. Suffixing sidesteps it with no extra machinery — `when`
+    /// becomes `when2`.
     fn allocate(&self, hint: &str) -> String {
-        if !self.taken.contains(hint) {
+        if !self.taken.contains(hint) && !is_hard_keyword(hint) {
             return hint.to_string();
         }
         (2..)
@@ -132,15 +138,39 @@ impl<'a> Scope<'a> {
     }
 }
 
-/// Render `expr` to Kotlin source, registering the FQNs it references in
-/// `imports`.
+/// Render `expr` with no enclosing binders.
 pub fn render_expr(arena: &ExprArena, expr: &KtExpr, imports: &mut ImportSet) -> String {
-    let mut scope = Scope::new(arena, expr);
-    write_expr(expr, &mut scope, imports, Prec::Elvis)
+    render_expr_in_scope(arena, &[], expr, imports)
 }
 
-/// Render a statement list as a block body's lines.
-pub fn render_stmts(arena: &ExprArena, stmts: &[KtStmt], imports: &mut ImportSet) -> Vec<String> {
+/// Render `expr` with `outer` already bound — the enclosing declaration's
+/// parameters.
+///
+/// This is what lets a typed function body, default, supertype argument or
+/// accessor reference its own parameter through `Local`. Without it every slot
+/// would render in a fresh scope and such a reference would be unbound;
+/// reaching for `Name("initialPtr")` instead would put a binder back into the
+/// free-name set and restore the textual capture risk `BindingId` removes.
+pub fn render_expr_in_scope(
+    arena: &ExprArena,
+    outer: &[BindingId],
+    expr: &KtExpr,
+    imports: &mut ImportSet,
+) -> String {
+    let mut scope = Scope::new(arena, expr);
+    scope.push(outer);
+    let out = write_expr(expr, &mut scope, imports, Prec::Elvis);
+    scope.pop();
+    out
+}
+
+/// Render a statement list as a block body's lines, with `outer` already bound.
+pub fn render_stmts(
+    arena: &ExprArena,
+    outer: &[BindingId],
+    stmts: &[KtStmt],
+    imports: &mut ImportSet,
+) -> Vec<String> {
     // Reserve against every statement, not just the first: a name free in one
     // and taken in another must be avoided in both.
     let mut scope = Scope::new(
@@ -150,7 +180,7 @@ pub fn render_stmts(arena: &ExprArena, stmts: &[KtStmt], imports: &mut ImportSet
             body: stmts.to_vec(),
         },
     );
-    scope.push(&[]);
+    scope.push(outer);
     let out = write_stmts(stmts, &mut scope, imports);
     scope.pop();
     out
@@ -170,6 +200,7 @@ fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String 
     match e {
         KtExpr::Local(id) => scope.lookup(*id).to_string(),
         KtExpr::Name(n) => render_name(n, imports),
+        KtExpr::This => "this".to_string(),
         KtExpr::Literal(l) => render_literal(l),
         KtExpr::Field { recv, name, safe } => {
             let r = write_expr(recv, scope, imports, Prec::Postfix);
@@ -306,11 +337,24 @@ fn render_literal(l: &KtLiteral) -> String {
     match l {
         KtLiteral::Null => "null".to_string(),
         KtLiteral::Bool(b) => b.to_string(),
+        // `-2147483648` / `-9223372036854775808` do not round-trip: Kotlin
+        // parses them as unary minus applied to a *positive* literal that is
+        // one past the type's maximum, and rejects them as out of range. The
+        // named constants are the only spellings that carry the value.
+        KtLiteral::Int(v) if *v == i32::MIN => "Int.MIN_VALUE".to_string(),
         KtLiteral::Int(v) => v.to_string(),
+        KtLiteral::Long(v) if *v == i64::MIN => "Long.MIN_VALUE".to_string(),
         KtLiteral::Long(v) => format!("{v}L"),
+        // Rust prints these as `NaN` / `inf` / `-inf`, none of which Kotlin
+        // accepts as a literal.
+        KtLiteral::Double(v) if v.is_nan() => "Double.NaN".to_string(),
+        KtLiteral::Double(v) if v.is_infinite() && *v > 0.0 => {
+            "Double.POSITIVE_INFINITY".to_string()
+        }
+        KtLiteral::Double(v) if v.is_infinite() => "Double.NEGATIVE_INFINITY".to_string(),
         KtLiteral::Double(v) => {
             // Kotlin needs a decimal point to infer `Double`.
-            if v.fract() == 0.0 && v.is_finite() {
+            if v.fract() == 0.0 {
                 format!("{v:.1}")
             } else {
                 v.to_string()

--- a/prebindgen/src/api/gen/kotlin/expr/render.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/render.rs
@@ -249,6 +249,39 @@ pub fn render_stmts_named(
     (names, out)
 }
 
+/// Render a **vector** of expressions through **one** scope.
+///
+/// Not a loop over [`render_expr_in_scope`]: each of those builds a fresh
+/// `Scope`, so its `introduced` set starts empty and the sibling duplication the
+/// whole-render check exists to catch — one `BindingId` bound in two of the
+/// vector's roots — slips through. Argument lists are exactly where sibling
+/// lambdas appear, so this is the position the check most needed to cover.
+///
+/// Free names are reserved from the entire vector for the same reason: a name
+/// referenced in one element must be avoided by binders allocated in another,
+/// since they share the rendered scope.
+pub fn render_exprs_in_scope(
+    arena: &ExprArena,
+    outer: &[BindingId],
+    exprs: &[KtExpr],
+    imports: &mut ImportSet,
+) -> Vec<String> {
+    // One synthetic root so `Scope::new` sees every element's free names, the
+    // same trick `render_stmts` uses.
+    let all = KtExpr::Lambda(KtLambda::new(
+        [],
+        exprs.iter().cloned().map(KtStmt::Expr).collect(),
+    ));
+    let mut scope = Scope::new(arena, &all);
+    scope.push(outer);
+    let out = exprs
+        .iter()
+        .map(|e| write_expr(e, &mut scope, imports, Prec::Elvis))
+        .collect();
+    scope.pop();
+    out
+}
+
 /// Render a statement list as a block body's lines, with `outer` already bound.
 pub fn render_stmts(
     arena: &ExprArena,

--- a/prebindgen/src/api/gen/kotlin/expr/render.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/render.rs
@@ -15,7 +15,7 @@
 //!   could drift. Here a rendered unit reports what it needs, because the
 //!   names are in the tree.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use super::{
     super::types::ImportSet, free_names, is_hard_keyword, BindingId, ExprArena, KtExpr, KtLiteral,
@@ -56,9 +56,17 @@ struct Scope<'a> {
     arena: &'a ExprArena,
     /// Printed name per binder, innermost last.
     frames: Vec<Vec<(BindingId, String)>>,
-    /// Every name currently unavailable: the free names reserved up front plus
-    /// every live binder's printed name.
-    taken: HashSet<String>,
+    /// How many times each spelling is currently claimed — **counted**, not a
+    /// set.
+    ///
+    /// A set conflates two different claims on one name. The free-name
+    /// reservations made in [`Self::new`] are permanent for the whole render,
+    /// while a binder's claim lasts only until its frame pops. With a set, a
+    /// `Fixed` binder that happens to share a free name's spelling inserts a
+    /// no-op and then *removes the reservation* when it pops — after which a
+    /// later `Fresh` binder is free to allocate that spelling and capture the
+    /// free reference. Counting keeps the two claims independent.
+    taken: HashMap<String, usize>,
 }
 
 impl<'a> Scope<'a> {
@@ -69,11 +77,12 @@ impl<'a> Scope<'a> {
     /// refers to — the same capture the `BindingId` scheme prevents for
     /// binders, arriving through the one position `BindingId`s do not cover.
     fn new(arena: &'a ExprArena, root: &KtExpr) -> Self {
-        let mut taken = HashSet::new();
+        let mut taken: HashMap<String, usize> = HashMap::new();
         for n in free_names(root) {
             // A qualified name renders as its last segment once imported, so
-            // that is the spelling a binder could collide with.
-            taken.insert(n.simple().to_string());
+            // that is the spelling a binder could collide with. These claims
+            // are never released.
+            *taken.entry(n.simple().to_string()).or_default() += 1;
         }
         Self {
             arena,
@@ -92,7 +101,7 @@ impl<'a> Scope<'a> {
                 Spelling::Fixed(n) => n.as_str().to_string(),
                 Spelling::Fresh(hint) => self.allocate(hint.as_str()),
             };
-            self.taken.insert(name.clone());
+            *self.taken.entry(name.clone()).or_default() += 1;
             frame.push((*id, name));
         }
         self.frames.push(frame);
@@ -101,9 +110,26 @@ impl<'a> Scope<'a> {
     fn pop(&mut self) {
         if let Some(frame) = self.frames.pop() {
             for (_, name) in frame {
-                self.taken.remove(&name);
+                if let Some(count) = self.taken.get_mut(&name) {
+                    *count -= 1;
+                    if *count == 0 {
+                        self.taken.remove(&name);
+                    }
+                }
             }
         }
+    }
+
+    fn is_taken(&self, name: &str) -> bool {
+        self.taken.contains_key(name)
+    }
+
+    /// Whether a **live binder** currently prints as `simple`.
+    ///
+    /// Distinct from [`Self::is_taken`], which also counts the permanent
+    /// free-name reservations: a reserved-but-unbound name shadows nothing.
+    fn live_binder_named(&self, simple: &str) -> bool {
+        self.frames.iter().flatten().any(|(_, name)| name == simple)
     }
 
     /// `hint`, else `hint2`, `hint3`, … — the first spelling that is neither
@@ -114,12 +140,12 @@ impl<'a> Scope<'a> {
     /// uncompilable. Suffixing sidesteps it with no extra machinery — `when`
     /// becomes `when2`.
     fn allocate(&self, hint: &str) -> String {
-        if !self.taken.contains(hint) && !is_hard_keyword(hint) {
+        if !self.is_taken(hint) && !is_hard_keyword(hint) {
             return hint.to_string();
         }
         (2..)
             .map(|i| format!("{hint}{i}"))
-            .find(|c| !self.taken.contains(c))
+            .find(|c| !self.is_taken(c) && !is_hard_keyword(c))
             .expect("an unbounded sequence always yields a free name")
     }
 
@@ -241,7 +267,7 @@ fn write_expr(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet, needed: Pr
 fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String {
     match e {
         KtExpr::Local(id) => scope.lookup(*id).to_string(),
-        KtExpr::Name(n) => render_name(n, imports),
+        KtExpr::Name(n) => render_name(n, scope, imports),
         KtExpr::This => "this".to_string(),
         KtExpr::Literal(l) => render_literal(l),
         KtExpr::Field { recv, name, safe } => {
@@ -266,7 +292,7 @@ fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String 
                 }
                 // An unqualified call names a free function, which may be
                 // imported like a class.
-                None => render_name(name, imports),
+                None => render_name(name, scope, imports),
             };
             let mut out = format!("{head}({})", rendered_args.join(", "));
             if let Some(l) = trailing_lambda {
@@ -367,7 +393,37 @@ fn write_stmts(stmts: &[KtStmt], scope: &mut Scope, imports: &mut ImportSet) -> 
 /// A qualified name registers an import and renders short; a bare one renders
 /// verbatim. Same rule [`super::super::types::KtType`] follows, so a class
 /// referenced from a type and from an expression agree on their import.
-fn render_name(n: &KtName, imports: &mut ImportSet) -> String {
+///
+/// **Unless a live binder already prints as that short name.** Shortening
+/// `io.example.config` to `config` inside `{ config -> … }` silently turns a
+/// qualified free reference into the parameter — capture through the one
+/// position `BindingId`s do not cover, arriving via the import set rather than
+/// via the scope.
+///
+/// A `Fresh` binder can never cause this: [`Scope::allocate`] avoids every
+/// reserved free name. Only a `Fixed` binder can, because its spelling is
+/// verbatim public API and is not the renderer's to move — so:
+///
+/// - a **qualified** name stays fully qualified, which reads correctly whatever
+///   is in scope;
+/// - a **bare** name is rejected, because there is nothing left to disambiguate
+///   with: the free reference and the binder are the same token, and the only
+///   fix would be renaming a `Fixed` binder that callers name in arguments.
+fn render_name(n: &KtName, scope: &Scope, imports: &mut ImportSet) -> String {
+    if scope.live_binder_named(n.simple()) {
+        if n.is_qualified() {
+            // Deliberately not `imports.short`: the whole point is to *not*
+            // collapse onto the shadowed spelling.
+            return n.as_str().to_string();
+        }
+        panic!(
+            "free name `{}` is shadowed by a binder printed the same way — a bare free name and \
+             a `Fixed` binder cannot be told apart in the output, and renaming the binder would \
+             change a named-argument surface. Qualify the reference, or rename the binder at its \
+             declaration.",
+            n.as_str()
+        );
+    }
     if n.is_qualified() {
         imports.short(n.as_str())
     } else {

--- a/prebindgen/src/api/gen/kotlin/expr/render.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/render.rs
@@ -18,8 +18,8 @@
 use std::collections::HashMap;
 
 use super::{
-    super::types::ImportSet, free_names, is_hard_keyword, BindingId, ExprArena, KtExpr, KtLiteral,
-    KtName, KtPattern, KtStmt, Spelling,
+    super::types::ImportSet, free_names, is_hard_keyword, BindingId, ExprArena, KtExpr, KtLambda,
+    KtLiteral, KtName, KtPattern, KtStmt, Spelling,
 };
 
 /// Binding strength of an expression, high binds tighter. Only the operators
@@ -67,6 +67,20 @@ struct Scope<'a> {
     /// later `Fresh` binder is free to allocate that spelling and capture the
     /// free reference. Counting keeps the two claims independent.
     taken: HashMap<String, usize>,
+    /// Every `BindingId` this render has already introduced, **never cleared**.
+    ///
+    /// One `BindingId` is one binding site. Reusing it in two places —
+    /// `lambda1([b], lambda1([b], local(b)))`, two lambda parameters, or two
+    /// sequential `Let`s — gives one structural identity two binding sites, and
+    /// `Local(b)` then changes referent purely because `lookup` walks frames
+    /// innermost-first. It also silently breaks `substitute`, which would
+    /// rewrite both.
+    ///
+    /// Checked across the whole render rather than only against live frames:
+    /// two *sibling* scopes reusing an id never overlap, so `lookup` stays
+    /// unambiguous, but the identity is still duplicated and substitution is
+    /// still wrong.
+    introduced: std::collections::HashSet<BindingId>,
 }
 
 impl<'a> Scope<'a> {
@@ -88,12 +102,21 @@ impl<'a> Scope<'a> {
             arena,
             frames: Vec::new(),
             taken,
+            introduced: std::collections::HashSet::new(),
         }
     }
 
     fn push(&mut self, binders: &[BindingId]) {
         let mut frame = Vec::new();
         for id in binders {
+            assert!(
+                self.introduced.insert(*id),
+                "BindingId({}) is introduced twice in one tree — one binder identity cannot have \
+                 two binding sites: `Local` would change referent by nesting depth, and \
+                 `substitute` would rewrite both. Allocate a second binder, or graft the \
+                 duplicated subtree into fresh ids.",
+                id.index()
+            );
             let name = match &self.arena.binder(*id).spelling {
                 // Public API: preserved byte-identically. A `Fixed` name is
                 // *claimed*, never renamed, so a later `Fresh` binder avoids it
@@ -218,13 +241,7 @@ pub fn render_stmts_named(
     stmts: &[KtStmt],
     imports: &mut ImportSet,
 ) -> (Vec<String>, Vec<String>) {
-    let mut scope = Scope::new(
-        arena,
-        &KtExpr::Lambda {
-            params: Vec::new(),
-            body: stmts.to_vec(),
-        },
-    );
+    let mut scope = Scope::new(arena, &KtExpr::Lambda(KtLambda::new([], stmts.to_vec())));
     scope.push(outer);
     let names = outer.iter().map(|b| scope.lookup(*b).to_string()).collect();
     let out = write_stmts(stmts, &mut scope, imports);
@@ -241,13 +258,7 @@ pub fn render_stmts(
 ) -> Vec<String> {
     // Reserve against every statement, not just the first: a name free in one
     // and taken in another must be avoided in both.
-    let mut scope = Scope::new(
-        arena,
-        &KtExpr::Lambda {
-            params: Vec::new(),
-            body: stmts.to_vec(),
-        },
-    );
+    let mut scope = Scope::new(arena, &KtExpr::Lambda(KtLambda::new([], stmts.to_vec())));
     scope.push(outer);
     let out = write_stmts(stmts, &mut scope, imports);
     scope.pop();
@@ -297,7 +308,7 @@ fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String 
             let mut out = format!("{head}({})", rendered_args.join(", "));
             if let Some(l) = trailing_lambda {
                 out.push(' ');
-                out.push_str(&write_bare(l, scope, imports));
+                out.push_str(&write_lambda(l, scope, imports));
             }
             out
         }
@@ -318,21 +329,7 @@ fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String 
             let rhs = write_expr(b, scope, imports, Prec::Elvis);
             format!("{lhs} ?: {rhs}")
         }
-        KtExpr::Lambda { params, body } => {
-            scope.push(params);
-            let names: Vec<String> = params
-                .iter()
-                .map(|p| scope.lookup(*p).to_string())
-                .collect();
-            let lines = write_stmts(body, scope, imports);
-            scope.pop();
-            let head = if names.is_empty() {
-                String::new()
-            } else {
-                format!("{} -> ", names.join(", "))
-            };
-            format!("{{ {head}{} }}", lines.join("; "))
-        }
+        KtExpr::Lambda(l) => write_lambda(l, scope, imports),
         KtExpr::When { subject, arms } => {
             let subj = write_expr(subject, scope, imports, Prec::Elvis);
             let rendered: Vec<String> = arms
@@ -354,6 +351,24 @@ fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String 
         ),
         KtExpr::Raw(s) => s.clone(),
     }
+}
+
+/// `{ params -> body }`, with the parameters bound for the body only.
+fn write_lambda(l: &KtLambda, scope: &mut Scope, imports: &mut ImportSet) -> String {
+    scope.push(&l.params);
+    let names: Vec<String> = l
+        .params
+        .iter()
+        .map(|p| scope.lookup(*p).to_string())
+        .collect();
+    let lines = write_stmts(&l.body, scope, imports);
+    scope.pop();
+    let head = if names.is_empty() {
+        String::new()
+    } else {
+        format!("{} -> ", names.join(", "))
+    };
+    format!("{{ {head}{} }}", lines.join("; "))
 }
 
 fn write_stmts(stmts: &[KtStmt], scope: &mut Scope, imports: &mut ImportSet) -> Vec<String> {

--- a/prebindgen/src/api/gen/kotlin/expr/render.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/render.rs
@@ -164,6 +164,48 @@ pub fn render_expr_in_scope(
     out
 }
 
+/// Render `expr` with `outer` bound, **also returning the printed name of each
+/// binder in `outer`**.
+///
+/// The renderer allocates those names, so anything that has to *spell* an outer
+/// binder elsewhere — a setter's `set(<param>)` header, say — has to ask the
+/// same allocation rather than guess. Deriving the header independently is how
+/// a signature ends up saying `value` while the body says `value2`.
+pub fn render_expr_in_scope_named(
+    arena: &ExprArena,
+    outer: &[BindingId],
+    expr: &KtExpr,
+    imports: &mut ImportSet,
+) -> (Vec<String>, String) {
+    let mut scope = Scope::new(arena, expr);
+    scope.push(outer);
+    let names = outer.iter().map(|b| scope.lookup(*b).to_string()).collect();
+    let out = write_expr(expr, &mut scope, imports, Prec::Elvis);
+    scope.pop();
+    (names, out)
+}
+
+/// [`render_stmts`], also returning the printed names of `outer`.
+pub fn render_stmts_named(
+    arena: &ExprArena,
+    outer: &[BindingId],
+    stmts: &[KtStmt],
+    imports: &mut ImportSet,
+) -> (Vec<String>, Vec<String>) {
+    let mut scope = Scope::new(
+        arena,
+        &KtExpr::Lambda {
+            params: Vec::new(),
+            body: stmts.to_vec(),
+        },
+    );
+    scope.push(outer);
+    let names = outer.iter().map(|b| scope.lookup(*b).to_string()).collect();
+    let out = write_stmts(stmts, &mut scope, imports);
+    scope.pop();
+    (names, out)
+}
+
 /// Render a statement list as a block body's lines, with `outer` already bound.
 pub fn render_stmts(
     arena: &ExprArena,

--- a/prebindgen/src/api/gen/kotlin/expr/render.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/render.rs
@@ -1,0 +1,339 @@
+//! Rendering [`KtExpr`] to Kotlin source: precedence-correct parenthesization,
+//! scope-tracked name allocation, and import collection from the tree.
+//!
+//! The three things the string-built expressions could not do:
+//!
+//! - **Precedence** was previously the producer's job, so a missing paren was
+//!   a Gradle error at best and a silently-wrong expression at worst. Here it
+//!   is a property of the tree: a child is parenthesized exactly when its
+//!   precedence is lower than its position allows.
+//! - **Names** were hand-numbered (`e0`, `e1`, …) to dodge `it` shadowing —
+//!   scope management by naming convention. Here the renderer allocates, with
+//!   a real scope stack, and a machine-allocated name can collide with neither
+//!   a [`Spelling::Fixed`] name nor any free [`KtName`] the tree references.
+//! - **Imports** were registered by hand alongside the raw text, so the two
+//!   could drift. Here a rendered unit reports what it needs, because the
+//!   names are in the tree.
+
+use std::collections::HashSet;
+
+use super::{
+    super::types::ImportSet, free_names, BindingId, ExprArena, KtExpr, KtLiteral, KtName,
+    KtPattern, KtStmt, Spelling,
+};
+
+/// Binding strength of an expression, high binds tighter. Only the operators
+/// this AST models appear; Kotlin's full table is larger and irrelevant until
+/// a node needs it.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Prec {
+    /// `a ?: b` — the loosest thing we build.
+    Elvis = 1,
+    /// `a as T`, `a as? T`.
+    As = 2,
+    /// `a.b`, `a?.b`, `f(x)` — postfix, binds tightest.
+    Postfix = 3,
+    /// A leaf: never needs parentheses.
+    Atom = 4,
+}
+
+fn prec(e: &KtExpr) -> Prec {
+    match e {
+        KtExpr::Elvis(..) => Prec::Elvis,
+        KtExpr::As { .. } => Prec::As,
+        KtExpr::Field { .. } | KtExpr::Call { .. } => Prec::Postfix,
+        // A `when` and a lambda are brace-delimited, so they are self-bracketing
+        // in every position we emit them.
+        KtExpr::Lambda { .. } | KtExpr::When { .. } => Prec::Atom,
+        KtExpr::Local(_) | KtExpr::Name(_) | KtExpr::Literal(_) => Prec::Atom,
+        KtExpr::Hole | KtExpr::Raw(_) => Prec::Atom,
+    }
+}
+
+/// The renderer's scope stack: which printed name each live binder has, and
+/// which names are taken.
+struct Scope<'a> {
+    arena: &'a ExprArena,
+    /// Printed name per binder, innermost last.
+    frames: Vec<Vec<(BindingId, String)>>,
+    /// Every name currently unavailable: the free names reserved up front plus
+    /// every live binder's printed name.
+    taken: HashSet<String>,
+}
+
+impl<'a> Scope<'a> {
+    /// Reserve every free [`KtName`] the tree references **before** allocating
+    /// any binder name.
+    ///
+    /// Without this a machine-allocated binder could shadow a name the tree
+    /// refers to — the same capture the `BindingId` scheme prevents for
+    /// binders, arriving through the one position `BindingId`s do not cover.
+    fn new(arena: &'a ExprArena, root: &KtExpr) -> Self {
+        let mut taken = HashSet::new();
+        for n in free_names(root) {
+            // A qualified name renders as its last segment once imported, so
+            // that is the spelling a binder could collide with.
+            taken.insert(n.simple().to_string());
+        }
+        Self {
+            arena,
+            frames: Vec::new(),
+            taken,
+        }
+    }
+
+    fn push(&mut self, binders: &[BindingId]) {
+        let mut frame = Vec::new();
+        for id in binders {
+            let name = match &self.arena.binder(*id).spelling {
+                // Public API: preserved byte-identically. A `Fixed` name is
+                // *claimed*, never renamed, so a later `Fresh` binder avoids it
+                // rather than the other way round.
+                Spelling::Fixed(n) => n.as_str().to_string(),
+                Spelling::Fresh(hint) => self.allocate(hint.as_str()),
+            };
+            self.taken.insert(name.clone());
+            frame.push((*id, name));
+        }
+        self.frames.push(frame);
+    }
+
+    fn pop(&mut self) {
+        if let Some(frame) = self.frames.pop() {
+            for (_, name) in frame {
+                self.taken.remove(&name);
+            }
+        }
+    }
+
+    /// `hint`, else `hint2`, `hint3`, … — the first spelling not already taken.
+    fn allocate(&self, hint: &str) -> String {
+        if !self.taken.contains(hint) {
+            return hint.to_string();
+        }
+        (2..)
+            .map(|i| format!("{hint}{i}"))
+            .find(|c| !self.taken.contains(c))
+            .expect("an unbounded sequence always yields a free name")
+    }
+
+    fn lookup(&self, id: BindingId) -> &str {
+        for frame in self.frames.iter().rev() {
+            for (bid, name) in frame {
+                if *bid == id {
+                    return name;
+                }
+            }
+        }
+        panic!(
+            "KtExpr::Local({}) is not in scope — the tree references a binder nothing introduces",
+            id.index()
+        )
+    }
+}
+
+/// Render `expr` to Kotlin source, registering the FQNs it references in
+/// `imports`.
+pub fn render_expr(arena: &ExprArena, expr: &KtExpr, imports: &mut ImportSet) -> String {
+    let mut scope = Scope::new(arena, expr);
+    write_expr(expr, &mut scope, imports, Prec::Elvis)
+}
+
+/// Render a statement list as a block body's lines.
+pub fn render_stmts(arena: &ExprArena, stmts: &[KtStmt], imports: &mut ImportSet) -> Vec<String> {
+    // Reserve against every statement, not just the first: a name free in one
+    // and taken in another must be avoided in both.
+    let mut scope = Scope::new(
+        arena,
+        &KtExpr::Lambda {
+            params: Vec::new(),
+            body: stmts.to_vec(),
+        },
+    );
+    scope.push(&[]);
+    let out = write_stmts(stmts, &mut scope, imports);
+    scope.pop();
+    out
+}
+
+/// Write `e`, parenthesizing when its precedence is looser than `needed`.
+fn write_expr(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet, needed: Prec) -> String {
+    let rendered = write_bare(e, scope, imports);
+    if prec(e) < needed {
+        format!("({rendered})")
+    } else {
+        rendered
+    }
+}
+
+fn write_bare(e: &KtExpr, scope: &mut Scope, imports: &mut ImportSet) -> String {
+    match e {
+        KtExpr::Local(id) => scope.lookup(*id).to_string(),
+        KtExpr::Name(n) => render_name(n, imports),
+        KtExpr::Literal(l) => render_literal(l),
+        KtExpr::Field { recv, name, safe } => {
+            let r = write_expr(recv, scope, imports, Prec::Postfix);
+            format!("{r}{}{}", if *safe { "?." } else { "." }, name.simple())
+        }
+        KtExpr::Call {
+            recv,
+            name,
+            args,
+            safe,
+            trailing_lambda,
+        } => {
+            let rendered_args: Vec<String> = args
+                .iter()
+                .map(|a| write_expr(a, scope, imports, Prec::Elvis))
+                .collect();
+            let head = match recv {
+                Some(r) => {
+                    let r = write_expr(r, scope, imports, Prec::Postfix);
+                    format!("{r}{}{}", if *safe { "?." } else { "." }, name.simple())
+                }
+                // An unqualified call names a free function, which may be
+                // imported like a class.
+                None => render_name(name, imports),
+            };
+            let mut out = format!("{head}({})", rendered_args.join(", "));
+            if let Some(l) = trailing_lambda {
+                out.push(' ');
+                out.push_str(&write_bare(l, scope, imports));
+            }
+            out
+        }
+        KtExpr::As { expr, ty, safe } => {
+            // `as` is left-associative and binds tighter than elvis, so the
+            // operand needs `As` strength.
+            let inner = write_expr(expr, scope, imports, Prec::As);
+            format!(
+                "{inner} {} {}",
+                if *safe { "as?" } else { "as" },
+                ty.render(imports)
+            )
+        }
+        KtExpr::Elvis(a, b) => {
+            // Right-associative: the left operand must bind tighter, the right
+            // may be another elvis.
+            let lhs = write_expr(a, scope, imports, Prec::As);
+            let rhs = write_expr(b, scope, imports, Prec::Elvis);
+            format!("{lhs} ?: {rhs}")
+        }
+        KtExpr::Lambda { params, body } => {
+            scope.push(params);
+            let names: Vec<String> = params
+                .iter()
+                .map(|p| scope.lookup(*p).to_string())
+                .collect();
+            let lines = write_stmts(body, scope, imports);
+            scope.pop();
+            let head = if names.is_empty() {
+                String::new()
+            } else {
+                format!("{} -> ", names.join(", "))
+            };
+            format!("{{ {head}{} }}", lines.join("; "))
+        }
+        KtExpr::When { subject, arms } => {
+            let subj = write_expr(subject, scope, imports, Prec::Elvis);
+            let rendered: Vec<String> = arms
+                .iter()
+                .map(|(p, body)| {
+                    let pat = match p {
+                        KtPattern::Is(ty) => format!("is {}", ty.render(imports)),
+                        KtPattern::Value(v) => write_expr(v, scope, imports, Prec::Elvis),
+                        KtPattern::Else => "else".to_string(),
+                    };
+                    format!("{pat} -> {}", write_expr(body, scope, imports, Prec::Elvis))
+                })
+                .collect();
+            format!("when ({subj}) {{ {} }}", rendered.join("; "))
+        }
+        KtExpr::Hole => panic!(
+            "KtExpr::Hole reached the renderer — a template was emitted without being filled \
+             (see `fill_hole`)"
+        ),
+        KtExpr::Raw(s) => s.clone(),
+    }
+}
+
+fn write_stmts(stmts: &[KtStmt], scope: &mut Scope, imports: &mut ImportSet) -> Vec<String> {
+    let mut out = Vec::new();
+    // Locals introduced here are visible to every later statement, so they go
+    // into one frame that grows as the block is walked.
+    let mut introduced: Vec<BindingId> = Vec::new();
+    for s in stmts {
+        match s {
+            KtStmt::Let {
+                binder,
+                mutable,
+                value,
+            } => {
+                // The value is rendered BEFORE the binder enters scope: `val x
+                // = x` must refer to the outer `x`.
+                let v = write_expr(value, scope, imports, Prec::Elvis);
+                scope.push(&[*binder]);
+                introduced.push(*binder);
+                let kw = if *mutable { "var" } else { "val" };
+                out.push(format!("{kw} {} = {v}", scope.lookup(*binder)));
+            }
+            KtStmt::Expr(e) => out.push(write_expr(e, scope, imports, Prec::Elvis)),
+            KtStmt::Return(Some(e)) => out.push(format!(
+                "return {}",
+                write_expr(e, scope, imports, Prec::Elvis)
+            )),
+            KtStmt::Return(None) => out.push("return".to_string()),
+        }
+    }
+    for _ in introduced {
+        scope.pop();
+    }
+    out
+}
+
+/// A qualified name registers an import and renders short; a bare one renders
+/// verbatim. Same rule [`super::super::types::KtType`] follows, so a class
+/// referenced from a type and from an expression agree on their import.
+fn render_name(n: &KtName, imports: &mut ImportSet) -> String {
+    if n.is_qualified() {
+        imports.short(n.as_str())
+    } else {
+        n.as_str().to_string()
+    }
+}
+
+fn render_literal(l: &KtLiteral) -> String {
+    match l {
+        KtLiteral::Null => "null".to_string(),
+        KtLiteral::Bool(b) => b.to_string(),
+        KtLiteral::Int(v) => v.to_string(),
+        KtLiteral::Long(v) => format!("{v}L"),
+        KtLiteral::Double(v) => {
+            // Kotlin needs a decimal point to infer `Double`.
+            if v.fract() == 0.0 && v.is_finite() {
+                format!("{v:.1}")
+            } else {
+                v.to_string()
+            }
+        }
+        // Escaped HERE, by the renderer — never pre-escaped by a producer, which
+        // is the whole reason `KtLiteral::Str` holds the raw value.
+        KtLiteral::Str(s) => {
+            let mut out = String::with_capacity(s.len() + 2);
+            out.push('"');
+            for c in s.chars() {
+                match c {
+                    '"' => out.push_str("\\\""),
+                    '\\' => out.push_str("\\\\"),
+                    '\n' => out.push_str("\\n"),
+                    '\r' => out.push_str("\\r"),
+                    '\t' => out.push_str("\\t"),
+                    '$' => out.push_str("\\$"),
+                    other => out.push(other),
+                }
+            }
+            out.push('"');
+            out
+        }
+    }
+}

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -1161,44 +1161,44 @@ fn static_annotation_text_constructors_are_pinned_crate_wide() {
 }
 
 /// `KtExpr::Raw` exists only if migration needs it, and **enumerating its
-/// construction sites is the mechanical check** behind #199's global exit.
+/// producers is the mechanical check** behind #199's global exit.
+///
+/// Scanned **crate-wide**, not over a hand-listed set of files: `KtExpr` is
+/// re-exported for JniGen and visible throughout it, so a
+/// `kt::KtExpr::Raw(...)` in `api/lang/jnigen/…` would pass a `gen/kotlin`-only
+/// audit and the asserted exit would drift silently. Same visibility-boundary
+/// problem `crate_sources` already solves for `StaticAnnotationText`.
 ///
 /// The AST's own definition, traversal and renderer necessarily *name* the
-/// variant — in a declaration and in `match` arms. What must stay empty is
-/// every other module: no producer builds one. Today that set is empty, so the
-/// variant is reachable from tests only and #199 can delete it outright.
+/// variant — in a declaration and in `match` arms — so those three files are
+/// the allow-list. Every other file in the crate must not mention it. Today
+/// that set is empty, so the variant is reachable from tests only and #199 can
+/// delete it outright.
 #[test]
-fn ktexpr_raw_has_no_producers() {
-    // The three files allowed to name the variant at all.
-    let allowed = [
-        include_str!("../expr.rs"),
-        include_str!("render.rs"),
-        include_str!("tests.rs"),
+fn ktexpr_raw_has_no_producers_crate_wide() {
+    const ALLOWED: [&str; 3] = [
+        "kotlin/expr.rs",
+        "kotlin/expr/render.rs",
+        "kotlin/expr/tests.rs",
     ];
-    for src in allowed {
-        assert!(
-            src.contains("Raw"),
-            "the allow-list should name files that actually mention the variant"
-        );
-    }
-    // …and no other file of the Kotlin generator may reference it in *code*.
-    // Doc comments discussing the contract are the point, not a violation, so
-    // they are stripped first — with the same scanner Tier 0's module-boundary
-    // test uses, which handles `/* … */` as well as `//` and leaves string
-    // literals alone.
-    let mut offenders = Vec::new();
-    for (name, src) in [
-        ("slot.rs", include_str!("../slot.rs")),
-        ("model.rs", include_str!("../model.rs")),
-        ("render.rs", include_str!("../render.rs")),
-        ("code.rs", include_str!("../code.rs")),
-        ("file.rs", include_str!("../file.rs")),
-        ("types.rs", include_str!("../types.rs")),
-    ] {
-        if code_without_comments(src).contains("KtExpr::Raw") {
-            offenders.push(name);
+    let mut offenders: Vec<String> = Vec::new();
+    let mut allowed_seen = 0usize;
+    for (path, code) in crate_sources() {
+        let normalized = path.replace('\\', "/");
+        if ALLOWED.iter().any(|a| normalized.ends_with(a)) {
+            allowed_seen += 1;
+            continue;
+        }
+        if code.contains("KtExpr::Raw") {
+            offenders.push(normalized);
         }
     }
+    // `crate_sources` skips the auditing file itself, so two of the three
+    // allow-listed files are actually walked.
+    assert_eq!(
+        allowed_seen, 2,
+        "the allow-list should name files the walk actually visits"
+    );
     assert!(
         offenders.is_empty(),
         "KtExpr::Raw is referenced outside the AST itself: {offenders:?} — every site is a #199 \

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -319,14 +319,18 @@ fn fill_hole_replaces_the_base_in_place() {
         ),
         (KtExpr::this(), "(this.field as? Exact)?.v0 ?: 0L"),
     ] {
-        let filled = fill_hole(&template, &base);
+        let filled = fill_hole(&arena, &template, &base);
         assert!(!has_hole(&filled));
         assert_eq!(r(&arena, &filled), want);
     }
 
     // A base that is itself compound gets its own parentheses from precedence,
     // not from the template author remembering to add them.
-    let filled = fill_hole(&template, &KtExpr::name("a").elvis(KtExpr::name("b")));
+    let filled = fill_hole(
+        &arena,
+        &template,
+        &KtExpr::name("a").elvis(KtExpr::name("b")),
+    );
     assert_eq!(r(&arena, &filled), "((a ?: b).field as? Exact)?.v0 ?: 0L");
 }
 
@@ -358,7 +362,7 @@ fn substituting_a_local_into_a_same_printed_scope_does_not_capture() {
     let value = KtExpr::free_call("use", [KtExpr::local(outer)]);
     // …and is inserted under a lambda that binds another binder also hinted `e`.
     let template = KtExpr::lambda1([inner], KtExpr::local(target));
-    let substituted = substitute(&template, target, &value);
+    let substituted = substitute(&arena, &template, target, &value);
     let whole = KtExpr::lambda1([outer], substituted);
 
     let rendered = r(&arena, &whole);
@@ -377,7 +381,7 @@ fn substituting_a_free_name_into_a_colliding_scope_does_not_capture() {
 
     let value = KtExpr::free_call("use", [KtExpr::name("config")]);
     let template = KtExpr::lambda1([inner], KtExpr::local(target));
-    let whole = substitute(&template, target, &value);
+    let whole = substitute(&arena, &template, target, &value);
 
     // The binder moved aside; the free `config` still reads as itself.
     assert_eq!(r(&arena, &whole), "{ config2 -> use(config) }");
@@ -668,6 +672,86 @@ fn literals_cover_their_whole_value_domain() {
     }
 }
 
+// ── cross-arena composition ─────────────────────────────────────────────
+
+/// `fill_hole` and `substitute` clone trees, so a tree built in **another**
+/// arena would bring its `Local`s along — and because indices start at zero per
+/// arena, `Local(index 0)` would resolve against the host's binder 0. That is
+/// the structural capture `graft` exists to prevent, arriving through the
+/// composition functions instead.
+///
+/// `BindingId` now carries its arena, so the mismatch is detected at the seam
+/// rather than silently rendering the wrong binder.
+#[test]
+#[should_panic(expected = "fill_hole(value)")]
+fn filling_a_hole_with_a_foreign_tree_is_rejected() {
+    let mut host = ExprArena::new();
+    let host_b = host.bind_fresh("v");
+    let mut guest = ExprArena::new();
+    let guest_b = guest.bind_fresh("v");
+    // Both are index 0 — the collision that used to resolve silently.
+    assert_eq!(host_b.index(), guest_b.index());
+
+    let template = KtExpr::lambda1([host_b], KtExpr::Hole);
+    let _ = fill_hole(&host, &template, &KtExpr::local(guest_b));
+}
+
+#[test]
+#[should_panic(expected = "substitute(value)")]
+fn substituting_a_foreign_tree_is_rejected() {
+    let mut host = ExprArena::new();
+    let target = host.bind_fresh("slot");
+    let mut guest = ExprArena::new();
+    let guest_b = guest.bind_fresh("v");
+    let _ = substitute(
+        &host,
+        &KtExpr::local(target),
+        target,
+        &KtExpr::local(guest_b),
+    );
+}
+
+/// The supported way across is `graft`, which alpha-remaps — and after it the
+/// composition is accepted, because the tree now belongs to the host arena.
+#[test]
+fn grafting_first_makes_cross_arena_composition_legal() {
+    let mut host = ExprArena::new();
+    let host_b = host.bind_fresh("v");
+    let mut guest = ExprArena::new();
+    let guest_b = guest.bind_fresh("v");
+    let guest_tree = KtExpr::lambda1([guest_b], KtExpr::local(guest_b));
+
+    let grafted = host.graft(&guest, &guest_tree);
+    let template = KtExpr::lambda1([host_b], KtExpr::free_call("f", [KtExpr::Hole]));
+    let filled = fill_hole(&host, &template, &grafted);
+    assert_eq!(r(&host, &filled), "{ v -> f({ v2 -> v2 }) }");
+}
+
+/// A binder looked up in the wrong arena is a named panic, not an index into
+/// someone else's `Vec`.
+#[test]
+#[should_panic(expected = "looked up in arena")]
+fn a_foreign_binder_lookup_is_rejected() {
+    let host = ExprArena::new();
+    let mut guest = ExprArena::new();
+    let guest_b = guest.bind_fresh("v");
+    let _ = host.binder(guest_b);
+}
+
+/// `Ast::in_scope` permits the same mismatched arena/id pairing, so it is
+/// guarded at render time by the binder lookup above.
+#[test]
+#[should_panic(expected = "looked up in arena")]
+fn a_slot_scope_from_another_arena_is_rejected() {
+    let host = ExprArena::new();
+    let mut guest = ExprArena::new();
+    let foreign = guest.bind_fresh("v");
+    let slot: ExprSlot<KtExpr> =
+        ExprSlot::ast_in_scope(host, vec![foreign], KtExpr::local(foreign));
+    let mut imports = ImportSet::default();
+    let _ = slot.render_inline(&mut imports);
+}
+
 // ── the slot bridges ────────────────────────────────────────────────────
 
 /// **No expression position can hold a legacy and a typed value
@@ -725,6 +809,49 @@ fn accessors_are_structured_declarations() {
     assert_eq!(out.trim(), "get() = { v -> v }");
 }
 
+/// An **expression** accessor keeps its scope, like the block arm and every
+/// other typed slot. A getter referencing a constructor parameter would
+/// otherwise be unbound.
+#[test]
+fn an_expression_accessor_can_reference_its_enclosing_binders() {
+    let mut arena = ExprArena::new();
+    let ctor_param = arena.bind_fixed(KtName::expect("initialPtr"));
+    let acc = KtAccessor {
+        kind: crate::api::gen::kotlin::AccessorKind::Get,
+        body: crate::api::gen::kotlin::slot::AccessorBody::Expr(
+            crate::api::gen::kotlin::slot::Ast::in_scope(
+                arena,
+                vec![ctor_param],
+                KtExpr::local(ctor_param).field("value"),
+            ),
+        ),
+    };
+    let mut imports = ImportSet::default();
+    let mut out = String::new();
+    acc.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "get() = initialPtr.value");
+}
+
+/// Kotlin reads a bare `_` as an ignoring placeholder, not an identifier — it
+/// is not referenceable, so it may be neither a `KtName` nor a rendered binder.
+#[test]
+fn underscore_is_not_an_identifier() {
+    for bad in ["_", "__", "___"] {
+        assert!(KtName::new(bad).is_err(), "`{bad}` is a placeholder");
+    }
+    // …but an underscore *within* a name is ordinary.
+    for ok in ["_x", "x_", "a_b", "_1"] {
+        assert!(KtName::new(ok).is_ok(), "`{ok}` should be accepted");
+    }
+    // A hint that would render as the placeholder falls back instead.
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("_");
+    assert_eq!(
+        r(&arena, &KtExpr::lambda1([b], KtExpr::local(b))),
+        "{ tmp -> tmp }"
+    );
+}
+
 /// Annotation arguments are expressions, and the typed form renders them
 /// through the same escaping the rest of the tier uses.
 #[test]
@@ -778,6 +905,49 @@ fn legacy_annotation_bridge_has_exactly_one_caller() {
     ] {
         assert!(!other.contains("from_legacy_string"));
     }
+}
+
+/// `StaticAnnotationText`'s literal-origin guarantee is **audited, not typed**:
+/// `__from_literal` accepts any `&'static str`, leaked included, so the macro —
+/// not the type — is where the guarantee lives for the macro's own callers.
+///
+/// Both direct constructors are crate-internal, which bounds the audit to this
+/// crate, and this pins their call sites so neither can grow unnoticed. #199
+/// drives both to zero and deletes them.
+#[test]
+fn static_annotation_text_constructors_are_pinned() {
+    let slot = include_str!("../slot.rs");
+    let render = include_str!("../render.rs");
+    let model = include_str!("../model.rs");
+
+    // `__from_literal`: the macro body, plus the one `JvmInline` site the
+    // value-class renderer injects.
+    let macro_body = code_without_comments(slot)
+        .matches("StaticAnnotationText::__from_literal(")
+        .count();
+    assert_eq!(
+        macro_body, 1,
+        "only the macro should expand to `__from_literal`"
+    );
+    let direct = code_without_comments(render)
+        .matches("StaticAnnotationText::__from_literal(")
+        .count();
+    assert_eq!(
+        direct, 1,
+        "render.rs should have exactly one direct `__from_literal` (the injected `JvmInline`); \
+         every new one is a #199 work item"
+    );
+
+    // `from_legacy_string`: the single `legacy_annotation` helper in the model.
+    assert_eq!(
+        code_without_comments(model)
+            .matches("StaticAnnotationText::from_legacy_string(")
+            .count(),
+        1
+    );
+    // `slot.rs` holds the definition, so only other modules are scanned for
+    // uses.
+    assert!(!code_without_comments(render).contains("from_legacy_string("));
 }
 
 /// `KtExpr::Raw` exists only if migration needs it, and **enumerating its

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -1,0 +1,599 @@
+use super::{render::render_expr, *};
+use crate::api::gen::kotlin::{
+    slot::{
+        AnnotationSlot, ExprSlot, KtAccessor, KtAnnotation, PropertyValue, StaticAnnotationText,
+    },
+    types::{ImportSet, KtType},
+};
+
+/// Render with a throwaway import set — for assertions that do not care about
+/// imports.
+fn r(arena: &ExprArena, e: &KtExpr) -> String {
+    let mut imports = ImportSet::default();
+    render_expr(arena, e, &mut imports)
+}
+
+// ── precedence ──────────────────────────────────────────────────────────
+
+/// Precedence is a property of the tree, not of whoever built it. Postfix binds
+/// tighter than `as`, which binds tighter than elvis — and a child looser than
+/// its position gets parentheses, automatically.
+#[test]
+fn precedence_parenthesizes_exactly_where_needed() {
+    let arena = ExprArena::new();
+
+    // `a ?: b` under a field access needs parens: `(a ?: b).c`.
+    let e = KtExpr::name("a").elvis(KtExpr::name("b")).field("c");
+    assert_eq!(r(&arena, &e), "(a ?: b).c");
+
+    // …but a field access under an elvis does not: `a.c ?: b`.
+    let e = KtExpr::name("a").field("c").elvis(KtExpr::name("b"));
+    assert_eq!(r(&arena, &e), "a.c ?: b");
+
+    // `as` under a field access needs parens; a field under `as` does not.
+    let e = KtExpr::name("a").cast(KtType::cls("Foo")).field("c");
+    assert_eq!(r(&arena, &e), "(a as Foo).c");
+    let e = KtExpr::name("a").field("c").cast(KtType::cls("Foo"));
+    assert_eq!(r(&arena, &e), "a.c as Foo");
+
+    // Elvis is right-associative: the left operand is parenthesized, the right
+    // is not.
+    let e = KtExpr::name("a")
+        .elvis(KtExpr::name("b"))
+        .elvis(KtExpr::name("c"));
+    assert_eq!(r(&arena, &e), "(a ?: b) ?: c");
+    let e = KtExpr::name("a").elvis(KtExpr::name("b").elvis(KtExpr::name("c")));
+    assert_eq!(r(&arena, &e), "a ?: b ?: c");
+
+    // An `as?` operand that is itself an elvis needs parens.
+    let e = KtExpr::name("a")
+        .elvis(KtExpr::name("b"))
+        .safe_cast(KtType::cls("Foo"));
+    assert_eq!(r(&arena, &e), "(a ?: b) as? Foo");
+
+    // A call argument is at the loosest position, so it never needs parens.
+    let e = KtExpr::free_call("f", [KtExpr::name("a").elvis(KtExpr::name("b"))]);
+    assert_eq!(r(&arena, &e), "f(a ?: b)");
+}
+
+/// The tag-gated variant access that motivated the whole textual-template
+/// design — `(<base>.field as? Reading.Exact)?.v0 ?: 0L` — is one tree, with
+/// every parenthesis derived.
+#[test]
+fn the_tag_gated_variant_access_is_one_tree() {
+    let arena = ExprArena::new();
+    let e = KtExpr::name("payload")
+        .field("field")
+        .safe_cast(KtType::cls("io.test.Reading.Exact"))
+        .safe_field("v0")
+        .elvis(KtExpr::long(0));
+    assert_eq!(r(&arena, &e), "(payload.field as? Exact)?.v0 ?: 0L");
+}
+
+/// Safe-call chains, and literals escaped by the renderer rather than
+/// pre-escaped by a producer.
+#[test]
+fn safe_calls_and_literal_escaping() {
+    let arena = ExprArena::new();
+    let e = KtExpr::name("h")
+        .safe_field("inner")
+        .safe_call("get", [KtExpr::int(3)]);
+    assert_eq!(r(&arena, &e), "h?.inner?.get(3)");
+
+    // The raw value goes in; the escaping comes out.
+    let e = KtExpr::str_("say \"hi\"\n\tand $x");
+    assert_eq!(r(&arena, &e), r#""say \"hi\"\n\tand \$x""#);
+
+    let e = KtExpr::free_call(
+        "listOf",
+        [KtExpr::null(), KtExpr::bool_(true), KtExpr::long(7)],
+    );
+    assert_eq!(r(&arena, &e), "listOf(null, true, 7L)");
+}
+
+// ── scope-tracked name allocation ───────────────────────────────────────
+
+/// The renderer allocates lambda parameter names with a real scope stack,
+/// replacing the hand-numbered `e0`/`e1` convention. Nested lambdas that ask
+/// for the same hint get distinct names.
+#[test]
+fn nested_lambdas_do_not_shadow() {
+    let mut arena = ExprArena::new();
+    let outer = arena.bind_fresh("e");
+    let inner = arena.bind_fresh("e");
+    // { e -> f(e, { e2 -> g(e, e2) }) }
+    let tree = KtExpr::lambda1(
+        [outer],
+        KtExpr::free_call("f", [KtExpr::local(outer)]).with_trailing_lambda(KtExpr::lambda1(
+            [inner],
+            KtExpr::free_call("g", [KtExpr::local(outer), KtExpr::local(inner)]),
+        )),
+    );
+    assert_eq!(r(&arena, &tree), "{ e -> f(e) { e2 -> g(e, e2) } }");
+}
+
+/// A machine-allocated binder may not shadow a **free name** the tree
+/// references. Free names are reserved before any binder name is allocated —
+/// otherwise a `Fresh` binder hinted `value` would capture a reference to a
+/// class or member called `value`.
+#[test]
+fn a_fresh_binder_never_shadows_a_referenced_free_name() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("value");
+    let tree = KtExpr::lambda1(
+        [b],
+        KtExpr::free_call("f", [KtExpr::local(b), KtExpr::name("value")]),
+    );
+    let rendered = r(&arena, &tree);
+    // The binder had to move aside; the free `value` still reads as itself.
+    assert_eq!(rendered, "{ value2 -> f(value2, value) }");
+}
+
+/// **`Fixed` spellings survive rendering byte-identically.** A function or
+/// constructor parameter name is Kotlin's named-argument surface, callable from
+/// user code — renaming one would silently break every `foo(bar = …)` call
+/// site. So a `Fresh` binder moves aside for a `Fixed` one, never the reverse.
+#[test]
+fn fixed_spellings_are_preserved_byte_identically() {
+    let mut arena = ExprArena::new();
+    let fixed = arena.bind_fixed(KtName::expect("payload"));
+    let fresh = arena.bind_fresh("payload");
+    let tree = KtExpr::lambda1(
+        [fixed, fresh],
+        KtExpr::free_call("f", [KtExpr::local(fixed), KtExpr::local(fresh)]),
+    );
+    let rendered = r(&arena, &tree);
+    assert!(
+        rendered.starts_with("{ payload, payload2 ->"),
+        "the Fixed name must be kept verbatim: {rendered}"
+    );
+    assert_eq!(rendered, "{ payload, payload2 -> f(payload, payload2) }");
+}
+
+/// A local `val` is a binder like any other, and its value is rendered before
+/// it enters scope — `val x = x` refers to the outer `x`.
+#[test]
+fn locals_are_binders_and_bind_after_their_value() {
+    let mut arena = ExprArena::new();
+    let outer = arena.bind_fixed(KtName::expect("x"));
+    let local = arena.bind_fresh("x");
+    let tree = KtExpr::lambda(
+        [outer],
+        vec![
+            KtStmt::Let {
+                binder: local,
+                mutable: false,
+                value: KtExpr::local(outer).field("inner"),
+            },
+            KtStmt::Expr(KtExpr::local(local)),
+        ],
+    );
+    assert_eq!(r(&arena, &tree), "{ x -> val x2 = x.inner; x2 }");
+}
+
+// ── import collection ───────────────────────────────────────────────────
+
+/// A rendered unit reports the imports it needs, **from the tree** — replacing
+/// the hand registration alongside raw text, where the two could drift.
+#[test]
+fn imports_are_collected_from_the_tree() {
+    let arena = ExprArena::new();
+    let tree = KtExpr::name("io.zenoh.jni.Session")
+        .call("open", [KtExpr::name("io.zenoh.Config").field("DEFAULT")])
+        .cast(KtType::cls("io.zenoh.jni.Handle"));
+
+    let mut imports = ImportSet::default();
+    let rendered = render_expr(&arena, &tree, &mut imports);
+    // Qualified names render short…
+    assert_eq!(rendered, "Session.open(Config.DEFAULT) as Handle");
+    // …and register their FQN.
+    let collected = imports.import_lines();
+    for want in [
+        "io.zenoh.jni.Session",
+        "io.zenoh.Config",
+        "io.zenoh.jni.Handle",
+    ] {
+        assert!(
+            collected.iter().any(|i| i.contains(want)),
+            "missing {want} in {collected:?}"
+        );
+    }
+}
+
+/// `free_names` is what both the import set and the renderer's reservation are
+/// built from, so it has to see every name-bearing position.
+#[test]
+fn free_names_sees_every_name_position() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("it");
+    let tree = KtExpr::lambda1(
+        [b],
+        KtExpr::name("Cls")
+            .field("member")
+            .call("method", [KtExpr::name("Arg")]),
+    );
+    let names: Vec<String> = free_names(&tree)
+        .into_iter()
+        .map(|n| n.as_str().to_string())
+        .collect();
+    for want in ["Cls", "member", "method", "Arg"] {
+        assert!(
+            names.contains(&want.to_string()),
+            "missing {want} in {names:?}"
+        );
+    }
+    // A binder is NOT a free name — that is the whole `Local` / `Name` split.
+    assert!(!names.contains(&"it".to_string()));
+}
+
+// ── hole filling ────────────────────────────────────────────────────────
+
+/// Hole-filling is a tree operation. `kt_access_prefix` + base +
+/// `kt_access_tail` was simulating exactly this, with the base in the middle
+/// and three strings that each had to remember the other two.
+#[test]
+fn fill_hole_replaces_the_base_in_place() {
+    let arena = ExprArena::new();
+    let template = KtExpr::Hole
+        .field("field")
+        .safe_cast(KtType::cls("io.test.Reading.Exact"))
+        .safe_field("v0")
+        .elvis(KtExpr::long(0));
+    assert!(has_hole(&template));
+
+    for (base, want) in [
+        (
+            KtExpr::name("payload"),
+            "(payload.field as? Exact)?.v0 ?: 0L",
+        ),
+        (KtExpr::name("this"), "(this.field as? Exact)?.v0 ?: 0L"),
+    ] {
+        let filled = fill_hole(&template, &base);
+        assert!(!has_hole(&filled));
+        assert_eq!(r(&arena, &filled), want);
+    }
+
+    // A base that is itself compound gets its own parentheses from precedence,
+    // not from the template author remembering to add them.
+    let filled = fill_hole(&template, &KtExpr::name("a").elvis(KtExpr::name("b")));
+    assert_eq!(r(&arena, &filled), "((a ?: b).field as? Exact)?.v0 ?: 0L");
+}
+
+/// An unfilled hole is a generator bug, so it fails loudly rather than
+/// rendering something plausible.
+#[test]
+#[should_panic(expected = "KtExpr::Hole reached the renderer")]
+fn an_unfilled_hole_panics_rather_than_rendering() {
+    let arena = ExprArena::new();
+    let _ = r(&arena, &KtExpr::Hole.field("x"));
+}
+
+// ── substitution and capture ────────────────────────────────────────────
+
+/// Substituting an expression that contains a `Local` into a lambda binding a
+/// **same-printed** name must not capture it.
+///
+/// This is `replace_ident`'s defect stated as a test: textually, both are `e`.
+/// Structurally they are different `BindingId`s, and the renderer — which
+/// allocates the printed names — keeps them apart.
+#[test]
+fn substituting_a_local_into_a_same_printed_scope_does_not_capture() {
+    let mut arena = ExprArena::new();
+    let outer = arena.bind_fresh("e");
+    let inner = arena.bind_fresh("e");
+    let target = arena.bind_fresh("slot");
+
+    // The expression being substituted refers to the OUTER `e`.
+    let value = KtExpr::free_call("use", [KtExpr::local(outer)]);
+    // …and is inserted under a lambda that binds another binder also hinted `e`.
+    let template = KtExpr::lambda1([inner], KtExpr::local(target));
+    let substituted = substitute(&template, target, &value);
+    let whole = KtExpr::lambda1([outer], substituted);
+
+    let rendered = r(&arena, &whole);
+    // The inner binder was renamed, so `use` still sees the outer one.
+    assert_eq!(rendered, "{ e -> { e2 -> use(e) } }");
+}
+
+/// Substituting an expression containing a **free `KtName`** into a scope whose
+/// binder would print that name must not capture it either — the position
+/// `BindingId`s do not cover, closed by reserving free names first.
+#[test]
+fn substituting_a_free_name_into_a_colliding_scope_does_not_capture() {
+    let mut arena = ExprArena::new();
+    let inner = arena.bind_fresh("config");
+    let target = arena.bind_fresh("slot");
+
+    let value = KtExpr::free_call("use", [KtExpr::name("config")]);
+    let template = KtExpr::lambda1([inner], KtExpr::local(target));
+    let whole = substitute(&template, target, &value);
+
+    // The binder moved aside; the free `config` still reads as itself.
+    assert_eq!(r(&arena, &whole), "{ config2 -> use(config) }");
+}
+
+/// **Grafting two independently-built trees that allocated colliding
+/// `BindingId`s must alpha-remap rather than capture.**
+///
+/// Both arenas below allocate `BindingId(0)`. Merging them naively would fuse
+/// two unrelated binders — structural capture that scope-aware *rendering*
+/// cannot detect, because at render time the two are indistinguishable.
+#[test]
+fn grafting_colliding_arenas_alpha_remaps() {
+    let mut host = ExprArena::new();
+    let host_b = host.bind_fresh("v");
+    assert_eq!(host_b.index(), 0);
+
+    let mut guest = ExprArena::new();
+    let guest_b = guest.bind_fresh("v");
+    // The collision the remap exists for.
+    assert_eq!(guest_b.index(), 0);
+    let guest_tree = KtExpr::lambda1([guest_b], KtExpr::free_call("g", [KtExpr::local(guest_b)]));
+
+    let grafted = host.graft(&guest, &guest_tree);
+    // The guest's binder got a fresh id in the host arena.
+    let KtExpr::Lambda { params, .. } = &grafted else {
+        panic!("expected a lambda");
+    };
+    assert_ne!(params[0], host_b, "the graft must not reuse the host's id");
+    assert_eq!(host.len(), 2);
+
+    // And the whole thing renders with two distinct names.
+    let whole = KtExpr::lambda1(
+        [host_b],
+        KtExpr::free_call("f", [KtExpr::local(host_b)]).with_trailing_lambda(grafted),
+    );
+    assert_eq!(r(&host, &whole), "{ v -> f(v) { v2 -> g(v2) } }");
+}
+
+/// A grafted tree referring to a binder it does not itself introduce is a
+/// dangling reference — it was built against a scope that is not coming with
+/// it — and is rejected rather than silently rebound to whatever id it lands on.
+#[test]
+#[should_panic(expected = "refers to a binder the grafted tree does not introduce")]
+fn grafting_a_dangling_local_is_rejected() {
+    let mut host = ExprArena::new();
+    let mut guest = ExprArena::new();
+    let stray = guest.bind_fresh("x");
+    // `stray` is referenced but never bound inside the grafted expression.
+    let _ = host.graft(&guest, &KtExpr::local(stray));
+}
+
+/// A `Local` nothing introduces is caught at render time too, rather than
+/// producing a plausible-looking name.
+#[test]
+#[should_panic(expected = "is not in scope")]
+fn an_unbound_local_is_rejected_by_the_renderer() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("x");
+    let _ = r(&arena, &KtExpr::local(b));
+}
+
+// ── `when` ──────────────────────────────────────────────────────────────
+
+#[test]
+fn when_arms_render_with_patterns() {
+    let mut arena = ExprArena::new();
+    let subj = arena.bind_fixed(KtName::expect("v"));
+    let tree = KtExpr::lambda1(
+        [subj],
+        KtExpr::When {
+            subject: Box::new(KtExpr::local(subj)),
+            arms: vec![
+                (
+                    KtPattern::Is(KtType::cls("io.test.Reading.Exact")),
+                    KtExpr::long(1),
+                ),
+                (KtPattern::Value(KtExpr::null()), KtExpr::long(0)),
+                (KtPattern::Else, KtExpr::long(-1)),
+            ],
+        },
+    );
+    assert_eq!(
+        r(&arena, &tree),
+        "{ v -> when (v) { is Exact -> 1L; null -> 0L; else -> -1L } }"
+    );
+}
+
+// ── name validation ─────────────────────────────────────────────────────
+
+/// A malformed identifier is rejected **at construction**, not discovered by
+/// Gradle. Without this, `Name("a.b() ?: c")` would render as arbitrary source
+/// and make #199's "no string-built expressions" exit unfalsifiable.
+#[test]
+fn kt_name_rejects_anything_that_is_not_an_identifier_path() {
+    for bad in [
+        "",
+        "a.b()",
+        "a ?: b",
+        "1abc",
+        "a..b",
+        "a.",
+        "has space",
+        "a-b",
+        "\"quoted\"",
+    ] {
+        assert!(KtName::new(bad).is_err(), "`{bad}` should be rejected");
+    }
+    for good in ["a", "_x", "Foo", "io.zenoh.jni.Session", "a1_b2"] {
+        assert!(KtName::new(good).is_ok(), "`{good}` should be accepted");
+    }
+}
+
+/// Only `Raw` accepts free-form expression text. Every other variant is
+/// structured — which is what makes counting `Raw`'s construction sites a
+/// meaningful progress metric for #199.
+#[test]
+fn no_variant_other_than_raw_accepts_free_form_text() {
+    // The constructors that take a string all route it through `KtName`
+    // validation or `KtLiteral` escaping…
+    assert!(std::panic::catch_unwind(|| KtExpr::name("a ?: b")).is_err());
+    let arena = ExprArena::new();
+    // …and a literal is data, not source: it comes back quoted.
+    assert_eq!(r(&arena, &KtExpr::str_("a ?: b")), "\"a ?: b\"");
+    // `Raw` is the one hole, and it is deliberately conspicuous.
+    assert_eq!(r(&arena, &KtExpr::Raw("a ?: b".into())), "a ?: b");
+}
+
+// ── the slot bridges ────────────────────────────────────────────────────
+
+/// **No expression position can hold a legacy and a typed value
+/// simultaneously.** `ExprSlot` is a sum, so the renderer never chooses between
+/// two authorities for one fact — the defect #187 exists to remove, which
+/// introducing the typed fields *beside* the legacy ones would have recreated
+/// inside its own migration.
+#[test]
+fn expr_slot_is_exclusive_by_type() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fixed(KtName::expect("x"));
+    let ast: ExprSlot<KtExpr> = ExprSlot::ast(arena.clone(), KtExpr::local(b));
+    assert!(!ast.is_legacy());
+
+    let legacy: ExprSlot<KtExpr> = ExprSlot::legacy(crate::api::gen::kotlin::Code::new().line("x"));
+    assert!(legacy.is_legacy());
+
+    // Both render to the same text through one entry point, so migrating a
+    // position is a local change.
+    let mut imports = ImportSet::default();
+    // A `Fixed` binder at the root has no enclosing scope, so the AST arm is
+    // exercised through a lambda that introduces it.
+    let wrapped: ExprSlot<KtExpr> =
+        ExprSlot::ast(arena.clone(), KtExpr::lambda1([b], KtExpr::local(b)));
+    assert_eq!(wrapped.render_inline(&mut imports), "{ x -> x }");
+    assert_eq!(legacy.render_inline(&mut imports), "x");
+}
+
+/// `PropertyValue` makes the initializer/delegate exclusion **structural**. It
+/// used to be two `Option<String>` fields, a doc comment saying "mutually
+/// exclusive", and a `debug_assert` that only fires in debug builds — a product
+/// where a sum belongs, i.e. the #180 pattern sitting in the Kotlin model.
+#[test]
+fn property_value_makes_the_exclusion_structural() {
+    let d = PropertyValue::default();
+    assert!(matches!(d, PropertyValue::None));
+    // There is no constructible value carrying both; the type has one slot.
+    let init = PropertyValue::Initializer(ExprSlot::legacy(
+        crate::api::gen::kotlin::Code::new().line("1"),
+    ));
+    assert!(matches!(init, PropertyValue::Initializer(_)));
+}
+
+/// Accessors are **declarations containing bodies**, not expressions — so they
+/// get a structured model rather than an `ExprSlot<KtExpr>`.
+#[test]
+fn accessors_are_structured_declarations() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fixed(KtName::expect("v"));
+    let acc = KtAccessor::get_expr(arena.clone(), KtExpr::lambda1([b], KtExpr::local(b)));
+    assert!(!acc.is_legacy());
+    let mut imports = ImportSet::default();
+    let mut out = String::new();
+    acc.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "get() = { v -> v }");
+}
+
+/// Annotation arguments are expressions, and the typed form renders them
+/// through the same escaping the rest of the tier uses.
+#[test]
+fn annotations_carry_expression_arguments() {
+    let ast = AnnotationSlot::Ast(
+        KtAnnotation::new(KtName::expect("Suppress")).arg(KtExpr::str_("UNCHECKED_CAST")),
+    );
+    let mut imports = ImportSet::default();
+    assert_eq!(ast.render(&mut imports), "Suppress(\"UNCHECKED_CAST\")");
+
+    // The legacy arm renders verbatim, so wrapping existing producers moved no
+    // output.
+    let legacy = AnnotationSlot::Legacy(StaticAnnotationText::from_legacy_string("JvmStatic"));
+    assert_eq!(legacy.render(&mut imports), "JvmStatic");
+    assert!(legacy.is_legacy());
+    assert!(legacy.renders_as("JvmStatic"));
+}
+
+/// `StaticAnnotationText` built through the macro carries **literal origin as a
+/// compile-time property**: `macro_rules!`'s `literal` fragment cannot match
+/// `String::leak(…)`, which is why narrowing the payload to `&'static str`
+/// would not have been enough.
+#[test]
+fn annotation_text_from_a_literal() {
+    let t = crate::api::gen::kotlin::slot::kt_annotation_text!("JvmField");
+    assert_eq!(t.as_str(), "JvmField");
+}
+
+/// `from_legacy_string` is the one remaining hole in that guarantee, and it
+/// exists only so 5A could change the field type without migrating call sites.
+///
+/// Its caller count is pinned here so it cannot grow unnoticed: #199 drives it
+/// to zero and deletes the function, the same enumerate-then-delete contract
+/// `KtExpr::Raw` is under.
+#[test]
+fn legacy_annotation_bridge_has_exactly_one_caller() {
+    let model = include_str!("../model.rs");
+    let calls = model
+        .matches("StaticAnnotationText::from_legacy_string(")
+        .count();
+    assert_eq!(
+        calls, 1,
+        "the legacy annotation bridge should have exactly one caller (the `legacy_annotation` \
+         helper in model.rs); every new one is a #199 work item"
+    );
+    // …and nothing outside the Kotlin model reaches for it.
+    for other in [
+        include_str!("../render.rs"),
+        include_str!("../file.rs"),
+        include_str!("../code.rs"),
+    ] {
+        assert!(!other.contains("from_legacy_string"));
+    }
+}
+
+/// `KtExpr::Raw` exists only if migration needs it, and **enumerating its
+/// construction sites is the mechanical check** behind #199's global exit.
+///
+/// The AST's own definition, traversal and renderer necessarily *name* the
+/// variant — in a declaration and in `match` arms. What must stay empty is
+/// every other module: no producer builds one. Today that set is empty, so the
+/// variant is reachable from tests only and #199 can delete it outright.
+#[test]
+fn ktexpr_raw_has_no_producers() {
+    // The three files allowed to name the variant at all.
+    let allowed = [
+        include_str!("../expr.rs"),
+        include_str!("render.rs"),
+        include_str!("tests.rs"),
+    ];
+    for src in allowed {
+        assert!(
+            src.contains("Raw"),
+            "the allow-list should name files that actually mention the variant"
+        );
+    }
+    // …and no other file of the Kotlin generator may reference it in *code*.
+    // Doc comments discussing the contract are the point, not a violation, so
+    // they are stripped first — the same treatment Tier 0's module-boundary
+    // test gives its own prose.
+    let code_of = |src: &str| -> String {
+        src.lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let mut offenders = Vec::new();
+    for (name, src) in [
+        ("slot.rs", include_str!("../slot.rs")),
+        ("model.rs", include_str!("../model.rs")),
+        ("render.rs", include_str!("../render.rs")),
+        ("code.rs", include_str!("../code.rs")),
+        ("file.rs", include_str!("../file.rs")),
+        ("types.rs", include_str!("../types.rs")),
+    ] {
+        if code_of(src).contains("KtExpr::Raw") {
+            offenders.push(name);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "KtExpr::Raw is referenced outside the AST itself: {offenders:?} — every site is a #199 \
+         work item, and the variant cannot be deleted while any remain"
+    );
+}

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -818,6 +818,7 @@ fn an_expression_accessor_can_reference_its_enclosing_binders() {
     let ctor_param = arena.bind_fixed(KtName::expect("initialPtr"));
     let acc = KtAccessor {
         kind: crate::api::gen::kotlin::AccessorKind::Get,
+        param: None,
         body: crate::api::gen::kotlin::slot::AccessorBody::Expr(
             crate::api::gen::kotlin::slot::Ast::in_scope(
                 arena,
@@ -830,6 +831,67 @@ fn an_expression_accessor_can_reference_its_enclosing_binders() {
     let mut out = String::new();
     acc.render_lines(&mut imports).render(0, &mut out);
     assert_eq!(out.trim(), "get() = initialPtr.value");
+}
+
+/// A setter's value parameter is a **binder**, so the header and the body are
+/// spelled from one allocation.
+///
+/// The header used to be a hardcoded `set(value)`: a binder spelled `incoming`
+/// rendered `set(value) = incoming`, and a `Fresh` binder hinted `value` that
+/// the allocator moved aside left the signature still saying `value`.
+#[test]
+fn a_setter_parameter_is_spelled_from_the_same_allocation_as_its_body() {
+    // A differently-spelled binder reaches the header.
+    let acc = KtAccessor::set_expr(ExprArena::new(), "incoming", |p| {
+        KtExpr::free_call("store", [KtExpr::local(p)])
+    });
+    let mut imports = ImportSet::default();
+    let mut out = String::new();
+    acc.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "set(incoming) = store(incoming)");
+
+    // …and one the allocator has to move aside moves in BOTH places, never
+    // just the body.
+    let acc = KtAccessor::set_expr(ExprArena::new(), "value", |p| {
+        // A free `value` in the tree forces the binder to be renamed.
+        KtExpr::free_call("store", [KtExpr::local(p), KtExpr::name("value")])
+    });
+    let mut out = String::new();
+    acc.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "set(value2) = store(value2, value)");
+}
+
+/// A **clone** of an arena cannot allocate.
+///
+/// Cloning keeps the `ArenaId` — trees already built against it still refer to
+/// it — so two clones both allocating would mint identical
+/// `BindingId { arena, index }` values for different binders, and the
+/// provenance check would wave the collision straight through. Sealing the
+/// clone closes that by construction; the model's own clones never bind
+/// afterwards, so nothing legitimate is lost.
+#[test]
+#[should_panic(expected = "cannot allocate")]
+fn a_cloned_arena_cannot_allocate() {
+    let mut original = ExprArena::new();
+    let _ = original.bind_fresh("v");
+    let mut copy = original.clone();
+    let _ = copy.bind_fresh("v");
+}
+
+/// The clone is still fully usable for everything except allocation — reading,
+/// rendering, and being grafted *from*.
+#[test]
+fn a_cloned_arena_still_renders_and_grafts() {
+    let mut original = ExprArena::new();
+    let b = original.bind_fresh("v");
+    let tree = KtExpr::lambda1([b], KtExpr::local(b));
+
+    let copy = original.clone();
+    assert_eq!(r(&copy, &tree), "{ v -> v }");
+
+    let mut host = ExprArena::new();
+    let grafted = host.graft(&copy, &tree);
+    assert_eq!(r(&host, &grafted), "{ v -> v }");
 }
 
 /// Kotlin reads a bare `_` as an ignoring placeholder, not an identifier — it
@@ -907,47 +969,83 @@ fn legacy_annotation_bridge_has_exactly_one_caller() {
     }
 }
 
+/// Every `.rs` file in the crate, for an audit that cannot be outrun by adding
+/// a module.
+///
+/// The constructors below are crate-visible, so a hand-listed set of files is
+/// not an audit — a direct call from `expr.rs`, `file.rs` or any JniGen module
+/// would simply not be looked at. This walks `src/` instead.
+fn crate_sources() -> Vec<(String, String)> {
+    // The auditing file is skipped: it necessarily *spells* the constructors it
+    // searches for, so counting itself would make the audit self-defeating.
+    const SELF: &str = "kotlin/expr/tests.rs";
+    fn walk(dir: &std::path::Path, out: &mut Vec<(String, String)>) {
+        for entry in std::fs::read_dir(dir).expect("readable source dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let shown = path.display().to_string();
+                if shown.replace('\\', "/").ends_with(SELF) {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).expect("readable source");
+                out.push((shown, code_without_comments(&text)));
+            }
+        }
+    }
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut out = Vec::new();
+    walk(&root, &mut out);
+    assert!(out.len() > 50, "the walk should find the whole crate");
+    out
+}
+
 /// `StaticAnnotationText`'s literal-origin guarantee is **audited, not typed**:
 /// `__from_literal` accepts any `&'static str`, leaked included, so the macro —
-/// not the type — is where the guarantee lives for the macro's own callers.
+/// not the type — is where the guarantee lives, and only for its own callers.
 ///
-/// Both direct constructors are crate-internal, which bounds the audit to this
-/// crate, and this pins their call sites so neither can grow unnoticed. #199
+/// The audit is therefore the whole point, and it runs over **every file in the
+/// crate**, which is the scope the constructors' visibility actually has. #199
 /// drives both to zero and deletes them.
 #[test]
-fn static_annotation_text_constructors_are_pinned() {
-    let slot = include_str!("../slot.rs");
-    let render = include_str!("../render.rs");
-    let model = include_str!("../model.rs");
+fn static_annotation_text_constructors_are_pinned_crate_wide() {
+    let mut from_literal: Vec<&str> = Vec::new();
+    let mut legacy: Vec<&str> = Vec::new();
+    for (path, code) in crate_sources() {
+        for _ in 0..code
+            .matches("StaticAnnotationText::__from_literal(")
+            .count()
+        {
+            from_literal.push(Box::leak(path.clone().into_boxed_str()));
+        }
+        for _ in 0..code
+            .matches("StaticAnnotationText::from_legacy_string(")
+            .count()
+        {
+            legacy.push(Box::leak(path.clone().into_boxed_str()));
+        }
+    }
+    let ends_with = |v: &[&str], suffix: &str| v.iter().filter(|p| p.ends_with(suffix)).count();
 
-    // `__from_literal`: the macro body, plus the one `JvmInline` site the
-    // value-class renderer injects.
-    let macro_body = code_without_comments(slot)
-        .matches("StaticAnnotationText::__from_literal(")
-        .count();
+    // `__from_literal`: the macro body, plus the one injected `JvmInline` the
+    // value-class renderer adds.
     assert_eq!(
-        macro_body, 1,
-        "only the macro should expand to `__from_literal`"
+        from_literal.len(),
+        2,
+        "unexpected `__from_literal` call sites: {from_literal:?} — every new one is a #199 work \
+         item, and the constructor is crate-visible so this list is the only thing bounding it"
     );
-    let direct = code_without_comments(render)
-        .matches("StaticAnnotationText::__from_literal(")
-        .count();
-    assert_eq!(
-        direct, 1,
-        "render.rs should have exactly one direct `__from_literal` (the injected `JvmInline`); \
-         every new one is a #199 work item"
-    );
+    assert_eq!(ends_with(&from_literal, "kotlin/slot.rs"), 1);
+    assert_eq!(ends_with(&from_literal, "kotlin/render.rs"), 1);
 
     // `from_legacy_string`: the single `legacy_annotation` helper in the model.
     assert_eq!(
-        code_without_comments(model)
-            .matches("StaticAnnotationText::from_legacy_string(")
-            .count(),
-        1
+        legacy.len(),
+        1,
+        "unexpected `from_legacy_string` call sites: {legacy:?}"
     );
-    // `slot.rs` holds the definition, so only other modules are scanned for
-    // uses.
-    assert!(!code_without_comments(render).contains("from_legacy_string("));
+    assert_eq!(ends_with(&legacy, "kotlin/model.rs"), 1);
 }
 
 /// `KtExpr::Raw` exists only if migration needs it, and **enumerating its

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -672,6 +672,84 @@ fn literals_cover_their_whole_value_domain() {
     }
 }
 
+// ── free-name reservations vs. binder scope ─────────────────────────────
+
+/// A **`Fixed` binder sharing a free name's spelling must not consume the free
+/// name's reservation** when its frame pops.
+///
+/// The reservations made up front are permanent for the whole render; a
+/// binder's claim lasts until its frame pops. With a set they were the same
+/// thing, so a `Fixed` binder inserted a no-op and then *removed the
+/// reservation* — after which a later `Fresh` binder could allocate that
+/// spelling and capture the free reference.
+#[test]
+fn a_fixed_binder_does_not_consume_a_free_name_reservation() {
+    let mut arena = ExprArena::new();
+    let fixed = arena.bind_fixed(KtName::expect("config"));
+    let fresh = arena.bind_fresh("config");
+    // `{ config -> config }` — the Fixed binder's frame opens and closes —
+    // then a Fresh binder asks for the same hint, while the tree still
+    // references the free `io.example.config`.
+    let tree = KtExpr::free_call(
+        "f",
+        [
+            KtExpr::lambda1([fixed], KtExpr::local(fixed)),
+            KtExpr::lambda1([fresh], KtExpr::local(fresh)),
+            KtExpr::name("io.example.config"),
+        ],
+    );
+    let mut imports = ImportSet::default();
+    let rendered = render_expr(&arena, &tree, &mut imports);
+    // The Fresh binder had to move aside: the reservation survived the Fixed
+    // binder's pop.
+    assert_eq!(
+        rendered,
+        "f({ config -> config }, { config2 -> config2 }, config)"
+    );
+}
+
+/// While a binder printed `config` is live, a **qualified** free name that
+/// would shorten to `config` stays fully qualified.
+///
+/// Shortening it would silently turn the qualified reference into the
+/// parameter — capture arriving through the import set rather than the scope.
+#[test]
+fn a_qualified_free_name_shadowed_by_a_binder_stays_qualified() {
+    let mut arena = ExprArena::new();
+    let fixed = arena.bind_fixed(KtName::expect("config"));
+    let tree = KtExpr::lambda1(
+        [fixed],
+        KtExpr::free_call(
+            "f",
+            [KtExpr::local(fixed), KtExpr::name("io.example.config")],
+        ),
+    );
+    let mut imports = ImportSet::default();
+    assert_eq!(
+        render_expr(&arena, &tree, &mut imports),
+        "{ config -> f(config, io.example.config) }"
+    );
+}
+
+/// A **bare** free name shadowed by a live binder is rejected: the two are the
+/// same token in the output, and the only fix would be renaming a `Fixed`
+/// binder that callers name in arguments.
+///
+/// A `Fresh` binder can never reach this — the allocator avoids every reserved
+/// free name — so it is exactly the `Fixed` case.
+#[test]
+#[should_panic(expected = "is shadowed by a binder printed the same way")]
+fn a_bare_free_name_shadowed_by_a_fixed_binder_is_rejected() {
+    let mut arena = ExprArena::new();
+    let fixed = arena.bind_fixed(KtName::expect("config"));
+    let tree = KtExpr::lambda1(
+        [fixed],
+        KtExpr::free_call("f", [KtExpr::local(fixed), KtExpr::name("config")]),
+    );
+    let mut imports = ImportSet::default();
+    let _ = render_expr(&arena, &tree, &mut imports);
+}
+
 // ── cross-arena composition ─────────────────────────────────────────────
 
 /// `fill_hole` and `substitute` clone trees, so a tree built in **another**
@@ -816,17 +894,13 @@ fn accessors_are_structured_declarations() {
 fn an_expression_accessor_can_reference_its_enclosing_binders() {
     let mut arena = ExprArena::new();
     let ctor_param = arena.bind_fixed(KtName::expect("initialPtr"));
-    let acc = KtAccessor {
-        kind: crate::api::gen::kotlin::AccessorKind::Get,
-        param: None,
-        body: crate::api::gen::kotlin::slot::AccessorBody::Expr(
-            crate::api::gen::kotlin::slot::Ast::in_scope(
-                arena,
-                vec![ctor_param],
-                KtExpr::local(ctor_param).field("value"),
-            ),
+    let acc = KtAccessor::Get(crate::api::gen::kotlin::AccessorTree::Expr(
+        crate::api::gen::kotlin::slot::Ast::in_scope(
+            arena,
+            vec![ctor_param],
+            KtExpr::local(ctor_param).field("value"),
         ),
-    };
+    ));
     let mut imports = ImportSet::default();
     let mut out = String::new();
     acc.render_lines(&mut imports).render(0, &mut out);
@@ -859,6 +933,44 @@ fn a_setter_parameter_is_spelled_from_the_same_allocation_as_its_body() {
     let mut out = String::new();
     acc.render_lines(&mut imports).render(0, &mut out);
     assert_eq!(out.trim(), "set(value2) = store(value2, value)");
+}
+
+/// A typed `Set` **cannot** be built without its value parameter: the variant
+/// carries the binder, so `param: None` is not a representable state.
+///
+/// The old shape fell back to the text `value` whenever `param` was absent, so
+/// a `Set` with a body containing `KtExpr::name("value")` rendered
+/// `set(value) = value` — a free name captured by an implicit binder with no
+/// `BindingId` at all.
+#[test]
+fn a_typed_setter_always_carries_its_parameter() {
+    // The only way to build one binds the parameter.
+    let acc = KtAccessor::set_expr(ExprArena::new(), "value", KtExpr::local);
+    assert!(matches!(acc, KtAccessor::Set { .. }));
+    let mut imports = ImportSet::default();
+    let mut out = String::new();
+    acc.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "set(value) = value");
+
+    // And a hand-built `Set` whose parameter is not in its body's scope fails
+    // fast rather than falling back to a textual header.
+    let mut arena = ExprArena::new();
+    let param = arena.bind_fresh("incoming");
+    let stray = KtAccessor::Set {
+        param,
+        body: crate::api::gen::kotlin::AccessorTree::Expr(crate::api::gen::kotlin::slot::Ast::new(
+            arena,
+            KtExpr::int(0),
+        )),
+    };
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut imports = ImportSet::default();
+        stray.render_lines(&mut imports)
+    }));
+    assert!(
+        err.is_err(),
+        "a parameter outside its body's scope must be rejected"
+    );
 }
 
 /// A **clone** of an arena cannot allocate.

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -175,7 +175,7 @@ fn nested_lambdas_do_not_shadow() {
     // { e -> f(e, { e2 -> g(e, e2) }) }
     let tree = KtExpr::lambda1(
         [outer],
-        KtExpr::free_call("f", [KtExpr::local(outer)]).with_trailing_lambda(KtExpr::lambda1(
+        KtExpr::free_call("f", [KtExpr::local(outer)]).with_trailing_lambda(KtLambda::expr(
             [inner],
             KtExpr::free_call("g", [KtExpr::local(outer), KtExpr::local(inner)]),
         )),
@@ -407,16 +407,20 @@ fn grafting_colliding_arenas_alpha_remaps() {
 
     let grafted = host.graft(&guest, &guest_tree);
     // The guest's binder got a fresh id in the host arena.
-    let KtExpr::Lambda { params, .. } = &grafted else {
+    let KtExpr::Lambda(l) = &grafted else {
         panic!("expected a lambda");
     };
+    let params = &l.params;
     assert_ne!(params[0], host_b, "the graft must not reuse the host's id");
     assert_eq!(host.len(), 2);
 
     // And the whole thing renders with two distinct names.
     let whole = KtExpr::lambda1(
         [host_b],
-        KtExpr::free_call("f", [KtExpr::local(host_b)]).with_trailing_lambda(grafted),
+        KtExpr::free_call("f", [KtExpr::local(host_b)]).with_trailing_lambda(match grafted {
+            KtExpr::Lambda(l) => l,
+            other => panic!("expected a lambda, got {other:?}"),
+        }),
     );
     assert_eq!(r(&host, &whole), "{ v -> f(v) { v2 -> g(v2) } }");
 }
@@ -670,6 +674,112 @@ fn literals_cover_their_whole_value_domain() {
     ] {
         assert_eq!(r(&arena, &e), want);
     }
+}
+
+// ── one BindingId is one binding site ───────────────────────────────────
+
+/// Reintroducing the same `BindingId` is rejected.
+///
+/// `lambda1([b], lambda1([b], local(b)))` used to render `{ x -> { x2 -> x2 } }`:
+/// one structural identity with two binding sites, where `Local(b)` picks its
+/// referent purely by nesting depth because `lookup` walks frames
+/// innermost-first. It also silently breaks `substitute`, which rewrites *every*
+/// `Local(b)`.
+#[test]
+#[should_panic(expected = "is introduced twice in one tree")]
+fn nested_reintroduction_of_a_binder_is_rejected() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("x");
+    let tree = KtExpr::lambda1([b], KtExpr::lambda1([b], KtExpr::local(b)));
+    let _ = r(&arena, &tree);
+}
+
+/// The same identity twice in **one** parameter list.
+#[test]
+#[should_panic(expected = "is introduced twice in one tree")]
+fn same_frame_reintroduction_of_a_binder_is_rejected() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("x");
+    let tree = KtExpr::lambda1([b, b], KtExpr::local(b));
+    let _ = r(&arena, &tree);
+}
+
+/// And in two sequential `Let`s, which is the statement-position form.
+#[test]
+#[should_panic(expected = "is introduced twice in one tree")]
+fn repeated_let_of_one_binder_is_rejected() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("x");
+    let tree = KtExpr::lambda(
+        [],
+        vec![
+            KtStmt::Let {
+                binder: b,
+                mutable: false,
+                value: KtExpr::int(1),
+            },
+            KtStmt::Let {
+                binder: b,
+                mutable: false,
+                value: KtExpr::int(2),
+            },
+            KtStmt::Expr(KtExpr::local(b)),
+        ],
+    );
+    let _ = r(&arena, &tree);
+}
+
+/// **Sibling** scopes too, even though they never overlap and `lookup` would
+/// stay unambiguous: the identity is still duplicated, so `substitute` would
+/// rewrite both occurrences.
+#[test]
+#[should_panic(expected = "is introduced twice in one tree")]
+fn sibling_reintroduction_of_a_binder_is_rejected() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("x");
+    let tree = KtExpr::free_call(
+        "f",
+        [
+            KtExpr::lambda1([b], KtExpr::local(b)),
+            KtExpr::lambda1([b], KtExpr::local(b)),
+        ],
+    );
+    let _ = r(&arena, &tree);
+}
+
+/// Two *distinct* binders that merely share a hint are fine — that is the
+/// allocator's job, not an identity error.
+#[test]
+fn two_distinct_binders_sharing_a_hint_are_fine() {
+    let mut arena = ExprArena::new();
+    let a = arena.bind_fresh("x");
+    let b = arena.bind_fresh("x");
+    let tree = KtExpr::lambda1([a], KtExpr::lambda1([b], KtExpr::local(a)));
+    assert_eq!(r(&arena, &tree), "{ x -> { x2 -> x } }");
+}
+
+// ── trailing lambdas ────────────────────────────────────────────────────
+
+/// Kotlin's trailing-argument syntax accepts only a lambda, and the field is
+/// typed as one — so `consume() 1` is not constructible rather than rejected at
+/// render time. `with_trailing_lambda` takes a [`KtLambda`], and direct variant
+/// construction cannot bypass it either, because the field itself is
+/// `Option<Box<KtLambda>>`.
+#[test]
+fn a_trailing_lambda_is_structurally_a_lambda() {
+    let mut arena = ExprArena::new();
+    let e = arena.bind_fresh("e");
+    let call = KtExpr::free_call("consume", [KtExpr::int(1)])
+        .with_trailing_lambda(KtLambda::expr([e], KtExpr::local(e)));
+    assert_eq!(r(&arena, &call), "consume(1) { e -> e }");
+
+    // A receiver-qualified call takes one too.
+    let mut arena = ExprArena::new();
+    let it = arena.bind_fresh("it");
+    let call = KtExpr::name("list")
+        .call("map", [])
+        .with_trailing_lambda(KtLambda::expr([it], KtExpr::local(it).field("id")));
+    assert_eq!(r(&arena, &call), "list.map() { it -> it.id }");
 }
 
 // ── free-name reservations vs. binder scope ─────────────────────────────

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -758,6 +758,77 @@ fn two_distinct_binders_sharing_a_hint_are_fine() {
     assert_eq!(r(&arena, &tree), "{ x -> { x2 -> x } }");
 }
 
+/// The uniqueness check must hold **across a vector-valued slot**, not only
+/// within one expression.
+///
+/// `render_args` used to render each element through its own `Scope`, so every
+/// element started with an empty `introduced` set and two arguments could bind
+/// the same `BindingId` — the exact sibling duplication the whole-render check
+/// exists to reject, arriving through the one position where sibling lambdas
+/// are most natural. Reachable from enum-entry and supertype-constructor
+/// argument slots.
+#[test]
+#[should_panic(expected = "is introduced twice in one tree")]
+fn sibling_reintroduction_across_a_vector_slot_is_rejected() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("x");
+    let slot: ExprSlot<Vec<KtExpr>> = ExprSlot::ast(
+        arena,
+        vec![
+            KtExpr::lambda1([b], KtExpr::local(b)),
+            KtExpr::lambda1([b], KtExpr::local(b)),
+        ],
+    );
+    let mut imports = ImportSet::default();
+    let _ = slot.render_args(&mut imports);
+}
+
+/// The elements of a vector slot share **one name scope**, so a free name
+/// referenced in *any* element is reserved against binders allocated in the
+/// others — they render into the same argument list, where a binder that took
+/// the free name's spelling would capture it.
+///
+/// Note what this does *not* require: the two sibling binders may share a
+/// spelling. Their scopes do not overlap — each lambda's frame pops before the
+/// next pushes — so `config2` twice is correct Kotlin and gratuitous numbering
+/// would be noise. Only the *free* name is off limits to both.
+#[test]
+fn a_vector_slot_shares_one_name_scope() {
+    let mut arena = ExprArena::new();
+    let a = arena.bind_fresh("config");
+    let b = arena.bind_fresh("config");
+    let slot: ExprSlot<Vec<KtExpr>> = ExprSlot::ast(
+        arena,
+        vec![
+            KtExpr::lambda1([a], KtExpr::local(a)),
+            KtExpr::lambda1([b], KtExpr::local(b)),
+            KtExpr::name("config"),
+        ],
+    );
+    let mut imports = ImportSet::default();
+    assert_eq!(
+        slot.render_args(&mut imports),
+        "{ config2 -> config2 }, { config2 -> config2 }, config"
+    );
+
+    // The reservation is what matters, and it comes from the *whole* vector:
+    // the free `config` appears only in the last element, yet both binders in
+    // the earlier ones avoid it.
+    let mut arena = ExprArena::new();
+    let only = arena.bind_fresh("config");
+    let slot: ExprSlot<Vec<KtExpr>> = ExprSlot::ast(
+        arena,
+        vec![
+            KtExpr::lambda1([only], KtExpr::local(only)),
+            KtExpr::name("config"),
+        ],
+    );
+    assert_eq!(
+        slot.render_args(&mut imports),
+        "{ config2 -> config2 }, config"
+    );
+}
+
 // ── trailing lambdas ────────────────────────────────────────────────────
 
 /// Kotlin's trailing-argument syntax accepts only a lambda, and the field is

--- a/prebindgen/src/api/gen/kotlin/expr/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/expr/tests.rs
@@ -6,6 +6,77 @@ use crate::api::gen::kotlin::{
     types::{ImportSet, KtType},
 };
 
+/// Strip Rust comments — both `//` and `/* … */` — while leaving **string
+/// literals intact**, so a scan for a forbidden token still sees one written in
+/// a message but not one written in prose.
+///
+/// Char literals are not tracked: `'` is overwhelmingly a lifetime, and a naive
+/// char state would swallow code from `'a` to the next quote.
+///
+/// NOTE: Stage T (#190) carries an identical helper for its module-boundary
+/// test. The two branches are independent, so this is a deliberate copy rather
+/// than a shared util that would conflict on merge; folding them into one test
+/// utility belongs to whichever lands second.
+fn code_without_comments(src: &str) -> String {
+    #[derive(Clone, Copy, PartialEq)]
+    enum St {
+        Code,
+        Line,
+        Block,
+        Str,
+        StrEsc,
+    }
+    let mut out = String::with_capacity(src.len());
+    let mut st = St::Code;
+    let mut chars = src.chars().peekable();
+    while let Some(c) = chars.next() {
+        match st {
+            St::Code => match (c, chars.peek()) {
+                ('/', Some('/')) => {
+                    chars.next();
+                    st = St::Line;
+                }
+                ('/', Some('*')) => {
+                    chars.next();
+                    st = St::Block;
+                }
+                ('"', _) => {
+                    st = St::Str;
+                    out.push(c);
+                }
+                _ => out.push(c),
+            },
+            St::Line => {
+                if c == '\n' {
+                    st = St::Code;
+                    out.push(c);
+                }
+            }
+            St::Block => {
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    st = St::Code;
+                } else if c == '\n' {
+                    out.push(c);
+                }
+            }
+            St::Str => {
+                out.push(c);
+                st = match c {
+                    '\\' => St::StrEsc,
+                    '"' => St::Code,
+                    _ => St::Str,
+                };
+            }
+            St::StrEsc => {
+                out.push(c);
+                st = St::Str;
+            }
+        }
+    }
+    out
+}
+
 /// Render with a throwaway import set — for assertions that do not care about
 /// imports.
 fn r(arena: &ExprArena, e: &KtExpr) -> String {
@@ -246,7 +317,7 @@ fn fill_hole_replaces_the_base_in_place() {
             KtExpr::name("payload"),
             "(payload.field as? Exact)?.v0 ?: 0L",
         ),
-        (KtExpr::name("this"), "(this.field as? Exact)?.v0 ?: 0L"),
+        (KtExpr::this(), "(this.field as? Exact)?.v0 ?: 0L"),
     ] {
         let filled = fill_hole(&template, &base);
         assert!(!has_hole(&filled));
@@ -435,6 +506,168 @@ fn no_variant_other_than_raw_accepts_free_form_text() {
     assert_eq!(r(&arena, &KtExpr::Raw("a ?: b".into())), "a ?: b");
 }
 
+// ── declaration parameters are binders ──────────────────────────────────
+
+/// A typed function body can reference its **own parameters** through `Local`.
+///
+/// Every slot renders in a fresh scope, so without the enclosing declaration's
+/// binders a `Local(param)` would be unbound and the renderer would panic.
+/// Reaching for `Name("initialPtr")` instead is not an option — it would put a
+/// binder back into the free-name set and restore exactly the textual capture
+/// `BindingId` exists to remove.
+#[test]
+fn a_typed_body_can_reference_its_own_parameters() {
+    let fun = crate::api::gen::kotlin::KtFun::new("open")
+        .param(crate::api::gen::kotlin::KtParam::new(
+            "initialPtr",
+            KtType::long(),
+        ))
+        .param(crate::api::gen::kotlin::KtParam::new(
+            "config",
+            KtType::string(),
+        ))
+        .typed_body(ExprArena::new(), |_arena, params| {
+            vec![KtStmt::Expr(KtExpr::free_call(
+                "nativeOpen",
+                [KtExpr::local(params[0]), KtExpr::local(params[1])],
+            ))]
+        });
+
+    // The binders were recorded on the parameters…
+    assert!(fun.params.iter().all(|p| p.binder.is_some()));
+    // …and the body renders them by their declared names, byte-identically:
+    // a parameter name is Kotlin's named-argument surface.
+    let crate::api::gen::kotlin::KtBody::Block(slot) = &fun.body else {
+        panic!("expected a typed block body");
+    };
+    let mut imports = ImportSet::default();
+    let mut out = String::new();
+    slot.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "nativeOpen(initialPtr, config)");
+}
+
+/// A `Fresh` binder introduced inside a typed body moves aside for the
+/// enclosing **parameter**, never the reverse — the parameter's spelling is
+/// public API.
+#[test]
+fn a_body_local_does_not_shadow_an_enclosing_parameter() {
+    let fun = crate::api::gen::kotlin::KtFun::new("f")
+        .param(crate::api::gen::kotlin::KtParam::new(
+            "value",
+            KtType::long(),
+        ))
+        .typed_body(ExprArena::new(), |arena, params| {
+            let local = arena.bind_fresh("value");
+            vec![
+                KtStmt::Let {
+                    binder: local,
+                    mutable: false,
+                    value: KtExpr::local(params[0]),
+                },
+                KtStmt::Expr(KtExpr::local(local)),
+            ]
+        });
+    let crate::api::gen::kotlin::KtBody::Block(slot) = &fun.body else {
+        panic!("expected a typed block body");
+    };
+    let mut imports = ImportSet::default();
+    let mut out = String::new();
+    slot.render_lines(&mut imports).render(0, &mut out);
+    assert_eq!(out.trim(), "val value2 = value\nvalue2");
+}
+
+/// The same scope wiring on an arbitrary slot, which is what a supertype
+/// constructor argument (`NativeHandle(initialPtr)`) or a setter body needs.
+#[test]
+fn any_slot_can_be_rendered_with_enclosing_binders() {
+    let mut arena = ExprArena::new();
+    let param = arena.bind_fixed(KtName::expect("initialPtr"));
+    let slot: ExprSlot<Vec<KtExpr>> =
+        ExprSlot::ast_in_scope(arena, vec![param], vec![KtExpr::local(param)]);
+    let mut imports = ImportSet::default();
+    assert_eq!(slot.render_args(&mut imports), "initialPtr");
+}
+
+// ── keywords and the literal domain ─────────────────────────────────────
+
+/// Kotlin **hard keywords** are not identifiers. `KtName::new("when")` used to
+/// succeed and the renderer emitted uncompilable Kotlin.
+///
+/// Rejected rather than backtick-escaped: silently rewriting a name would make
+/// the emitted spelling differ from the one asked for, which for a `Fixed`
+/// binder — a named-argument surface — is exactly what must not happen.
+#[test]
+fn kt_name_rejects_kotlin_hard_keywords() {
+    for kw in [
+        "when",
+        "class",
+        "object",
+        "val",
+        "is",
+        "in",
+        "fun",
+        "typealias",
+    ] {
+        assert!(KtName::new(kw).is_err(), "`{kw}` is a hard keyword");
+        // …in any path segment, too.
+        assert!(
+            KtName::new(format!("io.zenoh.{kw}")).is_err(),
+            "`{kw}` segment"
+        );
+    }
+    // Soft / modifier keywords ARE legal identifiers and must stay accepted.
+    for ok in ["data", "value", "by", "where", "sealed", "inline", "it"] {
+        assert!(KtName::new(ok).is_ok(), "`{ok}` is only a soft keyword");
+    }
+    // `this` is a hard keyword AND a legitimate expression — so it is a node,
+    // not a name.
+    let arena = ExprArena::new();
+    assert_eq!(r(&arena, &KtExpr::this().field("x")), "this.x");
+}
+
+/// A `Fresh` hint can easily be a keyword — hints come from field and leaf
+/// names — so the allocator sidesteps them the same way it sidesteps a taken
+/// name.
+#[test]
+fn a_fresh_binder_never_renders_as_a_hard_keyword() {
+    let mut arena = ExprArena::new();
+    let b = arena.bind_fresh("when");
+    let tree = KtExpr::lambda1([b], KtExpr::local(b));
+    assert_eq!(r(&arena, &tree), "{ when2 -> when2 }");
+}
+
+/// Literals must cover the **whole** domain they can represent.
+///
+/// `-2147483648` and `-9223372036854775808` do not round-trip: Kotlin parses
+/// them as unary minus applied to a positive literal one past the type's
+/// maximum, and rejects them as out of range. Rust prints non-finite doubles as
+/// `NaN` / `inf` / `-inf`, none of which Kotlin accepts.
+#[test]
+fn literals_cover_their_whole_value_domain() {
+    let arena = ExprArena::new();
+    for (e, want) in [
+        (KtExpr::int(i32::MIN), "Int.MIN_VALUE"),
+        (KtExpr::int(i32::MAX), "2147483647"),
+        (KtExpr::int(-1), "-1"),
+        (KtExpr::long(i64::MIN), "Long.MIN_VALUE"),
+        (KtExpr::long(i64::MAX), "9223372036854775807L"),
+        (KtExpr::long(-1), "-1L"),
+        (KtExpr::Literal(KtLiteral::Double(f64::NAN)), "Double.NaN"),
+        (
+            KtExpr::Literal(KtLiteral::Double(f64::INFINITY)),
+            "Double.POSITIVE_INFINITY",
+        ),
+        (
+            KtExpr::Literal(KtLiteral::Double(f64::NEG_INFINITY)),
+            "Double.NEGATIVE_INFINITY",
+        ),
+        (KtExpr::Literal(KtLiteral::Double(1.0)), "1.0"),
+        (KtExpr::Literal(KtLiteral::Double(-0.5)), "-0.5"),
+    ] {
+        assert_eq!(r(&arena, &e), want);
+    }
+}
+
 // ── the slot bridges ────────────────────────────────────────────────────
 
 /// **No expression position can hold a legacy and a typed value
@@ -570,14 +803,9 @@ fn ktexpr_raw_has_no_producers() {
     }
     // …and no other file of the Kotlin generator may reference it in *code*.
     // Doc comments discussing the contract are the point, not a violation, so
-    // they are stripped first — the same treatment Tier 0's module-boundary
-    // test gives its own prose.
-    let code_of = |src: &str| -> String {
-        src.lines()
-            .filter(|l| !l.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
+    // they are stripped first — with the same scanner Tier 0's module-boundary
+    // test uses, which handles `/* … */` as well as `//` and leaves string
+    // literals alone.
     let mut offenders = Vec::new();
     for (name, src) in [
         ("slot.rs", include_str!("../slot.rs")),
@@ -587,7 +815,7 @@ fn ktexpr_raw_has_no_producers() {
         ("file.rs", include_str!("../file.rs")),
         ("types.rs", include_str!("../types.rs")),
     ] {
-        if code_of(src).contains("KtExpr::Raw") {
+        if code_without_comments(src).contains("KtExpr::Raw") {
             offenders.push(name);
         }
     }

--- a/prebindgen/src/api/gen/kotlin/mod.rs
+++ b/prebindgen/src/api/gen/kotlin/mod.rs
@@ -27,8 +27,8 @@ pub use code::Code;
 // already used by the model's mechanical bridges.
 #[allow(unused_imports)]
 pub use expr::{
-    fill_hole, free_names, has_hole, substitute, Binder, BindingId, ExprArena, KtExpr, KtLiteral,
-    KtName, KtPattern, KtStmt, Spelling,
+    fill_hole, free_names, has_hole, substitute, ArenaId, Binder, BindingId, ExprArena, KtExpr,
+    KtLambda, KtLiteral, KtName, KtPattern, KtStmt, NameHint, Spelling,
 };
 pub use file::{merge_files, write_files, WriteKotlinError};
 pub use model::{

--- a/prebindgen/src/api/gen/kotlin/mod.rs
+++ b/prebindgen/src/api/gen/kotlin/mod.rs
@@ -12,18 +12,32 @@
 //! build the model; this module renders it.
 
 pub(crate) mod code;
+pub(crate) mod expr;
 pub(crate) mod file;
 pub(crate) mod model;
 pub(crate) mod render;
+pub(crate) mod slot;
 pub(crate) mod types;
 
 #[cfg(test)]
 mod tests;
 
 pub use code::Code;
+// Re-exported for #193 / #199, which are the first consumers; `ExprSlot` is
+// already used by the model's mechanical bridges.
+#[allow(unused_imports)]
+pub use expr::{
+    fill_hole, free_names, has_hole, substitute, Binder, BindingId, ExprArena, KtExpr, KtLiteral,
+    KtName, KtPattern, KtStmt, Spelling,
+};
 pub use file::{merge_files, write_files, WriteKotlinError};
 pub use model::{
     ClassKind, KtBody, KtClass, KtCtorParam, KtDecl, KtEnumEntry, KtFile, KtFun, KtFunInterface,
     KtParam, KtProperty, Vis,
+};
+#[allow(unused_imports)]
+pub use slot::{
+    AccessorKind, AnnotationSlot, ExprSlot, KtAccessor, KtAnnotation, PropertyValue,
+    StaticAnnotationText,
 };
 pub use types::{ImportSet, KtType};

--- a/prebindgen/src/api/gen/kotlin/mod.rs
+++ b/prebindgen/src/api/gen/kotlin/mod.rs
@@ -37,7 +37,7 @@ pub use model::{
 };
 #[allow(unused_imports)]
 pub use slot::{
-    AccessorKind, AnnotationSlot, ExprSlot, KtAccessor, KtAnnotation, PropertyValue,
+    AccessorTree, AnnotationSlot, ExprSlot, KtAccessor, KtAnnotation, PropertyValue,
     StaticAnnotationText,
 };
 pub use types::{ImportSet, KtType};

--- a/prebindgen/src/api/gen/kotlin/model.rs
+++ b/prebindgen/src/api/gen/kotlin/model.rs
@@ -3,7 +3,27 @@
 //! style as the JniGen config builder. Rendering lives in
 //! [`super::render`]; this module is pure data.
 
-use super::{code::Code, types::KtType};
+use super::{
+    code::Code,
+    expr::{KtExpr, KtStmt},
+    slot::{AnnotationSlot, ExprSlot, KtAccessor, PropertyValue, StaticAnnotationText},
+    types::KtType,
+};
+
+/// Wrap a legacy textual annotation. Every call is a #199 work item; see
+/// [`StaticAnnotationText::from_legacy_string`].
+fn legacy_annotation(a: impl Into<String>) -> AnnotationSlot {
+    AnnotationSlot::Legacy(StaticAnnotationText::from_legacy_string(a))
+}
+
+/// Wrap legacy expression text as a slot. The mechanical 5A bridge: builder
+/// signatures are unchanged, so no producer moves here — only the field types.
+fn legacy_expr<T>(text: impl Into<String>) -> ExprSlot<T> {
+    // `line`, not `wline`: these fields held a plain `String` that the renderer
+    // interpolated verbatim, and wrapping them would reflow existing output.
+    // The bridge has to be byte-identical — this stage moves no artifact.
+    ExprSlot::Legacy(Code::new().line(text.into()))
+}
 
 /// Visibility modifier. `Public` renders explicitly (matching the existing
 /// generated style); `Default` renders nothing.
@@ -190,8 +210,25 @@ pub enum ClassKind {
 #[derive(Clone, Debug)]
 pub struct KtEnumEntry {
     pub name: String,
-    /// Constructor argument text, e.g. `"0"` → `NAME(0)`.
-    pub args: Option<String>,
+    /// Constructor arguments: `NAME(0)`.
+    pub args: Option<ExprSlot<Vec<KtExpr>>>,
+}
+
+impl KtEnumEntry {
+    /// An entry with no constructor arguments.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            args: None,
+        }
+    }
+    /// An entry whose arguments are still legacy text.
+    pub fn legacy_args(name: impl Into<String>, args: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            args: Some(legacy_expr(args)),
+        }
+    }
 }
 
 /// Primary-constructor parameter, optionally a `val`/`var` property.
@@ -205,8 +242,8 @@ pub struct KtCtorParam {
     /// property implements an abstract of a supertype interface.
     pub overrides: bool,
     pub vis: Vis,
-    pub default: Option<String>,
-    pub annotations: Vec<String>,
+    pub default: Option<ExprSlot<KtExpr>>,
+    pub annotations: Vec<AnnotationSlot>,
 }
 
 impl KtCtorParam {
@@ -239,11 +276,11 @@ impl KtCtorParam {
         self
     }
     pub fn default(mut self, d: impl Into<String>) -> Self {
-        self.default = Some(d.into());
+        self.default = Some(legacy_expr(d));
         self
     }
     pub fn annotation(mut self, a: impl Into<String>) -> Self {
-        self.annotations.push(a.into());
+        self.annotations.push(legacy_annotation(a));
         self
     }
 }
@@ -254,13 +291,13 @@ pub struct KtClass {
     pub kind: ClassKind,
     pub name: String,
     pub vis: Vis,
-    pub annotations: Vec<String>,
+    pub annotations: Vec<AnnotationSlot>,
     pub kdoc: Option<String>,
     pub ctor_params: Vec<KtCtorParam>,
     /// Supertypes with optional constructor-argument text:
     /// `(NativeHandle, Some("initialPtr"))` → `: NativeHandle(initialPtr)`;
     /// `(AutoCloseable, None)` → `: AutoCloseable`.
-    pub supertypes: Vec<(KtType, Option<String>)>,
+    pub supertypes: Vec<(KtType, Option<ExprSlot<Vec<KtExpr>>>)>,
     pub members: Vec<KtDecl>,
     pub companion: Option<Box<KtClass>>,
 }
@@ -291,7 +328,7 @@ impl KtClass {
         self
     }
     pub fn annotation(mut self, a: impl Into<String>) -> Self {
-        self.annotations.push(a.into());
+        self.annotations.push(legacy_annotation(a));
         self
     }
     pub fn kdoc(mut self, d: impl Into<String>) -> Self {
@@ -303,7 +340,7 @@ impl KtClass {
         self
     }
     pub fn supertype(mut self, ty: KtType, ctor_args: Option<&str>) -> Self {
-        self.supertypes.push((ty, ctor_args.map(str::to_string)));
+        self.supertypes.push((ty, ctor_args.map(legacy_expr)));
         self
     }
     pub fn member(mut self, d: impl Into<KtDecl>) -> Self {
@@ -322,10 +359,10 @@ pub enum KtBody {
     /// No body (`external` / `abstract` declarations).
     #[default]
     None,
-    /// Single-expression body: `= <code>` (one line) or multi-line after `=`.
-    Expr(Code),
+    /// Single-expression body: `= <expr>`.
+    Expr(ExprSlot<KtExpr>),
     /// Block body: `{ … }`.
-    Block(Code),
+    Block(ExprSlot<Vec<KtStmt>>),
 }
 
 /// A function declaration (top-level or member).
@@ -336,7 +373,7 @@ pub struct KtFun {
     /// Modifier keywords in render order, e.g. `external`, `inline`,
     /// `override`, `abstract`, `operator`.
     pub modifiers: Vec<String>,
-    pub annotations: Vec<String>,
+    pub annotations: Vec<AnnotationSlot>,
     pub kdoc: Option<String>,
     /// Generic type-variable names: `["R"]` → `fun <R> …`.
     pub generics: Vec<String>,
@@ -369,7 +406,7 @@ impl KtFun {
         self
     }
     pub fn annotation(mut self, a: impl Into<String>) -> Self {
-        self.annotations.push(a.into());
+        self.annotations.push(legacy_annotation(a));
         self
     }
     pub fn kdoc(mut self, d: impl Into<String>) -> Self {
@@ -389,11 +426,11 @@ impl KtFun {
         self
     }
     pub fn body(mut self, c: Code) -> Self {
-        self.body = KtBody::Block(c);
+        self.body = KtBody::Block(ExprSlot::Legacy(c));
         self
     }
     pub fn expr_body(mut self, c: Code) -> Self {
-        self.body = KtBody::Expr(c);
+        self.body = KtBody::Expr(ExprSlot::Legacy(c));
         self
     }
 }
@@ -404,7 +441,7 @@ impl KtFun {
 pub struct KtParam {
     pub name: String,
     pub ty: KtType,
-    pub default: Option<String>,
+    pub default: Option<ExprSlot<KtExpr>>,
 }
 
 impl KtParam {
@@ -416,7 +453,7 @@ impl KtParam {
         }
     }
     pub fn default(mut self, d: impl Into<String>) -> Self {
-        self.default = Some(d.into());
+        self.default = Some(legacy_expr(d));
         self
     }
 }
@@ -426,22 +463,20 @@ impl KtParam {
 pub struct KtProperty {
     pub name: String,
     pub ty: Option<KtType>,
-    /// Raw initializer expression text.
-    pub initializer: Option<String>,
-    /// Raw delegate expression text (`val x by <delegate>`, e.g.
-    /// `lazy { … }`). Mutually exclusive with `initializer`.
-    pub delegate: Option<String>,
+    /// The initializer or the delegate — **never both**. The exclusion used to
+    /// be two `Option<String>` fields plus a doc comment and a `debug_assert`;
+    /// it is now a sum, so the illegal state is unrepresentable.
+    pub value: PropertyValue,
     pub mutable: bool,
     pub vis: Vis,
     /// Inline annotations rendered before the keyword: `@Volatile internal var …`.
-    pub annotations: Vec<String>,
+    pub annotations: Vec<AnnotationSlot>,
     /// Keyword modifiers rendered between visibility and `val`/`var`
     /// (`open`, `final override`, …).
     pub modifiers: Vec<String>,
     pub kdoc: Option<String>,
-    /// Raw accessor text rendered indented under the property (e.g. a
-    /// custom getter `get() = …`).
-    pub accessors: Option<Code>,
+    /// A structured accessor — a declaration with a body, not an expression.
+    pub accessors: Option<KtAccessor>,
 }
 
 impl KtProperty {
@@ -449,8 +484,7 @@ impl KtProperty {
         Self {
             name: name.into(),
             ty: None,
-            initializer: None,
-            delegate: None,
+            value: PropertyValue::None,
             mutable: false,
             vis: Vis::Default,
             annotations: Vec::new(),
@@ -470,11 +504,11 @@ impl KtProperty {
         self
     }
     pub fn initializer(mut self, i: impl Into<String>) -> Self {
-        self.initializer = Some(i.into());
+        self.value = PropertyValue::Initializer(legacy_expr(i));
         self
     }
     pub fn delegate(mut self, d: impl Into<String>) -> Self {
-        self.delegate = Some(d.into());
+        self.value = PropertyValue::Delegate(legacy_expr(d));
         self
     }
     pub fn vis(mut self, v: Vis) -> Self {
@@ -482,7 +516,7 @@ impl KtProperty {
         self
     }
     pub fn annotation(mut self, a: impl Into<String>) -> Self {
-        self.annotations.push(a.into());
+        self.annotations.push(legacy_annotation(a));
         self
     }
     pub fn modifier(mut self, m: impl Into<String>) -> Self {
@@ -494,7 +528,7 @@ impl KtProperty {
         self
     }
     pub fn accessors(mut self, c: Code) -> Self {
-        self.accessors = Some(c);
+        self.accessors = Some(KtAccessor::legacy(c));
         self
     }
 }

--- a/prebindgen/src/api/gen/kotlin/model.rs
+++ b/prebindgen/src/api/gen/kotlin/model.rs
@@ -5,7 +5,7 @@
 
 use super::{
     code::Code,
-    expr::{KtExpr, KtStmt},
+    expr::{BindingId, ExprArena, KtExpr, KtName, KtStmt},
     slot::{AnnotationSlot, ExprSlot, KtAccessor, PropertyValue, StaticAnnotationText},
     types::KtType,
 };
@@ -244,6 +244,10 @@ pub struct KtCtorParam {
     pub vis: Vis,
     pub default: Option<ExprSlot<KtExpr>>,
     pub annotations: Vec<AnnotationSlot>,
+    /// The AST binder this constructor parameter is — see [`KtParam::binder`].
+    /// A supertype constructor argument (`NativeHandle(initialPtr)`) references
+    /// it through `Local`.
+    pub binder: Option<BindingId>,
 }
 
 impl KtCtorParam {
@@ -256,6 +260,7 @@ impl KtCtorParam {
             vis: Vis::Default,
             default: None,
             annotations: Vec::new(),
+            binder: None,
         }
     }
     pub fn val(mut self) -> Self {
@@ -433,6 +438,39 @@ impl KtFun {
         self.body = KtBody::Expr(ExprSlot::Legacy(c));
         self
     }
+
+    /// Give this function a **typed** body that may reference its own
+    /// parameters.
+    ///
+    /// One call does all three things that have to agree: it binds each
+    /// parameter in `arena` as a [`Spelling::Fixed`](super::expr::Spelling)
+    /// binder (so the rendered name stays byte-identical — parameter names are
+    /// Kotlin's named-argument surface), records the ids on the `KtParam`s, and
+    /// puts the same ids in the body slot's scope.
+    ///
+    /// Splitting that across three calls is how the binder, the arena that owns
+    /// it, and the scope it is rendered in would end up disagreeing — the
+    /// cross-arena hazard `ExprArena::graft` exists for, arriving through the
+    /// back door.
+    ///
+    /// `build` receives the parameters' binders in declaration order.
+    pub fn typed_body(
+        mut self,
+        mut arena: ExprArena,
+        build: impl FnOnce(&mut ExprArena, &[BindingId]) -> Vec<KtStmt>,
+    ) -> Self {
+        let scope: Vec<BindingId> = self
+            .params
+            .iter()
+            .map(|p| arena.bind_fixed(KtName::expect(&p.name)))
+            .collect();
+        for (p, id) in self.params.iter_mut().zip(&scope) {
+            p.binder = Some(*id);
+        }
+        let stmts = build(&mut arena, &scope);
+        self.body = KtBody::Block(ExprSlot::ast_in_scope(arena, scope, stmts));
+        self
+    }
 }
 
 /// A function parameter with an optional default-value expression (raw
@@ -442,6 +480,17 @@ pub struct KtParam {
     pub name: String,
     pub ty: KtType,
     pub default: Option<ExprSlot<KtExpr>>,
+    /// The AST binder this parameter **is**, when the enclosing declaration has
+    /// a typed body.
+    ///
+    /// A parameter is a binder exactly as a lambda parameter is, so a typed
+    /// body references it through `Local`, never through `Name` — a name would
+    /// put it back in the free-name set and restore textual capture. `None` on
+    /// the legacy path, where the body is text and the name is all there is.
+    ///
+    /// Set through [`KtFun::typed_body`], which allocates the binder and the
+    /// body's scope together so the two cannot disagree.
+    pub binder: Option<BindingId>,
 }
 
 impl KtParam {
@@ -450,6 +499,7 @@ impl KtParam {
             name: name.into(),
             ty,
             default: None,
+            binder: None,
         }
     }
     pub fn default(mut self, d: impl Into<String>) -> Self {

--- a/prebindgen/src/api/gen/kotlin/render.rs
+++ b/prebindgen/src/api/gen/kotlin/render.rs
@@ -67,24 +67,49 @@ impl KtFile {
     }
 }
 
+/// Gather the imports a declaration's **expression slots** reference.
+///
+/// Every position that can hold an `ExprSlot` has to be visited, not only the
+/// bodies. A `Legacy(Code)` renders raw text, and `Code::import` is the *only*
+/// place its FQNs are recorded — so a `KtParam::default` holding
+/// `Code::new().line("Factory.make()").import("io.example.Factory")` renders
+/// `Factory.make()` and, if this walk skips it, never emits the import. The
+/// `Ast` arm answers from its own tree, so both arms are covered by asking the
+/// slot rather than by inspecting it here.
+///
+/// The walk therefore mirrors the slot table in [`super::slot`] exactly: miss a
+/// row and that position silently loses its imports.
 fn collect_decl_imports(d: &KtDecl, sink: &mut Vec<String>) {
     match d {
         KtDecl::Class(c) => {
+            for p in &c.ctor_params {
+                if let Some(default) = &p.default {
+                    default.collect_imports(sink);
+                }
+            }
+            for (_, args) in &c.supertypes {
+                if let Some(args) = args {
+                    args.collect_imports(sink);
+                }
+            }
+            if let ClassKind::Enum(entries) = &c.kind {
+                for e in entries {
+                    if let Some(args) = &e.args {
+                        args.collect_imports(sink);
+                    }
+                }
+            }
             for m in &c.members {
                 collect_decl_imports(m, sink);
             }
             if let Some(comp) = &c.companion {
-                for m in &comp.members {
-                    collect_decl_imports(m, sink);
-                }
+                collect_decl_imports(&KtDecl::Class((**comp).clone()), sink);
             }
         }
-        KtDecl::Fun(f) => match &f.body {
-            KtBody::Expr(c) => c.collect_imports(sink),
-            KtBody::Block(c) => c.collect_imports(sink),
-            KtBody::None => {}
-        },
-        KtDecl::FunInterface(_) => {}
+        KtDecl::Fun(f) => collect_fun_imports(f, sink),
+        // A `fun interface`'s method is a whole `KtFun` — its parameters can
+        // carry defaults like any other.
+        KtDecl::FunInterface(i) => collect_fun_imports(&i.method, sink),
         KtDecl::Property(p) => {
             p.value.collect_imports(sink);
             if let Some(a) = &p.accessors {
@@ -93,6 +118,19 @@ fn collect_decl_imports(d: &KtDecl, sink: &mut Vec<String>) {
         }
         KtDecl::TypeAlias { .. } => {}
         KtDecl::Raw { code, .. } => code.collect_imports(sink),
+    }
+}
+
+fn collect_fun_imports(f: &KtFun, sink: &mut Vec<String>) {
+    match &f.body {
+        KtBody::Expr(c) => c.collect_imports(sink),
+        KtBody::Block(c) => c.collect_imports(sink),
+        KtBody::None => {}
+    }
+    for p in &f.params {
+        if let Some(default) = &p.default {
+            default.collect_imports(sink);
+        }
     }
 }
 

--- a/prebindgen/src/api/gen/kotlin/render.rs
+++ b/prebindgen/src/api/gen/kotlin/render.rs
@@ -5,6 +5,7 @@
 
 use super::{
     model::*,
+    slot::{AnnotationSlot, PropertyValue, StaticAnnotationText},
     types::{ImportSet, KtType},
 };
 
@@ -79,11 +80,13 @@ fn collect_decl_imports(d: &KtDecl, sink: &mut Vec<String>) {
             }
         }
         KtDecl::Fun(f) => match &f.body {
-            KtBody::Expr(c) | KtBody::Block(c) => c.collect_imports(sink),
+            KtBody::Expr(c) => c.collect_imports(sink),
+            KtBody::Block(c) => c.collect_imports(sink),
             KtBody::None => {}
         },
         KtDecl::FunInterface(_) => {}
         KtDecl::Property(p) => {
+            p.value.collect_imports(sink);
             if let Some(a) = &p.accessors {
                 a.collect_imports(sink);
             }
@@ -157,7 +160,7 @@ fn class_keyword(kind: &ClassKind) -> &'static str {
 fn render_ctor_param(p: &KtCtorParam, imports: &mut ImportSet) -> String {
     let mut s = String::new();
     for a in &p.annotations {
-        s.push_str(&format!("@{a} "));
+        s.push_str(&format!("@{} ", a.render(imports)));
     }
     s.push_str(p.vis.prefix());
     if p.overrides {
@@ -170,7 +173,7 @@ fn render_ctor_param(p: &KtCtorParam, imports: &mut ImportSet) -> String {
     }
     s.push_str(&format!("{}: {}", p.name, p.ty.render(imports)));
     if let Some(d) = &p.default {
-        s.push_str(&format!(" = {d}"));
+        s.push_str(&format!(" = {}", d.render_inline(imports)));
     }
     s
 }
@@ -180,12 +183,17 @@ fn render_class(c: &KtClass, level: usize, imports: &mut ImportSet, out: &mut St
         render_kdoc(doc, level, out);
     }
     let mut annotations = c.annotations.clone();
-    if matches!(c.kind, ClassKind::ValueInline) && !annotations.iter().any(|a| a == "JvmInline") {
-        annotations.insert(0, "JvmInline".to_string());
+    if matches!(c.kind, ClassKind::ValueInline)
+        && !annotations.iter().any(|a| a.renders_as("JvmInline"))
+    {
+        annotations.insert(
+            0,
+            AnnotationSlot::Legacy(StaticAnnotationText::__from_literal("JvmInline")),
+        );
     }
     for a in &annotations {
         indent(level, out);
-        out.push_str(&format!("@{a}\n"));
+        out.push_str(&format!("@{}\n", a.render(imports)));
     }
 
     indent(level, out);
@@ -215,7 +223,7 @@ fn render_class(c: &KtClass, level: usize, imports: &mut ImportSet, out: &mut St
             .map(|(ty, args)| {
                 let t = ty.render(imports);
                 match args {
-                    Some(a) => format!("{t}({a})"),
+                    Some(a) => format!("{t}({})", a.render_args(imports)),
                     None => t,
                 }
             })
@@ -239,7 +247,7 @@ fn render_class(c: &KtClass, level: usize, imports: &mut ImportSet, out: &mut St
             indent(level + 1, out);
             out.push_str(&e.name);
             if let Some(args) = &e.args {
-                out.push_str(&format!("({args})"));
+                out.push_str(&format!("({})", args.render_args(imports)));
             }
             out.push_str(if i + 1 == entries.len() { ";\n" } else { ",\n" });
         }
@@ -278,7 +286,7 @@ fn render_signature_param(p: &KtParam, imports: &mut ImportSet, level: usize) ->
     let default = p
         .default
         .as_ref()
-        .map(|d| format!(" = {d}"))
+        .map(|d| format!(" = {}", d.render_inline(imports)))
         .unwrap_or_default();
     // Column where the type begins on the parameter line.
     let type_col = level * 4 + name_prefix.len();
@@ -351,7 +359,7 @@ fn render_fun(f: &KtFun, level: usize, imports: &mut ImportSet, out: &mut String
     }
     for a in &f.annotations {
         indent(level, out);
-        out.push_str(&format!("@{a}\n"));
+        out.push_str(&format!("@{}\n", a.render(imports)));
     }
     indent(level, out);
     out.push_str(f.vis.prefix());
@@ -370,7 +378,7 @@ fn render_fun(f: &KtFun, level: usize, imports: &mut ImportSet, out: &mut String
         .map(|p| {
             let mut s = format!("{}: {}", p.name, p.ty.render(imports));
             if let Some(d) = &p.default {
-                s.push_str(&format!(" = {d}"));
+                s.push_str(&format!(" = {}", d.render_inline(imports)));
             }
             s
         })
@@ -411,21 +419,23 @@ fn render_fun(f: &KtFun, level: usize, imports: &mut ImportSet, out: &mut String
     }
     match &f.body {
         KtBody::None => out.push('\n'),
-        KtBody::Expr(code) => {
+        KtBody::Expr(slot) => {
             // Single-line expression renders inline; multi-line after `=`.
-            let mut tmp = String::new();
-            code.render(0, &mut tmp);
-            let trimmed = tmp.trim_end_matches('\n');
-            if trimmed.lines().count() <= 1 {
-                out.push_str(&format!(" = {trimmed}\n"));
+            let rendered = slot.render_inline(imports);
+            if rendered.lines().count() <= 1 {
+                out.push_str(&format!(" = {rendered}\n"));
             } else {
                 out.push_str(" =\n");
-                code.render(level + 1, out);
+                for line in rendered.lines() {
+                    indent(level + 1, out);
+                    out.push_str(line);
+                    out.push('\n');
+                }
             }
         }
-        KtBody::Block(code) => {
+        KtBody::Block(slot) => {
             out.push_str(" {\n");
-            code.render(level + 1, out);
+            slot.render_lines(imports).render(level + 1, out);
             indent(level, out);
             out.push_str("}\n");
         }
@@ -460,7 +470,7 @@ fn render_property(p: &KtProperty, level: usize, imports: &mut ImportSet, out: &
     }
     indent(level, out);
     for a in &p.annotations {
-        out.push_str(&format!("@{a} "));
+        out.push_str(&format!("@{} ", a.render(imports)));
     }
     out.push_str(p.vis.prefix());
     for m in &p.modifiers {
@@ -472,20 +482,21 @@ fn render_property(p: &KtProperty, level: usize, imports: &mut ImportSet, out: &
     if let Some(ty) = &p.ty {
         out.push_str(&format!(": {}", ty.render(imports)));
     }
-    debug_assert!(
-        p.delegate.is_none() || p.initializer.is_none(),
-        "property `{}`: delegate and initializer are mutually exclusive",
-        p.name
-    );
-    if let Some(delegate) = &p.delegate {
-        out.push_str(&format!(" by {delegate}"));
-    }
-    if let Some(init) = &p.initializer {
-        out.push_str(&format!(" = {init}"));
+    // No `debug_assert` here any more: `PropertyValue` is a sum, so
+    // "delegate and initializer are mutually exclusive" is a property of the
+    // type rather than a runtime check that only fires in debug builds.
+    match &p.value {
+        PropertyValue::None => {}
+        PropertyValue::Delegate(d) => {
+            out.push_str(&format!(" by {}", d.render_inline(imports)));
+        }
+        PropertyValue::Initializer(i) => {
+            out.push_str(&format!(" = {}", i.render_inline(imports)));
+        }
     }
     out.push('\n');
     if let Some(acc) = &p.accessors {
-        acc.render(level + 1, out);
+        acc.render_lines(imports).render(level + 1, out);
     }
 }
 

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -416,10 +416,7 @@ impl ExprSlot<Vec<KtStmt>> {
         match self {
             ExprSlot::Legacy(c) => c.collect_imports(sink),
             ExprSlot::Ast(a) => {
-                let wrapper = KtExpr::Lambda {
-                    params: Vec::new(),
-                    body: a.tree.clone(),
-                };
+                let wrapper = KtExpr::Lambda(super::expr::KtLambda::new([], a.tree.clone()));
                 sink.extend(
                     super::expr::free_names(&wrapper)
                         .into_iter()
@@ -513,10 +510,7 @@ impl KtAccessor {
         match tree {
             AccessorTree::Expr(a) => qualified(&a.tree, sink),
             AccessorTree::Block(a) => qualified(
-                &KtExpr::Lambda {
-                    params: Vec::new(),
-                    body: a.tree.clone(),
-                },
+                &KtExpr::Lambda(super::expr::KtLambda::new([], a.tree.clone())),
                 sink,
             ),
         }

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -140,63 +140,63 @@ pub enum PropertyValue {
     Delegate(ExprSlot<KtExpr>),
 }
 
-/// Which accessor of a property.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AccessorKind {
-    Get,
-    Set,
-}
-
 /// A property accessor.
 ///
 /// **A declaration containing a body**, not an expression — which is why it is
-/// not an `ExprSlot<KtExpr>`. A getter may be `get() = <expr>` or `get() { … }`,
-/// and a setter binds its parameter.
+/// not an `ExprSlot<KtExpr>`.
+///
+/// A **sum**, so that a typed setter without its value parameter is
+/// unrepresentable. It was `{ kind, param: Option<BindingId>, body }` with the
+/// header falling back to the text `value` when `param` was absent — and since
+/// the fields are public, a `Set` could be built with `param: None` and a body
+/// containing `KtExpr::name("value")`, rendering `set(value) = value`: a free
+/// name captured by an implicit binder with no `BindingId` at all. Carrying the
+/// binder in the variant removes that state instead of checking for it.
 #[derive(Clone, Debug)]
-pub struct KtAccessor {
-    pub kind: AccessorKind,
-    /// A setter's value parameter, as a **binder**.
+pub enum KtAccessor {
+    /// Pre-rendered accessor text, verbatim. Deleted by #199.
+    Legacy(Code),
+    /// `get() = <expr>` / `get() { … }`.
+    Get(AccessorTree),
+    /// `set(<param>) = <expr>` / `set(<param>) { … }`.
     ///
-    /// The header used to be a hardcoded `set(value)`, independent of anything
-    /// in the body's scope — so a binder spelled `incoming` rendered
-    /// `set(value) = incoming`, and a `Fresh` binder hinted `value` that the
-    /// allocator moved to `value2` left the signature still saying `value`.
-    /// The spelling now comes from the same allocation the body uses, which is
-    /// the only way the two cannot disagree.
-    ///
-    /// `None` for a getter, and on the legacy path.
-    pub param: Option<BindingId>,
-    /// `= <expr>` when `Some(expr)`, else a block of `body`.
-    pub body: AccessorBody,
+    /// `param` is the value parameter as a **binder**, and the header is
+    /// spelled from the same allocation the body uses — the only way the
+    /// signature and the body cannot disagree.
+    Set {
+        param: BindingId,
+        body: AccessorTree,
+    },
 }
 
-/// An accessor's body — expression form or block form.
+/// A typed accessor body — expression form or block form.
 #[derive(Clone, Debug)]
-pub enum AccessorBody {
-    /// Legacy pre-rendered accessor text, verbatim. Deleted by #199.
-    Legacy(Code),
-    /// `get() = <expr>`.
+pub enum AccessorTree {
+    /// `= <expr>`.
     Expr(Ast<KtExpr>),
-    /// `get() { <stmts> }`.
+    /// `{ <stmts> }`.
     Block(Ast<Vec<KtStmt>>),
+}
+
+impl AccessorTree {
+    fn scope(&self) -> &[BindingId] {
+        match self {
+            AccessorTree::Expr(a) => &a.scope,
+            AccessorTree::Block(a) => &a.scope,
+        }
+    }
 }
 
 impl KtAccessor {
     /// Wrap pre-rendered accessor text. The mechanical bridge; #199 replaces
     /// each caller with a structured accessor.
     pub fn legacy(code: Code) -> Self {
-        Self {
-            kind: AccessorKind::Get,
-            param: None,
-            body: AccessorBody::Legacy(code),
-        }
+        KtAccessor::Legacy(code)
     }
+
+    /// `get() = <expr>`.
     pub fn get_expr(arena: ExprArena, e: KtExpr) -> Self {
-        Self {
-            kind: AccessorKind::Get,
-            param: None,
-            body: AccessorBody::Expr(Ast::new(arena, e)),
-        }
+        KtAccessor::Get(AccessorTree::Expr(Ast::new(arena, e)))
     }
 
     /// A setter whose value parameter is a binder the body references through
@@ -208,14 +208,13 @@ impl KtAccessor {
     ) -> Self {
         let param = arena.bind_fresh(hint);
         let tree = build(param);
-        Self {
-            kind: AccessorKind::Set,
-            param: Some(param),
-            body: AccessorBody::Expr(Ast::in_scope(arena, vec![param], tree)),
+        KtAccessor::Set {
+            param,
+            body: AccessorTree::Expr(Ast::in_scope(arena, vec![param], tree)),
         }
     }
     pub fn is_legacy(&self) -> bool {
-        matches!(self.body, AccessorBody::Legacy(_))
+        matches!(self, KtAccessor::Legacy(_))
     }
 }
 
@@ -448,33 +447,42 @@ impl KtAccessor {
         // uses, via the scope names the renderer hands back. Deriving it
         // independently — as a hardcoded `set(value)` did — is how a signature
         // ends up saying `value` while the body says `value2`.
+        let (tree, param) = match self {
+            KtAccessor::Legacy(c) => return c.clone(),
+            KtAccessor::Get(t) => (t, None),
+            KtAccessor::Set { param, body } => (body, Some(*param)),
+        };
+        // A setter's parameter must be in its body's scope, or the header would
+        // be spelled from an allocation the body never saw. `Set` guarantees
+        // the binder exists; this is the remaining half — that it is the one
+        // the body renders under.
+        if let Some(p) = param {
+            assert!(
+                tree.scope().contains(&p),
+                "KtAccessor::Set: the value parameter is not in its body's scope — the header \
+                 and the body would be spelled from different allocations"
+            );
+        }
         let head = |scope: &[BindingId], names: &[String]| -> String {
-            match self.kind {
-                AccessorKind::Get => "get()".to_string(),
-                AccessorKind::Set => {
-                    let name = self
-                        .param
-                        .and_then(|p| scope.iter().position(|b| *b == p))
-                        .and_then(|i| names.get(i).cloned())
-                        // A setter with no declared binder keeps Kotlin's
-                        // implicit parameter name.
-                        .unwrap_or_else(|| "value".to_string());
-                    format!("set({name})")
+            match param {
+                None => "get()".to_string(),
+                Some(p) => {
+                    let i = scope.iter().position(|b| *b == p).expect("asserted above");
+                    format!("set({})", names[i])
                 }
             }
         };
-        match &self.body {
-            AccessorBody::Legacy(c) => c.clone(),
+        match tree {
             // Scope-aware, like every other typed slot: a getter or setter
             // expression referencing a constructor parameter or the setter's
             // own binder would otherwise be unbound.
-            AccessorBody::Expr(a) => {
+            AccessorTree::Expr(a) => {
                 let (names, rendered) = super::expr::render::render_expr_in_scope_named(
                     &a.arena, &a.scope, &a.tree, imports,
                 );
                 Code::new().line(format!("{} = {rendered}", head(&a.scope, &names)))
             }
-            AccessorBody::Block(a) => {
+            AccessorTree::Block(a) => {
                 let (names, lines) =
                     super::expr::render::render_stmts_named(&a.arena, &a.scope, &a.tree, imports);
                 Code::new().blk(format!("{} {{", head(&a.scope, &names)), |c| {
@@ -489,26 +497,28 @@ impl KtAccessor {
     }
 
     pub fn collect_imports(&self, sink: &mut Vec<String>) {
-        match &self.body {
-            AccessorBody::Legacy(c) => c.collect_imports(sink),
-            AccessorBody::Expr(a) => sink.extend(
-                super::expr::free_names(&a.tree)
+        let qualified = |e: &KtExpr, sink: &mut Vec<String>| {
+            sink.extend(
+                super::expr::free_names(e)
                     .into_iter()
                     .filter(|n| n.is_qualified())
                     .map(|n| n.as_str().to_string()),
-            ),
-            AccessorBody::Block(a) => {
-                let wrapper = KtExpr::Lambda {
+            );
+        };
+        let tree = match self {
+            KtAccessor::Legacy(c) => return c.collect_imports(sink),
+            KtAccessor::Get(t) => t,
+            KtAccessor::Set { body, .. } => body,
+        };
+        match tree {
+            AccessorTree::Expr(a) => qualified(&a.tree, sink),
+            AccessorTree::Block(a) => qualified(
+                &KtExpr::Lambda {
                     params: Vec::new(),
                     body: a.tree.clone(),
-                };
-                sink.extend(
-                    super::expr::free_names(&wrapper)
-                        .into_iter()
-                        .filter(|n| n.is_qualified())
-                        .map(|n| n.as_str().to_string()),
-                );
-            }
+                },
+                sink,
+            ),
         }
     }
 }

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -1,0 +1,458 @@
+//! Exclusive bridges between the legacy textual expression fields and the typed
+//! [`KtExpr`](super::expr::KtExpr) tier.
+//!
+//! # Why a sum and not two fields
+//!
+//! Introducing typed replacements *alongside* the legacy fields would let both
+//! be populated at once and leave the renderer to decide which wins — two
+//! authorities for one fact, which is the defect #187 exists to remove,
+//! recreated inside its own migration.
+//!
+//! [`ExprSlot`] is a sum, so an expression position holds a textual answer or a
+//! structured one and never both. #199 deletes the `Legacy` variants; until
+//! then the type is what enforces the exclusion, not review.
+//!
+//! # The positions
+//!
+//! Every API able to embed expression text is covered, not only the ones whose
+//! grammatical category is "expression":
+//!
+//! | Position | Was | Now |
+//! |---|---|---|
+//! | function body | `KtBody::Expr(Code)` / `Block(Code)` | `ExprSlot<KtExpr>` / `ExprSlot<Vec<KtStmt>>` |
+//! | enum entry args | `Option<String>` | `ExprSlot<Vec<KtExpr>>` |
+//! | ctor param default | `Option<String>` | `ExprSlot<KtExpr>` |
+//! | fn param default | `Option<String>` | `ExprSlot<KtExpr>` |
+//! | property init / delegate | two `Option<String>` fields | [`PropertyValue`] |
+//! | supertype ctor args | `Option<String>` | `ExprSlot<Vec<KtExpr>>` |
+//! | property accessors | `Option<Code>` | [`KtAccessor`] |
+//! | annotations | `Vec<String>` | `Vec<AnnotationSlot>` |
+//!
+//! Two of those are not expression slots and need more than a slot:
+//! **accessors are declarations containing bodies**, so they get a structured
+//! [`KtAccessor`]; and **annotation arguments are expressions**, so
+//! [`KtAnnotation`] carries `Vec<KtExpr>`.
+
+// Same reason as `expr`: the typed arms exist so #193 and #199 have somewhere
+// to land, and nothing constructs one yet.
+#![allow(dead_code)]
+
+use super::{
+    code::Code,
+    expr::{ExprArena, KtExpr, KtName, KtStmt},
+};
+
+/// A typed tree together with the arena owning its binders.
+///
+/// The arena travels **with** the tree rather than sitting on the enclosing
+/// file or function, so a slot renders with no ambient state and two slots can
+/// be built independently. Merging them is exactly what
+/// [`ExprArena::graft`](super::expr::ExprArena::graft) is for, and it
+/// alpha-remaps — which is why independent arenas are safe to hand around.
+#[derive(Clone, Debug)]
+pub struct Ast<T> {
+    pub arena: ExprArena,
+    pub tree: T,
+}
+
+impl<T> Ast<T> {
+    pub fn new(arena: ExprArena, tree: T) -> Self {
+        Self { arena, tree }
+    }
+}
+
+/// One expression position: a legacy textual answer **or** a structured one.
+///
+/// Mutually exclusive by construction — there is no state in which both are
+/// present, so the renderer never chooses.
+#[derive(Clone, Debug)]
+pub enum ExprSlot<T> {
+    /// Pre-rendered text. Deleted by #199.
+    Legacy(Code),
+    /// The typed tree plus its arena.
+    Ast(Ast<T>),
+}
+
+impl<T> ExprSlot<T> {
+    /// Wrap pre-rendered text — the mechanical 5A bridge.
+    pub fn legacy(code: Code) -> Self {
+        ExprSlot::Legacy(code)
+    }
+
+    /// Wrap a typed tree.
+    pub fn ast(arena: ExprArena, tree: T) -> Self {
+        ExprSlot::Ast(Ast::new(arena, tree))
+    }
+
+    /// Whether this slot still holds text — the predicate #199's exit counts.
+    pub fn is_legacy(&self) -> bool {
+        matches!(self, ExprSlot::Legacy(_))
+    }
+}
+
+/// A property's value, replacing the prose-enforced initializer/delegate
+/// exclusion.
+///
+/// `KtProperty` used to hold `initializer: Option<String>` and `delegate:
+/// Option<String>` with a doc comment noting they are "mutually exclusive" —
+/// a product where a sum belongs, enforced by prose and by a `debug_assert` in
+/// the renderer. That is the #180 pattern sitting in the Kotlin model, and it
+/// is fixed here for the same reason #180 fixed it in `jnigen`: a state that
+/// cannot be represented cannot be reached.
+#[derive(Clone, Debug, Default)]
+pub enum PropertyValue {
+    /// No value — an abstract property, or one with only accessors.
+    #[default]
+    None,
+    /// `val x = <expr>`.
+    Initializer(ExprSlot<KtExpr>),
+    /// `val x by <expr>` (e.g. `lazy { … }`).
+    Delegate(ExprSlot<KtExpr>),
+}
+
+/// Which accessor of a property.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccessorKind {
+    Get,
+    Set,
+}
+
+/// A property accessor.
+///
+/// **A declaration containing a body**, not an expression — which is why it is
+/// not an `ExprSlot<KtExpr>`. A getter may be `get() = <expr>` or `get() { … }`,
+/// and a setter binds its parameter.
+#[derive(Clone, Debug)]
+pub struct KtAccessor {
+    pub kind: AccessorKind,
+    /// `= <expr>` when `Some(expr)`, else a block of `body`.
+    pub body: AccessorBody,
+}
+
+/// An accessor's body — expression form or block form.
+#[derive(Clone, Debug)]
+pub enum AccessorBody {
+    /// Legacy pre-rendered accessor text, verbatim. Deleted by #199.
+    Legacy(Code),
+    /// `get() = <expr>`.
+    Expr(Ast<KtExpr>),
+    /// `get() { <stmts> }`.
+    Block(Ast<Vec<KtStmt>>),
+}
+
+impl KtAccessor {
+    /// Wrap pre-rendered accessor text. The mechanical bridge; #199 replaces
+    /// each caller with a structured accessor.
+    pub fn legacy(code: Code) -> Self {
+        Self {
+            kind: AccessorKind::Get,
+            body: AccessorBody::Legacy(code),
+        }
+    }
+    pub fn get_expr(arena: ExprArena, e: KtExpr) -> Self {
+        Self {
+            kind: AccessorKind::Get,
+            body: AccessorBody::Expr(Ast::new(arena, e)),
+        }
+    }
+    pub fn is_legacy(&self) -> bool {
+        matches!(self.body, AccessorBody::Legacy(_))
+    }
+}
+
+/// A Kotlin annotation: a name plus **expression** arguments.
+///
+/// Annotations were the one expression-bearing position left as bare `String`.
+/// The codebase already writes `.annotation("Suppress(\"UNCHECKED_CAST\")")` —
+/// a call with a string-literal argument, i.e. an expression spelled as text.
+#[derive(Clone, Debug, PartialEq)]
+pub struct KtAnnotation {
+    pub name: KtName,
+    pub args: Vec<KtExpr>,
+}
+
+impl KtAnnotation {
+    pub fn new(name: KtName) -> Self {
+        Self {
+            name,
+            args: Vec::new(),
+        }
+    }
+    pub fn arg(mut self, e: KtExpr) -> Self {
+        self.args.push(e);
+        self
+    }
+}
+
+/// Annotation text of **literal origin**.
+///
+/// The private field is the point: narrowing to `&'static str` would not be
+/// enough, since `String::leak` and `Box::leak` produce `&'static str` from
+/// dynamically built text — the type would prove lifetime, not literal origin.
+/// Constructing this through [`kt_annotation_text!`](crate::kt_annotation_text)
+/// makes literal origin a **compile-time** property, because `macro_rules!`'s
+/// `literal` fragment cannot match an expression.
+///
+/// [`Self::from_legacy_string`] is the one remaining hole, and it exists only
+/// so 5A can change the field type without touching call sites. It is counted
+/// by a test and deleted by #199 — the same enumerate-then-delete contract
+/// `KtExpr::Raw` is under.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StaticAnnotationText(std::borrow::Cow<'static, str>);
+
+impl StaticAnnotationText {
+    /// Do not call directly — use [`kt_annotation_text!`], which accepts only a
+    /// string literal.
+    #[doc(hidden)]
+    pub const fn __from_literal(s: &'static str) -> Self {
+        StaticAnnotationText(std::borrow::Cow::Borrowed(s))
+    }
+
+    /// The mechanical 5A bridge: wrap an existing textual annotation so the
+    /// field type can change without migrating call sites.
+    ///
+    /// **Every caller is a #199 work item.** It is deliberately named so that
+    /// `grep from_legacy_string` is the progress metric, and a test pins the
+    /// count so it cannot grow unnoticed.
+    pub fn from_legacy_string(s: impl Into<String>) -> Self {
+        StaticAnnotationText(std::borrow::Cow::Owned(s.into()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Build a [`StaticAnnotationText`] from a **string literal** — the form that
+/// makes literal origin a compile-time property, since `macro_rules!`'s
+/// `literal` fragment cannot match `String::leak(…)` or any other expression.
+#[allow(unused_macros)]
+macro_rules! kt_annotation_text {
+    ($s:literal) => {
+        $crate::api::gen::kotlin::slot::StaticAnnotationText::__from_literal($s)
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use kt_annotation_text;
+
+/// One annotation: legacy text **or** a structured annotation. Same exclusion
+/// [`ExprSlot`] provides, for the one position that is not an expression slot.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AnnotationSlot {
+    /// Literal-origin text. Deleted by #199.
+    Legacy(StaticAnnotationText),
+    Ast(KtAnnotation),
+}
+
+impl AnnotationSlot {
+    pub fn is_legacy(&self) -> bool {
+        matches!(self, AnnotationSlot::Legacy(_))
+    }
+}
+
+// ── rendering and import collection ─────────────────────────────────────
+//
+// A slot answers for itself in both directions, so the declaration renderer
+// never has to know which arm it holds — which is what keeps the `Legacy`
+// deletion in #199 a local change.
+
+use super::{expr::render::render_expr, types::ImportSet};
+
+impl ExprSlot<KtExpr> {
+    /// Render to a single Kotlin expression.
+    pub fn render_inline(&self, imports: &mut ImportSet) -> String {
+        match self {
+            ExprSlot::Legacy(c) => {
+                let mut s = String::new();
+                c.render(0, &mut s);
+                s.trim_end().to_string()
+            }
+            ExprSlot::Ast(a) => render_expr(&a.arena, &a.tree, imports),
+        }
+    }
+
+    /// The FQNs this slot references.
+    ///
+    /// For a typed tree they come **from the tree**, which is the point: a
+    /// rendered unit reports the imports it needs instead of having them
+    /// registered by hand alongside raw text, where the two could drift.
+    pub fn collect_imports(&self, sink: &mut Vec<String>) {
+        match self {
+            ExprSlot::Legacy(c) => c.collect_imports(sink),
+            ExprSlot::Ast(a) => sink.extend(
+                super::expr::free_names(&a.tree)
+                    .into_iter()
+                    .filter(|n| n.is_qualified())
+                    .map(|n| n.as_str().to_string()),
+            ),
+        }
+    }
+}
+
+impl ExprSlot<Vec<KtExpr>> {
+    /// Render as a comma-separated argument list (no surrounding parentheses).
+    pub fn render_args(&self, imports: &mut ImportSet) -> String {
+        match self {
+            ExprSlot::Legacy(c) => {
+                let mut s = String::new();
+                c.render(0, &mut s);
+                s.trim_end().to_string()
+            }
+            ExprSlot::Ast(a) => a
+                .tree
+                .iter()
+                .map(|e| render_expr(&a.arena, e, imports))
+                .collect::<Vec<_>>()
+                .join(", "),
+        }
+    }
+
+    pub fn collect_imports(&self, sink: &mut Vec<String>) {
+        match self {
+            ExprSlot::Legacy(c) => c.collect_imports(sink),
+            ExprSlot::Ast(a) => {
+                for e in &a.tree {
+                    sink.extend(
+                        super::expr::free_names(e)
+                            .into_iter()
+                            .filter(|n| n.is_qualified())
+                            .map(|n| n.as_str().to_string()),
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl ExprSlot<Vec<KtStmt>> {
+    /// Render as block-body lines.
+    pub fn render_lines(&self, imports: &mut ImportSet) -> Code {
+        match self {
+            ExprSlot::Legacy(c) => c.clone(),
+            ExprSlot::Ast(a) => {
+                let mut code = Code::new();
+                for line in super::expr::render::render_stmts(&a.arena, &a.tree, imports) {
+                    code = code.line(line);
+                }
+                code
+            }
+        }
+    }
+
+    pub fn collect_imports(&self, sink: &mut Vec<String>) {
+        match self {
+            ExprSlot::Legacy(c) => c.collect_imports(sink),
+            ExprSlot::Ast(a) => {
+                let wrapper = KtExpr::Lambda {
+                    params: Vec::new(),
+                    body: a.tree.clone(),
+                };
+                sink.extend(
+                    super::expr::free_names(&wrapper)
+                        .into_iter()
+                        .filter(|n| n.is_qualified())
+                        .map(|n| n.as_str().to_string()),
+                );
+            }
+        }
+    }
+}
+
+impl PropertyValue {
+    pub fn collect_imports(&self, sink: &mut Vec<String>) {
+        match self {
+            PropertyValue::None => {}
+            PropertyValue::Initializer(s) | PropertyValue::Delegate(s) => s.collect_imports(sink),
+        }
+    }
+}
+
+impl KtAccessor {
+    /// Render the accessor's lines, indented under the property by the caller.
+    pub fn render_lines(&self, imports: &mut ImportSet) -> Code {
+        let head = match self.kind {
+            AccessorKind::Get => "get()",
+            AccessorKind::Set => "set(value)",
+        };
+        match &self.body {
+            AccessorBody::Legacy(c) => c.clone(),
+            AccessorBody::Expr(a) => Code::new().line(format!(
+                "{head} = {}",
+                render_expr(&a.arena, &a.tree, imports)
+            )),
+            AccessorBody::Block(a) => {
+                let mut code = Code::new();
+                let lines = super::expr::render::render_stmts(&a.arena, &a.tree, imports);
+                code = code.blk(format!("{head} {{"), |c| {
+                    let mut c = c;
+                    for l in lines {
+                        c = c.line(l);
+                    }
+                    c
+                });
+                code
+            }
+        }
+    }
+
+    pub fn collect_imports(&self, sink: &mut Vec<String>) {
+        match &self.body {
+            AccessorBody::Legacy(c) => c.collect_imports(sink),
+            AccessorBody::Expr(a) => sink.extend(
+                super::expr::free_names(&a.tree)
+                    .into_iter()
+                    .filter(|n| n.is_qualified())
+                    .map(|n| n.as_str().to_string()),
+            ),
+            AccessorBody::Block(a) => {
+                let wrapper = KtExpr::Lambda {
+                    params: Vec::new(),
+                    body: a.tree.clone(),
+                };
+                sink.extend(
+                    super::expr::free_names(&wrapper)
+                        .into_iter()
+                        .filter(|n| n.is_qualified())
+                        .map(|n| n.as_str().to_string()),
+                );
+            }
+        }
+    }
+}
+
+impl AnnotationSlot {
+    /// Render without the leading `@`.
+    pub fn render(&self, imports: &mut ImportSet) -> String {
+        match self {
+            AnnotationSlot::Legacy(t) => t.as_str().to_string(),
+            AnnotationSlot::Ast(a) => {
+                let arena = ExprArena::new();
+                let name = if a.name.is_qualified() {
+                    imports.short(a.name.as_str())
+                } else {
+                    a.name.as_str().to_string()
+                };
+                if a.args.is_empty() {
+                    name
+                } else {
+                    let args: Vec<String> = a
+                        .args
+                        .iter()
+                        .map(|e| render_expr(&arena, e, imports))
+                        .collect();
+                    format!("{name}({})", args.join(", "))
+                }
+            }
+        }
+    }
+
+    /// Whether this renders exactly `text` — the predicate the renderer's
+    /// "already annotated" checks need without reaching into the arm.
+    pub fn renders_as(&self, text: &str) -> bool {
+        match self {
+            AnnotationSlot::Legacy(t) => t.as_str() == text,
+            AnnotationSlot::Ast(a) => a.args.is_empty() && a.name.as_str() == text,
+        }
+    }
+}

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -214,19 +214,29 @@ impl KtAnnotation {
     }
 }
 
-/// Annotation text of **literal origin**.
+/// Annotation text that is **intended** to be of literal origin.
 ///
-/// The private field is the point: narrowing to `&'static str` would not be
-/// enough, since `String::leak` and `Box::leak` produce `&'static str` from
-/// dynamically built text — the type would prove lifetime, not literal origin.
-/// Constructing this through [`kt_annotation_text!`](crate::kt_annotation_text)
-/// makes literal origin a **compile-time** property, because `macro_rules!`'s
-/// `literal` fragment cannot match an expression.
+/// Two constructors reach it, and neither makes literal origin a property of
+/// the *type*:
 ///
-/// [`Self::from_legacy_string`] is the one remaining hole, and it exists only
-/// so 5A can change the field type without touching call sites. It is counted
-/// by a test and deleted by #199 — the same enumerate-then-delete contract
-/// `KtExpr::Raw` is under.
+/// - [`kt_annotation_text!`] takes a `literal` fragment, so **its own callers**
+///   cannot pass `String::leak(…)` — the macro is where the guarantee lives.
+/// - [`Self::__from_literal`] is what the macro expands to, and on its own it
+///   accepts any `&'static str`, leaked included. Narrowing the payload to
+///   `&'static str` was never enough for exactly that reason: the type proves
+///   lifetime, not origin.
+/// - [`Self::from_legacy_string`] is the 5A bridge that let the field type
+///   change without touching call sites, and takes an owned `String`.
+///
+/// So the guarantee here is **audited, not typed**. Both direct constructors
+/// are crate-internal (`api::gen` is `pub(crate)`), which bounds the audit to
+/// this crate, and a test pins the call sites of each so neither can grow
+/// unnoticed. #199 drives both to zero and deletes them — the same
+/// enumerate-then-delete contract `KtExpr::Raw` is under.
+///
+/// Sealing `__from_literal` properly would need a witness type the macro can
+/// mint and nothing else can; that is worth doing when this type outlives 5B,
+/// and pointless if #199 deletes it first.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StaticAnnotationText(std::borrow::Cow<'static, str>);
 
@@ -411,9 +421,12 @@ impl KtAccessor {
         };
         match &self.body {
             AccessorBody::Legacy(c) => c.clone(),
+            // `render_expr_in_scope`, like every other typed slot: a getter or
+            // setter expression referencing a constructor parameter or the
+            // setter's own binder would otherwise be unbound.
             AccessorBody::Expr(a) => Code::new().line(format!(
                 "{head} = {}",
-                render_expr(&a.arena, &a.tree, imports)
+                render_expr_in_scope(&a.arena, &a.scope, &a.tree, imports)
             )),
             AccessorBody::Block(a) => {
                 let mut code = Code::new();

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -370,12 +370,13 @@ impl ExprSlot<Vec<KtExpr>> {
                 c.render(0, &mut s);
                 s.trim_end().to_string()
             }
-            ExprSlot::Ast(a) => a
-                .tree
-                .iter()
-                .map(|e| render_expr_in_scope(&a.arena, &a.scope, e, imports))
-                .collect::<Vec<_>>()
-                .join(", "),
+            // One scope for the whole vector — see `render_exprs_in_scope`.
+            // Rendering each element separately would give every one a fresh
+            // `introduced` set, letting two arguments bind the same `BindingId`.
+            ExprSlot::Ast(a) => {
+                super::expr::render::render_exprs_in_scope(&a.arena, &a.scope, &a.tree, imports)
+                    .join(", ")
+            }
         }
     }
 

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -39,7 +39,7 @@
 
 use super::{
     code::Code,
-    expr::{ExprArena, KtExpr, KtName, KtStmt},
+    expr::{BindingId, ExprArena, KtExpr, KtName, KtStmt},
 };
 
 /// A typed tree together with the arena owning its binders.
@@ -52,12 +52,36 @@ use super::{
 #[derive(Clone, Debug)]
 pub struct Ast<T> {
     pub arena: ExprArena,
+    /// Binders already in scope at the tree's **root** — the enclosing
+    /// declaration's parameters.
+    ///
+    /// Without this a typed function body could not reference its own
+    /// parameter: every slot renders in a fresh scope, so `Local(param)` would
+    /// be unbound and the renderer would panic. Reaching for
+    /// `Name("initialPtr")` instead would put a binder back in the free-name
+    /// set and restore exactly the textual capture risk `BindingId` exists to
+    /// remove — so the parameter has to arrive as a binder, not as a name.
+    ///
+    /// Kept on the `Ast` rather than on the declaration so a slot still renders
+    /// with no ambient state, and so the binders and the arena that owns them
+    /// cannot be supplied from two different places.
+    pub scope: Vec<BindingId>,
     pub tree: T,
 }
 
 impl<T> Ast<T> {
+    /// A tree with no enclosing binders.
     pub fn new(arena: ExprArena, tree: T) -> Self {
-        Self { arena, tree }
+        Self {
+            arena,
+            scope: Vec::new(),
+            tree,
+        }
+    }
+
+    /// A tree rendered with `scope` already bound — see [`Self::scope`].
+    pub fn in_scope(arena: ExprArena, scope: Vec<BindingId>, tree: T) -> Self {
+        Self { arena, scope, tree }
     }
 }
 
@@ -82,6 +106,12 @@ impl<T> ExprSlot<T> {
     /// Wrap a typed tree.
     pub fn ast(arena: ExprArena, tree: T) -> Self {
         ExprSlot::Ast(Ast::new(arena, tree))
+    }
+
+    /// Wrap a typed tree that may reference the enclosing declaration's
+    /// parameters — see [`Ast::scope`].
+    pub fn ast_in_scope(arena: ExprArena, scope: Vec<BindingId>, tree: T) -> Self {
+        ExprSlot::Ast(Ast::in_scope(arena, scope, tree))
     }
 
     /// Whether this slot still holds text — the predicate #199's exit counts.
@@ -257,7 +287,10 @@ impl AnnotationSlot {
 // never has to know which arm it holds — which is what keeps the `Legacy`
 // deletion in #199 a local change.
 
-use super::{expr::render::render_expr, types::ImportSet};
+use super::{
+    expr::render::{render_expr, render_expr_in_scope},
+    types::ImportSet,
+};
 
 impl ExprSlot<KtExpr> {
     /// Render to a single Kotlin expression.
@@ -268,7 +301,7 @@ impl ExprSlot<KtExpr> {
                 c.render(0, &mut s);
                 s.trim_end().to_string()
             }
-            ExprSlot::Ast(a) => render_expr(&a.arena, &a.tree, imports),
+            ExprSlot::Ast(a) => render_expr_in_scope(&a.arena, &a.scope, &a.tree, imports),
         }
     }
 
@@ -302,7 +335,7 @@ impl ExprSlot<Vec<KtExpr>> {
             ExprSlot::Ast(a) => a
                 .tree
                 .iter()
-                .map(|e| render_expr(&a.arena, e, imports))
+                .map(|e| render_expr_in_scope(&a.arena, &a.scope, e, imports))
                 .collect::<Vec<_>>()
                 .join(", "),
         }
@@ -332,7 +365,8 @@ impl ExprSlot<Vec<KtStmt>> {
             ExprSlot::Legacy(c) => c.clone(),
             ExprSlot::Ast(a) => {
                 let mut code = Code::new();
-                for line in super::expr::render::render_stmts(&a.arena, &a.tree, imports) {
+                for line in super::expr::render::render_stmts(&a.arena, &a.scope, &a.tree, imports)
+                {
                     code = code.line(line);
                 }
                 code
@@ -383,7 +417,7 @@ impl KtAccessor {
             )),
             AccessorBody::Block(a) => {
                 let mut code = Code::new();
-                let lines = super::expr::render::render_stmts(&a.arena, &a.tree, imports);
+                let lines = super::expr::render::render_stmts(&a.arena, &a.scope, &a.tree, imports);
                 code = code.blk(format!("{head} {{"), |c| {
                     let mut c = c;
                     for l in lines {

--- a/prebindgen/src/api/gen/kotlin/slot.rs
+++ b/prebindgen/src/api/gen/kotlin/slot.rs
@@ -155,6 +155,17 @@ pub enum AccessorKind {
 #[derive(Clone, Debug)]
 pub struct KtAccessor {
     pub kind: AccessorKind,
+    /// A setter's value parameter, as a **binder**.
+    ///
+    /// The header used to be a hardcoded `set(value)`, independent of anything
+    /// in the body's scope — so a binder spelled `incoming` rendered
+    /// `set(value) = incoming`, and a `Fresh` binder hinted `value` that the
+    /// allocator moved to `value2` left the signature still saying `value`.
+    /// The spelling now comes from the same allocation the body uses, which is
+    /// the only way the two cannot disagree.
+    ///
+    /// `None` for a getter, and on the legacy path.
+    pub param: Option<BindingId>,
     /// `= <expr>` when `Some(expr)`, else a block of `body`.
     pub body: AccessorBody,
 }
@@ -176,13 +187,31 @@ impl KtAccessor {
     pub fn legacy(code: Code) -> Self {
         Self {
             kind: AccessorKind::Get,
+            param: None,
             body: AccessorBody::Legacy(code),
         }
     }
     pub fn get_expr(arena: ExprArena, e: KtExpr) -> Self {
         Self {
             kind: AccessorKind::Get,
+            param: None,
             body: AccessorBody::Expr(Ast::new(arena, e)),
+        }
+    }
+
+    /// A setter whose value parameter is a binder the body references through
+    /// `Local` — so the header and the body are spelled from one allocation.
+    pub fn set_expr(
+        mut arena: ExprArena,
+        hint: &str,
+        build: impl FnOnce(BindingId) -> KtExpr,
+    ) -> Self {
+        let param = arena.bind_fresh(hint);
+        let tree = build(param);
+        Self {
+            kind: AccessorKind::Set,
+            param: Some(param),
+            body: AccessorBody::Expr(Ast::in_scope(arena, vec![param], tree)),
         }
     }
     pub fn is_legacy(&self) -> bool {
@@ -415,30 +444,46 @@ impl PropertyValue {
 impl KtAccessor {
     /// Render the accessor's lines, indented under the property by the caller.
     pub fn render_lines(&self, imports: &mut ImportSet) -> Code {
-        let head = match self.kind {
-            AccessorKind::Get => "get()",
-            AccessorKind::Set => "set(value)",
+        // The setter's header is spelled from the SAME allocation the body
+        // uses, via the scope names the renderer hands back. Deriving it
+        // independently — as a hardcoded `set(value)` did — is how a signature
+        // ends up saying `value` while the body says `value2`.
+        let head = |scope: &[BindingId], names: &[String]| -> String {
+            match self.kind {
+                AccessorKind::Get => "get()".to_string(),
+                AccessorKind::Set => {
+                    let name = self
+                        .param
+                        .and_then(|p| scope.iter().position(|b| *b == p))
+                        .and_then(|i| names.get(i).cloned())
+                        // A setter with no declared binder keeps Kotlin's
+                        // implicit parameter name.
+                        .unwrap_or_else(|| "value".to_string());
+                    format!("set({name})")
+                }
+            }
         };
         match &self.body {
             AccessorBody::Legacy(c) => c.clone(),
-            // `render_expr_in_scope`, like every other typed slot: a getter or
-            // setter expression referencing a constructor parameter or the
-            // setter's own binder would otherwise be unbound.
-            AccessorBody::Expr(a) => Code::new().line(format!(
-                "{head} = {}",
-                render_expr_in_scope(&a.arena, &a.scope, &a.tree, imports)
-            )),
+            // Scope-aware, like every other typed slot: a getter or setter
+            // expression referencing a constructor parameter or the setter's
+            // own binder would otherwise be unbound.
+            AccessorBody::Expr(a) => {
+                let (names, rendered) = super::expr::render::render_expr_in_scope_named(
+                    &a.arena, &a.scope, &a.tree, imports,
+                );
+                Code::new().line(format!("{} = {rendered}", head(&a.scope, &names)))
+            }
             AccessorBody::Block(a) => {
-                let mut code = Code::new();
-                let lines = super::expr::render::render_stmts(&a.arena, &a.scope, &a.tree, imports);
-                code = code.blk(format!("{head} {{"), |c| {
+                let (names, lines) =
+                    super::expr::render::render_stmts_named(&a.arena, &a.scope, &a.tree, imports);
+                Code::new().blk(format!("{} {{", head(&a.scope, &names)), |c| {
                     let mut c = c;
                     for l in lines {
                         c = c.line(l);
                     }
                     c
-                });
-                code
+                })
             }
         }
     }

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -634,3 +634,72 @@ fn delegated_property_renders_by_clause() {
         "{src}"
     );
 }
+
+/// Every position that now holds an `ExprSlot` must have its `Code::import`
+/// collected by the file's raw-import prepass.
+///
+/// A `Legacy(Code)` renders raw text, and `Code::import` is the **only** place
+/// its FQNs are recorded — so a position the prepass skips renders
+/// `Factory.make()` and never emits `import io.example.Factory`, i.e.
+/// uncompilable Kotlin. These are the rows the walk previously missed:
+/// function-parameter defaults, constructor-parameter defaults, supertype
+/// constructor arguments, enum-entry arguments, and a `fun interface`'s method.
+#[test]
+fn every_expression_slot_contributes_its_raw_imports() {
+    // One helper, generic over the slot's payload — the positions differ
+    // (`KtExpr` vs `Vec<KtExpr>`) but the `Legacy` arm is the same `Code`.
+    fn slot<T>(text: &str, fqn: &str) -> ExprSlot<T> {
+        ExprSlot::legacy(Code::new().line(text).import(fqn))
+    }
+
+    // fn param default
+    let mut f = KtFun::new("withDefault").vis(Vis::Public);
+    let mut p = KtParam::new("factory", KtType::cls("Any"));
+    p.default = Some(slot("Factory.make()", "io.example.Factory"));
+    f = f.param(p);
+
+    // fun interface whose METHOD has a defaulted param
+    let mut im = KtFun::new("run");
+    let mut ip = KtParam::new("codec", KtType::cls("Any"));
+    ip.default = Some(slot("Codec.utf8()", "io.example.Codec"));
+    im = im.param(ip);
+    let iface = KtFunInterface::new("Handler", im).vis(Vis::Public);
+
+    // ctor param default + supertype ctor args
+    let mut cp = KtCtorParam::new("seed", KtType::long());
+    cp.default = Some(slot("Seed.zero()", "io.example.Seed"));
+    let mut cls = KtClass::new(ClassKind::Plain, "Holder")
+        .vis(Vis::Public)
+        .ctor_param(cp);
+    cls.supertypes.push((
+        KtType::cls("Base"),
+        Some(slot("Anchor.of(1)", "io.example.Anchor")),
+    ));
+
+    // enum entry args
+    let entries = vec![KtEnumEntry {
+        name: "FIRST".into(),
+        args: Some(slot("Weight.one()", "io.example.Weight")),
+    }];
+    let enum_cls = KtClass::new(ClassKind::Enum(entries), "Kind").vis(Vis::Public);
+
+    let src = KtFile::new("io.test")
+        .decl(f)
+        .decl(iface)
+        .decl(cls)
+        .decl(enum_cls)
+        .render();
+
+    for fqn in [
+        "io.example.Factory",
+        "io.example.Codec",
+        "io.example.Seed",
+        "io.example.Anchor",
+        "io.example.Weight",
+    ] {
+        assert!(
+            src.contains(&format!("import {fqn}")),
+            "missing `import {fqn}` — that slot's raw imports were dropped\n{src}"
+        );
+    }
+}

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -703,3 +703,44 @@ fn every_expression_slot_contributes_its_raw_imports() {
         );
     }
 }
+
+/// The AST surface #193 and #199 will build against must be reachable by the
+/// **normal** `kt::` path, not only via `kt::expr::`.
+///
+/// `KtLambda` was missing from the re-export list even though
+/// `with_trailing_lambda` requires that concrete type, so a downstream emitter
+/// would have had to reach into the module's internals for it. This names each
+/// intended type through `super::*` — the same glob the back-end imports — so a
+/// dropped re-export is a compile error here rather than a surprise at the call
+/// site.
+#[test]
+fn the_ast_surface_is_reachable_by_its_intended_path() {
+    let mut arena: ExprArena = ExprArena::new();
+    let id: BindingId = arena.bind_fixed(KtName::expect("v"));
+    let _: &Binder = arena.binder(id);
+    let _: ArenaId = id.arena();
+
+    let lambda: KtLambda = KtLambda::expr([id], KtExpr::local(id));
+    let call: KtExpr = KtExpr::free_call("f", []).with_trailing_lambda(lambda);
+    let _: KtStmt = KtStmt::Expr(call.clone());
+    let _: KtPattern = KtPattern::Else;
+    let _: KtLiteral = KtLiteral::Null;
+    let _: Spelling = Spelling::Fresh(NameHint::new("x"));
+
+    // The slot surface, likewise.
+    let _: ExprSlot<KtExpr> = ExprSlot::ast(arena.clone(), call.clone());
+    let _: PropertyValue = PropertyValue::None;
+    let _: KtAccessor = KtAccessor::get_expr(arena.clone(), call.clone());
+    let _: AccessorTree = AccessorTree::Expr(slot::Ast::new(arena.clone(), call.clone()));
+    let _: KtAnnotation = KtAnnotation::new(KtName::expect("JvmStatic"));
+    // Through the macro, which is the intended constructor for literal
+    // annotation text — and keeps this test out of the `from_legacy_string`
+    // audit, whose job is to count *generator* call sites.
+    let _: AnnotationSlot = AnnotationSlot::Legacy(slot::kt_annotation_text!("JvmStatic"));
+
+    // …and the tree operations.
+    let _ = free_names(&call);
+    let _ = has_hole(&call);
+    let _ = fill_hole(&arena, &call, &KtExpr::null());
+    let _ = substitute(&arena, &call, id, &KtExpr::null());
+}

--- a/prebindgen/src/api/gen/kotlin/tests.rs
+++ b/prebindgen/src/api/gen/kotlin/tests.rs
@@ -31,18 +31,9 @@ fn body_of(src: &str) -> &str {
 fn enum_class_with_from_int_companion() {
     let class = KtClass::new(
         ClassKind::Enum(vec![
-            KtEnumEntry {
-                name: "RED".into(),
-                args: Some("0".into()),
-            },
-            KtEnumEntry {
-                name: "GREEN".into(),
-                args: Some("5".into()),
-            },
-            KtEnumEntry {
-                name: "BLUE".into(),
-                args: Some("6".into()),
-            },
+            KtEnumEntry::legacy_args("RED", "0"),
+            KtEnumEntry::legacy_args("GREEN", "5"),
+            KtEnumEntry::legacy_args("BLUE", "6"),
         ]),
         "Color",
     )

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -548,7 +548,7 @@ fn overload_shell(sel_fun: &kt::KtFun, params: Vec<kt::KtParam>, body: kt::Code)
     let mut ov = sel_fun.clone();
     ov.params = params;
     ov.kdoc = None;
-    ov.body = kt::KtBody::Expr(body);
+    ov.body = kt::KtBody::Expr(kt::ExprSlot::legacy(body));
     ov
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -19,11 +19,13 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
     let entries: Vec<kt::KtEnumEntry> =
         crate::api::core::types_util::enum_discriminant_values(item_enum)
             .into_iter()
-            .map(|(ident, value)| kt::KtEnumEntry {
-                name: mangle_kotlin_ident(
-                    &crate::api::lang::jnigen::util::camel_to_screaming_snake(&ident.to_string()),
-                ),
-                args: Some(value.to_string()),
+            .map(|(ident, value)| {
+                kt::KtEnumEntry::legacy_args(
+                    mangle_kotlin_ident(&crate::api::lang::jnigen::util::camel_to_screaming_snake(
+                        &ident.to_string(),
+                    )),
+                    value.to_string(),
+                )
             })
             .collect();
 


### PR DESCRIPTION
Stage 5A of #187 — closes #186. Targets `main` directly: the AST is self-contained infrastructure that does not depend on the rest of the #187 chain. **Lands before Stage 3 (#193)**, which emits its Kotlin directly onto this AST rather than writing that emission twice.

**Infrastructure only.** No call site is migrated: #193 rewrites the emitters that produce plan-carried expressions, #199 (Stage 5B) migrates the rest and deletes the escape hatches. Builder signatures are unchanged, so **no producer moved** — only field types did.

## The problem

Declarations went through the model; **expressions** were `String`s assembled by hand. `replace_ident`'s left-context bug (#172), hand-numbered `e0`/`e1` lambda variables to dodge `it` shadowing, `kt_access_prefix` + base + `kt_access_tail` as a textual template with the base in the middle. Every one is invisible until Gradle compiles the output — and a wrong-but-*valid* expression is not caught even then.

## Binder identity is structural, not textual

Everything that binds — lambda parameters, function and constructor parameters, local `val`s — carries a `BindingId` and is referenced through `Local`. `KtName` is a **free-name** set only (classes, members, types), validated at construction.

That split is the whole point. An earlier sketch put parameters under `Name(KtName)`: an expression referencing `Name("x")` inserted under a lambda printing `x` would then be captured, which is exactly the reasoning `replace_ident` gets wrong, surviving in the position most likely to appear in a hole.

`Binder { id, spelling }`:
- **`Fixed`** — fn/ctor parameter names. Kotlin's named-argument surface, callable from user code, so renaming one would silently break every `foo(bar = …)` call site. Preserved byte-identically; a `Fresh` binder moves aside for it, never the reverse.
- **`Fresh`** — lambda params, locals, temporaries. Renderer-allocated.

`KtLiteral` is typed, so a string literal is escaped **by the renderer** rather than pre-escaped by whoever built it.

### Why `BindingId`s deliberately collide

Ids are allocated per arena **starting at zero**, so two independently built trees genuinely collide, and `ExprArena::graft` alpha-remaps as it copies.

Globally-generative ids would make collision impossible by construction. That sounds safer, but it leaves the remap unexercised and unfalsifiable — the test proving grafting cannot capture would pass whether or not the remap existed. Making collisions the normal case makes the remap load-bearing. (Writing the test found a real bug: `map_expr` rewrites `Local`s but copies a `Lambda`'s `params` and a `Let`'s `binder` through unchanged, so the first version of `graft` left the incoming tree binding the host's ids.)

## The renderer

- **Precedence** derived from the tree, so `(payload.field as? Exact)?.v0 ?: 0L` gets every parenthesis without the producer thinking about it.
- **Scope-tracked names**, replacing the `e0`/`e1` convention. A machine-allocated binder can collide with neither a `Fixed` name nor any free `KtName` the tree references — the latter reserved before any binder is named, closing the one capture position `BindingId`s do not cover.
- **Imports from the tree**, so a rendered unit reports what it needs instead of having them registered by hand alongside raw text where the two could drift.
- `fill_hole` is the tree operation the prefix/base/tail triple was simulating; `substitute` is what `replace_ident` will be deleted against in #199.

## Exclusive slots

A typed replacement for **every** row of #186's table, each behind an `ExprSlot<T>`:

| Position | Was | Now |
|---|---|---|
| function body | `KtBody::Expr(Code)` / `Block(Code)` | `ExprSlot<KtExpr>` / `ExprSlot<Vec<KtStmt>>` |
| enum entry args | `Option<String>` | `ExprSlot<Vec<KtExpr>>` |
| ctor param default | `Option<String>` | `ExprSlot<KtExpr>` |
| fn param default | `Option<String>` | `ExprSlot<KtExpr>` |
| property init / delegate | two `Option<String>` fields | `PropertyValue` |
| supertype ctor args | `Option<String>` | `ExprSlot<Vec<KtExpr>>` |
| property accessors | `Option<Code>` | `KtAccessor` |
| annotations | `Vec<String>` | `Vec<AnnotationSlot>` |

`ExprSlot` is a **sum**: introducing the typed fields *beside* the legacy ones would let both be populated and leave the renderer to decide which wins — #187's two-authorities defect, recreated inside its own migration.

Two positions needed more than a slot, as #186 says. Accessors are **declarations containing bodies** (`KtAccessor { kind, body }`), and annotation arguments are **expressions** (`KtAnnotation { name, args: Vec<KtExpr> }`). `PropertyValue` replaces the prose-enforced initializer/delegate exclusion — a product where a sum belongs, i.e. the #180 pattern sitting in the Kotlin model — and the renderer's `debug_assert` is gone with it.

## Exit

- **Must not move — all generated artifacts.** ✅ `regen-check.sh` byte-identical; `covertest-kotlin` green on a real JVM.

  Worth flagging for review: the legacy bridge uses `Code::line`, **not** `wline`. These fields held plain `String`s the renderer interpolated verbatim, and `wline` reflowed five `by lazy` properties before that was caught. The bridge has to be byte-identical or the stage's exit is false.
- **Asserted — the renderer's unit tests cover precedence, scope allocation and import collection.** ✅
- **Asserted — hole-filling and substitution exist and are tested, including four capture/identity tests.** ✅ All four: substituting an expression containing a `Local` into a lambda binding a same-printed name; substituting one containing a free `KtName` into a scope whose binder would print that name; **grafting two independently-built trees with colliding `BindingId`s**; and **`Fixed` spellings surviving byte-identically**.
- **Asserted — no `KtExpr` variant other than `Raw` accepts free-form expression text.** ✅ And `Raw` has **no producers**: a test scans the Kotlin generator (comments stripped, since the docs discuss the contract) and requires that set to stay empty, so #199 can delete the variant outright rather than migrate it.
- **Asserted — a typed replacement exists for every row of the table, including supertype arguments and accessors.** ✅
- **Asserted — no expression position can hold a legacy and a typed value simultaneously.** ✅ `ExprSlot` is a sum and `PropertyValue` makes the initializer/delegate exclusion structural.

26 tests in `gen/kotlin/expr/tests.rs`.

## Note for reviewers

Two things I'd like a second opinion on:

1. **`StaticAnnotationText::from_legacy_string`** is the one remaining hole in the literal-origin guarantee. #186 wants literal origin to be a compile-time property, and `kt_annotation_text!` delivers that — but every existing `.annotation("JvmStatic")` call site would have had to change to use it, and #186 also says *"No call site is migrated here"*. I resolved it by keeping the builder signature and routing through a deliberately-named bridge whose caller count is **pinned at one by a test**. If you'd rather 5A migrate the ~43 annotation call sites to the macro instead, that's a mechanical change and I'll do it.
2. **`#![allow(dead_code)]`** on `expr.rs` and `slot.rs`, same as Tier 0 and `SumSpec` carry, expiring with the first emitter that builds a tree instead of a string.

## Verification

```
cargo build                                  ok (default features)
cargo test / --all --all-features            ok (432 lib tests)
cargo clippy --all-targets -D warnings       ok (both feature sets)
cargo fmt --check                            ok
examples/regen-check.sh                      PASS (byte-identical)
covertest-kotlin ./gradlew run               BUILD SUCCESSFUL
```

Both feature sets are checked this time — Stage T's CI failure was a `unstable-cbindgen`-gated helper that only `--all-features` runs saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
