### PR TITLE
jnigen: run a converter's full stage chain at every leaf site

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -240,6 +240,11 @@ fn main() {
                 // resources: one alternative carries an opaque handle, one
                 // carries nothing at all.
                 .class(sealed_class!(Lookup))
+                // `Hold`'s payload is a CONVERTED type, so its leaf crosses
+                // through the `convert!(Duration)` chain; `HoldPolicy` puts
+                // that same payload in the data-class-field position.
+                .class(sealed_class!(Hold))
+                .class(data_class!(HoldPolicy))
                 // `Observation` carries that sum as a data-class FIELD —
                 // required (`reading`) and optional (`fallback`) — beside
                 // ordinary flattened leaves, so the tag-gated groups must
@@ -480,6 +485,12 @@ fn main() {
                 .fun(fun!(archive_set_reading))
                 .fun(fun!(archive_reading))
                 .fun(fun!(archive_reading_maybe))
+                // A sum payload that is a CONVERTED type (`convert!(Duration)`),
+                // so its boundary conversion is a chain rather than one wire
+                // converter — exercised as the function's own return and as a
+                // (required + optional) data-class field, the two encoders.
+                .fun(fun!(hold_echo))
+                .fun(fun!(hold_policy_echo))
                 // #144: `Option<CacheConfig>` input reaching a non-null enum
                 // field through the nested `RepliesConfig`.
                 .fun(fun!(cache_config_weight))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -453,6 +453,7 @@ fn main() {
                 .fun(fun!(percent_optional))
                 .fun(fun!(percent_invalid_output))
                 .fun(fun!(label_reverse))
+                .fun(fun!(label_series_echo))
                 .fun(fun!(annotated_new))
                 .fun(fun!(annotated_alternate_value))
                 .fun(fun!(annotated_ttl))
@@ -502,6 +503,10 @@ fn main() {
                 .fun(fun!(unsigned_series))
                 .fun(fun!(duration_optional))
                 .fun(fun!(duration_boundary_echo))
+                // The converted analogue of `unsigned_emit`: a whole-value
+                // callback argument, which encodes on its own path rather than
+                // through the data-class or sum emitters.
+                .fun(fun!(duration_emit))
                 .fun(fun!(duration_out_of_range)),
         )
         // analytics: the param-variant / return-field matrix (type default /

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -61,12 +61,14 @@ Base package: `io.prebindgen.covertest`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
   - shaped by: return `DurationBoundary` decomposed → [required, delay] (Callback delivery)
+- `duration_emit` — `fun durationEmit(value: ULong, f: DurationCallback, onError: JniErrorHandler<Unit>)`
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy>): HoldPolicy`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
+- `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>>): List<String>`
 - `lookup_each` — `fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>)`
 - `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
   - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -63,6 +63,9 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `DurationBoundary` decomposed → [delay] (Callback delivery)
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
+- `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold`
+  - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
+- `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy>): HoldPolicy`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
 - `lookup_each` — `fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>)`
 - `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
@@ -168,6 +171,8 @@ Base package: `io.prebindgen.covertest`
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
+- `Hold`: sealed_class → `io.prebindgen.covertest.model.Hold` (wire `?`)
+- `HoldPolicy`: data_class → `io.prebindgen.covertest.model.HoldPolicy` (wire `jni :: objects :: JObject`)
 - `Lookup`: sealed_class → `io.prebindgen.covertest.model.Lookup` (wire `?`)
 - `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -60,7 +60,7 @@ Base package: `io.prebindgen.covertest`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
