### PR TITLE
jnigen: give byte-backed Kotlin values content equality

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -286,14 +286,18 @@ fn main() {
                 // Fixed-width unsigned mappings: Int / Long widening plus
                 // ULong over a raw jlong bit pattern.
                 .class(data_class!(Unsigned))
-                // `Stamp` as a `@JvmInline value class` over its raw bytes; its readers
+                // `Stamp` as a by-value blob over its raw bytes; its readers
                 // become instance methods (`secs()` / `nanos()`), and `Vec<Stamp>`
                 // surfaces as `List<ByteArray>`.
                 .class(
                     value_class!(Stamp)
                         .method(fun!(stamp_secs))
                         .method(fun!(stamp_nanos)),
-                ),
+                )
+                // `BlobValue` is the array-backed EQUALITY probe: a raw-bytes
+                // field beside a scalar, plus a nested value blob. Both compare
+                // by identity in Kotlin unless the binding says otherwise.
+                .class(data_class!(BlobValue)),
         )
         // ── Subpackage `errors`: the Result error channel ───────────────────
         .package(package!("errors").class(
@@ -501,6 +505,7 @@ fn main() {
                 .fun(fun!(unsigned_data_maybe))
                 .fun(fun!(unsigned_emit))
                 .fun(fun!(unsigned_series))
+                .fun(fun!(blob_value_new))
                 .fun(fun!(duration_optional))
                 .fun(fun!(duration_boundary_echo))
                 // The converted analogue of `unsigned_emit`: a whole-value

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -297,7 +297,7 @@ fn main() {
                 // `BlobValue` is the array-backed EQUALITY probe: a raw-bytes
                 // field beside a scalar, plus a nested value blob. Both compare
                 // by identity in Kotlin unless the binding says otherwise.
-                .class(data_class!(BlobValue)),
+                .class(data_class!(BlobValue).jobject_input()),
         )
         // ── Subpackage `errors`: the Result error channel ───────────────────
         .package(package!("errors").class(
@@ -506,6 +506,7 @@ fn main() {
                 .fun(fun!(unsigned_emit))
                 .fun(fun!(unsigned_series))
                 .fun(fun!(blob_value_new))
+                .fun(fun!(blob_value_echo))
                 .fun(fun!(duration_optional))
                 .fun(fun!(duration_boundary_echo))
                 // The converted analogue of `unsigned_emit`: a whole-value

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -57,6 +57,7 @@ Base package: `io.prebindgen.covertest`
 - `archive_reading_maybe` — `fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `archive_set_reading` — `fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandler<Unit>)`
+- `blob_value_new` — `fun blobValueNew(id: ByteArray, n: Long, secs: Long, onError: JniErrorHandler<BlobValue>): BlobValue`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
@@ -170,6 +171,7 @@ Base package: `io.prebindgen.covertest`
 
 - `Annotated`: data_class → `io.prebindgen.covertest.model.Annotated` (wire `jni :: objects :: JObject`)
 - `Archive`: ptr_class → `io.prebindgen.covertest.analytics.SummaryVault` (wire `jni :: sys :: jlong`)
+- `BlobValue`: data_class → `io.prebindgen.covertest.model.BlobValue` (wire `jni :: objects :: JObject`)
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -57,7 +57,7 @@ Base package: `io.prebindgen.covertest`
 - `archive_reading_maybe` — `fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `archive_set_reading` — `fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandler<Unit>)`
-- `blob_value_new` — `fun blobValueNew(id: ByteArray, n: Long, secs: Long, onError: JniErrorHandler<BlobValue>): BlobValue`
+- `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, onError: JniErrorHandler<BlobValue>): BlobValue`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -57,7 +57,8 @@ Base package: `io.prebindgen.covertest`
 - `archive_reading_maybe` — `fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `archive_set_reading` — `fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandler<Unit>)`
-- `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, onError: JniErrorHandler<BlobValue>): BlobValue`
+- `blob_value_echo` — `fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue>): BlobValue`
+- `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue>): BlobValue`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
@@ -171,7 +172,7 @@ Base package: `io.prebindgen.covertest`
 
 - `Annotated`: data_class → `io.prebindgen.covertest.model.Annotated` (wire `jni :: objects :: JObject`)
 - `Archive`: ptr_class → `io.prebindgen.covertest.analytics.SummaryVault` (wire `jni :: sys :: jlong`)
-- `BlobValue`: data_class → `io.prebindgen.covertest.model.BlobValue` (wire `jni :: objects :: JObject`)
+- `BlobValue`: data_class → `io.prebindgen.covertest.model.BlobValue` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -701,7 +701,14 @@ internal object CovNative {
         errorSink: Any,
     )
 
-    external fun blobValueNew(secs: Long, id: ByteArray, errorSink: Any): BlobValue
+    external fun blobValueEcho(value: BlobValue, errorSink: Any): BlobValue
+
+    external fun blobValueNew(
+        secs: Long,
+        id: ByteArray,
+        chunks: List<ByteArray>,
+        errorSink: Any,
+    ): BlobValue
 
     external fun cacheConfigWeight(
         cachePresent: Boolean,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -2,6 +2,7 @@
 package io.prebindgen.covertest
 
 import io.prebindgen.covertest.model.Annotated
+import io.prebindgen.covertest.model.BlobValue
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.Hold
 import io.prebindgen.covertest.model.HoldPolicy
@@ -699,6 +700,8 @@ internal object CovNative {
         s1: Long,
         errorSink: Any,
     )
+
+    external fun blobValueNew(id: ByteArray, n: Long, secs: Long, errorSink: Any): BlobValue
 
     external fun cacheConfigWeight(
         cachePresent: Boolean,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -701,7 +701,7 @@ internal object CovNative {
         errorSink: Any,
     )
 
-    external fun blobValueNew(id: ByteArray, n: Long, secs: Long, errorSink: Any): BlobValue
+    external fun blobValueNew(secs: Long, id: ByteArray, errorSink: Any): BlobValue
 
     external fun cacheConfigWeight(
         cachePresent: Boolean,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -228,24 +228,25 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
  * (`Timestamp(ntp64, id)`), and it is a different emitted form from the
  * array-first one.
  */
-public data class BlobValue(val stamp: Stamp, val id: ByteArray) {
+public data class BlobValue(val stamp: Stamp, val id: ByteArray, val chunks: List<ByteArray>) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BlobValue) return false
-        return stamp == other.stamp && id.contentEquals(other.id)
+        return stamp == other.stamp && id.contentEquals(other.id) && (chunks.size == other.chunks.size && chunks.indices.all { __i -> val __x = chunks[__i]; val __y = other.chunks[__i]; __x.contentEquals(__y) })
     }
 
     override fun hashCode(): Int {
         var result = stamp.hashCode()
         result = 31 * result + id.contentHashCode()
+        result = 31 * result + (chunks.fold(1) { __acc, __e -> 31 * __acc + __e.contentHashCode() })
         return result
     }
 
-    override fun toString(): String = "BlobValue(stamp=$stamp, id=${id.contentToString()})"
+    override fun toString(): String = "BlobValue(stamp=${stamp}, id=${id.contentToString()}, chunks=${chunks.joinToString(", ", "[", "]") { __e -> "${__e.contentToString()}" }})"
 
     public companion object {
         @JvmStatic
-        public fun fromParts(stamp: ByteArray, id: ByteArray): BlobValue = BlobValue(Stamp(stamp), id)
+        public fun fromParts(stamp: ByteArray, id: ByteArray, chunks: List<ByteArray>): BlobValue = BlobValue(Stamp(stamp), id, chunks)
     }
 }
 
@@ -1583,9 +1584,30 @@ public fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong> {
 }
 
 /** Build a [`BlobValue`] (its equality is asserted from Kotlin). */
-public fun blobValueNew(secs: Long, id: ByteArray, onError: JniErrorHandler<BlobValue>): BlobValue {
+public fun blobValueNew(
+    secs: Long,
+    id: ByteArray,
+    chunks: List<ByteArray>,
+    onError: JniErrorHandler<BlobValue>,
+): BlobValue {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.blobValueNew(secs, id, __bcap)
+    val __ret = CovNative.blobValueNew(secs, id, chunks, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * Round-trip a [`BlobValue`] through the WHOLE-OBJECT input decoder.
+ *
+ * The binding marks this class `.jobject_input()`, so the decoder reads each
+ * field off the Kotlin object by JVM descriptor. A value-blob field's slot is
+ * the wrapper class (it stopped being `@JvmInline`-erased when it gained value
+ * equality), which the old `[B` lookup got wrong — `NoSuchFieldError` on the
+ * first decode.
+ */
+public fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue>): BlobValue {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.blobValueEcho(value, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -212,33 +212,40 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
 
 /**
  * A value whose equality is **array-backed** on the JVM side: a raw-bytes
- * field beside an ordinary scalar, plus a nested value blob.
+ * field beside a nested value blob.
  *
  * Kotlin arrays compare by identity, so both the direct `Vec<u8>` field and
  * the nested [`Stamp`] would make two equal-content values compare unequal
  * unless the binding emits content-based operators. This mirrors the two
  * shapes that broke downstream (a `Vec<u8>` struct field, and a struct
- * carrying a value blob), which nothing else here exercised.
+ * carrying a value blob), which nothing else here exercised. Two fields are
+ * enough: one array-backed and one not covers both comparison branches, and
+ * a third of either kind would only repeat an emitted form.
+ *
+ * Field ORDER is deliberate: the raw bytes come last, so the generated
+ * `hashCode` folds them as `31 * result + id.contentHashCode()` rather than
+ * seeding the accumulator with them. That is the shape a real value takes
+ * (`Timestamp(ntp64, id)`), and it is a different emitted form from the
+ * array-first one.
  */
-public data class BlobValue(val id: ByteArray, val n: Long, val stamp: Stamp) {
+public data class BlobValue(val stamp: Stamp, val id: ByteArray) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BlobValue) return false
-        return id.contentEquals(other.id) && n == other.n && stamp == other.stamp
+        return stamp == other.stamp && id.contentEquals(other.id)
     }
 
     override fun hashCode(): Int {
-        var result = id.contentHashCode()
-        result = 31 * result + n.hashCode()
-        result = 31 * result + stamp.hashCode()
+        var result = stamp.hashCode()
+        result = 31 * result + id.contentHashCode()
         return result
     }
 
-    override fun toString(): String = "BlobValue(id=${id.contentToString()}, n=$n, stamp=$stamp)"
+    override fun toString(): String = "BlobValue(stamp=$stamp, id=${id.contentToString()})"
 
     public companion object {
         @JvmStatic
-        public fun fromParts(id: ByteArray, n: Long, stamp: ByteArray): BlobValue = BlobValue(id, n, Stamp(stamp))
+        public fun fromParts(stamp: ByteArray, id: ByteArray): BlobValue = BlobValue(Stamp(stamp), id)
     }
 }
 
@@ -1576,14 +1583,9 @@ public fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong> {
 }
 
 /** Build a [`BlobValue`] (its equality is asserted from Kotlin). */
-public fun blobValueNew(
-    id: ByteArray,
-    n: Long,
-    secs: Long,
-    onError: JniErrorHandler<BlobValue>,
-): BlobValue {
+public fun blobValueNew(secs: Long, id: ByteArray, onError: JniErrorHandler<BlobValue>): BlobValue {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.blobValueNew(id, n, secs, __bcap)
+    val __ret = CovNative.blobValueNew(secs, id, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -211,6 +211,38 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
 }
 
 /**
+ * A value whose equality is **array-backed** on the JVM side: a raw-bytes
+ * field beside an ordinary scalar, plus a nested value blob.
+ *
+ * Kotlin arrays compare by identity, so both the direct `Vec<u8>` field and
+ * the nested [`Stamp`] would make two equal-content values compare unequal
+ * unless the binding emits content-based operators. This mirrors the two
+ * shapes that broke downstream (a `Vec<u8>` struct field, and a struct
+ * carrying a value blob), which nothing else here exercised.
+ */
+public data class BlobValue(val id: ByteArray, val n: Long, val stamp: Stamp) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BlobValue) return false
+        return id.contentEquals(other.id) && n == other.n && stamp == other.stamp
+    }
+
+    override fun hashCode(): Int {
+        var result = id.contentHashCode()
+        result = 31 * result + n.hashCode()
+        result = 31 * result + stamp.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "BlobValue(id=${id.contentToString()}, n=$n, stamp=$stamp)"
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(id: ByteArray, n: Long, stamp: ByteArray): BlobValue = BlobValue(id, n, Stamp(stamp))
+    }
+}
+
+/**
  * Outer cache config crossed as `Option<CacheConfig>`. Its optional-ness
  * propagates into the non-optional nested [`RepliesConfig`], whose non-null
  * `priority` enum field must decode with exactly **one** Elvis default (#144).
@@ -745,10 +777,25 @@ public data class Unsigned(val byte: Int, val short: Int, val int: Long, val lon
  * `close()`), and `Vec<Stamp>` surfaces as `List<ByteArray>`.
  *
  * Typed by-value wrapper for the native Rust `Stamp` (a `Copy` blob carried
- * as its raw bytes; `@JvmInline`-erased to `ByteArray` at the JNI boundary).
+ * as its raw bytes; it crosses the JNI boundary as a bare `ByteArray`).
+ *
+ * Not a `@JvmInline value class`: Kotlin 1.9 reserves `equals`/`hashCode`
+ * members on a value class, so one cannot be given the value equality this
+ * type has in Rust — arrays would compare by identity.
  */
-@JvmInline
-public value class Stamp(public val bytes: ByteArray) {
+public data class Stamp(public val bytes: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Stamp) return false
+        return bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+
+    override fun toString(): String = "Stamp(bytes=${bytes.contentToString()})"
+
     /** Seconds component (value-class **accessor**, receiver = the value bytes). */
     public fun secs(onError: JniErrorHandler<Long>): Long {
         val __bcap = JniErrorHandlerCapture.acquire()
@@ -1526,6 +1573,19 @@ public fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong> {
     val __ret = CovNative.unsignedSeries(ArrayList<ULong>(), __u64FolderRawHolder.instance, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as List<ULong>
+}
+
+/** Build a [`BlobValue`] (its equality is asserted from Kotlin). */
+public fun blobValueNew(
+    id: ByteArray,
+    n: Long,
+    secs: Long,
+    onError: JniErrorHandler<BlobValue>,
+): BlobValue {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.blobValueNew(id, n, secs, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -675,17 +675,18 @@ fun main() {
         check(s1.toString().contains("bytes=[")) { "toString must render bytes, got ${s1}" }
 
         // A data class with a DIRECT `ByteArray` field plus a NESTED value
-        // blob — the two shapes that broke downstream.
-        val b1 = blobValueNew(byteArrayOf(1, 2, 3), 9L, 7L, boom)
-        val b2 = blobValueNew(byteArrayOf(1, 2, 3), 9L, 7L, boom)
+        // blob — the two shapes that broke downstream. The bytes sit LAST, so
+        // this also covers the `31 * result + …contentHashCode()` fold form
+        // that a real value (`Timestamp(ntp64, id)`) produces.
+        val b1 = blobValueNew(7L, byteArrayOf(1, 2, 3), boom)
+        val b2 = blobValueNew(7L, byteArrayOf(1, 2, 3), boom)
         check(b1 == b2) { "array-backed data class must compare by content: $b1 vs $b2" }
         check(b1.hashCode() == b2.hashCode())
         check(hashSetOf(b1, b2).size == 1)
-        // Each component must actually participate — a comparison that ignored
-        // one of them would still pass the equality checks above.
-        check(blobValueNew(byteArrayOf(1, 2, 4), 9L, 7L, boom) != b1) { "id must matter" }
-        check(blobValueNew(byteArrayOf(1, 2, 3), 8L, 7L, boom) != b1) { "n must matter" }
-        check(blobValueNew(byteArrayOf(1, 2, 3), 9L, 8L, boom) != b1) { "nested blob must matter" }
+        // Both components must actually participate — a comparison that ignored
+        // either would still pass the equality checks above.
+        check(blobValueNew(7L, byteArrayOf(1, 2, 4), boom) != b1) { "id must matter" }
+        check(blobValueNew(8L, byteArrayOf(1, 2, 3), boom) != b1) { "nested blob must matter" }
         check(b1.toString().contains("id=[1, 2, 3]")) { "toString must render bytes, got $b1" }
     }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -41,6 +41,7 @@ import io.prebindgen.covertest.model.Reading
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
+import io.prebindgen.covertest.model.blobValueNew
 import io.prebindgen.covertest.model.annotatedAlternateValue
 import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.durationOptional
@@ -652,6 +653,40 @@ fun main() {
         check(series[0].secs(boom) == 0L)
         check(series[2].secs(boom) == 2L && series[2].nanos(boom) == 0L)
         check(stampSeries(0L, boom).isEmpty())
+    }
+
+    // ── array-backed VALUE EQUALITY ─────────────────────────────────────────
+    // The Rust types derive `Eq`, so the Kotlin mirrors must compare by
+    // content. Kotlin arrays compare by IDENTITY, which silently breaks that
+    // for every `ByteArray`-backed property — a value blob's `bytes`, a
+    // `Vec<u8>` field, and any value carrying one of those. Kotlin's own
+    // `data class` codegen is inconsistent here (its `hashCode`/`toString` DO
+    // special-case arrays, its `equals` does not), so `==` is the assertion
+    // that matters and `hashCode` alone would not have caught the defect.
+    section("array-backed value equality (content, not identity)") {
+        // A value blob: two independently-built values with equal bytes.
+        val s1 = stampNew(7L, 42L, boom)
+        val s2 = stampNew(7L, 42L, boom)
+        check(s1 == s2) { "value blob must compare by content: $s1 vs $s2" }
+        check(s1.hashCode() == s2.hashCode())
+        check(stampNew(8L, 42L, boom) != s1) { "different content must not compare equal" }
+        // The whole contract, not just `==`: a hash container must de-duplicate.
+        check(hashSetOf(s1, s2).size == 1) { "value blob must de-duplicate in a HashSet" }
+        check(s1.toString().contains("bytes=[")) { "toString must render bytes, got ${s1}" }
+
+        // A data class with a DIRECT `ByteArray` field plus a NESTED value
+        // blob — the two shapes that broke downstream.
+        val b1 = blobValueNew(byteArrayOf(1, 2, 3), 9L, 7L, boom)
+        val b2 = blobValueNew(byteArrayOf(1, 2, 3), 9L, 7L, boom)
+        check(b1 == b2) { "array-backed data class must compare by content: $b1 vs $b2" }
+        check(b1.hashCode() == b2.hashCode())
+        check(hashSetOf(b1, b2).size == 1)
+        // Each component must actually participate — a comparison that ignored
+        // one of them would still pass the equality checks above.
+        check(blobValueNew(byteArrayOf(1, 2, 4), 9L, 7L, boom) != b1) { "id must matter" }
+        check(blobValueNew(byteArrayOf(1, 2, 3), 8L, 7L, boom) != b1) { "n must matter" }
+        check(blobValueNew(byteArrayOf(1, 2, 3), 9L, 8L, boom) != b1) { "nested blob must matter" }
+        check(b1.toString().contains("id=[1, 2, 3]")) { "toString must render bytes, got $b1" }
     }
 
     // ── Option<scalar> nullable primitive return + data_class instance

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -41,6 +41,7 @@ import io.prebindgen.covertest.model.Reading
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
+import io.prebindgen.covertest.model.blobValueEcho
 import io.prebindgen.covertest.model.blobValueNew
 import io.prebindgen.covertest.model.annotatedAlternateValue
 import io.prebindgen.covertest.model.celsiusDouble
@@ -678,16 +679,38 @@ fun main() {
         // blob — the two shapes that broke downstream. The bytes sit LAST, so
         // this also covers the `31 * result + …contentHashCode()` fold form
         // that a real value (`Timestamp(ntp64, id)`) produces.
-        val b1 = blobValueNew(7L, byteArrayOf(1, 2, 3), boom)
-        val b2 = blobValueNew(7L, byteArrayOf(1, 2, 3), boom)
+        fun blob(secs: Long, id: ByteArray, chunks: List<ByteArray>) =
+            blobValueNew(secs, id, chunks, boom)
+
+        val chunks = listOf(byteArrayOf(9), byteArrayOf(8, 7))
+        val b1 = blob(7L, byteArrayOf(1, 2, 3), chunks)
+        val b2 = blob(7L, byteArrayOf(1, 2, 3), listOf(byteArrayOf(9), byteArrayOf(8, 7)))
         check(b1 == b2) { "array-backed data class must compare by content: $b1 vs $b2" }
         check(b1.hashCode() == b2.hashCode())
         check(hashSetOf(b1, b2).size == 1)
-        // Both components must actually participate — a comparison that ignored
-        // either would still pass the equality checks above.
-        check(blobValueNew(7L, byteArrayOf(1, 2, 4), boom) != b1) { "id must matter" }
-        check(blobValueNew(8L, byteArrayOf(1, 2, 3), boom) != b1) { "nested blob must matter" }
+        // Every component must actually participate — a comparison that ignored
+        // any of them would still pass the equality checks above.
+        check(blob(7L, byteArrayOf(1, 2, 4), chunks) != b1) { "id must matter" }
+        check(blob(8L, byteArrayOf(1, 2, 3), chunks) != b1) { "nested blob must matter" }
+        // A CONTAINER of arrays: `List<ByteArray>` inherits `ByteArray`'s
+        // identity equality, so the operators must dig through the container.
+        check(blob(7L, byteArrayOf(1, 2, 3), listOf(byteArrayOf(9), byteArrayOf(8, 6))) != b1) {
+            "chunk contents must matter"
+        }
+        check(blob(7L, byteArrayOf(1, 2, 3), listOf(byteArrayOf(9))) != b1) {
+            "chunk count must matter"
+        }
         check(b1.toString().contains("id=[1, 2, 3]")) { "toString must render bytes, got $b1" }
+        check(b1.toString().contains("chunks=[[9], [8, 7]]")) {
+            "toString must render nested bytes, got $b1"
+        }
+
+        // WHOLE-OBJECT input decode (`.jobject_input()`): the decoder reads each
+        // field off the Kotlin object by JVM descriptor. A value-blob field's
+        // slot is the wrapper class, not `[B` — reading the old descriptor threw
+        // `NoSuchFieldError` on the first decode.
+        check(blobValueEcho(b1, boom) == b1) { "jobject-input round trip must preserve the value" }
+        check(blobValueEcho(blob(0L, ByteArray(0), emptyList()), boom).chunks.isEmpty())
     }
 
     // ── Option<scalar> nullable primitive return + data_class instance

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -509,6 +509,50 @@ pub(crate) unsafe fn Archive_to_jlong_cd73502c<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn BlobValue_to_JObject_89b5dab7<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::BlobValue,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::objects::JObject = Vec_u8_to_JByteArray_7936d5de(
+                env,
+                v.id.clone(),
+            )?
+            .into();
+        let ___n: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.n.clone())?;
+        let ___stamp: jni::objects::JObject = {
+            Stamp_to_JByteArray_2fc9bd18(env, v.stamp.clone())?
+        }
+            .into();
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/BlobValue",
+                "fromParts",
+                "([BJ[B)Lio/prebindgen/covertest/model/BlobValue;",
+                &[
+                    jni::objects::JValue::Object(&___id),
+                    jni::objects::JValue::from(___n),
+                    jni::objects::JValue::Object(&___stamp),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn CacheConfig_to_JObject_db89a97c<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::CacheConfig,
@@ -795,6 +839,30 @@ pub(crate) unsafe fn JByteArray_to_Stamp_2fc9bd18<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JByteArray_to_Vec_u8_7936d5de<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JByteArray<'v>,
+) -> ::core::result::Result<Vec<u8>, __JniErr> {
+    Ok({
+        env.convert_byte_array(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("decode_byte_array: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Annotated_b543f0d9<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -845,6 +913,52 @@ pub(crate) unsafe fn JObject_to_Annotated_b543f0d9<'env, 'v>(
             alternate,
             ttl,
             priority,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::BlobValue, __JniErr> {
+    Ok({
+        let __id_jobj: jni::objects::JObject = env
+            .get_field(v, "id", "[B")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("BlobValue.id: {}", e)))?;
+        let __id_raw: jni::objects::JByteArray = __id_jobj.into();
+        let id = JByteArray_to_Vec_u8_7936d5de(env, &__id_raw)?;
+        let __n_raw: jni::sys::jlong = env
+            .get_field(v, "n", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("BlobValue.n: {}", e)))? as _;
+        let n = jlong_to_i64_fbf9a9bc(env, &__n_raw)?;
+        let __stamp_jobj: jni::objects::JObject = env
+            .get_field(v, "stamp", "[B")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("BlobValue.stamp: {}", e)))?;
+        let __stamp_raw: jni::objects::JByteArray = __stamp_jobj.into();
+        let stamp = JByteArray_to_Stamp_2fc9bd18(env, &__stamp_raw)?;
+        perftest_flat::BlobValue {
+            id,
+            n,
+            stamp,
         }
     })
 }
@@ -6882,6 +6996,30 @@ pub(crate) unsafe fn Vec_String_to_JObject_1e282499<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<u8>,
+) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
+    Ok({
+        env.byte_array_from_slice(v.as_slice())
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_byte_array: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn bool_to_jboolean_31306d98<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: bool,
@@ -9612,6 +9750,78 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
                 &__e.to_string(),
             );
             ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    id: jni::objects::JByteArray<'a>,
+    n: jni::sys::jlong,
+    secs: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let id = match JByteArray_to_Vec_u8_7936d5de(&mut env, &id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let secs = match jlong_to_i64_fbf9a9bc(&mut env, &secs) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::blob_value_new(id, n, secs);
+    match BlobValue_to_JObject_89b5dab7(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -523,14 +523,19 @@ pub(crate) unsafe fn BlobValue_to_JObject_89b5dab7<'a>(
                 v.id.clone(),
             )?
             .into();
+        let ___chunks: jni::objects::JObject = Vec_Vec_u8_to_JObject_43404875(
+            env,
+            v.chunks.clone(),
+        )?;
         let __obj = env
             .call_static_method(
                 "io/prebindgen/covertest/model/BlobValue",
                 "fromParts",
-                "([B[B)Lio/prebindgen/covertest/model/BlobValue;",
+                "([B[BLjava/util/List;)Lio/prebindgen/covertest/model/BlobValue;",
                 &[
                     jni::objects::JValue::Object(&___stamp),
                     jni::objects::JValue::Object(&___id),
+                    jni::objects::JValue::Object(&___chunks),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -931,12 +936,21 @@ pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
 ) -> ::core::result::Result<perftest_flat::BlobValue, __JniErr> {
     Ok({
         let __stamp_jobj: jni::objects::JObject = env
-            .get_field(v, "stamp", "[B")
+            .get_field(v, "stamp", "Lio/prebindgen/covertest/model/Stamp;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("BlobValue.stamp: {}", e)))?;
-        let __stamp_raw: jni::objects::JByteArray = __stamp_jobj.into();
+        let __stamp_bytes: jni::objects::JObject = if __stamp_jobj.is_null() {
+            jni::objects::JObject::null()
+        } else {
+            env.get_field(&__stamp_jobj, "bytes", "[B")
+                .and_then(|val| val.l())
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("BlobValue.stamp: {}", e)))?
+        };
+        let __stamp_raw: jni::objects::JByteArray = __stamp_bytes.into();
         let stamp = JByteArray_to_Stamp_2fc9bd18(env, &__stamp_raw)?;
         let __id_jobj: jni::objects::JObject = env
             .get_field(v, "id", "[B")
@@ -946,9 +960,17 @@ pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
             >>::from(format!("BlobValue.id: {}", e)))?;
         let __id_raw: jni::objects::JByteArray = __id_jobj.into();
         let id = JByteArray_to_Vec_u8_7936d5de(env, &__id_raw)?;
+        let __chunks_raw: jni::objects::JObject = env
+            .get_field(v, "chunks", "Ljava/util/List;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("BlobValue.chunks: {}", e)))?;
+        let chunks = JObject_to_Vec_Vec_u8_43404875(env, &__chunks_raw)?;
         perftest_flat::BlobValue {
             stamp,
             id,
+            chunks,
         }
     })
 }
@@ -2419,6 +2441,45 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
                 env,
                 &__elem_wire,
             )?;
+            __out.push(__elem);
+        }
+        __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Vec<Vec<u8>>, __JniErr> {
+    Ok({
+        let __list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __it = __list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __out: Vec<Vec<u8>> = Vec::new();
+        while let Some(__obj) = __it
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            let __elem_wire: jni::objects::JByteArray = __obj.into();
+            let __elem: Vec<u8> = JByteArray_to_Vec_u8_7936d5de(env, &__elem_wire)?;
             __out.push(__elem);
         }
         __out
@@ -6986,6 +7047,43 @@ pub(crate) unsafe fn Vec_String_to_JObject_1e282499<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Vec_Vec_u8_to_JObject_43404875<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<Vec<u8>>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let __list_obj = env
+            .new_object("java/util/ArrayList", "()V", &[])
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
+        let __list = jni::objects::JList::from_env(env, &__list_obj)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        for __elem in v.into_iter() {
+            let __elem_wire = Vec_u8_to_JByteArray_7936d5de(env, __elem)?;
+            let __elem_obj: jni::objects::JObject = __elem_wire.into();
+            __list
+                .add(env, &__elem_obj)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-add: {}", e)))?;
+        }
+        __list_obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<u8>,
@@ -9745,11 +9843,54 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match JObject_to_BlobValue_89b5dab7(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::blob_value_echo(value);
+    match BlobValue_to_JObject_89b5dab7(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
     secs: jni::sys::jlong,
     id: jni::objects::JByteArray<'a>,
+    chunks: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -9784,7 +9925,21 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
             return jni::objects::JObject::null().into();
         }
     };
-    let __out = perftest_flat::blob_value_new(secs, id);
+    let chunks = match JObject_to_Vec_Vec_u8_43404875(&mut env, &chunks) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::blob_value_new(secs, id, chunks);
     match BlobValue_to_JObject_89b5dab7(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -514,25 +514,23 @@ pub(crate) unsafe fn BlobValue_to_JObject_89b5dab7<'a>(
     v: perftest_flat::BlobValue,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let ___stamp: jni::objects::JObject = {
+            Stamp_to_JByteArray_2fc9bd18(env, v.stamp.clone())?
+        }
+            .into();
         let ___id: jni::objects::JObject = Vec_u8_to_JByteArray_7936d5de(
                 env,
                 v.id.clone(),
             )?
             .into();
-        let ___n: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.n.clone())?;
-        let ___stamp: jni::objects::JObject = {
-            Stamp_to_JByteArray_2fc9bd18(env, v.stamp.clone())?
-        }
-            .into();
         let __obj = env
             .call_static_method(
                 "io/prebindgen/covertest/model/BlobValue",
                 "fromParts",
-                "([BJ[B)Lio/prebindgen/covertest/model/BlobValue;",
+                "([B[B)Lio/prebindgen/covertest/model/BlobValue;",
                 &[
-                    jni::objects::JValue::Object(&___id),
-                    jni::objects::JValue::from(___n),
                     jni::objects::JValue::Object(&___stamp),
+                    jni::objects::JValue::Object(&___id),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -932,21 +930,6 @@ pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::BlobValue, __JniErr> {
     Ok({
-        let __id_jobj: jni::objects::JObject = env
-            .get_field(v, "id", "[B")
-            .and_then(|val| val.l())
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("BlobValue.id: {}", e)))?;
-        let __id_raw: jni::objects::JByteArray = __id_jobj.into();
-        let id = JByteArray_to_Vec_u8_7936d5de(env, &__id_raw)?;
-        let __n_raw: jni::sys::jlong = env
-            .get_field(v, "n", "J")
-            .and_then(|val| val.j())
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("BlobValue.n: {}", e)))? as _;
-        let n = jlong_to_i64_fbf9a9bc(env, &__n_raw)?;
         let __stamp_jobj: jni::objects::JObject = env
             .get_field(v, "stamp", "[B")
             .and_then(|val| val.l())
@@ -955,10 +938,17 @@ pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
             >>::from(format!("BlobValue.stamp: {}", e)))?;
         let __stamp_raw: jni::objects::JByteArray = __stamp_jobj.into();
         let stamp = JByteArray_to_Stamp_2fc9bd18(env, &__stamp_raw)?;
+        let __id_jobj: jni::objects::JObject = env
+            .get_field(v, "id", "[B")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("BlobValue.id: {}", e)))?;
+        let __id_raw: jni::objects::JByteArray = __id_jobj.into();
+        let id = JByteArray_to_Vec_u8_7936d5de(env, &__id_raw)?;
         perftest_flat::BlobValue {
-            id,
-            n,
             stamp,
+            id,
         }
     })
 }
@@ -9758,43 +9748,14 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveStore<'a>
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
-    id: jni::objects::JByteArray<'a>,
-    n: jni::sys::jlong,
     secs: jni::sys::jlong,
+    id: jni::objects::JByteArray<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let id = match JByteArray_to_Vec_u8_7936d5de(&mut env, &id) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
-            signal_binding_error(
-                &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                &__e.to_string(),
-            );
-            return jni::objects::JObject::null().into();
-        }
-    };
-    let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
-            signal_binding_error(
-                &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                &__e.to_string(),
-            );
-            return jni::objects::JObject::null().into();
-        }
-    };
     let secs = match jlong_to_i64_fbf9a9bc(&mut env, &secs) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
@@ -9809,7 +9770,21 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
             return jni::objects::JObject::null().into();
         }
     };
-    let __out = perftest_flat::blob_value_new(id, n, secs);
+    let id = match JByteArray_to_Vec_u8_7936d5de(&mut env, &id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::blob_value_new(secs, id);
     match BlobValue_to_JObject_89b5dab7(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -328,6 +328,32 @@ pub fn stamp_secs(s: &Stamp) -> i64 {
     s.secs
 }
 
+/// A value whose equality is **array-backed** on the JVM side: a raw-bytes
+/// field beside an ordinary scalar, plus a nested value blob.
+///
+/// Kotlin arrays compare by identity, so both the direct `Vec<u8>` field and
+/// the nested [`Stamp`] would make two equal-content values compare unequal
+/// unless the binding emits content-based operators. This mirrors the two
+/// shapes that broke downstream (a `Vec<u8>` struct field, and a struct
+/// carrying a value blob), which nothing else here exercised.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlobValue {
+    pub id: Vec<u8>,
+    pub n: i64,
+    pub stamp: Stamp,
+}
+
+/// Build a [`BlobValue`] (its equality is asserted from Kotlin).
+#[prebindgen]
+pub fn blob_value_new(id: Vec<u8>, n: i64, secs: i64) -> BlobValue {
+    BlobValue {
+        id,
+        n,
+        stamp: Stamp { secs, nanos: 0 },
+    }
+}
+
 /// Nanoseconds component (value-class **accessor**).
 #[prebindgen]
 pub fn stamp_nanos(s: &Stamp) -> i64 {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -329,28 +329,34 @@ pub fn stamp_secs(s: &Stamp) -> i64 {
 }
 
 /// A value whose equality is **array-backed** on the JVM side: a raw-bytes
-/// field beside an ordinary scalar, plus a nested value blob.
+/// field beside a nested value blob.
 ///
 /// Kotlin arrays compare by identity, so both the direct `Vec<u8>` field and
 /// the nested [`Stamp`] would make two equal-content values compare unequal
 /// unless the binding emits content-based operators. This mirrors the two
 /// shapes that broke downstream (a `Vec<u8>` struct field, and a struct
-/// carrying a value blob), which nothing else here exercised.
+/// carrying a value blob), which nothing else here exercised. Two fields are
+/// enough: one array-backed and one not covers both comparison branches, and
+/// a third of either kind would only repeat an emitted form.
+///
+/// Field ORDER is deliberate: the raw bytes come last, so the generated
+/// `hashCode` folds them as `31 * result + id.contentHashCode()` rather than
+/// seeding the accumulator with them. That is the shape a real value takes
+/// (`Timestamp(ntp64, id)`), and it is a different emitted form from the
+/// array-first one.
 #[prebindgen]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlobValue {
-    pub id: Vec<u8>,
-    pub n: i64,
     pub stamp: Stamp,
+    pub id: Vec<u8>,
 }
 
 /// Build a [`BlobValue`] (its equality is asserted from Kotlin).
 #[prebindgen]
-pub fn blob_value_new(id: Vec<u8>, n: i64, secs: i64) -> BlobValue {
+pub fn blob_value_new(secs: i64, id: Vec<u8>) -> BlobValue {
     BlobValue {
-        id,
-        n,
         stamp: Stamp { secs, nanos: 0 },
+        id,
     }
 }
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -349,15 +349,32 @@ pub fn stamp_secs(s: &Stamp) -> i64 {
 pub struct BlobValue {
     pub stamp: Stamp,
     pub id: Vec<u8>,
+    /// A CONTAINER of arrays. `List<ByteArray>` inherits `ByteArray`'s
+    /// identity equality just as a bare array does, so the generated operators
+    /// have to dig through the container rather than stopping at the property.
+    pub chunks: Vec<Vec<u8>>,
 }
 
 /// Build a [`BlobValue`] (its equality is asserted from Kotlin).
 #[prebindgen]
-pub fn blob_value_new(secs: i64, id: Vec<u8>) -> BlobValue {
+pub fn blob_value_new(secs: i64, id: Vec<u8>, chunks: Vec<Vec<u8>>) -> BlobValue {
     BlobValue {
         stamp: Stamp { secs, nanos: 0 },
         id,
+        chunks,
     }
+}
+
+/// Round-trip a [`BlobValue`] through the WHOLE-OBJECT input decoder.
+///
+/// The binding marks this class `.jobject_input()`, so the decoder reads each
+/// field off the Kotlin object by JVM descriptor. A value-blob field's slot is
+/// the wrapper class (it stopped being `@JvmInline`-erased when it gained value
+/// equality), which the old `[B` lookup got wrong — `NoSuchFieldError` on the
+/// first decode.
+#[prebindgen]
+pub fn blob_value_echo(value: BlobValue) -> BlobValue {
+    value
 }
 
 /// Nanoseconds component (value-class **accessor**).

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -96,13 +96,37 @@ pub(crate) fn struct_input_body(
                     });
                 }
                 ProjectionKind::ValueBlob => {
-                    let descriptor = "[B";
+                    // The JVM slot is the WRAPPER class, then its `bytes`. It
+                    // was `[B` while a value blob was `@JvmInline`-erased; the
+                    // wrapper is a real class now (it has to be, to carry value
+                    // equality), so reading `[B` here raises
+                    // `NoSuchFieldError` at the first decode.
+                    let fqn = ext
+                        .kotlin_fqn(&proj.leaf_key)
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "value_blob field `{struct_name}.{fname}`: no Kotlin FQN for `{}`",
+                                proj.leaf_key
+                            )
+                        });
+                    let sig = format!("L{};", fqn.replace('.', "/"));
                     let tmp_ident = format_ident!("__{}_jobj", fname_ident);
+                    let bytes_ident = format_ident!("__{}_bytes", fname_ident);
                     field_preludes.push(quote! {
-                        let #tmp_ident: jni::objects::JObject = env.get_field(v, #camel, #descriptor)
+                        let #tmp_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
                             .and_then(|val| val.l())
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                        let #raw_ident: #field_wire = #tmp_ident.into();
+                        // A null wrapper stays a null `[B`, so the field's own
+                        // converter carves `None` exactly as it did before.
+                        let #bytes_ident: jni::objects::JObject = if #tmp_ident.is_null() {
+                            jni::objects::JObject::null()
+                        } else {
+                            env.get_field(&#tmp_ident, "bytes", "[B")
+                                .and_then(|val| val.l())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
+                        };
+                        let #raw_ident: #field_wire = #bytes_ident.into();
                         let #fname_ident = #field_conv;
                     });
                 }
@@ -455,6 +479,32 @@ fn read_kotlin_property(
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
                     };
                     #decode
+                },
+                quote!(#bind),
+            ));
+        }
+        // A value blob's JVM slot is the WRAPPER class, then its `bytes` — it
+        // was `[B` only while the wrapper was `@JvmInline`-erased. Same
+        // correction as the data-class field path in `struct_input_body`.
+        if matches!(proj.kind, ProjectionKind::ValueBlob) {
+            let fqn = ext.kotlin_fqn(&proj.leaf_key).map(|v| v.to_string())?;
+            let sig = format!("L{};", fqn.replace('.', "/"));
+            let obj = format_ident!("{}_obj", bind);
+            let wire = entry.destination.clone();
+            return Some((
+                quote! {
+                    let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
+                    let #raw: #wire = if #obj.is_null() {
+                        jni::objects::JObject::null().into()
+                    } else {
+                        env.get_field(&#obj, "bytes", "[B")
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
+                            .into()
+                    };
+                    let #bind = #conv;
                 },
                 quote!(#bind),
             ));

--- a/prebindgen/src/api/lang/jnigen/jni/equality.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/equality.rs
@@ -33,21 +33,101 @@
 
 use super::*;
 
-/// A property whose Kotlin type compares by identity and therefore needs
-/// content-aware operators.
-enum ArrayProp {
-    /// `ByteArray` / `ByteArray?`.
-    Bytes { nullable: bool },
+/// Whether a Kotlin type carries an array anywhere inside it, and therefore
+/// compares by identity unless the generated operators dig in.
+///
+/// Recursive, because a container of arrays is just as identity-compared as a
+/// bare one: `List<ByteArray>` (from `Vec<Vec<u8>>`) inherits `ByteArray`'s
+/// `equals`, so two lists of equal chunks are unequal and `toString` renders
+/// `[[B@3830f1c0]`. A container of *classes* is fine — those already compare
+/// by value — so only an array at the bottom makes a property array-bearing.
+fn array_bearing(ty: &kt::KtType) -> bool {
+    match ty {
+        kt::KtType::Named { fqn, args, .. } => {
+            fqn.rsplit('.').next().unwrap_or(fqn) == "ByteArray" || args.iter().any(array_bearing)
+        }
+        kt::KtType::Function { .. } => false,
+    }
 }
 
-/// Classify one constructor property. `None` for everything that already
-/// compares by value (scalars, `String`, enums, nested generated classes).
-fn array_prop(ty: &kt::KtType) -> Option<ArrayProp> {
-    match ty.simple_name() {
-        Some("ByteArray") => Some(ArrayProp::Bytes {
-            nullable: ty.is_nullable(),
-        }),
+/// The element type of a single-argument container (`List<T>` -> `T`).
+fn element_of(ty: &kt::KtType) -> Option<&kt::KtType> {
+    match ty {
+        kt::KtType::Named { args, .. } if args.len() == 1 => Some(&args[0]),
         _ => None,
+    }
+}
+
+/// `a == b` for one value of type `ty`, digging through containers.
+///
+/// `a`/`b` are Kotlin expressions. Nullability is handled per level: a
+/// `ByteArray?` rides `contentEquals`'s nullable-receiver overload, while a
+/// nullable container needs an explicit both-null / both-present test.
+fn eq_expr(a: &str, b: &str, ty: &kt::KtType) -> String {
+    if !array_bearing(ty) {
+        return format!("{a} == {b}");
+    }
+    if element_of(ty).is_none() {
+        // The array itself.
+        return format!("{a}.contentEquals({b})");
+    }
+    let elem = element_of(ty).expect("checked above");
+    let inner = eq_expr("__x", "__y", elem);
+    let cmp = format!(
+        "{a}.size == {b}.size && {a}.indices.all {{ __i -> \
+         val __x = {a}[__i]; val __y = {b}[__i]; {inner} }}"
+    );
+    if ty.is_nullable() {
+        format!("(({a} == null && {b} == null) || ({a} != null && {b} != null && {cmp}))")
+    } else {
+        format!("({cmp})")
+    }
+}
+
+/// `hashCode` for one value of type `ty`, digging through containers. The
+/// container fold mirrors `Arrays.hashCode`'s 31-multiplier so a `List` and the
+/// array it came from agree.
+fn hash_expr(x: &str, ty: &kt::KtType) -> String {
+    if !array_bearing(ty) {
+        return if ty.is_nullable() {
+            format!("({x}?.hashCode() ?: 0)")
+        } else {
+            format!("{x}.hashCode()")
+        };
+    }
+    match element_of(ty) {
+        None if ty.is_nullable() => format!("({x}?.contentHashCode() ?: 0)"),
+        None => format!("{x}.contentHashCode()"),
+        Some(elem) => {
+            let inner = hash_expr("__e", elem);
+            let fold = format!("{x}.fold(1) {{ __acc, __e -> 31 * __acc + {inner} }}");
+            if ty.is_nullable() {
+                format!("({x}?.let {{ __l -> {} }} ?: 0)", fold.replace(x, "__l"))
+            } else {
+                format!("({fold})")
+            }
+        }
+    }
+}
+
+/// `toString` rendering for one value of type `ty`, digging through containers
+/// so a nested array never prints as `[B@1a2b3c`.
+fn str_expr(x: &str, ty: &kt::KtType) -> String {
+    if !array_bearing(ty) {
+        return format!("${{{x}}}");
+    }
+    match element_of(ty) {
+        None if ty.is_nullable() => format!("${{{x}?.contentToString()}}"),
+        None => format!("${{{x}.contentToString()}}"),
+        Some(elem) => {
+            let inner = str_expr("__e", elem);
+            let join = format!("{x}.joinToString(\", \", \"[\", \"]\") {{ __e -> \"{inner}\" }}");
+            if ty.is_nullable() {
+                format!("${{{x}?.let {{ __l -> {} }}}}", join.replace(x, "__l"))
+            } else {
+                format!("${{{join}}}")
+            }
+        }
     }
 }
 
@@ -63,43 +143,29 @@ pub(crate) fn content_equality_members(
     class_name: &str,
     props: &[(String, kt::KtType)],
 ) -> Option<Vec<kt::KtFun>> {
-    if !props.iter().any(|(_, ty)| array_prop(ty).is_some()) {
+    if !props.iter().any(|(_, ty)| array_bearing(ty)) {
         return None;
     }
 
     // `equals`: identity short-circuit, type check, then per-property
-    // comparison — `contentEquals` for arrays (its nullable-receiver overload
-    // covers `ByteArray?`), `==` for everything else.
+    // comparison that digs through any container down to the arrays.
     let comparisons: Vec<String> = props
         .iter()
-        .map(|(name, ty)| match array_prop(ty) {
-            Some(ArrayProp::Bytes { .. }) => format!("{name}.contentEquals(other.{name})"),
-            None => format!("{name} == other.{name}"),
-        })
+        .map(|(name, ty)| eq_expr(name, &format!("other.{name}"), ty))
         .collect();
-    let mut equals_body = kt::Code::new()
+    let equals_body = kt::Code::new()
         .line("if (this === other) return true")
-        .line(format!("if (other !is {class_name}) return false"));
-    equals_body = equals_body.line(format!("return {}", comparisons.join(" && ")));
+        .line(format!("if (other !is {class_name}) return false"))
+        .line(format!("return {}", comparisons.join(" && ")));
     let equals = kt::KtFun::new("equals")
         .modifier("override")
         .param(kt::KtParam::new("other", kt::KtType::any().nullable()))
         .returns(kt::KtType::boolean())
         .body(equals_body);
 
-    // `hashCode`: the standard 31-multiplier fold, with `contentHashCode` for
-    // arrays (`?: 0` for an absent one, matching how Kotlin hashes a null).
-    let hash_of = |name: &str, ty: &kt::KtType| -> String {
-        match array_prop(ty) {
-            Some(ArrayProp::Bytes { nullable: true }) => {
-                format!("({name}?.contentHashCode() ?: 0)")
-            }
-            Some(ArrayProp::Bytes { nullable: false }) => format!("{name}.contentHashCode()"),
-            None if ty.is_nullable() => format!("({name}?.hashCode() ?: 0)"),
-            None => format!("{name}.hashCode()"),
-        }
-    };
-    let first = hash_of(&props[0].0, &props[0].1);
+    // `hashCode`: the standard 31-multiplier fold over the same per-property
+    // expressions, so equal values always agree.
+    let first = hash_expr(&props[0].0, &props[0].1);
     let hash_body = if props.len() == 1 {
         // A single property needs no accumulator — `var result` would draw a
         // "never reassigned" warning in the generated source.
@@ -107,7 +173,7 @@ pub(crate) fn content_equality_members(
     } else {
         let mut b = kt::Code::new().line(format!("var result = {first}"));
         for (name, ty) in &props[1..] {
-            b = b.line(format!("result = 31 * result + {}", hash_of(name, ty)));
+            b = b.line(format!("result = 31 * result + {}", hash_expr(name, ty)));
         }
         b.line("return result")
     };
@@ -116,18 +182,10 @@ pub(crate) fn content_equality_members(
         .returns(kt::KtType::int())
         .body(hash_body);
 
-    // `toString`: an array would otherwise render as `[B@1a2b3c`.
+    // `toString`: an array at any depth would otherwise render as `[B@1a2b3c`.
     let rendered: Vec<String> = props
         .iter()
-        .map(|(name, ty)| match array_prop(ty) {
-            Some(ArrayProp::Bytes { nullable: true }) => {
-                format!("{name}=${{{name}?.contentToString()}}")
-            }
-            Some(ArrayProp::Bytes { nullable: false }) => {
-                format!("{name}=${{{name}.contentToString()}}")
-            }
-            None => format!("{name}=${name}"),
-        })
+        .map(|(name, ty)| format!("{name}={}", str_expr(name, ty)))
         .collect();
     let to_string = kt::KtFun::new("toString")
         .modifier("override")

--- a/prebindgen/src/api/lang/jnigen/jni/equality.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/equality.rs
@@ -1,0 +1,138 @@
+//! Content-based `equals` / `hashCode` / `toString` for generated Kotlin
+//! classes with an **array-backed** property.
+//!
+//! A generated class mirrors a Rust type that derives `PartialEq`/`Eq`, so two
+//! values with equal contents must compare equal. Kotlin arrays compare by
+//! IDENTITY, which breaks that for every `Vec<u8>` field (`ByteArray`) and for
+//! the `ByteArray` a value blob carries:
+//!
+//! ```text
+//! Timestamp(1uL, byteArrayOf(1,2,3)) == Timestamp(1uL, byteArrayOf(1,2,3))  // false
+//! ```
+//!
+//! Kotlin is inconsistent here rather than uniformly identity-based: a `data
+//! class`'s generated `hashCode`/`toString` DO special-case arrays
+//! (`contentHashCode` / `contentToString`), while its `equals` does not. So a
+//! broken value has an equal hash and an unequal `equals` — it lands in the
+//! right `HashMap` bucket and is then rejected. Both members are emitted here
+//! anyway, so the behavior is stated by the generated source rather than
+//! inherited from a compiler special case that only covers two of the three.
+//!
+//! ## Why value blobs are not `@JvmInline`
+//!
+//! Kotlin 1.9 (the version this generator targets downstream) rejects
+//! `equals`/`hashCode` members on a value class outright — *"Member with the
+//! name 'equals' is reserved for future releases"* — and its typed-equals
+//! replacement (`operator fun equals(other: T)`) is experimental, needing an
+//! opt-in flag every consumer would have to set. A `@JvmInline value class`
+//! therefore CANNOT be given value equality at this language level, so
+//! [`super::kotlin_emit`] emits value blobs as a plain `data class`. That costs
+//! one small allocation per crossing at the wrapper tier (the JNI ABI is
+//! unaffected — externs declare `ByteArray` directly and the wrapper passes
+//! `.bytes`), which is the price of the type behaving like the value it is.
+
+use super::*;
+
+/// A property whose Kotlin type compares by identity and therefore needs
+/// content-aware operators.
+enum ArrayProp {
+    /// `ByteArray` / `ByteArray?`.
+    Bytes { nullable: bool },
+}
+
+/// Classify one constructor property. `None` for everything that already
+/// compares by value (scalars, `String`, enums, nested generated classes).
+fn array_prop(ty: &kt::KtType) -> Option<ArrayProp> {
+    match ty.simple_name() {
+        Some("ByteArray") => Some(ArrayProp::Bytes {
+            nullable: ty.is_nullable(),
+        }),
+        _ => None,
+    }
+}
+
+/// The `equals` / `hashCode` / `toString` trio a class needs when any
+/// constructor property is array-backed.
+///
+/// `None` when none is — the compiler's own generation is already correct
+/// there, and emitting these would be pure churn on every existing class.
+///
+/// `props` is the class's constructor properties in declaration order, as
+/// `(kotlin_name, kotlin_type)`.
+pub(crate) fn content_equality_members(
+    class_name: &str,
+    props: &[(String, kt::KtType)],
+) -> Option<Vec<kt::KtFun>> {
+    if !props.iter().any(|(_, ty)| array_prop(ty).is_some()) {
+        return None;
+    }
+
+    // `equals`: identity short-circuit, type check, then per-property
+    // comparison — `contentEquals` for arrays (its nullable-receiver overload
+    // covers `ByteArray?`), `==` for everything else.
+    let comparisons: Vec<String> = props
+        .iter()
+        .map(|(name, ty)| match array_prop(ty) {
+            Some(ArrayProp::Bytes { .. }) => format!("{name}.contentEquals(other.{name})"),
+            None => format!("{name} == other.{name}"),
+        })
+        .collect();
+    let mut equals_body = kt::Code::new()
+        .line("if (this === other) return true")
+        .line(format!("if (other !is {class_name}) return false"));
+    equals_body = equals_body.line(format!("return {}", comparisons.join(" && ")));
+    let equals = kt::KtFun::new("equals")
+        .modifier("override")
+        .param(kt::KtParam::new("other", kt::KtType::any().nullable()))
+        .returns(kt::KtType::boolean())
+        .body(equals_body);
+
+    // `hashCode`: the standard 31-multiplier fold, with `contentHashCode` for
+    // arrays (`?: 0` for an absent one, matching how Kotlin hashes a null).
+    let hash_of = |name: &str, ty: &kt::KtType| -> String {
+        match array_prop(ty) {
+            Some(ArrayProp::Bytes { nullable: true }) => {
+                format!("({name}?.contentHashCode() ?: 0)")
+            }
+            Some(ArrayProp::Bytes { nullable: false }) => format!("{name}.contentHashCode()"),
+            None if ty.is_nullable() => format!("({name}?.hashCode() ?: 0)"),
+            None => format!("{name}.hashCode()"),
+        }
+    };
+    let first = hash_of(&props[0].0, &props[0].1);
+    let hash_body = if props.len() == 1 {
+        // A single property needs no accumulator — `var result` would draw a
+        // "never reassigned" warning in the generated source.
+        kt::Code::new().line(format!("return {first}"))
+    } else {
+        let mut b = kt::Code::new().line(format!("var result = {first}"));
+        for (name, ty) in &props[1..] {
+            b = b.line(format!("result = 31 * result + {}", hash_of(name, ty)));
+        }
+        b.line("return result")
+    };
+    let hash_code = kt::KtFun::new("hashCode")
+        .modifier("override")
+        .returns(kt::KtType::int())
+        .body(hash_body);
+
+    // `toString`: an array would otherwise render as `[B@1a2b3c`.
+    let rendered: Vec<String> = props
+        .iter()
+        .map(|(name, ty)| match array_prop(ty) {
+            Some(ArrayProp::Bytes { nullable: true }) => {
+                format!("{name}=${{{name}?.contentToString()}}")
+            }
+            Some(ArrayProp::Bytes { nullable: false }) => {
+                format!("{name}=${{{name}.contentToString()}}")
+            }
+            None => format!("{name}=${name}"),
+        })
+        .collect();
+    let to_string = kt::KtFun::new("toString")
+        .modifier("override")
+        .returns(kt::KtType::string())
+        .expr_body(kt::Code::new().line(format!("\"{class_name}({})\"", rendered.join(", "))));
+
+    Some(vec![equals, hash_code, to_string])
+}

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -421,13 +421,16 @@ impl JniGen {
             };
             let framework_line = format!(
                 "Typed by-value wrapper for the native Rust `{}` (a `Copy` blob carried\n\
-                 as its raw bytes; `@JvmInline`-erased to `ByteArray` at the JNI boundary).",
+                 as its raw bytes; it crosses the JNI boundary as a bare `ByteArray`).\n\n\
+                 Not a `@JvmInline value class`: Kotlin 1.9 reserves `equals`/`hashCode`\n\
+                 members on a value class, so one cannot be given the value equality this\n\
+                 type has in Rust — arrays would compare by identity.",
                 key.as_str()
             );
             let class_kdoc = crate::api::lang::jnigen::jni::source_item_doc(registry, key)
                 .map(|d| format!("{d}\n\n{framework_line}"))
                 .unwrap_or(framework_line);
-            let mut class = KtClass::new(ClassKind::ValueInline, &class_name)
+            let mut class = KtClass::new(ClassKind::Data, &class_name)
                 .vis(Vis::Public)
                 .kdoc(class_kdoc)
                 .ctor_param(
@@ -435,6 +438,16 @@ impl JniGen {
                         .val()
                         .vis(Vis::Public),
                 );
+            // The blob IS the value, so it compares by content.
+            for m in crate::api::lang::jnigen::jni::equality::content_equality_members(
+                &class_name,
+                &[("bytes".to_string(), KtType::byte_array())],
+            )
+            .into_iter()
+            .flatten()
+            {
+                class = class.member(m);
+            }
             let mut imports: BTreeSet<String> = BTreeSet::new();
             let members = self
                 .class_members
@@ -744,6 +757,7 @@ impl JniGen {
             if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_variant.attrs) {
                 vclass = vclass.kdoc(doc);
             }
+            let mut vprops: Vec<(String, KtType)> = Vec::new();
             for (field, item_field) in variant.fields.iter().zip(item_variant.fields.iter()) {
                 let prop = sum_field_property_name(field);
                 let ty = self.sum_payload_kt_type(
@@ -753,7 +767,17 @@ impl JniGen {
                     &prop,
                     item_field,
                 );
+                vprops.push((prop.clone(), ty.clone()));
                 vclass = vclass.ctor_param(KtCtorParam::new(&prop, ty).val().vis(Vis::Public));
+            }
+            // An array-backed payload (a `Vec<u8>` variant field) compares by
+            // identity otherwise — same rule as a data-class property.
+            for m in
+                crate::api::lang::jnigen::jni::equality::content_equality_members(&vname, &vprops)
+                    .into_iter()
+                    .flatten()
+            {
+                vclass = vclass.member(m);
             }
             class = class.member(vclass);
         }

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -582,6 +582,7 @@ mod classify;
 mod config;
 mod decl;
 mod emit;
+mod equality;
 mod iface;
 mod prim;
 mod selector;

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -94,6 +94,9 @@ pub(crate) fn build_data_class(
     });
 
     let mut ctor_params: Vec<kt::KtCtorParam> = Vec::new();
+    // Property (name, type) pairs, for the content-equality members an
+    // array-backed property needs — see [`equality::content_equality_members`].
+    let mut equality_props: Vec<(String, kt::KtType)> = Vec::new();
     // Track per-field destructible (name, folded close strategy) so the
     // bottom emitter can produce a matching `close()` body for each.
     let mut destructible_fields: Vec<(String, crate::api::lang::jnigen::jni::FoldStrategy)> =
@@ -137,8 +140,9 @@ pub(crate) fn build_data_class(
             }
         }
 
-        ctor_params
-            .push(kt::KtCtorParam::new(&kotlin_field_name, pf.kind.property_type(&owner)).val());
+        let property_type = pf.kind.property_type(&owner);
+        equality_props.push((kotlin_field_name.clone(), property_type.clone()));
+        ctor_params.push(kt::KtCtorParam::new(&kotlin_field_name, property_type).val());
         if let Some(strategy) = pf.kind.destructible() {
             destructible_fields.push((kotlin_field_name, strategy));
         }
@@ -170,6 +174,17 @@ pub(crate) fn build_data_class(
     }
     for p in ctor_params {
         class = class.ctor_param(p);
+    }
+    // Array-backed properties compare by identity in Kotlin, so a class with
+    // one gets explicit content-based operators (the Rust type derives `Eq`).
+    for m in crate::api::lang::jnigen::jni::equality::content_equality_members(
+        class_name,
+        &equality_props,
+    )
+    .into_iter()
+    .flatten()
+    {
+        class = class.member(m);
     }
     // Supertype clause: a data class with a destructible native-handle field
     // implements `AutoCloseable`; otherwise no supertype.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -263,12 +263,22 @@ fn value_class_interface_emits_generated_api() {
     assert!(ac.contains("interfaceZStampApi{"), "{all}");
     assert!(ac.contains("valbytes:ByteArray"), "{all}");
     assert!(ac.contains("funsecs("), "{all}");
+    // A value blob is a `data class`, NOT `@JvmInline value class`: Kotlin 1.9
+    // reserves `equals`/`hashCode` members on a value class, so an inline one
+    // could not carry the content equality the Rust `Copy` blob has.
     assert!(
-        ac.contains("valueclassZStamp(overridepublicvalbytes:ByteArray):ZStampApi{")
-            || ac.contains("valueclassZStamp(publicoverridevalbytes:ByteArray):ZStampApi{"),
+        ac.contains("dataclassZStamp(overridepublicvalbytes:ByteArray):ZStampApi{")
+            || ac.contains("dataclassZStamp(publicoverridevalbytes:ByteArray):ZStampApi{"),
         "{all}"
     );
+    assert!(!ac.contains("@JvmInlinepublic"), "{all}");
     assert!(ac.contains("publicoverridefunsecs("), "{all}");
+    // …and it compares by CONTENT, not by array identity.
+    assert!(
+        ac.contains("returnbytes.contentEquals(other.bytes)"),
+        "{all}"
+    );
+    assert!(ac.contains("returnbytes.contentHashCode()"), "{all}");
 }
 
 /// Per-declaration class rename (`.name()`, the type-level dual of the per-fn


### PR DESCRIPTION
Reported on [ZettaScaleLabs/zenoh-flat-jni#16](https://github.com/ZettaScaleLabs/zenoh-flat-jni/pull/16): generated values with equal contents compare unequal.

```kotlin
Timestamp(1uL, byteArrayOf(1, 2, 3)) == Timestamp(1uL, byteArrayOf(1, 2, 3))  // false
EntityGlobalId(ZenohId(byteArrayOf(1)), 7) == EntityGlobalId(ZenohId(byteArrayOf(1)), 7)  // false
```

A generated class mirrors a Rust type deriving `PartialEq`/`Eq`, so this is the generator contradicting the type it mirrors — not a binding bug.

## What Kotlin actually does

Measured on Kotlin 1.9.0 before writing any code:

| | `==` | `hashCode` equal |
|---|---|---|
| `@JvmInline value class V(val b: ByteArray)` | ❌ false | ✅ true |
| `data class D(val n: ULong, val id: ByteArray)` | ❌ false | ✅ true |
| `data class` holding the value class | ❌ false | ✅ true |
| plain class + explicit content ops | ✅ true | ✅ true |

Kotlin is **inconsistent**, not uniformly identity-based: a data class's generated `hashCode`/`toString` *do* special-case arrays (`contentHashCode`/`contentToString`) while its `equals` does not. That is why the report saw `eq=false hashEq=true` — a broken value finds the right `HashMap` bucket and is then rejected. `==` is the observable defect; a hashCode check alone would not have found it. (`hashSetOf(t1, t2).size == 2` confirms the practical damage.)

## Why value blobs lose `@JvmInline`

Kotlin 1.9 rejects the members outright:

```
e: Member with the name 'equals' is reserved for future releases
e: The feature "custom equals in value classes" is experimental and should be enabled explicitly
```

So an inline value class **cannot** be given value equality at this language level, and the experimental typed-equals replacement would force an opt-in flag on every consumer of a shared tier. Value blobs are therefore emitted as a plain `data class`.

Cost: one small allocation per crossing at the wrapper tier. **The JNI ABI is untouched** — externs already declare `ByteArray` (`external fun zenohIdToString(z: ByteArray, …)`) and the wrapper passes `.bytes` explicitly, so the erasure was never load-bearing. Value blobs are also documented as off-hot-path.

## The change

`equality::content_equality_members` emits `equals`/`hashCode`/`toString` for any class with an array-backed constructor property and **nothing** for the rest, so existing classes keep the compiler's own generation and the diff stays confined. Three emitters feed it: `data_class!` (`render.rs`), value blobs and `sealed_class!` variant payloads (`kotlin_emit.rs`).

## Coverage

Nothing exercised the broken shapes — covertest had the `Stamp` value blob but **no data class with a `ByteArray` field**, which is precisely why this reached a consumer. `BlobValue` adds both (a `Vec<u8>` field beside a scalar, plus a nested value blob) and the new section asserts content equality, hash equality, `HashSet` de-duplication, `toString`, and that *each* component participates (a comparison ignoring one would otherwise still pass).

Verified the section fails without the fix:

```
IllegalStateException: value blob must compare by content:
  Stamp(bytes=[7, 0, …]) vs Stamp(bytes=[7, 0, …])
```

`PASS - 46 sections`, 334 lib tests, fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)