### PR TITLE
One frontend for array lengths, and a typed source model that carries extents to C (#210, first step of #211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,5 @@ See example projects in the [examples directory](https://github.com/milyin/prebi
 
 - **prebindgen API Reference**: [docs.rs/prebindgen](https://docs.rs/prebindgen)
 - **prebindgen-proc-macro API Reference**: [docs.rs/prebindgen-proc-macro](https://docs.rs/prebindgen-proc-macro)
+- **The source language**: [docs/source-language.md](docs/source-language.md) — which Rust forms a `#[prebindgen]` crate may use
+- **Data-carrying enums**: [docs/sum-types.md](docs/sum-types.md)

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -146,14 +146,25 @@ can answer:
 |---|---|---|
 | const index | const name + origin crate | `A` is `4` in crate X |
 | type table (`Registry::array_len`) | `TypeKey` | this array type's length is `4` |
-| per-use source model *(not built yet — #211's `SourceModel`)* | use site | field `S::a` was written `[u8; A]` |
+| per-use source model *(not built — #211's `SourceModel`)* | use site | field `S::a` was written `[u8; A]` |
 
-So `Registry::array_len` returns a bare `usize`. It **cannot** report which
-spelling produced the type, because by the time a `TypeKey` exists that question
-has more than one true answer — and storing one would make it depend on which
-occurrence was seen last. The occurrence model that does know the spelling is
-crate-private for exactly that reason: there is no type-keyed table it could be
-handed out through honestly.
+`Registry::array_len` returns a bare `usize`, and the third row does not exist
+yet. So **the spelling is discarded at the frontend**: after
+`Registry::from_items`, nothing — no type table, no adapter — can tell that
+`S::a` wrote `A`, `S::b` wrote `B`, and `S::literal` wrote `4`.
+
+That is a **policy decision**, not a consequence of Rust's type equality, so it
+is stated rather than assumed. The reasoning: those three are one Rust type, one
+`TypeKey` and one converter, so letting an adapter render them differently would
+mean two destination representations for a single Rust type — which the
+type-keyed converter table cannot express. The capability would be incoherent
+here even if the provenance were carried.
+
+The cost is real and bounded: a C header cannot echo `uint8_t x[MAX_SIZE]`, only
+`uint8_t x[16]`. If that becomes wanted, provenance must arrive on the **use
+site** — field, parameter, return — in the per-use `SourceModel`, and never on a
+type-keyed table, where three occupants of one key cannot be told apart by the
+key.
 
 ### What is refused, and why
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -56,7 +56,7 @@ Decided by `Registry::scan_fn_signature`
 | a `self` receiver | **refused** — `ScanError::UnsupportedReceiver` |
 | a non-ident parameter pattern (`(a, b): (u8, u8)`) | **refused** — `ScanError::UnsupportedParamPattern` |
 | generic parameters / `where` clauses | unspecified |
-| `impl Fn(T, …) + Send + Sync + 'static` parameter | supported — the callback form |
+| `impl Fn(T, …) + Send + Sync + 'static` parameter | supported — the callback form, see [Callbacks](#callbacks) |
 | any other `impl Trait` | **refused** — `ScanError::DisallowedImplTrait` |
 
 A source crate stays **plain idiomatic Rust**: values are returned by value,
@@ -81,7 +81,7 @@ and canonicalized at ingest by `types_util::normalize_type`.
 | the unit `()` | supported | |
 | a non-empty tuple | **refused** | No adapter has ever lowered one; only `()` is in the language. |
 | raw pointer | walked, adapter-dependent | |
-| `impl Fn(…)` | supported in a parameter position | |
+| `impl Fn(…) + Send + Sync + 'static` | supported in a parameter position | Must return `()` — see [Callbacks](#callbacks). |
 | any other `impl Trait` | refused | |
 | a path with a qualified self (`<T as Trait>::Assoc`) | **refused** | `#[prebindgen]` never captures `impl` blocks, so what it resolves to is unknowable. Outside modeled positions `normalize_type` still leaves it verbatim. |
 
@@ -124,6 +124,40 @@ complete rule set is documented on that function; in summary:
 Because a declaration in `build.rs` is matched against the *normalized*
 spelling, declaring a source item with its crate path
 (`ptr_class!(myflat::Foo)`) is a hard error with a fix-it, not a silent miss.
+
+## Callbacks
+
+**Decided by the frontend** — `core::registry::extract_fn_trait_sig`, the single
+acceptance gate for every callback position.
+
+The accepted form is exactly `impl Fn(T, …) + Send + Sync + 'static`, and the
+`Fn` **must return `()`** (elided or written). Bound order is free and
+canonicalized; so are a trailing input comma and an explicit `-> ()`.
+
+| Form | Status |
+|---|---|
+| `impl Fn(u8) + Send + Sync + 'static` | supported |
+| `impl Fn(u8,) -> () + Sync + Send + 'static` | supported — same type, canonicalized |
+| `impl Fn(u8) -> u16 + …` | **reserved** — issue [#216](https://github.com/milyin/prebindgen/issues/216) |
+| `impl Fn(u8) -> impl Fn(u8) + …` | **reserved** |
+| `impl for<'a> Fn(&'a u8) + …` | **unsupported** |
+
+### Reserved is not the same as unsupported
+
+A refusal says which of two things it is, because they call for opposite
+responses:
+
+* **reserved** — the language intends this and the machinery does not exist
+  yet. Wait, or work around it; the diagnostic names the tracking issue.
+* **unsupported** — it cannot work here and will not. Redesign.
+
+A callback returning a value is *reserved*: every callback wire is void-shaped
+today — C's `call` has no return, jnigen's `run` returns void — so the result
+would be dropped. It used to be **accepted** and silently dropped, which is the
+bug this refusal replaces.
+
+A higher-ranked binder is *unsupported*: no FFI boundary can be generic over a
+lifetime, so no adapter could ever carry one.
 
 ## Array lengths
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -8,12 +8,16 @@ It is the contract between the source crate and every generator: what a form
 *means* is decided once, by the frontend; how it *crosses a boundary* is decided
 per adapter.
 
-> **Read this first:** only the [array-length subgrammar](#array-lengths) has
-> actually moved into `core::frontend` so far. Every other row below records
-> where the decision is made *today*, which is often inside an adapter. #211
-> tracks moving them. Rows marked **frontend** are decided once and are
-> identical for every generator; rows marked with a site are not, and may differ
-> between C and JNI until they migrate.
+> **Read this first:** the [type grammar](#types) and the
+> [array-length subgrammar](#array-lengths) have moved into `core::frontend`,
+> but they are enforced there **only in modeled positions** — today, the fields
+> of a `#[prebindgen]` struct. Item kinds, function signatures and every other
+> type position are still decided at their use sites, often inside an adapter,
+> and #211 tracks moving them.
+>
+> So a row below can be refused by the frontend in a struct field and reach an
+> adapter unexamined in a function parameter. Where that distinction matters it
+> is stated on the row.
 
 Anything not listed here is **unspecified**. A form that happens to work is not
 thereby part of the language, and the frontend may start refusing it.
@@ -62,21 +66,43 @@ to JNI is the adapter's job.
 
 ## Types
 
-Type positions are walked by `immediate_subtype_positions`
-(`prebindgen/src/api/core/registry.rs`) and canonicalized at ingest by
-`types_util::normalize_type`.
+**Decided by the frontend** in modeled positions —
+`core::frontend::model::lower_type` produces a closed `SourceType`, and lowering
+is total: a form with no variant is refused. Elsewhere, type positions are
+walked by `immediate_subtype_positions` (`prebindgen/src/api/core/registry.rs`)
+and canonicalized at ingest by `types_util::normalize_type`.
 
 | Form | Status | Notes |
 |---|---|---|
 | path type (`Foo`, `Vec<u8>`, `Option<&T>`) | supported | |
-| reference (`&T`, `&mut T`) | supported | |
+| reference (`&T`, `&'a T`, `&mut T`) | supported | |
 | slice (`&[T]`) | supported | |
 | fixed-size array (`[T; N]`) | supported | Length: see [below](#array-lengths). |
-| tuple | supported | |
+| the unit `()` | supported | |
+| a non-empty tuple | **refused** | No adapter has ever lowered one; only `()` is in the language. |
 | raw pointer | walked, adapter-dependent | |
 | `impl Fn(…)` | supported in a parameter position | |
 | any other `impl Trait` | refused | |
-| a path with a qualified self (`<T as Trait>::Assoc`) | left verbatim | Never normalized; its spelling is its identity. |
+| a path with a qualified self (`<T as Trait>::Assoc`) | **refused** | `#[prebindgen]` never captures `impl` blocks, so what it resolves to is unknowable. Outside modeled positions `normalize_type` still leaves it verbatim. |
+
+### Lifetimes are part of a type's name
+
+A lifetime is preserved exactly — `Foo<'static>` is **not** `Foo`, and
+`&'static T` is not `&T` — but it is never modeled as structure, because it
+means nothing to a destination language. The model keeps it verbatim so the
+projection reconstructs the type it came from.
+
+That matters beyond spelling: declarations are matched against the normalized
+form, so `ptr_class!(ZKeyExpr<'static>)` only ever matches a captured
+`ZKeyExpr<'static>`.
+
+### A builtin must be spelled bare
+
+`String` / `Option` / `Vec` / `Box` / `Result` are recognized only as a bare,
+single-segment path. `normalize_type` has already reduced the genuine std
+spellings at ingest and deliberately leaves unknown crate paths alone, so
+`foreign::Option<u8>` is a **foreign named type** that merely shares a name —
+collapsing it would silently retype the value and select the wrong converter.
 
 ### Path normalization
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -131,6 +131,30 @@ literally are **one type and one converter** — they always were in Rust, and t
 frontend now agrees. And a changed const shows up in the diff of a committed
 generated artifact, where echoing the name would have shown nothing at all.
 
+### Three identities, kept apart
+
+Normalization is deliberately lossy, and that dictates which question each layer
+can answer:
+
+```text
+[u8; A]  where A = 4
+[u8; B]  where B = 4     ──>   [u8; 4]
+[u8; 4]
+```
+
+| Layer | Keyed by | Answers |
+|---|---|---|
+| const index | const name + origin crate | `A` is `4` in crate X |
+| type table (`Registry::array_len`) | `TypeKey` | this array type's length is `4` |
+| per-use source model *(not built yet — #211's `SourceModel`)* | use site | field `S::a` was written `[u8; A]` |
+
+So `Registry::array_len` returns a bare `usize`. It **cannot** report which
+spelling produced the type, because by the time a `TypeKey` exists that question
+has more than one true answer — and storing one would make it depend on which
+occurrence was seen last. The occurrence model that does know the spelling is
+crate-private for exactly that reason: there is no type-keyed table it could be
+handed out through honestly.
+
 ### What is refused, and why
 
 | Form | Reason |

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -104,7 +104,7 @@ spelling, declaring a source item with its crate path
 **Decided by the frontend** — `core::frontend::lower_array_len`. This is the
 only subgrammar with an executable acceptance matrix
 (`prebindgen/src/api/core/frontend/tests.rs`); it is closed, and both adapters
-consume the same `ArrayLen`.
+consume the same `ArrayExtent`.
 
 ### A length is always a number
 
@@ -119,17 +119,21 @@ Two spellings reach that number, and nothing else does:
 | Form | Status | Lowers to |
 |---|---|---|
 | `[u8; 4]`, `[u8; 16usize]` | supported | `Literal(4)` / `Literal(16)` |
-| `[u8; N]` where `#[prebindgen] pub const N: usize = 4;` | supported | `Const { name: N, value: 4 }` |
+| `[u8; N]` where `#[prebindgen] pub const N: usize = 4;` | supported | `{ value: 4, source: Const(N) }` |
 | everything else | **refused** | see below |
 
-Both carry the value; the const also keeps its name, for diagnostics. **Emission
-uses the number**, so no length is ever a path in generated code:
-`[u8; ARRAY_BYTES]` emits as `[u8; 4]`.
+Both carry the value, and a const extent also carries **which const**. Which of
+the two an emitter uses is that adapter's choice:
 
-Two consequences worth stating. A const length and the same number written
-literally are **one type and one converter** — they always were in Rust, and the
-frontend now agrees. And a changed const shows up in the diff of a committed
-generated artifact, where echoing the name would have shown nothing at all.
+* generated **Rust** always uses the number, so no length is ever a path there
+  and there is nothing to qualify — `[u8; ARRAY_BYTES]` emits as `[u8; 4]`;
+* a **C header** uses the name — `uint8_t tag[MARKER_TAG_LEN]` — because a
+  symbolic extent is part of that API's meaning;
+* **Kotlin** has nowhere to put an extent at all.
+
+The value is what makes a const length and the same number written literally
+**one type and one converter** — they always were in Rust, and the frontend
+agrees.
 
 ### Three identities, kept apart
 
@@ -138,7 +142,7 @@ can answer:
 
 ```text
 [u8; A]  where A = 4
-[u8; B]  where B = 4     ──>   [u8; 4]
+[u8; B]  where B = 4     ──>   [u8; 4]     (one Rust type, one converter)
 [u8; 4]
 ```
 
@@ -146,25 +150,29 @@ can answer:
 |---|---|---|
 | const index | const name + origin crate | `A` is `4` in crate X |
 | type table (`Registry::array_len`) | `TypeKey` | this array type's length is `4` |
-| per-use source model *(not built — #211's `SourceModel`)* | use site | field `S::a` was written `[u8; A]` |
+| **source model** (`Registry::source_struct`) | **use site** — struct + field | field `S::a` was written `[u8; A]` |
 
-`Registry::array_len` returns a bare `usize`, and the third row does not exist
-yet. So **the spelling is discarded at the frontend**: after
-`Registry::from_items`, nothing — no type table, no adapter — can tell that
-`S::a` wrote `A`, `S::b` wrote `B`, and `S::literal` wrote `4`.
+`Registry::array_len` returns a bare `usize` and **cannot** report the spelling:
+by the time a `TypeKey` exists that question has more than one true answer, and
+storing one would make it depend on which occurrence was seen last.
 
-That is a **policy decision**, not a consequence of Rust's type equality, so it
-is stated rather than assumed. The reasoning: those three are one Rust type, one
-`TypeKey` and one converter, so letting an adapter render them differently would
-mean two destination representations for a single Rust type — which the
-type-keyed converter table cannot express. The capability would be incoherent
-here even if the provenance were carried.
+The spelling lives on the **use site** instead, in the typed source model, as an
+`ArrayExtent { value, source }`. Both halves have consumers:
 
-The cost is real and bounded: a C header cannot echo `uint8_t x[MAX_SIZE]`, only
-`uint8_t x[16]`. If that becomes wanted, provenance must arrive on the **use
-site** — field, parameter, return — in the per-use `SourceModel`, and never on a
-type-keyed table, where three occupants of one key cannot be told apart by the
-key.
+* `value` is what a destination language needs when it cannot reference a Rust
+  const at all — Kotlin gets `[u8; 4]`;
+* `source` is what a C header needs, because a symbolic extent is part of that
+  API's meaning. `uint8_t tag[MARKER_TAG_LEN]` makes changing the size one edit
+  rather than a hunt through literals.
+
+An adapter reads the extent **as a decided fact**. It must never recover it by
+re-reading `syn` — that is issue #211's invariant 6, and the reason the model
+exists rather than a side channel carrying the original syntax.
+
+A const an extent names is carried into the destination language by the adapter
+that spells it: `lang::Cbindgen` re-emits such a const with its literal value so
+cbindgen produces `#define MARKER_TAG_LEN 4`. Without that the header would name
+a symbol it never defines.
 
 ### What is refused, and why
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -162,7 +162,12 @@ An explicit higher-ranked binder is *reserved* too, and for a subtler reason:
 the accepted `impl Fn(&u8)` **is** higher-ranked — it desugars to
 `impl for<'a> Fn(&'a u8)`, and the two are mutually substitutable. So the two
 spellings are one type, and this is simply the last such pair not yet
-canonicalized. Write the elided form.
+canonicalized.
+
+Rewriting with elision is exact **only when every bound lifetime is used once**.
+Elision binds each input separately, so `Fn(&T, &T)` is `for<'a, 'b> Fn(&'a T,
+&'b T)` — a signature that ties two inputs to one lifetime has no accepted
+spelling yet, and rewriting it would change its meaning.
 
 ## Array lengths
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -140,7 +140,7 @@ canonicalized; so are a trailing input comma and an explicit `-> ()`.
 | `impl Fn(u8,) -> () + Sync + Send + 'static` | supported — same type, canonicalized |
 | `impl Fn(u8) -> u16 + …` | **reserved** — issue [#216](https://github.com/milyin/prebindgen/issues/216) |
 | `impl Fn(u8) -> impl Fn(u8) + …` | **reserved** |
-| `impl for<'a> Fn(&'a u8) + …` | **unsupported** |
+| `impl for<'a> Fn(&'a u8) + …` | **reserved** — issue [#222](https://github.com/milyin/prebindgen/issues/222) |
 
 ### Reserved is not the same as unsupported
 
@@ -149,15 +149,20 @@ responses:
 
 * **reserved** — the language intends this and the machinery does not exist
   yet. Wait, or work around it; the diagnostic names the tracking issue.
-* **unsupported** — it cannot work here and will not. Redesign.
+* **unsupported** — it cannot work here and will not. Redesign. A non-empty
+  tuple and an associated type are the examples, above; every *callback*
+  refusal is currently reserved.
 
 A callback returning a value is *reserved*: every callback wire is void-shaped
 today — C's `call` has no return, jnigen's `run` returns void — so the result
 would be dropped. It used to be **accepted** and silently dropped, which is the
 bug this refusal replaces.
 
-A higher-ranked binder is *unsupported*: no FFI boundary can be generic over a
-lifetime, so no adapter could ever carry one.
+An explicit higher-ranked binder is *reserved* too, and for a subtler reason:
+the accepted `impl Fn(&u8)` **is** higher-ranked — it desugars to
+`impl for<'a> Fn(&'a u8)`, and the two are mutually substitutable. So the two
+spellings are one type, and this is simply the last such pair not yet
+canonicalized. Write the elided form.
 
 ## Array lengths
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -112,17 +112,59 @@ A length is a literal or a plain path, and nothing else:
 enum ArrayLen {
     Literal(usize),
     SourceConst  { path },   // resolved to a #[prebindgen] item, stored absolute
-    ExternalConst { path },  // names nothing the registry indexes; emitted verbatim
+    ExternalConst { path },  // not a source path; emitted verbatim
 }
 ```
+
+### How a path is resolved
+
+The source crate may spell a path **however it likes** — bare, `crate`-rooted,
+through the module the item is declared in. Lowering is two decisions, in this
+order:
+
+**1. Is the path source-relative?** Yes if its head segment is `crate`, `self`,
+an ingested source crate's module name, or an indexed item's name. Everything
+else is `ExternalConst` and is emitted **verbatim, exactly as written**.
+
+Classification comes first, before any rewriting, so the verbatim guarantee
+actually holds. It also mirrors the type rule: a foreign crate's path is never
+touched, because the registry has no index of a foreign namespace and
+`a::Holder` and `b::Holder` may be genuinely different things. So
+`other_crate::Holder::N` stays put even though `Holder` happens to name an
+indexed item.
+
+**2. Which segment names the item?** The **leftmost** segment that names an
+indexed item — skipping a const or function that has segments after it, since
+nothing is reachable *through* a const.
+
+Everything before that anchor is a module path **within the source crate** and
+is replaced wholesale by the item's origin module. Everything after it is
+relative to the item and is kept.
+
+Replacing the prefix is sound because prebindgen items live in **one flat,
+uniquely named namespace**, so the bare name already identifies the item and the
+module prefix carries no information. That is the same invariant
+`normalize_type` relies on for types.
+
+> **This requires the item to be reachable as `<crate>::<bare name>`.** An item
+> declared in a private or nested module must be re-exported at the source
+> crate's root. `zenoh-flat` does exactly this: `ZENOH_ID_MAX_SIZE` lives in
+> `base::config::zenoh_id` and is re-exported from `lib.rs`.
+
+Leftmost-first matters: in `Holder::N` where a free const `N` is *also* indexed,
+`Holder` is the anchor and `N` is its associated const — not the other way
+round.
 
 | Form | Status | Lowers to |
 |---|---|---|
 | `[u8; 4]`, `[u8; 16usize]` | supported | `Literal` |
 | `[u8; MAX]` — a `#[prebindgen]` const | supported | `SourceConst`, spelled `myflat::MAX` |
-| `[u8; Holder::N]` — an associated const | supported | `SourceConst`, spelled `myflat::Holder::N`; only the **owner** is qualified |
+| `[u8; Holder::N]` — an associated const | supported | `SourceConst`, `myflat::Holder::N`; segments after the item are kept |
 | `[u8; crate::MAX]`, `[u8; myflat::MAX]` | supported | Same value as the bare spelling |
-| `[u8; usize::MAX]` | supported | `ExternalConst`, verbatim |
+| `[u8; crate::limits::MAX]`, `[u8; myflat::limits::MAX]` | supported | Same value again — the intermediate module is dropped |
+| `[u8; crate::limits::Holder::N]` | supported | `myflat::Holder::N` |
+| `[u8; usize::MAX]`, `[u8; other_crate::X]` | supported | `ExternalConst`, verbatim |
+| `[u8; crate::limits::UNMARKED]` | **refused** | `UnresolvedSourcePath` — claims a source item, names none |
 | `[u8; <Holder>::N]`, `[u8; <Holder as Tr>::N]` | **refused** | `QualifiedSelf` |
 | `[u8; ::MAX]` | **refused** | `CrateRootPath` |
 | `[u8; A + 1]`, `[u8; -1]`, `[u8; A as usize]`, `[u8; (A)]` | **refused** | Const arithmetic is not in the language |
@@ -130,8 +172,9 @@ enum ArrayLen {
 | `[u8; const { … }]`, `[u8; match … ]`, `[u8; if let … ]`, `[u8; \|\| 3]` | **refused** | Anything that can bind a name |
 | a non-integer or oversized literal | **refused** | |
 
-Everything refused has the same fix: **hoist the value into a named `const`**
-and use that as the length.
+Everything refused for *shape* has the same fix: **hoist the value into a named
+`const`** and use that as the length. `UnresolvedSourcePath` has a different
+one: mark the intended item `#[prebindgen]`.
 
 ### The `#[prebindgen]` trap
 
@@ -147,12 +190,21 @@ pub struct Arrays {
 }
 ```
 
-Without it the registry never indexes the const, so the length lowers to
-`ExternalConst` and is emitted **bare** — and the generated crate, which is not
-the source crate, cannot resolve it. The const does **not** have to be declared
-to the binding: a length is a compile-time namespace, not part of any
-destination language's surface. The covertest fixture in
-`examples/perftest-flat/src/ext.rs` pins exactly this arrangement.
+Without it the registry never indexes the const, and what happens depends on how
+the length was spelled:
+
+* **source-relative** (`crate::limits::UNMARKED`, `myflat::UNMARKED`) — a **hard
+  frontend error**. The path claims to name a source item and names none, so
+  there is nothing to qualify it with.
+* **bare** (`UNMARKED`) — indistinguishable from an external namespace, so it
+  lowers to `ExternalConst` and is emitted verbatim. The generated crate, which
+  is not the source crate, then fails to resolve it. This is the one remaining
+  quiet case; prefer the `crate::`-rooted spelling if you want the loud one.
+
+The const does **not** have to be declared to the binding: a length is a
+compile-time namespace, not part of any destination language's surface. The
+covertest fixture in `examples/perftest-flat/src/ext.rs` pins exactly this
+arrangement.
 
 ### Why this one is closed
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -106,79 +106,67 @@ only subgrammar with an executable acceptance matrix
 (`prebindgen/src/api/core/frontend/tests.rs`); it is closed, and both adapters
 consume the same `ArrayLen`.
 
-A length is a literal or a plain path, and nothing else:
+### A length is always a number
 
-```rust
-enum ArrayLen {
-    Literal(usize),
-    SourceConst  { path },   // resolved to a #[prebindgen] item, stored absolute
-    ExternalConst { path },  // not a source path; emitted verbatim
-}
-```
+That is the contract, not an implementation detail. A binding generator runs in
+`build.rs`, where it cannot evaluate arbitrary Rust; and some destination
+languages cannot reference a Rust const at all — a surface that groups a small
+array into scalars needs the count literally. A length the frontend cannot
+reduce to a `usize` is therefore not a length prebindgen accepts.
 
-### How a path is resolved
-
-The source crate may spell a path **however it likes** — bare, `crate`-rooted,
-through the module the item is declared in. Lowering is two decisions, in this
-order:
-
-**1. Is the path source-relative?** Yes if its head segment is `crate`, `self`,
-an ingested source crate's module name, or an indexed item's name. Everything
-else is `ExternalConst` and is emitted **verbatim, exactly as written**.
-
-Classification comes first, before any rewriting, so the verbatim guarantee
-actually holds. It also mirrors the type rule: a foreign crate's path is never
-touched, because the registry has no index of a foreign namespace and
-`a::Holder` and `b::Holder` may be genuinely different things. So
-`other_crate::Holder::N` stays put even though `Holder` happens to name an
-indexed item.
-
-**2. Which segment names the item?** The **leftmost** segment that names an
-indexed item — skipping a const or function that has segments after it, since
-nothing is reachable *through* a const.
-
-Everything before that anchor is a module path **within the source crate** and
-is replaced wholesale by the item's origin module. Everything after it is
-relative to the item and is kept.
-
-Replacing the prefix is sound because prebindgen items live in **one flat,
-uniquely named namespace**, so the bare name already identifies the item and the
-module prefix carries no information. That is the same invariant
-`normalize_type` relies on for types.
-
-> **This requires the item to be reachable as `<crate>::<bare name>`.** An item
-> declared in a private or nested module must be re-exported at the source
-> crate's root. `zenoh-flat` does exactly this: `ZENOH_ID_MAX_SIZE` lives in
-> `base::config::zenoh_id` and is re-exported from `lib.rs`.
-
-Leftmost-first matters: in `Holder::N` where a free const `N` is *also* indexed,
-`Holder` is the anchor and `N` is its associated const — not the other way
-round.
+Two spellings reach that number, and nothing else does:
 
 | Form | Status | Lowers to |
 |---|---|---|
-| `[u8; 4]`, `[u8; 16usize]` | supported | `Literal` |
-| `[u8; MAX]` — a `#[prebindgen]` const | supported | `SourceConst`, spelled `myflat::MAX` |
-| `[u8; Holder::N]` — an associated const | supported | `SourceConst`, `myflat::Holder::N`; segments after the item are kept |
-| `[u8; crate::MAX]`, `[u8; myflat::MAX]` | supported | Same value as the bare spelling |
-| `[u8; crate::limits::MAX]`, `[u8; myflat::limits::MAX]` | supported | Same value again — the intermediate module is dropped |
-| `[u8; crate::limits::Holder::N]` | supported | `myflat::Holder::N` |
-| `[u8; usize::MAX]`, `[u8; other_crate::X]` | supported | `ExternalConst`, verbatim |
-| `[u8; crate::limits::UNMARKED]` | **refused** | `UnresolvedSourcePath` — claims a source item, names none |
-| `[u8; <Holder>::N]`, `[u8; <Holder as Tr>::N]` | **refused** | `QualifiedSelf` |
-| `[u8; ::MAX]` | **refused** | `CrateRootPath` |
-| `[u8; A + 1]`, `[u8; -1]`, `[u8; A as usize]`, `[u8; (A)]` | **refused** | Const arithmetic is not in the language |
-| `[u8; array_len()]` | **refused** | A `const fn` call is not in the language |
-| `[u8; const { … }]`, `[u8; match … ]`, `[u8; if let … ]`, `[u8; \|\| 3]` | **refused** | Anything that can bind a name |
-| a non-integer or oversized literal | **refused** | |
+| `[u8; 4]`, `[u8; 16usize]` | supported | `Literal(4)` / `Literal(16)` |
+| `[u8; N]` where `#[prebindgen] pub const N: usize = 4;` | supported | `Const { name: N, value: 4 }` |
+| everything else | **refused** | see below |
 
-Everything refused for *shape* has the same fix: **hoist the value into a named
-`const`** and use that as the length. `UnresolvedSourcePath` has a different
-one: mark the intended item `#[prebindgen]`.
+Both carry the value; the const also keeps its name, for diagnostics. **Emission
+uses the number**, so no length is ever a path in generated code:
+`[u8; ARRAY_BYTES]` emits as `[u8; 4]`.
 
-### The `#[prebindgen]` trap
+Two consequences worth stating. A const length and the same number written
+literally are **one type and one converter** — they always were in Rust, and the
+frontend now agrees. And a changed const shows up in the diff of a committed
+generated artifact, where echoing the name would have shown nothing at all.
 
-A const used as a length must itself be marked `#[prebindgen]`:
+### What is refused, and why
+
+| Form | Reason |
+|---|---|
+| `[u8; MAX]` where `MAX` is not `#[prebindgen]` | `NotAMarkedConst` |
+| `[u8; N]` where `N`'s value is not an integer literal | `ConstIsNotALiteral` |
+| `[u8; N]` where `N` is marked in a *different* source crate | `ForeignSourceConst` |
+| `[u8; crate::limits::MAX]`, `[u8; myflat::MAX]`, `[u8; limits::MAX]` | `NotABareName` |
+| `[u8; Holder::N]` — an associated const | `NotABareName` |
+| `[u8; <Holder>::N]`, `[u8; <Holder as Tr>::N]` | `NotABareName` |
+| `[u8; usize::MAX]`, `[u8; ::MAX]`, `[u8; other_crate::X]` | `NotABareName` |
+| `[u8; A + 1]`, `[u8; -1]`, `[u8; A as usize]`, `[u8; (A)]` | `NotLiteralOrName` |
+| `[u8; array_len()]` | `NotLiteralOrName` |
+| `[u8; const { … }]`, `[u8; match … ]`, `[u8; if let … ]`, `[u8; \|\| 3]` | `NotLiteralOrName` |
+| a non-integer or oversized literal | `NotAnIntegerLiteral` / `IntegerOutOfRange` |
+
+**Only a bare name.** `#[prebindgen]` items live in one flat, uniquely named
+namespace, so the bare name is the item's complete address. Any longer path
+either restates that (`crate::limits::MAX`) or reaches somewhere the frontend
+cannot follow — a module it does not index, an `impl` block it never captured, a
+foreign crate. Neither can be reduced to a number, and guessing between them is
+how a length silently becomes the wrong one.
+
+This also removes a genuine ambiguity: without indexing modules, a relative
+`limits::MAX` is indistinguishable from an external crate path of the same
+shape.
+
+**Only your own crate's const.** Uniqueness holds across the *marked* namespace
+only. A source crate may have an unmarked `MAX` of its own and mean that one,
+while a chained source has a marked `MAX` — and the marked one is all the
+frontend can see. Resolving to it would silently change the length rather than
+fail, so a length must name a const from the item's own source crate.
+
+### The `#[prebindgen]` requirement
+
+A const used as an array length must itself be marked:
 
 ```rust
 #[prebindgen]
@@ -190,21 +178,18 @@ pub struct Arrays {
 }
 ```
 
-Without it the registry never indexes the const, and what happens depends on how
-the length was spelled:
-
-* **source-relative** (`crate::limits::UNMARKED`, `myflat::UNMARKED`) — a **hard
-  frontend error**. The path claims to name a source item and names none, so
-  there is nothing to qualify it with.
-* **bare** (`UNMARKED`) — indistinguishable from an external namespace, so it
-  lowers to `ExternalConst` and is emitted verbatim. The generated crate, which
-  is not the source crate, then fails to resolve it. This is the one remaining
-  quiet case; prefer the `crate::`-rooted spelling if you want the loud one.
+The generated crate sees **only** what the macro exposed. Without the attribute
+the const is never captured, so the frontend has no value to read and refuses
+the length outright — it is not a warning and not a downstream compile error.
 
 The const does **not** have to be declared to the binding: a length is a
-compile-time namespace, not part of any destination language's surface. The
+compile-time value, not part of any destination language's surface. The
 covertest fixture in `examples/perftest-flat/src/ext.rs` pins exactly this
 arrangement.
+
+Note the restriction is on **lengths**, not on consts. A `#[prebindgen] const`
+may be computed however you like; it just cannot be used as an array length
+unless its value is a plain integer literal.
 
 ### Why this one is closed
 
@@ -216,9 +201,10 @@ nothing tying them together. They disagreed eight times
 to qualify, emitting an unresolvable path into the generated crate.
 
 `lower_array_len` returns `Ok` only if the length was fully understood **and**
-fully resolved. "Accepted" therefore means "lowered", by construction, and a
-form the function does not lower is a form the language does not accept. There
-is no second list to drift from.
+reduced to a number. "Accepted" therefore means "lowered", by construction, and
+a form the function does not lower is a form the language does not accept. There
+is no second list to drift from — and because the result is a number, there is
+no path left to qualify and no namespace left to get wrong.
 
 ## Diagnostics
 

--- a/docs/source-language.md
+++ b/docs/source-language.md
@@ -1,0 +1,176 @@
+# The prebindgen source language
+
+Status: **partial specification**. Tracked by
+[#211](https://github.com/milyin/prebindgen/issues/211).
+
+This document states which Rust forms a `#[prebindgen]` source crate may use.
+It is the contract between the source crate and every generator: what a form
+*means* is decided once, by the frontend; how it *crosses a boundary* is decided
+per adapter.
+
+> **Read this first:** only the [array-length subgrammar](#array-lengths) has
+> actually moved into `core::frontend` so far. Every other row below records
+> where the decision is made *today*, which is often inside an adapter. #211
+> tracks moving them. Rows marked **frontend** are decided once and are
+> identical for every generator; rows marked with a site are not, and may differ
+> between C and JNI until they migrate.
+
+Anything not listed here is **unspecified**. A form that happens to work is not
+thereby part of the language, and the frontend may start refusing it.
+
+## Item kinds
+
+A `#[prebindgen]` attribute may be applied to:
+
+| Form | Status | Notes |
+|---|---|---|
+| `struct` with named fields | supported | The only struct shape whose fields are scanned. |
+| `struct` with unnamed fields (tuple struct) | indexed, fields not scanned | Usable as an opaque handle; its fields are not a boundary surface. |
+| `enum`, unit variants only | supported | |
+| `enum` with payload variants | adapter-dependent | See [`sum-types.md`](sum-types.md). |
+| `fn` | supported | Free functions only — see [Functions](#functions). |
+| `const` | supported | Also the only way to name a value in an [array length](#array-lengths). |
+| `union` | captured, not supported | Recorded by the proc-macro; no adapter lowers one. |
+| `type` alias | captured, not supported | Recorded; not resolved as a distinct type. |
+| anything else | passthrough | Emitted verbatim into the generated file, uninterpreted. |
+
+Names live in **one flat namespace** across every ingested source crate: two
+`#[prebindgen]` items with the same bare name are a hard error
+(`ScanError::DuplicateName`), whichever crates they came from.
+
+An unnamed `const _` passes through ungated — it is how the injected feature
+guard is emitted.
+
+## Functions
+
+Decided by `Registry::scan_fn_signature`
+(`prebindgen/src/api/core/registry.rs`).
+
+| Form | Status |
+|---|---|
+| free `fn` with ident parameters | supported |
+| a `self` receiver | **refused** — `ScanError::UnsupportedReceiver` |
+| a non-ident parameter pattern (`(a, b): (u8, u8)`) | **refused** — `ScanError::UnsupportedParamPattern` |
+| generic parameters / `where` clauses | unspecified |
+| `impl Fn(T, …) + Send + Sync + 'static` parameter | supported — the callback form |
+| any other `impl Trait` | **refused** — `ScanError::DisallowedImplTrait` |
+
+A source crate stays **plain idiomatic Rust**: values are returned by value,
+fallible calls return `Result<T, E>`, and there is no `#[repr(C)]`, no raw
+pointer plumbing, and no destination-language vocabulary. Lowering to a C ABI or
+to JNI is the adapter's job.
+
+## Types
+
+Type positions are walked by `immediate_subtype_positions`
+(`prebindgen/src/api/core/registry.rs`) and canonicalized at ingest by
+`types_util::normalize_type`.
+
+| Form | Status | Notes |
+|---|---|---|
+| path type (`Foo`, `Vec<u8>`, `Option<&T>`) | supported | |
+| reference (`&T`, `&mut T`) | supported | |
+| slice (`&[T]`) | supported | |
+| fixed-size array (`[T; N]`) | supported | Length: see [below](#array-lengths). |
+| tuple | supported | |
+| raw pointer | walked, adapter-dependent | |
+| `impl Fn(…)` | supported in a parameter position | |
+| any other `impl Trait` | refused | |
+| a path with a qualified self (`<T as Trait>::Assoc`) | left verbatim | Never normalized; its spelling is its identity. |
+
+### Path normalization
+
+`normalize_type` reduces a captured type path to one canonical spelling. The
+complete rule set is documented on that function; in summary:
+
+* `Group` / `Paren` wrappers unwrap;
+* a path headed by `crate` / `self`, or by an ingested source crate's module
+  name, reduces to its **final** segment (`crate::a::Foo<T>` ≡ `Foo<T>`);
+* a std-prelude path reduces to its bare form — exactly
+  `std|core|alloc :: vec::Vec | option::Option | result::Result | string::String
+  | boxed::Box`;
+* **nothing else** is touched. `std::ffi::CString` stays qualified, and an
+  unknown crate path (`zenoh::KeyExpr`) is never reduced — the registry has no
+  index of a foreign namespace, so `a::KeyExpr` and `b::KeyExpr` may be
+  genuinely distinct types.
+* Lifetimes are **not** normalized: `&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`.
+
+Because a declaration in `build.rs` is matched against the *normalized*
+spelling, declaring a source item with its crate path
+(`ptr_class!(myflat::Foo)`) is a hard error with a fix-it, not a silent miss.
+
+## Array lengths
+
+**Decided by the frontend** — `core::frontend::lower_array_len`. This is the
+only subgrammar with an executable acceptance matrix
+(`prebindgen/src/api/core/frontend/tests.rs`); it is closed, and both adapters
+consume the same `ArrayLen`.
+
+A length is a literal or a plain path, and nothing else:
+
+```rust
+enum ArrayLen {
+    Literal(usize),
+    SourceConst  { path },   // resolved to a #[prebindgen] item, stored absolute
+    ExternalConst { path },  // names nothing the registry indexes; emitted verbatim
+}
+```
+
+| Form | Status | Lowers to |
+|---|---|---|
+| `[u8; 4]`, `[u8; 16usize]` | supported | `Literal` |
+| `[u8; MAX]` — a `#[prebindgen]` const | supported | `SourceConst`, spelled `myflat::MAX` |
+| `[u8; Holder::N]` — an associated const | supported | `SourceConst`, spelled `myflat::Holder::N`; only the **owner** is qualified |
+| `[u8; crate::MAX]`, `[u8; myflat::MAX]` | supported | Same value as the bare spelling |
+| `[u8; usize::MAX]` | supported | `ExternalConst`, verbatim |
+| `[u8; <Holder>::N]`, `[u8; <Holder as Tr>::N]` | **refused** | `QualifiedSelf` |
+| `[u8; ::MAX]` | **refused** | `CrateRootPath` |
+| `[u8; A + 1]`, `[u8; -1]`, `[u8; A as usize]`, `[u8; (A)]` | **refused** | Const arithmetic is not in the language |
+| `[u8; array_len()]` | **refused** | A `const fn` call is not in the language |
+| `[u8; const { … }]`, `[u8; match … ]`, `[u8; if let … ]`, `[u8; \|\| 3]` | **refused** | Anything that can bind a name |
+| a non-integer or oversized literal | **refused** | |
+
+Everything refused has the same fix: **hoist the value into a named `const`**
+and use that as the length.
+
+### The `#[prebindgen]` trap
+
+A const used as a length must itself be marked `#[prebindgen]`:
+
+```rust
+#[prebindgen]
+pub const ARRAY_BYTES: usize = 4;   // ← the attribute is load-bearing
+
+#[prebindgen]
+pub struct Arrays {
+    pub bytes: [u8; ARRAY_BYTES],
+}
+```
+
+Without it the registry never indexes the const, so the length lowers to
+`ExternalConst` and is emitted **bare** — and the generated crate, which is not
+the source crate, cannot resolve it. The const does **not** have to be declared
+to the binding: a length is a compile-time namespace, not part of any
+destination language's surface. The covertest fixture in
+`examples/perftest-flat/src/ext.rs` pins exactly this arrangement.
+
+### Why this one is closed
+
+Acceptance used to be a *separate judgement* from qualification: a whitelist
+decided what was allowed and a rewriter decided what it could resolve, with
+nothing tying them together. They disagreed eight times
+([#210](https://github.com/milyin/prebindgen/issues/210)) — most sharply over
+`<Holder>::N`, which the whitelist accepted and the rewriter silently declined
+to qualify, emitting an unresolvable path into the generated crate.
+
+`lower_array_len` returns `Ok` only if the length was fully understood **and**
+fully resolved. "Accepted" therefore means "lowered", by construction, and a
+form the function does not lower is a form the language does not accept. There
+is no second list to drift from.
+
+## Diagnostics
+
+Source-language violations surface as `ScanError` from
+`Registry::from_items` — **before** any adapter runs, so every generator refuses
+the same input with the same message. A refused item leaves no partially
+rewritten model behind.

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -221,6 +221,11 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
  * `flags` is the one element type that is NOT a cast: a `jboolean` is a `u8`,
  * and reinterpreting an out-of-range byte as a Rust `bool` would be undefined
  * behavior, so the decode normalizes instead.
+ *
+ * `bytes` is deliberately sized by a named `const` ([`ARRAY_BYTES`]) rather
+ * than a literal: a length is a source-language fact, and the frontend must
+ * resolve it to a path the GENERATED crate can name. A literal would prove
+ * nothing about that.
  */
 public data class Arrays(val bytes: ByteArray, val shorts: ShortArray, val ints: IntArray, val longs: LongArray, val doubles: DoubleArray, val flags: BooleanArray, val raw: LongArray) {
     override fun equals(other: Any?): Boolean {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -223,9 +223,10 @@ public data class Annotated(val payload: Payload, val alternate: Payload?, val t
  * behavior, so the decode normalizes instead.
  *
  * `bytes` is deliberately sized by a named `const` ([`ARRAY_BYTES`]) rather
- * than a literal: a length is a source-language fact, and the frontend must
- * resolve it to a path the GENERATED crate can name. A literal would prove
- * nothing about that.
+ * than a literal: a length is a source-language fact the frontend has to
+ * evaluate, and only a named const exercises that. It emits as `[u8; 4]` —
+ * identical to the literal spelling, which is the point: one type, one
+ * converter, whichever way the source wrote it.
  */
 public data class Arrays(val bytes: ByteArray, val shorts: ShortArray, val ints: IntArray, val longs: LongArray, val doubles: DoubleArray, val flags: BooleanArray, val raw: LongArray) {
     override fun equals(other: Any?): Boolean {

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -751,6 +751,19 @@ fun main() {
             "wrong-length array must report a binding error, got: $lenErr"
         }
 
+        // `bytes` is `[u8; ARRAY_BYTES]` — sized by a `#[prebindgen]` const, not
+        // a literal. That this crate COMPILES is most of the check: the frontend
+        // resolved the length to `perftest_flat::ARRAY_BYTES`, a path the
+        // generated crate can name; a bare `ARRAY_BYTES` would not build here.
+        // The rest is that the resolved const still means 4 at runtime, so the
+        // length guard fires on 3 and passes on 4.
+        check(a2.bytes.size == 4) { "const-sized length must be 4, got ${a2.bytes.size}" }
+        var constLenErr: String? = null
+        arraysEcho(a1.copy(bytes = byteArrayOf(1, 2, 3))) { je -> constLenErr = je; a1 }
+        check(constLenErr?.contains("fixed-size array decode") == true) {
+            "wrong-length const-sized array must report a binding error, got: $constLenErr"
+        }
+
         // WHOLE-OBJECT input decode (`.jobject_input()`): the decoder reads each
         // field off the Kotlin object by JVM descriptor. A value-blob field's
         // slot is the wrapper class, not `[B` — reading the old descriptor threw

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -752,11 +752,11 @@ fun main() {
         }
 
         // `bytes` is `[u8; ARRAY_BYTES]` — sized by a `#[prebindgen]` const, not
-        // a literal. That this crate COMPILES is most of the check: the frontend
-        // resolved the length to `perftest_flat::ARRAY_BYTES`, a path the
-        // generated crate can name; a bare `ARRAY_BYTES` would not build here.
-        // The rest is that the resolved const still means 4 at runtime, so the
-        // length guard fires on 3 and passes on 4.
+        // a literal. The frontend EVALUATES that const at generation time, so
+        // the check is the value: if it read anything but 4, the round trip
+        // below would reject a 4-byte array and accept a 3-byte one. Nothing in
+        // the generated Rust names the const, which is why this has to be a
+        // runtime assertion rather than a source grep.
         check(a2.bytes.size == 4) { "const-sized length must be 4, got ${a2.bytes.size}" }
         var constLenErr: String? = null
         arraysEcho(a1.copy(bytes = byteArrayOf(1, 2, 3))) { je -> constLenErr = je; a1 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -510,7 +510,7 @@ pub(crate) unsafe fn Arrays_to_JObject_71120c08<'a>(
     v: perftest_flat::Arrays,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        let ___bytes: jni::objects::JObject = u8_4_to_JByteArray_39abedfa(
+        let ___bytes: jni::objects::JObject = u8_perftest_flat_ARRAY_BYTES_to_JByteArray_5c8f23fa(
                 env,
                 v.bytes.clone(),
             )?
@@ -989,10 +989,10 @@ pub(crate) unsafe fn JByteArray_to_u8_2_9ca14e44<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JByteArray_to_u8_4_39abedfa<'env, 'v>(
+pub(crate) unsafe fn JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JByteArray<'v>,
-) -> ::core::result::Result<[u8; 4], __JniErr> {
+) -> ::core::result::Result<[u8; perftest_flat::ARRAY_BYTES], __JniErr> {
     Ok({
         let __buf = env
             .convert_byte_array(v)
@@ -1001,14 +1001,14 @@ pub(crate) unsafe fn JByteArray_to_u8_4_39abedfa<'env, 'v>(
                     String,
                 >>::from(format!("fixed-size array decode: {}", e))
             })?;
-        let __arr: [u8; 4] = __buf
+        let __arr: [u8; perftest_flat::ARRAY_BYTES] = __buf
             .as_slice()
             .try_into()
             .map_err(|_| {
                 <__JniErr as ::core::convert::From<
                     String,
                 >>::from(
-                    "fixed-size array decode: `[u8 ; 4]` expects a different length"
+                    "fixed-size array decode: `[u8 ; perftest_flat :: ARRAY_BYTES]` expects a different length"
                         .to_string(),
                 )
             })?;
@@ -1290,7 +1290,10 @@ pub(crate) unsafe fn JObject_to_Arrays_71120c08<'env, 'v>(
                 String,
             >>::from(format!("Arrays.bytes: {}", e)))?;
         let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
-        let bytes = JByteArray_to_u8_4_39abedfa(env, &__bytes_raw)?;
+        let bytes = JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa(
+            env,
+            &__bytes_raw,
+        )?;
         let __shorts_jobj: jni::objects::JObject = env
             .get_field(v, "shorts", "[S")
             .and_then(|val| val.l())
@@ -8540,9 +8543,9 @@ pub(crate) unsafe fn u64_to_jlong_4384a5d6<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn u8_4_to_JByteArray_39abedfa<'a>(
+pub(crate) unsafe fn u8_perftest_flat_ARRAY_BYTES_to_JByteArray_5c8f23fa<'a>(
     env: &mut jni::JNIEnv<'a>,
-    v: [u8; 4],
+    v: [u8; perftest_flat::ARRAY_BYTES],
 ) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
     Ok({
         env.byte_array_from_slice(&v)
@@ -10609,7 +10612,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_arraysEcho<'a>(
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let __flat_a_bytes = match JByteArray_to_u8_4_39abedfa(&mut env, &a_bytes) {
+    let __flat_a_bytes = match JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa(
+        &mut env,
+        &a_bytes,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -10723,7 +10729,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_arraysEcho<'a>(
     const __CB_DESCR: &str = "([B[S[I[J[D[Z[J)Ljava/lang/Object;";
     let __out = perftest_flat::arrays_echo(a);
     let __obj0: jni::objects::JObject = {
-        let __enc0 = match u8_4_to_JByteArray_39abedfa(&mut env, __out.bytes.clone()) {
+        let __enc0 = match u8_perftest_flat_ARRAY_BYTES_to_JByteArray_5c8f23fa(
+            &mut env,
+            __out.bytes.clone(),
+        ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
                 signal_binding_error(

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -510,7 +510,7 @@ pub(crate) unsafe fn Arrays_to_JObject_71120c08<'a>(
     v: perftest_flat::Arrays,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        let ___bytes: jni::objects::JObject = u8_perftest_flat_ARRAY_BYTES_to_JByteArray_5c8f23fa(
+        let ___bytes: jni::objects::JObject = u8_4_to_JByteArray_39abedfa(
                 env,
                 v.bytes.clone(),
             )?
@@ -989,10 +989,10 @@ pub(crate) unsafe fn JByteArray_to_u8_2_9ca14e44<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa<'env, 'v>(
+pub(crate) unsafe fn JByteArray_to_u8_4_39abedfa<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JByteArray<'v>,
-) -> ::core::result::Result<[u8; perftest_flat::ARRAY_BYTES], __JniErr> {
+) -> ::core::result::Result<[u8; 4], __JniErr> {
     Ok({
         let __buf = env
             .convert_byte_array(v)
@@ -1001,14 +1001,14 @@ pub(crate) unsafe fn JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa<'env, '
                     String,
                 >>::from(format!("fixed-size array decode: {}", e))
             })?;
-        let __arr: [u8; perftest_flat::ARRAY_BYTES] = __buf
+        let __arr: [u8; 4] = __buf
             .as_slice()
             .try_into()
             .map_err(|_| {
                 <__JniErr as ::core::convert::From<
                     String,
                 >>::from(
-                    "fixed-size array decode: `[u8 ; perftest_flat :: ARRAY_BYTES]` expects a different length"
+                    "fixed-size array decode: `[u8 ; 4]` expects a different length"
                         .to_string(),
                 )
             })?;
@@ -1290,10 +1290,7 @@ pub(crate) unsafe fn JObject_to_Arrays_71120c08<'env, 'v>(
                 String,
             >>::from(format!("Arrays.bytes: {}", e)))?;
         let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
-        let bytes = JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa(
-            env,
-            &__bytes_raw,
-        )?;
+        let bytes = JByteArray_to_u8_4_39abedfa(env, &__bytes_raw)?;
         let __shorts_jobj: jni::objects::JObject = env
             .get_field(v, "shorts", "[S")
             .and_then(|val| val.l())
@@ -8543,9 +8540,9 @@ pub(crate) unsafe fn u64_to_jlong_4384a5d6<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn u8_perftest_flat_ARRAY_BYTES_to_JByteArray_5c8f23fa<'a>(
+pub(crate) unsafe fn u8_4_to_JByteArray_39abedfa<'a>(
     env: &mut jni::JNIEnv<'a>,
-    v: [u8; perftest_flat::ARRAY_BYTES],
+    v: [u8; 4],
 ) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
     Ok({
         env.byte_array_from_slice(&v)
@@ -10612,10 +10609,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_arraysEcho<'a>(
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let __flat_a_bytes = match JByteArray_to_u8_perftest_flat_ARRAY_BYTES_5c8f23fa(
-        &mut env,
-        &a_bytes,
-    ) {
+    let __flat_a_bytes = match JByteArray_to_u8_4_39abedfa(&mut env, &a_bytes) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -10729,10 +10723,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_arraysEcho<'a>(
     const __CB_DESCR: &str = "([B[S[I[J[D[Z[J)Ljava/lang/Object;";
     let __out = perftest_flat::arrays_echo(a);
     let __obj0: jni::objects::JObject = {
-        let __enc0 = match u8_perftest_flat_ARRAY_BYTES_to_JByteArray_5c8f23fa(
-            &mut env,
-            __out.bytes.clone(),
-        ) {
+        let __enc0 = match u8_4_to_JByteArray_39abedfa(&mut env, __out.bytes.clone()) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
                 signal_binding_error(

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -103,6 +103,14 @@ fn generate_ffi_bindings() -> PathBuf {
     cbindgen = cbindgen.enum_type(pq!(InsideFoo));
     cbindgen = cbindgen.data_struct(pq!(Foo));
 
+    // A fixed-size array field sized by a NAMED const. The header must carry the
+    // symbolic extent — `uint8_t tag[MARKER_TAG_LEN]` — which is why the
+    // frontend's model records what the source wrote rather than only its value.
+    // `MARKER_TAG_LEN` is never declared here: an extent is a compile-time
+    // value, not part of the C surface, so it must reach the header without the
+    // binding having to name it.
+    cbindgen = cbindgen.data_struct(pq!(Marker));
+
     // The history-replay callback signature -> a `closure_value_t` closure struct
     // (`.base_name` gives the otherwise `f64`-derived struct a descriptive name).
     cbindgen = cbindgen
@@ -126,6 +134,9 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(calculator_absorb),
         pq!(foo_new),
         pq!(foo_get_id),
+        // The const-sized array crossing both ways, by value.
+        pq!(marker_new),
+        pq!(marker_tag_sum),
         pq!(inside_foo_default),
         // The tagged union crossing OUT: constructed and returned. Nothing to
         // validate on this side — Rust always writes a live arm.

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -340,6 +340,37 @@ static void test_alias_preflight(void) {
     calculator_drop(merged);
 }
 
+/* A fixed-size array field sized by a NAMED const.
+ *
+ * The header must define `MARKER_TAG_LEN` and spell the field
+ * `uint8_t tag[MARKER_TAG_LEN]` — a symbolic extent is part of the C API's
+ * meaning, since it makes changing the size one edit rather than a hunt through
+ * literals. Most of this test is that it COMPILES: using the macro below would
+ * be an error if cbindgen had emitted `uint8_t tag[4]` with no `#define`, which
+ * is exactly what a path-aliased const produces.
+ *
+ * The rest is that the array crosses by value in both directions with no
+ * conversion — `[u8; N]` is already `#[repr(C)]`-compatible. */
+static void test_const_sized_array_field(void) {
+    marker_t m = marker_new(1, 2, 3, 4, 100);
+
+    /* The extent is the symbol, and the symbol is the right number. */
+    CHECK(sizeof(m.tag) == MARKER_TAG_LEN);
+    CHECK(MARKER_TAG_LEN == 4);
+
+    CHECK(m.tag[0] == 1);
+    CHECK(m.tag[3] == 4);
+    CHECK(m.weight == 100);
+
+    /* Back across by value: 1+2+3+4+100. */
+    CHECK(marker_tag_sum(m) == 110);
+
+    /* A C-side edit survives the round trip, so the bytes are really copied
+     * rather than the struct being rebuilt from somewhere else. */
+    m.tag[0] = 11;
+    CHECK(marker_tag_sum(m) == 120);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
@@ -350,6 +381,7 @@ int main(void) {
     test_out_of_domain_bool_data_struct_field();
     test_nested_union_payload();
     test_alias_preflight();
+    test_const_sized_array_field();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
@@ -357,6 +389,7 @@ int main(void) {
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
            "converter-derived payloads, out-of-domain bool payload and "
-           "data-struct field, nested union payload, alias preflight\n");
+           "data-struct field, nested union payload, alias preflight, "
+           "const-sized array field\n");
     return 0;
 }

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -68,6 +68,12 @@ pub struct foo_t {
     pub stable_field: u64,
 }
 #[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct marker_t {
+    pub tag: [u8; MARKER_TAG_LEN],
+    pub weight: u32,
+}
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum inside_foo_t {
@@ -236,6 +242,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     ::core::result::Result::Err(
         ::std::format!("invalid discriminant {} for `inside_foo_t`", __raw),
     )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Marker(v: marker_t) -> example_flat::Marker {
+    example_flat::Marker {
+        tag: v.tag,
+        weight: v.weight,
+    }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
@@ -453,7 +466,15 @@ pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_u32(v: u32) -> u32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_u8(v: u8) -> u8 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -492,6 +513,13 @@ pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Marker(v: example_flat::Marker) -> marker_t {
+    marker_t {
+        tag: v.tag,
+        weight: v.weight,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -563,7 +591,15 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_u32(v: u32) -> u32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_u8(v: u8) -> u8 {
     v
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
@@ -992,6 +1028,34 @@ pub unsafe extern "C" fn inside_foo_value(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn marker_new(
+    b0: u8,
+    b1: u8,
+    b2: u8,
+    b3: u8,
+    weight: u32,
+) -> marker_t {
+    let b0 = __cbg_in_u8(b0);
+    let b1 = __cbg_in_u8(b1);
+    let b2 = __cbg_in_u8(b2);
+    let b3 = __cbg_in_u8(b3);
+    let weight = __cbg_in_u32(weight);
+    let __v = example_flat::marker_new(b0, b1, b2, b3, weight);
+    let __ret: marker_t;
+    __ret = __cbg_out_Marker(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn marker_tag_sum(m: marker_t) -> u32 {
+    let m = __cbg_in_Marker(m);
+    let __v = example_flat::marker_tag_sum(m);
+    let __ret: u32;
+    __ret = __cbg_out_u32(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
     let n = match __cbg_in_Note(n) {
         ::core::result::Result::Ok(__v) => __v,
@@ -1204,6 +1268,13 @@ pub unsafe extern "C" fn shape_try_area(
         }
     }
 }
+/// Width of [`Marker::tag`] — a `#[prebindgen]` const used as an ARRAY EXTENT.
+///
+/// The value must be a plain integer literal: a generator runs in `build.rs`,
+/// where it cannot evaluate Rust, and the C header needs the number to define
+/// the symbol. Being `#[prebindgen]` is what makes it visible at all — the
+/// generated crate sees only what the macro exposed.
+pub const MARKER_TAG_LEN: usize = 4;
 const _: () = {
     konst::assertc_eq!(
         example_flat::FEATURES, "",

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -68,6 +68,12 @@ pub struct foo_t {
     pub stable_field: u64,
 }
 #[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct marker_t {
+    pub tag: [u8; MARKER_TAG_LEN],
+    pub weight: u32,
+}
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum inside_foo_t {
@@ -236,6 +242,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     ::core::result::Result::Err(
         ::std::format!("invalid discriminant {} for `inside_foo_t`", __raw),
     )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Marker(v: marker_t) -> example_flat::Marker {
+    example_flat::Marker {
+        tag: v.tag,
+        weight: v.weight,
+    }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
@@ -453,7 +466,15 @@ pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_u32(v: u32) -> u32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_in_u8(v: u8) -> u8 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -492,6 +513,13 @@ pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Marker(v: example_flat::Marker) -> marker_t {
+    marker_t {
+        tag: v.tag,
+        weight: v.weight,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -563,7 +591,15 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_u32(v: u32) -> u32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_u8(v: u8) -> u8 {
     v
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
@@ -992,6 +1028,34 @@ pub unsafe extern "C" fn inside_foo_value(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn marker_new(
+    b0: u8,
+    b1: u8,
+    b2: u8,
+    b3: u8,
+    weight: u32,
+) -> marker_t {
+    let b0 = __cbg_in_u8(b0);
+    let b1 = __cbg_in_u8(b1);
+    let b2 = __cbg_in_u8(b2);
+    let b3 = __cbg_in_u8(b3);
+    let weight = __cbg_in_u32(weight);
+    let __v = example_flat::marker_new(b0, b1, b2, b3, weight);
+    let __ret: marker_t;
+    __ret = __cbg_out_Marker(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn marker_tag_sum(m: marker_t) -> u32 {
+    let m = __cbg_in_Marker(m);
+    let __v = example_flat::marker_tag_sum(m);
+    let __ret: u32;
+    __ret = __cbg_out_u32(__v);
+    __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
     let n = match __cbg_in_Note(n) {
         ::core::result::Result::Ok(__v) => __v,
@@ -1204,6 +1268,13 @@ pub unsafe extern "C" fn shape_try_area(
         }
     }
 }
+/// Width of [`Marker::tag`] — a `#[prebindgen]` const used as an ARRAY EXTENT.
+///
+/// The value must be a plain integer literal: a generator runs in `build.rs`,
+/// where it cannot evaluate Rust, and the C header needs the number to define
+/// the symbol. Being `#[prebindgen]` is what makes it visible at all — the
+/// generated crate sees only what the macro exposed.
+pub const MARKER_TAG_LEN: usize = 4;
 const _: () = {
     konst::assertc_eq!(
         example_flat::FEATURES, "",

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -12,6 +12,16 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * Width of [`Marker::tag`] — a `#[prebindgen]` const used as an ARRAY EXTENT.
+ *
+ * The value must be a plain integer literal: a generator runs in `build.rs`,
+ * where it cannot evaluate Rust, and the C header needs the number to define
+ * the symbol. Being `#[prebindgen]` is what makes it visible at all — the
+ * generated crate sees only what the macro exposed.
+ */
+#define MARKER_TAG_LEN 4
+
 typedef enum operation_t {
   Add = 0,
   Sub = 1,
@@ -105,6 +115,11 @@ typedef struct foo_t {
   uint64_t stable_field;
 } foo_t;
 
+typedef struct marker_t {
+  uint8_t tag[MARKER_TAG_LEN];
+  uint32_t weight;
+} marker_t;
+
 extern void *malloc(uintptr_t size);
 
 extern void free(void *ptr);
@@ -158,6 +173,10 @@ struct foo_t foo_new(uint64_t id);
 enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
+
+struct marker_t marker_new(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3, uint32_t weight);
+
+uint32_t marker_tag_sum(struct marker_t m);
 
 bool note_emphatic(struct note_t n);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -12,6 +12,16 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * Width of [`Marker::tag`] — a `#[prebindgen]` const used as an ARRAY EXTENT.
+ *
+ * The value must be a plain integer literal: a generator runs in `build.rs`,
+ * where it cannot evaluate Rust, and the C header needs the number to define
+ * the symbol. Being `#[prebindgen]` is what makes it visible at all — the
+ * generated crate sees only what the macro exposed.
+ */
+#define MARKER_TAG_LEN 4
+
 typedef enum operation_t {
   Add = 0,
   Sub = 1,
@@ -105,6 +115,11 @@ typedef struct foo_t {
   uint64_t stable_field;
 } foo_t;
 
+typedef struct marker_t {
+  uint8_t tag[MARKER_TAG_LEN];
+  uint32_t weight;
+} marker_t;
+
 extern void *malloc(uintptr_t size);
 
 extern void free(void *ptr);
@@ -158,6 +173,10 @@ struct foo_t foo_new(uint64_t id);
 enum inside_foo_t inside_foo_default(void);
 
 int32_t inside_foo_value(enum inside_foo_t x);
+
+struct marker_t marker_new(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3, uint32_t weight);
+
+uint32_t marker_tag_sum(struct marker_t m);
 
 bool note_emphatic(struct note_t n);
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -491,3 +491,48 @@ pub fn inside_foo_default() -> InsideFoo {
 pub fn inside_foo_value(x: InsideFoo) -> i32 {
     x as i32
 }
+
+/// Width of [`Marker::tag`] — a `#[prebindgen]` const used as an ARRAY EXTENT.
+///
+/// The value must be a plain integer literal: a generator runs in `build.rs`,
+/// where it cannot evaluate Rust, and the C header needs the number to define
+/// the symbol. Being `#[prebindgen]` is what makes it visible at all — the
+/// generated crate sees only what the macro exposed.
+#[prebindgen]
+pub const MARKER_TAG_LEN: usize = 4;
+
+/// A data struct with a fixed-size array field, sized by a NAMED const.
+///
+/// The const spelling is the point. `tag` must surface in C as
+/// `uint8_t tag[MARKER_TAG_LEN]`, not `uint8_t tag[4]`: a symbolic extent is
+/// part of the API's meaning, because it makes changing the size one edit
+/// rather than a hunt through literals. Carrying that fact from the source to
+/// the header is what the frontend's typed model exists for — the adapter reads
+/// the extent as a decided fact, never by re-parsing Rust syntax.
+///
+/// `[u8; N]` is already `#[repr(C)]`-compatible, so the array is its own C wire
+/// and the field copies with no conversion. An array of `bool` deliberately is
+/// NOT supported: its domain is `0`/`1`, and a mirror is reinterpreted wholesale
+/// with no per-element hook to normalise what C wrote.
+#[prebindgen]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Marker {
+    pub tag: [u8; MARKER_TAG_LEN],
+    pub weight: u32,
+}
+
+/// Build a [`Marker`] from its bytes.
+#[prebindgen]
+pub fn marker_new(b0: u8, b1: u8, b2: u8, b3: u8, weight: u32) -> Marker {
+    Marker {
+        tag: [b0, b1, b2, b3],
+        weight,
+    }
+}
+
+/// Sum a [`Marker`]'s tag bytes (consumes it by value, so the array crosses
+/// both ways).
+#[prebindgen]
+pub fn marker_tag_sum(m: Marker) -> u32 {
+    m.tag.iter().map(|b| *b as u32).sum::<u32>() + m.weight
+}

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -753,16 +753,17 @@ pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut strin
 /// Width of [`Arrays::bytes`] — a `#[prebindgen]` const used as an ARRAY
 /// LENGTH.
 ///
-/// It is deliberately NOT declared to any binding: a length is a compile-time
-/// value, not part of a destination language's surface, so evaluating it must
-/// not depend on the binding exposing it. Being `#[prebindgen]` is what matters
-/// — the frontend reads the value from the captured item, and an unmarked const
-/// is not captured at all.
+/// It is deliberately NOT declared to any binding: an extent is a compile-time
+/// value, not something a binding has to name, so resolving it must not depend
+/// on the binding exposing it. Being `#[prebindgen]` is what matters — the
+/// frontend reads the value from the captured item, and an unmarked const is
+/// not captured at all.
 ///
 /// The value must be a plain integer literal. A generator runs in `build.rs`
-/// and cannot evaluate Rust, and a destination language that groups a small
-/// array into scalars needs the count as a number.
-pub const ARRAY_BYTES: usize = perftest_flat::ARRAY_BYTES;
+/// and cannot evaluate Rust; the JNI side needs the count as a number because
+/// Kotlin cannot reference a Rust const, and the C side needs it to define the
+/// symbol its headers spell the extent with.
+pub const ARRAY_BYTES: usize = 4;
 /// The storage capacity limit advertised to bindings (a primitive const).
 pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;
 /// The coverage surface's tag string (a string const).

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -750,6 +750,15 @@ pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut strin
     __ret = __cbg_out_String(__v);
     __ret
 }
+/// Width of [`Arrays::bytes`] — a `#[prebindgen]` const used as an ARRAY
+/// LENGTH.
+///
+/// It is deliberately NOT declared to any binding: a length is a compile-time
+/// namespace, not part of a destination language's surface, so resolving it
+/// must not depend on the binding exposing it. Being `#[prebindgen]` is what
+/// matters — an unmarked const is invisible to the registry, would be emitted
+/// bare, and would not resolve in the generated crate.
+pub const ARRAY_BYTES: usize = perftest_flat::ARRAY_BYTES;
 /// The storage capacity limit advertised to bindings (a primitive const).
 pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;
 /// The coverage surface's tag string (a string const).

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -754,10 +754,14 @@ pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut strin
 /// LENGTH.
 ///
 /// It is deliberately NOT declared to any binding: a length is a compile-time
-/// namespace, not part of a destination language's surface, so resolving it
-/// must not depend on the binding exposing it. Being `#[prebindgen]` is what
-/// matters — an unmarked const is invisible to the registry, would be emitted
-/// bare, and would not resolve in the generated crate.
+/// value, not part of a destination language's surface, so evaluating it must
+/// not depend on the binding exposing it. Being `#[prebindgen]` is what matters
+/// — the frontend reads the value from the captured item, and an unmarked const
+/// is not captured at all.
+///
+/// The value must be a plain integer literal. A generator runs in `build.rs`
+/// and cannot evaluate Rust, and a destination language that groups a small
+/// array into scalars needs the count as a number.
 pub const ARRAY_BYTES: usize = perftest_flat::ARRAY_BYTES;
 /// The storage capacity limit advertised to bindings (a primitive const).
 pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;

--- a/examples/perftest-c/include/perftest.h
+++ b/examples/perftest-c/include/perftest.h
@@ -12,7 +12,22 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-
+/**
+ * Width of [`Arrays::bytes`] — a `#[prebindgen]` const used as an ARRAY
+ * LENGTH.
+ *
+ * It is deliberately NOT declared to any binding: an extent is a compile-time
+ * value, not something a binding has to name, so resolving it must not depend
+ * on the binding exposing it. Being `#[prebindgen]` is what matters — the
+ * frontend reads the value from the captured item, and an unmarked const is
+ * not captured at all.
+ *
+ * The value must be a plain integer literal. A generator runs in `build.rs`
+ * and cannot evaluate Rust; the JNI side needs the count as a number because
+ * Kotlin cannot reference a Rust const, and the C side needs it to define the
+ * symbol its headers spell the extent with.
+ */
+#define ARRAY_BYTES 4
 
 
 

--- a/examples/perftest-c/include/perftest.h
+++ b/examples/perftest-c/include/perftest.h
@@ -14,6 +14,8 @@
 
 
 
+
+
 typedef struct payload_handler_t {
   uint8_t _private[0];
 } payload_handler_t;

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -369,10 +369,14 @@ pub fn blob_value_new(secs: i64, id: Vec<u8>, chunks: Vec<Vec<u8>>) -> BlobValue
 /// LENGTH.
 ///
 /// It is deliberately NOT declared to any binding: a length is a compile-time
-/// namespace, not part of a destination language's surface, so resolving it
-/// must not depend on the binding exposing it. Being `#[prebindgen]` is what
-/// matters — an unmarked const is invisible to the registry, would be emitted
-/// bare, and would not resolve in the generated crate.
+/// value, not part of a destination language's surface, so evaluating it must
+/// not depend on the binding exposing it. Being `#[prebindgen]` is what matters
+/// — the frontend reads the value from the captured item, and an unmarked const
+/// is not captured at all.
+///
+/// The value must be a plain integer literal. A generator runs in `build.rs`
+/// and cannot evaluate Rust, and a destination language that groups a small
+/// array into scalars needs the count as a number.
 #[prebindgen]
 pub const ARRAY_BYTES: usize = 4;
 
@@ -388,9 +392,10 @@ pub const ARRAY_BYTES: usize = 4;
 /// behavior, so the decode normalizes instead.
 ///
 /// `bytes` is deliberately sized by a named `const` ([`ARRAY_BYTES`]) rather
-/// than a literal: a length is a source-language fact, and the frontend must
-/// resolve it to a path the GENERATED crate can name. A literal would prove
-/// nothing about that.
+/// than a literal: a length is a source-language fact the frontend has to
+/// evaluate, and only a named const exercises that. It emits as `[u8; 4]` —
+/// identical to the literal spelling, which is the point: one type, one
+/// converter, whichever way the source wrote it.
 #[prebindgen]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Arrays {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -368,15 +368,16 @@ pub fn blob_value_new(secs: i64, id: Vec<u8>, chunks: Vec<Vec<u8>>) -> BlobValue
 /// Width of [`Arrays::bytes`] — a `#[prebindgen]` const used as an ARRAY
 /// LENGTH.
 ///
-/// It is deliberately NOT declared to any binding: a length is a compile-time
-/// value, not part of a destination language's surface, so evaluating it must
-/// not depend on the binding exposing it. Being `#[prebindgen]` is what matters
-/// — the frontend reads the value from the captured item, and an unmarked const
-/// is not captured at all.
+/// It is deliberately NOT declared to any binding: an extent is a compile-time
+/// value, not something a binding has to name, so resolving it must not depend
+/// on the binding exposing it. Being `#[prebindgen]` is what matters — the
+/// frontend reads the value from the captured item, and an unmarked const is
+/// not captured at all.
 ///
 /// The value must be a plain integer literal. A generator runs in `build.rs`
-/// and cannot evaluate Rust, and a destination language that groups a small
-/// array into scalars needs the count as a number.
+/// and cannot evaluate Rust; the JNI side needs the count as a number because
+/// Kotlin cannot reference a Rust const, and the C side needs it to define the
+/// symbol its headers spell the extent with.
 #[prebindgen]
 pub const ARRAY_BYTES: usize = 4;
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -365,6 +365,17 @@ pub fn blob_value_new(secs: i64, id: Vec<u8>, chunks: Vec<Vec<u8>>) -> BlobValue
     }
 }
 
+/// Width of [`Arrays::bytes`] — a `#[prebindgen]` const used as an ARRAY
+/// LENGTH.
+///
+/// It is deliberately NOT declared to any binding: a length is a compile-time
+/// namespace, not part of a destination language's surface, so resolving it
+/// must not depend on the binding exposing it. Being `#[prebindgen]` is what
+/// matters — an unmarked const is invisible to the registry, would be emitted
+/// bare, and would not resolve in the generated crate.
+#[prebindgen]
+pub const ARRAY_BYTES: usize = 4;
+
 /// Fixed-size arrays of every JNI-primitive element type.
 ///
 /// Each crosses as the matching Kotlin primitive array — bulk-copied, nothing
@@ -375,10 +386,15 @@ pub fn blob_value_new(secs: i64, id: Vec<u8>, chunks: Vec<Vec<u8>>) -> BlobValue
 /// `flags` is the one element type that is NOT a cast: a `jboolean` is a `u8`,
 /// and reinterpreting an out-of-range byte as a Rust `bool` would be undefined
 /// behavior, so the decode normalizes instead.
+///
+/// `bytes` is deliberately sized by a named `const` ([`ARRAY_BYTES`]) rather
+/// than a literal: a length is a source-language fact, and the frontend must
+/// resolve it to a path the GENERATED crate can name. A literal would prove
+/// nothing about that.
 #[prebindgen]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Arrays {
-    pub bytes: [u8; 4],
+    pub bytes: [u8; ARRAY_BYTES],
     pub shorts: [i16; 2],
     pub ints: [i32; 3],
     pub longs: [i64; 2],

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -31,6 +31,7 @@
 //! in `docs/source-language.md` are still classified at their use sites.
 
 mod array_len;
+pub mod model;
 
 #[cfg(test)]
 mod tests;

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -36,6 +36,6 @@ mod array_len;
 mod tests;
 
 pub use self::array_len::{
-    lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ArrayLenResolver, NameIndex,
-    UnsupportedArrayLen,
+    lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ArrayLenResolver, ItemRole,
+    NameIndex, UnsupportedArrayLen,
 };

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -35,7 +35,7 @@ mod array_len;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use self::array_len::{resolve_array_lengths, ArrayLen, ConstIndex};
+pub(crate) use self::array_len::{resolve_array_lengths, ConstIndex};
 /// The frontend's **public** surface is the diagnostics — what a caller has to
 /// handle. The decided values are read from the registry
 /// ([`Registry::array_len`](crate::api::core::registry::Registry::array_len)),
@@ -49,8 +49,8 @@ pub(crate) use self::array_len::{resolve_array_lengths, ArrayLen, ConstIndex};
 /// callers a second, unvalidated route to a `SourceModel` — the very thing #211
 /// exists to prevent.
 ///
-/// [`ArrayLen`] is crate-private for a sharper reason: it models ONE
-/// OCCURRENCE, including which spelling produced it, and there is no public
-/// table it could be handed out through without a key that has already
-/// collapsed the spellings.
+/// A length's decided model is a bare `usize`. Which spelling produced it —
+/// `[u8; A]` versus `[u8; 4]` — is deliberately not carried; see
+/// `array_len::len_expr` for that policy and where provenance would go if it
+/// were ever wanted.
 pub use self::array_len::{ArrayLenReason, UnsupportedArrayLen};

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -26,9 +26,16 @@
 //!
 //! ## Scope today
 //!
-//! Only the fixed-size-array length subgrammar has moved here so far
-//! ([`array_len`]); issue #211 tracks migrating the rest. Constructs not listed
-//! in `docs/source-language.md` are still classified at their use sites.
+//! * [`array_len`] — the fixed-size-array length subgrammar.
+//! * [`model`] — a closed [`SourceType`](model::SourceType) covering the type
+//!   grammar in `docs/source-language.md`, plus
+//!   [`SourceStruct`](model::SourceStruct) for indexed structs. A struct
+//!   field's `syn` type is written from the model, so the model is authoritative
+//!   and the syntax is a projection of it.
+//!
+//! Functions and enums still keep their `syn` items, and every adapter except
+//! cbindgen's struct-field path still classifies types at its use site. Issue
+//! #211 tracks migrating the rest.
 
 mod array_len;
 pub mod model;
@@ -50,8 +57,10 @@ pub(crate) use self::array_len::{resolve_array_lengths, ConstIndex};
 /// callers a second, unvalidated route to a `SourceModel` — the very thing #211
 /// exists to prevent.
 ///
-/// A length's decided model is a bare `usize`. Which spelling produced it —
-/// `[u8; A]` versus `[u8; 4]` — is deliberately not carried; see
-/// `array_len::len_expr` for that policy and where provenance would go if it
-/// were ever wanted.
+/// A length's decided model is an
+/// [`ArrayExtent`](model::ArrayExtent): its **value**, and which const — if any
+/// — the use site named. The value is what a type-keyed table stores, since
+/// equal-valued lengths are one Rust type; the spelling lives on the use site
+/// in [`SourceStruct`](model::SourceStruct), which is what lets a C header emit
+/// `uint8_t tag[MARKER_TAG_LEN]`.
 pub use self::array_len::{ArrayLenReason, UnsupportedArrayLen};

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -35,15 +35,22 @@ mod array_len;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use self::array_len::{resolve_array_lengths, ConstIndex};
-/// The frontend's **public** surface is the decided model and its diagnostics —
-/// what a consumer of the IR needs.
+pub(crate) use self::array_len::{resolve_array_lengths, ArrayLen, ConstIndex};
+/// The frontend's **public** surface is the diagnostics — what a caller has to
+/// handle. The decided values are read from the registry
+/// ([`Registry::array_len`](crate::api::core::registry::Registry::array_len)),
+/// not from here.
 ///
 /// Lowering itself is crate-private on purpose. The entry point is
 /// [`Registry::from_items`](crate::api::core::registry::Registry::from_items),
 /// which runs the frontend over the whole stream; there is no supported way to
 /// lower one construct in isolation, because the decisions need the complete
-/// name index and the item's origin. Exposing the machinery would offer callers
-/// a second, unvalidated route to a `SourceModel` — the very thing #211 exists
-/// to prevent.
-pub use self::array_len::{ArrayLen, ArrayLenReason, UnsupportedArrayLen};
+/// const index and the item's origin. Exposing the machinery would offer
+/// callers a second, unvalidated route to a `SourceModel` — the very thing #211
+/// exists to prevent.
+///
+/// [`ArrayLen`] is crate-private for a sharper reason: it models ONE
+/// OCCURRENCE, including which spelling produced it, and there is no public
+/// table it could be handed out through without a key that has already
+/// collapsed the spellings.
+pub use self::array_len::{ArrayLenReason, UnsupportedArrayLen};

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -35,7 +35,15 @@ mod array_len;
 #[cfg(test)]
 mod tests;
 
-pub use self::array_len::{
-    lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ArrayLenResolver, ItemRole,
-    NameIndex, UnsupportedArrayLen,
-};
+pub(crate) use self::array_len::{resolve_array_lengths, ConstIndex};
+/// The frontend's **public** surface is the decided model and its diagnostics —
+/// what a consumer of the IR needs.
+///
+/// Lowering itself is crate-private on purpose. The entry point is
+/// [`Registry::from_items`](crate::api::core::registry::Registry::from_items),
+/// which runs the frontend over the whole stream; there is no supported way to
+/// lower one construct in isolation, because the decisions need the complete
+/// name index and the item's origin. Exposing the machinery would offer callers
+/// a second, unvalidated route to a `SourceModel` — the very thing #211 exists
+/// to prevent.
+pub use self::array_len::{ArrayLen, ArrayLenReason, UnsupportedArrayLen};

--- a/prebindgen/src/api/core/frontend.rs
+++ b/prebindgen/src/api/core/frontend.rs
@@ -1,0 +1,41 @@
+//! The Rust frontend: the single authority for what captured `#[prebindgen]`
+//! source **means**.
+//!
+//! Everything downstream of this module — the registry's planning phases and
+//! every language adapter — consumes the frontend's decisions rather than the
+//! captured syntax. An adapter chooses how a value crosses ITS boundary and
+//! how it appears in the destination language; it does not get to decide what
+//! the source Rust means, or whether its spelling is allowed.
+//!
+//! The accepted subset is written down in `docs/source-language.md`.
+//!
+//! ## Why one walk per construct
+//!
+//! The frontend's rule is that **validation is a consequence of lowering**, not
+//! a separate judgement. For each source construct there is one fallible
+//! function from captured syntax to a closed representation; a form it cannot
+//! lower is, by construction, a form the language does not accept.
+//!
+//! That is not a stylistic preference. Array lengths previously had two
+//! independent walks — a whitelist deciding what was accepted and a rewriter
+//! deciding what it could qualify — with nothing tying them together. They
+//! disagreed eight times (issue #210), most sharply over `[u8; <Holder>::N]`,
+//! which the whitelist accepted and the rewriter silently declined to qualify,
+//! emitting a path the generated crate cannot resolve. With one walk that shape
+//! is not representable.
+//!
+//! ## Scope today
+//!
+//! Only the fixed-size-array length subgrammar has moved here so far
+//! ([`array_len`]); issue #211 tracks migrating the rest. Constructs not listed
+//! in `docs/source-language.md` are still classified at their use sites.
+
+mod array_len;
+
+#[cfg(test)]
+mod tests;
+
+pub use self::array_len::{
+    lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ArrayLenResolver, NameIndex,
+    UnsupportedArrayLen,
+};

--- a/prebindgen/src/api/core/frontend/array_len.rs
+++ b/prebindgen/src/api/core/frontend/array_len.rs
@@ -8,22 +8,14 @@ use std::{collections::HashMap, fmt};
 
 use quote::ToTokens;
 
-/// A fixed-size array's length, after the frontend has decided it.
+/// A fixed-size array's length is **a number, and nothing else** — that is the
+/// decided model, and `usize` is its whole representation.
 ///
-/// **This models one OCCURRENCE, not a type.** It records which spelling was
-/// written, which is a property of the use site — `[u8; A]` and `[u8; 4]` are
-/// the same Rust type and the same [`TypeKey`](crate::api::core::TypeKey) when
-/// `A == 4`, so a table keyed by type cannot carry this without its answer
-/// depending on which occurrence was stored last. That is why the registry's
-/// type-keyed table holds a bare `usize` and this stays crate-private: source-
-/// use provenance belongs to a per-use model (issue #211's `SourceModel`).
-///
-/// **A length is always a known number.** That is the whole design: a binding
-/// generator runs in `build.rs`, where it cannot evaluate arbitrary Rust, and
-/// some destination languages cannot reference a Rust const at all — a Kotlin
-/// surface that groups a small array into scalars needs the count literally.
-/// A length that the frontend cannot reduce to a `usize` is therefore not a
-/// length prebindgen accepts.
+/// A binding generator runs in `build.rs`, where it cannot evaluate arbitrary
+/// Rust, and some destination languages cannot reference a Rust const at all —
+/// a surface that groups a small array into scalars needs the count literally.
+/// A length the frontend cannot reduce to a `usize` is therefore not a length
+/// prebindgen accepts.
 ///
 /// Two spellings reach that number, and nothing else does:
 ///
@@ -32,41 +24,30 @@ use quote::ToTokens;
 ///   integer literal — `[u8; ARRAY_BYTES]` where
 ///   `#[prebindgen] pub const ARRAY_BYTES: usize = 4`.
 ///
-/// Both carry the value; the const also keeps its name, for diagnostics at the
-/// site that lowered it. Emission uses the number
-/// ([`ArrayLen::to_expr`]), so no length is ever a path in generated code and
-/// there is nothing to qualify — the class of defect that produced issues #209
-/// and #210 is gone rather than fixed.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ArrayLen {
-    /// Written as an integer literal.
-    Literal(usize),
-    /// Written as the bare name of a `#[prebindgen]` const, evaluated here.
-    Const { name: syn::Ident, value: usize },
-}
-
-impl ArrayLen {
-    /// The number of elements. Total — every accepted length has one.
-    pub(crate) fn value(&self) -> usize {
-        match self {
-            ArrayLen::Literal(n) => *n,
-            ArrayLen::Const { value, .. } => *value,
-        }
-    }
-
-    /// The length as it is spelled in generated code: always the literal.
-    ///
-    /// Emitting the number rather than the const path is what makes a length
-    /// independent of the generated crate's namespace. It also makes a changed
-    /// const **visible** in the diff of a committed generated artifact, where
-    /// echoing the name would have shown nothing at all.
-    pub(crate) fn to_expr(&self) -> syn::Expr {
-        let lit = syn::LitInt::new(&self.value().to_string(), proc_macro2::Span::call_site());
-        syn::Expr::Lit(syn::ExprLit {
-            attrs: Vec::new(),
-            lit: syn::Lit::Int(lit),
-        })
-    }
+/// # The spelling is deliberately discarded
+///
+/// This is a **frontend policy decision**, not a consequence of Rust's type
+/// equality, so it is stated rather than assumed: which spelling a use site
+/// wrote is not part of an array's meaning, and no adapter is offered it.
+///
+/// `[u8; A]` and `[u8; B]` with `A == B == 4` are one Rust type, one `TypeKey`
+/// and one converter. Letting an adapter render them differently would mean two
+/// destination representations for a single Rust type, which the type-keyed
+/// converter table cannot express — so the capability would be incoherent here
+/// even if the provenance were carried.
+///
+/// The cost is real and bounded: a C header cannot echo `uint8_t x[MAX_SIZE]`,
+/// only `uint8_t x[16]`. If that becomes wanted, provenance must be keyed by
+/// **use site** — field, parameter, return — in issue #211's per-use
+/// `SourceModel`, never by `TypeKey`, which has already collapsed the spellings.
+/// Reintroducing a name into any type-keyed table makes the stored answer depend
+/// on which occurrence was seen last.
+fn len_expr(n: usize) -> syn::Expr {
+    let lit = syn::LitInt::new(&n.to_string(), proc_macro2::Span::call_site());
+    syn::Expr::Lit(syn::ExprLit {
+        attrs: Vec::new(),
+        lit: syn::Lit::Int(lit),
+    })
 }
 
 /// A length the prebindgen source language does not accept.
@@ -246,7 +227,7 @@ pub(crate) fn lower_array_len(
     array: &str,
     item_crate: Option<&str>,
     consts: &ConstIndex,
-) -> Result<ArrayLen, UnsupportedArrayLen> {
+) -> Result<usize, UnsupportedArrayLen> {
     let fail = |reason| UnsupportedArrayLen {
         array: array.to_string(),
         offending: len.to_token_stream().to_string(),
@@ -254,7 +235,7 @@ pub(crate) fn lower_array_len(
     };
     match len {
         syn::Expr::Lit(_) => match int_literal(len) {
-            Some(n) => Ok(ArrayLen::Literal(n)),
+            Some(n) => Ok(n),
             None => Err(fail(match len {
                 // Told apart so an out-of-range integer does not report as
                 // "not an integer".
@@ -272,8 +253,10 @@ pub(crate) fn lower_array_len(
             {
                 return Err(fail(ArrayLenReason::NotABareName));
             }
-            let name = ep.path.segments[0].ident.clone();
-            let Some(entry) = consts.consts.get(&name.to_string()) else {
+            // Only the const's VALUE leaves this function; which name carried
+            // it is not part of the length. See `len_expr` for why that is a
+            // stated policy rather than an omission.
+            let Some(entry) = consts.consts.get(&ep.path.segments[0].ident.to_string()) else {
                 return Err(fail(ArrayLenReason::NotAMarkedConst));
             };
             // Provenance before value: a same-named const from another source
@@ -288,7 +271,7 @@ pub(crate) fn lower_array_len(
             let Some(value) = entry.value else {
                 return Err(fail(ArrayLenReason::ConstIsNotALiteral));
             };
-            Ok(ArrayLen::Const { name, value })
+            Ok(value)
         }
         _ => Err(fail(ArrayLenReason::NotLiteralOrName)),
     }
@@ -301,7 +284,7 @@ pub(crate) fn lower_array_len(
 pub(crate) struct ArrayLenResolver<'a> {
     consts: &'a ConstIndex,
     item_crate: Option<&'a str>,
-    found: Vec<(syn::Type, ArrayLen)>,
+    found: Vec<(syn::Type, usize)>,
     error: Option<UnsupportedArrayLen>,
 }
 
@@ -318,7 +301,7 @@ impl<'a> ArrayLenResolver<'a> {
     /// The `(array type, length)` pairs found in walk order — array types in
     /// their rewritten spelling — or the first length that could not be
     /// lowered.
-    pub(crate) fn finish(self) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
+    pub(crate) fn finish(self) -> Result<Vec<(syn::Type, usize)>, UnsupportedArrayLen> {
         match self.error {
             Some(e) => Err(e),
             None => Ok(self.found),
@@ -340,7 +323,7 @@ impl syn::visit_mut::VisitMut for ArrayLenResolver<'_> {
         let rendered = arr.to_token_stream().to_string();
         match lower_array_len(&arr.len, &rendered, self.item_crate, self.consts) {
             Ok(len) => {
-                arr.len = len.to_expr();
+                arr.len = len_expr(len);
                 self.found.push((syn::Type::Array(arr.clone()), len));
             }
             Err(e) => self.error = Some(e),
@@ -365,7 +348,7 @@ pub(crate) fn resolve_array_lengths<T: Clone>(
     consts: &ConstIndex,
     item_crate: Option<&str>,
     visit: impl FnOnce(&mut ArrayLenResolver<'_>, &mut T),
-) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
+) -> Result<Vec<(syn::Type, usize)>, UnsupportedArrayLen> {
     let mut candidate = node.clone();
     let mut resolver = ArrayLenResolver::new(consts, item_crate);
     visit(&mut resolver, &mut candidate);

--- a/prebindgen/src/api/core/frontend/array_len.rs
+++ b/prebindgen/src/api/core/frontend/array_len.rs
@@ -1,8 +1,8 @@
 //! The fixed-size-array length subgrammar: one closed representation and one
 //! fallible walk that produces it.
 //!
-//! See the module docs of [`super`] for why acceptance and rewriting are the
-//! same operation here.
+//! See the module docs of [`super`] for why acceptance and lowering are the same
+//! operation here.
 
 use std::{collections::HashMap, fmt};
 
@@ -10,73 +10,61 @@ use quote::ToTokens;
 
 /// A fixed-size array's length, after the frontend has decided it.
 ///
-/// This is the ONLY representation of a length downstream — qualification,
-/// planning, and both language adapters read this rather than the captured
-/// `syn::Expr`. The set of variants IS the accepted subgrammar: a length that
-/// cannot be lowered to one of them is refused before any adapter runs.
+/// **A length is always a known number.** That is the whole design: a binding
+/// generator runs in `build.rs`, where it cannot evaluate arbitrary Rust, and
+/// some destination languages cannot reference a Rust const at all — a Kotlin
+/// surface that groups a small array into scalars needs the count literally.
+/// A length that the frontend cannot reduce to a `usize` is therefore not a
+/// length prebindgen accepts.
 ///
-/// The grammar is deliberately flat and non-recursive. Const arithmetic
-/// (`[u8; A + 1]`), casts (`[u8; A as usize]`), and `const fn` calls
-/// (`[u8; array_len()]`) are NOT part of the prebindgen language — hoist the
-/// value into a named `const` and use that as the length.
+/// Two spellings reach that number, and nothing else does:
+///
+/// * an integer literal — `[u8; 4]`;
+/// * the **bare name** of a `#[prebindgen]` const whose own initializer is an
+///   integer literal — `[u8; ARRAY_BYTES]` where
+///   `#[prebindgen] pub const ARRAY_BYTES: usize = 4`.
+///
+/// Both carry the value; the const also keeps its name, for diagnostics and for
+/// generators that want to echo it. Emission uses the number
+/// ([`ArrayLen::to_expr`]), so no length is ever a path in generated code and
+/// there is nothing to qualify — the class of defect that produced issues #209
+/// and #210 is gone rather than fixed.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ArrayLen {
-    /// An integer literal — `[u8; 4]`.
+    /// Written as an integer literal.
     Literal(usize),
-    /// A path naming a `#[prebindgen]` item, stored **absolute**: the item's
-    /// origin module replaces whatever module prefix the source wrote, so the
-    /// length resolves in the generated crate.
-    ///
-    /// Replacing rather than preserving the prefix is sound because prebindgen
-    /// items live in one flat, uniquely-named namespace and are reachable as
-    /// `<origin crate>::<bare name>` — the same invariant `normalize_type`
-    /// already relies on for types. So every spelling of one item collapses to
-    /// one value:
-    ///
-    /// * `MAX`, `crate::MAX`, `myflat::MAX`, `crate::limits::MAX` →
-    ///   `myflat::MAX`;
-    /// * `Holder::N`, `crate::limits::Holder::N` → `myflat::Holder::N`, where
-    ///   the segments AFTER the item are relative to it and are kept.
-    SourceConst { path: syn::Path },
-    /// A path that does not name anything in a source crate — `usize::MAX`,
-    /// `u8::BITS`, a foreign crate's path. Emitted **verbatim**, exactly as
-    /// written: there is no origin module to prefix, and rewriting it would be
-    /// a guess.
-    ///
-    /// A `#[prebindgen]`-less const referred to by its bare name lands here and
-    /// will not resolve in the generated crate. Mark it `#[prebindgen]` so the
-    /// registry indexes it. (Referred to *source-relatively* —
-    /// `crate::limits::UNMARKED` — it is a hard error instead; see
-    /// [`ArrayLenReason::UnresolvedSourcePath`].)
-    ExternalConst { path: syn::Path },
+    /// Written as the bare name of a `#[prebindgen]` const, evaluated here.
+    Const { name: syn::Ident, value: usize },
 }
 
 impl ArrayLen {
-    /// The length as it must be spelled in generated code.
-    pub fn to_expr(&self) -> syn::Expr {
+    /// The number of elements. Total — every accepted length has one.
+    pub fn value(&self) -> usize {
         match self {
-            ArrayLen::Literal(n) => {
-                let lit = syn::LitInt::new(&n.to_string(), proc_macro2::Span::call_site());
-                syn::Expr::Lit(syn::ExprLit {
-                    attrs: Vec::new(),
-                    lit: syn::Lit::Int(lit),
-                })
-            }
-            ArrayLen::SourceConst { path } | ArrayLen::ExternalConst { path } => {
-                syn::Expr::Path(syn::ExprPath {
-                    attrs: Vec::new(),
-                    qself: None,
-                    path: path.clone(),
-                })
-            }
+            ArrayLen::Literal(n) => *n,
+            ArrayLen::Const { value, .. } => *value,
         }
+    }
+
+    /// The length as it is spelled in generated code: always the literal.
+    ///
+    /// Emitting the number rather than the const path is what makes a length
+    /// independent of the generated crate's namespace. It also makes a changed
+    /// const **visible** in the diff of a committed generated artifact, where
+    /// echoing the name would have shown nothing at all.
+    pub fn to_expr(&self) -> syn::Expr {
+        let lit = syn::LitInt::new(&self.value().to_string(), proc_macro2::Span::call_site());
+        syn::Expr::Lit(syn::ExprLit {
+            attrs: Vec::new(),
+            lit: syn::Lit::Int(lit),
+        })
     }
 }
 
 /// A length the prebindgen source language does not accept.
 ///
-/// Names the offending sub-expression, not just the array type: the whole point
-/// of the single walk is that it knows exactly which part it could not lower.
+/// Names the offending sub-expression, not just the array: the point of the
+/// single walk is that it knows exactly which part it could not lower.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnsupportedArrayLen {
     /// The array type as written, for context — `[u8 ; A + 1]`.
@@ -88,58 +76,92 @@ pub struct UnsupportedArrayLen {
 }
 
 /// Why [`lower_array_len`] refused a length.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ArrayLenReason {
-    /// Not a literal or a plain path: arithmetic, a cast, a call, a block, a
-    /// `match`, a closure — anything with structure the grammar does not have.
-    NotLiteralOrPath,
+    /// Not a literal and not a plain name: arithmetic, a cast, a call, a block,
+    /// a `match`, a closure — anything with structure the grammar lacks.
+    NotLiteralOrName,
     /// A literal that is not a non-negative integer.
     NotAnIntegerLiteral,
     /// An integer literal too large for `usize`.
     IntegerOutOfRange,
-    /// A path with a qualified self — `<Holder>::N`, `<Holder as Trait>::N`.
-    /// The owner is a type, not a path segment, so there is no leading segment
-    /// to resolve against the source namespace.
-    QualifiedSelf,
-    /// A path rooted at the crate root — `::MAX`. In the generated crate that
-    /// names a dependency of the CONSUMER, which the frontend cannot see.
-    CrateRootPath,
-    /// A **source-relative** path — one headed by `crate` / `self` / a source
-    /// crate's module — none of whose segments names a `#[prebindgen]` item.
+    /// A path with more than one segment, a qualified self, or a leading `::` —
+    /// `crate::limits::MAX`, `usize::MAX`, `<Holder>::N`, `::MAX`.
     ///
-    /// It claims to name something in the source crate, so it cannot be
-    /// emitted verbatim: the generated crate is a different crate, where the
-    /// same spelling resolves to something else or to nothing. Marking the
-    /// intended item `#[prebindgen]` is the fix.
-    UnresolvedSourcePath,
+    /// A length names a `#[prebindgen]` const, and those live in one flat,
+    /// uniquely-named namespace, so the bare name is the complete address. Any
+    /// longer path either restates that (`crate::limits::MAX`) or reaches
+    /// somewhere the frontend cannot follow — a module it does not index, an
+    /// associated const it never captured, a foreign crate. Neither can be
+    /// reduced to a number, and guessing between them is how a length silently
+    /// becomes the wrong one.
+    NotABareName,
+    /// A bare name that is not a `#[prebindgen]` const.
+    ///
+    /// The generated crate sees **only** what the macro exposed, so an unmarked
+    /// const is not merely unqualifiable — it does not exist downstream.
+    NotAMarkedConst,
+    /// A `#[prebindgen]` const whose own initializer is not an integer literal.
+    ///
+    /// `build.rs` cannot evaluate it, and a destination language that needs the
+    /// count cannot either. Hoist the arithmetic into the value the const is
+    /// computed FROM, or write the number.
+    ConstIsNotALiteral,
+    /// A `#[prebindgen]` const from a different source crate than the item
+    /// using it.
+    ///
+    /// Uniqueness holds across the *marked* namespace only, so a bare name in
+    /// one source crate can collide with an unmarked name of its own — the
+    /// frontend would silently bind to the other crate's value. Requiring the
+    /// length's const to come from the item's own crate makes that
+    /// unrepresentable.
+    ForeignSourceConst {
+        /// Crate the const was marked in.
+        const_crate: String,
+        /// Crate the item using it came from.
+        item_crate: String,
+    },
 }
 
 impl fmt::Display for UnsupportedArrayLen {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let what = match self.reason {
-            ArrayLenReason::NotLiteralOrPath => {
-                "is neither an integer literal nor a plain path to a const"
+        let what = match &self.reason {
+            ArrayLenReason::NotLiteralOrName => {
+                "is neither an integer literal nor the name of a const".to_string()
             }
-            ArrayLenReason::NotAnIntegerLiteral => "is not a non-negative integer literal",
-            ArrayLenReason::IntegerOutOfRange => "does not fit in a `usize`",
-            ArrayLenReason::QualifiedSelf => {
-                "uses a qualified self (`<T>::N` / `<T as Trait>::N`), whose owner is a type \
-                 rather than a resolvable path segment"
+            ArrayLenReason::NotAnIntegerLiteral => {
+                "is not a non-negative integer literal".to_string()
             }
-            ArrayLenReason::CrateRootPath => {
-                "is rooted at `::`, which names a dependency of the generated crate rather than \
-                 a `#[prebindgen]` item"
+            ArrayLenReason::IntegerOutOfRange => "does not fit in a `usize`".to_string(),
+            ArrayLenReason::NotABareName => {
+                "is a path rather than a bare name; `#[prebindgen]` items live in one flat \
+                 namespace, so the bare name is the whole address"
+                    .to_string()
             }
-            ArrayLenReason::UnresolvedSourcePath => {
-                "is a source-relative path that names no `#[prebindgen]` item, so there is no \
-                 module it can be qualified with — mark the intended item `#[prebindgen]`"
+            ArrayLenReason::NotAMarkedConst => {
+                "names no `#[prebindgen]` const — the generated crate sees only what the macro \
+                 exposed, so mark it `#[prebindgen]`"
+                    .to_string()
             }
+            ArrayLenReason::ConstIsNotALiteral => {
+                "names a const whose value is not an integer literal, so `build.rs` cannot \
+                 evaluate it"
+                    .to_string()
+            }
+            ArrayLenReason::ForeignSourceConst {
+                const_crate,
+                item_crate,
+            } => format!(
+                "names a const marked in `{const_crate}`, but the item using it comes from \
+                 `{item_crate}` — a length must name a const from its own source crate"
+            ),
         };
         write!(
             f,
-            "fixed-size array `{}`: the length `{}` {what}. A length must be an integer literal \
-             or a path to a `#[prebindgen]` const (`MAX`, `Holder::N`) — hoist anything else into \
-             a named `const` and use that as the length.",
+            "fixed-size array `{}`: the length `{}` {what}. A length must be an integer literal, \
+             or the bare name of a `#[prebindgen]` const that is itself an integer literal \
+             (`pub const N: usize = 4;`) — a generator runs in `build.rs` and cannot evaluate \
+             anything else, and some destination languages need the count as a number.",
             self.array, self.offending
         )
     }
@@ -147,108 +169,75 @@ impl fmt::Display for UnsupportedArrayLen {
 
 impl std::error::Error for UnsupportedArrayLen {}
 
-/// What an indexed item may be within a length path.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ItemRole {
-    /// A struct or enum: may own the segments that follow it (`Holder::N`), or
-    /// stand alone.
-    Owner,
-    /// A const or function: can only be the FINAL segment. Nothing is reachable
-    /// *through* it, so a const named `limits` can never be the `limits` of
-    /// `crate::limits::MAX` — that one is a module.
-    Leaf,
+/// One `#[prebindgen]` const, as a length sees it.
+struct ConstEntry {
+    /// The literal value, or `None` when the initializer is not one. Present
+    /// either way, so "not a const" and "not a usable const" stay distinct
+    /// diagnostics.
+    value: Option<usize>,
+    /// Crate the const was marked in; `None` for an origin-less stream.
+    origin: Option<String>,
 }
 
-/// The source namespace a length is resolved against.
+/// The `#[prebindgen]` consts a length may name.
 ///
-/// Built once per registry, from every named item the registry indexes — a
-/// length may name a const or the type that owns an associated const, and
-/// enumerating item kinds at the use site is exactly the drift this module
-/// exists to remove.
-pub struct NameIndex {
-    /// Indexed item name → the module it is reachable under (its origin crate,
-    /// or the registry's default module) and what it may be in a path.
-    names: HashMap<String, (syn::Path, ItemRole)>,
-    /// Path heads that make a path SOURCE-RELATIVE: `crate`, `self`, and every
-    /// ingested source crate's module name.
-    module_heads: Vec<String>,
+/// Built once per registry. Deliberately holds **only consts**: nothing else can
+/// be a length now that the grammar is a bare name, so there is no item-kind
+/// enumeration here to drift.
+pub(crate) struct ConstIndex {
+    consts: HashMap<String, ConstEntry>,
 }
 
-impl NameIndex {
-    /// `names` maps each indexed item's ident to the module it is reachable
-    /// under and its role; `source_modules` is the registry's ingested-source
-    /// module list.
-    pub fn new(names: HashMap<String, (syn::Path, ItemRole)>, source_modules: &[String]) -> Self {
-        let mut module_heads = vec!["crate".to_string(), "self".to_string()];
-        module_heads.extend(source_modules.iter().cloned());
+impl ConstIndex {
+    /// `consts` maps each `#[prebindgen]` const's name to its initializer and
+    /// the crate it was marked in.
+    pub(crate) fn new<I>(consts: I) -> Self
+    where
+        I: IntoIterator<Item = (String, syn::Expr, Option<String>)>,
+    {
         Self {
-            names,
-            module_heads,
+            consts: consts
+                .into_iter()
+                .map(|(name, expr, origin)| {
+                    let entry = ConstEntry {
+                        value: int_literal(&expr),
+                        origin,
+                    };
+                    (name, entry)
+                })
+                .collect(),
         }
     }
+}
 
-    /// Does this path claim to name something in a `#[prebindgen]` source
-    /// crate?
-    ///
-    /// True when the head is `crate` / `self` / a source crate's module, or is
-    /// itself an indexed item. Everything else — `usize::MAX`, `u8::BITS`, a
-    /// foreign crate's path — is external and is left alone.
-    ///
-    /// This is the FIRST decision, before anything is rewritten, so that
-    /// [`ArrayLen::ExternalConst`]'s verbatim guarantee actually holds. It also
-    /// mirrors `normalize_type`'s rule for types: an unknown crate path is
-    /// never touched, because the registry has no index of a foreign namespace
-    /// and `a::Holder` and `b::Holder` may be genuinely different things.
-    fn is_source_relative(&self, path: &syn::Path) -> bool {
-        let head = path.segments[0].ident.to_string();
-        self.module_heads.contains(&head) || self.names.contains_key(&head)
-    }
-
-    /// Index of the segment that names the `#[prebindgen]` item this path
-    /// denotes, or `None` if no segment does.
-    ///
-    /// Everything BEFORE the anchor is a module path within the source crate;
-    /// everything after is relative to the item. Because prebindgen items live
-    /// in one flat, uniquely-named namespace and are reachable as
-    /// `<origin crate>::<bare name>`, the module prefix carries no information
-    /// and is replaced wholesale — which is what lets `crate::limits::MAX`,
-    /// `myflat::limits::MAX` and a bare `MAX` all mean the same length.
-    ///
-    /// Scanning is **leftmost-first** because a later segment may be an
-    /// associated item rather than the anchor: in `Holder::N` with a free const
-    /// `N` also indexed, `Holder` is the anchor and `N` is its associated
-    /// const. A `Leaf` item is skipped when segments follow it, since nothing
-    /// is reachable through a const or a function — that is the only case where
-    /// a module and an indexed item can share a name, Rust putting modules and
-    /// types in one namespace but consts in another.
-    fn anchor(&self, path: &syn::Path) -> Option<usize> {
-        let last = path.segments.len() - 1;
-        path.segments.iter().enumerate().find_map(|(i, seg)| {
-            let (_, role) = self.names.get(&seg.ident.to_string())?;
-            (i == last || *role == ItemRole::Owner).then_some(i)
-        })
-    }
-
-    /// The module an indexed item is reachable under.
-    fn module_of(&self, ident: &str) -> Option<&syn::Path> {
-        self.names.get(ident).map(|(module, _)| module)
-    }
+/// The `usize` an expression denotes, if it is plainly an integer literal.
+fn int_literal(expr: &syn::Expr) -> Option<usize> {
+    let syn::Expr::Lit(lit) = expr else {
+        return None;
+    };
+    let syn::Lit::Int(int) = &lit.lit else {
+        return None;
+    };
+    int.base10_parse::<usize>().ok()
 }
 
 /// Lower one array length to its closed representation.
 ///
-/// **The contract**: `Ok` means the length was fully understood AND fully
-/// resolved. There is no separate acceptance check to drift from this — a form
+/// **The contract**: `Ok` means the length was fully understood AND reduced to a
+/// number. There is no separate acceptance check to drift from this — a form
 /// this function does not lower is, by construction, a form the language does
 /// not accept. That is the fix for the validator/rewriter pair this replaces
-/// (issue #210): eight defects there were the two walks disagreeing about one
-/// input.
+/// (issue #210), where eight defects in a row were two walks disagreeing about
+/// one input.
 ///
-/// `array` is the array type's rendered form, used only for the diagnostic.
-pub fn lower_array_len(
+/// `array` is the array type's rendered form and `item_crate` the origin of the
+/// item the length was written in; both are used for diagnostics, and
+/// `item_crate` additionally pins provenance.
+pub(crate) fn lower_array_len(
     len: &syn::Expr,
     array: &str,
-    names: &NameIndex,
+    item_crate: Option<&str>,
+    consts: &ConstIndex,
 ) -> Result<ArrayLen, UnsupportedArrayLen> {
     let fail = |reason| UnsupportedArrayLen {
         array: array.to_string(),
@@ -256,63 +245,63 @@ pub fn lower_array_len(
         reason,
     };
     match len {
-        syn::Expr::Lit(lit) => {
-            let syn::Lit::Int(int) = &lit.lit else {
-                return Err(fail(ArrayLenReason::NotAnIntegerLiteral));
-            };
-            let n = int
-                .base10_parse::<usize>()
-                .map_err(|_| fail(ArrayLenReason::IntegerOutOfRange))?;
-            Ok(ArrayLen::Literal(n))
-        }
+        syn::Expr::Lit(_) => match int_literal(len) {
+            Some(n) => Ok(ArrayLen::Literal(n)),
+            None => Err(fail(match len {
+                // Told apart so an out-of-range integer does not report as
+                // "not an integer".
+                syn::Expr::Lit(l) if matches!(l.lit, syn::Lit::Int(_)) => {
+                    ArrayLenReason::IntegerOutOfRange
+                }
+                _ => ArrayLenReason::NotAnIntegerLiteral,
+            })),
+        },
         syn::Expr::Path(ep) => {
-            if ep.qself.is_some() {
-                return Err(fail(ArrayLenReason::QualifiedSelf));
+            // A bare name, and nothing longer. See `NotABareName` for why the
+            // flat namespace makes every longer path either redundant or
+            // unfollowable.
+            if ep.qself.is_some() || ep.path.leading_colon.is_some() || ep.path.segments.len() != 1
+            {
+                return Err(fail(ArrayLenReason::NotABareName));
             }
-            if ep.path.leading_colon.is_some() {
-                return Err(fail(ArrayLenReason::CrateRootPath));
-            }
-            // Classify BEFORE rewriting anything: an external path is returned
-            // byte-for-byte as written, which is the whole of its contract.
-            if !names.is_source_relative(&ep.path) {
-                return Ok(ArrayLen::ExternalConst {
-                    path: ep.path.clone(),
-                });
-            }
-            // Source-relative: find the segment that names the item, drop the
-            // module prefix, keep everything after it.
-            let Some(at) = names.anchor(&ep.path) else {
-                return Err(fail(ArrayLenReason::UnresolvedSourcePath));
+            let name = ep.path.segments[0].ident.clone();
+            let Some(entry) = consts.consts.get(&name.to_string()) else {
+                return Err(fail(ArrayLenReason::NotAMarkedConst));
             };
-            let anchor = ep.path.segments[at].ident.to_string();
-            let Some(module) = names.module_of(&anchor) else {
-                return Err(fail(ArrayLenReason::UnresolvedSourcePath));
+            // Provenance before value: a same-named const from another source
+            // may well be a literal, and using it would be the silent wrong
+            // answer rather than an error.
+            if entry.origin.as_deref() != item_crate {
+                return Err(fail(ArrayLenReason::ForeignSourceConst {
+                    const_crate: entry.origin.clone().unwrap_or_else(|| "<unstamped>".into()),
+                    item_crate: item_crate.unwrap_or("<unstamped>").to_string(),
+                }));
+            }
+            let Some(value) = entry.value else {
+                return Err(fail(ArrayLenReason::ConstIsNotALiteral));
             };
-            let mut qualified = module.clone();
-            qualified
-                .segments
-                .extend(ep.path.segments.iter().skip(at).cloned());
-            Ok(ArrayLen::SourceConst { path: qualified })
+            Ok(ArrayLen::Const { name, value })
         }
-        _ => Err(fail(ArrayLenReason::NotLiteralOrPath)),
+        _ => Err(fail(ArrayLenReason::NotLiteralOrName)),
     }
 }
 
 /// The [`syn::visit_mut::VisitMut`] pass that lowers array lengths.
 ///
 /// Prefer [`resolve_array_lengths`], which drives this and gives the
-/// transactional guarantee. Use the pass directly only when the node must be
-/// walked in place.
-pub struct ArrayLenResolver<'a> {
-    names: &'a NameIndex,
+/// transactional guarantee.
+pub(crate) struct ArrayLenResolver<'a> {
+    consts: &'a ConstIndex,
+    item_crate: Option<&'a str>,
     found: Vec<(syn::Type, ArrayLen)>,
     error: Option<UnsupportedArrayLen>,
 }
 
 impl<'a> ArrayLenResolver<'a> {
-    pub fn new(names: &'a NameIndex) -> Self {
+    pub(crate) fn new(consts: &'a ConstIndex, item_crate: Option<&'a str>) -> Self {
         Self {
-            names,
+            consts,
+            item_crate,
             found: Vec::new(),
             error: None,
         }
@@ -321,7 +310,7 @@ impl<'a> ArrayLenResolver<'a> {
     /// The `(array type, length)` pairs found in walk order — array types in
     /// their rewritten spelling — or the first length that could not be
     /// lowered.
-    pub fn finish(self) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
+    pub(crate) fn finish(self) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
         match self.error {
             Some(e) => Err(e),
             None => Ok(self.found),
@@ -341,7 +330,7 @@ impl syn::visit_mut::VisitMut for ArrayLenResolver<'_> {
             return;
         }
         let rendered = arr.to_token_stream().to_string();
-        match lower_array_len(&arr.len, &rendered, self.names) {
+        match lower_array_len(&arr.len, &rendered, self.item_crate, self.consts) {
             Ok(len) => {
                 arr.len = len.to_expr();
                 self.found.push((syn::Type::Array(arr.clone()), len));
@@ -351,25 +340,26 @@ impl syn::visit_mut::VisitMut for ArrayLenResolver<'_> {
     }
 }
 
-/// Lower every fixed-size array length reachable from `node` and rewrite each
-/// to its canonical spelling.
+/// Lower every fixed-size array length reachable from `node` and rewrite each to
+/// its numeric form.
 ///
 /// **Transactional**: the walk runs on a clone and is committed only if every
 /// length lowered, so a refused node leaves no partially rewritten model.
 ///
 /// `visit` selects the `syn` entry point for the node kind — e.g.
-/// `|r, f| r.visit_item_fn_mut(f)`. Taking it from the caller keeps this
-/// generic over the item kinds the registry indexes without a `syn::Item`
-/// round trip that could only be unwrapped with an `unreachable!`.
+/// `|r, f| r.visit_item_fn_mut(f)`. Taking it from the caller keeps this generic
+/// over the item kinds the registry indexes without a `syn::Item` round trip
+/// that could only be unwrapped with an `unreachable!`.
 ///
 /// Returns the `(array type, length)` pairs found, in walk order.
-pub fn resolve_array_lengths<T: Clone>(
+pub(crate) fn resolve_array_lengths<T: Clone>(
     node: &mut T,
-    names: &NameIndex,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
     visit: impl FnOnce(&mut ArrayLenResolver<'_>, &mut T),
 ) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
     let mut candidate = node.clone();
-    let mut resolver = ArrayLenResolver::new(names);
+    let mut resolver = ArrayLenResolver::new(consts, item_crate);
     visit(&mut resolver, &mut candidate);
     let found = resolver.finish()?;
     *node = candidate;

--- a/prebindgen/src/api/core/frontend/array_len.rs
+++ b/prebindgen/src/api/core/frontend/array_len.rs
@@ -10,6 +10,14 @@ use quote::ToTokens;
 
 /// A fixed-size array's length, after the frontend has decided it.
 ///
+/// **This models one OCCURRENCE, not a type.** It records which spelling was
+/// written, which is a property of the use site — `[u8; A]` and `[u8; 4]` are
+/// the same Rust type and the same [`TypeKey`](crate::api::core::TypeKey) when
+/// `A == 4`, so a table keyed by type cannot carry this without its answer
+/// depending on which occurrence was stored last. That is why the registry's
+/// type-keyed table holds a bare `usize` and this stays crate-private: source-
+/// use provenance belongs to a per-use model (issue #211's `SourceModel`).
+///
 /// **A length is always a known number.** That is the whole design: a binding
 /// generator runs in `build.rs`, where it cannot evaluate arbitrary Rust, and
 /// some destination languages cannot reference a Rust const at all — a Kotlin
@@ -24,13 +32,13 @@ use quote::ToTokens;
 ///   integer literal — `[u8; ARRAY_BYTES]` where
 ///   `#[prebindgen] pub const ARRAY_BYTES: usize = 4`.
 ///
-/// Both carry the value; the const also keeps its name, for diagnostics and for
-/// generators that want to echo it. Emission uses the number
+/// Both carry the value; the const also keeps its name, for diagnostics at the
+/// site that lowered it. Emission uses the number
 /// ([`ArrayLen::to_expr`]), so no length is ever a path in generated code and
 /// there is nothing to qualify — the class of defect that produced issues #209
 /// and #210 is gone rather than fixed.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ArrayLen {
+pub(crate) enum ArrayLen {
     /// Written as an integer literal.
     Literal(usize),
     /// Written as the bare name of a `#[prebindgen]` const, evaluated here.
@@ -39,7 +47,7 @@ pub enum ArrayLen {
 
 impl ArrayLen {
     /// The number of elements. Total — every accepted length has one.
-    pub fn value(&self) -> usize {
+    pub(crate) fn value(&self) -> usize {
         match self {
             ArrayLen::Literal(n) => *n,
             ArrayLen::Const { value, .. } => *value,
@@ -52,7 +60,7 @@ impl ArrayLen {
     /// independent of the generated crate's namespace. It also makes a changed
     /// const **visible** in the diff of a committed generated artifact, where
     /// echoing the name would have shown nothing at all.
-    pub fn to_expr(&self) -> syn::Expr {
+    pub(crate) fn to_expr(&self) -> syn::Expr {
         let lit = syn::LitInt::new(&self.value().to_string(), proc_macro2::Span::call_site());
         syn::Expr::Lit(syn::ExprLit {
             attrs: Vec::new(),

--- a/prebindgen/src/api/core/frontend/array_len.rs
+++ b/prebindgen/src/api/core/frontend/array_len.rs
@@ -1,6 +1,17 @@
 //! The fixed-size-array length subgrammar: one closed representation and one
 //! fallible walk that produces it.
 //!
+//! A length must reduce to a **known number** — a generator runs in `build.rs`,
+//! where it cannot evaluate arbitrary Rust. Two spellings reach one, and nothing
+//! else does: an integer literal, or the bare name of a `#[prebindgen]` const
+//! whose own initializer is an integer literal.
+//!
+//! Both the number and the spelling travel, as an
+//! [`ArrayExtent`](super::model::ArrayExtent): the value is the semantic length
+//! that makes `[u8; A]` and `[u8; 4]` one type, and the const identity is what
+//! lets a C header emit `uint8_t x[NAME]`. See that type for which consumer
+//! needs which half.
+//!
 //! See the module docs of [`super`] for why acceptance and lowering are the same
 //! operation here.
 
@@ -8,47 +19,7 @@ use std::{collections::HashMap, fmt};
 
 use quote::ToTokens;
 
-/// A fixed-size array's length is **a number, and nothing else** — that is the
-/// decided model, and `usize` is its whole representation.
-///
-/// A binding generator runs in `build.rs`, where it cannot evaluate arbitrary
-/// Rust, and some destination languages cannot reference a Rust const at all —
-/// a surface that groups a small array into scalars needs the count literally.
-/// A length the frontend cannot reduce to a `usize` is therefore not a length
-/// prebindgen accepts.
-///
-/// Two spellings reach that number, and nothing else does:
-///
-/// * an integer literal — `[u8; 4]`;
-/// * the **bare name** of a `#[prebindgen]` const whose own initializer is an
-///   integer literal — `[u8; ARRAY_BYTES]` where
-///   `#[prebindgen] pub const ARRAY_BYTES: usize = 4`.
-///
-/// # The spelling is deliberately discarded
-///
-/// This is a **frontend policy decision**, not a consequence of Rust's type
-/// equality, so it is stated rather than assumed: which spelling a use site
-/// wrote is not part of an array's meaning, and no adapter is offered it.
-///
-/// `[u8; A]` and `[u8; B]` with `A == B == 4` are one Rust type, one `TypeKey`
-/// and one converter. Letting an adapter render them differently would mean two
-/// destination representations for a single Rust type, which the type-keyed
-/// converter table cannot express — so the capability would be incoherent here
-/// even if the provenance were carried.
-///
-/// The cost is real and bounded: a C header cannot echo `uint8_t x[MAX_SIZE]`,
-/// only `uint8_t x[16]`. If that becomes wanted, provenance must be keyed by
-/// **use site** — field, parameter, return — in issue #211's per-use
-/// `SourceModel`, never by `TypeKey`, which has already collapsed the spellings.
-/// Reintroducing a name into any type-keyed table makes the stored answer depend
-/// on which occurrence was seen last.
-fn len_expr(n: usize) -> syn::Expr {
-    let lit = syn::LitInt::new(&n.to_string(), proc_macro2::Span::call_site());
-    syn::Expr::Lit(syn::ExprLit {
-        attrs: Vec::new(),
-        lit: syn::Lit::Int(lit),
-    })
-}
+use super::model::{ArrayExtent, ConstId, ExtentSource};
 
 /// A length the prebindgen source language does not accept.
 ///
@@ -227,7 +198,7 @@ pub(crate) fn lower_array_len(
     array: &str,
     item_crate: Option<&str>,
     consts: &ConstIndex,
-) -> Result<usize, UnsupportedArrayLen> {
+) -> Result<ArrayExtent, UnsupportedArrayLen> {
     let fail = |reason| UnsupportedArrayLen {
         array: array.to_string(),
         offending: len.to_token_stream().to_string(),
@@ -235,7 +206,10 @@ pub(crate) fn lower_array_len(
     };
     match len {
         syn::Expr::Lit(_) => match int_literal(len) {
-            Some(n) => Ok(n),
+            Some(value) => Ok(ArrayExtent {
+                value,
+                source: ExtentSource::Literal,
+            }),
             None => Err(fail(match len {
                 // Told apart so an out-of-range integer does not report as
                 // "not an integer".
@@ -253,10 +227,8 @@ pub(crate) fn lower_array_len(
             {
                 return Err(fail(ArrayLenReason::NotABareName));
             }
-            // Only the const's VALUE leaves this function; which name carried
-            // it is not part of the length. See `len_expr` for why that is a
-            // stated policy rather than an omission.
-            let Some(entry) = consts.consts.get(&ep.path.segments[0].ident.to_string()) else {
+            let name = ep.path.segments[0].ident.to_string();
+            let Some(entry) = consts.consts.get(&name) else {
                 return Err(fail(ArrayLenReason::NotAMarkedConst));
             };
             // Provenance before value: a same-named const from another source
@@ -271,7 +243,15 @@ pub(crate) fn lower_array_len(
             let Some(value) = entry.value else {
                 return Err(fail(ArrayLenReason::ConstIsNotALiteral));
             };
-            Ok(value)
+            // Both halves travel: the value is the semantic length, the const
+            // identity is what lets a C header spell `uint8_t x[NAME]`.
+            Ok(ArrayExtent {
+                value,
+                source: ExtentSource::Const(ConstId {
+                    name,
+                    origin: entry.origin.clone(),
+                }),
+            })
         }
         _ => Err(fail(ArrayLenReason::NotLiteralOrName)),
     }
@@ -284,7 +264,7 @@ pub(crate) fn lower_array_len(
 pub(crate) struct ArrayLenResolver<'a> {
     consts: &'a ConstIndex,
     item_crate: Option<&'a str>,
-    found: Vec<(syn::Type, usize)>,
+    found: Vec<(syn::Type, ArrayExtent)>,
     error: Option<UnsupportedArrayLen>,
 }
 
@@ -301,7 +281,7 @@ impl<'a> ArrayLenResolver<'a> {
     /// The `(array type, length)` pairs found in walk order — array types in
     /// their rewritten spelling — or the first length that could not be
     /// lowered.
-    pub(crate) fn finish(self) -> Result<Vec<(syn::Type, usize)>, UnsupportedArrayLen> {
+    pub(crate) fn finish(self) -> Result<Vec<(syn::Type, ArrayExtent)>, UnsupportedArrayLen> {
         match self.error {
             Some(e) => Err(e),
             None => Ok(self.found),
@@ -322,9 +302,9 @@ impl syn::visit_mut::VisitMut for ArrayLenResolver<'_> {
         }
         let rendered = arr.to_token_stream().to_string();
         match lower_array_len(&arr.len, &rendered, self.item_crate, self.consts) {
-            Ok(len) => {
-                arr.len = len_expr(len);
-                self.found.push((syn::Type::Array(arr.clone()), len));
+            Ok(extent) => {
+                arr.len = extent.to_expr();
+                self.found.push((syn::Type::Array(arr.clone()), extent));
             }
             Err(e) => self.error = Some(e),
         }
@@ -348,7 +328,7 @@ pub(crate) fn resolve_array_lengths<T: Clone>(
     consts: &ConstIndex,
     item_crate: Option<&str>,
     visit: impl FnOnce(&mut ArrayLenResolver<'_>, &mut T),
-) -> Result<Vec<(syn::Type, usize)>, UnsupportedArrayLen> {
+) -> Result<Vec<(syn::Type, ArrayExtent)>, UnsupportedArrayLen> {
     let mut candidate = node.clone();
     let mut resolver = ArrayLenResolver::new(consts, item_crate);
     visit(&mut resolver, &mut candidate);

--- a/prebindgen/src/api/core/frontend/array_len.rs
+++ b/prebindgen/src/api/core/frontend/array_len.rs
@@ -1,0 +1,315 @@
+//! The fixed-size-array length subgrammar: one closed representation and one
+//! fallible walk that produces it.
+//!
+//! See the module docs of [`super`] for why acceptance and rewriting are the
+//! same operation here.
+
+use std::{collections::HashMap, fmt};
+
+use quote::ToTokens;
+
+/// A fixed-size array's length, after the frontend has decided it.
+///
+/// This is the ONLY representation of a length downstream — qualification,
+/// planning, and both language adapters read this rather than the captured
+/// `syn::Expr`. The set of variants IS the accepted subgrammar: a length that
+/// cannot be lowered to one of them is refused before any adapter runs.
+///
+/// The grammar is deliberately flat and non-recursive. Const arithmetic
+/// (`[u8; A + 1]`), casts (`[u8; A as usize]`), and `const fn` calls
+/// (`[u8; array_len()]`) are NOT part of the prebindgen language — hoist the
+/// value into a named `const` and use that as the length.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArrayLen {
+    /// An integer literal — `[u8; 4]`.
+    Literal(usize),
+    /// A path naming a `#[prebindgen]` item, stored **absolute**: the leading
+    /// segment carries the item's origin module, so the length resolves in the
+    /// generated crate.
+    ///
+    /// Covers a free const (`MAX` → `myflat::MAX`) and an associated const
+    /// (`Holder::N` → `myflat::Holder::N`, where only the OWNER is qualified —
+    /// `::N` is relative to it).
+    SourceConst { path: syn::Path },
+    /// A path naming nothing the registry indexes — `usize::MAX`, `u8::BITS`.
+    /// Emitted verbatim: it is not a source item, so there is no origin module
+    /// to prefix and rewriting it would be a guess.
+    ///
+    /// A `#[prebindgen]`-less const in the source crate lands here and will not
+    /// resolve in the generated crate. Mark it `#[prebindgen]` so the registry
+    /// indexes it.
+    ExternalConst { path: syn::Path },
+}
+
+impl ArrayLen {
+    /// The length as it must be spelled in generated code.
+    pub fn to_expr(&self) -> syn::Expr {
+        match self {
+            ArrayLen::Literal(n) => {
+                let lit = syn::LitInt::new(&n.to_string(), proc_macro2::Span::call_site());
+                syn::Expr::Lit(syn::ExprLit {
+                    attrs: Vec::new(),
+                    lit: syn::Lit::Int(lit),
+                })
+            }
+            ArrayLen::SourceConst { path } | ArrayLen::ExternalConst { path } => {
+                syn::Expr::Path(syn::ExprPath {
+                    attrs: Vec::new(),
+                    qself: None,
+                    path: path.clone(),
+                })
+            }
+        }
+    }
+}
+
+/// A length the prebindgen source language does not accept.
+///
+/// Names the offending sub-expression, not just the array type: the whole point
+/// of the single walk is that it knows exactly which part it could not lower.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedArrayLen {
+    /// The array type as written, for context — `[u8 ; A + 1]`.
+    pub array: String,
+    /// The sub-expression that could not be lowered — `A + 1`.
+    pub offending: String,
+    /// Why it could not be lowered.
+    pub reason: ArrayLenReason,
+}
+
+/// Why [`lower_array_len`] refused a length.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArrayLenReason {
+    /// Not a literal or a plain path: arithmetic, a cast, a call, a block, a
+    /// `match`, a closure — anything with structure the grammar does not have.
+    NotLiteralOrPath,
+    /// A literal that is not a non-negative integer.
+    NotAnIntegerLiteral,
+    /// An integer literal too large for `usize`.
+    IntegerOutOfRange,
+    /// A path with a qualified self — `<Holder>::N`, `<Holder as Trait>::N`.
+    /// The owner is a type, not a path segment, so there is no leading segment
+    /// to resolve against the source namespace.
+    QualifiedSelf,
+    /// A path rooted at the crate root — `::MAX`. In the generated crate that
+    /// names a dependency of the CONSUMER, which the frontend cannot see.
+    CrateRootPath,
+}
+
+impl fmt::Display for UnsupportedArrayLen {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let what = match self.reason {
+            ArrayLenReason::NotLiteralOrPath => {
+                "is neither an integer literal nor a plain path to a const"
+            }
+            ArrayLenReason::NotAnIntegerLiteral => "is not a non-negative integer literal",
+            ArrayLenReason::IntegerOutOfRange => "does not fit in a `usize`",
+            ArrayLenReason::QualifiedSelf => {
+                "uses a qualified self (`<T>::N` / `<T as Trait>::N`), whose owner is a type \
+                 rather than a resolvable path segment"
+            }
+            ArrayLenReason::CrateRootPath => {
+                "is rooted at `::`, which names a dependency of the generated crate rather than \
+                 a `#[prebindgen]` item"
+            }
+        };
+        write!(
+            f,
+            "fixed-size array `{}`: the length `{}` {what}. A length must be an integer literal \
+             or a path to a `#[prebindgen]` const (`MAX`, `Holder::N`) — hoist anything else into \
+             a named `const` and use that as the length.",
+            self.array, self.offending
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedArrayLen {}
+
+/// The source namespace a length is resolved against.
+///
+/// Built once per registry, from every named item the registry indexes — a
+/// length may name a const or the type that owns an associated const, and
+/// enumerating item kinds at the use site is exactly the drift this module
+/// exists to remove.
+pub struct NameIndex {
+    /// Indexed item name → the module it is reachable under (its origin crate,
+    /// or the registry's default module).
+    names: HashMap<String, syn::Path>,
+    /// Path heads a captured length may already carry: `crate`, `self`, and
+    /// every ingested source crate's module name. Stripped before resolution —
+    /// see [`NameIndex::strip_source_head`].
+    module_heads: Vec<String>,
+}
+
+impl NameIndex {
+    /// `names` maps each indexed item's ident to the module it is reachable
+    /// under; `source_modules` is the registry's ingested-source module list.
+    pub fn new(names: HashMap<String, syn::Path>, source_modules: &[String]) -> Self {
+        let mut module_heads = vec!["crate".to_string(), "self".to_string()];
+        module_heads.extend(source_modules.iter().cloned());
+        Self {
+            names,
+            module_heads,
+        }
+    }
+
+    /// Drop a leading `crate` / `self` / source-crate segment, so a captured
+    /// `crate::MAX` and a captured `MAX` resolve identically.
+    ///
+    /// The expression-path analogue of `normalize_type`'s path reduction, and
+    /// deliberately NOT the same rule: that one reduces to the FINAL segment,
+    /// which is right for a type (the last segment is the type name) and wrong
+    /// here (`myflat::Holder::N` must keep its `Holder`, the owner of `N`).
+    fn strip_source_head(&self, path: &syn::Path) -> syn::Path {
+        if path.segments.len() < 2 {
+            return path.clone();
+        }
+        let head = path.segments[0].ident.to_string();
+        if !self.module_heads.contains(&head) {
+            return path.clone();
+        }
+        let mut stripped = path.clone();
+        stripped.segments = stripped.segments.into_iter().skip(1).collect();
+        stripped
+    }
+
+    /// The module an indexed item is reachable under, or `None` when the name
+    /// is not a source item.
+    fn module_of(&self, ident: &str) -> Option<&syn::Path> {
+        self.names.get(ident)
+    }
+}
+
+/// Lower one array length to its closed representation.
+///
+/// **The contract**: `Ok` means the length was fully understood AND fully
+/// resolved. There is no separate acceptance check to drift from this — a form
+/// this function does not lower is, by construction, a form the language does
+/// not accept. That is the fix for the validator/rewriter pair this replaces
+/// (issue #210): eight defects there were the two walks disagreeing about one
+/// input.
+///
+/// `array` is the array type's rendered form, used only for the diagnostic.
+pub fn lower_array_len(
+    len: &syn::Expr,
+    array: &str,
+    names: &NameIndex,
+) -> Result<ArrayLen, UnsupportedArrayLen> {
+    let fail = |reason| UnsupportedArrayLen {
+        array: array.to_string(),
+        offending: len.to_token_stream().to_string(),
+        reason,
+    };
+    match len {
+        syn::Expr::Lit(lit) => {
+            let syn::Lit::Int(int) = &lit.lit else {
+                return Err(fail(ArrayLenReason::NotAnIntegerLiteral));
+            };
+            let n = int
+                .base10_parse::<usize>()
+                .map_err(|_| fail(ArrayLenReason::IntegerOutOfRange))?;
+            Ok(ArrayLen::Literal(n))
+        }
+        syn::Expr::Path(ep) => {
+            if ep.qself.is_some() {
+                return Err(fail(ArrayLenReason::QualifiedSelf));
+            }
+            if ep.path.leading_colon.is_some() {
+                return Err(fail(ArrayLenReason::CrateRootPath));
+            }
+            let path = names.strip_source_head(&ep.path);
+            // One segment names the const itself; more than one means the
+            // leading segment is the type that owns it. Either way it is the
+            // leading segment that carries the origin module, and the rest is
+            // relative to it.
+            let head = path.segments[0].ident.to_string();
+            match names.module_of(&head) {
+                Some(module) => {
+                    let mut qualified = module.clone();
+                    qualified.segments.extend(path.segments.iter().cloned());
+                    Ok(ArrayLen::SourceConst { path: qualified })
+                }
+                None => Ok(ArrayLen::ExternalConst { path }),
+            }
+        }
+        _ => Err(fail(ArrayLenReason::NotLiteralOrPath)),
+    }
+}
+
+/// The [`syn::visit_mut::VisitMut`] pass that lowers array lengths.
+///
+/// Prefer [`resolve_array_lengths`], which drives this and gives the
+/// transactional guarantee. Use the pass directly only when the node must be
+/// walked in place.
+pub struct ArrayLenResolver<'a> {
+    names: &'a NameIndex,
+    found: Vec<(syn::Type, ArrayLen)>,
+    error: Option<UnsupportedArrayLen>,
+}
+
+impl<'a> ArrayLenResolver<'a> {
+    pub fn new(names: &'a NameIndex) -> Self {
+        Self {
+            names,
+            found: Vec::new(),
+            error: None,
+        }
+    }
+
+    /// The `(array type, length)` pairs found in walk order — array types in
+    /// their rewritten spelling — or the first length that could not be
+    /// lowered.
+    pub fn finish(self) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
+        match self.error {
+            Some(e) => Err(e),
+            None => Ok(self.found),
+        }
+    }
+}
+
+impl syn::visit_mut::VisitMut for ArrayLenResolver<'_> {
+    fn visit_type_array_mut(&mut self, arr: &mut syn::TypeArray) {
+        if self.error.is_some() {
+            return;
+        }
+        // Element first: a nested array's length is rewritten before this one's
+        // type is recorded, so `found` holds canonical spellings throughout.
+        syn::visit_mut::visit_type_mut(self, &mut arr.elem);
+        if self.error.is_some() {
+            return;
+        }
+        let rendered = arr.to_token_stream().to_string();
+        match lower_array_len(&arr.len, &rendered, self.names) {
+            Ok(len) => {
+                arr.len = len.to_expr();
+                self.found.push((syn::Type::Array(arr.clone()), len));
+            }
+            Err(e) => self.error = Some(e),
+        }
+    }
+}
+
+/// Lower every fixed-size array length reachable from `node` and rewrite each
+/// to its canonical spelling.
+///
+/// **Transactional**: the walk runs on a clone and is committed only if every
+/// length lowered, so a refused node leaves no partially rewritten model.
+///
+/// `visit` selects the `syn` entry point for the node kind — e.g.
+/// `|r, f| r.visit_item_fn_mut(f)`. Taking it from the caller keeps this
+/// generic over the item kinds the registry indexes without a `syn::Item`
+/// round trip that could only be unwrapped with an `unreachable!`.
+///
+/// Returns the `(array type, length)` pairs found, in walk order.
+pub fn resolve_array_lengths<T: Clone>(
+    node: &mut T,
+    names: &NameIndex,
+    visit: impl FnOnce(&mut ArrayLenResolver<'_>, &mut T),
+) -> Result<Vec<(syn::Type, ArrayLen)>, UnsupportedArrayLen> {
+    let mut candidate = node.clone();
+    let mut resolver = ArrayLenResolver::new(names);
+    visit(&mut resolver, &mut candidate);
+    let found = resolver.finish()?;
+    *node = candidate;
+    Ok(found)
+}

--- a/prebindgen/src/api/core/frontend/array_len.rs
+++ b/prebindgen/src/api/core/frontend/array_len.rs
@@ -23,21 +23,31 @@ use quote::ToTokens;
 pub enum ArrayLen {
     /// An integer literal — `[u8; 4]`.
     Literal(usize),
-    /// A path naming a `#[prebindgen]` item, stored **absolute**: the leading
-    /// segment carries the item's origin module, so the length resolves in the
-    /// generated crate.
+    /// A path naming a `#[prebindgen]` item, stored **absolute**: the item's
+    /// origin module replaces whatever module prefix the source wrote, so the
+    /// length resolves in the generated crate.
     ///
-    /// Covers a free const (`MAX` → `myflat::MAX`) and an associated const
-    /// (`Holder::N` → `myflat::Holder::N`, where only the OWNER is qualified —
-    /// `::N` is relative to it).
+    /// Replacing rather than preserving the prefix is sound because prebindgen
+    /// items live in one flat, uniquely-named namespace and are reachable as
+    /// `<origin crate>::<bare name>` — the same invariant `normalize_type`
+    /// already relies on for types. So every spelling of one item collapses to
+    /// one value:
+    ///
+    /// * `MAX`, `crate::MAX`, `myflat::MAX`, `crate::limits::MAX` →
+    ///   `myflat::MAX`;
+    /// * `Holder::N`, `crate::limits::Holder::N` → `myflat::Holder::N`, where
+    ///   the segments AFTER the item are relative to it and are kept.
     SourceConst { path: syn::Path },
-    /// A path naming nothing the registry indexes — `usize::MAX`, `u8::BITS`.
-    /// Emitted verbatim: it is not a source item, so there is no origin module
-    /// to prefix and rewriting it would be a guess.
+    /// A path that does not name anything in a source crate — `usize::MAX`,
+    /// `u8::BITS`, a foreign crate's path. Emitted **verbatim**, exactly as
+    /// written: there is no origin module to prefix, and rewriting it would be
+    /// a guess.
     ///
-    /// A `#[prebindgen]`-less const in the source crate lands here and will not
-    /// resolve in the generated crate. Mark it `#[prebindgen]` so the registry
-    /// indexes it.
+    /// A `#[prebindgen]`-less const referred to by its bare name lands here and
+    /// will not resolve in the generated crate. Mark it `#[prebindgen]` so the
+    /// registry indexes it. (Referred to *source-relatively* —
+    /// `crate::limits::UNMARKED` — it is a hard error instead; see
+    /// [`ArrayLenReason::UnresolvedSourcePath`].)
     ExternalConst { path: syn::Path },
 }
 
@@ -94,6 +104,14 @@ pub enum ArrayLenReason {
     /// A path rooted at the crate root — `::MAX`. In the generated crate that
     /// names a dependency of the CONSUMER, which the frontend cannot see.
     CrateRootPath,
+    /// A **source-relative** path — one headed by `crate` / `self` / a source
+    /// crate's module — none of whose segments names a `#[prebindgen]` item.
+    ///
+    /// It claims to name something in the source crate, so it cannot be
+    /// emitted verbatim: the generated crate is a different crate, where the
+    /// same spelling resolves to something else or to nothing. Marking the
+    /// intended item `#[prebindgen]` is the fix.
+    UnresolvedSourcePath,
 }
 
 impl fmt::Display for UnsupportedArrayLen {
@@ -112,6 +130,10 @@ impl fmt::Display for UnsupportedArrayLen {
                 "is rooted at `::`, which names a dependency of the generated crate rather than \
                  a `#[prebindgen]` item"
             }
+            ArrayLenReason::UnresolvedSourcePath => {
+                "is a source-relative path that names no `#[prebindgen]` item, so there is no \
+                 module it can be qualified with — mark the intended item `#[prebindgen]`"
+            }
         };
         write!(
             f,
@@ -125,6 +147,18 @@ impl fmt::Display for UnsupportedArrayLen {
 
 impl std::error::Error for UnsupportedArrayLen {}
 
+/// What an indexed item may be within a length path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemRole {
+    /// A struct or enum: may own the segments that follow it (`Holder::N`), or
+    /// stand alone.
+    Owner,
+    /// A const or function: can only be the FINAL segment. Nothing is reachable
+    /// *through* it, so a const named `limits` can never be the `limits` of
+    /// `crate::limits::MAX` — that one is a module.
+    Leaf,
+}
+
 /// The source namespace a length is resolved against.
 ///
 /// Built once per registry, from every named item the registry indexes — a
@@ -133,18 +167,18 @@ impl std::error::Error for UnsupportedArrayLen {}
 /// exists to remove.
 pub struct NameIndex {
     /// Indexed item name → the module it is reachable under (its origin crate,
-    /// or the registry's default module).
-    names: HashMap<String, syn::Path>,
-    /// Path heads a captured length may already carry: `crate`, `self`, and
-    /// every ingested source crate's module name. Stripped before resolution —
-    /// see [`NameIndex::strip_source_head`].
+    /// or the registry's default module) and what it may be in a path.
+    names: HashMap<String, (syn::Path, ItemRole)>,
+    /// Path heads that make a path SOURCE-RELATIVE: `crate`, `self`, and every
+    /// ingested source crate's module name.
     module_heads: Vec<String>,
 }
 
 impl NameIndex {
     /// `names` maps each indexed item's ident to the module it is reachable
-    /// under; `source_modules` is the registry's ingested-source module list.
-    pub fn new(names: HashMap<String, syn::Path>, source_modules: &[String]) -> Self {
+    /// under and its role; `source_modules` is the registry's ingested-source
+    /// module list.
+    pub fn new(names: HashMap<String, (syn::Path, ItemRole)>, source_modules: &[String]) -> Self {
         let mut module_heads = vec!["crate".to_string(), "self".to_string()];
         module_heads.extend(source_modules.iter().cloned());
         Self {
@@ -153,30 +187,51 @@ impl NameIndex {
         }
     }
 
-    /// Drop a leading `crate` / `self` / source-crate segment, so a captured
-    /// `crate::MAX` and a captured `MAX` resolve identically.
+    /// Does this path claim to name something in a `#[prebindgen]` source
+    /// crate?
     ///
-    /// The expression-path analogue of `normalize_type`'s path reduction, and
-    /// deliberately NOT the same rule: that one reduces to the FINAL segment,
-    /// which is right for a type (the last segment is the type name) and wrong
-    /// here (`myflat::Holder::N` must keep its `Holder`, the owner of `N`).
-    fn strip_source_head(&self, path: &syn::Path) -> syn::Path {
-        if path.segments.len() < 2 {
-            return path.clone();
-        }
+    /// True when the head is `crate` / `self` / a source crate's module, or is
+    /// itself an indexed item. Everything else — `usize::MAX`, `u8::BITS`, a
+    /// foreign crate's path — is external and is left alone.
+    ///
+    /// This is the FIRST decision, before anything is rewritten, so that
+    /// [`ArrayLen::ExternalConst`]'s verbatim guarantee actually holds. It also
+    /// mirrors `normalize_type`'s rule for types: an unknown crate path is
+    /// never touched, because the registry has no index of a foreign namespace
+    /// and `a::Holder` and `b::Holder` may be genuinely different things.
+    fn is_source_relative(&self, path: &syn::Path) -> bool {
         let head = path.segments[0].ident.to_string();
-        if !self.module_heads.contains(&head) {
-            return path.clone();
-        }
-        let mut stripped = path.clone();
-        stripped.segments = stripped.segments.into_iter().skip(1).collect();
-        stripped
+        self.module_heads.contains(&head) || self.names.contains_key(&head)
     }
 
-    /// The module an indexed item is reachable under, or `None` when the name
-    /// is not a source item.
+    /// Index of the segment that names the `#[prebindgen]` item this path
+    /// denotes, or `None` if no segment does.
+    ///
+    /// Everything BEFORE the anchor is a module path within the source crate;
+    /// everything after is relative to the item. Because prebindgen items live
+    /// in one flat, uniquely-named namespace and are reachable as
+    /// `<origin crate>::<bare name>`, the module prefix carries no information
+    /// and is replaced wholesale — which is what lets `crate::limits::MAX`,
+    /// `myflat::limits::MAX` and a bare `MAX` all mean the same length.
+    ///
+    /// Scanning is **leftmost-first** because a later segment may be an
+    /// associated item rather than the anchor: in `Holder::N` with a free const
+    /// `N` also indexed, `Holder` is the anchor and `N` is its associated
+    /// const. A `Leaf` item is skipped when segments follow it, since nothing
+    /// is reachable through a const or a function — that is the only case where
+    /// a module and an indexed item can share a name, Rust putting modules and
+    /// types in one namespace but consts in another.
+    fn anchor(&self, path: &syn::Path) -> Option<usize> {
+        let last = path.segments.len() - 1;
+        path.segments.iter().enumerate().find_map(|(i, seg)| {
+            let (_, role) = self.names.get(&seg.ident.to_string())?;
+            (i == last || *role == ItemRole::Owner).then_some(i)
+        })
+    }
+
+    /// The module an indexed item is reachable under.
     fn module_of(&self, ident: &str) -> Option<&syn::Path> {
-        self.names.get(ident)
+        self.names.get(ident).map(|(module, _)| module)
     }
 }
 
@@ -217,20 +272,27 @@ pub fn lower_array_len(
             if ep.path.leading_colon.is_some() {
                 return Err(fail(ArrayLenReason::CrateRootPath));
             }
-            let path = names.strip_source_head(&ep.path);
-            // One segment names the const itself; more than one means the
-            // leading segment is the type that owns it. Either way it is the
-            // leading segment that carries the origin module, and the rest is
-            // relative to it.
-            let head = path.segments[0].ident.to_string();
-            match names.module_of(&head) {
-                Some(module) => {
-                    let mut qualified = module.clone();
-                    qualified.segments.extend(path.segments.iter().cloned());
-                    Ok(ArrayLen::SourceConst { path: qualified })
-                }
-                None => Ok(ArrayLen::ExternalConst { path }),
+            // Classify BEFORE rewriting anything: an external path is returned
+            // byte-for-byte as written, which is the whole of its contract.
+            if !names.is_source_relative(&ep.path) {
+                return Ok(ArrayLen::ExternalConst {
+                    path: ep.path.clone(),
+                });
             }
+            // Source-relative: find the segment that names the item, drop the
+            // module prefix, keep everything after it.
+            let Some(at) = names.anchor(&ep.path) else {
+                return Err(fail(ArrayLenReason::UnresolvedSourcePath));
+            };
+            let anchor = ep.path.segments[at].ident.to_string();
+            let Some(module) = names.module_of(&anchor) else {
+                return Err(fail(ArrayLenReason::UnresolvedSourcePath));
+            };
+            let mut qualified = module.clone();
+            qualified
+                .segments
+                .extend(ep.path.segments.iter().skip(at).cloned());
+            Ok(ArrayLen::SourceConst { path: qualified })
         }
         _ => Err(fail(ArrayLenReason::NotLiteralOrPath)),
     }

--- a/prebindgen/src/api/core/frontend/model.rs
+++ b/prebindgen/src/api/core/frontend/model.rs
@@ -65,28 +65,33 @@ pub enum SourceType {
     /// Any other named type: a `#[prebindgen]` struct or enum, or a foreign
     /// path.
     ///
-    /// `name` is the normalized spelling WITHOUT generic arguments — the type's
-    /// identity, not syntax to re-inspect; the arguments are modeled in `args`.
-    /// A lifetime argument survives in `name` alone, since it is part of the
-    /// spelling but carries no structure.
+    /// `path` carries the type's **identity** — leading `::`, every segment,
+    /// and the final ident — with the last segment's generic arguments stripped
+    /// out into `args`. Keeping them in both places would be two
+    /// representations of one fact.
+    ///
+    /// `args` preserves the arguments **in source order**, lifetimes included,
+    /// which is what makes the projection reconstruct `Foo<'a, T>` exactly. A
+    /// lifetime is part of the spelling and nothing more: it is carried
+    /// verbatim, never modeled as structure, because it means nothing to a
+    /// destination language.
     Named {
-        name: syn::Path,
-        args: Vec<SourceType>,
+        path: syn::TypePath,
+        args: Vec<NamedArg>,
     },
     /// `[T; N]`. The extent carries how it was written — see [`ArrayExtent`].
     Array {
         elem: Box<SourceType>,
         extent: ArrayExtent,
     },
-    /// `&T` / `&mut T`.
+    /// `&T` / `&'a T` / `&mut T`.
     Ref {
+        lifetime: Option<syn::Lifetime>,
         mutable: bool,
         inner: Box<SourceType>,
     },
     /// `[T]`, only ever behind a [`SourceType::Ref`].
     Slice(Box<SourceType>),
-    /// `(A, B, …)`; the empty tuple is [`SourceType::Unit`].
-    Tuple(Vec<SourceType>),
     /// `*const T` / `*mut T`.
     Ptr {
         mutable: bool,
@@ -96,6 +101,17 @@ pub enum SourceType {
     Callback { args: Vec<SourceType> },
     /// `()`.
     Unit,
+}
+
+/// One generic argument of a [`SourceType::Named`], in source order.
+///
+/// A lifetime is kept verbatim rather than modeled: it is part of the type's
+/// spelling — `Foo<'static>` is not `Foo` — but carries nothing a destination
+/// language can act on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NamedArg {
+    Lifetime(syn::Lifetime),
+    Type(SourceType),
 }
 
 /// The primitives the source language accepts. Mirrors the set every adapter
@@ -246,6 +262,16 @@ pub enum UnsupportedTypeReason {
     /// A generic that takes a fixed arity and did not get it — `Option` with no
     /// argument, `Result` with one.
     WrongGenericArity { expected: usize },
+    /// A non-empty tuple. Only `()` is in the language: no adapter has ever
+    /// lowered a tuple, so accepting one would defer the failure to a late
+    /// "unresolved type" instead of naming it here.
+    UnsupportedTuple,
+    /// A path with a qualified self — `<T as Trait>::Assoc`.
+    ///
+    /// The frontend never captures `impl` blocks, so it cannot know what an
+    /// associated type resolves to; carrying the spelling would only move the
+    /// failure downstream.
+    AssociatedType,
     /// A lifetime or const generic argument in a position the model does not
     /// represent.
     UnsupportedGenericArgument,
@@ -272,6 +298,18 @@ impl fmt::Display for UnsupportedType {
             UnsupportedTypeReason::WrongGenericArity { expected } => write!(
                 f,
                 "type `{}` needs exactly {expected} type argument(s)",
+                self.offending
+            ),
+            UnsupportedTypeReason::UnsupportedTuple => write!(
+                f,
+                "type `{}` is a tuple; only the unit `()` is supported — return the \
+                 components separately, or wrap them in a `#[prebindgen]` struct",
+                self.offending
+            ),
+            UnsupportedTypeReason::AssociatedType => write!(
+                f,
+                "type `{}` is an associated type; `#[prebindgen]` never captures `impl` \
+                 blocks, so its resolution is unknowable here — name the concrete type",
                 self.offending
             ),
             UnsupportedTypeReason::UnsupportedGenericArgument => write!(
@@ -325,6 +363,7 @@ pub(crate) fn lower_type(
         syn::Type::Group(g) => lower_type(&g.elem, consts, item_crate),
         syn::Type::Paren(p) => lower_type(&p.elem, consts, item_crate),
         syn::Type::Reference(r) => Ok(SourceType::Ref {
+            lifetime: r.lifetime.clone(),
             mutable: r.mutability.is_some(),
             inner: Box::new(lower_type(&r.elem, consts, item_crate)?),
         }),
@@ -336,12 +375,9 @@ pub(crate) fn lower_type(
             inner: Box::new(lower_type(&p.elem, consts, item_crate)?),
         }),
         syn::Type::Tuple(t) if t.elems.is_empty() => Ok(SourceType::Unit),
-        syn::Type::Tuple(t) => Ok(SourceType::Tuple(
-            t.elems
-                .iter()
-                .map(|e| lower_type(e, consts, item_crate))
-                .collect::<Result<_, _>>()?,
-        )),
+        // Only the unit is in the language. Refusing here names the type;
+        // accepting would defer the failure to an "unresolved type" much later.
+        syn::Type::Tuple(_) => Err(fail(UnsupportedTypeReason::UnsupportedTuple)),
         syn::Type::Array(a) => {
             let rendered = a.to_token_stream().to_string();
             let extent = lower_array_len(&a.len, &rendered, item_crate, consts)
@@ -375,22 +411,30 @@ fn lower_path(
         offending: ty.to_token_stream().to_string(),
         reason,
     };
-    // A qualified self (`<T as Trait>::Assoc`) is never normalized and has no
-    // modeled meaning; its spelling is its identity, so it stays a named type.
+    // An associated type is refused rather than carried: the frontend never
+    // captures `impl` blocks, so what `<T as Trait>::Assoc` resolves to is
+    // unknowable here, and keeping the spelling would only move the failure
+    // downstream.
+    if tp.qself.is_some() {
+        return Err(fail(UnsupportedTypeReason::AssociatedType));
+    }
     let Some(last) = tp.path.segments.last() else {
         return Err(fail(UnsupportedTypeReason::UnsupportedForm));
     };
     let name = last.ident.to_string();
-    let args: Vec<SourceType> = match &last.arguments {
+
+    // Arguments in SOURCE ORDER, lifetimes kept verbatim. Order and lifetimes
+    // are what make the projection reconstruct the type exactly.
+    let args: Vec<NamedArg> = match &last.arguments {
         syn::PathArguments::None => Vec::new(),
         syn::PathArguments::AngleBracketed(ab) => {
             let mut out = Vec::new();
             for a in &ab.args {
                 match a {
-                    syn::GenericArgument::Type(t) => out.push(lower_type(t, consts, item_crate)?),
-                    // A lifetime is part of a type's identity but carries no
-                    // structure to model; it survives in `name`'s spelling.
-                    syn::GenericArgument::Lifetime(_) => {}
+                    syn::GenericArgument::Type(t) => {
+                        out.push(NamedArg::Type(lower_type(t, consts, item_crate)?))
+                    }
+                    syn::GenericArgument::Lifetime(lt) => out.push(NamedArg::Lifetime(lt.clone())),
                     _ => return Err(fail(UnsupportedTypeReason::UnsupportedGenericArgument)),
                 }
             }
@@ -401,58 +445,71 @@ fn lower_path(
         }
     };
 
-    let arity = |n: usize| {
-        if args.len() == n {
-            Ok(())
-        } else {
-            Err(fail(UnsupportedTypeReason::WrongGenericArity {
-                expected: n,
-            }))
-        }
-    };
-    let one = |mut args: Vec<SourceType>| Box::new(args.remove(0));
-
-    // A bare primitive, before anything else. Guarded on `qself`/args so a
-    // user type that happens to end in `u8` cannot be mistaken for one.
-    if tp.qself.is_none() && tp.path.segments.len() == 1 && args.is_empty() {
-        if let Some(kind) = ScalarKind::from_name(&name) {
-            return Ok(SourceType::Scalar(kind));
-        }
-    }
-    // Only bare / prelude-normalized spellings reach here: `normalize_type` has
-    // already reduced `std::option::Option` and friends at ingest.
-    match name.as_str() {
-        "String" if args.is_empty() => Ok(SourceType::Str),
-        "Option" => {
-            arity(1)?;
-            Ok(SourceType::Optional(one(args)))
-        }
-        "Vec" => {
-            arity(1)?;
-            Ok(SourceType::Sequence(one(args)))
-        }
-        "Box" => {
-            arity(1)?;
-            Ok(SourceType::Boxed(one(args)))
-        }
-        "Result" => {
-            arity(2)?;
-            let mut args = args;
-            let err = Box::new(args.remove(1));
-            let ok = Box::new(args.remove(0));
-            Ok(SourceType::Fallible { ok, err })
-        }
-        _ => {
-            // The name is the type's IDENTITY and nothing else: the generic
-            // arguments live in `args`, modeled, so keeping a copy of them in
-            // the path too would be two representations of one fact.
-            let mut name = tp.path.clone();
-            if let Some(last) = name.segments.last_mut() {
-                last.arguments = syn::PathArguments::None;
+    // A builtin must be spelled BARE. `normalize_type` has already reduced the
+    // real std paths (`std::option::Option` → `Option`) at ingest and
+    // deliberately leaves unknown crate paths alone, so anything still carrying
+    // a prefix is a foreign type that merely shares a name — `foreign::Option`
+    // is not `Option`, and collapsing it would silently retype the field.
+    let is_bare = tp.path.leading_colon.is_none() && tp.path.segments.len() == 1;
+    if is_bare {
+        if args.is_empty() {
+            if let Some(kind) = ScalarKind::from_name(&name) {
+                return Ok(SourceType::Scalar(kind));
             }
-            Ok(SourceType::Named { name, args })
+            if name == "String" {
+                return Ok(SourceType::Str);
+            }
+        }
+        // A builtin generic takes types only; a lifetime argument on one is not
+        // a shape this language has.
+        let types: Option<Vec<SourceType>> = args
+            .iter()
+            .map(|a| match a {
+                NamedArg::Type(t) => Some(t.clone()),
+                NamedArg::Lifetime(_) => None,
+            })
+            .collect();
+        if let Some(mut types) = types {
+            let arity = |n: usize| {
+                if types.len() == n {
+                    Ok(())
+                } else {
+                    Err(fail(UnsupportedTypeReason::WrongGenericArity {
+                        expected: n,
+                    }))
+                }
+            };
+            match name.as_str() {
+                "Option" => {
+                    arity(1)?;
+                    return Ok(SourceType::Optional(Box::new(types.remove(0))));
+                }
+                "Vec" => {
+                    arity(1)?;
+                    return Ok(SourceType::Sequence(Box::new(types.remove(0))));
+                }
+                "Box" => {
+                    arity(1)?;
+                    return Ok(SourceType::Boxed(Box::new(types.remove(0))));
+                }
+                "Result" => {
+                    arity(2)?;
+                    let err = Box::new(types.remove(1));
+                    let ok = Box::new(types.remove(0));
+                    return Ok(SourceType::Fallible { ok, err });
+                }
+                _ => {}
+            }
         }
     }
+
+    // Everything else keeps its full path as identity, with the last segment's
+    // arguments stripped out into `args` so one fact has one representation.
+    let mut path = tp.clone();
+    if let Some(last) = path.path.segments.last_mut() {
+        last.arguments = syn::PathArguments::None;
+    }
+    Ok(SourceType::Named { path, args })
 }
 
 impl SourceType {
@@ -484,36 +541,49 @@ impl SourceType {
                 let (o, e) = (ok.to_syn(), err.to_syn());
                 syn::parse_quote!(Result<#o, #e>)
             }
-            SourceType::Named { name, args } => {
-                let mut path = name.clone();
+            SourceType::Named { path, args } => {
+                let mut out = path.clone();
                 if !args.is_empty() {
-                    if let Some(last) = path.segments.last_mut() {
-                        let ts: Vec<syn::Type> = args.iter().map(|a| a.to_syn()).collect();
-                        let ab: syn::AngleBracketedGenericArguments = syn::parse_quote!(<#(#ts),*>);
+                    if let Some(last) = out.path.segments.last_mut() {
+                        // Rebuilt in SOURCE ORDER, lifetimes included, so
+                        // `Foo<'a, T>` comes back exactly as written.
+                        let rendered: Vec<proc_macro2::TokenStream> = args
+                            .iter()
+                            .map(|a| match a {
+                                NamedArg::Lifetime(lt) => quote::quote!(#lt),
+                                NamedArg::Type(t) => {
+                                    let t = t.to_syn();
+                                    quote::quote!(#t)
+                                }
+                            })
+                            .collect();
+                        let ab: syn::AngleBracketedGenericArguments =
+                            syn::parse_quote!(<#(#rendered),*>);
                         last.arguments = syn::PathArguments::AngleBracketed(ab);
                     }
                 }
-                syn::Type::Path(syn::TypePath { qself: None, path })
+                syn::Type::Path(out)
             }
             SourceType::Array { elem, extent } => {
                 let (t, n) = (elem.to_syn(), extent.to_expr());
                 syn::parse_quote!([#t; #n])
             }
-            SourceType::Ref { mutable, inner } => {
+            SourceType::Ref {
+                lifetime,
+                mutable,
+                inner,
+            } => {
                 let t = inner.to_syn();
-                if *mutable {
-                    syn::parse_quote!(&mut #t)
-                } else {
-                    syn::parse_quote!(&#t)
+                match (lifetime, mutable) {
+                    (Some(lt), true) => syn::parse_quote!(&#lt mut #t),
+                    (Some(lt), false) => syn::parse_quote!(&#lt #t),
+                    (None, true) => syn::parse_quote!(&mut #t),
+                    (None, false) => syn::parse_quote!(&#t),
                 }
             }
             SourceType::Slice(inner) => {
                 let t = inner.to_syn();
                 syn::parse_quote!([#t])
-            }
-            SourceType::Tuple(elems) => {
-                let ts: Vec<syn::Type> = elems.iter().map(|e| e.to_syn()).collect();
-                syn::parse_quote!((#(#ts),*))
             }
             SourceType::Ptr { mutable, inner } => {
                 let t = inner.to_syn();
@@ -568,10 +638,12 @@ impl SourceType {
                 ok.collect_extents(out);
                 err.collect_extents(out);
             }
-            SourceType::Tuple(ts) | SourceType::Callback { args: ts } => {
-                ts.iter().for_each(|t| t.collect_extents(out))
-            }
-            SourceType::Named { args, .. } => args.iter().for_each(|t| t.collect_extents(out)),
+            SourceType::Callback { args } => args.iter().for_each(|t| t.collect_extents(out)),
+            SourceType::Named { args, .. } => args.iter().for_each(|a| {
+                if let NamedArg::Type(t) = a {
+                    t.collect_extents(out)
+                }
+            }),
             SourceType::Scalar(_) | SourceType::Str | SourceType::Unit => {}
         }
     }

--- a/prebindgen/src/api/core/frontend/model.rs
+++ b/prebindgen/src/api/core/frontend/model.rs
@@ -257,8 +257,11 @@ pub enum UnsupportedTypeReason {
     /// A syntactic form with no place in the language: a bare trait object, a
     /// closure type, a macro, `Self`, a never type, an inferred type.
     UnsupportedForm,
-    /// `impl Trait` that is not `Fn(..) + Send + Sync + 'static`.
-    DisallowedImplTrait,
+    /// `impl Trait` that is not an accepted callback — see
+    /// [`CallbackReject`](crate::api::core::registry::CallbackReject), which
+    /// says whether the form is reserved for a future release or cannot work
+    /// at all.
+    DisallowedImplTrait(crate::api::core::registry::CallbackReject),
     /// A generic that takes a fixed arity and did not get it — `Option` with no
     /// argument, `Result` with one.
     WrongGenericArity { expected: usize },
@@ -289,11 +292,11 @@ impl fmt::Display for UnsupportedType {
                 "type `{}` is a form the prebindgen source language does not accept",
                 self.offending
             ),
-            UnsupportedTypeReason::DisallowedImplTrait => write!(
+            UnsupportedTypeReason::DisallowedImplTrait(reason) => write!(
                 f,
-                "type `{}` is an `impl Trait` other than \
-                 `impl Fn(..) + Send + Sync + 'static`, the only one supported",
-                self.offending
+                "type `{}` is not an accepted callback — {}",
+                self.offending,
+                reason.describe()
             ),
             UnsupportedTypeReason::WrongGenericArity { expected } => write!(
                 f,
@@ -387,14 +390,17 @@ pub(crate) fn lower_type(
                 extent,
             })
         }
-        syn::Type::ImplTrait(_) => match crate::api::core::registry::extract_fn_trait_args(ty) {
-            Some(args) => Ok(SourceType::Callback {
+        // The callback gate lives in `registry` because it is also the live
+        // acceptance check for function parameters, which are not modeled yet.
+        // Mapping its reason through keeps ONE authority.
+        syn::Type::ImplTrait(_) => match crate::api::core::registry::extract_fn_trait_sig(ty) {
+            Ok(args) => Ok(SourceType::Callback {
                 args: args
                     .iter()
                     .map(|a| lower_type(a, consts, item_crate))
                     .collect::<Result<_, _>>()?,
             }),
-            None => Err(fail(UnsupportedTypeReason::DisallowedImplTrait)),
+            Err(reason) => Err(fail(UnsupportedTypeReason::DisallowedImplTrait(reason))),
         },
         syn::Type::Path(tp) => lower_path(ty, tp, consts, item_crate),
         _ => Err(fail(UnsupportedTypeReason::UnsupportedForm)),

--- a/prebindgen/src/api/core/frontend/model.rs
+++ b/prebindgen/src/api/core/frontend/model.rs
@@ -1,0 +1,578 @@
+//! The language-neutral source model: what a captured Rust type **means**.
+//!
+//! This is the beginning of issue #211's `SourceModel`. Its purpose is stated
+//! there and is worth restating, because it is what every design choice here
+//! answers to:
+//!
+//! > Language adapters do not parse captured source or keep parallel
+//! > whitelists/classifiers for source syntax. Emitters do not recover semantic
+//! > facts by re-reading raw source syntax.
+//!
+//! So a fact an adapter needs is a **node in this model**, never something it
+//! re-derives from `syn`. The array extent is the worked example: a C header has
+//! to be able to emit `uint8_t tag[MARKER_TAG_LEN]`, and the only way for the
+//! adapter to know that the extent was written as a named const — rather than
+//! guessing from syntax it should not be reading — is for the model to say so.
+//!
+//! [`SourceType`] also *is* the answer to the questions adapters currently ask
+//! `syn` themselves: `is_scalar`, `is_string`, `is_vec`, `is_option`,
+//! `box_inner`, `pat_match_top`. Those become `match` arms on a closed enum.
+//! Deleting the duplicates is stages F5/F6 of the umbrella (#215); this module
+//! is what makes it possible.
+//!
+//! # Boundary today
+//!
+//! * **Types** — complete. [`lower_type`] is total over the grammar in
+//!   `docs/source-language.md`; anything else is a frontend error.
+//! * **Items** — structs only ([`SourceStruct`]). Functions and enums keep
+//!   their `syn` items for now, which #211 step 4 explicitly allows while
+//!   adapters migrate.
+//! * **Adapters** — only cbindgen's struct-field path consumes this. Everything
+//!   else reads the `syn::Type` projection ([`SourceType::to_syn`]).
+
+use std::fmt;
+
+use quote::ToTokens;
+
+use super::array_len::{lower_array_len, ConstIndex};
+
+#[cfg(test)]
+mod tests;
+
+/// A Rust type as the frontend decided it.
+///
+/// The variants are the accepted type grammar: a form with no variant here is a
+/// form the prebindgen source language does not accept. Acceptance is therefore
+/// a consequence of lowering, the same contract [`lower_array_len`] established
+/// for extents.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceType {
+    /// A primitive with a fixed C/JVM counterpart.
+    Scalar(ScalarKind),
+    /// `String` — an owned, heap-allocated UTF-8 string.
+    Str,
+    /// `Option<T>`.
+    Optional(Box<SourceType>),
+    /// `Vec<T>`.
+    Sequence(Box<SourceType>),
+    /// `Box<T>`.
+    Boxed(Box<SourceType>),
+    /// `Result<T, E>`.
+    Fallible {
+        ok: Box<SourceType>,
+        err: Box<SourceType>,
+    },
+    /// Any other named type: a `#[prebindgen]` struct or enum, or a foreign
+    /// path.
+    ///
+    /// `name` is the normalized spelling WITHOUT generic arguments — the type's
+    /// identity, not syntax to re-inspect; the arguments are modeled in `args`.
+    /// A lifetime argument survives in `name` alone, since it is part of the
+    /// spelling but carries no structure.
+    Named {
+        name: syn::Path,
+        args: Vec<SourceType>,
+    },
+    /// `[T; N]`. The extent carries how it was written — see [`ArrayExtent`].
+    Array {
+        elem: Box<SourceType>,
+        extent: ArrayExtent,
+    },
+    /// `&T` / `&mut T`.
+    Ref {
+        mutable: bool,
+        inner: Box<SourceType>,
+    },
+    /// `[T]`, only ever behind a [`SourceType::Ref`].
+    Slice(Box<SourceType>),
+    /// `(A, B, …)`; the empty tuple is [`SourceType::Unit`].
+    Tuple(Vec<SourceType>),
+    /// `*const T` / `*mut T`.
+    Ptr {
+        mutable: bool,
+        inner: Box<SourceType>,
+    },
+    /// `impl Fn(A, B, …) + Send + Sync + 'static` — the callback form.
+    Callback { args: Vec<SourceType> },
+    /// `()`.
+    Unit,
+}
+
+/// The primitives the source language accepts. Mirrors the set every adapter
+/// already treats as directly representable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScalarKind {
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+    F32,
+    F64,
+}
+
+impl ScalarKind {
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "bool" => Self::Bool,
+            "i8" => Self::I8,
+            "i16" => Self::I16,
+            "i32" => Self::I32,
+            "i64" => Self::I64,
+            "isize" => Self::Isize,
+            "u8" => Self::U8,
+            "u16" => Self::U16,
+            "u32" => Self::U32,
+            "u64" => Self::U64,
+            "usize" => Self::Usize,
+            "f32" => Self::F32,
+            "f64" => Self::F64,
+            _ => return None,
+        })
+    }
+
+    /// The Rust spelling — the identity this was lowered from.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::I8 => "i8",
+            Self::I16 => "i16",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::Isize => "isize",
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::Usize => "usize",
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+
+    fn to_syn(self) -> syn::Type {
+        let ident = syn::Ident::new(self.as_str(), proc_macro2::Span::call_site());
+        syn::parse_quote!(#ident)
+    }
+}
+
+/// A fixed-size array's extent: its value, and how the source wrote it.
+///
+/// Both halves are load-bearing and belong to **different consumers**:
+///
+/// * `value` is the semantic length. It is what makes `[u8; A]` and `[u8; 4]`
+///   one Rust type, one [`TypeKey`](crate::api::core::TypeKey) and one
+///   converter, and it is what a generator needs when a destination language
+///   has no way to reference a Rust const — a Kotlin surface that groups a
+///   small array into scalars needs the count as a number.
+/// * `source` is how it was written. A C header must be able to emit
+///   `uint8_t tag[MARKER_TAG_LEN]`, because the symbolic extent is part of that
+///   API's meaning: changing the size is then one edit rather than a hunt
+///   through literals.
+///
+/// This lives on the **use site** — a field of a [`SourceStruct`] — and never
+/// on anything keyed by type. Three fields whose extents are equal share one
+/// `TypeKey`, so a type-keyed table could only report whichever of them was
+/// stored last.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArrayExtent {
+    pub value: usize,
+    pub source: ExtentSource,
+}
+
+/// How an [`ArrayExtent`] was spelled at its use site.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExtentSource {
+    /// Written as an integer literal — `[u8; 4]`.
+    Literal,
+    /// Written as the name of a `#[prebindgen]` const — `[u8; MARKER_TAG_LEN]`.
+    Const(ConstId),
+}
+
+/// A `#[prebindgen]` const, identified the way the flat namespace identifies
+/// everything: by name, plus the crate it was marked in.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConstId {
+    pub name: String,
+    /// Crate the const was marked in; `None` for an origin-less stream.
+    pub origin: Option<String>,
+}
+
+impl ArrayExtent {
+    /// The extent as generated Rust spells it by default: the number.
+    ///
+    /// An adapter that wants the symbolic form reads [`Self::source`] and builds
+    /// its own — that is a spelling choice, and spelling choices are the
+    /// adapter's half of the boundary.
+    pub fn to_expr(&self) -> syn::Expr {
+        let lit = syn::LitInt::new(&self.value.to_string(), proc_macro2::Span::call_site());
+        syn::Expr::Lit(syn::ExprLit {
+            attrs: Vec::new(),
+            lit: syn::Lit::Int(lit),
+        })
+    }
+
+    /// The const this extent named, if it named one.
+    pub fn const_id(&self) -> Option<&ConstId> {
+        match &self.source {
+            ExtentSource::Literal => None,
+            ExtentSource::Const(id) => Some(id),
+        }
+    }
+}
+
+/// A type the prebindgen source language does not accept.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedType {
+    /// The offending type as written.
+    pub offending: String,
+    pub reason: UnsupportedTypeReason,
+}
+
+/// Why [`lower_type`] refused a type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnsupportedTypeReason {
+    /// A syntactic form with no place in the language: a bare trait object, a
+    /// closure type, a macro, `Self`, a never type, an inferred type.
+    UnsupportedForm,
+    /// `impl Trait` that is not `Fn(..) + Send + Sync + 'static`.
+    DisallowedImplTrait,
+    /// A generic that takes a fixed arity and did not get it — `Option` with no
+    /// argument, `Result` with one.
+    WrongGenericArity { expected: usize },
+    /// A lifetime or const generic argument in a position the model does not
+    /// represent.
+    UnsupportedGenericArgument,
+    /// The array's extent — see
+    /// [`ArrayLenReason`](super::ArrayLenReason).
+    BadArrayExtent(Box<super::UnsupportedArrayLen>),
+}
+
+impl fmt::Display for UnsupportedType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.reason {
+            UnsupportedTypeReason::BadArrayExtent(e) => return write!(f, "{e}"),
+            UnsupportedTypeReason::UnsupportedForm => write!(
+                f,
+                "type `{}` is a form the prebindgen source language does not accept",
+                self.offending
+            ),
+            UnsupportedTypeReason::DisallowedImplTrait => write!(
+                f,
+                "type `{}` is an `impl Trait` other than \
+                 `impl Fn(..) + Send + Sync + 'static`, the only one supported",
+                self.offending
+            ),
+            UnsupportedTypeReason::WrongGenericArity { expected } => write!(
+                f,
+                "type `{}` needs exactly {expected} type argument(s)",
+                self.offending
+            ),
+            UnsupportedTypeReason::UnsupportedGenericArgument => write!(
+                f,
+                "type `{}` has a generic argument that is not a type",
+                self.offending
+            ),
+        }?;
+        write!(f, " — see docs/source-language.md for the accepted grammar")
+    }
+}
+
+impl std::error::Error for UnsupportedType {}
+
+/// One field of a [`SourceStruct`].
+#[derive(Clone, Debug)]
+pub struct SourceField {
+    pub name: syn::Ident,
+    pub ty: SourceType,
+}
+
+/// A `#[prebindgen]` struct, as the frontend decided it.
+///
+/// Named fields only — the one struct shape whose fields are a boundary
+/// surface. A tuple struct is still indexed (it can be an opaque handle) but
+/// has no modeled fields.
+#[derive(Clone, Debug, Default)]
+pub struct SourceStruct {
+    pub fields: Vec<SourceField>,
+}
+
+/// Lower a captured type to its model.
+///
+/// **Total over the accepted grammar**: `Ok` means every part of the type was
+/// understood, so a form this function does not lower is a form the language
+/// does not accept. There is no separate acceptance list to drift from — the
+/// same contract, and for the same reason, as [`lower_array_len`].
+///
+/// `item_crate` is the origin of the item the type was written in; an extent
+/// must name a const from that same crate.
+pub(crate) fn lower_type(
+    ty: &syn::Type,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<SourceType, UnsupportedType> {
+    let fail = |reason| UnsupportedType {
+        offending: ty.to_token_stream().to_string(),
+        reason,
+    };
+    match ty {
+        syn::Type::Group(g) => lower_type(&g.elem, consts, item_crate),
+        syn::Type::Paren(p) => lower_type(&p.elem, consts, item_crate),
+        syn::Type::Reference(r) => Ok(SourceType::Ref {
+            mutable: r.mutability.is_some(),
+            inner: Box::new(lower_type(&r.elem, consts, item_crate)?),
+        }),
+        syn::Type::Slice(s) => Ok(SourceType::Slice(Box::new(lower_type(
+            &s.elem, consts, item_crate,
+        )?))),
+        syn::Type::Ptr(p) => Ok(SourceType::Ptr {
+            mutable: p.mutability.is_some(),
+            inner: Box::new(lower_type(&p.elem, consts, item_crate)?),
+        }),
+        syn::Type::Tuple(t) if t.elems.is_empty() => Ok(SourceType::Unit),
+        syn::Type::Tuple(t) => Ok(SourceType::Tuple(
+            t.elems
+                .iter()
+                .map(|e| lower_type(e, consts, item_crate))
+                .collect::<Result<_, _>>()?,
+        )),
+        syn::Type::Array(a) => {
+            let rendered = a.to_token_stream().to_string();
+            let extent = lower_array_len(&a.len, &rendered, item_crate, consts)
+                .map_err(|e| fail(UnsupportedTypeReason::BadArrayExtent(Box::new(e))))?;
+            Ok(SourceType::Array {
+                elem: Box::new(lower_type(&a.elem, consts, item_crate)?),
+                extent,
+            })
+        }
+        syn::Type::ImplTrait(_) => match crate::api::core::registry::extract_fn_trait_args(ty) {
+            Some(args) => Ok(SourceType::Callback {
+                args: args
+                    .iter()
+                    .map(|a| lower_type(a, consts, item_crate))
+                    .collect::<Result<_, _>>()?,
+            }),
+            None => Err(fail(UnsupportedTypeReason::DisallowedImplTrait)),
+        },
+        syn::Type::Path(tp) => lower_path(ty, tp, consts, item_crate),
+        _ => Err(fail(UnsupportedTypeReason::UnsupportedForm)),
+    }
+}
+
+fn lower_path(
+    ty: &syn::Type,
+    tp: &syn::TypePath,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<SourceType, UnsupportedType> {
+    let fail = |reason| UnsupportedType {
+        offending: ty.to_token_stream().to_string(),
+        reason,
+    };
+    // A qualified self (`<T as Trait>::Assoc`) is never normalized and has no
+    // modeled meaning; its spelling is its identity, so it stays a named type.
+    let Some(last) = tp.path.segments.last() else {
+        return Err(fail(UnsupportedTypeReason::UnsupportedForm));
+    };
+    let name = last.ident.to_string();
+    let args: Vec<SourceType> = match &last.arguments {
+        syn::PathArguments::None => Vec::new(),
+        syn::PathArguments::AngleBracketed(ab) => {
+            let mut out = Vec::new();
+            for a in &ab.args {
+                match a {
+                    syn::GenericArgument::Type(t) => out.push(lower_type(t, consts, item_crate)?),
+                    // A lifetime is part of a type's identity but carries no
+                    // structure to model; it survives in `name`'s spelling.
+                    syn::GenericArgument::Lifetime(_) => {}
+                    _ => return Err(fail(UnsupportedTypeReason::UnsupportedGenericArgument)),
+                }
+            }
+            out
+        }
+        syn::PathArguments::Parenthesized(_) => {
+            return Err(fail(UnsupportedTypeReason::UnsupportedForm))
+        }
+    };
+
+    let arity = |n: usize| {
+        if args.len() == n {
+            Ok(())
+        } else {
+            Err(fail(UnsupportedTypeReason::WrongGenericArity {
+                expected: n,
+            }))
+        }
+    };
+    let one = |mut args: Vec<SourceType>| Box::new(args.remove(0));
+
+    // A bare primitive, before anything else. Guarded on `qself`/args so a
+    // user type that happens to end in `u8` cannot be mistaken for one.
+    if tp.qself.is_none() && tp.path.segments.len() == 1 && args.is_empty() {
+        if let Some(kind) = ScalarKind::from_name(&name) {
+            return Ok(SourceType::Scalar(kind));
+        }
+    }
+    // Only bare / prelude-normalized spellings reach here: `normalize_type` has
+    // already reduced `std::option::Option` and friends at ingest.
+    match name.as_str() {
+        "String" if args.is_empty() => Ok(SourceType::Str),
+        "Option" => {
+            arity(1)?;
+            Ok(SourceType::Optional(one(args)))
+        }
+        "Vec" => {
+            arity(1)?;
+            Ok(SourceType::Sequence(one(args)))
+        }
+        "Box" => {
+            arity(1)?;
+            Ok(SourceType::Boxed(one(args)))
+        }
+        "Result" => {
+            arity(2)?;
+            let mut args = args;
+            let err = Box::new(args.remove(1));
+            let ok = Box::new(args.remove(0));
+            Ok(SourceType::Fallible { ok, err })
+        }
+        _ => {
+            // The name is the type's IDENTITY and nothing else: the generic
+            // arguments live in `args`, modeled, so keeping a copy of them in
+            // the path too would be two representations of one fact.
+            let mut name = tp.path.clone();
+            if let Some(last) = name.segments.last_mut() {
+                last.arguments = syn::PathArguments::None;
+            }
+            Ok(SourceType::Named { name, args })
+        }
+    }
+}
+
+impl SourceType {
+    /// The `syn::Type` this models — the **semantic** form, with every array
+    /// extent as its number.
+    ///
+    /// This is the projection everything unmigrated consumes, `TypeKey`
+    /// included, which is why `[u8; A]` and `[u8; 4]` stay one type and one
+    /// converter. It is a projection, not a second source of truth: the model
+    /// is what the frontend stores, and the `syn` item's field types are
+    /// written from this.
+    pub fn to_syn(&self) -> syn::Type {
+        match self {
+            SourceType::Scalar(k) => k.to_syn(),
+            SourceType::Str => syn::parse_quote!(String),
+            SourceType::Optional(inner) => {
+                let t = inner.to_syn();
+                syn::parse_quote!(Option<#t>)
+            }
+            SourceType::Sequence(inner) => {
+                let t = inner.to_syn();
+                syn::parse_quote!(Vec<#t>)
+            }
+            SourceType::Boxed(inner) => {
+                let t = inner.to_syn();
+                syn::parse_quote!(Box<#t>)
+            }
+            SourceType::Fallible { ok, err } => {
+                let (o, e) = (ok.to_syn(), err.to_syn());
+                syn::parse_quote!(Result<#o, #e>)
+            }
+            SourceType::Named { name, args } => {
+                let mut path = name.clone();
+                if !args.is_empty() {
+                    if let Some(last) = path.segments.last_mut() {
+                        let ts: Vec<syn::Type> = args.iter().map(|a| a.to_syn()).collect();
+                        let ab: syn::AngleBracketedGenericArguments = syn::parse_quote!(<#(#ts),*>);
+                        last.arguments = syn::PathArguments::AngleBracketed(ab);
+                    }
+                }
+                syn::Type::Path(syn::TypePath { qself: None, path })
+            }
+            SourceType::Array { elem, extent } => {
+                let (t, n) = (elem.to_syn(), extent.to_expr());
+                syn::parse_quote!([#t; #n])
+            }
+            SourceType::Ref { mutable, inner } => {
+                let t = inner.to_syn();
+                if *mutable {
+                    syn::parse_quote!(&mut #t)
+                } else {
+                    syn::parse_quote!(&#t)
+                }
+            }
+            SourceType::Slice(inner) => {
+                let t = inner.to_syn();
+                syn::parse_quote!([#t])
+            }
+            SourceType::Tuple(elems) => {
+                let ts: Vec<syn::Type> = elems.iter().map(|e| e.to_syn()).collect();
+                syn::parse_quote!((#(#ts),*))
+            }
+            SourceType::Ptr { mutable, inner } => {
+                let t = inner.to_syn();
+                if *mutable {
+                    syn::parse_quote!(*mut #t)
+                } else {
+                    syn::parse_quote!(*const #t)
+                }
+            }
+            SourceType::Callback { args } => {
+                let ts: Vec<syn::Type> = args.iter().map(|a| a.to_syn()).collect();
+                syn::parse_quote!(impl Fn(#(#ts),*) + Send + Sync + 'static)
+            }
+            SourceType::Unit => syn::parse_quote!(()),
+        }
+    }
+
+    /// The extent of this type when it is an array, else `None`. The one fact
+    /// an adapter cannot get from [`Self::to_syn`], and the reason this model
+    /// exists.
+    pub fn array_extent(&self) -> Option<&ArrayExtent> {
+        match self {
+            SourceType::Array { extent, .. } => Some(extent),
+            _ => None,
+        }
+    }
+
+    /// Every extent reachable from this type, outermost first — so a nested
+    /// `[[u8; A]; B]` yields `B` then `A`.
+    ///
+    /// Used to find which consts an emitted C type may name, and therefore
+    /// which must reach the header as a `#define`.
+    pub fn extents(&self) -> Vec<&ArrayExtent> {
+        let mut out = Vec::new();
+        self.collect_extents(&mut out);
+        out
+    }
+
+    fn collect_extents<'a>(&'a self, out: &mut Vec<&'a ArrayExtent>) {
+        match self {
+            SourceType::Array { elem, extent } => {
+                out.push(extent);
+                elem.collect_extents(out);
+            }
+            SourceType::Optional(t)
+            | SourceType::Sequence(t)
+            | SourceType::Boxed(t)
+            | SourceType::Slice(t)
+            | SourceType::Ref { inner: t, .. }
+            | SourceType::Ptr { inner: t, .. } => t.collect_extents(out),
+            SourceType::Fallible { ok, err } => {
+                ok.collect_extents(out);
+                err.collect_extents(out);
+            }
+            SourceType::Tuple(ts) | SourceType::Callback { args: ts } => {
+                ts.iter().for_each(|t| t.collect_extents(out))
+            }
+            SourceType::Named { args, .. } => args.iter().for_each(|t| t.collect_extents(out)),
+            SourceType::Scalar(_) | SourceType::Str | SourceType::Unit => {}
+        }
+    }
+}

--- a/prebindgen/src/api/core/frontend/model/tests.rs
+++ b/prebindgen/src/api/core/frontend/model/tests.rs
@@ -6,9 +6,10 @@
 use quote::ToTokens;
 
 use super::{
-    lower_type, ArrayExtent, ConstId, ExtentSource, ScalarKind, SourceType, UnsupportedTypeReason,
+    lower_type, ArrayExtent, ConstId, ExtentSource, NamedArg, ScalarKind, SourceType,
+    UnsupportedTypeReason,
 };
-use crate::api::core::frontend::ConstIndex;
+use crate::api::core::{frontend::ConstIndex, TypeKey};
 
 fn consts() -> ConstIndex {
     ConstIndex::new([
@@ -36,7 +37,7 @@ fn named(src: &str) -> SourceType {
         panic!("not a path")
     };
     SourceType::Named {
-        name: tp.path,
+        path: tp,
         args: Vec::new(),
     }
 }
@@ -79,15 +80,23 @@ fn accepted_types() {
         (
             "Wrapper<u8>",
             SourceType::Named {
-                name: syn::parse_quote!(Wrapper),
-                args: vec![SourceType::Scalar(ScalarKind::U8)],
+                path: syn::parse_quote!(Wrapper),
+                args: vec![NamedArg::Type(SourceType::Scalar(ScalarKind::U8))],
             },
         ),
-        // A lifetime is part of the spelling, not modeled structure.
-        ("KeyExpr<'static>", named("KeyExpr")),
+        // A lifetime is kept VERBATIM as an argument: part of the spelling, not
+        // modeled structure — and `Foo<'static>` is not `Foo`.
+        (
+            "KeyExpr<'static>",
+            SourceType::Named {
+                path: syn::parse_quote!(KeyExpr),
+                args: vec![NamedArg::Lifetime(syn::parse_quote!('static))],
+            },
+        ),
         (
             "&u8",
             SourceType::Ref {
+                lifetime: None,
                 mutable: false,
                 inner: Box::new(SourceType::Scalar(ScalarKind::U8)),
             },
@@ -95,6 +104,7 @@ fn accepted_types() {
         (
             "&mut Foo",
             SourceType::Ref {
+                lifetime: None,
                 mutable: true,
                 inner: Box::new(named("Foo")),
             },
@@ -102,6 +112,7 @@ fn accepted_types() {
         (
             "&[u8]",
             SourceType::Ref {
+                lifetime: None,
                 mutable: false,
                 inner: Box::new(SourceType::Slice(Box::new(SourceType::Scalar(
                     ScalarKind::U8,
@@ -114,10 +125,6 @@ fn accepted_types() {
                 mutable: false,
                 inner: Box::new(SourceType::Scalar(ScalarKind::U8)),
             },
-        ),
-        (
-            "(u8, String)",
-            SourceType::Tuple(vec![SourceType::Scalar(ScalarKind::U8), SourceType::Str]),
         ),
         (
             "impl Fn(u8) + Send + Sync + 'static",
@@ -211,6 +218,16 @@ fn refused_types() {
             "Result<u8>",
             UnsupportedTypeReason::WrongGenericArity { expected: 2 },
         ),
+        // Only `()` is in the language. No adapter has ever lowered a tuple —
+        // every `Type::Tuple` site in both of them is the unit case or a
+        // generic walk — so accepting one only deferred the failure to a late
+        // "unresolved type".
+        ("(u8, String)", UnsupportedTypeReason::UnsupportedTuple),
+        ("(Foo,)", UnsupportedTypeReason::UnsupportedTuple),
+        // An associated type: `#[prebindgen]` never captures `impl` blocks, so
+        // what this resolves to is unknowable here.
+        ("<T as Trait>::Assoc", UnsupportedTypeReason::AssociatedType),
+        ("<Holder>::N", UnsupportedTypeReason::AssociatedType),
     ];
     for (src, reason) in cases {
         match lower(src) {
@@ -227,43 +244,90 @@ fn refused_types() {
     );
 }
 
-/// `to_syn` round-trips: the projection of a lowered type re-lowers to itself.
+/// **The projection preserves type IDENTITY.**
 ///
-/// This is what makes the `syn` field types stored on an item a projection
-/// rather than a second source of truth — they cannot say something the model
-/// does not.
+/// For every accepted form, the `TypeKey` of the normalized original equals the
+/// `TypeKey` of its projection — so writing `field.ty = ty.to_syn()` in pass 3
+/// cannot change what a type *is*.
+///
+/// This compares against the **normalized original**, which is what makes it
+/// detect loss. Its predecessor projected an already-projected type and so only
+/// proved a lossy function idempotent; it passed while `&'static Foo` became
+/// `&Foo`, `Foo<'static>` became `Foo`, and `foreign::Option<u8>` became the
+/// prelude `Option<u8>`.
+///
+/// Arrays are the one deliberate exception — the extent becomes its number —
+/// so they are asserted against the expected numeric form instead.
 #[test]
-fn to_syn_round_trips() {
-    for src in [
+fn the_projection_preserves_type_identity() {
+    let identity = [
         "u8",
+        "bool",
         "String",
         "()",
         "Option<Vec<u8>>",
         "Box<Foo>",
         "Result<u8, String>",
+        "Foo",
         "Wrapper<u8>",
+        // The five the review found. Each was silently rewritten before.
+        "& 'static Foo",
+        "&'a mut Foo",
+        "Foo<'static>",
+        "Foo<'a, u8>",
+        "foreign::Option<u8>",
+        "a::b::Foo<u8>",
+        "::root::Foo",
+        // Neighbours of those, to pin that the fix did not overshoot.
+        "&Foo",
         "&mut Foo",
         "&[u8]",
         "*mut u8",
-        "(u8, String)",
-        "[u8; 4]",
-        "[[u8; N]; M]",
         "impl Fn(u8) + Send + Sync + 'static",
-    ] {
-        let once = lower(src).unwrap_or_else(|r| panic!("`{src}` refused: {r:?}"));
-        let projected = once.to_syn();
-        let twice = lower_type(&projected, &consts(), Some("myflat")).unwrap_or_else(|e| {
-            panic!(
-                "`{src}` projection `{}` refused: {e}",
-                projected.to_token_stream()
-            )
-        });
-        // The extent's SPELLING is deliberately not in the projection, so
-        // compare the semantic form.
+    ];
+    for src in identity {
+        let ty: syn::Type = syn::parse_str(src).unwrap_or_else(|e| panic!("`{src}`: {e}"));
+        let lowered = lower(src).unwrap_or_else(|r| panic!("`{src}` was refused: {r:?}"));
         assert_eq!(
-            twice.to_syn().to_token_stream().to_string(),
-            projected.to_token_stream().to_string(),
-            "`{src}` did not round-trip"
+            TypeKey::from_type(&ty),
+            TypeKey::from_type(&lowered.to_syn()),
+            "`{src}` lost identity: projected as `{}`",
+            lowered.to_syn().to_token_stream()
         );
     }
+
+    // An extent is deliberately projected as its value, and nothing else moves.
+    let arr = lower("[u8; N]").unwrap();
+    assert_eq!(
+        TypeKey::from_type(&arr.to_syn()),
+        TypeKey::from_type(&syn::parse_quote!([u8; 4]))
+    );
+    let nested = lower("Option<[[u8; N]; M]>").unwrap();
+    assert_eq!(
+        TypeKey::from_type(&nested.to_syn()),
+        TypeKey::from_type(&syn::parse_quote!(Option<[[u8; 4]; 2]>))
+    );
+}
+
+/// A builtin must be spelled BARE. `foreign::Option` merely shares a name with
+/// the prelude type and is a different type; collapsing it would silently
+/// retype the field and pick the wrong converter.
+///
+/// `normalize_type` is what makes this safe to demand: it reduces the real std
+/// paths to bare form at ingest and deliberately leaves unknown crate paths
+/// alone.
+#[test]
+fn a_builtin_must_be_spelled_bare() {
+    assert!(matches!(lower("Option<u8>"), Ok(SourceType::Optional(_))));
+    assert!(matches!(lower("Vec<u8>"), Ok(SourceType::Sequence(_))));
+    assert!(matches!(lower("String"), Ok(SourceType::Str)));
+
+    for foreign in ["foreign::Option<u8>", "foreign::Vec<u8>", "foreign::String"] {
+        assert!(
+            matches!(lower(foreign), Ok(SourceType::Named { .. })),
+            "`{foreign}` must stay a foreign named type"
+        );
+    }
+    // A user type ending in a scalar's name is not that scalar either.
+    assert!(matches!(lower("mycrate::u8"), Ok(SourceType::Named { .. })));
 }

--- a/prebindgen/src/api/core/frontend/model/tests.rs
+++ b/prebindgen/src/api/core/frontend/model/tests.rs
@@ -1,0 +1,269 @@
+//! The type-lowering matrix.
+//!
+//! Source spelling → the [`SourceType`] it means, or the precise reason it is
+//! refused. A new accepted or refused form is a row.
+
+use quote::ToTokens;
+
+use super::{
+    lower_type, ArrayExtent, ConstId, ExtentSource, ScalarKind, SourceType, UnsupportedTypeReason,
+};
+use crate::api::core::frontend::ConstIndex;
+
+fn consts() -> ConstIndex {
+    ConstIndex::new([
+        (
+            "N".to_string(),
+            syn::parse_quote!(4),
+            Some("myflat".to_string()),
+        ),
+        (
+            "M".to_string(),
+            syn::parse_quote!(2),
+            Some("myflat".to_string()),
+        ),
+    ])
+}
+
+fn lower(src: &str) -> Result<SourceType, UnsupportedTypeReason> {
+    let ty: syn::Type = syn::parse_str(src).expect("test input must parse");
+    lower_type(&ty, &consts(), Some("myflat")).map_err(|e| e.reason)
+}
+
+fn named(src: &str) -> SourceType {
+    let ty: syn::Type = syn::parse_str(src).expect("parse");
+    let syn::Type::Path(tp) = ty else {
+        panic!("not a path")
+    };
+    SourceType::Named {
+        name: tp.path,
+        args: Vec::new(),
+    }
+}
+
+/// ACCEPTED forms, and the model each means.
+///
+/// The model *is* the classification: `is_scalar`, `is_string`, `is_vec`,
+/// `is_option` and `box_inner` are these variants, not questions an adapter
+/// re-asks `syn`. That is what stages F5/F6 will delete.
+#[test]
+fn accepted_types() {
+    let cases: &[(&str, SourceType)] = &[
+        ("u8", SourceType::Scalar(ScalarKind::U8)),
+        ("bool", SourceType::Scalar(ScalarKind::Bool)),
+        ("f64", SourceType::Scalar(ScalarKind::F64)),
+        ("usize", SourceType::Scalar(ScalarKind::Usize)),
+        ("String", SourceType::Str),
+        ("()", SourceType::Unit),
+        (
+            "Option<u8>",
+            SourceType::Optional(Box::new(SourceType::Scalar(ScalarKind::U8))),
+        ),
+        (
+            "Vec<Vec<u8>>",
+            SourceType::Sequence(Box::new(SourceType::Sequence(Box::new(
+                SourceType::Scalar(ScalarKind::U8),
+            )))),
+        ),
+        ("Box<String>", SourceType::Boxed(Box::new(SourceType::Str))),
+        (
+            "Result<u8, String>",
+            SourceType::Fallible {
+                ok: Box::new(SourceType::Scalar(ScalarKind::U8)),
+                err: Box::new(SourceType::Str),
+            },
+        ),
+        // A user type, and a user type with arguments — the fallback, which is
+        // where an indexed struct/enum and a foreign path both land.
+        ("Foo", named("Foo")),
+        (
+            "Wrapper<u8>",
+            SourceType::Named {
+                name: syn::parse_quote!(Wrapper),
+                args: vec![SourceType::Scalar(ScalarKind::U8)],
+            },
+        ),
+        // A lifetime is part of the spelling, not modeled structure.
+        ("KeyExpr<'static>", named("KeyExpr")),
+        (
+            "&u8",
+            SourceType::Ref {
+                mutable: false,
+                inner: Box::new(SourceType::Scalar(ScalarKind::U8)),
+            },
+        ),
+        (
+            "&mut Foo",
+            SourceType::Ref {
+                mutable: true,
+                inner: Box::new(named("Foo")),
+            },
+        ),
+        (
+            "&[u8]",
+            SourceType::Ref {
+                mutable: false,
+                inner: Box::new(SourceType::Slice(Box::new(SourceType::Scalar(
+                    ScalarKind::U8,
+                )))),
+            },
+        ),
+        (
+            "*const u8",
+            SourceType::Ptr {
+                mutable: false,
+                inner: Box::new(SourceType::Scalar(ScalarKind::U8)),
+            },
+        ),
+        (
+            "(u8, String)",
+            SourceType::Tuple(vec![SourceType::Scalar(ScalarKind::U8), SourceType::Str]),
+        ),
+        (
+            "impl Fn(u8) + Send + Sync + 'static",
+            SourceType::Callback {
+                args: vec![SourceType::Scalar(ScalarKind::U8)],
+            },
+        ),
+    ];
+    for (src, expect) in cases {
+        let got = lower(src).unwrap_or_else(|r| panic!("`{src}` was refused: {r:?}"));
+        assert_eq!(&got, expect, "`{src}` lowered to the wrong model");
+    }
+}
+
+/// An array carries BOTH halves of its extent: the value, and which const —
+/// if any — the source named. That pairing is the whole reason this model
+/// exists rather than a bare `usize`.
+#[test]
+fn array_extents_carry_value_and_spelling() {
+    let literal = lower("[u8; 4]").unwrap();
+    assert_eq!(
+        literal,
+        SourceType::Array {
+            elem: Box::new(SourceType::Scalar(ScalarKind::U8)),
+            extent: ArrayExtent {
+                value: 4,
+                source: ExtentSource::Literal,
+            },
+        }
+    );
+
+    let by_const = lower("[u8; N]").unwrap();
+    assert_eq!(
+        by_const,
+        SourceType::Array {
+            elem: Box::new(SourceType::Scalar(ScalarKind::U8)),
+            extent: ArrayExtent {
+                value: 4,
+                source: ExtentSource::Const(ConstId {
+                    name: "N".to_string(),
+                    origin: Some("myflat".to_string()),
+                }),
+            },
+        }
+    );
+
+    // Same semantic type, distinguishable spelling — the pair a type-keyed
+    // table cannot hold and a use-site model can.
+    assert_eq!(
+        literal.to_syn().to_token_stream().to_string(),
+        by_const.to_syn().to_token_stream().to_string()
+    );
+    assert_ne!(literal, by_const);
+}
+
+/// Nested extents are collected outermost-first, which is what tells an emitter
+/// which consts a spelled type will name.
+#[test]
+fn nested_extents_are_collected() {
+    let ty = lower("[[u8; N]; M]").unwrap();
+    let names: Vec<Option<&str>> = ty
+        .extents()
+        .iter()
+        .map(|e| e.const_id().map(|c| c.name.as_str()))
+        .collect();
+    assert_eq!(names, vec![Some("M"), Some("N")]);
+    // And through a wrapper, since a field may be `Option<[u8; N]>`.
+    let wrapped = lower("Option<[u8; N]>").unwrap();
+    assert_eq!(wrapped.extents().len(), 1);
+    assert_eq!(wrapped.extents()[0].value, 4);
+}
+
+/// REFUSED forms. Acceptance is a consequence of lowering, so a form absent
+/// from the accepted table is refused by construction.
+#[test]
+fn refused_types() {
+    let cases: &[(&str, UnsupportedTypeReason)] = &[
+        (
+            "impl Iterator<Item = u8>",
+            UnsupportedTypeReason::DisallowedImplTrait,
+        ),
+        ("dyn Fn(u8)", UnsupportedTypeReason::UnsupportedForm),
+        ("fn(u8) -> u8", UnsupportedTypeReason::UnsupportedForm),
+        ("_", UnsupportedTypeReason::UnsupportedForm),
+        ("!", UnsupportedTypeReason::UnsupportedForm),
+        (
+            "Option<u8, u8>",
+            UnsupportedTypeReason::WrongGenericArity { expected: 1 },
+        ),
+        (
+            "Result<u8>",
+            UnsupportedTypeReason::WrongGenericArity { expected: 2 },
+        ),
+    ];
+    for (src, reason) in cases {
+        match lower(src) {
+            Ok(v) => panic!("`{src}` was accepted as {v:?}"),
+            Err(got) => assert_eq!(&got, reason, "`{src}` refused for the wrong reason"),
+        }
+    }
+    // A bad extent is reported as such, not flattened into "unsupported form" —
+    // the length subgrammar's own diagnostic survives being nested in a type.
+    let err = lower("[u8; MISSING]").unwrap_err();
+    assert!(
+        matches!(err, UnsupportedTypeReason::BadArrayExtent(_)),
+        "{err:?}"
+    );
+}
+
+/// `to_syn` round-trips: the projection of a lowered type re-lowers to itself.
+///
+/// This is what makes the `syn` field types stored on an item a projection
+/// rather than a second source of truth — they cannot say something the model
+/// does not.
+#[test]
+fn to_syn_round_trips() {
+    for src in [
+        "u8",
+        "String",
+        "()",
+        "Option<Vec<u8>>",
+        "Box<Foo>",
+        "Result<u8, String>",
+        "Wrapper<u8>",
+        "&mut Foo",
+        "&[u8]",
+        "*mut u8",
+        "(u8, String)",
+        "[u8; 4]",
+        "[[u8; N]; M]",
+        "impl Fn(u8) + Send + Sync + 'static",
+    ] {
+        let once = lower(src).unwrap_or_else(|r| panic!("`{src}` refused: {r:?}"));
+        let projected = once.to_syn();
+        let twice = lower_type(&projected, &consts(), Some("myflat")).unwrap_or_else(|e| {
+            panic!(
+                "`{src}` projection `{}` refused: {e}",
+                projected.to_token_stream()
+            )
+        });
+        // The extent's SPELLING is deliberately not in the projection, so
+        // compare the semantic form.
+        assert_eq!(
+            twice.to_syn().to_token_stream().to_string(),
+            projected.to_token_stream().to_string(),
+            "`{src}` did not round-trip"
+        );
+    }
+}

--- a/prebindgen/src/api/core/frontend/model/tests.rs
+++ b/prebindgen/src/api/core/frontend/model/tests.rs
@@ -9,7 +9,7 @@ use super::{
     lower_type, ArrayExtent, ConstId, ExtentSource, NamedArg, ScalarKind, SourceType,
     UnsupportedTypeReason,
 };
-use crate::api::core::{frontend::ConstIndex, TypeKey};
+use crate::api::core::{frontend::ConstIndex, registry::CallbackReject, TypeKey};
 
 fn consts() -> ConstIndex {
     ConstIndex::new([
@@ -204,7 +204,7 @@ fn refused_types() {
     let cases: &[(&str, UnsupportedTypeReason)] = &[
         (
             "impl Iterator<Item = u8>",
-            UnsupportedTypeReason::DisallowedImplTrait,
+            UnsupportedTypeReason::DisallowedImplTrait(CallbackReject::NotCallbackShape),
         ),
         ("dyn Fn(u8)", UnsupportedTypeReason::UnsupportedForm),
         ("fn(u8) -> u8", UnsupportedTypeReason::UnsupportedForm),
@@ -228,6 +228,23 @@ fn refused_types() {
         // what this resolves to is unknowable here.
         ("<T as Trait>::Assoc", UnsupportedTypeReason::AssociatedType),
         ("<Holder>::N", UnsupportedTypeReason::AssociatedType),
+        // RESERVED: the language intends these; no wire carries them yet.
+        // Previously the return was not read at all, so it was accepted and
+        // then silently dropped.
+        (
+            "impl Fn(u8) -> u16 + Send + Sync + 'static",
+            UnsupportedTypeReason::DisallowedImplTrait(CallbackReject::NonUnitReturn),
+        ),
+        (
+            "impl Fn(u8) -> impl Fn(u8) + Send + Sync + 'static + Send + Sync + 'static",
+            UnsupportedTypeReason::DisallowedImplTrait(CallbackReject::ReturnsCallback),
+        ),
+        // UNSUPPORTED: no FFI boundary can be generic over a lifetime, so this
+        // one is not waiting on machinery.
+        (
+            "impl for<'a> Fn(&'a u8) + Send + Sync + 'static",
+            UnsupportedTypeReason::DisallowedImplTrait(CallbackReject::HigherRankedBinder),
+        ),
     ];
     for (src, reason) in cases {
         match lower(src) {
@@ -288,6 +305,12 @@ fn the_projection_preserves_type_identity() {
         "&[u8]",
         "*mut u8",
         "impl Fn(u8) + Send + Sync + 'static",
+        // One callback, four spellings. `normalize_type` collapses the
+        // punctuation and the bound order, so all four are one key.
+        "impl Fn(u8,) + Send + Sync + 'static",
+        "impl Fn(u8) -> () + Send + Sync + 'static",
+        "impl Fn(u8) + Sync + Send + 'static",
+        "impl Fn(u8,) -> () + Sync + Send + 'static",
     ];
     for src in identity {
         let ty: syn::Type = syn::parse_str(src).unwrap_or_else(|e| panic!("`{src}`: {e}"));

--- a/prebindgen/src/api/core/frontend/model/tests.rs
+++ b/prebindgen/src/api/core/frontend/model/tests.rs
@@ -278,6 +278,10 @@ fn the_projection_preserves_type_identity() {
         "foreign::Option<u8>",
         "a::b::Foo<u8>",
         "::root::Foo",
+        // Punctuation, not identity: `normalize_type` collapses both before a
+        // key is formed, so the projection agrees with every other position.
+        "Wrapper::<u8>",
+        "Wrapper<u8,>",
         // Neighbours of those, to pin that the fix did not overshoot.
         "&Foo",
         "&mut Foo",

--- a/prebindgen/src/api/core/frontend/model/tests.rs
+++ b/prebindgen/src/api/core/frontend/model/tests.rs
@@ -239,8 +239,9 @@ fn refused_types() {
             "impl Fn(u8) -> impl Fn(u8) + Send + Sync + 'static + Send + Sync + 'static",
             UnsupportedTypeReason::DisallowedImplTrait(CallbackReject::ReturnsCallback),
         ),
-        // UNSUPPORTED: no FFI boundary can be generic over a lifetime, so this
-        // one is not waiting on machinery.
+        // RESERVED: the elided `impl Fn(&u8)` IS higher-ranked, so this is the
+        // last two-spellings-one-type case rather than an impossibility — it
+        // waits on the exact elision rule in #222, not on any wire.
         (
             "impl for<'a> Fn(&'a u8) + Send + Sync + 'static",
             UnsupportedTypeReason::DisallowedImplTrait(CallbackReject::HigherRankedBinder),

--- a/prebindgen/src/api/core/frontend/tests.rs
+++ b/prebindgen/src/api/core/frontend/tests.rs
@@ -295,6 +295,11 @@ fn lengths_resolve_in_function_signatures() {
 /// A const length and the same number written literally are ONE type, and
 /// therefore one converter. They always were in Rust; evaluating the length
 /// makes the frontend agree.
+///
+/// The two halves are the layering: [`ArrayLen`] distinguishes the spellings
+/// because it models one OCCURRENCE, and the emitted type does not because it
+/// models the type. Anything keyed by type must take the second answer — see
+/// [`equal_lengths_collapse_to_one_typed_entry`].
 #[test]
 fn a_const_length_and_its_literal_are_the_same_type() {
     let from_const: syn::Expr = syn::parse_quote!(MAX);
@@ -303,4 +308,52 @@ fn a_const_length_and_its_literal_are_the_same_type() {
     let b = lower_array_len(&from_literal, "[u8 ; 4]", Some("myflat"), &consts()).unwrap();
     assert_ne!(a, b, "the spellings stay distinguishable in the model");
     assert_eq!(spelled(&a), spelled(&b), "but they emit one type");
+}
+
+/// Distinct source spellings of equal length produce ONE type and therefore one
+/// registry entry — so what a type-keyed table can hold is the number, and not
+/// which spelling produced it.
+///
+/// Three fields, two of them const-spelled with the same value: every one is
+/// `[u8; 4]` after lowering. If the registry's table carried the occurrence
+/// model, the stored answer would be whichever field the iteration reached last
+/// — silently order dependent, and false for the other two either way.
+#[test]
+fn equal_lengths_collapse_to_one_typed_entry() {
+    let mut item: syn::ItemStruct = syn::parse_quote!(
+        pub struct S {
+            pub a: [u8; MAX],
+            pub b: [u8; ALSO_FOUR],
+            pub literal: [u8; 4],
+        }
+    );
+    let index = ConstIndex::new([
+        (
+            "MAX".to_string(),
+            syn::parse_quote!(4),
+            Some("myflat".to_string()),
+        ),
+        (
+            "ALSO_FOUR".to_string(),
+            syn::parse_quote!(4),
+            Some("myflat".to_string()),
+        ),
+    ]);
+    let found = resolve_array_lengths(&mut item, &index, Some("myflat"), |r, s| {
+        syn::visit_mut::VisitMut::visit_item_struct_mut(r, s)
+    })
+    .unwrap();
+
+    // Three occurrences, each remembering its own spelling...
+    assert_eq!(found.len(), 3);
+    assert!(matches!(found[0].1, ArrayLen::Const { .. }));
+    assert!(matches!(found[2].1, ArrayLen::Literal(4)));
+    // ...but one type between them, so a type-keyed table has one row.
+    let types: std::collections::BTreeSet<String> = found
+        .iter()
+        .map(|(ty, _)| ty.to_token_stream().to_string().replace(' ', ""))
+        .collect();
+    assert_eq!(types, ["[u8;4]".to_string()].into_iter().collect());
+    // Every occurrence agrees on the only thing that table can store.
+    assert!(found.iter().all(|(_, len)| len.value() == 4));
 }

--- a/prebindgen/src/api/core/frontend/tests.rs
+++ b/prebindgen/src/api/core/frontend/tests.rs
@@ -5,41 +5,48 @@
 //! test — which is the difference between this and the characterization tests it
 //! replaces, each of which was written one defect at a time (issue #210).
 
-use std::collections::HashMap;
-
 use quote::ToTokens;
 
 use super::{
-    lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ItemRole, NameIndex,
+    array_len::lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ConstIndex,
 };
 
-/// The namespace every row below resolves against, in `myflat`:
+/// The consts every row below resolves against, all marked in `myflat`:
 ///
-/// * `MAX` — a free const, and `N` — a second one, present only so the
-///   `Holder::N` rows prove the OWNER wins over a same-named free const;
-/// * `Holder` — a struct owning an associated const;
-/// * `array_len` — a `const fn`;
-/// * `limits` — a const that SHARES ITS NAME with an intermediate module, the
-///   one case where a module and an indexed item can collide (Rust puts modules
-///   and types in one namespace, consts in another).
-fn names() -> NameIndex {
-    let module: syn::Path = syn::parse_quote!(myflat);
-    let names: HashMap<String, (syn::Path, ItemRole)> = [
-        ("MAX", ItemRole::Leaf),
-        ("N", ItemRole::Leaf),
-        ("Holder", ItemRole::Owner),
-        ("array_len", ItemRole::Leaf),
-        ("limits", ItemRole::Leaf),
-    ]
-    .into_iter()
-    .map(|(n, role)| (n.to_string(), (module.clone(), role)))
-    .collect();
-    NameIndex::new(names, &["myflat".to_string()])
+/// * `MAX` — an ordinary literal-valued const;
+/// * `SUFFIXED` — the same, written with a suffix;
+/// * `COMPUTED` — marked, but its value is an expression `build.rs` cannot
+///   evaluate;
+/// * `OTHER_MAX` — marked in a DIFFERENT source crate, for the provenance rows.
+fn consts() -> ConstIndex {
+    ConstIndex::new([
+        (
+            "MAX".to_string(),
+            syn::parse_quote!(4),
+            Some("myflat".to_string()),
+        ),
+        (
+            "SUFFIXED".to_string(),
+            syn::parse_quote!(16usize),
+            Some("myflat".to_string()),
+        ),
+        (
+            "COMPUTED".to_string(),
+            syn::parse_quote!(2 * 4),
+            Some("myflat".to_string()),
+        ),
+        (
+            "OTHER_MAX".to_string(),
+            syn::parse_quote!(8),
+            Some("helpers".to_string()),
+        ),
+    ])
 }
 
+/// Lower as if written inside an item from `myflat`.
 fn lower(src: &str) -> Result<ArrayLen, ArrayLenReason> {
     let expr: syn::Expr = syn::parse_str(src).expect("test input must parse");
-    lower_array_len(&expr, "[u8 ; …]", &names()).map_err(|e| e.reason)
+    lower_array_len(&expr, "[u8 ; …]", Some("myflat"), &consts()).map_err(|e| e.reason)
 }
 
 /// Render a lowered length the way it will be spelled in generated code.
@@ -49,200 +56,108 @@ fn spelled(len: &ArrayLen) -> String {
 
 /// ACCEPTED shapes: what each lowers to, and how it is then spelled.
 ///
+/// Every accepted length is a NUMBER — that is the contract, not an
+/// implementation detail. A generator runs in `build.rs` and cannot evaluate
+/// Rust, and a destination language that groups a small array into scalars needs
+/// the count literally.
+///
 /// The spelling column is the half that used to be a separate walk. Pairing it
 /// with acceptance in one table is the point: a row cannot say "accepted"
-/// without also saying what it resolves to.
+/// without also saying what it emits.
 #[test]
 fn accepted_array_lengths() {
     let cases: &[(&str, ArrayLen, &str)] = &[
-        // Integer literals, including a suffixed one.
         ("4", ArrayLen::Literal(4), "4"),
         ("0", ArrayLen::Literal(0), "0"),
         ("16usize", ArrayLen::Literal(16), "16"),
-        // A free const: the whole path is the name.
+        // A marked const is evaluated here and emitted as its VALUE, so nothing
+        // in generated code is a path and there is nothing to qualify.
         (
             "MAX",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::MAX),
+            ArrayLen::Const {
+                name: syn::parse_quote!(MAX),
+                value: 4,
             },
-            "myflat :: MAX",
-        ),
-        // An associated const: only the OWNER is qualified — `::N` is relative
-        // to it, so `myflat::Holder::myflat::N` must not be constructible.
-        (
-            "Holder::N",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::Holder::N),
-            },
-            "myflat :: Holder :: N",
-        ),
-        // Already-qualified captured spellings resolve to the same value as the
-        // bare ones, so a source crate that writes `crate::MAX` is not speaking
-        // a different language from one that writes `MAX`.
-        (
-            "crate::MAX",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::MAX),
-            },
-            "myflat :: MAX",
+            "4",
         ),
         (
-            "myflat::MAX",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::MAX),
+            "SUFFIXED",
+            ArrayLen::Const {
+                name: syn::parse_quote!(SUFFIXED),
+                value: 16,
             },
-            "myflat :: MAX",
-        ),
-        // The OWNER is kept, unlike type-path reduction, which would collapse
-        // this to `N` — and `N` is itself an indexed free const here, so this
-        // also pins that the LEFTMOST anchor wins.
-        (
-            "myflat::Holder::N",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::Holder::N),
-            },
-            "myflat :: Holder :: N",
-        ),
-        // An INTERMEDIATE MODULE between the source head and the item. The
-        // module prefix carries no information — a `#[prebindgen]` item is
-        // reachable as `<crate>::<bare name>` — so it is replaced wholesale and
-        // this means exactly the same length as a bare `MAX`.
-        (
-            "crate::limits::MAX",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::MAX),
-            },
-            "myflat :: MAX",
-        ),
-        (
-            "myflat::limits::MAX",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::MAX),
-            },
-            "myflat :: MAX",
-        ),
-        // ...including when the item is an associated const behind a module.
-        (
-            "crate::limits::Holder::N",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::Holder::N),
-            },
-            "myflat :: Holder :: N",
-        ),
-        // `limits` is BOTH an intermediate module and an indexed const. A const
-        // owns nothing, so it cannot be the anchor with segments following it;
-        // the scan skips it and `MAX` anchors. Without the role check this
-        // would emit `myflat::limits::MAX` — the const, not the module.
-        (
-            "limits::MAX",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::MAX),
-            },
-            "myflat :: MAX",
-        ),
-        // ...and as the FINAL segment the same name is the const itself.
-        (
-            "crate::limits",
-            ArrayLen::SourceConst {
-                path: syn::parse_quote!(myflat::limits),
-            },
-            "myflat :: limits",
-        ),
-        // Not a source item: emitted verbatim. Prefixing an origin module here
-        // would be a guess, and `usize` has none.
-        (
-            "usize::MAX",
-            ArrayLen::ExternalConst {
-                path: syn::parse_quote!(usize::MAX),
-            },
-            "usize :: MAX",
-        ),
-        // A foreign crate's path is left ALONE even though its tail segment
-        // happens to name an indexed item. The registry has no index of a
-        // foreign namespace, so `other::Holder` and `myflat::Holder` may be
-        // genuinely different things — the same rule `normalize_type` applies
-        // to types.
-        (
-            "other_crate::Holder::N",
-            ArrayLen::ExternalConst {
-                path: syn::parse_quote!(other_crate::Holder::N),
-            },
-            "other_crate :: Holder :: N",
-        ),
-        // A const the source crate did not mark `#[prebindgen]` is, to the
-        // registry, indistinguishable from a foreign one — it lands here and
-        // will not resolve in the generated crate. Marking it is the fix.
-        (
-            "UNMARKED",
-            ArrayLen::ExternalConst {
-                path: syn::parse_quote!(UNMARKED),
-            },
-            "UNMARKED",
+            "16",
         ),
     ];
     for (src, expect, spell) in cases {
         let got = lower(src).unwrap_or_else(|r| panic!("`{src}` was refused: {r:?}"));
         assert_eq!(&got, expect, "`{src}` lowered to the wrong value");
         assert_eq!(&spelled(&got), spell, "`{src}` is spelled wrong");
+        assert_eq!(got.value(), expect.value(), "`{src}` has the wrong value");
     }
 }
 
 /// REFUSED shapes and why.
 ///
-/// Everything that is not a literal or a plain path, plus the path forms that
-/// carry no resolvable anchor. There is no separate list of
-/// accepted forms for this to drift from — a shape absent from the table above
-/// is refused by construction.
+/// There is no separate list of accepted forms for this to drift from — a shape
+/// absent from the table above is refused by construction.
 #[test]
 fn refused_array_lengths() {
     let cases: &[(&str, ArrayLenReason)] = &[
-        // Issue #210, defect #8: a qualified self was ACCEPTED by the old
-        // whitelist and silently declined by the old rewriter, emitting
-        // `<Holder>::N` into a crate where `Holder` is not in scope. One walk
-        // makes accepted-but-unqualified unrepresentable.
-        ("<Holder>::N", ArrayLenReason::QualifiedSelf),
-        ("<Holder as Trait>::N", ArrayLenReason::QualifiedSelf),
-        // Rooted at the crate root: names a dependency of the GENERATED crate,
-        // which the frontend cannot see.
-        ("::MAX", ArrayLenReason::CrateRootPath),
-        // Source-relative but naming no indexed item. It cannot be emitted
-        // verbatim — the generated crate is a DIFFERENT crate, where
-        // `crate::limits::UNMARKED` resolves to something else or to nothing —
-        // and there is no module to qualify it with. This is the loud form of
-        // the missing-`#[prebindgen]` trap; the bare spelling below is the
-        // quiet one.
-        (
-            "crate::limits::UNMARKED",
-            ArrayLenReason::UnresolvedSourcePath,
-        ),
-        ("myflat::UNMARKED", ArrayLenReason::UnresolvedSourcePath),
-        ("self::UNMARKED", ArrayLenReason::UnresolvedSourcePath),
-        // Const arithmetic and casts — deliberately out of the language.
-        ("MAX + 1", ArrayLenReason::NotLiteralOrPath),
-        ("-1", ArrayLenReason::NotLiteralOrPath),
-        ("MAX as usize", ArrayLenReason::NotLiteralOrPath),
-        ("(MAX)", ArrayLenReason::NotLiteralOrPath),
-        // A `const fn` call. Its callee is an indexed item, but the call is
-        // structure the flat grammar does not have.
-        ("array_len()", ArrayLenReason::NotLiteralOrPath),
-        // Anything that can BIND a name. A local shadowing a source item would
-        // otherwise be rewritten into it — `array_len` the local becoming
-        // `myflat::array_len` the function.
+        // ── not a bare name ──────────────────────────────────────────────
+        // Every one of these was a live defect or a live ambiguity while the
+        // grammar still admitted paths. A `#[prebindgen]` const is addressed by
+        // its bare name in one flat namespace, so a longer path either restates
+        // that or reaches somewhere the frontend cannot follow.
+        //
+        // Issue #210 defect #8: accepted by the old whitelist, silently NOT
+        // qualified by the old rewriter.
+        ("<Holder>::N", ArrayLenReason::NotABareName),
+        ("<Holder as Trait>::N", ArrayLenReason::NotABareName),
+        // An associated const. prebindgen never captures `impl` blocks, so its
+        // value is unknowable — supporting the spelling could only ever have
+        // produced a path, never a number.
+        ("Holder::N", ArrayLenReason::NotABareName),
+        // A module path. Indistinguishable from an external crate path without
+        // indexing modules, and redundant when the const IS marked.
+        ("crate::limits::MAX", ArrayLenReason::NotABareName),
+        ("myflat::limits::MAX", ArrayLenReason::NotABareName),
+        ("limits::MAX", ArrayLenReason::NotABareName),
+        ("crate::MAX", ArrayLenReason::NotABareName),
+        // An external path. `usize::MAX` is not even a fixed number — it is
+        // platform dependent, which is the whole hazard in miniature.
+        ("usize::MAX", ArrayLenReason::NotABareName),
+        ("other_crate::Holder::N", ArrayLenReason::NotABareName),
+        ("::MAX", ArrayLenReason::NotABareName),
+        // ── a bare name that is not a usable const ───────────────────────
+        // The generated crate sees ONLY what the macro exposed, so an unmarked
+        // const does not exist downstream. This used to be emitted verbatim and
+        // failed later, at rustc; it is a frontend error now.
+        ("UNMARKED", ArrayLenReason::NotAMarkedConst),
+        // Marked, but `build.rs` cannot evaluate it.
+        ("COMPUTED", ArrayLenReason::ConstIsNotALiteral),
+        // ── not a literal or a name ──────────────────────────────────────
+        ("MAX + 1", ArrayLenReason::NotLiteralOrName),
+        ("-1", ArrayLenReason::NotLiteralOrName),
+        ("MAX as usize", ArrayLenReason::NotLiteralOrName),
+        ("(MAX)", ArrayLenReason::NotLiteralOrName),
+        ("array_len()", ArrayLenReason::NotLiteralOrName),
+        // Anything that can BIND a name.
         (
             "const { let array_len = 3; array_len }",
-            ArrayLenReason::NotLiteralOrPath,
+            ArrayLenReason::NotLiteralOrName,
         ),
-        ("{ 3 }", ArrayLenReason::NotLiteralOrPath),
+        ("{ 3 }", ArrayLenReason::NotLiteralOrName),
         (
             "match 3 { array_len => array_len }",
-            ArrayLenReason::NotLiteralOrPath,
+            ArrayLenReason::NotLiteralOrName,
         ),
         (
             "if let array_len = 3 { array_len } else { 0 }",
-            ArrayLenReason::NotLiteralOrPath,
+            ArrayLenReason::NotLiteralOrName,
         ),
-        ("|| 3", ArrayLenReason::NotLiteralOrPath),
-        // Literals that are not lengths.
+        ("|| 3", ArrayLenReason::NotLiteralOrName),
+        // ── literals that are not lengths ────────────────────────────────
         ("\"4\"", ArrayLenReason::NotAnIntegerLiteral),
         ("true", ArrayLenReason::NotAnIntegerLiteral),
         (
@@ -258,17 +173,60 @@ fn refused_array_lengths() {
     }
 }
 
+/// A bare name must be a const from the item's OWN source crate.
+///
+/// Uniqueness holds across the **marked** namespace only. A source crate may
+/// have an unmarked `MAX` of its own and mean that one, while another chained
+/// source has a marked `MAX` — and the marked one is the only thing the frontend
+/// can see. Resolving to it would silently change the length rather than fail.
+///
+/// The value is deliberately *available* for the foreign const, so this pins
+/// provenance rather than incidental unresolvability.
+#[test]
+fn a_length_must_name_a_const_from_its_own_crate() {
+    let expr: syn::Expr = syn::parse_quote!(OTHER_MAX);
+    let err = lower_array_len(&expr, "[u8 ; OTHER_MAX]", Some("myflat"), &consts()).unwrap_err();
+    assert_eq!(
+        err.reason,
+        ArrayLenReason::ForeignSourceConst {
+            const_crate: "helpers".to_string(),
+            item_crate: "myflat".to_string(),
+        }
+    );
+    // ...and from `helpers` itself the same name is fine.
+    let got = lower_array_len(&expr, "[u8 ; OTHER_MAX]", Some("helpers"), &consts()).unwrap();
+    assert_eq!(got.value(), 8);
+}
+
+/// An origin-less stream is one anonymous crate, so provenance matches
+/// trivially. Core supports hand-built item streams with no
+/// `SourceLocation::crate_name`, and they must not be collateral of the
+/// provenance rule.
+#[test]
+fn origin_less_streams_resolve_against_themselves() {
+    let consts = ConstIndex::new([("MAX".to_string(), syn::parse_quote!(4), None)]);
+    let expr: syn::Expr = syn::parse_quote!(MAX);
+    let got = lower_array_len(&expr, "[u8 ; MAX]", None, &consts).unwrap();
+    assert_eq!(got.value(), 4);
+    // A stamped item may not reach an unstamped const either — same rule.
+    let err = lower_array_len(&expr, "[u8 ; MAX]", Some("myflat"), &consts).unwrap_err();
+    assert!(matches!(
+        err.reason,
+        ArrayLenReason::ForeignSourceConst { .. }
+    ));
+}
+
 /// The diagnostic names the offending sub-expression, not just the array — a
 /// caller with several arrays in one struct has to be told which one.
 #[test]
 fn rejection_names_the_offending_expression() {
     let expr: syn::Expr = syn::parse_quote!(MAX + 1);
-    let err = lower_array_len(&expr, "[u8 ; MAX + 1]", &names()).unwrap_err();
+    let err = lower_array_len(&expr, "[u8 ; MAX + 1]", Some("myflat"), &consts()).unwrap_err();
     assert_eq!(err.offending, "MAX + 1");
     assert_eq!(err.array, "[u8 ; MAX + 1]");
     let msg = err.to_string();
     assert!(msg.contains("MAX + 1"), "{msg}");
-    assert!(msg.contains("hoist"), "{msg}");
+    assert!(msg.contains("integer literal"), "{msg}");
 }
 
 /// A refused length leaves the node untouched — no half-rewritten model reaches
@@ -282,7 +240,7 @@ fn rejection_is_transactional() {
         }
     );
     let before = item.to_token_stream().to_string();
-    let err = resolve_array_lengths(&mut item, &names(), |r, s| {
+    let err = resolve_array_lengths(&mut item, &consts(), Some("myflat"), |r, s| {
         syn::visit_mut::VisitMut::visit_item_struct_mut(r, s)
     })
     .unwrap_err();
@@ -299,70 +257,50 @@ fn rejection_is_transactional() {
 fn nested_arrays_resolve_at_every_level() {
     let mut item: syn::ItemStruct = syn::parse_quote!(
         pub struct Grid {
-            pub cells: [[u8; MAX]; Holder::N],
+            pub cells: [[u8; MAX]; SUFFIXED],
         }
     );
-    let found = resolve_array_lengths(&mut item, &names(), |r, s| {
+    let found = resolve_array_lengths(&mut item, &consts(), Some("myflat"), |r, s| {
         syn::visit_mut::VisitMut::visit_item_struct_mut(r, s)
     })
     .unwrap();
     let rendered = item.to_token_stream().to_string().replace(' ', "");
-    assert!(
-        rendered.contains("[[u8;myflat::MAX];myflat::Holder::N]"),
-        "{rendered}"
-    );
+    assert!(rendered.contains("[[u8;4];16]"), "{rendered}");
     // Inner first, and the outer type is recorded in its REWRITTEN spelling —
     // a consumer keying on it never sees the captured one.
     let keys: Vec<String> = found
         .iter()
         .map(|(ty, _)| ty.to_token_stream().to_string().replace(' ', ""))
         .collect();
-    assert_eq!(
-        keys,
-        vec![
-            "[u8;myflat::MAX]".to_string(),
-            "[[u8;myflat::MAX];myflat::Holder::N]".to_string(),
-        ]
-    );
+    assert_eq!(keys, vec!["[u8;4]".to_string(), "[[u8;4];16]".to_string()]);
 }
 
 /// A length is resolved wherever a type can appear, not only in a struct field.
 #[test]
 fn lengths_resolve_in_function_signatures() {
     let mut item: syn::ItemFn = syn::parse_quote!(
-        pub fn echo(v: [u8; MAX]) -> [u8; Holder::N] {
+        pub fn echo(v: [u8; MAX]) -> [u8; SUFFIXED] {
             unimplemented!()
         }
     );
-    resolve_array_lengths(&mut item, &names(), |r, f| {
+    resolve_array_lengths(&mut item, &consts(), Some("myflat"), |r, f| {
         syn::visit_mut::VisitMut::visit_item_fn_mut(r, f)
     })
     .unwrap();
     let rendered = item.to_token_stream().to_string().replace(' ', "");
-    assert!(rendered.contains("v:[u8;myflat::MAX]"), "{rendered}");
-    assert!(rendered.contains("->[u8;myflat::Holder::N]"), "{rendered}");
+    assert!(rendered.contains("v:[u8;4]"), "{rendered}");
+    assert!(rendered.contains("->[u8;16]"), "{rendered}");
 }
 
-/// An origin-less stream documents `crate` as its module, so the same source
-/// spelling resolves to `crate::MAX` there. Both are pinned because deriving the
-/// name set from the origin map — which holds only stamped items — silently
-/// emitted every length bare for these streams.
+/// A const length and the same number written literally are ONE type, and
+/// therefore one converter. They always were in Rust; evaluating the length
+/// makes the frontend agree.
 #[test]
-fn origin_less_streams_resolve_against_the_crate_root() {
-    let names = NameIndex::new(
-        [(
-            "MAX".to_string(),
-            (syn::parse_quote!(crate), ItemRole::Leaf),
-        )]
-        .into_iter()
-        .collect(),
-        &[],
-    );
-    let expr: syn::Expr = syn::parse_quote!(MAX);
-    let got = lower_array_len(&expr, "[u8 ; MAX]", &names).unwrap();
-    assert_eq!(spelled(&got), "crate :: MAX");
-    // `crate::MAX` in the source is the same length, not a different one.
-    let expr: syn::Expr = syn::parse_quote!(crate::MAX);
-    let got = lower_array_len(&expr, "[u8 ; crate::MAX]", &names).unwrap();
-    assert_eq!(spelled(&got), "crate :: MAX");
+fn a_const_length_and_its_literal_are_the_same_type() {
+    let from_const: syn::Expr = syn::parse_quote!(MAX);
+    let from_literal: syn::Expr = syn::parse_quote!(4);
+    let a = lower_array_len(&from_const, "[u8 ; MAX]", Some("myflat"), &consts()).unwrap();
+    let b = lower_array_len(&from_literal, "[u8 ; 4]", Some("myflat"), &consts()).unwrap();
+    assert_ne!(a, b, "the spellings stay distinguishable in the model");
+    assert_eq!(spelled(&a), spelled(&b), "but they emit one type");
 }

--- a/prebindgen/src/api/core/frontend/tests.rs
+++ b/prebindgen/src/api/core/frontend/tests.rs
@@ -9,17 +9,31 @@ use std::collections::HashMap;
 
 use quote::ToTokens;
 
-use super::{lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, NameIndex};
+use super::{
+    lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ItemRole, NameIndex,
+};
 
-/// The namespace every row below resolves against: a free const `MAX`, a type
-/// `Holder` owning an associated const, and a `const fn` `array_len` — the three
-/// item kinds a length could plausibly name. All three live in `myflat`.
+/// The namespace every row below resolves against, in `myflat`:
+///
+/// * `MAX` — a free const, and `N` — a second one, present only so the
+///   `Holder::N` rows prove the OWNER wins over a same-named free const;
+/// * `Holder` — a struct owning an associated const;
+/// * `array_len` — a `const fn`;
+/// * `limits` — a const that SHARES ITS NAME with an intermediate module, the
+///   one case where a module and an indexed item can collide (Rust puts modules
+///   and types in one namespace, consts in another).
 fn names() -> NameIndex {
     let module: syn::Path = syn::parse_quote!(myflat);
-    let names: HashMap<String, syn::Path> = ["MAX", "Holder", "array_len"]
-        .into_iter()
-        .map(|n| (n.to_string(), module.clone()))
-        .collect();
+    let names: HashMap<String, (syn::Path, ItemRole)> = [
+        ("MAX", ItemRole::Leaf),
+        ("N", ItemRole::Leaf),
+        ("Holder", ItemRole::Owner),
+        ("array_len", ItemRole::Leaf),
+        ("limits", ItemRole::Leaf),
+    ]
+    .into_iter()
+    .map(|(n, role)| (n.to_string(), (module.clone(), role)))
+    .collect();
     NameIndex::new(names, &["myflat".to_string()])
 }
 
@@ -79,14 +93,60 @@ fn accepted_array_lengths() {
             },
             "myflat :: MAX",
         ),
-        // Stripping the source head keeps the OWNER, unlike type-path
-        // reduction, which would collapse this to `N`.
+        // The OWNER is kept, unlike type-path reduction, which would collapse
+        // this to `N` — and `N` is itself an indexed free const here, so this
+        // also pins that the LEFTMOST anchor wins.
         (
             "myflat::Holder::N",
             ArrayLen::SourceConst {
                 path: syn::parse_quote!(myflat::Holder::N),
             },
             "myflat :: Holder :: N",
+        ),
+        // An INTERMEDIATE MODULE between the source head and the item. The
+        // module prefix carries no information — a `#[prebindgen]` item is
+        // reachable as `<crate>::<bare name>` — so it is replaced wholesale and
+        // this means exactly the same length as a bare `MAX`.
+        (
+            "crate::limits::MAX",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::MAX),
+            },
+            "myflat :: MAX",
+        ),
+        (
+            "myflat::limits::MAX",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::MAX),
+            },
+            "myflat :: MAX",
+        ),
+        // ...including when the item is an associated const behind a module.
+        (
+            "crate::limits::Holder::N",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::Holder::N),
+            },
+            "myflat :: Holder :: N",
+        ),
+        // `limits` is BOTH an intermediate module and an indexed const. A const
+        // owns nothing, so it cannot be the anchor with segments following it;
+        // the scan skips it and `MAX` anchors. Without the role check this
+        // would emit `myflat::limits::MAX` — the const, not the module.
+        (
+            "limits::MAX",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::MAX),
+            },
+            "myflat :: MAX",
+        ),
+        // ...and as the FINAL segment the same name is the const itself.
+        (
+            "crate::limits",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::limits),
+            },
+            "myflat :: limits",
         ),
         // Not a source item: emitted verbatim. Prefixing an origin module here
         // would be a guess, and `usize` has none.
@@ -96,6 +156,18 @@ fn accepted_array_lengths() {
                 path: syn::parse_quote!(usize::MAX),
             },
             "usize :: MAX",
+        ),
+        // A foreign crate's path is left ALONE even though its tail segment
+        // happens to name an indexed item. The registry has no index of a
+        // foreign namespace, so `other::Holder` and `myflat::Holder` may be
+        // genuinely different things — the same rule `normalize_type` applies
+        // to types.
+        (
+            "other_crate::Holder::N",
+            ArrayLen::ExternalConst {
+                path: syn::parse_quote!(other_crate::Holder::N),
+            },
+            "other_crate :: Holder :: N",
         ),
         // A const the source crate did not mark `#[prebindgen]` is, to the
         // registry, indistinguishable from a foreign one — it lands here and
@@ -117,8 +189,8 @@ fn accepted_array_lengths() {
 
 /// REFUSED shapes and why.
 ///
-/// Everything that is not a literal or a plain path, plus the two path forms
-/// that carry no resolvable leading segment. There is no separate list of
+/// Everything that is not a literal or a plain path, plus the path forms that
+/// carry no resolvable anchor. There is no separate list of
 /// accepted forms for this to drift from — a shape absent from the table above
 /// is refused by construction.
 #[test]
@@ -133,6 +205,18 @@ fn refused_array_lengths() {
         // Rooted at the crate root: names a dependency of the GENERATED crate,
         // which the frontend cannot see.
         ("::MAX", ArrayLenReason::CrateRootPath),
+        // Source-relative but naming no indexed item. It cannot be emitted
+        // verbatim — the generated crate is a DIFFERENT crate, where
+        // `crate::limits::UNMARKED` resolves to something else or to nothing —
+        // and there is no module to qualify it with. This is the loud form of
+        // the missing-`#[prebindgen]` trap; the bare spelling below is the
+        // quiet one.
+        (
+            "crate::limits::UNMARKED",
+            ArrayLenReason::UnresolvedSourcePath,
+        ),
+        ("myflat::UNMARKED", ArrayLenReason::UnresolvedSourcePath),
+        ("self::UNMARKED", ArrayLenReason::UnresolvedSourcePath),
         // Const arithmetic and casts — deliberately out of the language.
         ("MAX + 1", ArrayLenReason::NotLiteralOrPath),
         ("-1", ArrayLenReason::NotLiteralOrPath),
@@ -266,9 +350,12 @@ fn lengths_resolve_in_function_signatures() {
 #[test]
 fn origin_less_streams_resolve_against_the_crate_root() {
     let names = NameIndex::new(
-        [("MAX".to_string(), syn::parse_quote!(crate))]
-            .into_iter()
-            .collect(),
+        [(
+            "MAX".to_string(),
+            (syn::parse_quote!(crate), ItemRole::Leaf),
+        )]
+        .into_iter()
+        .collect(),
         &[],
     );
     let expr: syn::Expr = syn::parse_quote!(MAX);

--- a/prebindgen/src/api/core/frontend/tests.rs
+++ b/prebindgen/src/api/core/frontend/tests.rs
@@ -48,7 +48,9 @@ fn consts() -> ConstIndex {
 /// Lower as if written inside an item from `myflat`.
 fn lower(src: &str) -> Result<usize, ArrayLenReason> {
     let expr: syn::Expr = syn::parse_str(src).expect("test input must parse");
-    lower_array_len(&expr, "[u8 ; …]", Some("myflat"), &consts()).map_err(|e| e.reason)
+    lower_array_len(&expr, "[u8 ; …]", Some("myflat"), &consts())
+        .map(|e| e.value)
+        .map_err(|e| e.reason)
 }
 
 /// ACCEPTED shapes and the number each denotes.
@@ -173,7 +175,7 @@ fn a_length_must_name_a_const_from_its_own_crate() {
     );
     // ...and from `helpers` itself the same name is fine.
     let got = lower_array_len(&expr, "[u8 ; OTHER_MAX]", Some("helpers"), &consts()).unwrap();
-    assert_eq!(got, 8);
+    assert_eq!(got.value, 8);
 }
 
 /// An origin-less stream is one anonymous crate, so provenance matches
@@ -185,7 +187,7 @@ fn origin_less_streams_resolve_against_themselves() {
     let consts = ConstIndex::new([("MAX".to_string(), syn::parse_quote!(4), None)]);
     let expr: syn::Expr = syn::parse_quote!(MAX);
     let got = lower_array_len(&expr, "[u8 ; MAX]", None, &consts).unwrap();
-    assert_eq!(got, 4);
+    assert_eq!(got.value, 4);
     // A stamped item may not reach an unstamped const either — same rule.
     let err = lower_array_len(&expr, "[u8 ; MAX]", Some("myflat"), &consts).unwrap_err();
     assert!(matches!(
@@ -270,22 +272,21 @@ fn lengths_resolve_in_function_signatures() {
     assert!(rendered.contains("->[u8;16]"), "{rendered}");
 }
 
-/// Equal-valued lengths are ONE type after ingest, and that is all any
-/// downstream consumer can see.
+/// Equal-valued lengths are ONE type after ingest — and the source model still
+/// knows which spelling each use wrote.
 ///
 /// This is the state **after `Registry::from_items`** — the boundary every
 /// adapter actually meets — not the interior of the lowering call. It pins both
-/// halves of the policy:
+/// halves, which fail in opposite directions:
 ///
-/// * all three uses resolve to semantic length 4 and share one type, so they
-///   share one converter;
-/// * nothing downstream can tell that `S::a` wrote `A`, `S::b` wrote `B`, and
-///   `S::literal` wrote `4`. The spelling is discarded at the frontend, on
-///   purpose — see `array_len::len_expr`.
+/// * all three uses resolve to semantic length 4 and share one type-keyed row,
+///   so they share one converter;
+/// * the model reports `A`, `B` and a literal per FIELD, so a C header can emit
+///   `uint8_t a[A]` while the converter stays `[u8; 4]`.
 ///
-/// If that policy is ever reversed, the provenance has to arrive on a per-USE
-/// record in a `SourceModel` (issue #211), never on this type-keyed table: three
-/// occupants of one key cannot be told apart by the key.
+/// The second half is why provenance lives on the use site and never on the
+/// type-keyed table: three occupants of one key cannot be told apart by the
+/// key, so a type-keyed answer would depend on which was stored last.
 #[test]
 fn equal_lengths_collapse_to_one_type_after_ingest() {
     let loc = SourceLocation {
@@ -338,4 +339,34 @@ fn equal_lengths_collapse_to_one_type_after_ingest() {
         1,
         "three uses of one type must be one row"
     );
+
+    // ...and per USE, the spelling survives.
+    let model = registry
+        .source_struct(&syn::parse_quote!(S))
+        .expect("S is modeled");
+    let spellings: Vec<(String, Option<String>)> = model
+        .fields
+        .iter()
+        .map(|f| {
+            let extent = f.ty.array_extent().expect("every field is an array");
+            assert_eq!(extent.value, 4, "one semantic length");
+            (
+                f.name.to_string(),
+                extent.const_id().map(|c| c.name.clone()),
+            )
+        })
+        .collect();
+    assert_eq!(
+        spellings,
+        vec![
+            ("a".to_string(), Some("A".to_string())),
+            ("b".to_string(), Some("B".to_string())),
+            ("literal".to_string(), None),
+        ],
+        "the model must distinguish uses the type key cannot"
+    );
+
+    // Both consts are recorded as ones an adapter may have to carry across.
+    assert!(registry.is_extent_const(&syn::parse_quote!(A)));
+    assert!(registry.is_extent_const(&syn::parse_quote!(B)));
 }

--- a/prebindgen/src/api/core/frontend/tests.rs
+++ b/prebindgen/src/api/core/frontend/tests.rs
@@ -7,8 +7,10 @@
 
 use quote::ToTokens;
 
-use super::{
-    array_len::lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ConstIndex,
+use super::{array_len::lower_array_len, resolve_array_lengths, ArrayLenReason, ConstIndex};
+use crate::{
+    api::core::{Registry, TypeKey},
+    SourceLocation,
 };
 
 /// The consts every row below resolves against, all marked in `myflat`:
@@ -44,56 +46,32 @@ fn consts() -> ConstIndex {
 }
 
 /// Lower as if written inside an item from `myflat`.
-fn lower(src: &str) -> Result<ArrayLen, ArrayLenReason> {
+fn lower(src: &str) -> Result<usize, ArrayLenReason> {
     let expr: syn::Expr = syn::parse_str(src).expect("test input must parse");
     lower_array_len(&expr, "[u8 ; …]", Some("myflat"), &consts()).map_err(|e| e.reason)
 }
 
-/// Render a lowered length the way it will be spelled in generated code.
-fn spelled(len: &ArrayLen) -> String {
-    len.to_expr().to_token_stream().to_string()
-}
-
-/// ACCEPTED shapes: what each lowers to, and how it is then spelled.
+/// ACCEPTED shapes and the number each denotes.
 ///
 /// Every accepted length is a NUMBER — that is the contract, not an
 /// implementation detail. A generator runs in `build.rs` and cannot evaluate
 /// Rust, and a destination language that groups a small array into scalars needs
-/// the count literally.
-///
-/// The spelling column is the half that used to be a separate walk. Pairing it
-/// with acceptance in one table is the point: a row cannot say "accepted"
-/// without also saying what it emits.
+/// the count literally. The lowered model is a `usize` and nothing more, so the
+/// spelling column that used to sit here would only have restated the value.
 #[test]
 fn accepted_array_lengths() {
-    let cases: &[(&str, ArrayLen, &str)] = &[
-        ("4", ArrayLen::Literal(4), "4"),
-        ("0", ArrayLen::Literal(0), "0"),
-        ("16usize", ArrayLen::Literal(16), "16"),
-        // A marked const is evaluated here and emitted as its VALUE, so nothing
-        // in generated code is a path and there is nothing to qualify.
-        (
-            "MAX",
-            ArrayLen::Const {
-                name: syn::parse_quote!(MAX),
-                value: 4,
-            },
-            "4",
-        ),
-        (
-            "SUFFIXED",
-            ArrayLen::Const {
-                name: syn::parse_quote!(SUFFIXED),
-                value: 16,
-            },
-            "16",
-        ),
+    let cases: &[(&str, usize)] = &[
+        ("4", 4),
+        ("0", 0),
+        ("16usize", 16),
+        // A marked const is evaluated here, so nothing in generated code is a
+        // path and there is nothing to qualify.
+        ("MAX", 4),
+        ("SUFFIXED", 16),
     ];
-    for (src, expect, spell) in cases {
+    for (src, expect) in cases {
         let got = lower(src).unwrap_or_else(|r| panic!("`{src}` was refused: {r:?}"));
         assert_eq!(&got, expect, "`{src}` lowered to the wrong value");
-        assert_eq!(&spelled(&got), spell, "`{src}` is spelled wrong");
-        assert_eq!(got.value(), expect.value(), "`{src}` has the wrong value");
     }
 }
 
@@ -195,7 +173,7 @@ fn a_length_must_name_a_const_from_its_own_crate() {
     );
     // ...and from `helpers` itself the same name is fine.
     let got = lower_array_len(&expr, "[u8 ; OTHER_MAX]", Some("helpers"), &consts()).unwrap();
-    assert_eq!(got.value(), 8);
+    assert_eq!(got, 8);
 }
 
 /// An origin-less stream is one anonymous crate, so provenance matches
@@ -207,7 +185,7 @@ fn origin_less_streams_resolve_against_themselves() {
     let consts = ConstIndex::new([("MAX".to_string(), syn::parse_quote!(4), None)]);
     let expr: syn::Expr = syn::parse_quote!(MAX);
     let got = lower_array_len(&expr, "[u8 ; MAX]", None, &consts).unwrap();
-    assert_eq!(got.value(), 4);
+    assert_eq!(got, 4);
     // A stamped item may not reach an unstamped const either — same rule.
     let err = lower_array_len(&expr, "[u8 ; MAX]", Some("myflat"), &consts).unwrap_err();
     assert!(matches!(
@@ -292,68 +270,72 @@ fn lengths_resolve_in_function_signatures() {
     assert!(rendered.contains("->[u8;16]"), "{rendered}");
 }
 
-/// A const length and the same number written literally are ONE type, and
-/// therefore one converter. They always were in Rust; evaluating the length
-/// makes the frontend agree.
+/// Equal-valued lengths are ONE type after ingest, and that is all any
+/// downstream consumer can see.
 ///
-/// The two halves are the layering: [`ArrayLen`] distinguishes the spellings
-/// because it models one OCCURRENCE, and the emitted type does not because it
-/// models the type. Anything keyed by type must take the second answer — see
-/// [`equal_lengths_collapse_to_one_typed_entry`].
+/// This is the state **after `Registry::from_items`** — the boundary every
+/// adapter actually meets — not the interior of the lowering call. It pins both
+/// halves of the policy:
+///
+/// * all three uses resolve to semantic length 4 and share one type, so they
+///   share one converter;
+/// * nothing downstream can tell that `S::a` wrote `A`, `S::b` wrote `B`, and
+///   `S::literal` wrote `4`. The spelling is discarded at the frontend, on
+///   purpose — see `array_len::len_expr`.
+///
+/// If that policy is ever reversed, the provenance has to arrive on a per-USE
+/// record in a `SourceModel` (issue #211), never on this type-keyed table: three
+/// occupants of one key cannot be told apart by the key.
 #[test]
-fn a_const_length_and_its_literal_are_the_same_type() {
-    let from_const: syn::Expr = syn::parse_quote!(MAX);
-    let from_literal: syn::Expr = syn::parse_quote!(4);
-    let a = lower_array_len(&from_const, "[u8 ; MAX]", Some("myflat"), &consts()).unwrap();
-    let b = lower_array_len(&from_literal, "[u8 ; 4]", Some("myflat"), &consts()).unwrap();
-    assert_ne!(a, b, "the spellings stay distinguishable in the model");
-    assert_eq!(spelled(&a), spelled(&b), "but they emit one type");
-}
+fn equal_lengths_collapse_to_one_type_after_ingest() {
+    let loc = SourceLocation {
+        crate_name: Some("myflat".to_string()),
+        ..Default::default()
+    };
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Const(syn::parse_quote!(
+                pub const A: usize = 4;
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Const(syn::parse_quote!(
+                pub const B: usize = 4;
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct S {
+                    pub a: [u8; A],
+                    pub b: [u8; B],
+                    pub literal: [u8; 4],
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<()>::from_items(items).unwrap();
 
-/// Distinct source spellings of equal length produce ONE type and therefore one
-/// registry entry — so what a type-keyed table can hold is the number, and not
-/// which spelling produced it.
-///
-/// Three fields, two of them const-spelled with the same value: every one is
-/// `[u8; 4]` after lowering. If the registry's table carried the occurrence
-/// model, the stored answer would be whichever field the iteration reached last
-/// — silently order dependent, and false for the other two either way.
-#[test]
-fn equal_lengths_collapse_to_one_typed_entry() {
-    let mut item: syn::ItemStruct = syn::parse_quote!(
-        pub struct S {
-            pub a: [u8; MAX],
-            pub b: [u8; ALSO_FOUR],
-            pub literal: [u8; 4],
-        }
+    // Every field is the same type, spelled as the number.
+    let (item, _) = &registry.structs[&syn::parse_quote!(S)];
+    let rendered = item.to_token_stream().to_string().replace(' ', "");
+    assert!(rendered.contains("a:[u8;4]"), "{rendered}");
+    assert!(rendered.contains("b:[u8;4]"), "{rendered}");
+    assert!(rendered.contains("literal:[u8;4]"), "{rendered}");
+    // ...so the const names are gone from the model entirely. Were the spelling
+    // retained anywhere reachable from here, this would be the assertion that
+    // caught it depending on iteration order.
+    assert!(!rendered.contains('A'), "{rendered}");
+    assert!(!rendered.contains('B'), "{rendered}");
+
+    // One type-keyed entry, and its value is stable and correct.
+    let key = TypeKey::parse("[u8; 4]").unwrap();
+    assert_eq!(registry.array_len(&key), Some(4));
+    assert_eq!(
+        registry.array_lens.len(),
+        1,
+        "three uses of one type must be one row"
     );
-    let index = ConstIndex::new([
-        (
-            "MAX".to_string(),
-            syn::parse_quote!(4),
-            Some("myflat".to_string()),
-        ),
-        (
-            "ALSO_FOUR".to_string(),
-            syn::parse_quote!(4),
-            Some("myflat".to_string()),
-        ),
-    ]);
-    let found = resolve_array_lengths(&mut item, &index, Some("myflat"), |r, s| {
-        syn::visit_mut::VisitMut::visit_item_struct_mut(r, s)
-    })
-    .unwrap();
-
-    // Three occurrences, each remembering its own spelling...
-    assert_eq!(found.len(), 3);
-    assert!(matches!(found[0].1, ArrayLen::Const { .. }));
-    assert!(matches!(found[2].1, ArrayLen::Literal(4)));
-    // ...but one type between them, so a type-keyed table has one row.
-    let types: std::collections::BTreeSet<String> = found
-        .iter()
-        .map(|(ty, _)| ty.to_token_stream().to_string().replace(' ', ""))
-        .collect();
-    assert_eq!(types, ["[u8;4]".to_string()].into_iter().collect());
-    // Every occurrence agrees on the only thing that table can store.
-    assert!(found.iter().all(|(_, len)| len.value() == 4));
 }

--- a/prebindgen/src/api/core/frontend/tests.rs
+++ b/prebindgen/src/api/core/frontend/tests.rs
@@ -1,0 +1,281 @@
+//! The frontend acceptance matrix.
+//!
+//! One table per closed subgrammar: source spelling → the lowered value, or the
+//! precise reason it is refused. A new accepted or refused shape is a row, not a
+//! test — which is the difference between this and the characterization tests it
+//! replaces, each of which was written one defect at a time (issue #210).
+
+use std::collections::HashMap;
+
+use quote::ToTokens;
+
+use super::{lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, NameIndex};
+
+/// The namespace every row below resolves against: a free const `MAX`, a type
+/// `Holder` owning an associated const, and a `const fn` `array_len` — the three
+/// item kinds a length could plausibly name. All three live in `myflat`.
+fn names() -> NameIndex {
+    let module: syn::Path = syn::parse_quote!(myflat);
+    let names: HashMap<String, syn::Path> = ["MAX", "Holder", "array_len"]
+        .into_iter()
+        .map(|n| (n.to_string(), module.clone()))
+        .collect();
+    NameIndex::new(names, &["myflat".to_string()])
+}
+
+fn lower(src: &str) -> Result<ArrayLen, ArrayLenReason> {
+    let expr: syn::Expr = syn::parse_str(src).expect("test input must parse");
+    lower_array_len(&expr, "[u8 ; …]", &names()).map_err(|e| e.reason)
+}
+
+/// Render a lowered length the way it will be spelled in generated code.
+fn spelled(len: &ArrayLen) -> String {
+    len.to_expr().to_token_stream().to_string()
+}
+
+/// ACCEPTED shapes: what each lowers to, and how it is then spelled.
+///
+/// The spelling column is the half that used to be a separate walk. Pairing it
+/// with acceptance in one table is the point: a row cannot say "accepted"
+/// without also saying what it resolves to.
+#[test]
+fn accepted_array_lengths() {
+    let cases: &[(&str, ArrayLen, &str)] = &[
+        // Integer literals, including a suffixed one.
+        ("4", ArrayLen::Literal(4), "4"),
+        ("0", ArrayLen::Literal(0), "0"),
+        ("16usize", ArrayLen::Literal(16), "16"),
+        // A free const: the whole path is the name.
+        (
+            "MAX",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::MAX),
+            },
+            "myflat :: MAX",
+        ),
+        // An associated const: only the OWNER is qualified — `::N` is relative
+        // to it, so `myflat::Holder::myflat::N` must not be constructible.
+        (
+            "Holder::N",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::Holder::N),
+            },
+            "myflat :: Holder :: N",
+        ),
+        // Already-qualified captured spellings resolve to the same value as the
+        // bare ones, so a source crate that writes `crate::MAX` is not speaking
+        // a different language from one that writes `MAX`.
+        (
+            "crate::MAX",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::MAX),
+            },
+            "myflat :: MAX",
+        ),
+        (
+            "myflat::MAX",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::MAX),
+            },
+            "myflat :: MAX",
+        ),
+        // Stripping the source head keeps the OWNER, unlike type-path
+        // reduction, which would collapse this to `N`.
+        (
+            "myflat::Holder::N",
+            ArrayLen::SourceConst {
+                path: syn::parse_quote!(myflat::Holder::N),
+            },
+            "myflat :: Holder :: N",
+        ),
+        // Not a source item: emitted verbatim. Prefixing an origin module here
+        // would be a guess, and `usize` has none.
+        (
+            "usize::MAX",
+            ArrayLen::ExternalConst {
+                path: syn::parse_quote!(usize::MAX),
+            },
+            "usize :: MAX",
+        ),
+        // A const the source crate did not mark `#[prebindgen]` is, to the
+        // registry, indistinguishable from a foreign one — it lands here and
+        // will not resolve in the generated crate. Marking it is the fix.
+        (
+            "UNMARKED",
+            ArrayLen::ExternalConst {
+                path: syn::parse_quote!(UNMARKED),
+            },
+            "UNMARKED",
+        ),
+    ];
+    for (src, expect, spell) in cases {
+        let got = lower(src).unwrap_or_else(|r| panic!("`{src}` was refused: {r:?}"));
+        assert_eq!(&got, expect, "`{src}` lowered to the wrong value");
+        assert_eq!(&spelled(&got), spell, "`{src}` is spelled wrong");
+    }
+}
+
+/// REFUSED shapes and why.
+///
+/// Everything that is not a literal or a plain path, plus the two path forms
+/// that carry no resolvable leading segment. There is no separate list of
+/// accepted forms for this to drift from — a shape absent from the table above
+/// is refused by construction.
+#[test]
+fn refused_array_lengths() {
+    let cases: &[(&str, ArrayLenReason)] = &[
+        // Issue #210, defect #8: a qualified self was ACCEPTED by the old
+        // whitelist and silently declined by the old rewriter, emitting
+        // `<Holder>::N` into a crate where `Holder` is not in scope. One walk
+        // makes accepted-but-unqualified unrepresentable.
+        ("<Holder>::N", ArrayLenReason::QualifiedSelf),
+        ("<Holder as Trait>::N", ArrayLenReason::QualifiedSelf),
+        // Rooted at the crate root: names a dependency of the GENERATED crate,
+        // which the frontend cannot see.
+        ("::MAX", ArrayLenReason::CrateRootPath),
+        // Const arithmetic and casts — deliberately out of the language.
+        ("MAX + 1", ArrayLenReason::NotLiteralOrPath),
+        ("-1", ArrayLenReason::NotLiteralOrPath),
+        ("MAX as usize", ArrayLenReason::NotLiteralOrPath),
+        ("(MAX)", ArrayLenReason::NotLiteralOrPath),
+        // A `const fn` call. Its callee is an indexed item, but the call is
+        // structure the flat grammar does not have.
+        ("array_len()", ArrayLenReason::NotLiteralOrPath),
+        // Anything that can BIND a name. A local shadowing a source item would
+        // otherwise be rewritten into it — `array_len` the local becoming
+        // `myflat::array_len` the function.
+        (
+            "const { let array_len = 3; array_len }",
+            ArrayLenReason::NotLiteralOrPath,
+        ),
+        ("{ 3 }", ArrayLenReason::NotLiteralOrPath),
+        (
+            "match 3 { array_len => array_len }",
+            ArrayLenReason::NotLiteralOrPath,
+        ),
+        (
+            "if let array_len = 3 { array_len } else { 0 }",
+            ArrayLenReason::NotLiteralOrPath,
+        ),
+        ("|| 3", ArrayLenReason::NotLiteralOrPath),
+        // Literals that are not lengths.
+        ("\"4\"", ArrayLenReason::NotAnIntegerLiteral),
+        ("true", ArrayLenReason::NotAnIntegerLiteral),
+        (
+            "99999999999999999999999999999999999",
+            ArrayLenReason::IntegerOutOfRange,
+        ),
+    ];
+    for (src, reason) in cases {
+        match lower(src) {
+            Ok(v) => panic!("`{src}` was accepted as {v:?}"),
+            Err(got) => assert_eq!(&got, reason, "`{src}` refused for the wrong reason"),
+        }
+    }
+}
+
+/// The diagnostic names the offending sub-expression, not just the array — a
+/// caller with several arrays in one struct has to be told which one.
+#[test]
+fn rejection_names_the_offending_expression() {
+    let expr: syn::Expr = syn::parse_quote!(MAX + 1);
+    let err = lower_array_len(&expr, "[u8 ; MAX + 1]", &names()).unwrap_err();
+    assert_eq!(err.offending, "MAX + 1");
+    assert_eq!(err.array, "[u8 ; MAX + 1]");
+    let msg = err.to_string();
+    assert!(msg.contains("MAX + 1"), "{msg}");
+    assert!(msg.contains("hoist"), "{msg}");
+}
+
+/// A refused length leaves the node untouched — no half-rewritten model reaches
+/// a caller that ignores the error (invariant 7 of issue #211).
+#[test]
+fn rejection_is_transactional() {
+    let mut item: syn::ItemStruct = syn::parse_quote!(
+        pub struct Blob {
+            pub good: [u8; MAX],
+            pub bad: [u8; MAX + 1],
+        }
+    );
+    let before = item.to_token_stream().to_string();
+    let err = resolve_array_lengths(&mut item, &names(), |r, s| {
+        syn::visit_mut::VisitMut::visit_item_struct_mut(r, s)
+    })
+    .unwrap_err();
+    assert_eq!(err.offending, "MAX + 1");
+    assert_eq!(
+        item.to_token_stream().to_string(),
+        before,
+        "the accepted field was rewritten despite the refusal"
+    );
+}
+
+/// Nested arrays lower innermost-first, and both levels are recorded.
+#[test]
+fn nested_arrays_resolve_at_every_level() {
+    let mut item: syn::ItemStruct = syn::parse_quote!(
+        pub struct Grid {
+            pub cells: [[u8; MAX]; Holder::N],
+        }
+    );
+    let found = resolve_array_lengths(&mut item, &names(), |r, s| {
+        syn::visit_mut::VisitMut::visit_item_struct_mut(r, s)
+    })
+    .unwrap();
+    let rendered = item.to_token_stream().to_string().replace(' ', "");
+    assert!(
+        rendered.contains("[[u8;myflat::MAX];myflat::Holder::N]"),
+        "{rendered}"
+    );
+    // Inner first, and the outer type is recorded in its REWRITTEN spelling —
+    // a consumer keying on it never sees the captured one.
+    let keys: Vec<String> = found
+        .iter()
+        .map(|(ty, _)| ty.to_token_stream().to_string().replace(' ', ""))
+        .collect();
+    assert_eq!(
+        keys,
+        vec![
+            "[u8;myflat::MAX]".to_string(),
+            "[[u8;myflat::MAX];myflat::Holder::N]".to_string(),
+        ]
+    );
+}
+
+/// A length is resolved wherever a type can appear, not only in a struct field.
+#[test]
+fn lengths_resolve_in_function_signatures() {
+    let mut item: syn::ItemFn = syn::parse_quote!(
+        pub fn echo(v: [u8; MAX]) -> [u8; Holder::N] {
+            unimplemented!()
+        }
+    );
+    resolve_array_lengths(&mut item, &names(), |r, f| {
+        syn::visit_mut::VisitMut::visit_item_fn_mut(r, f)
+    })
+    .unwrap();
+    let rendered = item.to_token_stream().to_string().replace(' ', "");
+    assert!(rendered.contains("v:[u8;myflat::MAX]"), "{rendered}");
+    assert!(rendered.contains("->[u8;myflat::Holder::N]"), "{rendered}");
+}
+
+/// An origin-less stream documents `crate` as its module, so the same source
+/// spelling resolves to `crate::MAX` there. Both are pinned because deriving the
+/// name set from the origin map — which holds only stamped items — silently
+/// emitted every length bare for these streams.
+#[test]
+fn origin_less_streams_resolve_against_the_crate_root() {
+    let names = NameIndex::new(
+        [("MAX".to_string(), syn::parse_quote!(crate))]
+            .into_iter()
+            .collect(),
+        &[],
+    );
+    let expr: syn::Expr = syn::parse_quote!(MAX);
+    let got = lower_array_len(&expr, "[u8 ; MAX]", &names).unwrap();
+    assert_eq!(spelled(&got), "crate :: MAX");
+    // `crate::MAX` in the source is the same length, not a different one.
+    let expr: syn::Expr = syn::parse_quote!(crate::MAX);
+    let got = lower_array_len(&expr, "[u8 ; crate::MAX]", &names).unwrap();
+    assert_eq!(spelled(&got), "crate :: MAX");
+}

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -34,7 +34,7 @@ pub(crate) mod write;
 
 pub use self::{
     domain::{DomainScalar, RepresentationDomain, ScalarValue},
-    frontend::{ArrayLen, UnsupportedArrayLen},
+    frontend::UnsupportedArrayLen,
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -21,6 +21,7 @@
 
 pub mod domain;
 pub mod expand;
+pub mod frontend;
 pub mod gravestone;
 pub mod niches;
 pub mod prebindgen;
@@ -33,6 +34,7 @@ pub(crate) mod write;
 
 pub use self::{
     domain::{DomainScalar, RepresentationDomain, ScalarValue},
+    frontend::{ArrayLen, UnsupportedArrayLen},
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -718,17 +718,17 @@ impl<M> Registry<M> {
     fn resolve_array_lengths(&mut self) -> Result<(), ScanError> {
         use syn::visit_mut::VisitMut;
 
-        use crate::api::core::frontend::{resolve_array_lengths, NameIndex};
+        use crate::api::core::frontend::{resolve_array_lengths, ItemRole, NameIndex};
 
         let crate_root: syn::Path = syn::parse_quote!(crate);
         let default_module = self.default_module().unwrap_or(crate_root);
-        let names: HashMap<String, syn::Path> = self
-            .named_item_idents()
-            .map(|ident| {
+        let names: HashMap<String, (syn::Path, ItemRole)> = self
+            .named_items()
+            .map(|(ident, role)| {
                 let module = self
                     .origin_module(ident)
                     .unwrap_or_else(|| default_module.clone());
-                (ident.to_string(), module)
+                (ident.to_string(), (module, role))
             })
             .collect();
         let names = NameIndex::new(names, &self.source_modules);
@@ -789,11 +789,30 @@ impl<M> Registry<M> {
     /// stream indexes items that map never sees, and callers are expected to
     /// pair this with `origin_module(..).unwrap_or_else(default_module)`.
     pub fn named_item_idents(&self) -> impl Iterator<Item = &syn::Ident> {
-        self.functions
+        self.named_items().map(|(ident, _)| ident)
+    }
+
+    /// [`Self::named_item_idents`] plus what each item may be inside a source
+    /// path: a struct or enum can own the segments that follow it
+    /// (`Holder::N`), a const or function can only be the last one.
+    ///
+    /// The single enumeration of item kinds — [`Self::named_item_idents`] is
+    /// derived from it, so a new kind is still added exactly once.
+    pub fn named_items(
+        &self,
+    ) -> impl Iterator<Item = (&syn::Ident, crate::api::core::frontend::ItemRole)> {
+        use crate::api::core::frontend::ItemRole;
+        let owners = self
+            .structs
             .keys()
-            .chain(self.structs.keys())
             .chain(self.enums.keys())
+            .map(|i| (i, ItemRole::Owner));
+        let leaves = self
+            .functions
+            .keys()
             .chain(self.consts.keys())
+            .map(|i| (i, ItemRole::Leaf));
+        owners.chain(leaves)
     }
 
     /// The frontend-decided length of a fixed-size array type, or `None` if

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -254,6 +254,17 @@ pub struct Registry<M = ()> {
     /// back to `crate`.
     pub(crate) source_modules: Vec<String>,
 
+    /// Every fixed-size array type the source defines, mapped to its
+    /// frontend-decided length. Filled at ingest by
+    /// [`crate::api::core::frontend::resolve_array_lengths`]; keyed by the
+    /// array type AFTER that rewrite, which is the only spelling anything
+    /// downstream sees.
+    ///
+    /// This is the single source of `N`: a consumer that needs the length —
+    /// planning, or an adapter deciding how an array crosses its boundary —
+    /// reads it from here instead of re-parsing `syn::TypeArray::len`.
+    pub(crate) array_lens: HashMap<TypeKey, crate::api::core::frontend::ArrayLen>,
+
     /// Type tables, one per direction. Each scanned type maps to its resolved
     /// [`TypeEntry`] (`Some`) or stays unresolved (`None`) until the structural
     /// resolver fills it.
@@ -318,6 +329,7 @@ impl<M> Default for Registry<M> {
             passthrough: Vec::new(),
             item_origins: HashMap::new(),
             source_modules: Vec::new(),
+            array_lens: HashMap::new(),
             input_types: Default::default(),
             output_types: Default::default(),
             type_locations: HashMap::new(),
@@ -391,6 +403,13 @@ pub enum ScanError {
         /// `(qualified spelling, bare fix-it name)` pairs.
         entries: Vec<(String, String)>,
     },
+    /// A fixed-size array's length is not in the accepted source subgrammar —
+    /// see [`crate::api::core::frontend::ArrayLen`]. Raised at ingest, before
+    /// any adapter runs, so every generator refuses the same input.
+    UnsupportedArrayLength {
+        error: Box<crate::api::core::frontend::UnsupportedArrayLen>,
+        loc: SourceLocation,
+    },
 }
 
 impl fmt::Display for ScanError {
@@ -463,6 +482,9 @@ impl fmt::Display for ScanError {
                     "source items live in one flat namespace keyed by their bare name; \
                      a crate-qualified spelling never matches captured signatures"
                 )
+            }
+            ScanError::UnsupportedArrayLength { error, loc } => {
+                write!(f, "{error} (at {loc})")
             }
         }
     }
@@ -678,7 +700,78 @@ impl<M> Registry<M> {
                 Err(e) => return Err(e),
             }
         }
+        // Pass 3: hand every indexed item to the frontend's array-length
+        // lowering. It runs here, not at emit time, because it needs the
+        // COMPLETE name index — a length may name any source item, including
+        // one from a later-chained stream — and because a source-language fact
+        // must be decided before any adapter sees the item (issue #211).
+        registry.resolve_array_lengths()?;
         Ok(registry)
+    }
+
+    /// Lower every fixed-size array length in every indexed item, rewriting
+    /// each to the spelling that resolves in the generated crate and recording
+    /// it in [`Self::array_lens`].
+    ///
+    /// Passthrough items are included: they are emitted verbatim, so their
+    /// lengths need the same qualification as a scanned signature's.
+    fn resolve_array_lengths(&mut self) -> Result<(), ScanError> {
+        use syn::visit_mut::VisitMut;
+
+        use crate::api::core::frontend::{resolve_array_lengths, NameIndex};
+
+        let crate_root: syn::Path = syn::parse_quote!(crate);
+        let default_module = self.default_module().unwrap_or(crate_root);
+        let names: HashMap<String, syn::Path> = self
+            .named_item_idents()
+            .map(|ident| {
+                let module = self
+                    .origin_module(ident)
+                    .unwrap_or_else(|| default_module.clone());
+                (ident.to_string(), module)
+            })
+            .collect();
+        let names = NameIndex::new(names, &self.source_modules);
+
+        let mut lens: HashMap<TypeKey, crate::api::core::frontend::ArrayLen> = HashMap::new();
+        // One accumulator for every map, so a length means the same thing
+        // whichever item kind it was written in.
+        let mut record = |found: Result<Vec<(syn::Type, _)>, _>,
+                          loc: &SourceLocation|
+         -> Result<(), ScanError> {
+            let found = found.map_err(|error| ScanError::UnsupportedArrayLength {
+                error: Box::new(error),
+                loc: loc.clone(),
+            })?;
+            lens.extend(
+                found
+                    .into_iter()
+                    .map(|(ty, len)| (TypeKey::from_type(&ty), len)),
+            );
+            Ok(())
+        };
+        for (item, loc) in self.functions.values_mut() {
+            let found = resolve_array_lengths(item, &names, |r, f| r.visit_item_fn_mut(f));
+            record(found, loc)?;
+        }
+        for (item, loc) in self.structs.values_mut() {
+            let found = resolve_array_lengths(item, &names, |r, s| r.visit_item_struct_mut(s));
+            record(found, loc)?;
+        }
+        for (item, loc) in self.enums.values_mut() {
+            let found = resolve_array_lengths(item, &names, |r, e| r.visit_item_enum_mut(e));
+            record(found, loc)?;
+        }
+        for (item, loc) in self.consts.values_mut() {
+            let found = resolve_array_lengths(item, &names, |r, c| r.visit_item_const_mut(c));
+            record(found, loc)?;
+        }
+        for (item, loc) in self.passthrough.iter_mut() {
+            let found = resolve_array_lengths(item, &names, |r, i| r.visit_item_mut(i));
+            record(found, loc)?;
+        }
+        self.array_lens = lens;
+        Ok(())
     }
 
     /// The origin crate's **module path** for an item ingested via
@@ -701,6 +794,17 @@ impl<M> Registry<M> {
             .chain(self.structs.keys())
             .chain(self.enums.keys())
             .chain(self.consts.keys())
+    }
+
+    /// The frontend-decided length of a fixed-size array type, or `None` if
+    /// `key` is not one the source defines.
+    ///
+    /// The single source of `N`. Read this rather than re-parsing
+    /// `syn::TypeArray::len`: the length has already been validated and
+    /// resolved once, and a second reading is where the two-authority drift
+    /// that issue #211 is about starts.
+    pub fn array_len(&self, key: &TypeKey) -> Option<&crate::api::core::frontend::ArrayLen> {
+        self.array_lens.get(key)
     }
 
     pub fn origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1731,9 +1731,12 @@ impl CallbackReject {
                  struct nested in a closure struct"
             }
             Self::HigherRankedBinder => {
-                "an explicit higher-ranked binder (`for<'a>`) is not yet supported — write the \
-                 elided form instead (`Fn(&T)`, which means exactly the same thing and is \
-                 accepted); tracked by https://github.com/milyin/prebindgen/issues/222"
+                "an explicit higher-ranked binder (`for<'a>`) is not yet supported. If every \
+                 bound lifetime is used exactly once, the elided form means the same thing and \
+                 is accepted (`for<'a> Fn(&'a T)` is `Fn(&T)`). If any is used twice, elision \
+                 does NOT preserve it — `Fn(&T, &T)` binds each input separately — so that \
+                 signature has no accepted spelling yet; tracked by \
+                 https://github.com/milyin/prebindgen/issues/222"
             }
         }
     }

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -741,14 +741,12 @@ impl<M> Registry<M> {
         // One accumulator for every map, so a length means the same thing
         // whichever item kind it was written in.
         //
-        // Only the VALUE is kept. `ArrayLen` models one occurrence and knows
-        // which spelling produced it; `TypeKey` has already collapsed the
-        // spellings, so carrying it across this boundary would make the stored
-        // answer depend on iteration order. See `Self::array_lens`.
+        // Equal-valued lengths share a key, because they share a Rust type.
+        // See `Self::array_lens`.
         let mut record = |found: Result<Vec<(syn::Type, _)>, _>,
                           loc: &SourceLocation|
          -> Result<(), ScanError> {
-            let found: Vec<(syn::Type, crate::api::core::frontend::ArrayLen)> =
+            let found: Vec<(syn::Type, usize)> =
                 found.map_err(|error| ScanError::UnsupportedArrayLength {
                     error: Box::new(error),
                     loc: loc.clone(),
@@ -756,7 +754,7 @@ impl<M> Registry<M> {
             lens.extend(
                 found
                     .into_iter()
-                    .map(|(ty, len)| (TypeKey::from_type(&ty), len.value())),
+                    .map(|(ty, len)| (TypeKey::from_type(&ty), len)),
             );
             Ok(())
         };

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1699,9 +1699,18 @@ pub enum CallbackReject {
     /// **Reserved.** A callback whose result is itself a callback: it would
     /// need a closure struct nested in a closure struct. No use for it yet.
     ReturnsCallback,
-    /// **Unsupported.** A higher-ranked binder, `impl for<'a> Fn(&'a T)`. No
-    /// FFI boundary can be generic over a lifetime, so no adapter could carry
-    /// it — this one is not waiting on machinery.
+    /// **Reserved.** An explicit higher-ranked binder, `impl for<'a> Fn(&'a T)`.
+    ///
+    /// Not an impossibility: the accepted elided spelling `impl Fn(&T)` IS
+    /// higher-ranked — it desugars to exactly this — and the two are mutually
+    /// substitutable in Rust. The binder constrains the Rust closure and is not
+    /// carried on any wire.
+    ///
+    /// So this is the last two-spellings-one-type case, refused only because
+    /// the canonicalization is not written: elision gives each elided input
+    /// lifetime its OWN fresh binder, so `for<'a> Fn(&'a T, &'a T)` is NOT
+    /// `Fn(&T, &T)`, and collapsing the equivalent form needs an exact rule.
+    /// Tracked by issue #222.
     HigherRankedBinder,
 }
 
@@ -1722,8 +1731,9 @@ impl CallbackReject {
                  struct nested in a closure struct"
             }
             Self::HigherRankedBinder => {
-                "a higher-ranked binder (`for<'a>`) cannot cross an FFI boundary, which has no \
-                 way to be generic over a lifetime — use a concrete lifetime"
+                "an explicit higher-ranked binder (`for<'a>`) is not yet supported — write the \
+                 elided form instead (`Fn(&T)`, which means exactly the same thing and is \
+                 accepted); tracked by https://github.com/milyin/prebindgen/issues/222"
             }
         }
     }
@@ -1767,7 +1777,7 @@ pub fn extract_fn_trait_sig(ty: &syn::Type) -> Result<Vec<syn::Type>, CallbackRe
                         // The return was previously not read at all, so a
                         // declared result was accepted and then dropped.
                         if let syn::ReturnType::Type(_, ret) = &p.output {
-                            if !crate::api::lang::jnigen::util::is_unit(ret) {
+                            if !crate::api::core::types_util::is_unit(ret) {
                                 // An `impl Trait` return is the nested-callback
                                 // case whether or not its own bounds are
                                 // complete — `Fn() -> impl Fn()` parses with the

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -398,6 +398,9 @@ pub enum ScanError {
     },
     DisallowedImplTrait {
         ty: String,
+        /// Which callback rule was broken — and whether it is reserved for a
+        /// future release or cannot work at all.
+        reason: CallbackReject,
         loc: SourceLocation,
     },
     UnsupportedReceiver {
@@ -467,23 +470,25 @@ impl fmt::Display for ScanError {
                     e.second
                 )
             }
-            ScanError::ConflictingFunctionIntent { name } => write!(
+            ScanError::ConflictingFunctionIntent { name } => {
+                write!(f, "function `{}` cannot be both declared and ignored", name)
+            }
+            ScanError::ConflictingTypeIntent { key } => {
+                write!(f, "type `{}` cannot be both declared and ignored", key)
+            }
+            ScanError::DisallowedImplTrait { ty, reason, loc } => write!(
                 f,
-                "function `{}` cannot be both declared and ignored",
-                name
-            ),
-            ScanError::ConflictingTypeIntent { key } => write!(
-                f,
-                "type `{}` cannot be both declared and ignored",
-                key
-            ),
-            ScanError::DisallowedImplTrait { ty, loc } => write!(
-                f,
-                "`impl Trait` is not allowed at {}: `{}` (only `impl Fn(...) + Send + Sync + 'static` is supported)",
-                loc, ty
+                "`impl Trait` is not allowed at {}: `{}` — {}",
+                loc,
+                ty,
+                reason.describe()
             ),
             ScanError::UnsupportedReceiver { loc } => {
-                write!(f, "method receiver (`self`) parameters are not supported at {}", loc)
+                write!(
+                    f,
+                    "method receiver (`self`) parameters are not supported at {}",
+                    loc
+                )
             }
             ScanError::UnsupportedParamPattern { loc } => {
                 write!(f, "non-ident parameter pattern is not supported at {}", loc)
@@ -1423,9 +1428,10 @@ impl<M> Registry<M> {
     ) -> Result<(), ScanError> {
         // Reject `impl Trait` except `impl Fn(...) + Send + Sync + 'static`.
         if let syn::Type::ImplTrait(it) = ty {
-            if extract_fn_trait_args(ty).is_none() {
+            if let Err(reason) = extract_fn_trait_sig(ty) {
                 return Err(ScanError::DisallowedImplTrait {
                     ty: it.to_token_stream().to_string(),
+                    reason,
                     loc: loc.clone(),
                 });
             }
@@ -1676,11 +1682,64 @@ pub fn immediate_subtype_positions(ty: &syn::Type) -> Vec<syn::Type> {
     }
 }
 
-/// If `ty` is `impl Fn(T1, T2, ...) + Send + Sync + 'static`, return the
-/// `Fn` argument types in declaration order. Otherwise None.
-pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
+/// Why a type that looks like the callback form is not one.
+///
+/// Split into two kinds on purpose. A refusal that only says *no* leaves the
+/// author guessing whether to redesign the API or wait for a release, and those
+/// are opposite responses — so each variant states which it is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallbackReject {
+    /// Not the callback shape at all — not an `impl Trait`, or its bounds are
+    /// not exactly `Fn(..) + Send + Sync + 'static`.
+    NotCallbackShape,
+    /// **Reserved.** `impl Fn(..) -> R` with `R` not `()`. Every callback wire
+    /// is void-shaped today — C's `call` has no return, and jnigen's `run`
+    /// returns void — so the result would be dropped. Tracked by issue #216.
+    NonUnitReturn,
+    /// **Reserved.** A callback whose result is itself a callback: it would
+    /// need a closure struct nested in a closure struct. No use for it yet.
+    ReturnsCallback,
+    /// **Unsupported.** A higher-ranked binder, `impl for<'a> Fn(&'a T)`. No
+    /// FFI boundary can be generic over a lifetime, so no adapter could carry
+    /// it — this one is not waiting on machinery.
+    HigherRankedBinder,
+}
+
+impl CallbackReject {
+    /// The half of the diagnostic that says which rule was broken, and whether
+    /// waiting would help.
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::NotCallbackShape => "only `impl Fn(...) + Send + Sync + 'static` is supported",
+            Self::NonUnitReturn => {
+                "a callback returning a value is not yet supported — every callback wire is \
+                 void-shaped today, so the result would be dropped (tracked by \
+                 https://github.com/milyin/prebindgen/issues/216); take the result through an \
+                 argument, or return `()`"
+            }
+            Self::ReturnsCallback => {
+                "a callback returning a callback is not yet supported — it would need a closure \
+                 struct nested in a closure struct"
+            }
+            Self::HigherRankedBinder => {
+                "a higher-ranked binder (`for<'a>`) cannot cross an FFI boundary, which has no \
+                 way to be generic over a lifetime — use a concrete lifetime"
+            }
+        }
+    }
+}
+
+/// The `Fn` argument types of `impl Fn(T1, T2, ...) + Send + Sync + 'static`,
+/// in declaration order.
+///
+/// **The single acceptance gate for callbacks.** Every caller that only needs
+/// the shape goes through [`extract_fn_trait_args`]; this one exists so the two
+/// error-reporting sites can say *why*. One function decides — a separate
+/// "why did it fail" helper beside an `Option`-returning gate is the
+/// two-authority drift issue #211 exists to remove.
+pub fn extract_fn_trait_sig(ty: &syn::Type) -> Result<Vec<syn::Type>, CallbackReject> {
     let syn::Type::ImplTrait(it) = ty else {
-        return None;
+        return Err(CallbackReject::NotCallbackShape);
     };
     let mut args: Option<Vec<syn::Type>> = None;
     let mut has_send = false;
@@ -1689,29 +1748,59 @@ pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
     for bound in &it.bounds {
         match bound {
             syn::TypeParamBound::Trait(tb) => {
-                let last = tb.path.segments.last()?;
+                // `for<'a> Fn(..)`. Checked before the path so the binder is
+                // reported as itself rather than as a shape mismatch.
+                if tb.lifetimes.is_some() {
+                    return Err(CallbackReject::HigherRankedBinder);
+                }
+                let last = tb
+                    .path
+                    .segments
+                    .last()
+                    .ok_or(CallbackReject::NotCallbackShape)?;
                 let name = last.ident.to_string();
                 match name.as_str() {
                     "Fn" => {
                         let syn::PathArguments::Parenthesized(p) = &last.arguments else {
-                            return None;
+                            return Err(CallbackReject::NotCallbackShape);
                         };
+                        // The return was previously not read at all, so a
+                        // declared result was accepted and then dropped.
+                        if let syn::ReturnType::Type(_, ret) = &p.output {
+                            if !crate::api::lang::jnigen::util::is_unit(ret) {
+                                // An `impl Trait` return is the nested-callback
+                                // case whether or not its own bounds are
+                                // complete — `Fn() -> impl Fn()` parses with the
+                                // trailing bounds attached to the OUTER list, so
+                                // asking whether the return is itself an
+                                // accepted callback would miss it.
+                                return Err(match &**ret {
+                                    syn::Type::ImplTrait(_) => CallbackReject::ReturnsCallback,
+                                    _ => CallbackReject::NonUnitReturn,
+                                });
+                            }
+                        }
                         args = Some(p.inputs.iter().cloned().collect());
                     }
                     "Send" => has_send = true,
                     "Sync" => has_sync = true,
-                    _ => return None,
+                    _ => return Err(CallbackReject::NotCallbackShape),
                 }
             }
             syn::TypeParamBound::Lifetime(lt) if lt.ident == "static" => has_static = true,
-            _ => return None,
+            _ => return Err(CallbackReject::NotCallbackShape),
         }
     }
-    if has_send && has_sync && has_static {
-        args
-    } else {
-        None
+    match args {
+        Some(args) if has_send && has_sync && has_static => Ok(args),
+        _ => Err(CallbackReject::NotCallbackShape),
     }
+}
+
+/// Shape-only view of [`extract_fn_trait_sig`] — `None` for anything that is
+/// not an accepted callback, whatever the reason.
+pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
+    extract_fn_trait_sig(ty).ok()
 }
 
 /// A **resolved** binding generation: the [`Registry`] after

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -718,20 +718,17 @@ impl<M> Registry<M> {
     fn resolve_array_lengths(&mut self) -> Result<(), ScanError> {
         use syn::visit_mut::VisitMut;
 
-        use crate::api::core::frontend::{resolve_array_lengths, ItemRole, NameIndex};
+        use crate::api::core::frontend::{resolve_array_lengths, ConstIndex};
 
-        let crate_root: syn::Path = syn::parse_quote!(crate);
-        let default_module = self.default_module().unwrap_or(crate_root);
-        let names: HashMap<String, (syn::Path, ItemRole)> = self
-            .named_items()
-            .map(|(ident, role)| {
-                let module = self
-                    .origin_module(ident)
-                    .unwrap_or_else(|| default_module.clone());
-                (ident.to_string(), (module, role))
-            })
-            .collect();
-        let names = NameIndex::new(names, &self.source_modules);
+        // Only consts can be a length, so only consts are indexed — the
+        // grammar is a bare name, and nothing else can answer it.
+        let consts = ConstIndex::new(self.consts.iter().map(|(ident, (item, loc))| {
+            (
+                ident.to_string(),
+                (*item.expr).clone(),
+                loc.crate_name.clone(),
+            )
+        }));
 
         let mut lens: HashMap<TypeKey, crate::api::core::frontend::ArrayLen> = HashMap::new();
         // One accumulator for every map, so a length means the same thing
@@ -750,69 +747,27 @@ impl<M> Registry<M> {
             );
             Ok(())
         };
-        for (item, loc) in self.functions.values_mut() {
-            let found = resolve_array_lengths(item, &names, |r, f| r.visit_item_fn_mut(f));
-            record(found, loc)?;
+        // Each item is lowered against ITS OWN origin: a bare name must be a
+        // const marked in the same crate. Uniqueness holds across the marked
+        // namespace only, so without this a source crate's unmarked const
+        // silently binds to another crate's marked one of the same name.
+        macro_rules! resolve_map {
+            ($map:expr, $visit:ident) => {
+                for (item, loc) in $map {
+                    let origin = loc.crate_name.clone();
+                    let found =
+                        resolve_array_lengths(item, &consts, origin.as_deref(), |r, n| r.$visit(n));
+                    record(found, loc)?;
+                }
+            };
         }
-        for (item, loc) in self.structs.values_mut() {
-            let found = resolve_array_lengths(item, &names, |r, s| r.visit_item_struct_mut(s));
-            record(found, loc)?;
-        }
-        for (item, loc) in self.enums.values_mut() {
-            let found = resolve_array_lengths(item, &names, |r, e| r.visit_item_enum_mut(e));
-            record(found, loc)?;
-        }
-        for (item, loc) in self.consts.values_mut() {
-            let found = resolve_array_lengths(item, &names, |r, c| r.visit_item_const_mut(c));
-            record(found, loc)?;
-        }
-        for (item, loc) in self.passthrough.iter_mut() {
-            let found = resolve_array_lengths(item, &names, |r, i| r.visit_item_mut(i));
-            record(found, loc)?;
-        }
+        resolve_map!(self.functions.values_mut(), visit_item_fn_mut);
+        resolve_map!(self.structs.values_mut(), visit_item_struct_mut);
+        resolve_map!(self.enums.values_mut(), visit_item_enum_mut);
+        resolve_map!(self.consts.values_mut(), visit_item_const_mut);
+        resolve_map!(self.passthrough.iter_mut(), visit_item_mut);
         self.array_lens = lens;
         Ok(())
-    }
-
-    /// The origin crate's **module path** for an item ingested via
-    /// the item's [`SourceLocation`] stamp, or `None` when unknown —
-    /// callers then fall
-    /// back to [`Self::default_module`].
-    /// Every **named** item the registry indexes — functions, structs, enums,
-    /// consts — regardless of whether the stream carried an origin stamp.
-    ///
-    /// Lives here, beside the maps, so an adapter that needs "anything the
-    /// source crate defines" does not enumerate item kinds itself: a new kind
-    /// is added once, here, instead of drifting in each adapter. Deliberately
-    /// NOT keyed off [`Self::item_origins`], which holds only the items whose
-    /// [`SourceLocation::crate_name`] was set — an origin-less hand-built
-    /// stream indexes items that map never sees, and callers are expected to
-    /// pair this with `origin_module(..).unwrap_or_else(default_module)`.
-    pub fn named_item_idents(&self) -> impl Iterator<Item = &syn::Ident> {
-        self.named_items().map(|(ident, _)| ident)
-    }
-
-    /// [`Self::named_item_idents`] plus what each item may be inside a source
-    /// path: a struct or enum can own the segments that follow it
-    /// (`Holder::N`), a const or function can only be the last one.
-    ///
-    /// The single enumeration of item kinds — [`Self::named_item_idents`] is
-    /// derived from it, so a new kind is still added exactly once.
-    pub fn named_items(
-        &self,
-    ) -> impl Iterator<Item = (&syn::Ident, crate::api::core::frontend::ItemRole)> {
-        use crate::api::core::frontend::ItemRole;
-        let owners = self
-            .structs
-            .keys()
-            .chain(self.enums.keys())
-            .map(|i| (i, ItemRole::Owner));
-        let leaves = self
-            .functions
-            .keys()
-            .chain(self.consts.keys())
-            .map(|i| (i, ItemRole::Leaf));
-        owners.chain(leaves)
     }
 
     /// The frontend-decided length of a fixed-size array type, or `None` if
@@ -826,6 +781,9 @@ impl<M> Registry<M> {
         self.array_lens.get(key)
     }
 
+    /// The origin crate's **module path** for an item ingested via the item's
+    /// [`SourceLocation`] stamp, or `None` when unknown — callers then fall
+    /// back to [`Self::default_module`].
     pub fn origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
         let crate_name = self.item_origins.get(ident)?;
         let module = crate_name.replace('-', "_");

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -256,14 +256,21 @@ pub struct Registry<M = ()> {
 
     /// Every fixed-size array type the source defines, mapped to its
     /// frontend-decided length. Filled at ingest by
-    /// [`crate::api::core::frontend::resolve_array_lengths`]; keyed by the
-    /// array type AFTER that rewrite, which is the only spelling anything
-    /// downstream sees.
+    /// [`crate::api::core::frontend::resolve_array_lengths`].
     ///
-    /// This is the single source of `N`: a consumer that needs the length —
-    /// planning, or an adapter deciding how an array crosses its boundary —
-    /// reads it from here instead of re-parsing `syn::TypeArray::len`.
-    pub(crate) array_lens: HashMap<TypeKey, crate::api::core::frontend::ArrayLen>,
+    /// **The value is a number, and only a number.** This table is keyed by
+    /// `TypeKey`, and `TypeKey` has already collapsed every source spelling of
+    /// one array type: `[u8; A]`, `[u8; B]` and `[u8; 4]` are one key when
+    /// `A == B == 4`, because they are one Rust type. So a type-keyed table can
+    /// answer "the length is 4" and cannot answer "the source wrote `A`" —
+    /// that second statement is false for the other occupants of the key.
+    /// Storing the spelling here would make the answer depend on which
+    /// occurrence happened to be inserted last.
+    ///
+    /// Source-use provenance is per occurrence, not per type; it belongs to a
+    /// per-use source model (issue #211's `SourceModel`), keyed by the use
+    /// site.
+    pub(crate) array_lens: HashMap<TypeKey, usize>,
 
     /// Type tables, one per direction. Each scanned type maps to its resolved
     /// [`TypeEntry`] (`Some`) or stays unresolved (`None`) until the structural
@@ -730,20 +737,26 @@ impl<M> Registry<M> {
             )
         }));
 
-        let mut lens: HashMap<TypeKey, crate::api::core::frontend::ArrayLen> = HashMap::new();
+        let mut lens: HashMap<TypeKey, usize> = HashMap::new();
         // One accumulator for every map, so a length means the same thing
         // whichever item kind it was written in.
+        //
+        // Only the VALUE is kept. `ArrayLen` models one occurrence and knows
+        // which spelling produced it; `TypeKey` has already collapsed the
+        // spellings, so carrying it across this boundary would make the stored
+        // answer depend on iteration order. See `Self::array_lens`.
         let mut record = |found: Result<Vec<(syn::Type, _)>, _>,
                           loc: &SourceLocation|
          -> Result<(), ScanError> {
-            let found = found.map_err(|error| ScanError::UnsupportedArrayLength {
-                error: Box::new(error),
-                loc: loc.clone(),
-            })?;
+            let found: Vec<(syn::Type, crate::api::core::frontend::ArrayLen)> =
+                found.map_err(|error| ScanError::UnsupportedArrayLength {
+                    error: Box::new(error),
+                    loc: loc.clone(),
+                })?;
             lens.extend(
                 found
                     .into_iter()
-                    .map(|(ty, len)| (TypeKey::from_type(&ty), len)),
+                    .map(|(ty, len)| (TypeKey::from_type(&ty), len.value())),
             );
             Ok(())
         };
@@ -777,8 +790,8 @@ impl<M> Registry<M> {
     /// `syn::TypeArray::len`: the length has already been validated and
     /// resolved once, and a second reading is where the two-authority drift
     /// that issue #211 is about starts.
-    pub fn array_len(&self, key: &TypeKey) -> Option<&crate::api::core::frontend::ArrayLen> {
-        self.array_lens.get(key)
+    pub fn array_len(&self, key: &TypeKey) -> Option<usize> {
+        self.array_lens.get(key).copied()
     }
 
     /// The origin crate's **module path** for an item ingested via the item's

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -272,6 +272,24 @@ pub struct Registry<M = ()> {
     /// site.
     pub(crate) array_lens: HashMap<TypeKey, usize>,
 
+    /// The typed source model of every indexed struct with named fields — the
+    /// beginning of issue #211's `SourceModel`.
+    ///
+    /// This is what an adapter consumes when it needs a **source** fact rather
+    /// than a semantic type: which const an array's extent named, so a C header
+    /// can emit `uint8_t tag[MARKER_TAG_LEN]`. The `syn` field types in
+    /// [`Self::structs`] are written from this model, so they are a projection
+    /// of it rather than a second source of truth.
+    pub(crate) source_structs: HashMap<syn::Ident, crate::api::core::frontend::model::SourceStruct>,
+
+    /// `#[prebindgen]` consts that a struct field's array extent named.
+    ///
+    /// An adapter that spells such an extent symbolically — the C mirror emits
+    /// `uint8_t tag[MARKER_TAG_LEN]` — must also make the const reachable in
+    /// the destination language, or the emitted code names something that does
+    /// not exist. This is the set that has to be carried across.
+    pub(crate) extent_consts: HashSet<syn::Ident>,
+
     /// Type tables, one per direction. Each scanned type maps to its resolved
     /// [`TypeEntry`] (`Some`) or stays unresolved (`None`) until the structural
     /// resolver fills it.
@@ -337,6 +355,8 @@ impl<M> Default for Registry<M> {
             item_origins: HashMap::new(),
             source_modules: Vec::new(),
             array_lens: HashMap::new(),
+            source_structs: HashMap::new(),
+            extent_consts: HashSet::new(),
             input_types: Default::default(),
             output_types: Default::default(),
             type_locations: HashMap::new(),
@@ -417,6 +437,15 @@ pub enum ScanError {
         error: Box<crate::api::core::frontend::UnsupportedArrayLen>,
         loc: SourceLocation,
     },
+    /// A struct field's type is not in the accepted source grammar — see
+    /// [`crate::api::core::frontend::model::SourceType`]. Raised at ingest,
+    /// before any adapter runs.
+    UnsupportedFieldType {
+        item: syn::Ident,
+        field: syn::Ident,
+        error: Box<crate::api::core::frontend::model::UnsupportedType>,
+        loc: SourceLocation,
+    },
 }
 
 impl fmt::Display for ScanError {
@@ -492,6 +521,14 @@ impl fmt::Display for ScanError {
             }
             ScanError::UnsupportedArrayLength { error, loc } => {
                 write!(f, "{error} (at {loc})")
+            }
+            ScanError::UnsupportedFieldType {
+                item,
+                field,
+                error,
+                loc,
+            } => {
+                write!(f, "field `{item}::{field}`: {error} (at {loc})")
             }
         }
     }
@@ -725,7 +762,10 @@ impl<M> Registry<M> {
     fn resolve_array_lengths(&mut self) -> Result<(), ScanError> {
         use syn::visit_mut::VisitMut;
 
-        use crate::api::core::frontend::{resolve_array_lengths, ConstIndex};
+        use crate::api::core::frontend::{
+            model::{lower_type, SourceField, SourceStruct},
+            resolve_array_lengths, ConstIndex,
+        };
 
         // Only consts can be a length, so only consts are indexed — the
         // grammar is a bare name, and nothing else can answer it.
@@ -738,6 +778,8 @@ impl<M> Registry<M> {
         }));
 
         let mut lens: HashMap<TypeKey, usize> = HashMap::new();
+        let mut source_structs: HashMap<syn::Ident, SourceStruct> = HashMap::new();
+        let mut extent_consts: HashSet<syn::Ident> = HashSet::new();
         // One accumulator for every map, so a length means the same thing
         // whichever item kind it was written in.
         //
@@ -746,15 +788,15 @@ impl<M> Registry<M> {
         let mut record = |found: Result<Vec<(syn::Type, _)>, _>,
                           loc: &SourceLocation|
          -> Result<(), ScanError> {
-            let found: Vec<(syn::Type, usize)> =
-                found.map_err(|error| ScanError::UnsupportedArrayLength {
+            let found: Vec<(syn::Type, crate::api::core::frontend::model::ArrayExtent)> = found
+                .map_err(|error| ScanError::UnsupportedArrayLength {
                     error: Box::new(error),
                     loc: loc.clone(),
                 })?;
             lens.extend(
                 found
                     .into_iter()
-                    .map(|(ty, len)| (TypeKey::from_type(&ty), len)),
+                    .map(|(ty, extent)| (TypeKey::from_type(&ty), extent.value)),
             );
             Ok(())
         };
@@ -773,11 +815,51 @@ impl<M> Registry<M> {
             };
         }
         resolve_map!(self.functions.values_mut(), visit_item_fn_mut);
-        resolve_map!(self.structs.values_mut(), visit_item_struct_mut);
         resolve_map!(self.enums.values_mut(), visit_item_enum_mut);
         resolve_map!(self.consts.values_mut(), visit_item_const_mut);
         resolve_map!(self.passthrough.iter_mut(), visit_item_mut);
+
+        // Structs go through the MODEL rather than the length walk: their
+        // fields are the one surface an adapter consumes as source (the C
+        // mirror), so they need the full typed IR, not just resolved extents.
+        // The `syn` field types are then written back from the model, so the
+        // two can never disagree — `to_syn` is a projection, not a copy.
+        for (ident, (item, loc)) in self.structs.iter_mut() {
+            let origin = loc.crate_name.clone();
+            let syn::Fields::Named(named) = &mut item.fields else {
+                continue;
+            };
+            let mut fields = Vec::with_capacity(named.named.len());
+            for field in named.named.iter_mut() {
+                let Some(name) = field.ident.clone() else {
+                    continue;
+                };
+                let ty = lower_type(&field.ty, &consts, origin.as_deref()).map_err(|error| {
+                    ScanError::UnsupportedFieldType {
+                        item: ident.clone(),
+                        field: name.clone(),
+                        error: Box::new(error),
+                        loc: loc.clone(),
+                    }
+                })?;
+                field.ty = ty.to_syn();
+                if let Some(extent) = ty.array_extent() {
+                    lens.insert(TypeKey::from_type(&field.ty), extent.value);
+                }
+                for extent in ty.extents() {
+                    if let Some(id) = extent.const_id() {
+                        extent_consts
+                            .insert(syn::Ident::new(&id.name, proc_macro2::Span::call_site()));
+                    }
+                }
+                fields.push(SourceField { name, ty });
+            }
+            source_structs.insert(ident.clone(), SourceStruct { fields });
+        }
+
         self.array_lens = lens;
+        self.source_structs = source_structs;
+        self.extent_consts = extent_consts;
         Ok(())
     }
 
@@ -790,6 +872,25 @@ impl<M> Registry<M> {
     /// that issue #211 is about starts.
     pub fn array_len(&self, key: &TypeKey) -> Option<usize> {
         self.array_lens.get(key).copied()
+    }
+
+    /// The typed source model of an indexed struct, or `None` when `ident` is
+    /// not an indexed struct with named fields.
+    ///
+    /// An adapter reads this when it needs a fact about the SOURCE — which
+    /// const an extent named — rather than the semantic type. It must not
+    /// re-derive such facts from `syn`; that is the whole point of #211.
+    /// Whether `ident` is a `#[prebindgen]` const that a struct field's array
+    /// extent named — see [`Self::extent_consts`].
+    pub fn is_extent_const(&self, ident: &syn::Ident) -> bool {
+        self.extent_consts.contains(ident)
+    }
+
+    pub fn source_struct(
+        &self,
+        ident: &syn::Ident,
+    ) -> Option<&crate::api::core::frontend::model::SourceStruct> {
+        self.source_structs.get(ident)
     }
 
     /// The origin crate's **module path** for an item ingested via the item's

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -36,7 +36,9 @@ pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
 ///    paths (`zenoh::KeyExpr`) are NEVER touched — the registry has no
 ///    index of a foreign namespace, so `a::KeyExpr` and `b::KeyExpr` may be
 ///    genuinely distinct types and their spelling is their identity.
-/// 5. Lifetimes are NOT normalized (`&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`)
+/// 5. Generic punctuation that carries no meaning is dropped: the turbofish
+///    (`Foo::<T>` ≡ `Foo<T>`) and a trailing comma (`Foo<T,>` ≡ `Foo<T>`).
+/// 6. Lifetimes are NOT normalized (`&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`)
 ///    — [`match_pattern`] treats lifetimes as fixed structure and
 ///    foreign-type declarations (`ptr_class!(ZKeyExpr<'static>)`) rely on
 ///    the verbatim spelling.
@@ -65,6 +67,24 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
                 }
             }
             syn::visit_mut::visit_type_mut(self, ty);
+        }
+
+        /// Drop generic punctuation that carries no meaning: the turbofish
+        /// (`Foo::<T>` ≡ `Foo<T>`) and a trailing comma (`Foo<T,>` ≡ `Foo<T>`).
+        ///
+        /// It belongs here rather than in any consumer because [`TypeKey`]'s
+        /// identity is the normalized token string, so two spellings of one type
+        /// would otherwise be two keys — and during the frontend migration they
+        /// would split by POSITION, a modeled struct field getting one key and a
+        /// function signature the other.
+        fn visit_path_arguments_mut(&mut self, args: &mut syn::PathArguments) {
+            if let syn::PathArguments::AngleBracketed(ab) = args {
+                ab.colon2_token = None;
+                if ab.args.trailing_punct() {
+                    ab.args = std::mem::take(&mut ab.args).into_iter().collect();
+                }
+            }
+            syn::visit_mut::visit_path_arguments_mut(self, args);
         }
     }
     Normalizer {

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -82,6 +82,12 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
         /// would split by POSITION, a modeled struct field getting one key and a
         /// function signature the other.
         fn visit_path_arguments_mut(&mut self, args: &mut syn::PathArguments) {
+            // Children FIRST, then canonicalize. The unit-return test below
+            // reads the return type, and it is this recursion that unwraps
+            // `Paren` — so testing first left `-> (())` needing a second pass
+            // to reach `Fn(u8)`, and a key could then depend on whether its
+            // input had already been normalized.
+            syn::visit_mut::visit_path_arguments_mut(self, args);
             match args {
                 syn::PathArguments::AngleBracketed(ab) => {
                     ab.colon2_token = None;
@@ -104,7 +110,6 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
                 }
                 syn::PathArguments::None => {}
             }
-            syn::visit_mut::visit_path_arguments_mut(self, args);
         }
 
         /// Put `impl Trait` bounds in one order: traits sorted by their token
@@ -435,7 +440,10 @@ pub fn is_result_type(ty: &syn::Type) -> bool {
 }
 
 /// True when `ty` is the unit type `()`.
-#[cfg(feature = "unstable-cbindgen")]
+///
+/// Lives in core, not in an adapter: it is a source-language fact — a callback
+/// must return unit — and core deciding that by reaching into one adapter is
+/// the dependency inversion issue #211 exists to prevent.
 pub fn is_unit(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty())
 }

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -36,8 +36,11 @@ pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
 ///    paths (`zenoh::KeyExpr`) are NEVER touched — the registry has no
 ///    index of a foreign namespace, so `a::KeyExpr` and `b::KeyExpr` may be
 ///    genuinely distinct types and their spelling is their identity.
-/// 5. Generic punctuation that carries no meaning is dropped: the turbofish
-///    (`Foo::<T>` ≡ `Foo<T>`) and a trailing comma (`Foo<T,>` ≡ `Foo<T>`).
+/// 5. Punctuation and ordering that carry no meaning are canonicalized: the
+///    turbofish (`Foo::<T>` ≡ `Foo<T>`), a trailing comma in either argument
+///    list (`Foo<T,>` ≡ `Foo<T>`, `Fn(T,)` ≡ `Fn(T)`), an explicitly-spelled
+///    unit return (`Fn(T) -> ()` ≡ `Fn(T)`), and `impl Trait` bound order
+///    (`Send + Sync` ≡ `Sync + Send`; lifetime bounds sort last).
 /// 6. Lifetimes are NOT normalized (`&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`)
 ///    — [`match_pattern`] treats lifetimes as fixed structure and
 ///    foreign-type declarations (`ptr_class!(ZKeyExpr<'static>)`) rely on
@@ -69,8 +72,9 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
             syn::visit_mut::visit_type_mut(self, ty);
         }
 
-        /// Drop generic punctuation that carries no meaning: the turbofish
-        /// (`Foo::<T>` ≡ `Foo<T>`) and a trailing comma (`Foo<T,>` ≡ `Foo<T>`).
+        /// Drop argument punctuation that carries no meaning: the turbofish
+        /// (`Foo::<T>` ≡ `Foo<T>`), a trailing comma in either list, and an
+        /// explicitly-spelled unit return (`Fn(T) -> ()` ≡ `Fn(T)`).
         ///
         /// It belongs here rather than in any consumer because [`TypeKey`]'s
         /// identity is the normalized token string, so two spellings of one type
@@ -78,13 +82,49 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
         /// would split by POSITION, a modeled struct field getting one key and a
         /// function signature the other.
         fn visit_path_arguments_mut(&mut self, args: &mut syn::PathArguments) {
-            if let syn::PathArguments::AngleBracketed(ab) = args {
-                ab.colon2_token = None;
-                if ab.args.trailing_punct() {
-                    ab.args = std::mem::take(&mut ab.args).into_iter().collect();
+            match args {
+                syn::PathArguments::AngleBracketed(ab) => {
+                    ab.colon2_token = None;
+                    if ab.args.trailing_punct() {
+                        ab.args = std::mem::take(&mut ab.args).into_iter().collect();
+                    }
                 }
+                // `Fn(..)`'s inputs are a different punctuation list with the
+                // same problem, plus an output that may spell unit explicitly:
+                // `Fn(u8,) -> ()` is `Fn(u8)`.
+                syn::PathArguments::Parenthesized(p) => {
+                    if p.inputs.trailing_punct() {
+                        p.inputs = std::mem::take(&mut p.inputs).into_iter().collect();
+                    }
+                    if let syn::ReturnType::Type(_, ret) = &p.output {
+                        if matches!(&**ret, syn::Type::Tuple(t) if t.elems.is_empty()) {
+                            p.output = syn::ReturnType::Default;
+                        }
+                    }
+                }
+                syn::PathArguments::None => {}
             }
             syn::visit_mut::visit_path_arguments_mut(self, args);
+        }
+
+        /// Put `impl Trait` bounds in one order: traits sorted by their token
+        /// string, lifetime bounds last.
+        ///
+        /// Bound order is semantically irrelevant in Rust and the callback gate
+        /// already accepts any order, so without this `Send + Sync` and
+        /// `Sync + Send` are one type with two keys. Lifetimes stay last
+        /// because a bound list may not begin with one.
+        fn visit_type_impl_trait_mut(&mut self, it: &mut syn::TypeImplTrait) {
+            syn::visit_mut::visit_type_impl_trait_mut(self, it);
+            let mut bounds: Vec<syn::TypeParamBound> =
+                std::mem::take(&mut it.bounds).into_iter().collect();
+            bounds.sort_by_key(|b| {
+                (
+                    matches!(b, syn::TypeParamBound::Lifetime(_)),
+                    b.to_token_stream().to_string(),
+                )
+            });
+            it.bounds = bounds.into_iter().collect();
         }
     }
     Normalizer {

--- a/prebindgen/src/api/core/types_util/tests.rs
+++ b/prebindgen/src/api/core/types_util/tests.rs
@@ -358,4 +358,18 @@ fn normalize_drops_turbofish_and_trailing_comma() {
     // A lifetime argument is identity and survives — only punctuation goes.
     assert_eq!(canon("Foo::<'static,>"), canon("Foo<'static>"));
     assert_ne!(canon("Foo<'static>"), canon("Foo"));
+
+    // `Fn(..)` is a second punctuation list with the same problem, plus a
+    // return that may spell unit explicitly and bounds whose order is
+    // irrelevant. One callback, four spellings, one key.
+    let cb = canon("impl Fn(u8) + Send + Sync + 'static");
+    assert_eq!(canon("impl Fn(u8,) + Send + Sync + 'static"), cb);
+    assert_eq!(canon("impl Fn(u8) -> () + Send + Sync + 'static"), cb);
+    assert_eq!(canon("impl Fn(u8) + Sync + Send + 'static"), cb);
+    assert_eq!(canon("impl Fn(u8,) -> () + Sync + Send + 'static"), cb);
+    // A lifetime bound sorts last, so the canonical form stays valid Rust.
+    assert!(cb.starts_with("impl Fn"), "{cb}");
+    assert!(cb.ends_with("'static"), "{cb}");
+    // A non-unit return is NOT punctuation and must survive to be refused.
+    assert_ne!(canon("impl Fn(u8) -> u16 + Send + Sync + 'static"), cb);
 }

--- a/prebindgen/src/api/core/types_util/tests.rs
+++ b/prebindgen/src/api/core/types_util/tests.rs
@@ -330,3 +330,32 @@ fn discriminants_non_literal_rejected() {
     };
     let _ = discriminants(e);
 }
+
+/// Turbofish and a trailing generic comma are punctuation, not identity, so
+/// they collapse before any `TypeKey` is formed.
+///
+/// This has to happen HERE rather than in a consumer: a key's identity is the
+/// normalized token string, so otherwise one type has two keys — and during the
+/// frontend migration they split by POSITION, a modeled struct field getting
+/// one and a function signature the other.
+#[test]
+fn normalize_drops_turbofish_and_trailing_comma() {
+    let canon = |s: &str| {
+        let mut t = ty(s);
+        normalize_type(&mut t, &[]);
+        t.to_token_stream().to_string()
+    };
+    let want = canon("Wrapper<u8>");
+    assert_eq!(canon("Wrapper::<u8>"), want);
+    assert_eq!(canon("Wrapper<u8,>"), want);
+    assert_eq!(canon("Wrapper::<u8,>"), want);
+    // Nested, and through the peelers a field type actually takes.
+    assert_eq!(
+        canon("Option<Wrapper::<u8,>>"),
+        canon("Option<Wrapper<u8>>")
+    );
+    assert_eq!(canon("Vec::<u8,>"), canon("Vec<u8>"));
+    // A lifetime argument is identity and survives — only punctuation goes.
+    assert_eq!(canon("Foo::<'static,>"), canon("Foo<'static>"));
+    assert_ne!(canon("Foo<'static>"), canon("Foo"));
+}

--- a/prebindgen/src/api/core/types_util/tests.rs
+++ b/prebindgen/src/api/core/types_util/tests.rs
@@ -372,4 +372,42 @@ fn normalize_drops_turbofish_and_trailing_comma() {
     assert!(cb.ends_with("'static"), "{cb}");
     // A non-unit return is NOT punctuation and must survive to be refused.
     assert_ne!(canon("impl Fn(u8) -> u16 + Send + Sync + 'static"), cb);
+    // A parenthesized unit return reaches the canonical form in ONE pass: the
+    // recursion that unwraps `Paren` has to run BEFORE the unit test, or this
+    // needs a second pass and the key depends on how many it has had.
+    assert_eq!(canon("impl Fn(u8) -> (()) + Send + Sync + 'static"), cb);
+}
+
+/// Normalization is idempotent: a canonical form is its own canonical form.
+///
+/// Asserted over every spelling the suite exercises rather than for one case,
+/// because the way this breaks is a rule that reads a node the recursion has
+/// not reached yet, and that mistake is not specific to any one rule. It
+/// matters because items are normalized at ingest and `TypeKey::from_type`
+/// normalizes again, while a directly built key normalizes once.
+#[test]
+fn normalize_is_idempotent() {
+    for src in [
+        "Wrapper::<u8>",
+        "Wrapper<u8,>",
+        "Option<Wrapper::<u8,>>",
+        "Foo::<'static,>",
+        "impl Fn(u8,) -> () + Sync + Send + 'static",
+        "impl Fn(u8) -> (()) + Send + Sync + 'static",
+        "impl Fn(u8) -> u16 + Send + Sync + 'static",
+        "crate::a::Foo<T>",
+        "std::option::Option<u8>",
+        "&'static [u8]",
+        "[u8; 4]",
+    ] {
+        let mut once = ty(src);
+        normalize_type(&mut once, &[]);
+        let mut twice = once.clone();
+        normalize_type(&mut twice, &[]);
+        assert_eq!(
+            once.to_token_stream().to_string(),
+            twice.to_token_stream().to_string(),
+            "`{src}` is not idempotent"
+        );
+    }
 }

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -42,7 +42,7 @@ impl Cbindgen {
             registry.output_entry(&ty).is_some()
                 && self
                     .struct_fields(registry, &ty)
-                    .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))
+                    .map(|fields| fields.iter().any(|(_, fty)| matches!(fty, SourceType::Str)))
                     .unwrap_or(false)
         })
     }
@@ -238,6 +238,7 @@ impl Cbindgen {
         self.struct_fields(registry, fty)
             .unwrap_or_default()
             .into_iter()
+            .map(|(name, fty)| (name, fty.to_syn()))
             .filter(|(_, fty)| self.data_field_owns(fty, registry))
             .collect()
     }
@@ -294,27 +295,62 @@ impl Cbindgen {
         })
     }
 
-    /// Fields (`name`, `type`) of a declared data struct, looked up from the
-    /// registry's indexed structs. `None` if the type isn't an indexed named
+    /// Fields (`name`, modeled type) of a declared data struct, read from the
+    /// frontend's **source model**. `None` if the type isn't an indexed named
     /// struct.
+    ///
+    /// Sourced from [`Registry::source_struct`] rather than from the
+    /// `syn::ItemStruct`, so a field carries the facts the frontend decided —
+    /// notably an array's [`ArrayExtent`], which is how the C mirror knows to
+    /// emit `uint8_t tag[MARKER_TAG_LEN]` instead of `[4]`. Re-reading the
+    /// `syn` item could only have recovered that by parsing source syntax,
+    /// which is what issue #211 exists to stop.
+    ///
+    /// The per-field *classification* (is it a `String`, a declared enum, an
+    /// opaque pointer) still runs on [`SourceType::to_syn`]; migrating that off
+    /// `syn` is stage F5 of the umbrella, not this change.
     pub(super) fn struct_fields(
         &self,
         registry: &Registry<()>,
         ty: &syn::Type,
-    ) -> Option<Vec<(syn::Ident, syn::Type)>> {
+    ) -> Option<Vec<(syn::Ident, SourceType)>> {
         let ident = type_path_tail(ty)?;
-        let (item, _) = registry.structs.get(&ident)?;
-        if let syn::Fields::Named(named) = &item.fields {
-            Some(
-                named
-                    .named
-                    .iter()
-                    .map(|f| (f.ident.clone().unwrap(), f.ty.clone()))
-                    .collect(),
-            )
-        } else {
-            None
+        let model = registry.source_struct(&ident)?;
+        Some(
+            model
+                .fields
+                .iter()
+                .map(|f| (f.name.clone(), f.ty.clone()))
+                .collect(),
+        )
+    }
+
+    /// How the C mirror spells a field's wire.
+    ///
+    /// Identical to `wire` except for an array whose extent named a const: that
+    /// keeps the **name**, because a symbolic extent is part of the C API's
+    /// meaning — changing the size stays one edit instead of a hunt through
+    /// literals. Recurses, so `[[u8; A]; B]` keeps both.
+    ///
+    /// The const is in scope in the generated crate because
+    /// [`Prebindgen::on_const`] re-emits it there with its literal value; see
+    /// `Cbindgen::on_const`.
+    pub(super) fn spell_field_wire(&self, fty: &SourceType, wire: &syn::Type) -> syn::Type {
+        fn spell(ty: &SourceType) -> Option<syn::Type> {
+            let SourceType::Array { elem, extent } = ty else {
+                return None;
+            };
+            let inner = spell(elem).unwrap_or_else(|| elem.to_syn());
+            let n: syn::Expr = match extent.const_id() {
+                Some(id) => {
+                    let ident = format_ident!("{}", id.name);
+                    syn::parse_quote!(#ident)
+                }
+                None => extent.to_expr(),
+            };
+            Some(syn::parse_quote!([#inner; #n]))
         }
+        spell(fty).unwrap_or_else(|| wire.clone())
     }
 
     /// Wire type of a `repr_c_struct` field in the generated **visible** mirror: a
@@ -394,7 +430,7 @@ impl Cbindgen {
             .unwrap_or_default()
             .into_iter()
             .filter_map(|(fname, fty)| {
-                self.restricted_validity_field(&fty)
+                self.restricted_validity_field(&fty.to_syn())
                     .map(|reason| (fname, reason))
             })
             .collect()

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -108,6 +108,7 @@ pub(crate) use crate::api::core::types_util::{
 };
 use crate::api::{
     core::{
+        frontend::model::SourceType,
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen},
         registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
@@ -731,5 +732,28 @@ fn c_field_wire(ty: &syn::Type) -> Option<syn::Type> {
     if is_scalar(ty) {
         return Some(ty.clone());
     }
+    if is_scalar_array(ty) {
+        // `[T; N]` is already `#[repr(C)]`-compatible and C sees `T x[N]`, so
+        // the array IS its own wire and the field copies with no conversion.
+        return Some(ty.clone());
+    }
     None
+}
+
+/// `true` for `[T; N]` (nested included) whose element is a scalar **other than
+/// `bool`**.
+///
+/// `bool` is excluded for the reason [`Cbindgen::restricted_validity_field`]
+/// gives: its domain is `0`/`1`, and a struct mirror is reinterpreted wholesale
+/// with no per-element hook, so a byte C wrote could become an invalid Rust
+/// `bool` before any generated code could look. Every other scalar holds any
+/// bit pattern legally.
+fn is_scalar_array(ty: &syn::Type) -> bool {
+    let syn::Type::Array(a) = ty else {
+        return false;
+    };
+    if is_bool(&a.elem) {
+        return false;
+    }
+    is_scalar(&a.elem) || is_scalar_array(&a.elem)
 }

--- a/prebindgen/src/api/lang/cbindgen/tests/structs.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/structs.rs
@@ -641,3 +641,105 @@ fn repr_c_struct_restricted_validity_field_audited_even_when_output_only() {
     let compact: String = src.split_whitespace().collect();
     assert!(compact.contains("pubflag:bool"), "{src}");
 }
+
+/// A `data_struct` field that is a fixed-size array sized by a `#[prebindgen]`
+/// const keeps the CONST NAME in the C mirror, and the const is re-emitted with
+/// its literal value so cbindgen can define the symbol.
+///
+/// Both halves are the point, and they fail in opposite directions: emitting
+/// `[u8; 4]` loses a symbolic extent that is part of the C API's meaning, while
+/// emitting `[u8; TAG_LEN]` without the const reaching the header names
+/// something undefined. Only the pair compiles AND reads correctly.
+///
+/// The mirror spells the name because the frontend's source model TOLD the
+/// adapter the extent named a const — not because the adapter re-read the
+/// source syntax, which issue #211 forbids.
+#[test]
+fn data_struct_const_sized_array_keeps_the_const_name() {
+    let loc = SourceLocation::default();
+    let items = [
+        (
+            syn::Item::Const(syn::parse_quote!(
+                pub const TAG_LEN: usize = 4;
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Marker {
+                    pub tag: [u8; TAG_LEN],
+                    pub plain: [u8; 2],
+                    pub weight: u32,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn marker_echo(m: Marker) -> Marker {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<()>::from_items(items).expect("index items");
+
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(myflat))
+        .data_struct(syn::parse_quote!(Marker))
+        .function(syn::parse_quote!(marker_echo));
+
+    let src = write(cbindgen, registry, "const_sized_array");
+    let compact: String = src.split_whitespace().collect();
+
+    // The mirror keeps the NAME for the const-sized field...
+    assert!(compact.contains("pubtag:[u8;TAG_LEN]"), "{src}");
+    // ...and the number for the one the source wrote as a literal.
+    assert!(compact.contains("pubplain:[u8;2]"), "{src}");
+
+    // The const reaches the generated crate with its VALUE, not as a path
+    // alias — cbindgen cannot evaluate `myflat::TAG_LEN`, so an alias would
+    // produce no `#define` and the mirror above would name an undefined symbol.
+    assert!(compact.contains("constTAG_LEN:usize=4;"), "{src}");
+    assert!(!compact.contains("TAG_LEN:usize=myflat::TAG_LEN"), "{src}");
+
+    // The array is its own wire, so the converters copy it with no conversion.
+    assert!(compact.contains("tag:v.tag"), "{src}");
+}
+
+/// An array of `bool` is refused, naming the field.
+///
+/// `bool`'s domain is `0`/`1` and a `data_struct` mirror is reinterpreted
+/// wholesale, so there is no per-element hook to normalise a byte C wrote —
+/// the same restricted-validity hazard that keeps a bare `bool` field on the
+/// `MaybeUninit` wire.
+#[test]
+#[should_panic(expected = "flags")]
+fn data_struct_bool_array_field_is_refused() {
+    let loc = SourceLocation::default();
+    let items = [
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Flags {
+                    pub flags: [bool; 3],
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn flags_echo(f: Flags) -> Flags {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = Registry::<()>::from_items(items).expect("index items");
+    let cbindgen = Cbindgen::new()
+        .source_module(syn::parse_quote!(myflat))
+        .data_struct(syn::parse_quote!(Flags))
+        .function(syn::parse_quote!(flags_echo));
+    write(cbindgen, registry, "bool_array");
+}

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -59,6 +59,7 @@ impl Cbindgen {
         let mut subs: Vec<syn::Type> = Vec::new();
         let mut fallible = false;
         for (fname, fty) in &fields {
+            let fty = &fty.to_syn();
             if is_string(fty) {
                 inits.push(quote!(#fname: if v.#fname.is_null() {
                     ::std::string::String::new()
@@ -129,6 +130,7 @@ impl Cbindgen {
         }
         let mut idents = Vec::new();
         for (fname, fty) in self.struct_fields(registry, ty)? {
+            let fty = fty.to_syn();
             // An owned-pointer field is one whose mirror wire is a raw pointer
             // (`Option<Box<T>>` / `Box<T>` → `*mut t_t`); scalars/enums are not.
             if matches!(self.mirror_field_wire(&fty), Some(syn::Type::Ptr(_))) {
@@ -572,14 +574,19 @@ impl Cbindgen {
             let c_struct = self.c_type_ident(&ty);
             let mut field_defs: Vec<TokenStream> = Vec::new();
             for (fname, fty) in &fields {
-                let wire = self.data_field_wire(fty).unwrap_or_else(|| {
+                let sty = fty.to_syn();
+                let wire = self.data_field_wire(&sty).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
                         fname,
                         type_short(&ty),
-                        fty.to_token_stream()
+                        sty.to_token_stream()
                     )
                 });
+                // An array extent that named a const keeps the NAME here — see
+                // `spell_field_wire`. This is the one place a SOURCE fact
+                // reaches emission, and it comes from the model.
+                let wire = self.spell_field_wire(fty, &wire);
                 field_defs.push(quote!(pub #fname: #wire));
             }
             items.push(syn::parse_quote!(
@@ -658,16 +665,18 @@ impl Cbindgen {
                 let field_defs: Vec<TokenStream> = fields
                     .iter()
                     .map(|(fname, fty)| {
-                        let wire = self.mirror_field_wire(fty).unwrap_or_else(|| {
+                        let sty = fty.to_syn();
+                        let wire = self.mirror_field_wire(&sty).unwrap_or_else(|| {
                             panic!(
                                 "Cbindgen::repr_c_struct: field `{}` of `{}` has unsupported \
                                  type `{}` (expected a scalar, a declared `enum_type`, or an \
                                  opaque pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
                                 fname,
                                 type_short(&ty),
-                                fty.to_token_stream()
+                                sty.to_token_stream()
                             )
                         });
+                        let wire = self.spell_field_wire(fty, &wire);
                         quote!(pub #fname: #wire)
                     })
                     .collect();
@@ -1446,13 +1455,32 @@ impl Prebindgen for Cbindgen {
     type Metadata = ();
 
     // Consts have no declaration mechanism here (`declared_consts` stays
-    // `None`), so every indexed const re-emits through the default
-    // `on_const` — a path-alias against this source module, keeping consts
-    // with non-portable initializers valid in the generated file. (cbindgen
-    // cannot evaluate a path initializer, so aliased consts don't surface
-    // as `#define`s in the C header.)
+    // `None`), so every indexed const re-emits through `on_const` below.
     fn source_module(&self) -> Option<&syn::Path> {
         self.source_module.as_ref()
+    }
+
+    /// Re-emit a const as a **path alias** against the source module — except
+    /// one an array extent named, which is emitted **verbatim**, keeping its
+    /// literal initializer.
+    ///
+    /// The distinction is forced by cbindgen: it cannot evaluate a path
+    /// initializer, so an aliased const produces no `#define`. That is fine
+    /// while nothing references it, and fatal once the C mirror spells an
+    /// extent symbolically — `uint8_t tag[MARKER_TAG_LEN]` beside no
+    /// `#define MARKER_TAG_LEN` is a header that does not compile.
+    ///
+    /// Only extent consts change, so every other const keeps the alias and its
+    /// link to the source crate. An extent const is always an integer literal
+    /// (the frontend refuses any other kind as a length), so emitting it
+    /// verbatim is exact rather than a re-derivation.
+    fn on_const(&self, c: &syn::ItemConst, registry: &Registry<()>) -> TokenStream {
+        match self.source_module() {
+            Some(m) if c.ident != "_" && !registry.is_extent_const(&c.ident) => {
+                crate::api::core::prebindgen::const_path_alias(c, m)
+            }
+            _ => c.to_token_stream(),
+        }
     }
 
     // ── Structural type resolution ──────────────────────────────────────
@@ -1809,6 +1837,7 @@ impl Cbindgen {
             let mut inits: Vec<TokenStream> = Vec::new();
             let mut subs: Vec<syn::Type> = Vec::new();
             for (fname, fty) in &fields {
+                let fty = &fty.to_syn();
                 if is_string(fty) {
                     inits.push(quote!(#fname: __cbg_alloc_cstr(v.#fname)));
                 } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -41,13 +41,17 @@ pub(crate) fn rust_short_name_opt(key: &TypeKey) -> Option<String> {
 /// the full AST — function signatures, generic args, type ascriptions,
 /// casts, turbofish — so any emitted item passes through one universal pass
 /// instead of each emit site having to remember to qualify.
+///
+/// Array LENGTHS are deliberately absent: `syn` models a length as an
+/// expression, and this pass would have to tell a source const apart from a
+/// converter body's local. That decision belongs to the source language, not to
+/// emission, and is made once at ingest by
+/// [`crate::api::core::frontend::resolve_array_lengths`] — by the time an item
+/// reaches here every length is already absolute.
 pub(crate) struct QualifyEmittedTypes<'a> {
     /// Bare type name → the module it is reachable under (the item's origin
     /// crate, or the registry's default module).
     pub(crate) source_names: &'a std::collections::HashMap<String, syn::Path>,
-    /// Every indexed source name (consts, structs, enums) → the same. Applied
-    /// ONLY inside an array length — see [`QualifyLengthPaths`].
-    pub(crate) length_names: &'a std::collections::HashMap<String, syn::Path>,
 }
 
 impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
@@ -61,129 +65,6 @@ impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
             }
         }
         syn::visit_mut::visit_type_path_mut(self, tp);
-    }
-
-    /// Qualify a `#[prebindgen]` const used as an ARRAY LENGTH (`[u8; MAX]`).
-    ///
-    /// `syn` models the length as an expression, so `visit_type_path_mut` never
-    /// sees it and the generated file would reference a const that is not in
-    /// scope. The rewrite is confined to `arr.len` on purpose: a generated
-    /// converter body is full of expression paths that are LOCALS (`v`, `env`),
-    /// and a source crate may legally declare `pub const env: usize` — so a
-    /// whole-item expression pass would rewrite those locals to
-    /// `mycrate::env` even when restricted to registered const idents. An array
-    /// length cannot contain a local, which is what makes this scope safe.
-    fn visit_type_array_mut(&mut self, arr: &mut syn::TypeArray) {
-        syn::visit_mut::visit_type_mut(self, &mut arr.elem);
-        reject_unsupported_array_length(arr);
-        let mut lengths = QualifyLengthPaths {
-            length_names: self.length_names,
-        };
-        syn::visit_mut::visit_expr_mut(&mut lengths, &mut arr.len);
-    }
-}
-
-/// Refuse an array length built from anything but a small, closed set of
-/// expression forms.
-///
-/// [`QualifyLengthPaths`] rewrites a bare path to its origin module, which is
-/// sound only while every path in the length names a source ITEM. Anything that
-/// can bind a name breaks that premise — a local shadowing a source item gets
-/// rewritten into it:
-///
-/// ```ignore
-/// [u8; const { let array_len = 3; array_len }]   // `array_len` is a LOCAL
-/// [u8; match 3 { array_len => array_len }]       // ...so is this one
-/// ```
-///
-/// Qualifying either yields `myflat::array_len`, a function item where a
-/// `usize` was meant; a same-typed collision would compile and silently change
-/// the length.
-///
-/// This is a WHITELIST on purpose. Listing the binding forms instead means
-/// every omitted or newly added `syn::Expr` variant silently reopens the hole —
-/// which is exactly how `match` and `if let` slipped past the first attempt.
-/// Inverting it makes the failure mode "a legitimate length is refused", which
-/// is loud and trivially worked around by hoisting the value into a named
-/// `const`.
-fn reject_unsupported_array_length(arr: &mut syn::TypeArray) {
-    // Rendered before the mutable walk below borrows the length.
-    let rendered = quote::ToTokens::to_token_stream(&*arr).to_string();
-    struct Check(Option<&'static str>);
-    // `VisitMut` rather than `Visit`: syn's immutable visitor is behind a
-    // feature this crate does not enable, and the walk mutates nothing.
-    impl syn::visit_mut::VisitMut for Check {
-        fn visit_expr_mut(&mut self, e: &mut syn::Expr) {
-            let ok = matches!(
-                e,
-                // A literal length, `[u8; 4]`.
-                syn::Expr::Lit(_)
-                    // The names this pass exists to qualify: `MAX`,
-                    // `Holder::N`, and the callee of `array_len()`.
-                    | syn::Expr::Path(_)
-                    // Const arithmetic over those: `A + 1`, `-1`, `(A) * 2`,
-                    // `A as usize`, `array_len()`.
-                    | syn::Expr::Binary(_)
-                    | syn::Expr::Unary(_)
-                    | syn::Expr::Paren(_)
-                    | syn::Expr::Group(_)
-                    | syn::Expr::Cast(_)
-                    | syn::Expr::Call(_)
-            );
-            if !ok && self.0.is_none() {
-                self.0 = Some("an unsupported expression form");
-            }
-            syn::visit_mut::visit_expr_mut(self, e);
-        }
-    }
-    let mut check = Check(None);
-    syn::visit_mut::VisitMut::visit_expr_mut(&mut check, &mut arr.len);
-    if let Some(what) = check.0 {
-        panic!(
-            "fixed-size array `{rendered}`: the length uses {what}. Only a literal, a path, a \
-             call, and const arithmetic over those are supported — anything that can bind a name \
-             (`const {{ … }}`, `match`, `if let`, a closure, a loop) would let a LOCAL be \
-             mistaken for a source item, because this generator qualifies the length's paths \
-             against their source module. Hoist the value into a named `const` and use that as \
-             the length."
-        );
-    }
-}
-
-/// Qualifies the source-crate paths in an array's LENGTH expression, run only
-/// by [`QualifyEmittedTypes::visit_type_array_mut`]. Separate from the type
-/// visitor so it can never reach a converter body's locals.
-///
-/// A length is an ordinary Rust const expression, so it reaches the source
-/// crate two ways and both need the origin module prefixed:
-///
-/// * a **free const**, `[u8; MAX]` — the whole path is the name;
-/// * an **associated const**, `[u8; Holder::N]` — the LEADING segment is the
-///   owning type. Only that segment is rewritten; the rest (`::N`, and any
-///   further associated item) is relative to it and must be left alone.
-///
-/// Both look up the same registry-wide map, so an owner that exists only as a
-/// compile-time namespace does not have to be declared to the binding: forcing
-/// that would emit a dead Kotlin class purely to make the generated Rust
-/// compile.
-struct QualifyLengthPaths<'a> {
-    length_names: &'a std::collections::HashMap<String, syn::Path>,
-}
-
-impl syn::visit_mut::VisitMut for QualifyLengthPaths<'_> {
-    fn visit_expr_path_mut(&mut self, ep: &mut syn::ExprPath) {
-        if ep.qself.is_none() && ep.path.leading_colon.is_none() {
-            // One segment names the const itself; more than one means the
-            // leading segment is the type that owns it. Either way it is the
-            // leading segment that carries the origin module.
-            let ident = ep.path.segments[0].ident.to_string();
-            if let Some(module) = self.length_names.get(&ident) {
-                let mut qualified = module.clone();
-                qualified.segments.extend(ep.path.segments.iter().cloned());
-                ep.path = qualified;
-            }
-        }
-        syn::visit_mut::visit_expr_path_mut(self, ep);
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -724,7 +724,7 @@ impl ReturnSurface {
             .and_then(|m| m.value_rust_key.as_ref())
             .map(TypeKey::to_type)
             .unwrap_or_else(|| ty.clone());
-        if crate::api::lang::jnigen::util::is_unit(&canonical) {
+        if crate::api::core::types_util::is_unit(&canonical) {
             return (Self::Unit, canonical);
         }
         // Projection return (opaque handle or `ULong`): read the folded

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1497,6 +1497,14 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
             pub struct Blob {
                 pub bytes: [u8; env],
                 pub assoc: [u8; Holder::N],
+                // The same const reached through the module it is DECLARED in.
+                // A source crate may spell a length however it likes; the
+                // module prefix carries no information, because a
+                // `#[prebindgen]` item is reachable as `<crate>::<bare name>`.
+                // So this must emit the identical length to `bytes` above —
+                // not `limits::env`, which names nothing in the generated
+                // crate.
+                pub nested: [u8; crate::limits::env],
             }
         )),
         loc.clone(),
@@ -1536,6 +1544,13 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
     );
     assert!(!rc.contains(&format!("{module}::env,")), "{rust}");
     assert!(!rc.contains(&format!("&mut{module}::env")), "{rust}");
+
+    // `crate::limits::env` collapses onto the SAME length as the bare `env`:
+    // one converter, not two, since both spellings denote one const. The
+    // intermediate module must not survive — `limits` names nothing in the
+    // generated crate, and emitting it either fails to compile or binds a
+    // consumer-side module.
+    assert!(!rc.contains("limits"), "{rust}");
 
     // An ASSOCIATED const qualifies its leading TYPE segment and leaves the
     // rest of the path relative to it — `myflat::Holder::N`, never

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1580,11 +1580,20 @@ fn check_array_length_rejected(field_ty: syn::Type) {
     let Err(err) = Registry::<KotlinMeta>::from_items(items) else {
         panic!("the frontend accepted `{}`", quote::quote!(#field_ty));
     };
+    // A struct field is lowered through the source MODEL, so its refusal names
+    // the field; a length elsewhere (a signature, an enum variant) still comes
+    // from the length walk alone. Either way it is a frontend error raised
+    // before JniGen exists.
     assert!(
-        matches!(err, crate::core::ScanError::UnsupportedArrayLength { .. }),
+        matches!(
+            err,
+            crate::core::ScanError::UnsupportedFieldType { .. }
+                | crate::core::ScanError::UnsupportedArrayLength { .. }
+        ),
         "{err}"
     );
     // The diagnostic states the accepted form, so the message is actionable
     // without reading the generator.
     assert!(err.to_string().contains("integer literal"), "{err}");
+    assert!(err.to_string().contains("Blob::local"), "{err}");
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1436,42 +1436,34 @@ fn data_class_properties_match_their_from_parts_params() {
     assert!(kc.contains("Level.fromInt(level)"), "{kotlin}");
 }
 
-/// End-to-end proof that the frontend's array-length resolution
+/// End-to-end proof that the frontend's array-length evaluation
 /// ([`crate::api::core::frontend`]) survives all the way into emitted code, and
-/// that it reaches ONLY the length — never a converter body's locals.
+/// that it touches ONLY the length — never a converter body's locals.
 ///
 /// The exhaustive shape-by-shape coverage lives in the frontend's acceptance
-/// matrix; what only an end-to-end test can show is the locals invariant below,
-/// which is about generated converter bodies.
+/// matrix; what only an end-to-end test can show is the locals invariant, which
+/// is about generated converter bodies.
 ///
-/// Neither owner is declared to JniGen: each is a compile-time namespace, not a
-/// boundary type, so qualification must not depend on a Kotlin class existing
-/// for it.
+/// The const is deliberately named `env`, which is also the name of the `JNIEnv`
+/// local every generated converter uses. A source crate may legally declare it
+/// (`#[allow(non_upper_case_globals)] pub const env`), so a whole-item
+/// expression pass would rewrite `env.get_java_vm()` to `4.get_java_vm()` —
+/// thousands of `no method named get_java_vm found`. Scoping the pass to
+/// `TypeArray::len` is what keeps the two apart.
 ///
-/// The const here is deliberately named `env`, which is also the name of the
-/// `JNIEnv` local every generated converter uses. A source crate may legally
-/// declare it (`#[allow(non_upper_case_globals)] pub const env`), so a
-/// whole-item expression pass would rewrite `env.get_java_vm()` to
-/// `myflat::env.get_java_vm()` even when restricted to registered const idents
-/// — thousands of `no method named get_java_vm found for type usize`. Scoping
-/// the pass to `TypeArray::len` is what makes the two cases distinguishable.
+/// The const is NEVER declared to JniGen: a length is a compile-time value, not
+/// part of the Kotlin surface, so evaluating it must not depend on a Kotlin
+/// `val` existing for it.
 #[test]
-fn array_length_const_is_qualified_without_touching_locals() {
-    // Stamped stream: names qualify with the origin crate's module.
-    check_array_length_qualification(myflat_loc(), "myflat");
+fn array_length_const_is_evaluated_without_touching_locals() {
+    // A stamped stream, and an origin-less one. A length carries no module now,
+    // so the two must produce IDENTICAL output — which is the point: evaluating
+    // the const removed provenance from the emitted length entirely.
+    check_array_length_evaluation(myflat_loc());
+    check_array_length_evaluation(SourceLocation::default());
 }
 
-/// The same contract for an ORIGIN-LESS stream. Core supports hand-built item
-/// streams with no `SourceLocation::crate_name` and documents `crate` as their
-/// module, so the name set must not be derived from the origin map — those
-/// items are absent from it entirely, and deriving from it silently emitted
-/// every length bare.
-#[test]
-fn array_length_qualification_falls_back_to_crate_without_an_origin() {
-    check_array_length_qualification(SourceLocation::default(), "crate");
-}
-
-fn check_array_length_qualification(loc: SourceLocation, module: &str) {
+fn check_array_length_evaluation(loc: SourceLocation) {
     let mut items: Vec<(syn::Item, SourceLocation)> = Vec::new();
     items.push((
         syn::Item::Const(syn::parse_quote!(
@@ -1480,31 +1472,10 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
         )),
         loc.clone(),
     ));
-    // A type owning an ASSOCIATED const, used as the other length below. It is
-    // deliberately NEVER declared to JniGen: it is only the Rust namespace for
-    // a compile-time length, not a boundary type, so qualification must not
-    // require a Kotlin class to exist for it.
-    items.push((
-        syn::Item::Struct(syn::parse_quote!(
-            pub struct Holder {
-                pub marker: u8,
-            }
-        )),
-        loc.clone(),
-    ));
     items.push((
         syn::Item::Struct(syn::parse_quote!(
             pub struct Blob {
                 pub bytes: [u8; env],
-                pub assoc: [u8; Holder::N],
-                // The same const reached through the module it is DECLARED in.
-                // A source crate may spell a length however it likes; the
-                // module prefix carries no information, because a
-                // `#[prebindgen]` item is reachable as `<crate>::<bare name>`.
-                // So this must emit the identical length to `bytes` above —
-                // not `limits::env`, which names nothing in the generated
-                // crate.
-                pub nested: [u8; crate::limits::env],
             }
         )),
         loc.clone(),
@@ -1523,7 +1494,7 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
             .class(crate::data_class!(Blob))
             .fun(crate::fun!(blob_echo)),
     );
-    let dir = unique_test_dir(&format!("jnigen_array_len_const_{module}"));
+    let dir = unique_test_dir("jnigen_array_len_const");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = registry.resolve(jni).unwrap();
@@ -1531,50 +1502,16 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
     let rust = std::fs::read_to_string(rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
 
-    // The length IS qualified — otherwise the generated file names a const
-    // that is not in scope.
-    assert!(rc.contains(&format!("[u8;{module}::env]")), "{rust}");
-    // ...and the identically-named LOCAL is untouched. These two assertions
-    // fail in opposite directions, so neither alone pins the behavior: the
-    // `env` here is the `&mut JNIEnv` every converter body threads through.
+    // The length is the VALUE. Emitting the const's name instead would put a
+    // path into a crate that may not have it in scope; emitting the number is
+    // what makes the length independent of the generated crate's namespace.
+    assert!(rc.contains("[u8;4]"), "{rust}");
+    assert!(!rc.contains("[u8;env]"), "{rust}");
+    // ...and the identically-named LOCAL is untouched. These assertions fail in
+    // opposite directions, so neither alone pins the behavior: the `env` here is
+    // the `&mut JNIEnv` every converter body threads through.
     assert!(rc.contains("env.byte_array_from_slice"), "{rust}");
-    assert!(
-        !rc.contains(&format!("{module}::env.byte_array_from_slice")),
-        "{rust}"
-    );
-    assert!(!rc.contains(&format!("{module}::env,")), "{rust}");
-    assert!(!rc.contains(&format!("&mut{module}::env")), "{rust}");
-
-    // `crate::limits::env` collapses onto the SAME length as the bare `env`:
-    // one converter, not two, since both spellings denote one const. The
-    // intermediate module must not survive — `limits` names nothing in the
-    // generated crate, and emitting it either fails to compile or binds a
-    // consumer-side module.
-    assert!(!rc.contains("limits"), "{rust}");
-
-    // An ASSOCIATED const qualifies its leading TYPE segment and leaves the
-    // rest of the path relative to it — `myflat::Holder::N`, never
-    // `myflat::Holder::myflat::N`. `Holder` is UNDECLARED, so this also pins
-    // that qualification reads the registry rather than the declared surface.
-    // Asserted at the two CODE positions (return type and param type); the bare
-    // spelling legitimately survives inside the decode's diagnostic string,
-    // which names the type as the source wrote it.
-    assert!(
-        rc.contains(&format!("Result<[u8;{module}::Holder::N]")),
-        "{rust}"
-    );
-    assert!(
-        rc.contains(&format!("v:[u8;{module}::Holder::N]")),
-        "{rust}"
-    );
-    assert!(!rc.contains("Result<[u8;Holder::N]"), "{rust}");
-    assert!(!rc.contains("v:[u8;Holder::N]"), "{rust}");
-    // The leading segment is rewritten ONCE — the associated item stays
-    // relative to the type it belongs to.
-    assert!(
-        !rc.contains(&format!("{module}::Holder::{module}")),
-        "{rust}"
-    );
+    assert!(!rc.contains("4.byte_array_from_slice"), "{rust}");
 }
 
 /// A length outside the accepted subgrammar is refused, and refused **before
@@ -1606,6 +1543,10 @@ fn array_length_outside_the_grammar_is_rejected_at_ingest() {
     // A `const fn` CALL. Deliberately no longer in the language: hoist the value
     // into a named `const` and use that.
     check_array_length_rejected(syn::parse_quote!([u8; array_len()]));
+    // An UNMARKED const. The generated crate sees only what the macro exposed,
+    // so this names nothing there — the length has to fail here rather than at
+    // the consumer's rustc, or worse, bind to something else.
+    check_array_length_rejected(syn::parse_quote!([u8; UNMARKED]));
 }
 
 fn check_array_length_rejected(field_ty: syn::Type) {
@@ -1643,7 +1584,7 @@ fn check_array_length_rejected(field_ty: syn::Type) {
         matches!(err, crate::core::ScanError::UnsupportedArrayLength { .. }),
         "{err}"
     );
-    // The diagnostic names the fix, so the message is actionable without
-    // reading the generator.
-    assert!(err.to_string().contains("hoist"), "{err}");
+    // The diagnostic states the accepted form, so the message is actionable
+    // without reading the generator.
+    assert!(err.to_string().contains("integer literal"), "{err}");
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1436,13 +1436,17 @@ fn data_class_properties_match_their_from_parts_params() {
     assert!(kc.contains("Level.fromInt(level)"), "{kotlin}");
 }
 
-/// Every shape an array length can take — a FREE const, an ASSOCIATED const,
-/// and a `const fn` CALL — is qualified against its origin module, and that
-/// rewrite reaches ONLY the length, never a converter body's locals.
+/// End-to-end proof that the frontend's array-length resolution
+/// ([`crate::api::core::frontend`]) survives all the way into emitted code, and
+/// that it reaches ONLY the length — never a converter body's locals.
 ///
-/// None of the three owners is declared to JniGen: each is a compile-time
-/// namespace, not a boundary type, so qualification must not depend on a
-/// Kotlin class existing for it.
+/// The exhaustive shape-by-shape coverage lives in the frontend's acceptance
+/// matrix; what only an end-to-end test can show is the locals invariant below,
+/// which is about generated converter bodies.
+///
+/// Neither owner is declared to JniGen: each is a compile-time namespace, not a
+/// boundary type, so qualification must not depend on a Kotlin class existing
+/// for it.
 ///
 /// The const here is deliberately named `env`, which is also the name of the
 /// `JNIEnv` local every generated converter uses. A source crate may legally
@@ -1488,23 +1492,11 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
         )),
         loc.clone(),
     ));
-    // A `const fn` whose CALL is a length. Also never declared: its result
-    // determines an array size, which is no reason to put it in the Kotlin
-    // surface.
-    items.push((
-        syn::Item::Fn(syn::parse_quote!(
-            pub const fn array_len() -> usize {
-                4
-            }
-        )),
-        loc.clone(),
-    ));
     items.push((
         syn::Item::Struct(syn::parse_quote!(
             pub struct Blob {
                 pub bytes: [u8; env],
                 pub assoc: [u8; Holder::N],
-                pub called: [u8; array_len()],
             }
         )),
         loc.clone(),
@@ -1568,63 +1560,37 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
         !rc.contains(&format!("{module}::Holder::{module}")),
         "{rust}"
     );
-
-    // A `const fn` CALL is a third shape a length can take, and its callee is
-    // an indexed item like the other two. Also undeclared.
-    assert!(
-        rc.contains(&format!("Result<[u8;{module}::array_len()]")),
-        "{rust}"
-    );
-    assert!(
-        rc.contains(&format!("v:[u8;{module}::array_len()]")),
-        "{rust}"
-    );
-    assert!(!rc.contains("Result<[u8;array_len()]"), "{rust}");
-    assert!(!rc.contains("v:[u8;array_len()]"), "{rust}");
 }
 
-/// An array length whose expression form is not on the supported whitelist is
-/// REJECTED, not qualified.
+/// A length outside the accepted subgrammar is refused, and refused **before
+/// JniGen exists** — the failure comes out of `Registry::from_items`, so no
+/// adapter gets the chance to interpret it differently.
 ///
-/// An inline `const { … }` block may bind locals, and this generator qualifies
-/// a length's bare paths against their source module — so a local shadowing a
-/// source item would be rewritten into it (`array_len` the local becoming
-/// `myflat::array_len` the fn). Scope tracking is the general answer; the shape
-/// has no place in an FFI boundary type, so the whole family is refused with a
-/// message naming the type and the fix. Silently mis-qualifying is the
-/// alternative this exists to prevent.
+/// That placement is the point. These shapes used to be caught by a whitelist
+/// inside this adapter, one walk away from the rewriter that qualified them;
+/// every defect in issue #210 was the two disagreeing. The exhaustive per-shape
+/// table lives in the frontend's acceptance matrix — what this pins is that the
+/// decision is made at ingest and reaches the adapter as a hard error.
 #[test]
-#[should_panic(expected = "an unsupported expression form")]
-fn array_length_inline_const_block_is_rejected() {
-    // A local bound by an inline const block, shadowing the indexed fn.
+fn array_length_outside_the_grammar_is_rejected_at_ingest() {
+    // A local bound by an inline const block, shadowing the indexed `array_len`
+    // fn. Qualifying it would silently turn a `usize` into a function item.
     check_array_length_rejected(syn::parse_quote!(
         [u8; const {
             let array_len = 3;
             array_len
         }]
     ));
-}
-
-/// `match` arms bind their patterns directly, with no `Expr::Block` node in
-/// between — which is how this form slipped past the first, blacklist-shaped
-/// attempt. The whitelist refuses it because `match` is simply not on the list.
-#[test]
-#[should_panic(expected = "an unsupported expression form")]
-fn array_length_match_arm_binding_is_rejected() {
+    // A `match` arm binds its pattern directly, with no `Expr::Block` node in
+    // between — which is how this shape slipped past a blacklist-shaped check.
     check_array_length_rejected(syn::parse_quote!(
         [u8; match 3 {
             array_len => array_len,
         }]
     ));
-}
-
-/// `if let` likewise binds without an intervening block node.
-#[test]
-#[should_panic(expected = "an unsupported expression form")]
-fn array_length_if_let_binding_is_rejected() {
-    check_array_length_rejected(syn::parse_quote!(
-        [u8; if let array_len = 3 { array_len } else { 0 }]
-    ));
+    // A `const fn` CALL. Deliberately no longer in the language: hoist the value
+    // into a named `const` and use that.
+    check_array_length_rejected(syn::parse_quote!([u8; array_len()]));
 }
 
 fn check_array_length_rejected(field_ty: syn::Type) {
@@ -1655,15 +1621,14 @@ fn check_array_length_rejected(field_ty: syn::Type) {
         )),
         loc.clone(),
     ));
-    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
-    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
-        crate::package!("blob")
-            .class(crate::data_class!(Blob))
-            .fun(crate::fun!(blob_echo)),
+    let Err(err) = Registry::<KotlinMeta>::from_items(items) else {
+        panic!("the frontend accepted `{}`", quote::quote!(#field_ty));
+    };
+    assert!(
+        matches!(err, crate::core::ScanError::UnsupportedArrayLength { .. }),
+        "{err}"
     );
-    let dir = unique_test_dir("jnigen_array_len_scope");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let generation = registry.resolve(jni).unwrap();
-    generation.write_rust(dir.join("gen.rs")).unwrap();
+    // The diagnostic names the fix, so the message is actionable without
+    // reading the generator.
+    assert!(err.to_string().contains("hoist"), "{err}");
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -372,36 +372,8 @@ impl JniGen {
     /// site having to remember to qualify.
     fn qualify_item(&self, item: &mut syn::Item, registry: &Registry<KotlinMeta>) {
         let source_names = self.emitted_source_type_names(registry);
-        // Names reachable from an array LENGTH (`[u8; MAX]`, `[u8; Holder::N]`).
-        //
-        // Registry-wide, NOT the declared-surface `source_names`: a length's
-        // owner is a compile-time namespace, not a boundary type. Requiring it
-        // to be declared would force an otherwise-unused Kotlin class into
-        // existence just to make the generated Rust compile, and would be
-        // asymmetric with consts, which qualify whether or not JniGen declared
-        // them.
-        // EVERY named item the registry indexes. A length is an arbitrary const
-        // expression, so it can name a const, the type owning an associated
-        // const, or a `const fn` — and enumerating item KINDS here missed one
-        // of those three twice, so the enumeration lives in core
-        // (`named_item_idents`) where a new kind is added once.
-        //
-        // The NAME SET is independent of origin stamps and the VALUE falls back
-        // to the default module: an origin-less hand-built stream indexes items
-        // that `item_origins` never sees, and those still need qualifying (core
-        // documents `crate` as their module).
-        let length_names: std::collections::HashMap<String, syn::Path> = registry
-            .named_item_idents()
-            .map(|ident| {
-                let module = registry
-                    .origin_module(ident)
-                    .unwrap_or_else(|| self.default_module(registry));
-                (ident.to_string(), module)
-            })
-            .collect();
         let mut visitor = QualifyEmittedTypes {
             source_names: &source_names,
-            length_names: &length_names,
         };
         syn::visit_mut::VisitMut::visit_item_mut(&mut visitor, item);
     }

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -63,10 +63,5 @@ pub(crate) fn camel_to_screaming_snake(s: &str) -> String {
     out
 }
 
-/// True iff `ty` is the unit type `()`.
-pub(crate) fn is_unit(ty: &syn::Type) -> bool {
-    matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty())
-}
-
 #[cfg(test)]
 mod tests;

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -290,9 +290,9 @@ macro_rules! ident {
 /// `docs/source-language.md`; [`core::frontend`] is the module that decides it.
 pub mod core {
     pub use crate::api::core::{
-        ArrayLen, ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot,
-        Niches, Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage,
-        Transmute, TypeEntry, TypeKey, UnsupportedArrayLen, WriteRustError,
+        ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot, Niches,
+        Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage, Transmute,
+        TypeEntry, TypeKey, UnsupportedArrayLen, WriteRustError,
     };
 
     /// The Rust frontend: the single authority for what captured
@@ -303,7 +303,7 @@ pub mod core {
     /// here is the model it decides and the diagnostics it raises, not the
     /// lowering machinery.
     pub mod frontend {
-        pub use crate::api::core::frontend::{ArrayLen, ArrayLenReason, UnsupportedArrayLen};
+        pub use crate::api::core::frontend::{ArrayLenReason, UnsupportedArrayLen};
     }
 }
 

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -285,12 +285,25 @@ macro_rules! ident {
 /// The supported JNI / Kotlin adapter ships in [`mod@lang`] as
 /// [`lang::JniGen`]. The C / cbindgen proof of concept is available separately
 /// with the `unstable-cbindgen` feature.
+///
+/// Which Rust forms a `#[prebindgen]` source crate may use is specified in
+/// `docs/source-language.md`; [`core::frontend`] is the module that decides it.
 pub mod core {
     pub use crate::api::core::{
-        ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot, Niches,
-        Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage, Transmute,
-        TypeEntry, TypeKey, WriteRustError,
+        ArrayLen, ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot,
+        Niches, Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage,
+        Transmute, TypeEntry, TypeKey, UnsupportedArrayLen, WriteRustError,
     };
+
+    /// The Rust frontend: the single authority for what captured
+    /// `#[prebindgen]` source means. See `docs/source-language.md` for the
+    /// accepted subset.
+    pub mod frontend {
+        pub use crate::api::core::frontend::{
+            lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ArrayLenResolver,
+            NameIndex, UnsupportedArrayLen,
+        };
+    }
 }
 
 /// Runtime traits implemented by inline-opaque (`value_opaque`) FFI counterpart

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -298,11 +298,12 @@ pub mod core {
     /// The Rust frontend: the single authority for what captured
     /// `#[prebindgen]` source means. See `docs/source-language.md` for the
     /// accepted subset.
+    ///
+    /// The frontend runs as part of [`Registry::from_items`]; what is public
+    /// here is the model it decides and the diagnostics it raises, not the
+    /// lowering machinery.
     pub mod frontend {
-        pub use crate::api::core::frontend::{
-            lower_array_len, resolve_array_lengths, ArrayLen, ArrayLenReason, ArrayLenResolver,
-            NameIndex, UnsupportedArrayLen,
-        };
+        pub use crate::api::core::frontend::{ArrayLen, ArrayLenReason, UnsupportedArrayLen};
     }
 }
 


### PR DESCRIPTION
Closes #210. Stage **F0** of #215 (umbrella for #211), and starts **F2**.

> Updated to describe the final state (`e76cd88`). Eleven commits, each answering a review round — see [History](#history).

## The problem

Array-length handling had **two independent walks** over the same expression, both in `jnigen/jni/emit/names.rs`:

* `reject_unsupported_array_length` — a whitelist deciding what is **accepted**;
* `QualifyLengthPaths` — a rewriter deciding what it can **qualify**.

Nothing tied them together, so they drifted eight times. #8 was still open: `[u8; <Holder>::N]` was accepted and emitted verbatim into a crate where `Holder` is not in scope. Cbindgen, meanwhile, had no array handling at all.

## The grammar

**A length is a number.** A generator runs in `build.rs`, where it cannot evaluate Rust. Two spellings reach one, and nothing else does:

| Form | Status |
|---|---|
| `[u8; 4]`, `[u8; 16usize]` | supported |
| `[u8; N]` — **bare name, same source crate, literal initializer** | supported |
| everything else | **refused** |

Refused includes any longer path (`crate::limits::MAX`, `Holder::N`, `usize::MAX`, `<Holder>::N`), an unmarked const, a computed const, a const from another source crate, const arithmetic, `const fn` calls, and anything that can bind a name.

The restriction is on **lengths**, not consts — a `#[prebindgen] const` may still be computed however you like.

## The mechanism

One fallible lowering in `core::frontend`. `Ok` means the length was fully understood **and** reduced to a number, so acceptance is a *consequence* of lowering rather than a parallel judgement. It runs at **ingest**, as pass 3 of `Registry::from_items`, before any adapter exists. jnigen's `reject_unsupported_array_length`, `QualifyLengthPaths` and `length_names` are deleted.

**Same-source provenance**: uniqueness holds across the *marked* namespace only, so a bare name must be a const marked in the item's own source crate — otherwise one crate's unmarked const silently binds to another's marked one of the same name.

## The typed source model

A C header must be able to emit `uint8_t tag[MARKER_TAG_LEN]`, not `[4]` — a symbolic extent is part of that API's meaning. Carrying that fact by stashing the original `syn::Type` for cbindgen to re-read would violate #211's invariants 5 and 6, so the fact goes **in the IR** instead, beginning `SourceModel`:

* `SourceType` — closed and language-neutral; lowering is **total** over the documented grammar.
* `ArrayExtent { value, source }` on the **use site**. `value` keeps `[u8; A]` and `[u8; 4]` one type and one converter; `source` is what C spells.
* The model is the source of truth; the `syn` field types are `to_syn()` of it, never a second representation.

Scope is bounded: **types** complete, **items** structs-only, **adapters** cbindgen's struct-field path. Per-field *classification* still runs on the projection — `SourceType` already answers `is_scalar`/`is_string`/`is_vec`, but deleting those duplicates is F5/F6.

`TypeKey` stays numeric, so jnigen is untouched: covertest PASS, generated Kotlin and Rust byte-identical.

## What the C side needed besides the fact

Both verified with a cbindgen probe rather than assumed:

* **cbindgen had no array support.** `c_field_wire` now accepts an array of non-`bool` scalars — `[u8; N]` is already `#[repr(C)]`-compatible, so it is its own wire and the field copies with no conversion. `[bool; N]` stays refused: its domain is `0`/`1` and a mirror is reinterpreted wholesale with no per-element hook.
* **Consts never reached the header.** They were aliased to `= perftest_flat::ARRAY_BYTES`, which cbindgen cannot evaluate, so it emitted no `#define`. The probe showed that with the alias cbindgen still emits `uint8_t tag[ALIAS_LEN]` — a header referencing an **undefined** symbol. So the literal-value change is load-bearing, not cosmetic. Only extent consts change; the rest keep the alias.

Result:

```c
#define MARKER_TAG_LEN 4
typedef struct marker_t {
  uint8_t tag[MARKER_TAG_LEN];
  uint32_t weight;
} marker_t;
```

## Tests

- **Acceptance matrices** — one for lengths, one for types: source spelling → model, or precise rejection. A new shape is a row. `<Holder>::N` is the #210 regression.
- `a_length_must_name_a_const_from_its_own_crate` — the foreign const has a *usable* value, so it pins provenance rather than incidental unresolvability.
- `equal_lengths_collapse_to_one_type_after_ingest` — inspects state after `from_items` and pins **both** halves: one type-keyed row, and the model still reporting `A`, `B` and a literal per field.
- `data_struct_const_sized_array_keeps_the_const_name` + `..._bool_array_field_is_refused`.
- **smoke.c** round-trips `Marker` under ASan/LSan/UBSan and uses `MARKER_TAG_LEN` as an array bound — the test *compiling* is most of the proof, since a missing `#define` is a compile error.

## History

Eleven commits, each a review round:

1. `0a91388` — frontend seed: one walk, resolution at ingest, jnigen's duplicate machinery deleted
2. `7f1380c` — resolve a path by its item, not its first segment
3. `4880ffe` — a length is a number, not a path; dissolved the multi-source provenance hole and the relative-module ambiguity
4. `961be86` — a type-keyed table stores the number, not the spelling
5. `32370af` — the spelling is discarded, and the model says so
6. `21ab04a` — **reversed**: a C header can spell an extent by name, via the typed source model
7. `13978e7` — the projection preserves type identity (lifetimes, foreign paths; tuples and associated types refused)
8. `a3cf2af` — turbofish and a trailing generic comma normalize away, at the canonicalization boundary
9. `ca21e16` — the callback gate stops dropping the return; refusals say whether they are reserved (#216) or definitive
10. `2b84e02` — normalization is idempotent again; the HRTB refusal is reserved (#222), not "impossible"; `is_unit` lives in core
11. `e76cd88` — the HRTB fix-it states its condition; elision is only exact when each bound lifetime is used once

## Verification

- `cargo test --all --all-features` — 429 lib tests + integration
- clippy `--deny warnings`, fmt — clean
- `examples/regen-check.sh` — byte-identical
- `./examples/smoke-asan.sh` — PASS on Linux CI
- `covertest-kotlin ./gradlew run` — PASS, 46 sections

The `x86_64` goldens are **derived** from the `aarch64` pair (only that arch regenerates locally); the substitution was first verified to reproduce the committed `x86_64` files exactly at HEAD. CI on x86_64 confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)