-  - shaped by: return `DurationBoundary` decomposed → [delay] (Callback delivery)
+  - shaped by: return `DurationBoundary` decomposed → [required, delay] (Callback delivery)
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
 - `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -379,6 +379,22 @@ public fun interface PayloadListCallback {
     public fun run(arg0: List<Payload>)
 }
 
+public fun interface DurationCallback {
+    public fun run(duration: ULong)
+}
+
+public fun interface DurationCallbackRaw {
+    public fun run(duration: Long)
+}
+
+public fun DurationCallback.asRaw(): DurationCallbackRaw =
+    DurationCallbackRaw {
+        duration ->
+        run(
+            duration.toULong()
+        )
+    }
+
 public fun interface StorageCallback {
     public fun run(storage: Storage)
 }
@@ -698,6 +714,8 @@ internal object CovNative {
 
     external fun durationBoundaryEcho(value: DurationBoundary, build: Any, errorSink: Any): Any?
 
+    external fun durationEmit(value: Long, f: Any, errorSink: Any)
+
     external fun durationOptional(value: Long, errorSink: Any): Long
 
     external fun durationOutOfRange(errorSink: Any): Long
@@ -715,6 +733,8 @@ internal object CovNative {
     ): HoldPolicy
 
     external fun labelReverse(l: String, errorSink: Any): String
+
+    external fun labelSeriesEcho(labels: List<String>, errorSink: Any): List<String>
 
     external fun lookupEach(n: Long, total: Double, sink: Any, errorSink: Any)
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -3,6 +3,8 @@ package io.prebindgen.covertest
 
 import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.DurationBoundary
+import io.prebindgen.covertest.model.Hold
+import io.prebindgen.covertest.model.HoldPolicy
 import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.Observation
@@ -703,6 +705,14 @@ internal object CovNative {
     external fun escapeProbeNew(value: Long, errorSink: Any): Long
 
     external fun escape_probe_value(p: Long, errorSink: Any): Long
+
+    external fun holdEcho(h: Hold, build: Any, errorSink: Any): Any?
+
+    external fun holdPolicyEcho(
+        pHold: Hold,
+        pGrace: io.prebindgen.covertest.model.Hold?,
+        errorSink: Any,
+    ): HoldPolicy
 
     external fun labelReverse(l: String, errorSink: Any): String
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -2,6 +2,7 @@
 package io.prebindgen.covertest.model
 
 import io.prebindgen.covertest.CovNative
+import io.prebindgen.covertest.DurationCallback
 import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.Payload
@@ -1010,6 +1011,27 @@ public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
 }
 
 /**
+ * Round-trip a collection of labels — a `Vec` whose ELEMENT is a converted
+ * type.
+ *
+ * `Duration` cannot take this path (a `Vec` needs a JObject-shaped element
+ * wire, and its representation is a primitive `jlong`, so `Vec<Duration>` is
+ * refused at resolve time), but `Label` lowers to `String` and therefore does.
+ * The `Vec` converters build their element conversion inline, in both
+ * directions, so each has to compose the element's chain rather than call its
+ * wire-facing converter alone.
+ */
+public fun labelSeriesEcho(
+    labels: List<String>,
+    onError: JniErrorHandler<List<String>>,
+): List<String> {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.labelSeriesEcho(labels, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * Assemble an [`Annotated`] (nested data-class **output** + bare
  * `Option<scalar>` / `Option<enum>` inputs).
  */
@@ -1532,6 +1554,20 @@ public fun durationBoundaryEcho(
     val __ret = CovNative.durationBoundaryEcho(value, __DurationBoundaryBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as DurationBoundary
+}
+
+/**
+ * Deliver a converted value through the generated typed/raw callback twin —
+ * the converted analogue of [`unsigned_emit`].
+ *
+ * A callback argument that crosses WHOLE (no deconstructor, so no leaf plan)
+ * is its own encoder path, independent of the data-class and sum emitters, so
+ * a converted type has to reach its representation here too.
+ */
+public fun durationEmit(value: ULong, f: DurationCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.durationEmit(value.toLong(), f.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -36,6 +36,36 @@ public enum class Priority(public override val value: Int) : PriorityKind, Ranke
 }
 
 /**
+ * How long something is held: for an explicit period, or indefinitely.
+ *
+ * A **sum whose payload is a converted type**. `Duration` crosses through the
+ * binding's `convert!` declaration, so this payload's boundary conversion is
+ * two steps (`Duration -> u64 -> jlong`, and back) rather than the single
+ * wire converter every other sum payload here uses — the position where an
+ * emitter that reads only the wire-facing converter builds code that hands
+ * the semantic value where the representation is expected.
+ *
+ * JVM-side surface for the native Rust `Hold` sum: exactly one alternative is live.
+ */
+public sealed interface Hold {
+    /** Held with no end — the payload-less group. */
+    public data object Indefinite : Hold
+
+    /** Held for this long. */
+    public data class For(public val v0: ULong) : Hold
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(tag: Int, for_v0: ULong): Hold =
+            when (tag) {
+                0 -> Indefinite
+                1 -> For(for_v0)
+                else -> throw IllegalArgumentException("Hold: invalid tag $tag")
+            }
+    }
+}
+
+/**
  * A sum whose alternatives are a **payload-less** variant and one carrying an
  * opaque **handle** — the shape a real lookup/reply result takes, and the one
  * that proves a tag-gated group can own a native resource: the live group
@@ -206,6 +236,26 @@ public data class DurationBoundary(val delay: ULong?) {
     public companion object {
         @JvmStatic
         public fun fromParts(delay: Long): DurationBoundary = DurationBoundary(if (delay == -1L) null else delay.toULong())
+    }
+}
+
+/**
+ * A retention policy: a required converted-payload sum beside an optional one.
+ *
+ * The data-class position for [`Hold`], so the converted payload is exercised
+ * both as a top-level sum and as a tag-gated group inside a `fromParts`
+ * bridge — the two encoders are separate code paths.
+ */
+public data class HoldPolicy(val hold: Hold, val grace: Hold?) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            hold__tag: Int,
+            hold_for_v0: Long,
+            grace__present: Boolean,
+            grace__tag: Int,
+            grace_for_v0: Long,
+        ): HoldPolicy = HoldPolicy(when (hold__tag) { 0 -> Hold.Indefinite; 1 -> Hold.For(hold_for_v0.toULong()); else -> throw IllegalArgumentException("Hold: invalid tag $hold__tag") }, if (grace__present) when (grace__tag) { 0 -> Hold.Indefinite; 1 -> Hold.For(grace_for_v0.toULong()); else -> throw IllegalArgumentException("Hold: invalid tag $grace__tag") } else null)
     }
 }
 
@@ -765,6 +815,15 @@ public fun interface DurationBoundaryBuilderRaw<out R> {
 internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
 DurationBoundaryBuilderRaw { delay -> DurationBoundary.fromParts(delay) }
 
+public fun interface HoldBuilderRaw<out R> {
+    public fun run(tag: Int, for_v0: Long): R
+}
+
+internal val __HoldBuilderRaw: HoldBuilderRaw<Hold> =
+HoldBuilderRaw { tag, for_v0 ->
+    when (tag) { 0 -> Hold.Indefinite; 1 -> Hold.For(for_v0.toULong()); else -> throw IllegalArgumentException("Hold: invalid tag $tag") }
+}
+
 public fun interface LookupBuilderRaw<out R> {
     public fun run(tag: Int, found_v0: Long, failed_v0: String?): R
 }
@@ -1318,6 +1377,27 @@ public fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading
     }
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as Reading?
+}
+
+/**
+ * Round-trip a converted-payload sum, whole.
+ *
+ * The Rust `Hold` result is delivered decomposed: the builder callback receives (`tag`, `for_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.holdEcho(h, __HoldBuilderRaw, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Hold
+}
+
+/** Round-trip a data class carrying converted-payload sums. */
+public fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy>): HoldPolicy {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.holdPolicyEcho(p.hold, p.grace, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -231,11 +231,16 @@ public data class CacheConfig(val replies: RepliesConfig, val ttl: Long) {
  * its echo executes both the whole-object input decoder and the `fromParts`
  * output encoder; the nullable duration itself still uses the raw `jlong`
  * niche whenever it crosses a generated JNI call boundary.
+ *
+ * The two fields are the two shapes a converted leaf takes, and they exercise
+ * DIFFERENT emitter paths: `delay` goes through the `Option<_>` wrapper, which
+ * composes its inner conversion chain itself, while `required` is a bare leaf
+ * the data-class encoder/decoder has to compose for.
  */
-public data class DurationBoundary(val delay: ULong?) {
+public data class DurationBoundary(val required: ULong, val delay: ULong?) {
     public companion object {
         @JvmStatic
-        public fun fromParts(delay: Long): DurationBoundary = DurationBoundary(if (delay == -1L) null else delay.toULong())
+        public fun fromParts(required: Long, delay: Long): DurationBoundary = DurationBoundary(required.toULong(), if (delay == -1L) null else delay.toULong())
     }
 }
 
@@ -809,11 +814,11 @@ public fun ReadingCallback.asRaw(): ReadingCallbackRaw =
     }
 
 public fun interface DurationBoundaryBuilderRaw<out R> {
-    public fun run(delay: Long): R
+    public fun run(required: Long, delay: Long): R
 }
 
 internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
-DurationBoundaryBuilderRaw { delay -> DurationBoundary.fromParts(delay) }
+DurationBoundaryBuilderRaw { required, delay -> DurationBoundary.fromParts(required, delay) }
 
 public fun interface HoldBuilderRaw<out R> {
     public fun run(tag: Int, for_v0: Long): R
@@ -1516,7 +1521,7 @@ public fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): UL
 /**
  * Round-trip [`DurationBoundary`] through the explicit object-input bridge.
  *
- * The Rust `DurationBoundary` result is delivered decomposed: the builder callback receives (`delay`).
+ * The Rust `DurationBoundary` result is delivered decomposed: the builder callback receives (`required`, `delay`).
  */
 @Suppress("UNCHECKED_CAST")
 public fun durationBoundaryEcho(

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -34,6 +34,8 @@ import io.prebindgen.covertest.model.ObjectBoundary63
 import io.prebindgen.covertest.model.ObjectBoundary64
 import io.prebindgen.covertest.model.ObjectBoundaryLeaf
 import io.prebindgen.covertest.model.Priority
+import io.prebindgen.covertest.model.Hold
+import io.prebindgen.covertest.model.HoldPolicy
 import io.prebindgen.covertest.model.Lookup
 import io.prebindgen.covertest.model.Reading
 import io.prebindgen.covertest.model.Stamp
@@ -44,6 +46,8 @@ import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.durationOptional
 import io.prebindgen.covertest.model.durationBoundaryEcho
 import io.prebindgen.covertest.model.durationOutOfRange
+import io.prebindgen.covertest.model.holdEcho
+import io.prebindgen.covertest.model.holdPolicyEcho
 import io.prebindgen.covertest.model.labelReverse
 import io.prebindgen.covertest.model.percentInvalidOutput
 import io.prebindgen.covertest.model.percentOptional
@@ -338,6 +342,32 @@ fun main() {
             invalid = e.message
         }
         check(invalid == "Reading: invalid tag 5")
+    }
+
+    // ── a sum payload that is a CONVERTED type ───────────────────────────────
+    // `Hold.For` carries a `Duration`, whose boundary conversion is the
+    // `convert!` chain `Duration -> u64 -> jlong` rather than a single wire
+    // converter. Every sum emitter has to run the whole chain: reading only the
+    // wire-facing converter passes the semantic value where the representation
+    // is expected. Exercised at all three positions — the function's own return
+    // (`holdEcho`), a required data-class field and an optional one
+    // (`holdPolicyEcho`), the last of which also decodes the sum back off a
+    // Kotlin property.
+    section("sum payload crossing a convert! chain") {
+        check(holdEcho(Hold.Indefinite, boom) == Hold.Indefinite)
+        check(holdEcho(Hold.For(12_345uL), boom) == Hold.For(12_345uL))
+        // The domain bounds still apply inside a variant group: the payload
+        // converter is the same one a bare `Duration` uses.
+        check(holdEcho(Hold.For(86_400_000uL), boom) == Hold.For(86_400_000uL))
+
+        val both = holdPolicyEcho(HoldPolicy(Hold.For(7uL), Hold.Indefinite), boom)
+        check(both == HoldPolicy(Hold.For(7uL), Hold.Indefinite))
+        val absent = holdPolicyEcho(HoldPolicy(Hold.Indefinite, null), boom)
+        check(absent == HoldPolicy(Hold.Indefinite, null))
+        // The optional group's payload must survive independently of the
+        // required one's — a chain wired to the wrong binding would cross them.
+        val onlyGrace = holdPolicyEcho(HoldPolicy(Hold.Indefinite, Hold.For(99uL)), boom)
+        check(onlyGrace == HoldPolicy(Hold.Indefinite, Hold.For(99uL)))
     }
 
     // ── a sum as a data-class FIELD, crossing Rust → Kotlin ───────────────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -45,10 +45,12 @@ import io.prebindgen.covertest.model.annotatedAlternateValue
 import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.durationOptional
 import io.prebindgen.covertest.model.durationBoundaryEcho
+import io.prebindgen.covertest.model.durationEmit
 import io.prebindgen.covertest.model.durationOutOfRange
 import io.prebindgen.covertest.model.holdEcho
 import io.prebindgen.covertest.model.holdPolicyEcho
 import io.prebindgen.covertest.model.labelReverse
+import io.prebindgen.covertest.model.labelSeriesEcho
 import io.prebindgen.covertest.model.percentInvalidOutput
 import io.prebindgen.covertest.model.percentOptional
 import io.prebindgen.covertest.model.percentScale
@@ -261,6 +263,16 @@ fun main() {
             durationBoundaryEcho(DurationBoundary(86_400_000uL, 1uL), boom) ==
                 DurationBoundary(86_400_000uL, 1uL),
         )
+
+        // A whole-value CALLBACK argument is a third encoder path, independent
+        // of the data-class and sum emitters above: the trampoline encodes the
+        // arg itself, with no leaf plan to carry the chain. The converted
+        // analogue of `unsignedEmit`.
+        var emittedDuration = 0uL
+        durationEmit(12_345uL, DurationCallback { emittedDuration = it }, boom)
+        check(emittedDuration == 12_345uL)
+        durationEmit(86_400_000uL, DurationCallback { emittedDuration = it }, boom)
+        check(emittedDuration == 86_400_000uL)
 
         var inputError: String? = null
         val inputFallback = durationOptional(86_400_001uL) { je ->
@@ -1055,6 +1067,15 @@ fun main() {
         check(msg?.contains("label must not be empty") == true) {
             "labelReverse(\"\") must report the empty-label error, got: $msg"
         }
+
+        // `Vec<Label>` — a collection whose ELEMENT is a converted type. The
+        // `Vec` converters build the element conversion inline in both
+        // directions, so each has to run the element's chain rather than its
+        // wire-facing converter alone. (`Vec<Duration>` cannot probe this: a
+        // `Vec` needs a JObject-shaped element wire and a bounded duration's
+        // is a primitive `Long`, so it is refused at resolve time.)
+        check(labelSeriesEcho(listOf("alpha", "beta"), boom) == listOf("alpha", "beta"))
+        check(labelSeriesEcho(emptyList(), boom) == emptyList<String>())
     }
 
     // ── Vec<opaque-handle> return: the Kotlin-side handle fold ───────────────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -231,18 +231,35 @@ fun main() {
         check(durationOptional(0uL, boom) == 0uL)
         check(durationOptional(86_400_000uL, boom) == 86_400_000uL)
 
-        // The data-class property is semantic `ULong?`, while its native
-        // output factory receives primitive Long + niche. The echo's explicit
-        // object input also executes the complete ULong -> Duration decoder.
+        // The data-class properties are semantic `ULong` / `ULong?`, while the
+        // native output factory receives primitive Longs (the optional one
+        // niche-encoded). The echo's explicit object input also executes the
+        // complete ULong -> Duration decoder.
+        //
+        // `required` and `delay` take DIFFERENT emitter paths: `delay` rides
+        // the `Option<_>` wrapper, which composes its inner conversion chain
+        // itself, while `required` is a bare leaf the whole-object decoder and
+        // the leaf encoder each have to compose for. Both fields therefore
+        // have to round-trip, not just the nullable one.
         val fromParts = DurationBoundary::class.java.getDeclaredMethod(
             "fromParts",
             java.lang.Long.TYPE,
+            java.lang.Long.TYPE,
         )
-        check(fromParts.parameterTypes.single() == java.lang.Long.TYPE)
-        check(durationBoundaryEcho(DurationBoundary(null), boom) == DurationBoundary(null))
+        check(fromParts.parameterTypes.all { it == java.lang.Long.TYPE })
         check(
-            durationBoundaryEcho(DurationBoundary(12_345uL), boom) ==
-                DurationBoundary(12_345uL),
+            durationBoundaryEcho(DurationBoundary(0uL, null), boom) ==
+                DurationBoundary(0uL, null),
+        )
+        check(
+            durationBoundaryEcho(DurationBoundary(7uL, 12_345uL), boom) ==
+                DurationBoundary(7uL, 12_345uL),
+        )
+        // The required field carries its own value rather than mirroring the
+        // optional one — a chain wired to the wrong binding would cross them.
+        check(
+            durationBoundaryEcho(DurationBoundary(86_400_000uL, 1uL), boom) ==
+                DurationBoundary(86_400_000uL, 1uL),
         )
 
         var inputError: String? = null

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2243,6 +2243,52 @@ pub(crate) unsafe fn JObject_to_Unsigned_7e3cc618<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Vec<perftest_flat::Label>, __JniErr> {
+    Ok({
+        let __list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __it = __list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __out: Vec<perftest_flat::Label> = Vec::new();
+        while let Some(__obj) = __it
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            let __elem_wire: jni::objects::JString = __obj.into();
+            let __elem: perftest_flat::Label = {
+                let __inner_s0 = JString_to_String_c7f3ca43(env, &__elem_wire)?;
+                let __inner_s1 = String_to_Label_c1a79668(env, __inner_s0)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
+                __inner_s1
+            };
+            __out.push(__elem);
+        }
+        __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -2272,6 +2318,99 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
             __out.push(__elem);
         }
         __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_impl_Fn_Duration_Send_Sync_static_98c9f460<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Duration) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Duration)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(J)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Duration)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Duration| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Duration)", e)))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!("push local frame for {}: {}", "Fn(Duration)", e),
+                    ))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __cb0_enc = {
+                        let __cb0_s0 = Duration_to_u64_e3980876(&mut env, __cb_arg0)
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        u64_to_jlong_4384a5d6(&mut env, __cb0_s0)?
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[jni::sys::jvalue { j: __cb0_enc }],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Duration)"));
+        })
     })
 }
 #[allow(
@@ -6589,6 +6728,49 @@ pub(crate) unsafe fn Unsigned_to_JObject_7e3cc618<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<perftest_flat::Label>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let __list_obj = env
+            .new_object("java/util/ArrayList", "()V", &[])
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
+        let __list = jni::objects::JList::from_env(env, &__list_obj)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        for __elem in v.into_iter() {
+            let __elem_wire = {
+                let __inner_s0 = Label_to_String_63dec766(env, __elem)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
+                String_to_JString_c7f3ca43(env, __inner_s0)?
+            };
+            let __elem_obj: jni::objects::JObject = __elem_wire.into();
+            __list
+                .add(env, &__elem_obj)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-add: {}", e)))?;
+        }
+        __list_obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<perftest_flat::Payload>,
@@ -9740,6 +9922,77 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationBoundary
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationEmit<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::sys::jlong,
+    f: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __value_s0 = match jlong_to_u64_4384a5d6(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let value = match u64_to_Duration_7c0845f9(&mut env, __value_s0) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let f = match JObject_to_impl_Fn_Duration_Send_Sync_static_98c9f460(&mut env, &f) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::duration_emit(value, f);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationOptional<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -10114,6 +10367,48 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
         }
     };
     match String_to_JString_c7f3ca43(&mut env, __out_s0) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelSeriesEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    labels: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let labels = match JObject_to_Vec_Label_3fdf860d(&mut env, &labels) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::label_series_echo(labels);
+    match Vec_Label_to_JObject_3fdf860d(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -12484,18 +12779,20 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSeries<'a>(
     let __vec = perftest_flat::stamp_series(count);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = match Stamp_to_JByteArray_2fc9bd18(&mut env, __elem) {
-            ::core::result::Result::Ok(__w) => __w,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return jni::objects::JObject::null().into();
+        let __enc = {
+            match Stamp_to_JByteArray_2fc9bd18(&mut env, __elem) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
             }
         };
         let __obj: jni::objects::JObject = __enc.into();
@@ -13402,18 +13699,20 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
     let __vec = perftest_flat::storage_labels(&s);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = match String_to_JString_c7f3ca43(&mut env, __elem) {
-            ::core::result::Result::Ok(__w) => __w,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return jni::objects::JObject::null().into();
+        let __enc = {
+            match String_to_JString_c7f3ca43(&mut env, __elem) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
             }
         };
         let __obj: jni::objects::JObject = __enc.into();
@@ -14181,18 +14480,20 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
     let __vec = perftest_flat::storage_shards(count, each);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = match Storage_to_jlong_1b233abd(&mut env, __elem) {
-            ::core::result::Result::Ok(__w) => __w,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return jni::objects::JObject::null().into();
+        let __enc = {
+            match Storage_to_jlong_1b233abd(&mut env, __elem) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
             }
         };
         __acc = match __CB_MID
@@ -14282,18 +14583,20 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
         ::core::option::Option::Some(__vec) => {
             let mut __acc = __acc;
             for __elem in __vec.into_iter() {
-                let __enc = match Storage_to_jlong_1b233abd(&mut env, __elem) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
+                let __enc = {
+                    match Storage_to_jlong_1b233abd(&mut env, __elem) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
                     }
                 };
                 __acc = match __CB_MID
@@ -17247,18 +17550,20 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedSeries<'
     let __vec = perftest_flat::unsigned_series();
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = match u64_to_jlong_4384a5d6(&mut env, __elem) {
-            ::core::result::Result::Ok(__w) => __w,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return jni::objects::JObject::null().into();
+        let __enc = {
+            match u64_to_jlong_4384a5d6(&mut env, __elem) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
             }
         };
         __acc = match __CB_MID

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -662,6 +662,94 @@ pub(crate) unsafe fn EscapeProbe_to_jlong_416aab42<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn HoldPolicy_to_JObject_d2a5bcc4<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::HoldPolicy,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___hold__tag: jni::sys::jint;
+        let ___hold_g0: jni::sys::jlong;
+        match &v.hold {
+            perftest_flat::Hold::Indefinite => {
+                ___hold__tag = 0;
+                ___hold_g0 = 0i64;
+            }
+            perftest_flat::Hold::For(__s0_0) => {
+                let ___hold_for_v0: jni::sys::jlong = {
+                    let ___hold_for_v0_s0 = Duration_to_u64_e3980876(env, __s0_0.clone())
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    u64_to_jlong_4384a5d6(env, ___hold_for_v0_s0)?
+                };
+                ___hold__tag = 1;
+                ___hold_g0 = ___hold_for_v0;
+            }
+        }
+        let ___grace_present: jni::sys::jboolean;
+        let ___grace__tag: jni::sys::jint;
+        let ___grace_g0: jni::sys::jlong;
+        match &v.grace {
+            ::core::option::Option::Some(__o0) => {
+                ___grace_present = 1u8;
+                match __o0 {
+                    perftest_flat::Hold::Indefinite => {
+                        ___grace__tag = 0;
+                        ___grace_g0 = 0i64;
+                    }
+                    perftest_flat::Hold::For(__s0_0) => {
+                        let ___grace_for_v0: jni::sys::jlong = {
+                            let ___grace_for_v0_s0 = Duration_to_u64_e3980876(
+                                    env,
+                                    __s0_0.clone(),
+                                )
+                                .map_err(|__e| <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(__e.to_string()))?;
+                            u64_to_jlong_4384a5d6(env, ___grace_for_v0_s0)?
+                        };
+                        ___grace__tag = 1;
+                        ___grace_g0 = ___grace_for_v0;
+                    }
+                }
+            }
+            ::core::option::Option::None => {
+                ___grace_present = 0u8;
+                ___grace__tag = 0i32;
+                ___grace_g0 = 0i64;
+            }
+        }
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/HoldPolicy",
+                "fromParts",
+                "(IJZIJ)Lio/prebindgen/covertest/model/HoldPolicy;",
+                &[
+                    jni::objects::JValue::from(___hold__tag),
+                    jni::objects::JValue::from(___hold_g0),
+                    jni::objects::JValue::from(___grace_present),
+                    jni::objects::JValue::from(___grace__tag),
+                    jni::objects::JValue::from(___grace_g0),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JByteArray_to_Stamp_2fc9bd18<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JByteArray<'v>,
@@ -822,6 +910,115 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
         perftest_flat::DurationBoundary {
             delay,
         }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_HoldPolicy_d2a5bcc4<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::HoldPolicy, __JniErr> {
+    Ok({
+        let __hold_raw: jni::objects::JObject = env
+            .get_field(v, "hold", "Lio/prebindgen/covertest/model/Hold;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("HoldPolicy.hold: {}", e)))?;
+        let hold = JObject_to_Hold_5f85caaf(env, &__hold_raw)?;
+        let __grace_raw: jni::objects::JObject = env
+            .get_field(v, "grace", "Lio/prebindgen/covertest/model/Hold;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("HoldPolicy.grace: {}", e)))?;
+        let grace = JObject_to_Option_Hold_230d7f9b(env, &__grace_raw)?;
+        perftest_flat::HoldPolicy {
+            hold,
+            grace,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Hold_5f85caaf<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Hold, __JniErr> {
+    Ok({
+        let __obj = v;
+        (|| -> ::core::result::Result<perftest_flat::Hold, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from("Hold: null value where a variant was required".to_string()),
+                );
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Hold$Indefinite")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Hold", ": instanceof ",
+                        "io/prebindgen/covertest/model/Hold$Indefinite", ": {}"), e
+                    ),
+                ))?
+            {
+                return ::core::result::Result::Ok(perftest_flat::Hold::Indefinite);
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Hold$For")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Hold", ": instanceof ",
+                        "io/prebindgen/covertest/model/Hold$For", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_raw: jni::sys::jlong = env
+                    .get_field(__obj, "v0", "J")
+                    .and_then(|val| val.j())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Hold.For.v0: {}", e)))? as _;
+                let __p_v0 = {
+                    let __p_v0_s0 = jlong_to_u64_4384a5d6(env, &__p_v0_raw)?;
+                    let __p_v0_s1 = u64_to_Duration_7c0845f9(env, __p_v0_s0)
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    __p_v0_s1
+                };
+                return ::core::result::Result::Ok(perftest_flat::Hold::For(__p_v0));
+            }
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from("Hold: value is not one of its declared variants".to_string()),
+            )
+        })()?
     })
 }
 #[allow(
@@ -1434,6 +1631,23 @@ pub(crate) unsafe fn JObject_to_Option_CacheConfig_a6be794d<'env, 'v>(
     Ok({
         if v.is_null() { None } else { Some(JObject_to_CacheConfig_db89a97c(env, v)?) }
     })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Option_Hold_230d7f9b<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Option<perftest_flat::Hold>, __JniErr> {
+    Ok({ if v.is_null() { None } else { Some(JObject_to_Hold_5f85caaf(env, v)?) } })
 }
 #[allow(
     non_snake_case,
@@ -9606,6 +9820,173 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escape_1probe_1v
                 &__e.to_string(),
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    h: jni::objects::JObject<'a>,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let h = match JObject_to_Hold_5f85caaf(&mut env, &h) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/HoldBuilderRaw";
+    const __CB_DESCR: &str = "(IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::hold_echo(h);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    match &__out {
+        perftest_flat::Hold::Indefinite => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Hold::For(__sv0) => {
+            let __enc___obj1_s0 = match Duration_to_u64_e3980876(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            let __enc___obj1 = match u64_to_jlong_4384a5d6(&mut env, __enc___obj1_s0) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdPolicyEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    p_hold: jni::objects::JObject<'a>,
+    p_grace: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_p_hold = match JObject_to_Hold_5f85caaf(&mut env, &p_hold) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __flat_p_grace = match JObject_to_Option_Hold_230d7f9b(&mut env, &p_grace) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __flat_p = perftest_flat::HoldPolicy {
+        hold: __flat_p_hold,
+        grace: __flat_p_grace,
+    };
+    let p = __flat_p;
+    let __out = perftest_flat::hold_policy_echo(p);
+    match HoldPolicy_to_JObject_d2a5bcc4(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -574,6 +574,13 @@ pub(crate) unsafe fn DurationBoundary_to_JObject_9c5bf9bc<'a>(
     v: perftest_flat::DurationBoundary,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let ___required: jni::sys::jlong = {
+            let ___required_s0 = Duration_to_u64_e3980876(env, v.required.clone())
+                .map_err(|__e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string()))?;
+            u64_to_jlong_4384a5d6(env, ___required_s0)?
+        };
         let ___delay: jni::sys::jlong = Option_Duration_to_jlong_1cfa4d44(
             env,
             v.delay.clone(),
@@ -582,8 +589,11 @@ pub(crate) unsafe fn DurationBoundary_to_JObject_9c5bf9bc<'a>(
             .call_static_method(
                 "io/prebindgen/covertest/model/DurationBoundary",
                 "fromParts",
-                "(J)Lio/prebindgen/covertest/model/DurationBoundary;",
-                &[jni::objects::JValue::from(___delay)],
+                "(JJ)Lio/prebindgen/covertest/model/DurationBoundary;",
+                &[
+                    jni::objects::JValue::from(___required),
+                    jni::objects::JValue::from(___delay),
+                ],
             )
             .and_then(|__v| __v.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -890,6 +900,20 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::DurationBoundary, __JniErr> {
     Ok({
+        let __required_raw: jni::sys::jlong = env
+            .get_field(v, "required", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("DurationBoundary.required: {}", e)))?;
+        let required = {
+            let required_s0 = jlong_to_u64_4384a5d6(env, &__required_raw)?;
+            let required_s1 = u64_to_Duration_7c0845f9(env, required_s0)
+                .map_err(|__e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string()))?;
+            required_s1
+        };
         let __delay_jobj: jni::objects::JObject = env
             .get_field(v, "delay", "Lkotlin/ULong;")
             .and_then(|val| val.l())
@@ -908,6 +932,7 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
             jlong_to_Option_Duration_1cfa4d44(env, &__delay_raw)?
         };
         perftest_flat::DurationBoundary {
+            required,
             delay,
         }
     })
@@ -9627,10 +9652,46 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationBoundary
     #[allow(non_upper_case_globals)]
     static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __CB_FQN: &str = "io/prebindgen/covertest/model/DurationBoundaryBuilderRaw";
-    const __CB_DESCR: &str = "(J)Ljava/lang/Object;";
+    const __CB_DESCR: &str = "(JJ)Ljava/lang/Object;";
     let __out = perftest_flat::duration_boundary_echo(&value);
     let __obj0: jni::sys::jvalue = {
-        let __enc0 = match Option_Duration_to_jlong_1cfa4d44(
+        let __enc0 = {
+            let __cs0_0 = match Duration_to_u64_e3980876(
+                &mut env,
+                __out.required.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            match u64_to_jlong_4384a5d6(&mut env, __cs0_0) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    let __obj1: jni::sys::jvalue = {
+        let __enc1 = match Option_Duration_to_jlong_1cfa4d44(
             &mut env,
             __out.delay.clone(),
         ) {
@@ -9647,10 +9708,17 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationBoundary
                 return jni::objects::JObject::null().into();
             }
         };
-        jni::sys::jvalue { j: __enc0 }
+        jni::sys::jvalue { j: __enc1 }
     };
     match __CB_MID
-        .call_object(&mut env, __CB_FQN, "run", __CB_DESCR, &__builder, &[__obj0])
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1],
+        )
     {
         ::core::result::Result::Ok(__o) => __o,
         ::core::result::Result::Err(__e) => {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -613,9 +613,15 @@ pub fn duration_out_of_range() -> Option<Duration> {
 /// its echo executes both the whole-object input decoder and the `fromParts`
 /// output encoder; the nullable duration itself still uses the raw `jlong`
 /// niche whenever it crosses a generated JNI call boundary.
+///
+/// The two fields are the two shapes a converted leaf takes, and they exercise
+/// DIFFERENT emitter paths: `delay` goes through the `Option<_>` wrapper, which
+/// composes its inner conversion chain itself, while `required` is a bare leaf
+/// the data-class encoder/decoder has to compose for.
 #[prebindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DurationBoundary {
+    pub required: Duration,
     pub delay: Option<Duration>,
 }
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -625,6 +625,47 @@ pub fn duration_boundary_echo(value: &DurationBoundary) -> DurationBoundary {
     value.clone()
 }
 
+/// How long something is held: for an explicit period, or indefinitely.
+///
+/// A **sum whose payload is a converted type**. `Duration` crosses through the
+/// binding's `convert!` declaration, so this payload's boundary conversion is
+/// two steps (`Duration -> u64 -> jlong`, and back) rather than the single
+/// wire converter every other sum payload here uses — the position where an
+/// emitter that reads only the wire-facing converter builds code that hands
+/// the semantic value where the representation is expected.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Hold {
+    /// Held with no end — the payload-less group.
+    Indefinite,
+    /// Held for this long.
+    For(Duration),
+}
+
+/// A retention policy: a required converted-payload sum beside an optional one.
+///
+/// The data-class position for [`Hold`], so the converted payload is exercised
+/// both as a top-level sum and as a tag-gated group inside a `fromParts`
+/// bridge — the two encoders are separate code paths.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HoldPolicy {
+    pub hold: Hold,
+    pub grace: Option<Hold>,
+}
+
+/// Round-trip a converted-payload sum, whole.
+#[prebindgen]
+pub fn hold_echo(h: Hold) -> Hold {
+    h
+}
+
+/// Round-trip a data class carrying converted-payload sums.
+#[prebindgen]
+pub fn hold_policy_echo(p: HoldPolicy) -> HoldPolicy {
+    p
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // convert! source-kind fixtures — one type per conversion source. Like
 // `Millis`, none of these types is `#[prebindgen]`-marked: each crosses the

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -631,6 +631,17 @@ pub fn duration_boundary_echo(value: &DurationBoundary) -> DurationBoundary {
     value.clone()
 }
 
+/// Deliver a converted value through the generated typed/raw callback twin —
+/// the converted analogue of [`unsigned_emit`].
+///
+/// A callback argument that crosses WHOLE (no deconstructor, so no leaf plan)
+/// is its own encoder path, independent of the data-class and sum emitters, so
+/// a converted type has to reach its representation here too.
+#[prebindgen]
+pub fn duration_emit(value: Duration, f: impl Fn(Duration) + Send + Sync + 'static) {
+    f(value)
+}
+
 /// How long something is held: for an explicit period, or indefinitely.
 ///
 /// A **sum whose payload is a converted type**. `Duration` crosses through the
@@ -756,6 +767,20 @@ pub struct Label(pub String);
 #[prebindgen]
 pub fn label_reverse(l: Label) -> Label {
     Label(l.0.chars().rev().collect())
+}
+
+/// Round-trip a collection of labels — a `Vec` whose ELEMENT is a converted
+/// type.
+///
+/// `Duration` cannot take this path (a `Vec` needs a JObject-shaped element
+/// wire, and its representation is a primitive `jlong`, so `Vec<Duration>` is
+/// refused at resolve time), but `Label` lowers to `String` and therefore does.
+/// The `Vec` converters build their element conversion inline, in both
+/// directions, so each has to compose the element's chain rather than call its
+/// wire-facing converter alone.
+#[prebindgen]
+pub fn label_series_echo(labels: Vec<Label>) -> Vec<Label> {
+    labels
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -204,9 +204,35 @@ pub(crate) fn callback_input(
             },
         };
         let arg_wire = arg_entry.destination.clone();
-        let conv = arg_entry.function.sig.ident.clone();
         let enc_ident = format_ident!("__cb{}_enc", i);
         let obj_ident = format_ident!("__cb{}_obj", i);
+
+        // The arg's COMPLETE Rust -> wire chain: the rust-side stages a custom
+        // `convert!` declaration inserts (`Duration -> u64`), then the
+        // wire-facing converter (`u64 -> jlong`). A whole-value callback arg
+        // has no leaf plan, so this is its own encoder path — calling only the
+        // wire-facing converter would hand it the semantic value where it
+        // expects the representation. Stage locals are keyed on the arg index.
+        let conv = {
+            let converter = arg_entry.converter_ident();
+            if arg_entry.pre_stages.is_empty() {
+                quote!(#converter(&mut env, #cb_val)?)
+            } else {
+                let mut body = TokenStream::new();
+                let mut previous = cb_val.clone();
+                for (order, (_, stage)) in arg_entry.output_stage_order().enumerate() {
+                    let stage_fn = &stage.function.sig.ident;
+                    let next = format_ident!("__cb{}_s{}", i, order);
+                    body.extend(quote! {
+                        let #next = #stage_fn(&mut env, #previous)
+                            .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
+                                __e.to_string()))?;
+                    });
+                    previous = quote!(#next);
+                }
+                quote!({ #body #converter(&mut env, #previous)? })
+            }
+        };
 
         // Plan-less opaque-handle arg: encode to a raw `jlong` (`Box::into_raw`)
         // and deliver it as-is. The typed handle class is constructed Kotlin-side
@@ -219,7 +245,7 @@ pub(crate) fn callback_input(
         if let Some(h) = &arg_entry.metadata.projection {
             if matches!(h.kind, ProjectionKind::Handle) {
                 preludes.push(quote! {
-                    let #enc_ident = #conv(&mut env, #cb_val)?;
+                    let #enc_ident = #conv;
                 });
                 jvalue_exprs.push(quote!(jni::sys::jvalue { j: #enc_ident }));
                 total += 1;
@@ -242,7 +268,7 @@ pub(crate) fn callback_input(
         if arg_is_prim {
             let letter = jni_field_access(&arg_wire).unwrap().1;
             preludes.push(quote! {
-                let #enc_ident = #conv(&mut env, #cb_val)?;
+                let #enc_ident = #conv;
             });
             jvalue_exprs.push(quote!(jni::sys::jvalue { #letter: #enc_ident }));
             total += 1;
@@ -250,7 +276,7 @@ pub(crate) fn callback_input(
         }
         let cast = cast_wire_to_jobject(&enc_ident, &arg_wire, &fail);
         preludes.push(quote! {
-            let #enc_ident = #conv(&mut env, #cb_val)?;
+            let #enc_ident = #conv;
             let #obj_ident: jni::objects::JObject = #cast;
         });
         jvalue_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -172,7 +172,7 @@ pub(crate) fn primitive_output(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)>
 /// conversions may carry semantic steps in `pre_stages` (for example
 /// `jlong -> u64 -> Duration`). Keep those steps inside the `Some` arm so a
 /// niche discriminator is tested before any conversion runs.
-fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn::Expr {
+pub(crate) fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn::Expr {
     let converter = inner.converter_ident();
     if inner.pre_stages.is_empty() {
         return syn::parse2(quote!(#converter(env, #wire)?))
@@ -197,7 +197,10 @@ fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn
 
 /// Invoke an inner output converter's complete `Rust -> wire` chain.
 /// Mirror of [`composed_inner_input`].
-fn composed_inner_output(inner: &TypeEntry<KotlinMeta>, value: TokenStream) -> syn::Expr {
+pub(crate) fn composed_inner_output(
+    inner: &TypeEntry<KotlinMeta>,
+    value: TokenStream,
+) -> syn::Expr {
     let converter = inner.converter_ident();
     if inner.pre_stages.is_empty() {
         return syn::parse2(quote!(#converter(env, #value)?))

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -425,8 +425,43 @@ pub(crate) fn encode_plan_leaves(
                 TypeKey::from_type(&leaf.out_ty)
             )
         });
-        let conv = out_entry.function.sig.ident.clone();
         let conv_fail = fail(quote!(__e.to_string()));
+        // The leaf's COMPLETE Rust -> wire chain: the rust-side stages a custom
+        // `convert!` declaration inserts (`Duration -> u64`), then the
+        // wire-facing converter (`u64 -> jlong`). Calling only the latter would
+        // hand it the semantic value where it expects the representation.
+        // Stage locals are keyed on the leaf index, so sibling leaves of the
+        // same type cannot collide.
+        let conv_stages: Vec<syn::Ident> = out_entry
+            .output_stage_order()
+            .map(|(_, stage)| stage.function.sig.ident.clone())
+            .collect();
+        let conv_fn = out_entry.converter_ident().clone();
+        let conv = |input: TokenStream| -> TokenStream {
+            let step = |f: &syn::Ident, arg: TokenStream| {
+                quote! {
+                    match #f(&mut env, #arg) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            #conv_fail
+                        }
+                    }
+                }
+            };
+            if conv_stages.is_empty() {
+                return step(&conv_fn, input);
+            }
+            let mut body = TokenStream::new();
+            let mut previous = input;
+            for (order, stage_fn) in conv_stages.iter().enumerate() {
+                let next = format_ident!("__cs{}_{}", idx, order);
+                let call = step(stage_fn, previous);
+                body.extend(quote! { let #next = #call; });
+                previous = quote!(#next);
+            }
+            let last = step(&conv_fn, previous);
+            quote!({ #body #last })
+        };
 
         // Bind `obj_ident` to a JObject-yielding `expr`.
         let bind_obj = |obj_ident: &syn::Ident, expr: TokenStream| -> TokenStream {
@@ -480,13 +515,9 @@ pub(crate) fn encode_plan_leaves(
                             true,
                             0,
                             &|reached| {
+                                let __encoded = conv(quote!(#reached));
                                 quote! {{
-                                    let #handle_ident: jni::sys::jlong = match #conv(&mut env, #reached) {
-                                        ::core::result::Result::Ok(__w) => __w,
-                                        ::core::result::Result::Err(__e) => {
-                                            #conv_fail
-                                        }
-                                    };
+                                    let #handle_ident: jni::sys::jlong = #__encoded;
                                     jni::sys::jvalue { j: #handle_ident }
                                 }}
                             },
@@ -508,13 +539,9 @@ pub(crate) fn encode_plan_leaves(
                             true,
                             0,
                             &|reached| {
+                                let __encoded = conv(quote!(#reached));
                                 quote! {{
-                                    let #handle_ident: jni::sys::jlong = match #conv(&mut env, #reached) {
-                                        ::core::result::Result::Ok(__w) => __w,
-                                        ::core::result::Result::Err(__e) => {
-                                            #conv_fail
-                                        }
-                                    };
+                                    let #handle_ident: jni::sys::jlong = #__encoded;
                                     match ::prebindgen::lang::box_jlong(&mut env, #handle_ident) {
                                         ::core::result::Result::Ok(__o) => __o,
                                         ::core::result::Result::Err(__e) => {
@@ -534,15 +561,12 @@ pub(crate) fn encode_plan_leaves(
                     let enc_ident = format_ident!("__enc{}", idx);
                     let cast = cast_wire_to_jobject(&enc_ident, &wire, fail);
                     if leaf.path.is_empty() && !by_ref {
+                        let __encoded = conv(quote!(#value));
+
                         stmts.extend(bind_obj(
                             obj_ident,
                             quote! {{
-                                let #enc_ident = match #conv(&mut env, #value) {
-                                    ::core::result::Result::Ok(__w) => __w,
-                                    ::core::result::Result::Err(__e) => {
-                                        #conv_fail
-                                    }
-                                };
+                                let #enc_ident = #__encoded;
                                 #cast
                             }},
                         ));
@@ -556,13 +580,9 @@ pub(crate) fn encode_plan_leaves(
                             true,
                             0,
                             &|reached| {
+                                let __encoded = conv(quote!(*#reached));
                                 quote! {{
-                                    let #enc_ident = match #conv(&mut env, *#reached) {
-                                        ::core::result::Result::Ok(__w) => __w,
-                                        ::core::result::Result::Err(__e) => {
-                                            #conv_fail
-                                        }
-                                    };
+                                    let #enc_ident = #__encoded;
                                     #cast
                                 }}
                             },
@@ -573,13 +593,9 @@ pub(crate) fn encode_plan_leaves(
                 ProjectionKind::Unsigned64 => {
                     let enc_ident = format_ident!("__enc{}", idx);
                     let encode = |reached: TokenStream| {
+                        let encoded = conv(reached);
                         quote! {{
-                            let #enc_ident: jni::sys::jlong = match #conv(&mut env, #reached) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    #conv_fail
-                                }
-                            };
+                            let #enc_ident: jni::sys::jlong = #encoded;
                             jni::sys::jvalue { j: #enc_ident }
                         }}
                     };
@@ -609,13 +625,9 @@ pub(crate) fn encode_plan_leaves(
                             true,
                             0,
                             &|reached| {
+                                let __encoded = conv(quote!(*#reached));
                                 quote! {{
-                                    let #enc_ident: jni::sys::jlong = match #conv(&mut env, *#reached) {
-                                        ::core::result::Result::Ok(__w) => __w,
-                                        ::core::result::Result::Err(__e) => {
-                                            #conv_fail
-                                        }
-                                    };
+                                    let #enc_ident: jni::sys::jlong = #__encoded;
                                     match ::prebindgen::lang::box_jlong(&mut env, #enc_ident) {
                                         ::core::result::Result::Ok(__o) => __o,
                                         ::core::result::Result::Err(__e) => {
@@ -678,13 +690,9 @@ pub(crate) fn encode_plan_leaves(
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
             let expr = reach(&|reached| {
+                let __encoded = conv(quote!(#reached));
                 quote! {{
-                    let #enc_ident = match #conv(&mut env, #reached) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            #conv_fail
-                        }
-                    };
+                    let #enc_ident = #__encoded;
                     jni::sys::jvalue { #letter: #enc_ident }
                 }}
             });
@@ -695,13 +703,9 @@ pub(crate) fn encode_plan_leaves(
         }
         let cast = cast_wire_to_jobject(&enc_ident, &wire, fail);
         let expr = reach(&|reached| {
+            let __encoded = conv(quote!(#reached));
             quote! {{
-                let #enc_ident = match #conv(&mut env, #reached) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        #conv_fail
-                    }
-                };
+                let #enc_ident = #__encoded;
                 #cast
             }}
         });

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -144,7 +144,35 @@ pub(crate) fn emit_unfold_delivery(
                     TypeKey::from_type(element)
                 )
             });
-            let elem_conv = out_entry.function.sig.ident.clone();
+            // The element's COMPLETE Rust -> wire chain. No `convert!` type is
+            // known to reach THIS path today (a fold element is single-leaf and
+            // whole, and the collection converters claim the shapes a converted
+            // element can take), but composing keeps the invariant uniform: a
+            // chain-less entry emits exactly the same call it did before. This
+            // is an extern body, so errors route to the sink rather than `?`.
+            let elem_conv = {
+                let step = |f: &syn::Ident, arg: TokenStream| {
+                    quote! {
+                        match #f(&mut env, #arg) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
+                                return #on_err;
+                            }
+                        }
+                    }
+                };
+                let mut body = TokenStream::new();
+                let mut previous = quote!(__elem);
+                for (order, (_, stage)) in out_entry.output_stage_order().enumerate() {
+                    let next = format_ident!("__es{}", order);
+                    let call = step(&stage.function.sig.ident, previous);
+                    body.extend(quote! { let #next = #call; });
+                    previous = quote!(#next);
+                }
+                let last = step(out_entry.converter_ident(), previous);
+                quote!({ #body #last })
+            };
             let elem_wire = out_entry.destination.clone();
             // Primitive-wire elements (including an opaque **handle**, whose wire
             // is `jlong`) cross as a raw typed jvalue; object wires (String /
@@ -168,13 +196,7 @@ pub(crate) fn emit_unfold_delivery(
             };
             let invoke = fold_invoke(&[arg_expr]);
             quote! {
-                let __enc = match #elem_conv(&mut env, __elem) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
-                        return #on_err;
-                    }
-                };
+                let __enc = #elem_conv;
                 #bind_obj
                 #invoke
             }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -476,12 +476,7 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if option_inner_type(ty).is_some() {
-            let inner_conv = registry
-                .input_entry(&enum_inner)?
-                .function
-                .sig
-                .ident
-                .clone();
+            let inner_conv = composed_entry_decode(registry.input_entry(&enum_inner)?, &raw, bind);
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None
@@ -489,7 +484,7 @@ fn read_kotlin_property(
                     let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
                         .and_then(|val| val.i())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    ::core::option::Option::Some(#inner_conv(env, &#raw)?)
+                    ::core::option::Option::Some(#inner_conv)
                 };
             }
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -393,8 +393,13 @@ fn read_kotlin_property(
 ) -> Option<(TokenStream, TokenStream)> {
     let entry = registry.input_entry(ty)?;
     let wire = entry.destination.clone();
-    let conv = entry.function.sig.ident.clone();
     let raw = format_ident!("{}_raw", bind);
+    // The COMPLETE wire → Rust chain, not just the wire-facing converter: a
+    // `convert!`-declared type reaches its Rust value through the rust-side
+    // stages that follow (`jlong → u64 → Duration`). Stage bindings are named
+    // off `bind`, so two payloads of the same type in one variant do not
+    // collide.
+    let conv = composed_property_decode(entry, bind);
 
     // A handle property is a `NativeHandle` object whose raw pointer comes
     // from `peek()`; an enum property is the Kotlin enum class, decoded
@@ -413,7 +418,7 @@ fn read_kotlin_property(
             // `Option<_>` keeps the niche-aware converter (jlong 0 ⇒ `None`).
             let closed_msg = "Operation on a closed native handle.";
             let decode = if option_inner_type(ty).is_some() {
-                quote! { let #bind = #conv(env, &#raw)?; }
+                quote! { let #bind = #conv; }
             } else {
                 quote! {
                     if #raw == 0 || (#raw & 1) == 1 {
@@ -483,7 +488,7 @@ fn read_kotlin_property(
                 let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
                     .and_then(|val| val.i())
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                let #bind = #conv(env, &#raw)?;
+                let #bind = #conv;
             }
         };
         return Some((
@@ -502,7 +507,7 @@ fn read_kotlin_property(
                 let #raw: #wire = env.get_field(#receiver, #prop, #sig)
                     .and_then(|val| val.#accessor())
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))? as _;
-                let #bind = #conv(env, &#raw)?;
+                let #bind = #conv;
             },
             quote!(#bind),
         )),
@@ -514,7 +519,7 @@ fn read_kotlin_property(
                         .and_then(|val| val.l())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
                     let #raw: #wire = #obj.into();
-                    let #bind = #conv(env, &#raw)?;
+                    let #bind = #conv;
                 },
                 quote!(#bind),
             ))
@@ -535,12 +540,47 @@ fn read_kotlin_property(
                     let #raw: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
                         .and_then(|val| val.l())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #bind = #conv(env, &#raw)?;
+                    let #bind = #conv;
                 },
                 quote!(#bind),
             ))
         }
     }
+}
+
+/// The complete `wire -> Rust` decode of one property: the wire-facing
+/// converter applied to `<bind>_raw`, followed by the rust-side stages a
+/// custom [`convert!`](crate::convert) declaration inserts.
+///
+/// The mirror of [`ConvChain::call`](super::super::struct_plan::ConvChain) on
+/// the output side, and of the structural wrappers' own chain composition:
+/// stopping at [`TypeEntry::converter_ident`] would bind the *representation*
+/// (`u64`) where the Rust value (`Duration`) is required, which does not
+/// compile. Stage bindings are derived from `bind`, so two properties of the
+/// same type in one scope get distinct names.
+fn composed_property_decode(
+    entry: &crate::core::TypeEntry<KotlinMeta>,
+    bind: &syn::Ident,
+) -> TokenStream {
+    let raw = format_ident!("{}_raw", bind);
+    let converter = entry.converter_ident();
+    if entry.pre_stages.is_empty() {
+        return quote!(#converter(env, &#raw)?);
+    }
+    let s0 = format_ident!("{}_s0", bind);
+    let mut body = quote! { let #s0 = #converter(env, &#raw)?; };
+    let mut previous = s0;
+    for (order, (_, stage)) in entry.input_stage_order().enumerate() {
+        let stage_fn = &stage.function.sig.ident;
+        let next = format_ident!("{}_s{}", bind, order + 1);
+        body.extend(quote! {
+            let #next = #stage_fn(env, #previous)
+                .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
+                    __e.to_string()))?;
+        });
+        previous = next;
+    }
+    quote!({ #body #previous })
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -30,7 +30,9 @@ pub(crate) fn struct_input_body(
         // fixed-point loop will retry on the next iteration.
         let field_entry = registry.input_entry(&field.ty)?;
         let field_wire = field_entry.destination.clone();
-        let field_conv = field_entry.function.sig.ident.clone();
+        // The field's COMPLETE decode, stages included — a `convert!` type
+        // reaches its Rust value through them (`jlong -> u64 -> Duration`).
+        let field_conv = composed_entry_decode(field_entry, &raw_ident, &fname_ident);
 
         // Projection fields — mirror of `struct_output_body`'s kind branch:
         //  * Handle: read the JNINativeHandle object from the JVM slot,
@@ -61,7 +63,7 @@ pub(crate) fn struct_input_body(
                             .map(|s| s.ident == "Option").unwrap_or(false)
                     );
                     let decode = if field_is_option {
-                        quote! { let #fname_ident = #field_conv(env, &#raw_ident)?; }
+                        quote! { let #fname_ident = #field_conv; }
                     } else {
                         quote! {
                             // Null or closed handle in a required field —
@@ -101,7 +103,7 @@ pub(crate) fn struct_input_body(
                             .and_then(|val| val.l())
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
                         let #raw_ident: #field_wire = #tmp_ident.into();
-                        let #fname_ident = #field_conv(env, &#raw_ident)?;
+                        let #fname_ident = #field_conv;
                     });
                 }
                 ProjectionKind::Unsigned64 => {
@@ -110,8 +112,11 @@ pub(crate) fn struct_input_body(
                             proj.strategy,
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
-                        let inner_conv =
-                            registry.input_entry(&inner_ty)?.function.sig.ident.clone();
+                        let inner_conv = composed_entry_decode(
+                            registry.input_entry(&inner_ty)?,
+                            &raw_ident,
+                            &fname_ident,
+                        );
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                         let decode = if niche {
                             // The Kotlin data-class property is still `ULong?`
@@ -119,10 +124,10 @@ pub(crate) fn struct_input_body(
                             // JNI converter is niche-keyed on primitive jlong.
                             // Run the complete field converter so every custom
                             // semantic stage (e.g. u64 -> Duration) is applied.
-                            quote! { #field_conv(env, &#raw_ident)? }
+                            quote! { #field_conv }
                         } else {
                             quote! {
-                                ::core::option::Option::Some(#inner_conv(env, &#raw_ident)?)
+                                ::core::option::Option::Some(#inner_conv)
                             }
                         };
                         field_preludes.push(quote! {
@@ -146,7 +151,7 @@ pub(crate) fn struct_input_body(
                                 .get_field(v, #camel, "J")
                                 .and_then(|val| val.j())
                                 .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                            let #fname_ident = #field_conv(env, &#raw_ident)?;
+                            let #fname_ident = #field_conv;
                         });
                     }
                 }
@@ -168,7 +173,11 @@ pub(crate) fn struct_input_body(
                 .map(|v| v.to_string())
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
-                let inner_conv = registry.input_entry(&f_inner)?.function.sig.ident.clone();
+                let inner_conv = composed_entry_decode(
+                    registry.input_entry(&f_inner)?,
+                    &raw_ident,
+                    &fname_ident,
+                );
                 let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                 let decode = if option_inner_type(&field.ty).is_some() {
                     quote! {
@@ -178,7 +187,7 @@ pub(crate) fn struct_input_body(
                             let #raw_ident: jni::sys::jint = env.call_method(&#tmp_ident, "getValue", "()I", &[])
                                 .and_then(|val| val.i())
                                 .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                            ::core::option::Option::Some(#inner_conv(env, &#raw_ident)?)
+                            ::core::option::Option::Some(#inner_conv)
                         };
                     }
                 } else {
@@ -186,7 +195,7 @@ pub(crate) fn struct_input_body(
                         let #raw_ident: jni::sys::jint = env.call_method(&#tmp_ident, "getValue", "()I", &[])
                             .and_then(|val| val.i())
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                        let #fname_ident = #inner_conv(env, &#raw_ident)?;
+                        let #fname_ident = #inner_conv;
                     }
                 };
                 field_preludes.push(quote! {
@@ -206,7 +215,7 @@ pub(crate) fn struct_input_body(
                     let #raw_ident: #field_wire = env.get_field(v, #camel, #sig)
                         .and_then(|val| val.#accessor())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))? as _;
-                    let #fname_ident = #field_conv(env, &#raw_ident)?;
+                    let #fname_ident = #field_conv;
                 });
             }
             Some((sig, _, true)) => {
@@ -216,7 +225,7 @@ pub(crate) fn struct_input_body(
                         .and_then(|val| val.l())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
                     let #raw_ident: #field_wire = #tmp_ident.into();
-                    let #fname_ident = #field_conv(env, &#raw_ident)?;
+                    let #fname_ident = #field_conv;
                 });
             }
             None => {
@@ -255,7 +264,7 @@ pub(crate) fn struct_input_body(
                     let #raw_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
                         .and_then(|val| val.l())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #fname_ident = #field_conv(env, &#raw_ident)?;
+                    let #fname_ident = #field_conv;
                 });
             }
         }
@@ -548,31 +557,37 @@ fn read_kotlin_property(
     }
 }
 
-/// The complete `wire -> Rust` decode of one property: the wire-facing
-/// converter applied to `<bind>_raw`, followed by the rust-side stages a
-/// custom [`convert!`](crate::convert) declaration inserts.
+/// The complete `wire -> Rust` decode of one value read out of a JVM object:
+/// the wire-facing converter applied to `raw`, followed by the rust-side
+/// stages a custom [`convert!`](crate::convert) declaration inserts.
 ///
 /// The mirror of [`ConvChain::call`](super::super::struct_plan::ConvChain) on
 /// the output side, and of the structural wrappers' own chain composition:
 /// stopping at [`TypeEntry::converter_ident`] would bind the *representation*
 /// (`u64`) where the Rust value (`Duration`) is required, which does not
-/// compile. Stage bindings are derived from `bind`, so two properties of the
-/// same type in one scope get distinct names.
-fn composed_property_decode(
+/// compile.
+///
+/// Every converter invocation in this module's whole-object decoders goes
+/// through here — a data-class field, a sealed-class property, and the inner
+/// converter an `Option`/enum slot delegates to — so a chain cannot be dropped
+/// by one branch happening not to have been the one under test. Stage bindings
+/// derive from `stage_base`, so two values of the same type in one scope get
+/// distinct names.
+fn composed_entry_decode(
     entry: &crate::core::TypeEntry<KotlinMeta>,
-    bind: &syn::Ident,
+    raw: &syn::Ident,
+    stage_base: &syn::Ident,
 ) -> TokenStream {
-    let raw = format_ident!("{}_raw", bind);
     let converter = entry.converter_ident();
     if entry.pre_stages.is_empty() {
         return quote!(#converter(env, &#raw)?);
     }
-    let s0 = format_ident!("{}_s0", bind);
+    let s0 = format_ident!("{}_s0", stage_base);
     let mut body = quote! { let #s0 = #converter(env, &#raw)?; };
     let mut previous = s0;
     for (order, (_, stage)) in entry.input_stage_order().enumerate() {
         let stage_fn = &stage.function.sig.ident;
-        let next = format_ident!("{}_s{}", bind, order + 1);
+        let next = format_ident!("{}_s{}", stage_base, order + 1);
         body.extend(quote! {
             let #next = #stage_fn(env, #previous)
                 .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
@@ -581,6 +596,15 @@ fn composed_property_decode(
         previous = next;
     }
     quote!({ #body #previous })
+}
+
+/// [`composed_entry_decode`] for a sealed-class property, whose raw binding is
+/// `<bind>_raw` by construction.
+fn composed_property_decode(
+    entry: &crate::core::TypeEntry<KotlinMeta>,
+    bind: &syn::Ident,
+) -> TokenStream {
+    composed_entry_decode(entry, &format_ident!("{}_raw", bind), bind)
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -221,9 +221,10 @@ fn encode_field(
     let mut slots: Vec<EncSlot> = Vec::new();
     {
         let id = format_ident!("__{}", base);
-        let conv_value = |conv: &syn::Ident| -> TokenStream {
-            quote! { #conv(#env_expr, #value.clone())? }
-        };
+        // The leaf's COMPLETE chain, not just its wire-facing converter: a
+        // `convert!`-declared type (`Duration`) reaches the wire through its
+        // rust-side stages first (`Duration → u64 → jlong`).
+        let conv_value = |conv: &ConvChain| -> TokenStream { conv.call(env_expr, value, base) };
         match kind {
             // Projection leaf (opaque handle → jlong, value class / blob → ByteArray).
             PlanFieldKind::Projection { conv, proj, .. } => {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -302,18 +302,37 @@ fn encode_group_leaf(
             TypeKey::from_type(&leaf.out_ty)
         )
     });
-    let conv = out_entry.function.sig.ident.clone();
     let wire = out_entry.destination.clone();
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);
-    let encode = quote! {
-        let #enc = match #conv(&mut env, #bind.clone()) {
+    // The payload's COMPLETE chain: a `convert!`-declared type reaches the
+    // wire through its rust-side stages first (`Duration → u64 → jlong`).
+    // Stopping at the wire-facing converter would hand it the semantic value
+    // where it expects the representation.
+    let mut encode = TokenStream::new();
+    let mut previous = quote!(#bind.clone());
+    for (order, (_, stage)) in out_entry.output_stage_order().enumerate() {
+        let stage_fn = &stage.function.sig.ident;
+        let next = format_ident!("__enc_{}_s{}", obj_ident, order);
+        encode.extend(quote! {
+            let #next = match #stage_fn(&mut env, #previous) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    #conv_fail
+                }
+            };
+        });
+        previous = quote!(#next);
+    }
+    let conv = out_entry.converter_ident();
+    encode.extend(quote! {
+        let #enc = match #conv(&mut env, #previous) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
                 #conv_fail
             }
         };
-    };
+    });
     if prim {
         let letter = jni_field_access(&wire)
             .expect("leaf_is_prim guarantees a primitive wire")

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -787,13 +787,22 @@ fn leaf_iface_param(
                 if nullable && !raw.is_nullable() {
                     raw = raw.nullable();
                 }
+                // The niche sentinel IS the absent representation, so it means
+                // something only where the leaf can be absent. A non-optional
+                // leaf (a required sum payload, say) owns the whole domain:
+                // mapping its sentinel to null would both invent an absence the
+                // type does not have and contradict the non-nullable typed view
+                // this same param declares.
+                let niche_sentinel = if builder_kt.is_nullable() {
+                    projection_leaf_sentinel(proj?)
+                } else {
+                    None
+                };
                 return Some(IfaceParam {
                     name,
                     typed: builder_kt.clone(),
                     raw,
-                    wrap: WrapKind::Unsigned64 {
-                        niche_sentinel: projection_leaf_sentinel(proj?),
-                    },
+                    wrap: WrapKind::Unsigned64 { niche_sentinel },
                 });
             }
             ProjectionKind::Handle => {}

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -40,26 +40,73 @@ pub(crate) enum LeafForm {
     Object,
 }
 
+/// The COMPLETE Rust → wire conversion of one leaf: the rust-side stages a
+/// custom [`convert!`](crate::convert) declaration inserts (`Duration → u64`)
+/// followed by the wire-facing converter (`u64 → jlong`).
+///
+/// A leaf must carry the whole chain, not just
+/// [`TypeEntry::converter_ident`](crate::core::TypeEntry::converter_ident):
+/// calling only the wire-facing function would hand it the *semantic* value
+/// (a `Duration`) where it expects the *representation* (a `u64`), which does
+/// not compile. Structural wrappers (`Option<_>`, `Vec<_>`) already compose
+/// the chain; this is the same composition for the positions the flattened
+/// `fromParts` bridge encodes itself.
+pub(crate) struct ConvChain {
+    /// Rust-side stages in output execution order — each consumes the
+    /// previous one's result, the first consumes the Rust value.
+    pub stages: Vec<syn::Ident>,
+    /// The wire-facing converter, applied last.
+    pub function: syn::Ident,
+}
+
+impl ConvChain {
+    /// Read the chain off a resolved output entry.
+    fn of(entry: &crate::core::TypeEntry<KotlinMeta>) -> Self {
+        ConvChain {
+            stages: entry
+                .output_stage_order()
+                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .collect(),
+            function: entry.converter_ident().clone(),
+        }
+    }
+
+    /// The expression converting `value` (a Rust value expression) to this
+    /// leaf's wire form, propagating any stage error with `?`.
+    pub(crate) fn call(&self, env: &TokenStream, value: &TokenStream, base: &str) -> TokenStream {
+        let function = &self.function;
+        if self.stages.is_empty() {
+            return quote! { #function(#env, #value.clone())? };
+        }
+        let mut body = TokenStream::new();
+        let mut previous = quote!(#value.clone());
+        for (order, stage) in self.stages.iter().enumerate() {
+            let next = format_ident!("__{}_s{}", base, order);
+            body.extend(quote! {
+                let #next = #stage(#env, #previous)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
+                        __e.to_string()))?;
+            });
+            previous = quote!(#next);
+        }
+        quote!({ #body #function(#env, #previous)? })
+    }
+}
+
 pub(crate) enum PlanFieldKind {
     /// Opaque-handle / value-blob leaf. Wire slot: `jlong` (`"J"`) for a
     /// handle, `ByteArray` (`"[B"`) for a blob; the factory rebuilds the
     /// typed value from `fqn`.
     Projection {
-        conv: syn::Ident,
+        conv: ConvChain,
         proj: Projection,
         fqn: String,
     },
     /// Bare enum → `jint` discriminant (`"I"`); factory calls `fromInt`.
-    Enum {
-        conv: syn::Ident,
-        kotlin: kt::KtType,
-    },
+    Enum { conv: ConvChain, kotlin: kt::KtType },
     /// `Option<enum>` → `box_jint`-boxed discriminant
     /// (`"Ljava/lang/Integer;"`, JVM null = `None`); factory takes `Int?`.
-    OptionEnum {
-        conv: syn::Ident,
-        kotlin: kt::KtType,
-    },
+    OptionEnum { conv: ConvChain, kotlin: kt::KtType },
     /// Nested plain data-class: its leaves inline here. `optional` prepends
     /// a `present: Boolean` flag (`"Z"`) and defaults the child slots in the
     /// `None` arm; the factory guards `Child.fromParts(…)` on the flag.
@@ -93,7 +140,7 @@ pub(crate) enum PlanFieldKind {
     },
     /// Simple leaf with its own output converter.
     Leaf {
-        conv: syn::Ident,
+        conv: ConvChain,
         /// The converter's destination wire type (boxed: `syn::Type` is the
         /// enum's size outlier).
         wire: Box<syn::Type>,
@@ -210,7 +257,7 @@ pub(crate) fn classify_field(
     }
 
     let field_entry = registry.output_entry(&effective_ty)?;
-    let conv = field_entry.function.sig.ident.clone();
+    let conv = ConvChain::of(field_entry);
 
     {
         // Projection leaf (opaque handle / value blob).

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -720,7 +720,13 @@ impl JniGen {
         if !is_jobject_shaped_wire(&inner_wire) {
             return None;
         }
-        let inner_conv = inner.function.sig.ident.clone();
+        // The element's COMPLETE wire -> Rust chain: a `convert!` element
+        // (`Label` -> `String`) reaches its value through the rust-side stages,
+        // not through the wire-facing converter alone.
+        let inner_conv = crate::api::lang::jnigen::jni::emit::composed_inner_input(
+            inner,
+            quote::quote!(&__elem_wire),
+        );
         let outer_ty: syn::Type = syn::parse_quote!(Vec<#t1>);
         let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
         let body: syn::Expr = syn::parse_quote!({
@@ -733,7 +739,7 @@ impl JniGen {
                 .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-next: {}", e)))?
             {
                 let __elem_wire: #inner_wire = __obj.into();
-                let __elem: #t1 = #inner_conv(env, &__elem_wire)?;
+                let __elem: #t1 = #inner_conv;
                 __out.push(__elem);
             }
             __out
@@ -2156,7 +2162,11 @@ impl JniGen {
             if !is_jobject_shaped_wire(&inner_wire) {
                 return None;
             }
-            let inner_conv = inner.function.sig.ident.clone();
+            // The element's COMPLETE Rust -> wire chain (see the input peer).
+            let inner_conv = crate::api::lang::jnigen::jni::emit::composed_inner_output(
+                inner,
+                quote::quote!(__elem),
+            );
             let outer_ty: syn::Type = syn::parse_quote!(Vec<#t1>);
             let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
             let body: syn::Expr = syn::parse_quote!({
@@ -2166,7 +2176,7 @@ impl JniGen {
                 let __list = jni::objects::JList::from_env(env, &__list_obj)
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-from-env: {}", e)))?;
                 for __elem in v.into_iter() {
-                    let __elem_wire = #inner_conv(env, __elem)?;
+                    let __elem_wire = #inner_conv;
                     let __elem_obj: jni::objects::JObject = __elem_wire.into();
                     __list.add(env, &__elem_obj)
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-add: {}", e)))?;
@@ -2230,7 +2240,11 @@ impl JniGen {
         if !is_jobject_shaped_wire(&inner_wire) {
             return None;
         }
-        let inner_conv = inner.function.sig.ident.clone();
+        // The element's COMPLETE Rust -> wire chain (see the `Vec<_>` peer).
+        let inner_conv = crate::api::lang::jnigen::jni::emit::composed_inner_output(
+            inner,
+            quote::quote!(::core::clone::Clone::clone(__elem)),
+        );
         let outer_ty: syn::Type = syn::parse_quote!(&[#elem]);
         let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
         let body: syn::Expr = syn::parse_quote!({
@@ -2240,7 +2254,7 @@ impl JniGen {
             let __list = jni::objects::JList::from_env(env, &__list_obj)
                 .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("&[_]: list-from-env: {}", e)))?;
             for __elem in v.iter() {
-                let __elem_wire = #inner_conv(env, ::core::clone::Clone::clone(__elem))?;
+                let __elem_wire = #inner_conv;
                 let __elem_obj: jni::objects::JObject = __elem_wire.into();
                 __list.add(env, &__elem_obj)
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("&[_]: list-add: {}", e)))?;


### PR DESCRIPTION
A `convert!`-declared type resolves to a `TypeEntry` whose `function` is only
the **wire-facing** step (`u64 -> jlong`); the semantic step lives in
`pre_stages` (`Duration -> u64`). Structural wrappers (`Option<_>`, `Vec<_>`)
compose the whole chain, and so does `render_entry_decode` — but three leaf
emitters read `entry.function.sig.ident` alone and emitted code that hands a
`Duration` where a `u64` is expected. It does not compile, so the defect shows
up as a broken build of the *generated* file rather than as wrong behavior.

## The three sites

Each is reached by a `convert!` type in a position the flattened bridge encodes
itself, rather than through a structural wrapper:

| site | position |
|---|---|
| `struct_plan::classify_field` → `struct_out`'s `conv_value` | data-class **field**, and a sum payload nested in one |
| `flat_input::read_kotlin_property` | whole-object **sum input** decode |
| `sum_out::encode_group_leaf` | a sum returned as the function's **own value** |

`classify_field` now carries a `ConvChain { stages, function }` instead of a
bare ident, so the plan itself records the chain and all three consumers of
`PlanFieldKind` agree by construction; the other two compose inline, mirroring
`emit/convert.rs`'s `composed_inner_{input,output}`.

## Second defect, same fixture

`iface::leaf_iface_param` attached the `Unsigned64` niche sentinel
unconditionally, so a **non-optional** payload emitted
`if (v == -1L) null else v.toULong()` against the non-nullable typed view the
same param declares. The sentinel *is* the absent representation, so it is now
gated on the builder's nullability: a required payload owns the whole domain
and has no absence to represent.

## Coverage

`perftest-flat` gains `Hold` (a sum whose payload is the converted `Duration`)
and `HoldPolicy` (that sum as a required **and** an optional data-class field),
plus `hold_echo` / `hold_policy_echo`. covertest-kotlin declares them and
exercises all three emitters in a new *"sum payload crossing a convert! chain"*
section — `PASS - 45 sections`, 334 lib tests green, fmt/clippy clean.

## Found by

Realigning `zenoh-flat-jni` to zenoh-flat HEAD, where `RecoveryMode` became a
data-carrying enum whose `PeriodicQueries` arm carries a `Duration`.
ZettaScaleLabs/zenoh-flat-jni's companion PR is blocked on this one landing on
`main` (its CI resolves prebindgen from this repo's `main` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)