### PR TITLE
jnigen: derive a return expansion from a value form (#213)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -40,8 +40,8 @@ pub struct ReplyStruct {
 
 A caller who sets both `RecoveryConfig` fields gets `heartbeat` ignored with no diagnostic; a caller
 who checks only `ReplyStruct::sample` reads an error reply as an empty success. These are
-[zenoh-flat #31](https://github.com/ZettaScaleLabs/zenoh-flat/issues/31) and
-[#30](https://github.com/ZettaScaleLabs/zenoh-flat/issues/30). flat's README already forbids bending
+[zenoh-flat #31](https://github.com/eclipse-zenoh/zenoh-flat/issues/31) and
+[#30](https://github.com/eclipse-zenoh/zenoh-flat/issues/30). flat's README already forbids bending
 its shapes to generator limits (§*Bindings choose; flat stays neutral*), so the fix belongs here.
 
 Sum types are also not exotic: Kotlin, Swift, Rust, TypeScript and Python (tagged unions) all express

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -35,7 +35,7 @@
 //! | JNI native-symbol escaping (#86)      | `esc_pkg.Esc_Probe` — underscored subpackage + class (escaped `freePtr` symbol) + hook-mangled `escape_probe_value` harness extern |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `expand_return!` `.fields(fields!(…))` (#213) | `Report` — boundary DERIVED from the value form instead of restated; covers every per-field rule (spliced `Summary`, inlined `Stamp`, `Option<data class>`, a sum with a handle payload, a plain leaf) |
-//! | `expand_return!` `.fields_into(fields!(…))` | `report_into_struct(r: Report)` — the CONSUMING value form: the value is given away and its fields MOVED out, so the clones the borrowing `report_to_struct` pays are not emitted at all |
+//! | `expand_return!` `.fields_self_into(fields!(…))` | `report_into_struct(r: Report)` — the CONSUMING value form: the value is given away and its fields MOVED out, so the clones the borrowing `report_to_struct` pays are not emitted at all |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | contextual method names               | method hook strips `storage`/`stamp` class prefixes; `summary_new`→`.name("of")` still overrides |
@@ -242,7 +242,7 @@ fn main() {
                 // carries nothing at all.
                 .class(sealed_class!(Lookup))
                 // `Report`'s output boundary is DERIVED from its value form
-                // (`.fields_into(fields!(report_into_struct))` below) instead of
+                // (`.fields_self_into(fields!(report_into_struct))` below) instead of
                 // being restated field by field — #213. The form it names is
                 // the CONSUMING one, so the fields are moved, not cloned.
                 .class(ptr_class!(Report))
@@ -392,7 +392,7 @@ fn main() {
         // into `(count, total)` rather than becoming a handle, `origin` inlines
         // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
         // decomposes into a selector plus one group per alternative.
-        .expand(expand_return!(Report).fields_into(fields!(report_into_struct)))
+        .expand(expand_return!(Report).fields_self_into(fields!(report_into_struct)))
         // ── Base-package handle type: `Storage` + scalar members ────────────
         // Back in the base package so the typed handle classes live alongside
         // `Payload`.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -34,6 +34,7 @@
 //! | split × builder-delivered return (#87) | `summaryMerge` — cartesian split + generic `<R>` wrapper; every overload re-declares `<R>` |
 //! | JNI native-symbol escaping (#86)      | `esc_pkg.Esc_Probe` — underscored subpackage + class (escaped `freePtr` symbol) + hook-mangled `escape_probe_value` harness extern |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
+//! | `expand_return!` `.fields(fields!(…))` (#213) | `Report` — boundary DERIVED from the value form `report_to_struct` instead of restated; covers every per-field rule (spliced `Summary`, inlined `Stamp`, `Option<data class>`, a sum with a handle payload, a plain leaf) |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | contextual method names               | method hook strips `storage`/`stamp` class prefixes; `summary_new`→`.name("of")` still overrides |
@@ -97,8 +98,8 @@
 
 use prebindgen::{
     constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
-    from, fun, into, lang::JniGen, matching, package, path, ptr_class, sealed_class, sig, try_from,
-    ty, variant,
+    fields, from, fun, into, lang::JniGen, matching, package, path, ptr_class, sealed_class, sig,
+    try_from, ty, variant,
 };
 
 fn strip_flat_class_prefix(class: &str, name: &str) -> String {
@@ -239,6 +240,10 @@ fn main() {
                 // resources: one alternative carries an opaque handle, one
                 // carries nothing at all.
                 .class(sealed_class!(Lookup))
+                // `Report`'s output boundary is DERIVED from its value form
+                // (`.fields(fields!(report_to_struct))` below) instead of being
+                // restated field by field — #213.
+                .class(ptr_class!(Report))
                 // `Hold`'s payload is a CONVERTED type, so its leaf crosses
                 // through the `convert!(Duration)` chain; `HoldPolicy` puts
                 // that same payload in the data-class-field position.
@@ -378,6 +383,14 @@ fn main() {
                 .field(fun!(summary_count))
                 .field(fun!(summary_total)),
         )
+        // `Report` default output DERIVED from its value form (#213): the
+        // leaves come from `ReportStruct`'s fields, so the list cannot drift
+        // from the struct the way a restated one does. Each field still crosses
+        // by ITS OWN type's boundary — `summary` splices `Summary`'s decl above
+        // into `(count, total)` rather than becoming a handle, `origin` inlines
+        // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
+        // decomposes into a selector plus one group per alternative.
+        .expand(expand_return!(Report).fields(fields!(report_to_struct)))
         // ── Base-package handle type: `Storage` + scalar members ────────────
         // Back in the base package so the typed handle classes live alongside
         // `Payload`.
@@ -490,6 +503,11 @@ fn main() {
                 // handle-carrying sum arriving through a CALLBACK, and a sum
                 // returned BORROWED (`&E` / `Option<&E>`).
                 .fun(fun!(lookup_each))
+                // #213: the output boundary DERIVED from the type's value form
+                // rather than restated. `report_each` delivers the decomposed
+                // `Report` in one crossing; the leaf list comes from
+                // `ReportStruct`'s fields, so it cannot drift from it.
+                .fun(fun!(report_each))
                 .fun(fun!(archive_set_reading))
                 .fun(fun!(archive_reading))
                 .fun(fun!(archive_reading_maybe))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -35,7 +35,7 @@
 //! | JNI native-symbol escaping (#86)      | `esc_pkg.Esc_Probe` — underscored subpackage + class (escaped `freePtr` symbol) + hook-mangled `escape_probe_value` harness extern |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
 //! | `expand_return!` `.fields(fields!(…))` (#213) | `Report` — boundary DERIVED from the value form instead of restated; covers every per-field rule (spliced `Summary`, inlined `Stamp`, `Option<data class>`, a sum with a handle payload, a plain leaf) |
-//! | CONSUMING value form (by-value accessor) | `report_into_struct(r: Report)` — the fields are MOVED out, so the clones the borrowing `report_to_struct` pays are not emitted at all |
+//! | `expand_return!` `.fields_into(fields!(…))` | `report_into_struct(r: Report)` — the CONSUMING value form: the value is given away and its fields MOVED out, so the clones the borrowing `report_to_struct` pays are not emitted at all |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | contextual method names               | method hook strips `storage`/`stamp` class prefixes; `summary_new`→`.name("of")` still overrides |
@@ -242,7 +242,7 @@ fn main() {
                 // carries nothing at all.
                 .class(sealed_class!(Lookup))
                 // `Report`'s output boundary is DERIVED from its value form
-                // (`.fields(fields!(report_into_struct))` below) instead of
+                // (`.fields_into(fields!(report_into_struct))` below) instead of
                 // being restated field by field — #213. The form it names is
                 // the CONSUMING one, so the fields are moved, not cloned.
                 .class(ptr_class!(Report))
@@ -392,7 +392,7 @@ fn main() {
         // into `(count, total)` rather than becoming a handle, `origin` inlines
         // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
         // decomposes into a selector plus one group per alternative.
-        .expand(expand_return!(Report).fields(fields!(report_into_struct)))
+        .expand(expand_return!(Report).fields_into(fields!(report_into_struct)))
         // ── Base-package handle type: `Storage` + scalar members ────────────
         // Back in the base package so the typed handle classes live alongside
         // `Payload`.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -34,7 +34,8 @@
 //! | split × builder-delivered return (#87) | `summaryMerge` — cartesian split + generic `<R>` wrapper; every overload re-declares `<R>` |
 //! | JNI native-symbol escaping (#86)      | `esc_pkg.Esc_Probe` — underscored subpackage + class (escaped `freePtr` symbol) + hook-mangled `escape_probe_value` harness extern |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
-//! | `expand_return!` `.fields(fields!(…))` (#213) | `Report` — boundary DERIVED from the value form `report_to_struct` instead of restated; covers every per-field rule (spliced `Summary`, inlined `Stamp`, `Option<data class>`, a sum with a handle payload, a plain leaf) |
+//! | `expand_return!` `.fields(fields!(…))` (#213) | `Report` — boundary DERIVED from the value form instead of restated; covers every per-field rule (spliced `Summary`, inlined `Stamp`, `Option<data class>`, a sum with a handle payload, a plain leaf) |
+//! | CONSUMING value form (by-value accessor) | `report_into_struct(r: Report)` — the fields are MOVED out, so the clones the borrowing `report_to_struct` pays are not emitted at all |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | contextual method names               | method hook strips `storage`/`stamp` class prefixes; `summary_new`→`.name("of")` still overrides |
@@ -241,8 +242,9 @@ fn main() {
                 // carries nothing at all.
                 .class(sealed_class!(Lookup))
                 // `Report`'s output boundary is DERIVED from its value form
-                // (`.fields(fields!(report_to_struct))` below) instead of being
-                // restated field by field — #213.
+                // (`.fields(fields!(report_into_struct))` below) instead of
+                // being restated field by field — #213. The form it names is
+                // the CONSUMING one, so the fields are moved, not cloned.
                 .class(ptr_class!(Report))
                 // `Hold`'s payload is a CONVERTED type, so its leaf crosses
                 // through the `convert!(Duration)` chain; `HoldPolicy` puts
@@ -390,7 +392,7 @@ fn main() {
         // into `(count, total)` rather than becoming a handle, `origin` inlines
         // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
         // decomposes into a selector plus one group per alternative.
-        .expand(expand_return!(Report).fields(fields!(report_to_struct)))
+        .expand(expand_return!(Report).fields(fields!(report_into_struct)))
         // ── Base-package handle type: `Storage` + scalar members ────────────
         // Back in the base package so the typed handle classes live alongside
         // `Payload`.

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -96,6 +96,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `report_each` — `fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>)`
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
@@ -202,6 +203,7 @@ Base package: `io.prebindgen.covertest`
 - `Priority`: enum_class → `io.prebindgen.covertest.model.Priority` (wire `jni :: sys :: jint`)
 - `Reading`: sealed_class → `io.prebindgen.covertest.model.Reading` (wire `?`)
 - `RepliesConfig`: data_class → `io.prebindgen.covertest.model.RepliesConfig` (wire `jni :: objects :: JObject`)
+- `Report`: ptr_class → `io.prebindgen.covertest.model.Report` (wire `jni :: sys :: jlong`)
 - `Stamp`: data_class → `io.prebindgen.covertest.model.Stamp` (wire `jni :: objects :: JObject`)
 - `Storage`: ptr_class → `io.prebindgen.covertest.Storage` (wire `jni :: sys :: jlong`)
 - `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -832,6 +832,8 @@ internal object CovNative {
 
     external fun readingSeries(n: Int, acc: Any?, fold: Any, errorSink: Any): Any?
 
+    external fun reportEach(n: Long, sink: Any, errorSink: Any)
+
     external fun stampNanos(sSecs: Long, sNanos: Long, errorSink: Any): Long
 
     external fun stampNew(secs: Long, nanos: Long, build: Any, errorSink: Any): Any?

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -5,6 +5,7 @@ import io.prebindgen.covertest.CovNative
 import io.prebindgen.covertest.DurationCallback
 import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
+import io.prebindgen.covertest.NativeHandle
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.__u64FolderRawHolder
@@ -858,6 +859,30 @@ public data class Unsigned(val byte: Int, val short: Int, val int: Long, val lon
     }
 }
 
+/** Typed handle for a native Zenoh `Report`. */
+public class Report(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): Report {
+        val p = ptr
+        ptr = p or 1L
+        return Report(p)
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+    }
+}
+
 public fun interface LookupCallback {
     public fun run(lookup: Lookup)
 }
@@ -903,6 +928,54 @@ public fun ReadingCallback.asRaw(): ReadingCallbackRaw =
         companion_v0 ->
         run(
             when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+        )
+    }
+
+public fun interface ReportCallback {
+    public fun run(
+        summary__count: Long,
+        summary__total: Double,
+        taken: Stamp?,
+        origin__secs: Long,
+        origin__nanos: Long,
+        outcome: Lookup,
+        label: String,
+    )
+}
+
+public fun interface ReportCallbackRaw {
+    public fun run(
+        summary__count: Long,
+        summary__total: Double,
+        taken: Stamp?,
+        origin__secs: Long,
+        origin__nanos: Long,
+        outcome__tag: Int,
+        outcome__found_v0: Long,
+        outcome__failed_v0: String?,
+        label: String,
+    )
+}
+
+public fun ReportCallback.asRaw(): ReportCallbackRaw =
+    ReportCallbackRaw {
+        summary__count,
+        summary__total,
+        taken,
+        origin__secs,
+        origin__nanos,
+        outcome__tag,
+        outcome__found_v0,
+        outcome__failed_v0,
+        label ->
+        run(
+            summary__count,
+            summary__total,
+            taken,
+            origin__secs,
+            origin__nanos,
+            when (outcome__tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(outcome__found_v0)); 2 -> Lookup.Failed(outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $outcome__tag") },
+            label
         )
     }
 
@@ -1476,6 +1549,17 @@ public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>
 public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>) {
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.lookupEach(n, total, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Deliver a [`Report`] to a callback — the decomposed value form arriving in
+ * ONE crossing, which is the whole point of deriving the boundary rather than
+ * handing over a handle the receiver must then query field by field.
+ */
+public fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.reportEach(n, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -67,6 +67,7 @@ import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.observationWhich
 import io.prebindgen.covertest.model.lookupEach
+import io.prebindgen.covertest.model.reportEach
 import io.prebindgen.covertest.model.lookupOf
 import io.prebindgen.covertest.model.archiveReading
 import io.prebindgen.covertest.model.archiveReadingMaybe
@@ -569,6 +570,58 @@ fun main() {
         check(s.count(boom) == 1L)
         s.close()
         check(s.isClosed())
+    }
+
+    // An output boundary DERIVED from the type's value form
+    // (`expand_return!(Report).fields(fields!(report_to_struct))`) instead of a
+    // restated field list — #213. The point is that deriving changes NOTHING
+    // about the wire: each field still crosses by its own type's boundary, all
+    // in ONE crossing, so a binding can swap a hand-written list (which drifts
+    // when the struct gains a field) for the derived one and keep its shape.
+    //
+    // Each parameter below lands on a different rule, and the signature itself
+    // is the assertion — it would not compile if a field had been derived
+    // wrongly:
+    //   summary__count/total  the field's type has its own expand_return! and
+    //                         is spliced by it — NOT handed over as a handle
+    //   taken                 Option<data class> stays ONE leaf
+    //   origin__secs/nanos    a non-optional data class INLINES
+    //   outcome               a sum, typed here, tag + groups on the wire
+    //   label                 a plain leaf
+    section("output boundary derived from a value form") {
+        val rows = mutableListOf<String>()
+        val kept = mutableListOf<Summary>()
+        reportEach(3L, { sCount, sTotal, taken, oSecs, oNanos, outcome, label ->
+            // The value form is called ONCE per delivery, so every leaf below
+            // comes from the same snapshot.
+            check(oSecs == 1L && oNanos == 2L)
+            val stamped = if (taken != null) "@${taken.secs}" else "-"
+            val which = when (outcome) {
+                is Lookup.Failed -> "failed"
+                Lookup.Absent -> "absent"
+                is Lookup.Found -> {
+                    val s = outcome.v0
+                    // A handle carried by a sum group, reached through a value
+                    // form: live, and the receiver's to close.
+                    check(!s.isClosed())
+                    kept.add(s)
+                    "found:${s.count(boom)}"
+                }
+            }
+            rows.add("$label|$sCount|$sTotal|$stamped|$which")
+        }, boom)
+
+        check(
+            rows == listOf(
+                "r0|0|0.0|@7|failed",
+                "r1|0|10.0|-|absent",
+                "r2|1|20.0|@7|found:1",
+            )
+        ) { "derived value-form leaves: $rows" }
+
+        check(kept.size == 1)
+        kept[0].close()
+        check(kept[0].isClosed())
     }
 
     // A sum returned BORROWED (`&Reading` / `Option<&Reading>`). The value stays

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3934,11 +3934,11 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                         String,
                     >>::from(format!("push local frame for {}: {}", "Fn(Report)", e)))?;
                 let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    let __vf = perftest_flat::report_to_struct(&__cb_arg0);
+                    let __vf0 = perftest_flat::report_to_struct(&__cb_arg0);
                     let __cb0_obj5: jni::sys::jvalue;
                     let __cb0_obj6: jni::sys::jvalue;
                     let __cb0_obj7: jni::objects::JObject;
-                    match &(&__vf).outcome {
+                    match &(&__vf0).outcome {
                         perftest_flat::Lookup::Absent => {
                             __cb0_obj5 = jni::sys::jvalue { i: 0 };
                             __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
@@ -3986,7 +3986,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj0: jni::sys::jvalue = {
                         let __enc0 = match i64_to_jlong_fbf9a9bc(
                             &mut env,
-                            perftest_flat::summary_count(&(&__vf).summary),
+                            perftest_flat::summary_count(&(&__vf0).summary),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4002,7 +4002,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj1: jni::sys::jvalue = {
                         let __enc1 = match f64_to_jdouble_9e4a8f70(
                             &mut env,
-                            perftest_flat::summary_total(&(&__vf).summary),
+                            perftest_flat::summary_total(&(&__vf0).summary),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4018,7 +4018,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj2: jni::objects::JObject = {
                         let __enc2 = match Option_Stamp_to_JObject_6375b503(
                             &mut env,
-                            __vf.taken.clone(),
+                            __vf0.taken.clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4034,7 +4034,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj3: jni::sys::jvalue = {
                         let __enc3 = match i64_to_jlong_fbf9a9bc(
                             &mut env,
-                            __vf.origin.secs.clone(),
+                            __vf0.origin.secs.clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4050,7 +4050,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj4: jni::sys::jvalue = {
                         let __enc4 = match i64_to_jlong_fbf9a9bc(
                             &mut env,
-                            __vf.origin.nanos.clone(),
+                            __vf0.origin.nanos.clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4066,7 +4066,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj8: jni::objects::JObject = {
                         let __enc8 = match String_to_JString_c7f3ca43(
                             &mut env,
-                            __vf.label.clone(),
+                            __vf0.label.clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -211,6 +211,22 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_model_Report_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::Report));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Report>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecFree(
     _env: jni::JNIEnv,
     _class: jni::objects::JClass,
@@ -3869,6 +3885,255 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Report) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Report)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(
+                &__invoke_class,
+                "run",
+                "(JDLio/prebindgen/covertest/model/Stamp;JJIJLjava/lang/String;Ljava/lang/String;)V",
+            )
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Report)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Report| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Report)", e)))?;
+                env.push_local_frame(24)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Report)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __vf = perftest_flat::report_to_struct(&__cb_arg0);
+                    let __cb0_obj5: jni::sys::jvalue;
+                    let __cb0_obj6: jni::sys::jvalue;
+                    let __cb0_obj7: jni::objects::JObject;
+                    match &(&__vf).outcome {
+                        perftest_flat::Lookup::Absent => {
+                            __cb0_obj5 = jni::sys::jvalue { i: 0 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj7 = jni::objects::JObject::null();
+                        }
+                        perftest_flat::Lookup::Found(__sv0) => {
+                            let __enc___cb0_obj6 = match Summary_to_jlong_3cb103b9(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj6 = jni::sys::jvalue {
+                                j: __enc___cb0_obj6,
+                            };
+                            __cb0_obj5 = jni::sys::jvalue { i: 1 };
+                            __cb0_obj7 = jni::objects::JObject::null();
+                        }
+                        perftest_flat::Lookup::Failed(__sv0) => {
+                            let __enc___cb0_obj7 = match String_to_JString_c7f3ca43(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj7 = __enc___cb0_obj7.into();
+                            __cb0_obj5 = jni::sys::jvalue { i: 2 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                    }
+                    let __cb0_obj0: jni::sys::jvalue = {
+                        let __enc0 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            perftest_flat::summary_count(&(&__vf).summary),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc0 }
+                    };
+                    let __cb0_obj1: jni::sys::jvalue = {
+                        let __enc1 = match f64_to_jdouble_9e4a8f70(
+                            &mut env,
+                            perftest_flat::summary_total(&(&__vf).summary),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { d: __enc1 }
+                    };
+                    let __cb0_obj2: jni::objects::JObject = {
+                        let __enc2 = match Option_Stamp_to_JObject_6375b503(
+                            &mut env,
+                            __vf.taken.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc2
+                    };
+                    let __cb0_obj3: jni::sys::jvalue = {
+                        let __enc3 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            __vf.origin.secs.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc3 }
+                    };
+                    let __cb0_obj4: jni::sys::jvalue = {
+                        let __enc4 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            __vf.origin.nanos.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc4 }
+                    };
+                    let __cb0_obj8: jni::objects::JObject = {
+                        let __enc8 = match String_to_JString_c7f3ca43(
+                            &mut env,
+                            __vf.label.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc8.into()
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj2.as_raw(),
+                                },
+                                __cb0_obj3,
+                                __cb0_obj4,
+                                __cb0_obj5,
+                                __cb0_obj6,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj7.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj8.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Report)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_Storage_Send_Sync_static_2f26edcf<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -6787,6 +7052,28 @@ pub(crate) unsafe fn Option_Priority_to_JObject_ad5cbb32<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_Stamp_to_JObject_6375b503<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Stamp>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        match v {
+            Some(value) => Stamp_to_JObject_f6b1e942(env, value)?,
+            None => jni::objects::JObject::null().into(),
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<&perftest_flat::Summary>,
@@ -7100,6 +7387,23 @@ pub(crate) unsafe fn RepliesConfig_to_JObject_eb8e9079<'a>(
             >>::from(format!("encode struct via fromParts: {}", e)))?;
         __obj
     })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Report_to_jlong_eaed4ba1<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Report,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
 }
 #[allow(
     non_snake_case,
@@ -8208,6 +8512,30 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_Report_eaed4ba1<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::Report>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Report) })
 }
 #[allow(
     non_snake_case,
@@ -14197,6 +14525,66 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingSeries<'a
         };
     }
     __acc
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_reportEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::report_each(n, sink);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3934,11 +3934,11 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                         String,
                     >>::from(format!("push local frame for {}: {}", "Fn(Report)", e)))?;
                 let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    let __vf0 = perftest_flat::report_to_struct(&__cb_arg0);
+                    let __vf0 = perftest_flat::report_into_struct(__cb_arg0);
                     let __cb0_obj5: jni::sys::jvalue;
                     let __cb0_obj6: jni::sys::jvalue;
                     let __cb0_obj7: jni::objects::JObject;
-                    match &(&__vf0).outcome {
+                    match &__vf0.outcome {
                         perftest_flat::Lookup::Absent => {
                             __cb0_obj5 = jni::sys::jvalue { i: 0 };
                             __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
@@ -3986,7 +3986,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj0: jni::sys::jvalue = {
                         let __enc0 = match i64_to_jlong_fbf9a9bc(
                             &mut env,
-                            perftest_flat::summary_count(&(&__vf0).summary),
+                            perftest_flat::summary_count(&__vf0.summary),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4002,7 +4002,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj1: jni::sys::jvalue = {
                         let __enc1 = match f64_to_jdouble_9e4a8f70(
                             &mut env,
-                            perftest_flat::summary_total(&(&__vf0).summary),
+                            perftest_flat::summary_total(&__vf0.summary),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4018,7 +4018,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj2: jni::objects::JObject = {
                         let __enc2 = match Option_Stamp_to_JObject_6375b503(
                             &mut env,
-                            __vf0.taken.clone(),
+                            __vf0.taken,
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4034,7 +4034,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj3: jni::sys::jvalue = {
                         let __enc3 = match i64_to_jlong_fbf9a9bc(
                             &mut env,
-                            __vf0.origin.secs.clone(),
+                            __vf0.origin.secs,
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4050,7 +4050,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj4: jni::sys::jvalue = {
                         let __enc4 = match i64_to_jlong_fbf9a9bc(
                             &mut env,
-                            __vf0.origin.nanos.clone(),
+                            __vf0.origin.nanos,
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -4066,7 +4066,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                     let __cb0_obj8: jni::objects::JObject = {
                         let __enc8 = match String_to_JString_c7f3ca43(
                             &mut env,
-                            __vf0.label.clone(),
+                            __vf0.label,
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -65,7 +65,7 @@ pub struct drawing_t {
 pub struct foo_t {
     pub id: u64,
     pub x86_64_field: u64,
-    pub unstable_field: u64,
+    pub stable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -205,7 +205,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        unstable_field: v.unstable_field,
+        stable_field: v.stable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -484,7 +484,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        unstable_field: v.unstable_field,
+        stable_field: v.stable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -880,17 +880,6 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
-pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
-    let c = match __cbg_in___mut_Calculator(c) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__msg) => {
-            panic!("{}", __msg);
-        }
-    };
-    example_flat::calculator_reset(c);
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -1217,7 +1206,7 @@ pub unsafe extern "C" fn shape_try_area(
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
+        example_flat::FEATURES, "",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -65,7 +65,7 @@ pub struct drawing_t {
 pub struct foo_t {
     pub id: u64,
     pub x86_64_field: u64,
-    pub stable_field: u64,
+    pub unstable_field: u64,
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -205,7 +205,7 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -484,7 +484,7 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
         id: v.id,
         x86_64_field: v.x86_64_field,
-        stable_field: v.stable_field,
+        unstable_field: v.unstable_field,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -880,6 +880,17 @@ pub unsafe extern "C" fn calculator_new_from_str(
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
+    let c = match __cbg_in___mut_Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    example_flat::calculator_reset(c);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
@@ -1206,7 +1217,7 @@ pub unsafe extern "C" fn shape_try_area(
 }
 const _: () = {
     konst::assertc_eq!(
-        example_flat::FEATURES, "",
+        example_flat::FEATURES, "example-flat/internal example-flat/unstable",
         "prebindgen: features mismatch between source crate and prebindgen generated file.\n\
                         This usually happens if source crate is compiled with different feature set\n\
                         for build dependencies and for library usage. You may need to explicitly set\n\

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -102,7 +102,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t x86_64_field;
-  uint64_t unstable_field;
+  uint64_t stable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -142,8 +142,6 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
-
-void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -102,7 +102,7 @@ typedef struct closure_value_t {
 typedef struct foo_t {
   uint64_t id;
   uint64_t x86_64_field;
-  uint64_t stable_field;
+  uint64_t unstable_field;
 } foo_t;
 
 extern void *malloc(uintptr_t size);
@@ -142,6 +142,8 @@ struct calculator_t *calculator_new(void);
 struct calculator_t *calculator_new_clone(const struct calculator_t *c);
 
 struct calculator_t *calculator_new_from_str(const char *s, char **e);
+
+void calculator_reset(struct calculator_t *c);
 
 char *calculator_to_string(const struct calculator_t *c);
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1382,6 +1382,88 @@ pub fn escape_probe_value(p: &EscapeProbe) -> i64 {
     p.value
 }
 
+// ── Value form: a type's own accessors gathered into one struct (#213) ──────
+
+/// An opaque handle whose output boundary is declared from its **value form**
+/// ([`report_to_struct`]) instead of a restated field list — the
+/// `expand_return!(Report).fields(fields!(report_to_struct))` exercise.
+///
+/// Its fields are chosen so each one lands on a different rule of the
+/// expansion, and so the derived boundary is the same one a hand-written
+/// `.field()` list would have produced:
+///
+/// | field | rule |
+/// |---|---|
+/// | `summary` | its type has its own `expand_return!` ⇒ spliced into `(count, total)`, NOT handed over as a handle |
+/// | `taken` | `Option<data class>` ⇒ stays ONE leaf, its converter builds the object |
+/// | `origin` | a non-optional declared `data class` ⇒ INLINES into its own fields |
+/// | `outcome` | a `sealed_class!` ⇒ its selector plus one group per alternative, with a handle payload |
+/// | `label` | a plain leaf |
+pub struct Report {
+    summary: Summary,
+    taken: Option<Stamp>,
+    origin: Stamp,
+    outcome: Lookup,
+    label: String,
+}
+
+/// The value form of [`Report`]: its fields as data, handles staying handles.
+#[prebindgen]
+pub struct ReportStruct {
+    /// Decomposed by `Summary`'s own boundary decl, not delivered as a handle.
+    pub summary: Summary,
+    /// Absent when the report was never stamped.
+    pub taken: Option<Stamp>,
+    /// Always present, so it inlines into `origin_secs` / `origin_nanos`.
+    pub origin: Stamp,
+    /// A tag-gated group set, one alternative live, carrying a handle.
+    pub outcome: Lookup,
+    /// A plain string leaf beside the rest.
+    pub label: String,
+}
+
+/// Build a [`Report`]. `count < 0` makes the outcome a failure, `0` absent.
+#[prebindgen]
+pub fn report_new(count: i64, total: f64, taken: bool, label: String) -> Report {
+    Report {
+        summary: summary_new(count.max(0), total),
+        taken: taken.then(|| stamp_new(7, 8)),
+        origin: stamp_new(1, 2),
+        outcome: lookup_of(count, total),
+        label,
+    }
+}
+
+/// Decompose a [`Report`] into its value form — the accessor
+/// `expand_return!(Report).fields(fields!(...))` names. Cloning the fields is
+/// what makes this a *value* form; the generated code calls it ONCE per
+/// delivery and reads every leaf off that one result.
+#[prebindgen]
+pub fn report_to_struct(r: &Report) -> ReportStruct {
+    ReportStruct {
+        summary: r.summary.clone(),
+        taken: r.taken,
+        origin: r.origin,
+        outcome: r.outcome.clone(),
+        label: r.label.clone(),
+    }
+}
+
+/// Deliver a [`Report`] to a callback — the decomposed value form arriving in
+/// ONE crossing, which is the whole point of deriving the boundary rather than
+/// handing over a handle the receiver must then query field by field.
+#[prebindgen]
+pub fn report_each(n: i64, sink: impl Fn(Report) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(report_new(
+            i - 1,
+            10.0 * i as f64,
+            i % 2 == 0,
+            format!("r{i}"),
+        ));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1449,6 +1449,27 @@ pub fn report_to_struct(r: &Report) -> ReportStruct {
     }
 }
 
+/// The **consuming** value form of [`Report`] — the same fields, reached by
+/// destroying the report instead of cloning out of a borrow.
+///
+/// This is the shape a hot receive path wants. Every callback hands its value
+/// over **owned** (`impl Fn(Report)`), so there is nothing to preserve: moving
+/// the fields out costs nothing, while [`report_to_struct`] pays a clone per
+/// handle field for a value it is about to drop. The binding picks whichever
+/// form it declares; `expand_return!(Report).fields(fields!(report_into_struct))`
+/// selects this one and the generated code then **moves** each field into its
+/// leaf rather than cloning it.
+#[prebindgen]
+pub fn report_into_struct(r: Report) -> ReportStruct {
+    ReportStruct {
+        summary: r.summary,
+        taken: r.taken,
+        origin: r.origin,
+        outcome: r.outcome,
+        label: r.label,
+    }
+}
+
 /// Deliver a [`Report`] to a callback — the decomposed value form arriving in
 /// ONE crossing, which is the whole point of deriving the boundary rather than
 /// handing over a handle the receiver must then query field by field.

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -196,10 +196,17 @@ pub trait Prebindgen {
     /// [`crate::api::core::unfold::UnfoldPlan`] on the registry and its leaf
     /// types are registered as required outputs.
     ///
-    /// Returned by value, same as [`Self::expansions`].
+    /// Returned by value, same as [`Self::expansions`]. The registry is
+    /// available because a declaration may name a **value form** (an accessor
+    /// returning "this type's fields in one struct") whose fields have to be
+    /// read off the indexed struct to become records.
     ///
     /// Default: `None`.
-    fn deconstructors(&self) -> Option<crate::api::core::unfold::Deconstructors> {
+    fn deconstructors(
+        &self,
+        registry: &Registry<Self::Metadata>,
+    ) -> Option<crate::api::core::unfold::Deconstructors> {
+        let _ = registry;
         None
     }
 

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1395,7 +1395,7 @@ impl<M> Registry<M> {
                 &declared.method_receivers,
             )?;
         }
-        if let Some(dec) = ext.deconstructors() {
+        if let Some(dec) = ext.deconstructors(self) {
             crate::api::core::unfold::apply(self, &dec, &declared.functions, &declared.accessors)?;
         }
         // Synthesized by-value `data_class` decompositions: build the leaves

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -37,7 +37,10 @@ mod plan;
 
 pub use self::{
     error::{UnfoldDeclError, UnfoldError},
-    plan::{DeconId, DeconSpec, Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan, UnfoldShape},
+    plan::{
+        steps_are_movable, DeconId, DeconSpec, Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan,
+        UnfoldShape,
+    },
 };
 
 // ──────────────────────────────────────────────────────────────────────
@@ -1314,11 +1317,15 @@ fn flatten<M>(
                     });
                 }
                 seen_identity = true;
-                // Owned at the root of an owned value (a `Copy` blob copies /
-                // an opaque handle moves); borrowed (clone) otherwise. The
-                // adapter-side type + projection come from this `out_ty`'s
-                // output converter.
-                let out_ty: syn::Type = if path_prefix.is_empty() && !by_ref {
+                // Owned where the value is OURS to give: the root of an owned
+                // plan (a `Copy` blob copies / an opaque handle moves), or a
+                // field of a value form that CONSUMED its value — that form was
+                // handed the value, so its fields move out like every other
+                // field of it. Borrowed (clone) otherwise. The adapter-side type
+                // + projection come from this `out_ty`'s output converter, so
+                // this is what decides whether the leaf is boxed by move or
+                // cloned through the borrowed-opaque one.
+                let out_ty: syn::Type = if place_is_owned(hoists, path_prefix, by_ref) {
                     source.clone()
                 } else {
                     syn::parse_quote!(&#source)
@@ -1679,6 +1686,25 @@ fn accessor_signature<M>(
         syn::ReturnType::Type(_, t) => (**t).clone(),
     };
     Ok((takes, ret))
+}
+
+/// Whether the value sitting at `path_prefix` is the plan's **to give away**:
+/// the root of an owned plan, or a field of a value form that consumed its
+/// value and is reached by a movable run of field steps.
+///
+/// Consulted where a leaf's `out_ty` is chosen, so the ownership decision is
+/// made ONCE, in the plan, rather than re-derived by each emitter — a leaf
+/// whose `out_ty` is the owned type is boxed by move, one whose `out_ty` is a
+/// borrow is cloned through the borrowed-opaque converter.
+fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> bool {
+    if path_prefix.is_empty() {
+        return !by_ref;
+    }
+    hoists
+        .iter()
+        .filter(|h| h.prefix.len() <= path_prefix.len() && path_prefix.starts_with(&h.prefix))
+        .max_by_key(|h| h.prefix.len())
+        .is_some_and(|h| h.consuming && steps_are_movable(&path_prefix[h.prefix.len()..]))
 }
 
 /// Whether an accessor takes its receiver **by value** — a *consuming* value

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -1370,18 +1370,18 @@ fn flatten<M>(
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
-                // declaring `.fields_into(..)` on a borrowing accessor is a
+                // declaring `.fields_self_into(..)` on a borrowing accessor is a
                 // named error instead of a silently downgraded boundary.
                 if consuming != accessor_consumes(registry, func) {
                     return Err(UnfoldError::Unsupported {
                         func: func.clone(),
                         reason: if consuming {
-                            "declared as a CONSUMING value form (`.fields_into(..)`) but the \
+                            "declared as a CONSUMING value form (`.fields_self_into(..)`) but the \
                              accessor borrows its receiver — declare it with `.fields(..)`, or \
                              name the by-value accessor"
                         } else {
                             "declared as a BORROWING value form (`.fields(..)`) but the accessor \
-                             takes its receiver by value — declare it with `.fields_into(..)`, or \
+                             takes its receiver by value — declare it with `.fields_self_into(..)`, or \
                              name the `&Self` accessor"
                         },
                     });

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -1338,6 +1338,20 @@ fn flatten<M>(
                 check_takes(func, &takes, source)?;
                 let mut root_path = path_prefix.to_vec();
                 root_path.push(PathStep::call(func.clone(), false));
+                // A hoist below an optional step cannot be emitted as an
+                // unconditional local: composing the path directly would pass
+                // `&Option<T>` to the child value-form accessor. The current
+                // flat leaf emitter has no conditional-hoist representation,
+                // so reject the shape instead of generating ill-typed Rust.
+                // A top-level `Option<T>` is represented by
+                // `UnfoldShape::Optional`, not by a path step, and is unaffected.
+                if root_path.iter().any(PathStep::is_optional) {
+                    return Err(UnfoldError::Unsupported {
+                        func: func.clone(),
+                        reason: "a nested value form reached through `Option` — conditional \
+                                 value-form hoisting is not implemented",
+                    });
+                }
                 // Evaluate this value form ONCE. Recorded at the prefix it sits
                 // at rather than as a lone accessor, so a nested value form
                 // (this record reached through another one's field) gets its own

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -37,7 +37,7 @@ mod plan;
 
 pub use self::{
     error::{UnfoldDeclError, UnfoldError},
-    plan::{DeconId, DeconSpec, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan, UnfoldShape},
+    plan::{DeconId, DeconSpec, Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan, UnfoldShape},
 };
 
 // ──────────────────────────────────────────────────────────────────────
@@ -1197,7 +1197,7 @@ fn build_plan<M>(
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     let mut visited: HashSet<TypeKey> = HashSet::new();
     visited.insert(TypeKey::from_type(source));
-    let mut hoists: Vec<Vec<PathStep>> = Vec::new();
+    let mut hoists: Vec<Hoist> = Vec::new();
     flatten(
         acc,
         registry,
@@ -1284,7 +1284,7 @@ fn flatten<M>(
     nullable: bool,
     visited: &mut HashSet<TypeKey>,
     leaves: &mut Vec<UnfoldLeaf>,
-    hoists: &mut Vec<Vec<PathStep>>,
+    hoists: &mut Vec<Hoist>,
 ) -> Result<(), UnfoldError> {
     let source_key = TypeKey::from_type(source);
     // The author-supplied (literal) leaf-name segment at this level, appended
@@ -1352,13 +1352,42 @@ fn flatten<M>(
                                  value-form hoisting is not implemented",
                     });
                 }
+                // A by-value receiver means the value form DESTROYS the value
+                // into its parts; the emitter then moves each field out instead
+                // of cloning it. Two shapes cannot survive that move:
+                let consuming = accessor_consumes(registry, func);
+                if consuming {
+                    // A sibling record — `.field_self()` or another `.field()` —
+                    // reads the value the form just consumed.
+                    if records.len() > 1 {
+                        return Err(UnfoldError::Unsupported {
+                            func: func.clone(),
+                            reason: "a consuming value form must be the only record of its \
+                                     declaration — it moves the value, so `.field_self()` or \
+                                     a sibling `.field()` would read a moved value",
+                        });
+                    }
+                    // Nested, it would move a field out of the parent's local,
+                    // breaking every sibling leaf that still reads that local.
+                    if !path_prefix.is_empty() {
+                        return Err(UnfoldError::Unsupported {
+                            func: func.clone(),
+                            reason: "a consuming value form cannot be reached through another \
+                                     value form — it would move a field out from under the \
+                                     parent's other leaves",
+                        });
+                    }
+                }
                 // Evaluate this value form ONCE. Recorded at the prefix it sits
                 // at rather than as a lone accessor, so a nested value form
                 // (this record reached through another one's field) gets its own
                 // hoist instead of being rebuilt per child leaf. `path_prefix`
                 // grows as `flatten` descends, so the list comes out
                 // outermost-first.
-                hoists.push(root_path.clone());
+                hoists.push(Hoist {
+                    prefix: root_path.clone(),
+                    consuming,
+                });
 
                 for fr in fields {
                     // A field's own `Option` makes everything under it nullable,
@@ -1628,6 +1657,26 @@ fn accessor_signature<M>(
         syn::ReturnType::Type(_, t) => (**t).clone(),
     };
     Ok((takes, ret))
+}
+
+/// Whether an accessor takes its receiver **by value** — a *consuming* value
+/// form, which destroys the object into its parts instead of cloning them out
+/// of a borrow.
+///
+/// Asked separately because [`accessor_signature`] peels the `&` in order to
+/// compare target types, so `f(v: T)` and `f(v: &T)` are indistinguishable
+/// there by design.
+fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
+    registry.functions.get(func).is_some_and(|(f, _)| {
+        f.sig
+            .inputs
+            .iter()
+            .find_map(|input| match input {
+                syn::FnArg::Typed(pt) => Some(!matches!(*pt.ty, syn::Type::Reference(_))),
+                _ => None,
+            })
+            .unwrap_or(false)
+    })
 }
 
 fn check_takes(

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -653,7 +653,7 @@ fn wire_fixed_returns<M>(
             delivery: Delivery::Callback,
             convert_out_ty: None,
             fixed_builder: true,
-            root_call: None,
+            hoists: Vec::new(),
         };
         registry.unfold_plans.insert(func.clone(), plan);
     }
@@ -720,7 +720,7 @@ fn wire_fixed_callbacks<M>(
                     delivery: Delivery::Callback,
                     convert_out_ty: None,
                     fixed_builder: true,
-                    root_call: None,
+                    hoists: Vec::new(),
                 };
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -835,7 +835,7 @@ fn whole_leaf_fold_plan(vec_elem: &syn::Type, shape: UnfoldShape) -> UnfoldPlan 
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
-        root_call: None,
+        hoists: Vec::new(),
     }
 }
 
@@ -1026,7 +1026,7 @@ fn process_decl<M>(
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
-                    root_call: None,
+                    hoists: Vec::new(),
                 }
             }
         } else {
@@ -1130,6 +1130,9 @@ fn register_decon_spec<M>(
         false,
         &mut visited,
         &mut leaves,
+        // A `DeconSpec` describes the leaf list only — signature artifacts are
+        // derived from it, never emitted code — so its hoists are discarded.
+        &mut Vec::new(),
     )?;
     require_unique_leaf_names(source, &leaves)?;
     registry.decon_plans.insert(
@@ -1194,6 +1197,7 @@ fn build_plan<M>(
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     let mut visited: HashSet<TypeKey> = HashSet::new();
     visited.insert(TypeKey::from_type(source));
+    let mut hoists: Vec<Vec<PathStep>> = Vec::new();
     flatten(
         acc,
         registry,
@@ -1205,6 +1209,7 @@ fn build_plan<M>(
         false,
         &mut visited,
         &mut leaves,
+        &mut hoists,
     )?;
     require_unique_leaf_names(source, &leaves)?;
     require_root_identity_last(by_ref, source, &leaves)?;
@@ -1219,12 +1224,7 @@ fn build_plan<M>(
         delivery: ed.delivery,
         convert_out_ty: None,
         fixed_builder: false,
-        // At most one value form per declaration (`ExpandReturnDecl::fields`
-        // enforces it), so the hoist is a single accessor, not a table.
-        root_call: records.iter().find_map(|r| match r {
-            DeconRecord::Fields { func, .. } => Some(func.clone()),
-            _ => None,
-        }),
+        hoists,
     })
 }
 
@@ -1284,6 +1284,7 @@ fn flatten<M>(
     nullable: bool,
     visited: &mut HashSet<TypeKey>,
     leaves: &mut Vec<UnfoldLeaf>,
+    hoists: &mut Vec<Vec<PathStep>>,
 ) -> Result<(), UnfoldError> {
     let source_key = TypeKey::from_type(source);
     // The author-supplied (literal) leaf-name segment at this level, appended
@@ -1337,6 +1338,13 @@ fn flatten<M>(
                 check_takes(func, &takes, source)?;
                 let mut root_path = path_prefix.to_vec();
                 root_path.push(PathStep::call(func.clone(), false));
+                // Evaluate this value form ONCE. Recorded at the prefix it sits
+                // at rather than as a lone accessor, so a nested value form
+                // (this record reached through another one's field) gets its own
+                // hoist instead of being rebuilt per child leaf. `path_prefix`
+                // grows as `flatten` descends, so the list comes out
+                // outermost-first.
+                hoists.push(root_path.clone());
 
                 for fr in fields {
                     // A field's own `Option` makes everything under it nullable,
@@ -1417,6 +1425,7 @@ fn flatten<M>(
                             nullable || opt,
                             visited,
                             leaves,
+                            hoists,
                         )?;
                         visited.remove(&child_key);
                     } else {
@@ -1491,6 +1500,7 @@ fn flatten<M>(
                         nullable || opt,
                         visited,
                         leaves,
+                        hoists,
                     )?;
                     visited.remove(&child_key);
                 } else {

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -37,7 +37,7 @@ mod plan;
 
 pub use self::{
     error::{UnfoldDeclError, UnfoldError},
-    plan::{DeconId, DeconSpec, LeafSource, UnfoldLeaf, UnfoldPlan, UnfoldShape},
+    plan::{DeconId, DeconSpec, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan, UnfoldShape},
 };
 
 // ──────────────────────────────────────────────────────────────────────
@@ -73,6 +73,36 @@ pub enum DeconRecord {
     /// moved for an owned `T`). At most one per
     /// deconstructor.
     Identity,
+    /// Read the fields of the type's **value form**: call `func` once
+    /// (`f(&T) -> TStruct`) and contribute one record per [`FieldRecord`],
+    /// reached by field access on the returned struct. The language adapter
+    /// builds the field list (it knows which structs are declared classes and
+    /// therefore inline); this record only says how to get there.
+    ///
+    /// Each field then decomposes exactly like an [`Acc`](Self::Acc) record's
+    /// return does — its own [`records`](FieldRecord::records) if the
+    /// declaration overrode it, else its type's own deconstructor if it has
+    /// one, else one leaf — so a value form and a hand-written field list
+    /// produce the same leaves.
+    Fields {
+        func: syn::Ident,
+        fields: Vec<FieldRecord>,
+    },
+}
+
+/// One field of a value form (see [`DeconRecord::Fields`]).
+#[derive(Clone)]
+pub struct FieldRecord {
+    /// Field-access chain from the value form's returned struct. More than one
+    /// element when the adapter inlined a nested declared class.
+    pub members: Vec<syn::Ident>,
+    /// The leaf name (already `__`-joined across inlined nesting).
+    pub name: String,
+    /// The field's type as written, `Option` / `Vec` layers included.
+    pub ty: syn::Type,
+    /// Explicit per-field records replacing the type's default decomposition;
+    /// `None` = decompose by the field type's own deconstructor, or one leaf.
+    pub records: Option<Vec<DeconRecord>>,
 }
 
 impl DeconRecord {
@@ -230,23 +260,7 @@ pub fn apply<M>(
     // Binding-local records skip the gate — there is no `#[prebindgen]` item
     // behind them — but keep the reserved-separator name check.
     for d in &acc.deconstructors {
-        for rec in &d.records {
-            let (func, name) = match rec {
-                DeconRecord::Acc { func, name } => (Some(func), name),
-                DeconRecord::LocalAcc { name, .. } => (None, name),
-                DeconRecord::Identity => continue,
-            };
-            // `"__"` is the reserved nesting/chain separator — author leaf names
-            // must not contain it.
-            if name.contains("__") {
-                return Err(UnfoldError::ReservedSeparator { name: name.clone() });
-            }
-            if let Some(func) = func {
-                if !accessor_fns.contains(func) {
-                    return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
-                }
-            }
-        }
+        check_records(&d.records, accessor_fns)?;
     }
 
     // Explicit decls first; they take precedence over (and suppress) a default
@@ -624,6 +638,7 @@ fn wire_fixed_returns<M>(
             delivery: Delivery::Callback,
             convert_out_ty: None,
             fixed_builder: true,
+            root_call: None,
         };
         registry.unfold_plans.insert(func.clone(), plan);
     }
@@ -690,6 +705,7 @@ fn wire_fixed_callbacks<M>(
                     delivery: Delivery::Callback,
                     convert_out_ty: None,
                     fixed_builder: true,
+                    root_call: None,
                 };
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -804,11 +820,57 @@ fn whole_leaf_fold_plan(vec_elem: &syn::Type, shape: UnfoldShape) -> UnfoldPlan 
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
+        root_call: None,
     }
 }
 
+/// The deconstructor gate: every accessor-function record must be a declared
+/// `.fun_accessor` (the single source of truth for "accessor"), and no author
+/// leaf name may contain the reserved `"__"` chain separator. Binding-local
+/// records skip the accessor check — there is no `#[prebindgen]` item behind
+/// them — but keep the name check.
+///
+/// Recurses into a value form's per-field override records, so an override is
+/// held to the same rules as the declaration it replaces.
+fn check_records(
+    records: &[DeconRecord],
+    accessor_fns: &HashSet<syn::Ident>,
+) -> Result<(), UnfoldError> {
+    for rec in records {
+        let (func, name) = match rec {
+            DeconRecord::Acc { func, name } => (Some(func), name),
+            DeconRecord::LocalAcc { name, .. } => (None, name),
+            DeconRecord::Identity => continue,
+            // A value form's field names come from struct idents, not from the
+            // author, so the `"__"` in an inlined nested name is the separator
+            // doing its job. An author-supplied rename is checked where it is
+            // declared.
+            DeconRecord::Fields { func, fields } => {
+                if !accessor_fns.contains(func) {
+                    return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
+                }
+                for fr in fields {
+                    if let Some(recs) = &fr.records {
+                        check_records(recs, accessor_fns)?;
+                    }
+                }
+                continue;
+            }
+        };
+        if name.contains("__") {
+            return Err(UnfoldError::ReservedSeparator { name: name.clone() });
+        }
+        if let Some(func) = func {
+            if !accessor_fns.contains(func) {
+                return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Strip a single leading `&` (one level) from a type.
-fn peel_ref(ty: &syn::Type) -> syn::Type {
+pub(crate) fn peel_ref(ty: &syn::Type) -> syn::Type {
     match ty {
         syn::Type::Reference(r) => (*r.elem).clone(),
         other => other.clone(),
@@ -949,6 +1011,7 @@ fn process_decl<M>(
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
+                    root_call: None,
                 }
             }
         } else {
@@ -1141,6 +1204,12 @@ fn build_plan<M>(
         delivery: ed.delivery,
         convert_out_ty: None,
         fixed_builder: false,
+        // At most one value form per declaration (`ExpandReturnDecl::fields`
+        // enforces it), so the hoist is a single accessor, not a table.
+        root_call: records.iter().find_map(|r| match r {
+            DeconRecord::Fields { func, .. } => Some(func.clone()),
+            _ => None,
+        }),
     })
 }
 
@@ -1194,7 +1263,7 @@ fn flatten<M>(
     registry: &Registry<M>,
     records: &[DeconRecord],
     source: &syn::Type,
-    path_prefix: &[syn::Ident],
+    path_prefix: &[PathStep],
     name_prefix: &[String],
     by_ref: bool,
     nullable: bool,
@@ -1245,6 +1314,93 @@ fn flatten<M>(
                     group: None,
                 });
             }
+            DeconRecord::Fields { func, fields } => {
+                // The value form is called once; every field hangs off that one
+                // call, so the whole record shares a single `Call` step and the
+                // emitter can hoist it.
+                let (takes, _ret) = accessor_signature(registry, func)?;
+                check_takes(func, &takes, source)?;
+                let mut root_path = path_prefix.to_vec();
+                root_path.push(PathStep::call(func.clone(), false));
+
+                for fr in fields {
+                    // A field's own `Option` makes everything under it nullable,
+                    // exactly as an `Option`-returning accessor step does.
+                    let (opt, core) = match option_inner_type(&fr.ty) {
+                        Some(inner) => (true, inner),
+                        None => (false, fr.ty.clone()),
+                    };
+                    let child_ty = peel_ref(&core);
+                    let child_key = TypeKey::from_type(&child_ty);
+
+                    // Same three-way choice a `.field()` record makes: declared
+                    // override, else the field type's own deconstructor, else
+                    // one leaf.
+                    let child_records = match &fr.records {
+                        Some(recs) => Some(recs.clone()),
+                        None => match find_deconstructor_by_type(acc, &child_key) {
+                            Some(child_decl) if !visited.contains(&child_key) => {
+                                Some(child_decl.records.clone())
+                            }
+                            Some(_) => {
+                                return Err(UnfoldError::Cycle {
+                                    target: child_key.to_string(),
+                                });
+                            }
+                            None => None,
+                        },
+                    };
+
+                    // The field's own `Option` is a nullable NESTING step only
+                    // when something is decomposed below it. For a plain leaf
+                    // the whole `Option<F>` is what the converter takes — the
+                    // same rule that makes a terminal accessor's `Option` ride
+                    // its converter instead of being unwrapped.
+                    let mut field_path = root_path.clone();
+                    let (last, lead) = fr
+                        .members
+                        .split_last()
+                        .expect("a field record addresses at least one member");
+                    // Only the LAST member can be optional — an inlined nested
+                    // class is reached directly, never through an `Option`.
+                    field_path.extend(lead.iter().map(|m| PathStep::field(m.clone(), false)));
+                    field_path.push(PathStep::field(
+                        last.clone(),
+                        opt && child_records.is_some(),
+                    ));
+
+                    if let Some(child_records) = child_records {
+                        visited.insert(child_key.clone());
+                        flatten(
+                            acc,
+                            registry,
+                            &child_records,
+                            &child_ty,
+                            &field_path,
+                            &seg_name(&fr.name),
+                            by_ref,
+                            nullable || opt,
+                            visited,
+                            leaves,
+                        )?;
+                        visited.remove(&child_key);
+                    } else {
+                        // A plain field leaf: the value is CLONED out of the
+                        // struct, so its converter takes the owned field type as
+                        // written — `Option` and all, which is why a terminal
+                        // `Option` step is not a nesting step for it.
+                        leaves.push(UnfoldLeaf {
+                            name: seg_name(&fr.name).join("__"),
+                            path: field_path,
+                            out_ty: fr.ty.clone(),
+                            identity: false,
+                            nullable,
+                            source: LeafSource::Field,
+                            group: None,
+                        });
+                    }
+                }
+            }
             DeconRecord::Acc { name, .. } | DeconRecord::LocalAcc { name, .. } => {
                 // A binding-local record resolves through its synthesized
                 // registry entry (see `synthesize_local_accessors`), so both
@@ -1253,7 +1409,7 @@ fn flatten<M>(
                 let (func, local) = match rec {
                     DeconRecord::Acc { func, .. } => (func.clone(), false),
                     DeconRecord::LocalAcc { path, .. } => (DeconRecord::local_ident(path), true),
-                    DeconRecord::Identity => unreachable!(),
+                    DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
                 let (takes, ret) = accessor_signature(registry, &func)?;
                 check_takes(&func, &takes, source)?;
@@ -1288,7 +1444,7 @@ fn flatten<M>(
                     visited.insert(child_key.clone());
                     let child_records = child_decl.records.clone();
                     let mut child_path = path_prefix.to_vec();
-                    child_path.push(func.clone());
+                    child_path.push(PathStep::call(func.clone(), opt));
                     flatten(
                         acc,
                         registry,
@@ -1332,7 +1488,7 @@ fn flatten<M>(
                         (ret, nullable, false)
                     };
                     let mut path = path_prefix.to_vec();
-                    path.push(func.clone());
+                    path.push(PathStep::call(func.clone(), opt));
                     leaves.push(UnfoldLeaf {
                         name: seg_name(name).join("__"),
                         path,

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -1070,16 +1070,28 @@ fn process_decl<M>(
             plan
         };
         // Delivery is by **leaf count**, not a per-decl flag:
-        //   * Output, single leaf, non-Iterable ⇒ Return (wrapper returns the
-        //     value via its ordinary output converter — `convert_out_ty`).
+        //   * Output, single non-nullable leaf, non-Iterable ⇒ Return (wrapper
+        //     returns the value via its ordinary output converter —
+        //     `convert_out_ty`).
         //   * Output, multiple leaves or Iterable (at any layer — an
         //     `Optional(Iterable)` fold has no single value to return) ⇒
         //     Callback (builder / fold).
         //   * Error ⇒ always Callback-shaped: every leaf is a `ze` arg after the
         //     fixed `je` (no return-value path; `convert_out_ty` stays None).
+        //
+        // A NULLABLE leaf is one whose path passes through an `Option` that
+        // something is decomposed below (`Option<Handle>` reached by
+        // `.field_self()`, a nested value form behind an `Option`). Returning it
+        // has nowhere to put the absent case: a return value is one expression,
+        // so there is no `None` arm, and `convert_out_ty` names the leaf's own
+        // type rather than an optional of it. Callback delivery has that arm
+        // already — the leaf crosses as a boxed `Long` / JVM null — so the
+        // shape goes there instead of being composed into Rust that hands
+        // `&Option<T>` to a converter typed for `T`.
         let single_return = ed.target == DeconTarget::Output
             && !plan.shape.has_iterable_layer()
-            && plan.leaves.len() == 1;
+            && plan.leaves.len() == 1
+            && !plan.leaves[0].nullable;
         let plan = if single_return {
             let leaf_ty = plan.leaves[0].out_ty.clone();
             let cv_ty: syn::Type = if matches!(plan.shape, UnfoldShape::Optional((), _)) {

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -86,6 +86,13 @@ pub enum DeconRecord {
     /// produce the same leaves.
     Fields {
         func: syn::Ident,
+        /// The accessor **consumes** its receiver (`f(T) -> TStruct`): the
+        /// value is moved in and each field moved *out* into its leaf, instead
+        /// of being cloned out of a borrow. Declared by the adapter rather than
+        /// read off the signature — giving the value away is a boundary
+        /// decision — and cross-checked against the signature when the records
+        /// are flattened, so the two cannot drift.
+        consuming: bool,
         fields: Vec<FieldRecord>,
     },
 }
@@ -860,7 +867,7 @@ fn check_records(
             // author, so the `"__"` in an inlined nested name is the separator
             // doing its job. An author-supplied rename is checked where it is
             // declared.
-            DeconRecord::Fields { func, fields } => {
+            DeconRecord::Fields { func, fields, .. } => {
                 if !accessor_fns.contains(func) {
                     return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
                 }
@@ -1330,12 +1337,36 @@ fn flatten<M>(
                     group: None,
                 });
             }
-            DeconRecord::Fields { func, fields } => {
+            DeconRecord::Fields {
+                func,
+                consuming,
+                fields,
+            } => {
+                let consuming = *consuming;
                 // The value form is called once; every field hangs off that one
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
                 let (takes, _ret) = accessor_signature(registry, func)?;
                 check_takes(func, &takes, source)?;
+                // The declarator states whether the value is given away; the
+                // signature has to agree, or the emitted call would not compile
+                // in the consumer's crate. Checked rather than inferred so that
+                // declaring `.fields_into(..)` on a borrowing accessor is a
+                // named error instead of a silently downgraded boundary.
+                if consuming != accessor_consumes(registry, func) {
+                    return Err(UnfoldError::Unsupported {
+                        func: func.clone(),
+                        reason: if consuming {
+                            "declared as a CONSUMING value form (`.fields_into(..)`) but the \
+                             accessor borrows its receiver — declare it with `.fields(..)`, or \
+                             name the by-value accessor"
+                        } else {
+                            "declared as a BORROWING value form (`.fields(..)`) but the accessor \
+                             takes its receiver by value — declare it with `.fields_into(..)`, or \
+                             name the `&Self` accessor"
+                        },
+                    });
+                }
                 let mut root_path = path_prefix.to_vec();
                 root_path.push(PathStep::call(func.clone(), false));
                 // A hoist below an optional step cannot be emitted as an
@@ -1352,31 +1383,22 @@ fn flatten<M>(
                                  value-form hoisting is not implemented",
                     });
                 }
-                // A by-value receiver means the value form DESTROYS the value
-                // into its parts; the emitter then moves each field out instead
-                // of cloning it. Two shapes cannot survive that move:
-                let consuming = accessor_consumes(registry, func);
-                if consuming {
-                    // A sibling record — `.field_self()` or another `.field()` —
-                    // reads the value the form just consumed.
-                    if records.len() > 1 {
-                        return Err(UnfoldError::Unsupported {
-                            func: func.clone(),
-                            reason: "a consuming value form must be the only record of its \
-                                     declaration — it moves the value, so `.field_self()` or \
-                                     a sibling `.field()` would read a moved value",
-                        });
-                    }
-                    // Nested, it would move a field out of the parent's local,
-                    // breaking every sibling leaf that still reads that local.
-                    if !path_prefix.is_empty() {
-                        return Err(UnfoldError::Unsupported {
-                            func: func.clone(),
-                            reason: "a consuming value form cannot be reached through another \
-                                     value form — it would move a field out from under the \
-                                     parent's other leaves",
-                        });
-                    }
+                // A consuming value form DESTROYS the value into its parts, so
+                // a sibling record — `.field_self()` or another `.field()` —
+                // would read what it just gave away. jnigen refuses this in the
+                // declarator, where the author can see it; this is the backstop
+                // for records built directly against core.
+                //
+                // Being reached through ANOTHER value form is fine: a hoisted
+                // value form is an owned struct and its fields are disjoint, so
+                // the parent's field is handed over by move.
+                if consuming && records.len() > 1 {
+                    return Err(UnfoldError::Unsupported {
+                        func: func.clone(),
+                        reason: "a consuming value form must be the only record of its \
+                                 declaration — it moves the value, so `.field_self()` or \
+                                 a sibling `.field()` would read a moved value",
+                    });
                 }
                 // Evaluate this value form ONCE. Recorded at the prefix it sits
                 // at rather than as a lone accessor, so a nested value form

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -100,9 +100,24 @@ pub struct FieldRecord {
     pub name: String,
     /// The field's type as written, `Option` / `Vec` layers included.
     pub ty: syn::Type,
-    /// Explicit per-field records replacing the type's default decomposition;
-    /// `None` = decompose by the field type's own deconstructor, or one leaf.
-    pub records: Option<Vec<DeconRecord>>,
+    /// How this field decomposes.
+    pub decon: FieldDecon,
+}
+
+/// How one [`FieldRecord`] decomposes.
+#[derive(Clone)]
+pub enum FieldDecon {
+    /// By the field type's own deconstructor if it has one, else one leaf —
+    /// the same default a [`DeconRecord::Acc`] record's return follows.
+    Default,
+    /// Explicit records, replacing the type default wholesale (the declaration
+    /// stated this field's complete leaf set).
+    Records(Vec<DeconRecord>),
+    /// Leaves the **adapter** built, appended with this field's path and name
+    /// prefixed onto each. For shapes whose leaf structure only the adapter
+    /// knows — a decomposed sum, which is a selector plus one group per
+    /// alternative rather than a product of records.
+    Leaves(Vec<UnfoldLeaf>),
 }
 
 impl DeconRecord {
@@ -850,7 +865,7 @@ fn check_records(
                     return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
                 }
                 for fr in fields {
-                    if let Some(recs) = &fr.records {
+                    if let FieldDecon::Records(recs) = &fr.decon {
                         check_records(recs, accessor_fns)?;
                     }
                 }
@@ -1335,10 +1350,12 @@ fn flatten<M>(
 
                     // Same three-way choice a `.field()` record makes: declared
                     // override, else the field type's own deconstructor, else
-                    // one leaf.
-                    let child_records = match &fr.records {
-                        Some(recs) => Some(recs.clone()),
-                        None => match find_deconstructor_by_type(acc, &child_key) {
+                    // one leaf — with the adapter able to pre-build the leaves
+                    // for a shape only it can describe.
+                    let child_records = match &fr.decon {
+                        FieldDecon::Records(recs) => Some(recs.clone()),
+                        FieldDecon::Leaves(_) => None,
+                        FieldDecon::Default => match find_deconstructor_by_type(acc, &child_key) {
                             Some(child_decl) if !visited.contains(&child_key) => {
                                 Some(child_decl.records.clone())
                             }
@@ -1350,6 +1367,8 @@ fn flatten<M>(
                             None => None,
                         },
                     };
+                    let decomposed =
+                        child_records.is_some() || matches!(fr.decon, FieldDecon::Leaves(_));
 
                     // The field's own `Option` is a nullable NESTING step only
                     // when something is decomposed below it. For a plain leaf
@@ -1364,10 +1383,26 @@ fn flatten<M>(
                     // Only the LAST member can be optional — an inlined nested
                     // class is reached directly, never through an `Option`.
                     field_path.extend(lead.iter().map(|m| PathStep::field(m.clone(), false)));
-                    field_path.push(PathStep::field(
-                        last.clone(),
-                        opt && child_records.is_some(),
-                    ));
+                    field_path.push(PathStep::field(last.clone(), opt && decomposed));
+
+                    // Adapter-built leaves: rebase each onto this field's path
+                    // and name. Their internal structure (a selector plus its
+                    // groups) is opaque here and passes through untouched.
+                    if let FieldDecon::Leaves(built) = &fr.decon {
+                        for l in built {
+                            let mut path = field_path.clone();
+                            path.extend(l.path.iter().cloned());
+                            let mut name = seg_name(&fr.name);
+                            name.push(l.name.clone());
+                            leaves.push(UnfoldLeaf {
+                                name: name.join("__"),
+                                path,
+                                nullable: l.nullable || nullable || opt,
+                                ..l.clone()
+                            });
+                        }
+                        continue;
+                    }
 
                     if let Some(child_records) = child_records {
                         visited.insert(child_key.clone());

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -205,12 +205,17 @@ pub struct UnfoldPlan {
     /// generic over `R`/`A` — it returns the concrete type). `false` for the
     /// accessor-declared deconstructors, whose builder is caller-supplied.
     pub fixed_builder: bool,
-    /// The **value-form accessor** every `.fields()` leaf reaches through
-    /// (`DeconRecord::Fields`), when the plan has one. Those leaves all begin
-    /// with the same [`PathStep::Call`], so the emitter binds one
-    /// `let __vf = f(value);` and reaches each leaf off it — otherwise every
+    /// Path prefixes that must be evaluated **once** and bound to a local, each
+    /// ending in a value-form [`PathStep::Call`] (`DeconRecord::Fields`).
+    /// Every leaf below such a prefix reaches off that local — otherwise each
     /// field would rebuild the whole struct, cloning all of it once per leaf.
-    pub root_call: Option<syn::Ident>,
+    ///
+    /// A list rather than a single accessor because value forms **compose**: a
+    /// field may splice a child type whose own boundary is derived from *its*
+    /// value form, and that child call is a second hoist nested under the
+    /// first. Ordered outermost-first, so a hoist can be composed from the
+    /// longest already-bound prefix of itself.
+    pub hoists: Vec<Vec<PathStep>>,
 }
 
 /// One flattened output leaf of a decomposed return value.

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -58,6 +58,71 @@ pub struct DeconSpec {
     pub leaves: Vec<UnfoldLeaf>,
 }
 
+/// One step of a leaf's [`UnfoldLeaf::path`] — how to get from the value
+/// reached so far to the next one.
+///
+/// A step is typed rather than a bare ident because a single path may **mix**
+/// the two: an `expand_return!(T).fields(fields!(t_to_struct))` leaf calls the
+/// value-form accessor, reads a struct field, and may then call that field
+/// type's own accessor — `Call(t_to_struct)`, `Field(key_expr)`,
+/// `Call(keyexpr_as_str)`. [`LeafSource`] still says what *kind* of leaf sits
+/// at the end of the path; the steps say how it is reached.
+///
+/// Each step also records whether it is **optional** — its accessor returns
+/// `Option<…>`, or its field is typed `Option<…>`. A `true` on a step *before*
+/// the last makes it a nullable nesting step: the emitter matches on it and the
+/// `None` arm short-circuits the whole leaf to null. The flag is carried rather
+/// than re-derived so both kinds answer the question the same way and the
+/// emitter needs no type walk (an accessor's `Option` was already peeled where
+/// the step was built).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum PathStep {
+    /// Call a `#[prebindgen]` accessor on the value reached so far:
+    /// `source_module::f(&value)`.
+    Call { ident: syn::Ident, optional: bool },
+    /// Read a struct field of the value reached so far: `value.f`.
+    Field { ident: syn::Ident, optional: bool },
+}
+
+impl PathStep {
+    /// An accessor call step.
+    pub fn call(ident: syn::Ident, optional: bool) -> Self {
+        Self::Call { ident, optional }
+    }
+
+    /// A struct-field read step.
+    pub fn field(ident: syn::Ident, optional: bool) -> Self {
+        Self::Field { ident, optional }
+    }
+
+    /// The step's ident, whichever kind it is.
+    pub fn ident(&self) -> &syn::Ident {
+        match self {
+            Self::Call { ident, .. } | Self::Field { ident, .. } => ident,
+        }
+    }
+
+    /// Whether the step yields an `Option` — a nullable nesting step when it is
+    /// not the last on the path.
+    pub fn is_optional(&self) -> bool {
+        match self {
+            Self::Call { optional, .. } | Self::Field { optional, .. } => *optional,
+        }
+    }
+
+    /// Whether the step is a plain (non-optional) field read — a path made only
+    /// of these renders as `value.a.b`, needing no nesting `match`.
+    pub fn is_plain_field(&self) -> bool {
+        matches!(
+            self,
+            Self::Field {
+                optional: false,
+                ..
+            }
+        )
+    }
+}
+
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum LeafSource {
@@ -140,6 +205,12 @@ pub struct UnfoldPlan {
     /// generic over `R`/`A` — it returns the concrete type). `false` for the
     /// accessor-declared deconstructors, whose builder is caller-supplied.
     pub fixed_builder: bool,
+    /// The **value-form accessor** every `.fields()` leaf reaches through
+    /// (`DeconRecord::Fields`), when the plan has one. Those leaves all begin
+    /// with the same [`PathStep::Call`], so the emitter binds one
+    /// `let __vf = f(value);` and reaches each leaf off it — otherwise every
+    /// field would rebuild the whole struct, cloning all of it once per leaf.
+    pub root_call: Option<syn::Ident>,
 }
 
 /// One flattened output leaf of a decomposed return value.
@@ -151,9 +222,10 @@ pub struct UnfoldLeaf {
     /// `"keyExpr"` → `"sample__keyExpr"`); a root identity leaf is `"handle"`.
     /// Names are unique within a deconstructor (a duplicate is a hard error).
     pub name: String,
-    /// Accessor-call chain from the root value (`[]` = the identity/root
-    /// itself; `[f]` = `f(&root)`; longer = nested records, M3).
-    pub path: Vec<syn::Ident>,
+    /// Reach chain from the root value (`[]` = the identity/root itself;
+    /// `[Call(f)]` = `f(&root)`; longer = nested records, M3). Steps of both
+    /// kinds may mix — see [`PathStep`].
+    pub path: Vec<PathStep>,
     /// Type whose resolved **output** converter encodes this leaf — a
     /// reference type for accessors (`&str`, `&F`), `&Source` for the identity
     /// leaf (so the borrowed-opaque clone converter / projection is reused).

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -205,17 +205,34 @@ pub struct UnfoldPlan {
     /// generic over `R`/`A` — it returns the concrete type). `false` for the
     /// accessor-declared deconstructors, whose builder is caller-supplied.
     pub fixed_builder: bool,
-    /// Path prefixes that must be evaluated **once** and bound to a local, each
-    /// ending in a value-form [`PathStep::Call`] (`DeconRecord::Fields`).
-    /// Every leaf below such a prefix reaches off that local — otherwise each
-    /// field would rebuild the whole struct, cloning all of it once per leaf.
+    /// Value forms that must be evaluated **once** and bound to a local. Every
+    /// leaf below one reaches off that local — otherwise each field would
+    /// rebuild the whole struct, cloning all of it once per leaf.
     ///
     /// A list rather than a single accessor because value forms **compose**: a
     /// field may splice a child type whose own boundary is derived from *its*
     /// value form, and that child call is a second hoist nested under the
     /// first. Ordered outermost-first, so a hoist can be composed from the
     /// longest already-bound prefix of itself.
-    pub hoists: Vec<Vec<PathStep>>,
+    pub hoists: Vec<Hoist>,
+}
+
+/// One hoisted value form: where it sits, and whether it **consumes** the value
+/// it decomposes.
+#[derive(Clone)]
+pub struct Hoist {
+    /// The path prefix to bind, ending in the value form's
+    /// [`PathStep::Call`] (`DeconRecord::Fields`).
+    pub prefix: Vec<PathStep>,
+    /// `true` when the accessor takes its receiver **by value**
+    /// (`f(v: T) -> TStruct`), so the value is moved in and each field can be
+    /// moved *out* into its leaf instead of cloned — the whole point of a
+    /// consuming value form.
+    ///
+    /// Carried on the hoist rather than on [`PathStep::Call`] because only a
+    /// value-form root can consume: the ordinary accessor-chain steps are
+    /// always borrows.
+    pub consuming: bool,
 }
 
 /// One flattened output leaf of a decomposed return value.

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -121,6 +121,28 @@ impl PathStep {
             }
         )
     }
+
+    /// Whether the step is a field read, `Option` or not.
+    pub fn is_field(&self) -> bool {
+        matches!(self, Self::Field { .. })
+    }
+}
+
+/// Whether a run of steps can be **moved** out of the value it hangs off:
+/// field reads only, with an `Option` allowed on the last one — a `None` arm
+/// still hands over the whole `Option` by value, while an `Option` in the
+/// middle would have to be unwrapped and so can only be borrowed through.
+///
+/// This is the one place the rule is written: the resolver uses it to decide
+/// whether a leaf OWNS what it reaches (its `out_ty` then being the owned type
+/// rather than a borrow), and the emitters use it to project that place. Two
+/// readings of it would drift, and the disagreement would be a borrow handed to
+/// an owning converter.
+pub fn steps_are_movable(steps: &[PathStep]) -> bool {
+    steps
+        .iter()
+        .enumerate()
+        .all(|(i, s)| s.is_field() && (!s.is_optional() || i + 1 == steps.len()))
 }
 
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1576,7 +1576,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
         delivery: Delivery::Return,
         convert_out_ty: None,
         fixed_builder: false,
-        root_call: None,
+        hoists: Vec::new(),
     };
     reg.unfold_plans.insert(ident("strings"), sentinel);
     apply_leaf_vec_folds(&mut reg, vec![syn::parse_quote!(String)], &declared)

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -88,7 +88,10 @@ fn accessor_optional_primitive() {
     );
     assert_eq!(plan.leaves.len(), 1);
     assert!(!plan.leaves[0].identity);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_timestamp_ntp64");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_timestamp_ntp64"
+    );
     assert_eq!(plan.leaves[0].out_ty.to_token_stream().to_string(), "i64");
     assert!(reg
         .required_outputs_scan
@@ -150,7 +153,10 @@ fn accessor_plan_byref() {
     // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
     assert!(!plan.leaves[1].identity);
     assert_eq!(plan.leaves[1].path.len(), 1);
-    assert_eq!(plan.leaves[1].path[0].to_string(), "z_keyexpr_as_str");
+    assert_eq!(
+        plan.leaves[1].path[0].ident().to_string(),
+        "z_keyexpr_as_str"
+    );
     assert_eq!(plan.leaves[1].out_ty.to_token_stream().to_string(), "& str");
 
     // Leaf out_tys registered as required outputs so the resolver builds
@@ -484,7 +490,7 @@ fn nested_accessor_flatten() {
     let path = |l: &UnfoldLeaf| {
         l.path
             .iter()
-            .map(|i| i.to_string())
+            .map(|i| i.ident().to_string())
             .collect::<Vec<_>>()
             .join(".")
     };
@@ -627,7 +633,7 @@ fn reply_product_double_option_flatten() {
     let path = |l: &UnfoldLeaf| {
         l.path
             .iter()
-            .map(|i| i.to_string())
+            .map(|i| i.ident().to_string())
             .collect::<Vec<_>>()
             .join(".")
     };
@@ -797,7 +803,10 @@ fn iterable_decomposed_plan() {
     assert!(matches!(&plan.shape, UnfoldShape::Iterable(_)));
     assert!(plan.element.is_none(), "decomposed: element not used");
     assert_eq!(plan.leaves.len(), 2);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_zenoh_id_to_string");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_zenoh_id_to_string"
+    );
     assert_eq!(
         plan.leaves[0].out_ty.to_token_stream().to_string(),
         "String"
@@ -1067,7 +1076,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         reg_with(&["fn storage_get_vec(s: &Storage) -> Option<Vec<Payload>> { todo!() }"]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
-        path: vec![ident(name)],
+        path: vec![PathStep::field(ident(name), false)],
         out_ty: ty,
         identity: false,
         nullable: false,
@@ -1120,7 +1129,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     ]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
-        path: vec![ident(name)],
+        path: vec![PathStep::field(ident(name), false)],
         out_ty: ty,
         identity: false,
         nullable: false,
@@ -1328,13 +1337,16 @@ fn callback_arg_plan_derived() {
     assert_eq!(plan.leaves.len(), 3);
     // Nested keyexpr identity (borrowed: non-root) + string + direct enum.
     assert!(plan.leaves[0].identity);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_sample_key_expr");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_sample_key_expr"
+    );
     assert_eq!(
         plan.leaves[0].out_ty.to_token_stream().to_string(),
         "& ZKeyExpr"
     );
     assert_eq!(
-        plan.leaves[1].path.last().unwrap().to_string(),
+        plan.leaves[1].path.last().unwrap().ident().to_string(),
         "z_keyexpr_as_str"
     );
     assert_eq!(
@@ -1412,7 +1424,10 @@ fn callback_arg_borrowed_decomposed() {
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 3);
     assert!(plan.leaves[0].identity);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_sample_key_expr");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_sample_key_expr"
+    );
     assert_eq!(
         plan.leaves[2].out_ty.to_token_stream().to_string(),
         "SampleKind"
@@ -1561,6 +1576,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
         delivery: Delivery::Return,
         convert_out_ty: None,
         fixed_builder: false,
+        root_call: None,
     };
     reg.unfold_plans.insert(ident("strings"), sentinel);
     apply_leaf_vec_folds(&mut reg, vec![syn::parse_quote!(String)], &declared)

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -936,6 +936,27 @@ impl JniGen {
             // An explicit override replaces the field type's default
             // decomposition wholesale — including any nesting it would have had.
             if let Some((_, ovr)) = decl.overrides.iter().find(|(f, _)| *f == dotted) {
+                // The override states the field's type, so it is cross-checked
+                // against the field the same way a per-fn `.expand_param` /
+                // `.expand_return` decl is checked against its parameter or
+                // return. Without this an override outlives an upstream
+                // field-type change — the very drift `.fields()` exists to
+                // catch — and two same-shaped handle types silently swap.
+                let peeled = vec_inner_type(&field.ty)
+                    .or_else(|| option_inner_type(&field.ty))
+                    .map(|t| crate::api::core::unfold::peel_ref(&t))
+                    .unwrap_or_else(|| crate::api::core::unfold::peel_ref(&field.ty));
+                let actual = TypeKey::from_type(&peeled);
+                assert!(
+                    actual == ovr.key,
+                    "fields!({}).field(\"{dotted}\", expand_return!({})): `{}.{dotted}` is \
+                     `{}`, not `{}` — a per-field override names the field's own type",
+                    decl.func,
+                    ovr.key.as_str(),
+                    st.ident,
+                    actual.as_str(),
+                    ovr.key.as_str(),
+                );
                 out.push(FieldRecord {
                     members: member_path,
                     name,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -889,7 +889,7 @@ impl JniGen {
         depth: usize,
         out: &mut Vec<crate::api::core::unfold::FieldRecord>,
     ) {
-        use crate::api::core::unfold::FieldRecord;
+        use crate::api::core::unfold::{FieldDecon, FieldRecord};
         let syn::Fields::Named(named) = &st.fields else {
             panic!(
                 "expand_return!({}).fields(fields!({})): `{}` has no named fields — a value \
@@ -940,7 +940,7 @@ impl JniGen {
                     members: member_path,
                     name,
                     ty: field.ty.clone(),
-                    records: Some(self.lower_fields(registry, &ovr.key, &ovr.fields)),
+                    decon: FieldDecon::Records(self.lower_fields(registry, &ovr.key, &ovr.fields)),
                 });
                 continue;
             }
@@ -948,29 +948,86 @@ impl JniGen {
             // A nested `data_class!` inlines when it is reached directly; behind
             // `Option` / `Vec` it stays one leaf, whose own converter builds the
             // object (the rule `synth_value_struct_leaves` already follows).
-            let nested = match self.type_kind(registry, &field.ty) {
-                TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
-                _ => None,
-            };
-            if let Some(child) = nested {
-                self.walk_value_form(
-                    registry,
-                    key,
-                    decl,
-                    &child,
-                    &member_path,
-                    &name,
-                    depth + 1,
-                    out,
-                );
-                continue;
+            // A `sealed_class!` field has no whole-value converter at all, so it
+            // must decompose into its selector and groups wherever it appears.
+            let bare = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
+            let probe = vec_inner_type(&bare).unwrap_or_else(|| bare.clone());
+            match self.type_kind(registry, &probe) {
+                TypeKind::DataStruct { st, cfg: Some(_) }
+                    if option_inner_type(&field.ty).is_none()
+                        && vec_inner_type(&field.ty).is_none() =>
+                {
+                    let child = st.clone();
+                    self.walk_value_form(
+                        registry,
+                        key,
+                        decl,
+                        &child,
+                        &member_path,
+                        &name,
+                        depth + 1,
+                        out,
+                    );
+                    continue;
+                }
+                TypeKind::Sum => {
+                    // A sum's leaves are a selector plus one group per
+                    // alternative, laid out side by side at a FIXED position.
+                    // A `Vec` of them has variable arity; an `Option` of one
+                    // needs a present flag the unfold leaf list has no notion of
+                    // (the `fromParts` bridge's `PlanFieldKind::Sum` does — a
+                    // data-class field can be `Option<sum>`).
+                    assert!(
+                        vec_inner_type(&bare).is_none(),
+                        "expand_return!({}).fields(fields!({})): field `{}.{}` is a \
+                         `Vec<{}>` — a sequence of tag-gated groups has variable arity and \
+                         cannot be laid out in a fixed leaf list",
+                        key.as_str(),
+                        decl.func,
+                        st.ident,
+                        dotted,
+                        probe.to_token_stream(),
+                    );
+                    assert!(
+                        option_inner_type(&field.ty).is_none(),
+                        "expand_return!({}).fields(fields!({})): field `{}.{}` is an \
+                         `Option<{}>` — an optional sum would need a present flag beside its \
+                         tag, which an output leaf list cannot carry. Give the field a \
+                         payload-less alternative instead of wrapping the sum in `Option`, \
+                         or override it with .field(\"{}\", ...)",
+                        key.as_str(),
+                        decl.func,
+                        st.ident,
+                        dotted,
+                        probe.to_token_stream(),
+                        dotted,
+                    );
+                    let ident = bare_path_ident(&probe).expect("a sum type is a path type");
+                    let (item_enum, _) = registry
+                        .enums
+                        .get(&ident)
+                        .expect("TypeKind::Sum implies an indexed enum");
+                    let sum_cfg = self.types[&TypeKey::from_type(&probe)]
+                        .sum()
+                        .expect("TypeKind::Sum implies a sealed-class config");
+                    out.push(FieldRecord {
+                        members: member_path,
+                        name,
+                        ty: field.ty.clone(),
+                        decon: FieldDecon::Leaves(crate::api::lang::jnigen::jni::synth_sum_leaves(
+                            self, sum_cfg, item_enum,
+                        )),
+                    });
+                    continue;
+                }
+                _ => {}
             }
 
             out.push(FieldRecord {
                 members: member_path,
                 name,
                 ty: field.ty.clone(),
-                records: None,
+                decon: FieldDecon::Default,
             });
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -748,6 +748,7 @@ impl JniGen {
     /// once, on the member), else the camel-cased Rust name.
     fn lower_fields(
         &self,
+        registry: &Registry<KotlinMeta>,
         key: &TypeKey,
         fields: &[LocalField],
     ) -> Vec<crate::api::core::unfold::DeconRecord> {
@@ -755,6 +756,10 @@ impl JniGen {
         fields
             .iter()
             .map(|f| match f {
+                LocalField::Fields(decl) => DeconRecord::Fields {
+                    func: decl.func.clone(),
+                    fields: self.lower_value_form(registry, key, decl),
+                },
                 LocalField::Named(func, name_override) => {
                     let name = name_override
                         .clone()
@@ -782,6 +787,194 @@ impl JniGen {
             .collect()
     }
 
+    /// Expand a `.fields(fields!(f))` declaration into one
+    /// [`FieldRecord`](crate::api::core::unfold::FieldRecord) per field of the
+    /// struct `f` returns — the value form.
+    ///
+    /// The walk is the adapter's job because only it knows which structs are
+    /// declared `data_class!`es: a **non-optional** nested one is inlined (its
+    /// own fields become records with `__`-joined names), matching what
+    /// `synth_value_struct_leaves` does for a by-value data class; everything
+    /// else is one record and core decides whether that record's type splices
+    /// its own `expand_return!`.
+    ///
+    /// Per-field `.field(...)` overrides and `.name(...)` renames key on the
+    /// **Rust field ident**, and both are checked against the struct: naming a
+    /// field the value form doesn't have is a hard error, which is the point —
+    /// a field renamed upstream must not silently lose its adjustment.
+    fn lower_value_form(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        key: &TypeKey,
+        decl: &FieldsDecl,
+    ) -> Vec<crate::api::core::unfold::FieldRecord> {
+        let func = &decl.func;
+        let (item_fn, _) = registry.functions.get(func).unwrap_or_else(|| {
+            panic!(
+                "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
+                 `{func}` — a value form is an accessor `fn {func}(v: &{}) -> {}Struct`",
+                key.as_str(),
+                key.as_str(),
+                key.as_str(),
+            )
+        });
+        let ret: syn::Type = match &item_fn.sig.output {
+            syn::ReturnType::Type(_, t) => crate::api::core::unfold::peel_ref(t),
+            syn::ReturnType::Default => panic!(
+                "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
+                 value form returns the struct holding this type's fields",
+                key.as_str()
+            ),
+        };
+        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, &ret) else {
+            panic!(
+                "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
+                 not a struct — a value form returns a struct whose fields become the leaves",
+                key.as_str(),
+                ret.to_token_stream(),
+            )
+        };
+        let st = st.clone();
+
+        let mut out = Vec::new();
+        self.walk_value_form(registry, key, decl, &st, &[], "", 0, &mut out);
+
+        // Every adjustment must have found its field. An unknown name is the
+        // drift this whole declarator exists to catch, so it is an error rather
+        // than a no-op.
+        let named: std::collections::HashSet<String> = out
+            .iter()
+            .map(|r: &crate::api::core::unfold::FieldRecord| {
+                r.members
+                    .iter()
+                    .map(|m| m.to_string())
+                    .collect::<Vec<_>>()
+                    .join(".")
+            })
+            .collect();
+        for (field, _) in decl.overrides.iter() {
+            assert!(
+                named.contains(field),
+                "fields!({func}).field(\"{field}\", ...): `{}` has no field `{field}` \
+                 (fields: {})",
+                st.ident,
+                named.iter().cloned().collect::<Vec<_>>().join(", "),
+            );
+        }
+        for (field, _) in decl.names.iter() {
+            assert!(
+                named.contains(field),
+                "fields!({func}).name(\"{field}\", ...): `{}` has no field `{field}` \
+                 (fields: {})",
+                st.ident,
+                named.iter().cloned().collect::<Vec<_>>().join(", "),
+            );
+        }
+        out
+    }
+
+    /// One level of [`Self::lower_value_form`]'s struct walk. `members` /
+    /// `name_prefix` accumulate through inlined nested data classes; an
+    /// override or rename keys on the dotted member path, so a nested field is
+    /// addressed as `"outer.inner"`.
+    #[allow(clippy::too_many_arguments)]
+    fn walk_value_form(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        key: &TypeKey,
+        decl: &FieldsDecl,
+        st: &syn::ItemStruct,
+        members: &[syn::Ident],
+        name_prefix: &str,
+        depth: usize,
+        out: &mut Vec<crate::api::core::unfold::FieldRecord>,
+    ) {
+        use crate::api::core::unfold::FieldRecord;
+        let syn::Fields::Named(named) = &st.fields else {
+            panic!(
+                "expand_return!({}).fields(fields!({})): `{}` has no named fields — a value \
+                 form is a plain struct whose fields become the leaves",
+                key.as_str(),
+                decl.func,
+                st.ident,
+            )
+        };
+        // A value form holding itself would expand forever; the cycle rule for
+        // everything reachable BELOW a field is core's `visited` check.
+        assert!(
+            depth <= 16,
+            "expand_return!({}).fields(fields!({})): `{}` nests data classes more than 16 \
+             deep — is a value form holding itself?",
+            key.as_str(),
+            decl.func,
+            st.ident,
+        );
+        for field in &named.named {
+            let Some(fname) = field.ident.as_ref() else {
+                continue;
+            };
+            let mut member_path = members.to_vec();
+            member_path.push(fname.clone());
+            let dotted = member_path
+                .iter()
+                .map(|m| m.to_string())
+                .collect::<Vec<_>>()
+                .join(".");
+            let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
+            let name = decl
+                .names
+                .iter()
+                .find(|(f, _)| *f == dotted)
+                .map(|(_, n)| n.clone())
+                .unwrap_or(camel);
+            let name = if name_prefix.is_empty() {
+                name
+            } else {
+                format!("{name_prefix}__{name}")
+            };
+
+            // An explicit override replaces the field type's default
+            // decomposition wholesale — including any nesting it would have had.
+            if let Some((_, ovr)) = decl.overrides.iter().find(|(f, _)| *f == dotted) {
+                out.push(FieldRecord {
+                    members: member_path,
+                    name,
+                    ty: field.ty.clone(),
+                    records: Some(self.lower_fields(registry, &ovr.key, &ovr.fields)),
+                });
+                continue;
+            }
+
+            // A nested `data_class!` inlines when it is reached directly; behind
+            // `Option` / `Vec` it stays one leaf, whose own converter builds the
+            // object (the rule `synth_value_struct_leaves` already follows).
+            let nested = match self.type_kind(registry, &field.ty) {
+                TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
+                _ => None,
+            };
+            if let Some(child) = nested {
+                self.walk_value_form(
+                    registry,
+                    key,
+                    decl,
+                    &child,
+                    &member_path,
+                    &name,
+                    depth + 1,
+                    out,
+                );
+                continue;
+            }
+
+            out.push(FieldRecord {
+                members: member_path,
+                name,
+                ty: field.ty.clone(),
+                records: None,
+            });
+        }
+    }
+
     /// Lower the raw [`ExpandReturnDecl`]s into the core's immutable
     /// [`Deconstructors`] record set — the output-side peer of
     /// [`Self::build_expansions`], a pure declaration → record mapping.
@@ -789,7 +982,10 @@ impl JniGen {
     /// them. `skip_output` is derived from the class members: a
     /// `.constructor()` member's return is a factory, never
     /// output-flattened.
-    pub(crate) fn build_deconstructors(&self) -> crate::api::core::unfold::Deconstructors {
+    pub(crate) fn build_deconstructors(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> crate::api::core::unfold::Deconstructors {
         use crate::api::core::unfold::{
             DeconSel, DeconTarget, DeconstructorDecl, Deconstructors, Delivery, OutputDecl,
         };
@@ -817,7 +1013,7 @@ impl JniGen {
             );
             dec.deconstructors.push(DeconstructorDecl {
                 target: decl.key.to_type(),
-                records: self.lower_fields(&decl.key, &decl.fields),
+                records: self.lower_fields(registry, &decl.key, &decl.fields),
                 default: Some((DeconTarget::Output, Delivery::Callback)),
             });
         }
@@ -838,7 +1034,7 @@ impl JniGen {
             );
             dec.outputs.push(OutputDecl {
                 func: func.clone(),
-                sel: DeconSel::Inline(self.lower_fields(&decl.key, &decl.fields)),
+                sel: DeconSel::Inline(self.lower_fields(registry, &decl.key, &decl.fields)),
                 target: DeconTarget::Output,
                 delivery: Delivery::Callback,
                 declared_source: Some(decl.key.to_type()),
@@ -1001,26 +1197,10 @@ impl JniGen {
                 LocalVariant::Ctor(f) => Some(f.clone()),
                 LocalVariant::SelfIdentity => None,
             });
-        let accessors = self
-            .return_expand_decls
-            .iter()
-            .map(|d| &d.fields)
-            .chain(self.fn_return_expands.iter().map(|(_, d)| &d.fields))
-            .flatten()
-            .filter_map(|f| match f {
-                LocalField::Named(func, _) => Some(func.clone()),
-                // A binding-local field's synthesized fn is helper-only too:
-                // called by the generated code, never externed, and its
-                // synthesized registry entry must not trip the warning.
-                LocalField::Local { path, .. } => Some(
-                    path.segments
-                        .last()
-                        .expect("validated non-empty at decl time")
-                        .ident
-                        .clone(),
-                ),
-                LocalField::SelfField => None,
-            });
+        // Includes a binding-local field's synthesized fn (called by the
+        // generated code, never externed, so its synthesized registry entry
+        // must not trip the warning) and a value form's accessor.
+        let accessors = self.field_referenced_fns().into_iter();
         // Synthesized binding-local fns from every entry form (path-built
         // fun! at fun/method/constructor/convert sites): their registry
         // entries exist only for signature reads — helper-only unless also
@@ -1037,26 +1217,52 @@ impl JniGen {
     /// from parameter composition. Derived from *usage* — a function need not
     /// also be a `.method()` class member to be referenced this way.
     pub(crate) fn field_accessor_fns(&self) -> std::collections::HashSet<syn::Ident> {
-        self.return_expand_decls
+        self.field_referenced_fns().into_iter().collect()
+    }
+
+    /// Every function ident referenced as a field by any `expand_return!` decl
+    /// (type-level or per-fn), recursing into a value form's per-field
+    /// overrides. The one walk behind both [`Self::field_accessor_fns`] and the
+    /// helper-only set in [`Self::boundary_referenced_fns`] — they ask the same
+    /// question of the same declarations, so a new field kind is taught to both
+    /// at once.
+    fn field_referenced_fns(&self) -> Vec<syn::Ident> {
+        fn walk(fields: &[LocalField], out: &mut Vec<syn::Ident>) {
+            for f in fields {
+                match f {
+                    LocalField::Named(func, _) => out.push(func.clone()),
+                    // A binding-local field's synthesized fn IS an accessor —
+                    // excluded from parameter composition, and acknowledged so
+                    // the registry's "skipping undeclared" warning stays quiet.
+                    LocalField::Local { path, .. } => out.push(
+                        path.segments
+                            .last()
+                            .expect("validated non-empty at decl time")
+                            .ident
+                            .clone(),
+                    ),
+                    LocalField::SelfField => {}
+                    // The value form's own accessor, plus whatever its
+                    // per-field overrides reference.
+                    LocalField::Fields(d) => {
+                        out.push(d.func.clone());
+                        for (_, ovr) in &d.overrides {
+                            walk(&ovr.fields, out);
+                        }
+                    }
+                }
+            }
+        }
+        let mut out = Vec::new();
+        for fields in self
+            .return_expand_decls
             .iter()
             .map(|d| &d.fields)
             .chain(self.fn_return_expands.iter().map(|(_, d)| &d.fields))
-            .flatten()
-            .filter_map(|f| match f {
-                LocalField::Named(func, _) => Some(func.clone()),
-                // A binding-local field's synthesized fn IS an accessor —
-                // excluded from parameter composition, and acknowledged so
-                // the registry's "skipping undeclared" warning stays quiet.
-                LocalField::Local { path, .. } => Some(
-                    path.segments
-                        .last()
-                        .expect("validated non-empty at decl time")
-                        .ident
-                        .clone(),
-                ),
-                LocalField::SelfField => None,
-            })
-            .collect()
+        {
+            walk(fields, &mut out);
+        }
+        out
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -942,8 +942,12 @@ impl JniGen {
                 // return. Without this an override outlives an upstream
                 // field-type change — the very drift `.fields()` exists to
                 // catch — and two same-shaped handle types silently swap.
-                let peeled = vec_inner_type(&field.ty)
-                    .or_else(|| option_inner_type(&field.ty))
+                // Core applies override records to the whole field after
+                // peeling only an outer `Option`: a `Vec<T>` remains `Vec<T>`.
+                // Mirror that exact normalization here; peeling `Vec` would
+                // accept `expand_return!(T)` and only fail later when core
+                // applies its records to `Vec<T>`.
+                let peeled = option_inner_type(&field.ty)
                     .map(|t| crate::api::core::unfold::peel_ref(&t))
                     .unwrap_or_else(|| crate::api::core::unfold::peel_ref(&field.ty));
                 let actual = TypeKey::from_type(&peeled);

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -758,6 +758,7 @@ impl JniGen {
             .map(|f| match f {
                 LocalField::Fields(decl) => DeconRecord::Fields {
                     func: decl.func.clone(),
+                    consuming: decl.consuming,
                     fields: self.lower_value_form(registry, key, decl),
                 },
                 LocalField::Named(func, name_override) => {

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -51,6 +51,11 @@ pub(crate) enum LocalField {
         sig: syn::Signature,
         name_override: Option<String>,
     },
+    /// Include **every field of the type's value form** — the struct returned
+    /// by the named accessor — each as its own field. Expands to the same
+    /// records the fields would produce if named one by one; see
+    /// [`ExpandReturnDecl::fields`].
+    Fields(FieldsDecl),
 }
 
 // Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
@@ -289,6 +294,16 @@ macro_rules! try_into {
 macro_rules! expand_return {
     ($t:ty) => {
         $crate::lang::ExpandReturnDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build a [`FieldsDecl`] from the ident of a **value-form accessor** —
+/// `fields!(sample_to_struct)` is `FieldsDecl::new(prebindgen::ident!(sample_to_struct))`.
+/// The argument of [`ExpandReturnDecl::fields`](crate::lang::ExpandReturnDecl::fields).
+#[macro_export]
+macro_rules! fields {
+    ($name:ident) => {
+        $crate::lang::FieldsDecl::new($crate::ident!($name))
     };
 }
 
@@ -718,6 +733,115 @@ impl ExpandReturnDecl {
     /// so the generated Rust moves the value only after those borrows.
     pub fn field_self(mut self) -> Self {
         self.fields.push(LocalField::SelfField);
+        self
+    }
+
+    /// Take the fields from the type's **value form** — a `#[prebindgen]`
+    /// accessor `f(&Self) -> SelfStruct` returning "this type's own accessors
+    /// gathered into one struct" — instead of restating them.
+    ///
+    /// `.fields(fields!(f))` is exactly `.field(...)` applied to each field of
+    /// that struct, so it has the same configurability (per-field overrides and
+    /// renames live on the [`FieldsDecl`]) and, crucially, the same
+    /// decomposition rule: **each field crosses by its own type's default
+    /// output boundary**. A field whose type has its own `expand_return!` is
+    /// decomposed by it (a `KeyExpr` field still crosses as its string, not as
+    /// a handle); a declared `data_class!` field expands into its fields; a
+    /// field behind `Option` / `Vec` stays one leaf. So swapping a hand-written
+    /// field list for `.fields(...)` keeps the boundary shape it already had —
+    /// what changes is that the list can no longer drift from the struct.
+    ///
+    /// ```
+    /// // Instead of restating SampleStruct's fields one by one:
+    /// let _ = prebindgen::expand_return!(Sample)
+    ///     .fields(prebindgen::fields!(sample_to_struct));
+    /// ```
+    ///
+    /// Mixes with the other declarators — `.fields(...).field_self()` delivers
+    /// the value form's fields *and* the live handle. At most one per decl.
+    pub fn fields(mut self, decl: FieldsDecl) -> Self {
+        assert!(
+            !self
+                .fields
+                .iter()
+                .any(|f| matches!(f, LocalField::Fields(_))),
+            "expand_return!({}).fields(fields!({})): the decl already expands a value form — \
+             one value form states the whole field set",
+            self.key.as_str(),
+            decl.func
+        );
+        self.fields.push(LocalField::Fields(decl));
+        self
+    }
+}
+
+/// A **value-form expansion**: the accessor whose returned struct supplies the
+/// fields, plus the per-field adjustments. Built with
+/// [`fields!`](crate::fields) and handed to
+/// [`ExpandReturnDecl::fields`].
+///
+/// Both adjusters key on the **Rust struct field name**, mirroring
+/// [`FunctionDecl::expand_param`]'s Rust-parameter-name key: an unknown field
+/// name or a repeated one is a hard error, so a field renamed upstream is
+/// caught rather than silently ignored.
+#[derive(Clone)]
+pub struct FieldsDecl {
+    pub(crate) func: syn::Ident,
+    pub(crate) overrides: Vec<(String, ExpandReturnDecl)>,
+    pub(crate) names: Vec<(String, String)>,
+}
+
+impl FieldsDecl {
+    pub fn new(func: syn::Ident) -> Self {
+        Self {
+            func,
+            overrides: Vec::new(),
+            names: Vec::new(),
+        }
+    }
+
+    /// Replace **one** field's decomposition, with the same
+    /// [`ExpandReturnDecl`] a type-level default uses — so the complete-set
+    /// rule applies here too: the decl states that field's entire leaf set.
+    /// Use it where the field's type default is not what this boundary wants
+    /// (a lone `.field_self()` keeps the raw handle instead of decomposing it).
+    pub fn field(mut self, field: impl AsRef<str>, decl: ExpandReturnDecl) -> Self {
+        let field = field.as_ref().to_string();
+        assert!(
+            !self.overrides.iter().any(|(f, _)| *f == field),
+            "fields!({}).field(\"{}\", ...): field already has an override — declare its \
+             complete field set in ONE decl",
+            self.func,
+            field
+        );
+        self.overrides.push((field, decl));
+        self
+    }
+
+    /// Rename **one** field's leaf, overriding the name derived from the struct
+    /// field ident. The literal Kotlin name, like `fun!(f).name(...)`.
+    pub fn name(mut self, field: impl AsRef<str>, kotlin_name: impl Into<String>) -> Self {
+        let field = field.as_ref().to_string();
+        let kotlin_name = kotlin_name.into();
+        assert!(
+            !self.names.iter().any(|(f, _)| *f == field),
+            "fields!({}).name(\"{}\", ...): field is already renamed",
+            self.func,
+            field
+        );
+        // The derived names of inlined nested fields are joined with `"__"`, so
+        // an author name carrying one would forge a nesting that isn't there.
+        // (Core rejects it for a `.field()` name; here the name never reaches
+        // that check, so it is made at the point of declaration.)
+        assert!(
+            !kotlin_name.contains("__"),
+            "fields!({}).name(\"{}\", \"{}\"): `__` is the reserved chain separator \
+             and cannot appear in a leaf name",
+            self.func,
+            field,
+            kotlin_name,
+        );
+        self.names.push((field, kotlin_name));
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -738,7 +738,7 @@ impl ExpandReturnDecl {
         self
     }
 
-    /// The one rule [`Self::fields_into`] adds: it hands the value **itself**
+    /// The one rule [`Self::fields_self_into`] adds: it hands the value **itself**
     /// over, so nothing else in the decl can still read it.
     fn reject_beside_consuming(&self, what: &str) {
         if let Some(f) = self.fields.iter().find_map(|f| match f {
@@ -746,7 +746,7 @@ impl ExpandReturnDecl {
             _ => None,
         }) {
             panic!(
-                "expand_return!({k}).fields_into(fields!({f})).{what}: `.fields_into(..)` hands \
+                "expand_return!({k}).fields_self_into(fields!({f})).{what}: `.fields_self_into(..)` hands \
                  the value ITSELF over as its fields, so nothing else can read it afterwards — \
                  it must be the decl's only record. Use `.fields(fields!(..))` with the \
                  borrowing form of the accessor if you need both.",
@@ -785,7 +785,7 @@ impl ExpandReturnDecl {
     ///
     /// Where the value is delivered **owned** — a callback argument
     /// (`impl Fn(Sample)`), an owned return — and nothing else needs it, use
-    /// [`fields_into`](Self::fields_into) instead: those clones are being paid
+    /// [`fields_self_into`](Self::fields_self_into) instead: those clones are being paid
     /// on a value that is about to be dropped.
     pub fn fields(mut self, decl: FieldsDecl) -> Self {
         self.reject_beside_consuming("fields(..)");
@@ -800,14 +800,14 @@ impl ExpandReturnDecl {
     ///
     /// This is the same decision [`field_self`](Self::field_self) makes, one
     /// step further: `.field_self()` hands the value over whole,
-    /// `.fields_into(...)` hands *the value itself* over as its parts, and
+    /// `.fields_self_into(...)` hands *the value itself* over as its parts, and
     /// `.fields(...)` hands over a copy of its parts. Use it wherever the value
     /// arrives owned and is not needed afterwards — the hot receive path this
     /// whole declarator exists to make cheap.
     ///
     /// ```
     /// let _ = prebindgen::expand_return!(Sample)
-    ///     .fields_into(prebindgen::fields!(sample_into_struct));
+    ///     .fields_self_into(prebindgen::fields!(sample_into_struct));
     /// ```
     ///
     /// Because it gives the value away it must be the decl's **only** record —
@@ -824,11 +824,11 @@ impl ExpandReturnDecl {
     /// so the emitter clones once up front and consumes the clone — the same
     /// cost the borrowing form would have paid, which keeps one declaration
     /// usable by both owned and `&T` returns of the type.
-    pub fn fields_into(mut self, decl: FieldsDecl) -> Self {
+    pub fn fields_self_into(mut self, decl: FieldsDecl) -> Self {
         self.reject_second_value_form(&decl);
         assert!(
             self.fields.is_empty(),
-            "expand_return!({k}).fields_into(fields!({f})): `.fields_into(..)` hands the value \
+            "expand_return!({k}).fields_self_into(fields!({f})): `.fields_self_into(..)` hands the value \
              ITSELF over as its fields, so it must be the decl's only record — the records \
              already declared would read a value that is gone. Use `.fields(fields!(..))` with \
              the borrowing form of the accessor if you need both.",
@@ -867,7 +867,7 @@ pub struct FieldsDecl {
     pub(crate) func: syn::Ident,
     pub(crate) overrides: Vec<(String, ExpandReturnDecl)>,
     pub(crate) names: Vec<(String, String)>,
-    /// Set by [`ExpandReturnDecl::fields_into`] — the accessor consumes its
+    /// Set by [`ExpandReturnDecl::fields_self_into`] — the accessor consumes its
     /// receiver. Declared rather than read off the signature, because giving
     /// the value away is a boundary decision; the two are cross-checked when
     /// the records are resolved.

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -737,8 +737,8 @@ impl ExpandReturnDecl {
     }
 
     /// Take the fields from the type's **value form** — a `#[prebindgen]`
-    /// accessor `f(&Self) -> SelfStruct` returning "this type's own accessors
-    /// gathered into one struct" — instead of restating them.
+    /// accessor returning "this type's own accessors gathered into one struct"
+    /// — instead of restating them.
     ///
     /// `.fields(fields!(f))` is exactly `.field(...)` applied to each field of
     /// that struct, so it has the same configurability (per-field overrides and
@@ -757,7 +757,31 @@ impl ExpandReturnDecl {
     ///     .fields(prebindgen::fields!(sample_to_struct));
     /// ```
     ///
-    /// Mixes with the other declarators — `.fields(...).field_self()` delivers
+    /// # Borrowing or consuming
+    ///
+    /// The accessor's receiver decides how the fields are read, and the choice
+    /// is **inferred from its signature** so it cannot drift from it:
+    ///
+    /// * `f(v: &Self) -> SelfStruct` — **borrowing**. The struct is built from
+    ///   a borrow, so each field is cloned into it, and the leaves clone again
+    ///   out of the struct.
+    /// * `f(v: Self) -> SelfStruct` — **consuming**. The value is moved in and
+    ///   each field is moved *out* into its leaf. No clones at all.
+    ///
+    /// Prefer the consuming form wherever the value is delivered owned — a
+    /// callback argument (`impl Fn(Sample)`) or an owned return — which is the
+    /// hot path this whole declarator exists to make cheap. There is nothing to
+    /// preserve there: the borrowing form clones fields out of a value it is
+    /// about to drop.
+    ///
+    /// Because a consuming form moves the value, it must be the decl's **only**
+    /// record (no `.field_self()`, no sibling `.field()` — they would read a
+    /// moved value) and it cannot be reached through another value form. Both
+    /// are declaration-time errors. A function returning `&Self` clones once up
+    /// front and consumes the clone, so one declaration still serves owned and
+    /// borrowed returns alike.
+    ///
+    /// A **borrowing** form mixes freely — `.fields(...).field_self()` delivers
     /// the value form's fields *and* the live handle. At most one per decl.
     pub fn fields(mut self, decl: FieldsDecl) -> Self {
         assert!(

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -697,6 +697,7 @@ impl ExpandReturnDecl {
     /// decomposition comes from ITS type's boundary decl, not from the
     /// accessor).
     pub fn field(mut self, accessor: FunctionDecl) -> Self {
+        self.reject_beside_consuming("field(..)");
         assert!(
             accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
             "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
@@ -732,8 +733,27 @@ impl ExpandReturnDecl {
     /// Declare it **last**, after any field that decomposes a nested handle,
     /// so the generated Rust moves the value only after those borrows.
     pub fn field_self(mut self) -> Self {
+        self.reject_beside_consuming("field_self()");
         self.fields.push(LocalField::SelfField);
         self
+    }
+
+    /// The one rule [`Self::fields_into`] adds: it hands the value **itself**
+    /// over, so nothing else in the decl can still read it.
+    fn reject_beside_consuming(&self, what: &str) {
+        if let Some(f) = self.fields.iter().find_map(|f| match f {
+            LocalField::Fields(d) if d.consuming => Some(&d.func),
+            _ => None,
+        }) {
+            panic!(
+                "expand_return!({k}).fields_into(fields!({f})).{what}: `.fields_into(..)` hands \
+                 the value ITSELF over as its fields, so nothing else can read it afterwards — \
+                 it must be the decl's only record. Use `.fields(fields!(..))` with the \
+                 borrowing form of the accessor if you need both.",
+                k = self.key.as_str(),
+                f = f,
+            );
+        }
     }
 
     /// Take the fields from the type's **value form** — a `#[prebindgen]`
@@ -757,45 +777,79 @@ impl ExpandReturnDecl {
     ///     .fields(prebindgen::fields!(sample_to_struct));
     /// ```
     ///
-    /// # Borrowing or consuming
+    /// The accessor **borrows** its receiver (`f(v: &Self) -> SelfStruct`):
+    /// the struct is built from a borrow, so each field is cloned into it and
+    /// the leaves clone again out of it, and the value survives. It therefore
+    /// mixes freely — `.fields(...).field_self()` delivers the value form's
+    /// fields *and* the live handle. At most one value form per decl.
     ///
-    /// The accessor's receiver decides how the fields are read, and the choice
-    /// is **inferred from its signature** so it cannot drift from it:
-    ///
-    /// * `f(v: &Self) -> SelfStruct` — **borrowing**. The struct is built from
-    ///   a borrow, so each field is cloned into it, and the leaves clone again
-    ///   out of the struct.
-    /// * `f(v: Self) -> SelfStruct` — **consuming**. The value is moved in and
-    ///   each field is moved *out* into its leaf. No clones at all.
-    ///
-    /// Prefer the consuming form wherever the value is delivered owned — a
-    /// callback argument (`impl Fn(Sample)`) or an owned return — which is the
-    /// hot path this whole declarator exists to make cheap. There is nothing to
-    /// preserve there: the borrowing form clones fields out of a value it is
-    /// about to drop.
-    ///
-    /// Because a consuming form moves the value, it must be the decl's **only**
-    /// record (no `.field_self()`, no sibling `.field()` — they would read a
-    /// moved value) and it cannot be reached through another value form. Both
-    /// are declaration-time errors. A function returning `&Self` clones once up
-    /// front and consumes the clone, so one declaration still serves owned and
-    /// borrowed returns alike.
-    ///
-    /// A **borrowing** form mixes freely — `.fields(...).field_self()` delivers
-    /// the value form's fields *and* the live handle. At most one per decl.
+    /// Where the value is delivered **owned** — a callback argument
+    /// (`impl Fn(Sample)`), an owned return — and nothing else needs it, use
+    /// [`fields_into`](Self::fields_into) instead: those clones are being paid
+    /// on a value that is about to be dropped.
     pub fn fields(mut self, decl: FieldsDecl) -> Self {
+        self.reject_beside_consuming("fields(..)");
+        self.reject_second_value_form(&decl);
+        self.fields.push(LocalField::Fields(decl));
+        self
+    }
+
+    /// Like [`fields`](Self::fields), but the accessor **consumes** its
+    /// receiver (`f(v: Self) -> SelfStruct`): the value is moved in and each
+    /// field is moved *out* into its leaf. No clones at all.
+    ///
+    /// This is the same decision [`field_self`](Self::field_self) makes, one
+    /// step further: `.field_self()` hands the value over whole,
+    /// `.fields_into(...)` hands *the value itself* over as its parts, and
+    /// `.fields(...)` hands over a copy of its parts. Use it wherever the value
+    /// arrives owned and is not needed afterwards — the hot receive path this
+    /// whole declarator exists to make cheap.
+    ///
+    /// ```
+    /// let _ = prebindgen::expand_return!(Sample)
+    ///     .fields_into(prebindgen::fields!(sample_into_struct));
+    /// ```
+    ///
+    /// Because it gives the value away it must be the decl's **only** record —
+    /// a `.field_self()` or a sibling `.field(...)` would read a value that is
+    /// gone — which is a declaration-time panic either way round. It may still
+    /// be reached through *another* value form: the parent's field is handed to
+    /// it by move, since a hoisted value form is an owned struct and its fields
+    /// are disjoint.
+    ///
+    /// The declarator and the accessor's signature must agree; naming a
+    /// `&Self` accessor here (or a by-value one on [`fields`](Self::fields)) is
+    /// an error, so the declared intent cannot drift from the function it
+    /// names. At a **borrowed** delivery position there is no value to give up,
+    /// so the emitter clones once up front and consumes the clone — the same
+    /// cost the borrowing form would have paid, which keeps one declaration
+    /// usable by both owned and `&T` returns of the type.
+    pub fn fields_into(mut self, decl: FieldsDecl) -> Self {
+        self.reject_second_value_form(&decl);
+        assert!(
+            self.fields.is_empty(),
+            "expand_return!({k}).fields_into(fields!({f})): `.fields_into(..)` hands the value \
+             ITSELF over as its fields, so it must be the decl's only record — the records \
+             already declared would read a value that is gone. Use `.fields(fields!(..))` with \
+             the borrowing form of the accessor if you need both.",
+            k = self.key.as_str(),
+            f = decl.func,
+        );
+        self.fields.push(LocalField::Fields(decl.consuming()));
+        self
+    }
+
+    fn reject_second_value_form(&self, decl: &FieldsDecl) {
         assert!(
             !self
                 .fields
                 .iter()
                 .any(|f| matches!(f, LocalField::Fields(_))),
-            "expand_return!({}).fields(fields!({})): the decl already expands a value form — \
+            "expand_return!({}): the decl already expands a value form (fields!({})) — \
              one value form states the whole field set",
             self.key.as_str(),
             decl.func
         );
-        self.fields.push(LocalField::Fields(decl));
-        self
     }
 }
 
@@ -813,6 +867,11 @@ pub struct FieldsDecl {
     pub(crate) func: syn::Ident,
     pub(crate) overrides: Vec<(String, ExpandReturnDecl)>,
     pub(crate) names: Vec<(String, String)>,
+    /// Set by [`ExpandReturnDecl::fields_into`] — the accessor consumes its
+    /// receiver. Declared rather than read off the signature, because giving
+    /// the value away is a boundary decision; the two are cross-checked when
+    /// the records are resolved.
+    pub(crate) consuming: bool,
 }
 
 impl FieldsDecl {
@@ -821,7 +880,13 @@ impl FieldsDecl {
             func,
             overrides: Vec::new(),
             names: Vec::new(),
+            consuming: false,
         }
+    }
+
+    pub(crate) fn consuming(mut self) -> Self {
+        self.consuming = true;
+        self
     }
 
     /// Replace **one** field's decomposition, with the same

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -428,34 +428,44 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    // A `.fields()` plan reaches every one of its leaves through ONE call of
-    // the value form: bind it to a local first, so the struct is built once
-    // per delivery rather than once per field.
-    let vf = format_ident!("__vf");
-    let mut stmts = match &plan.root_call {
-        Some(f) => {
-            let m = qualify(f);
-            let base = if by_ref {
-                value.clone()
-            } else {
-                quote!(&#value)
-            };
-            quote! { let #vf = #m::#f(#base); }
+    // Every value form on the plan is evaluated ONCE and bound to a local, so
+    // the struct is built once per delivery rather than once per field. Value
+    // forms compose, so this is a list: each hoist is composed from the longest
+    // hoist that is already a proper prefix of it (they arrive outermost-first),
+    // and from `value` otherwise.
+    let mut stmts = TokenStream::new();
+    let mut bound: Vec<(&[PathStep], syn::Ident)> = Vec::new();
+    // The longest already-bound prefix of `path`, if any.
+    let longest_bound =
+        |bound: &[(&[PathStep], syn::Ident)], path: &[PathStep]| -> Option<(usize, syn::Ident)> {
+            bound
+                .iter()
+                .filter(|(p, _)| p.len() < path.len() && path.starts_with(p))
+                .max_by_key(|(p, _)| p.len())
+                .map(|(p, id)| (p.len(), id.clone()))
+        };
+    for (i, prefix) in plan.hoists.iter().enumerate() {
+        let local = format_ident!("__vf{}", i);
+        let (from, mut expr) = match longest_bound(&bound, prefix) {
+            Some((at, outer)) => (at, quote!(&#outer)),
+            None if by_ref => (0, value.clone()),
+            None => (0, quote!(&#value)),
+        };
+        for step in &prefix[from..] {
+            expr = compose_step(&qualify, step, expr);
         }
-        None => TokenStream::new(),
-    };
-    // Leaves that go through the value form reach off that local with the
-    // shared `Call` step already consumed; a sibling `.field()` / `.field_self()`
-    // leaf still reaches from the value itself.
+        stmts.extend(quote! { let #local = #expr; });
+        bound.push((prefix.as_slice(), local));
+    }
+
+    // Reach a leaf off the innermost value form it sits under, with that
+    // prefix's steps already consumed; a leaf under none of them (a sibling
+    // `.field()` / `.field_self()`) still reaches from the value itself.
     let rebase =
         |leaf: &crate::api::core::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>) {
-            match (&plan.root_call, leaf.path.split_first()) {
-                (Some(rc), Some((PathStep::Call { ident, .. }, rest)))
-                    if ident == rc && !rest.is_empty() =>
-                {
-                    (quote!(#vf), false, rest.to_vec())
-                }
-                _ => (value.clone(), by_ref, leaf.path.clone()),
+            match longest_bound(&bound, &leaf.path) {
+                Some((at, local)) => (quote!(#local), false, leaf.path[at..].to_vec()),
+                None => (value.clone(), by_ref, leaf.path.clone()),
             }
         };
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -514,6 +514,28 @@ pub(crate) fn encode_plan_leaves(
     for (i, h) in plan.hoists.iter().enumerate() {
         let local = format_ident!("__vf{}", i);
         let (from, mut expr) = match longest_bound(&bound, &h.prefix) {
+            // A NESTED consuming form is handed the parent's field by MOVE: a
+            // hoisted value form is an owned struct and its fields are
+            // disjoint, so moving one out leaves every sibling leaf readable.
+            // `compose_step` borrows (`&(e).f`), so the field run to that field
+            // is projected here instead of going through it.
+            Some((at, outer)) if h.consuming => {
+                let last = h.prefix.len() - 1;
+                let lead = &h.prefix[at..last];
+                if lead.iter().all(PathStep::is_plain_field) {
+                    let segs: Vec<&syn::Ident> = lead.iter().map(PathStep::ident).collect();
+                    (last, quote!(#outer #(.#segs)*))
+                } else {
+                    // Reached through an accessor call, so what is in hand is a
+                    // borrow with nothing to give up — clone once and consume
+                    // the clone, exactly as a borrowed root does below.
+                    let mut e = quote!(&#outer);
+                    for step in lead {
+                        e = compose_step(&qualify, step, e);
+                    }
+                    (last, quote!((#e).clone()))
+                }
+            }
             Some((at, outer)) => (at, quote!(&#outer)),
             // A CONSUMING value form is handed the value itself, so its fields
             // move out instead of being cloned out of a borrow. A borrowed plan

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -394,10 +394,11 @@ pub(crate) fn reach_leaf_flat(
     // resolved to the owned type precisely so the owning converter boxes the
     // move instead of the borrowed one cloning it.
     //
-    // A trailing `Option` step is excluded here, not by `steps_are_movable`:
-    // return delivery has no `None` arm to put the absent case in, so the whole
-    // `Option` would have to reach the converter — which is what the callback
-    // path's nullable branch does with a `match`.
+    // A trailing `Option` step cannot arrive here at all: return delivery has
+    // no `None` arm for the absent case, so a nullable leaf is routed to
+    // callback delivery when the plan picks its `Delivery` — see
+    // `single_return` in `core/unfold.rs`. `is_plain_field` is what that rules
+    // out, and it stays as the local statement of the same fact.
     if consuming
         && !matches!(leaf.out_ty, syn::Type::Reference(_))
         && path.iter().all(PathStep::is_plain_field)

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -370,8 +370,10 @@ fn project_leading_fields(
 pub(crate) fn reach_leaf_flat(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
     leaf: &crate::api::core::unfold::UnfoldLeaf,
+    path: &[PathStep],
     base: TokenStream,
     base_is_ref: bool,
+    consuming: bool,
 ) -> TokenStream {
     use crate::api::core::unfold::LeafSource;
     // An optional step BEFORE the last one needs a `match` whose `None` arm has
@@ -379,14 +381,21 @@ pub(crate) fn reach_leaf_flat(
     // not a `JObject` that could be null — so the shape is refused here rather
     // than composed into code that cannot type-check in the consumer's crate.
     assert!(
-        !leaf.path.iter().rev().skip(1).any(PathStep::is_optional),
+        !path.iter().rev().skip(1).any(PathStep::is_optional),
         "jnigen unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
         leaf.name,
     );
-    let (mut e, lead) = project_leading_fields(&base, base_is_ref, &leaf.path);
-    for step in &leaf.path[lead..] {
+    // Under a CONSUMING value form the leaf OWNS its field, so it is moved out
+    // rather than cloned — the same rule `reach`'s `LeafSource::Field` arm
+    // applies on the multi-leaf path, and the reason both live in this file.
+    if leaf.source == LeafSource::Field && consuming && path.iter().all(PathStep::is_plain_field) {
+        let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+        return quote!(#base #(.#segs)*);
+    }
+    let (mut e, lead) = project_leading_fields(&base, base_is_ref, path);
+    for step in &path[lead..] {
         e = compose_step(qualify, step, e);
     }
     if leaf.source == LeafSource::Field {
@@ -394,6 +403,101 @@ pub(crate) fn reach_leaf_flat(
     } else {
         e
     }
+}
+
+/// Every value form on a plan, evaluated **once** and bound to a local
+/// (`__vf0`, `__vf1`, …), so a struct is built once per delivery rather than
+/// once per field. The bound prefixes come back with the statements, since
+/// reaching a leaf means starting from the innermost local it sits under.
+///
+/// Shared by both delivery paths — the multi-leaf encoder below and the
+/// single-leaf `Delivery::Return` shortcut in `emit/wrapper.rs`. The shortcut
+/// used to compose its reach straight off the raw value, which for a consuming
+/// value form emitted `f(&v)` against a by-value receiver: ill-typed Rust in
+/// the consumer's crate. One binder, so the two cannot disagree about what a
+/// hoist is or who owns it.
+pub(crate) struct Hoisted {
+    /// The `let __vfN = …;` bindings, outermost-first.
+    pub(crate) stmts: TokenStream,
+    /// Each hoist's path prefix and the local it was bound to.
+    bound: Vec<(Vec<PathStep>, syn::Ident)>,
+    /// Whether each bound hoist consumed the value it decomposed.
+    consuming: Vec<bool>,
+}
+
+impl Hoisted {
+    /// The innermost bound local `path` sits under, with that prefix already
+    /// consumed, and whether that hoist gave its value away. `None` for a leaf
+    /// under no value form at all — a sibling `.field()` / `.field_self()`,
+    /// which still reaches from the value itself.
+    pub(crate) fn rebase(&self, path: &[PathStep]) -> Option<(syn::Ident, Vec<PathStep>, bool)> {
+        self.bound
+            .iter()
+            .enumerate()
+            .filter(|(_, (p, _))| p.len() < path.len() && path.starts_with(p))
+            .max_by_key(|(_, (p, _))| p.len())
+            .map(|(i, (p, id))| (id.clone(), path[p.len()..].to_vec(), self.consuming[i]))
+    }
+}
+
+pub(crate) fn bind_hoists(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    hoists: &[crate::api::core::unfold::Hoist],
+    value: &TokenStream,
+    by_ref: bool,
+) -> Hoisted {
+    let mut out = Hoisted {
+        stmts: TokenStream::new(),
+        bound: Vec::new(),
+        consuming: Vec::new(),
+    };
+    // Value forms COMPOSE, so each hoist is built from the longest hoist that
+    // is already a proper prefix of it (they arrive outermost-first), and from
+    // `value` otherwise.
+    for (i, h) in hoists.iter().enumerate() {
+        let local = format_ident!("__vf{}", i);
+        let (from, mut expr) = match out.rebase(&h.prefix) {
+            // A NESTED consuming form is handed the parent's field by MOVE: a
+            // hoisted value form is an owned struct and its fields are
+            // disjoint, so moving one out leaves every sibling leaf readable.
+            // `compose_step` borrows (`&(e).f`), so the field run to that field
+            // is projected here instead of going through it.
+            Some((outer, rest, _)) if h.consuming => {
+                let last = h.prefix.len() - 1;
+                let lead = &rest[..rest.len() - 1];
+                if lead.iter().all(PathStep::is_plain_field) {
+                    let segs: Vec<&syn::Ident> = lead.iter().map(PathStep::ident).collect();
+                    (last, quote!(#outer #(.#segs)*))
+                } else {
+                    // Reached through an accessor call, so what is in hand is a
+                    // borrow with nothing to give up — clone once and consume
+                    // the clone, exactly as a borrowed root does below.
+                    let mut e = quote!(&#outer);
+                    for step in lead {
+                        e = compose_step(qualify, step, e);
+                    }
+                    (last, quote!((#e).clone()))
+                }
+            }
+            Some((outer, rest, _)) => (h.prefix.len() - rest.len(), quote!(&#outer)),
+            // A CONSUMING value form is handed the value itself, so its fields
+            // move out instead of being cloned out of a borrow. A borrowed plan
+            // has no value to give up, so it clones first — the same cost the
+            // borrowing form of the accessor would have paid, which keeps one
+            // declaration usable by both owned and `&T` returns of the type.
+            None if h.consuming && by_ref => (0, quote!(#value.clone())),
+            None if h.consuming => (0, value.clone()),
+            None if by_ref => (0, value.clone()),
+            None => (0, quote!(&#value)),
+        };
+        for step in &h.prefix[from..] {
+            expr = compose_step(qualify, step, expr);
+        }
+        out.stmts.extend(quote! { let #local = #expr; });
+        out.bound.push((h.prefix.clone(), local));
+        out.consuming.push(h.consuming);
+    }
+    out
 }
 
 /// Reach a leaf's input by folding its `path` over `base`, then hand the
@@ -495,83 +599,19 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    // Every value form on the plan is evaluated ONCE and bound to a local, so
-    // the struct is built once per delivery rather than once per field. Value
-    // forms compose, so this is a list: each hoist is composed from the longest
-    // hoist that is already a proper prefix of it (they arrive outermost-first),
-    // and from `value` otherwise.
-    let mut stmts = TokenStream::new();
-    let mut bound: Vec<(&[PathStep], syn::Ident)> = Vec::new();
-    // The longest already-bound prefix of `path`, if any.
-    let longest_bound =
-        |bound: &[(&[PathStep], syn::Ident)], path: &[PathStep]| -> Option<(usize, syn::Ident)> {
-            bound
-                .iter()
-                .filter(|(p, _)| p.len() < path.len() && path.starts_with(p))
-                .max_by_key(|(p, _)| p.len())
-                .map(|(p, id)| (p.len(), id.clone()))
-        };
-    for (i, h) in plan.hoists.iter().enumerate() {
-        let local = format_ident!("__vf{}", i);
-        let (from, mut expr) = match longest_bound(&bound, &h.prefix) {
-            // A NESTED consuming form is handed the parent's field by MOVE: a
-            // hoisted value form is an owned struct and its fields are
-            // disjoint, so moving one out leaves every sibling leaf readable.
-            // `compose_step` borrows (`&(e).f`), so the field run to that field
-            // is projected here instead of going through it.
-            Some((at, outer)) if h.consuming => {
-                let last = h.prefix.len() - 1;
-                let lead = &h.prefix[at..last];
-                if lead.iter().all(PathStep::is_plain_field) {
-                    let segs: Vec<&syn::Ident> = lead.iter().map(PathStep::ident).collect();
-                    (last, quote!(#outer #(.#segs)*))
-                } else {
-                    // Reached through an accessor call, so what is in hand is a
-                    // borrow with nothing to give up — clone once and consume
-                    // the clone, exactly as a borrowed root does below.
-                    let mut e = quote!(&#outer);
-                    for step in lead {
-                        e = compose_step(&qualify, step, e);
-                    }
-                    (last, quote!((#e).clone()))
-                }
-            }
-            Some((at, outer)) => (at, quote!(&#outer)),
-            // A CONSUMING value form is handed the value itself, so its fields
-            // move out instead of being cloned out of a borrow. A borrowed plan
-            // has no value to give up, so it clones first — the same cost the
-            // borrowing form of the accessor would have paid, which keeps one
-            // declaration usable by both owned and `&T` returns of the type.
-            None if h.consuming && by_ref => (0, quote!(#value.clone())),
-            None if h.consuming => (0, value.clone()),
-            None if by_ref => (0, value.clone()),
-            None => (0, quote!(&#value)),
-        };
-        for step in &h.prefix[from..] {
-            expr = compose_step(&qualify, step, expr);
-        }
-        stmts.extend(quote! { let #local = #expr; });
-        bound.push((h.prefix.as_slice(), local));
-    }
-
-    // Whether the innermost value form a leaf sits under CONSUMED its value —
-    // so the leaf owns its field and may move it out rather than clone it.
-    let hoist_consumes = |path: &[PathStep]| -> bool {
-        plan.hoists
-            .iter()
-            .filter(|h| h.prefix.len() < path.len() && path.starts_with(&h.prefix))
-            .max_by_key(|h| h.prefix.len())
-            .is_some_and(|h| h.consuming)
-    };
+    let hoisted = bind_hoists(&qualify, &plan.hoists, value, by_ref);
+    let mut stmts = hoisted.stmts.clone();
 
     // Reach a leaf off the innermost value form it sits under, with that
-    // prefix's steps already consumed; a leaf under none of them (a sibling
-    // `.field()` / `.field_self()`) still reaches from the value itself.
+    // prefix's steps already consumed, and say whether that form CONSUMED its
+    // value — so the leaf owns its field and may move it out rather than clone
+    // it. A leaf under no value form at all (a sibling `.field()` /
+    // `.field_self()`) still reaches from the value itself.
     let rebase =
-        |leaf: &crate::api::core::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>) {
-            match longest_bound(&bound, &leaf.path) {
-                Some((at, local)) => (quote!(#local), false, leaf.path[at..].to_vec()),
-                None => (value.clone(), by_ref, leaf.path.clone()),
+        |leaf: &crate::api::core::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>, bool) {
+            match hoisted.rebase(&leaf.path) {
+                Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
+                None => (value.clone(), by_ref, leaf.path.clone(), false),
             }
         };
 
@@ -593,7 +633,7 @@ pub(crate) fn encode_plan_leaves(
         .collect();
     for seg in &sum_segments {
         let leaf = &plan.leaves[seg.start];
-        let (base, base_is_ref, path) = rebase(leaf);
+        let (base, base_is_ref, path, _) = rebase(leaf);
         // The value to `match` on. The selector's own path reaches the sum
         // (empty when the sum IS the value); no step on it is optional, since
         // an optional sum is refused where the leaves are built.
@@ -631,8 +671,7 @@ pub(crate) fn encode_plan_leaves(
     for idx in order {
         let leaf = &plan.leaves[idx];
         let obj_ident = &obj_idents[idx];
-        let (value, by_ref, path) = rebase(leaf);
-        let consuming = hoist_consumes(&leaf.path);
+        let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
         let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
@@ -703,15 +742,31 @@ pub(crate) fn encode_plan_leaves(
                     TypeKey::from_type(&leaf.out_ty)
                 )
             });
+            // The place this handle lives, when it is OURS to give away: the
+            // owned root, or a field of a CONSUMING value form — that form
+            // handed its value over, so its handle fields move out like every
+            // other field rather than being cloned through the converter (which
+            // would also demand a `Clone` the type need not have). Reached by a
+            // plain-field run, so nothing borrows the local as a whole; an
+            // `Option` step would make the leaf nullable and is excluded by the
+            // same test.
+            let owned_place: Option<TokenStream> = if path.is_empty() && !by_ref {
+                Some(value.clone())
+            } else if consuming && path.iter().all(PathStep::is_plain_field) {
+                let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                Some(quote!(#value #(.#segs)*))
+            } else {
+                None
+            };
             match proj.kind {
                 ProjectionKind::Handle => {
                     let handle_ident = format_ident!("__h{}", idx);
-                    if path.is_empty() && !by_ref {
-                        // Owned root, non-nullable by construction (nullable
-                        // comes from path nesting): move into a Box, raw jlong.
+                    if let Some(place) = &owned_place {
+                        // Non-nullable by construction (nullable comes from path
+                        // nesting): move into a Box, raw jlong.
                         stmts.extend(quote! {
                             let #obj_ident: jni::sys::jvalue = jni::sys::jvalue {
-                                j: std::boxed::Box::into_raw(std::boxed::Box::new(#value))
+                                j: std::boxed::Box::into_raw(std::boxed::Box::new(#place))
                                     as jni::sys::jlong,
                             };
                         });

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -407,13 +407,6 @@ pub(crate) fn encode_plan_leaves(
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
-    // A decomposed **sum** is the one plan whose leaves are not independent:
-    // only one group is live per value, so the whole list is emitted as ONE
-    // `match` rather than per-leaf expressions. Same contract, different
-    // emitter — see [`encode_sum_leaves`].
-    if is_sum_leaves(&plan.leaves) {
-        return encode_sum_leaves(ext, registry, plan, obj_idents, value, fail);
-    }
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
@@ -466,8 +459,51 @@ pub(crate) fn encode_plan_leaves(
             }
         };
 
-    let mut order: Vec<usize> = (0..n).filter(|&i| !plan.leaves[i].identity).collect();
-    order.extend((0..n).filter(|&i| plan.leaves[i].identity));
+    // A decomposed **sum** is the one shape whose leaves are not independent:
+    // only one group is live per value, so its whole segment — the selector
+    // leaf plus the group leaves that follow it — is emitted as ONE `match`
+    // instead of per-leaf expressions. A plan may carry several: a sum that IS
+    // the returned value is the degenerate case of one segment covering
+    // everything, while a value form contributes one per sum-typed field.
+    let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
+        .filter(|&i| plan.leaves[i].source == crate::api::core::unfold::LeafSource::SumTag)
+        .map(|start| {
+            let end = (start + 1..n)
+                .take_while(|&i| plan.leaves[i].group.is_some())
+                .last()
+                .map_or(start + 1, |i| i + 1);
+            start..end
+        })
+        .collect();
+    for seg in &sum_segments {
+        let leaf = &plan.leaves[seg.start];
+        let (base, base_is_ref, path) = rebase(leaf);
+        // The value to `match` on. The selector's own path reaches the sum
+        // (empty when the sum IS the value); no step on it is optional, since
+        // an optional sum is refused where the leaves are built.
+        let mut matched = if base_is_ref { base } else { quote!(&#base) };
+        for step in &path {
+            matched = compose_step(&qualify, step, matched);
+        }
+        let (group_stmts, group_args) = encode_sum_group(
+            ext,
+            registry,
+            &plan.leaves[seg.clone()],
+            &obj_idents[seg.clone()],
+            matched,
+            fail,
+        );
+        stmts.extend(group_stmts);
+        for (k, e) in group_args.into_iter().enumerate() {
+            arg_exprs[seg.start + k] = e;
+        }
+    }
+
+    let in_sum = |i: usize| sum_segments.iter().any(|s| s.contains(&i));
+    let mut order: Vec<usize> = (0..n)
+        .filter(|&i| !plan.leaves[i].identity && !in_sum(i))
+        .collect();
+    order.extend((0..n).filter(|&i| plan.leaves[i].identity && !in_sum(i)));
 
     for idx in order {
         let leaf = &plan.leaves[idx];

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -315,7 +315,7 @@ pub(crate) fn cast_wire_to_jobject(
 /// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
 /// and re-borrows, so the result is a reference either way and steps chain
 /// uniformly.
-fn compose_step(
+pub(crate) fn compose_step(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
     step: &PathStep,
     e: TokenStream,
@@ -326,6 +326,73 @@ fn compose_step(
             quote!(#m::#ident(#e))
         }
         PathStep::Field { ident, .. } => quote!(&(#e).#ident),
+    }
+}
+
+/// Start a reach from `base`, projecting the **leading run of plain field
+/// steps** directly (`&base.a.b`) instead of through a borrow of the base
+/// (`&(&base).a.b`). Returns the expression and how many steps it consumed.
+///
+/// The two forms name the same value, but the second borrows the base **as a
+/// whole**, which the borrow checker rejects once a sibling leaf has moved a
+/// different field out of it. Projecting directly makes each leaf's borrow
+/// disjoint, so a consuming value form's field moves are order-independent
+/// rather than compiling only while the borrowing leaves happen to be declared
+/// first.
+fn project_leading_fields(
+    base: &TokenStream,
+    base_is_ref: bool,
+    path: &[PathStep],
+) -> (TokenStream, usize) {
+    if base_is_ref {
+        return (base.clone(), 0);
+    }
+    let n = path.iter().take_while(|s| s.is_plain_field()).count();
+    if n == 0 {
+        return (quote!(&#base), 0);
+    }
+    let segs: Vec<&syn::Ident> = path[..n].iter().map(PathStep::ident).collect();
+    (quote!(&#base #(.#segs)*), n)
+}
+
+/// Fold a leaf's whole `path` over `base` with no optional-step handling, then
+/// apply the terminal treatment its [`LeafSource`] calls for: a `Field` leaf is
+/// **cloned** out of the place it reached, because its converter takes the field
+/// type as written (owned); every other leaf keeps the borrow its converter
+/// expects.
+///
+/// This is the derivation the single-leaf [`Delivery::Return`] shortcut uses
+/// (`emit/wrapper.rs`). It exists here, beside [`reach_leaf`], so the two are
+/// read and changed together: they drifted once already — the shortcut was
+/// missing the `Field` clone and handed `&F` to an `F` converter.
+///
+/// [`Delivery::Return`]: crate::api::core::unfold::Delivery::Return
+pub(crate) fn reach_leaf_flat(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    leaf: &crate::api::core::unfold::UnfoldLeaf,
+    base: TokenStream,
+    base_is_ref: bool,
+) -> TokenStream {
+    use crate::api::core::unfold::LeafSource;
+    // An optional step BEFORE the last one needs a `match` whose `None` arm has
+    // somewhere to go. This derivation has none — it yields a plain Rust value,
+    // not a `JObject` that could be null — so the shape is refused here rather
+    // than composed into code that cannot type-check in the consumer's crate.
+    assert!(
+        !leaf.path.iter().rev().skip(1).any(PathStep::is_optional),
+        "jnigen unfold: leaf `{}` reaches through an optional step but is \
+         delivered as a single return value, which has no `None` arm — this \
+         shape needs callback delivery",
+        leaf.name,
+    );
+    let (mut e, lead) = project_leading_fields(&base, base_is_ref, &leaf.path);
+    for step in &leaf.path[lead..] {
+        e = compose_step(qualify, step, e);
+    }
+    if leaf.source == LeafSource::Field {
+        quote!((#e).clone())
+    } else {
+        e
     }
 }
 
@@ -353,17 +420,17 @@ fn reach_leaf(
     } else {
         path.len().saturating_sub(1)
     };
-    let mut e = if base_is_ref { base } else { quote!(&#base) };
-    match (0..limit).find(|&i| path[i].is_optional()) {
+    let (mut e, lead) = project_leading_fields(&base, base_is_ref, path);
+    match (lead..limit).find(|&i| path[i].is_optional()) {
         // No (more) optional nesting steps: compose the rest plainly.
         None => {
-            for step in path {
+            for step in &path[lead..] {
                 e = compose_step(qualify, step, e);
             }
             body(e)
         }
         Some(k) => {
-            for step in &path[..k] {
+            for step in &path[lead..k] {
                 e = compose_step(qualify, step, e);
             }
             let opt_e = compose_step(qualify, &path[k], e);
@@ -444,19 +511,36 @@ pub(crate) fn encode_plan_leaves(
                 .max_by_key(|(p, _)| p.len())
                 .map(|(p, id)| (p.len(), id.clone()))
         };
-    for (i, prefix) in plan.hoists.iter().enumerate() {
+    for (i, h) in plan.hoists.iter().enumerate() {
         let local = format_ident!("__vf{}", i);
-        let (from, mut expr) = match longest_bound(&bound, prefix) {
+        let (from, mut expr) = match longest_bound(&bound, &h.prefix) {
             Some((at, outer)) => (at, quote!(&#outer)),
+            // A CONSUMING value form is handed the value itself, so its fields
+            // move out instead of being cloned out of a borrow. A borrowed plan
+            // has no value to give up, so it clones first — the same cost the
+            // borrowing form of the accessor would have paid, which keeps one
+            // declaration usable by both owned and `&T` returns of the type.
+            None if h.consuming && by_ref => (0, quote!(#value.clone())),
+            None if h.consuming => (0, value.clone()),
             None if by_ref => (0, value.clone()),
             None => (0, quote!(&#value)),
         };
-        for step in &prefix[from..] {
+        for step in &h.prefix[from..] {
             expr = compose_step(&qualify, step, expr);
         }
         stmts.extend(quote! { let #local = #expr; });
-        bound.push((prefix.as_slice(), local));
+        bound.push((h.prefix.as_slice(), local));
     }
+
+    // Whether the innermost value form a leaf sits under CONSUMED its value —
+    // so the leaf owns its field and may move it out rather than clone it.
+    let hoist_consumes = |path: &[PathStep]| -> bool {
+        plan.hoists
+            .iter()
+            .filter(|h| h.prefix.len() < path.len() && path.starts_with(&h.prefix))
+            .max_by_key(|h| h.prefix.len())
+            .is_some_and(|h| h.consuming)
+    };
 
     // Reach a leaf off the innermost value form it sits under, with that
     // prefix's steps already consumed; a leaf under none of them (a sibling
@@ -491,8 +575,15 @@ pub(crate) fn encode_plan_leaves(
         // The value to `match` on. The selector's own path reaches the sum
         // (empty when the sum IS the value); no step on it is optional, since
         // an optional sum is refused where the leaves are built.
-        let mut matched = if base_is_ref { base } else { quote!(&#base) };
-        for step in &path {
+        //
+        // A plain field chain is borrowed DIRECTLY (`&base.a.b`) rather than
+        // through the base (`&(&base).a.b`). The two are the same value, but
+        // the second borrows the base as a whole, which the borrow checker
+        // rejects once a sibling leaf has moved another field out of it — and
+        // borrowing this field while sibling fields move is exactly what a
+        // consuming value form does.
+        let (mut matched, lead) = project_leading_fields(&base, base_is_ref, &path);
+        for step in &path[lead..] {
             matched = compose_step(&qualify, step, matched);
         }
         let (group_stmts, group_args) = encode_sum_group(
@@ -519,6 +610,7 @@ pub(crate) fn encode_plan_leaves(
         let leaf = &plan.leaves[idx];
         let obj_ident = &obj_idents[idx];
         let (value, by_ref, path) = rebase(leaf);
+        let consuming = hoist_consumes(&leaf.path);
         let value = &value;
         let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
@@ -714,6 +806,16 @@ pub(crate) fn encode_plan_leaves(
             match &leaf.source {
                 LeafSource::Accessor => {
                     reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body)
+                }
+                // Under a CONSUMING value form the leaf owns its field, so it
+                // is **moved** out; the whole point of consuming is that this
+                // clone disappears. Each field is read by exactly one leaf, so
+                // the partial moves are disjoint — but nothing may then borrow
+                // the local as a whole, which is why the reach below projects
+                // the field directly rather than through `&(&local)`.
+                LeafSource::Field if consuming && path.iter().all(PathStep::is_plain_field) => {
+                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                    body(quote!(#value #(.#segs)*))
                 }
                 LeafSource::Field if path.iter().all(PathStep::is_plain_field) => {
                     let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -1,6 +1,7 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
 
 use super::*;
+use crate::api::core::unfold::PathStep;
 
 /// Emit the output-expansion delivery body (output phase) for a function
 /// marked `.expand_output()`. The return value (`__out`) is decomposed by the
@@ -310,21 +311,37 @@ pub(crate) fn cast_wire_to_jobject(
     }
 }
 
-/// Reach a leaf's input by folding its accessor `path` over `base`, then hand
-/// the reached expression to `body` (which renders the encode and yields
-/// `JObject`). Every `Option`-returning nesting step becomes a `match`: its
-/// `None` arm short-circuits the whole leaf to `JObject::null()` (the value is
-/// absent ⇒ the leaf is null) — any number of `Option` steps on the path nest.
+/// Compose one [`PathStep`] onto the reference expression reached so far.
+/// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
+/// and re-borrows, so the result is a reference either way and steps chain
+/// uniformly.
+fn compose_step(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    step: &PathStep,
+    e: TokenStream,
+) -> TokenStream {
+    match step {
+        PathStep::Call { ident, .. } => {
+            let m = qualify(ident);
+            quote!(#m::#ident(#e))
+        }
+        PathStep::Field { ident, .. } => quote!(&(#e).#ident),
+    }
+}
+
+/// Reach a leaf's input by folding its `path` over `base`, then hand the
+/// reached expression to `body` (which renders the encode and yields
+/// `JObject`). Every optional nesting step becomes a `match`: its `None` arm
+/// short-circuits the whole leaf to `JObject::null()` (the value is absent ⇒
+/// the leaf is null) — any number of optional steps on the path nest.
 /// With `unwrap_last == false` the final path element composes directly — a
-/// non-identity leaf's converter takes the final accessor's **full** return
-/// type (`Option` included), so only the steps *before* it are nesting. An
+/// non-identity leaf's converter takes the final step's **full** type
+/// (`Option` included), so only the steps *before* it are nesting. An
 /// identity leaf (`unwrap_last == true`) delivers the reached value itself, so
 /// a final `Option` step unwraps too.
-#[allow(clippy::too_many_arguments)]
 fn reach_leaf(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    path: &[syn::Ident],
-    returns_option: &dyn Fn(&syn::Ident) -> bool,
+    path: &[PathStep],
     base: TokenStream,
     base_is_ref: bool,
     unwrap_last: bool,
@@ -337,27 +354,23 @@ fn reach_leaf(
         path.len().saturating_sub(1)
     };
     let mut e = if base_is_ref { base } else { quote!(&#base) };
-    match (0..limit).find(|&i| returns_option(&path[i])) {
-        // No (more) `Option` nesting steps: compose the rest plainly.
+    match (0..limit).find(|&i| path[i].is_optional()) {
+        // No (more) optional nesting steps: compose the rest plainly.
         None => {
-            for a in path {
-                let m = qualify(a);
-                e = quote!(#m::#a(#e));
+            for step in path {
+                e = compose_step(qualify, step, e);
             }
             body(e)
         }
         Some(k) => {
-            for a in &path[..k] {
-                let m = qualify(a);
-                e = quote!(#m::#a(#e));
+            for step in &path[..k] {
+                e = compose_step(qualify, step, e);
             }
-            let opt_acc = &path[k];
-            let opt_m = qualify(opt_acc);
+            let opt_e = compose_step(qualify, &path[k], e);
             let nested = format_ident!("__n{}", depth);
             let inner = reach_leaf(
                 qualify,
                 &path[k + 1..],
-                returns_option,
                 quote!(#nested),
                 true,
                 unwrap_last,
@@ -365,7 +378,7 @@ fn reach_leaf(
                 body,
             );
             quote! {
-                match #opt_m::#opt_acc(#e) {
+                match #opt_e {
                     ::core::option::Option::Some(#nested) => { #inner }
                     ::core::option::Option::None => jni::objects::JObject::null(),
                 }
@@ -422,25 +435,45 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    // True when accessor `acc`'s return type is `Option<…>` (a nullable nesting
-    // step on a leaf's path).
-    let returns_option = |acc: &syn::Ident| -> bool {
-        registry.functions.get(acc).is_some_and(|(f, _)| match &f.sig.output {
-            syn::ReturnType::Type(_, t) => matches!(
-                &**t,
-                syn::Type::Path(tp) if tp.path.segments.last().is_some_and(|s| s.ident == "Option")
-            ),
-            _ => false,
-        })
+    // A `.fields()` plan reaches every one of its leaves through ONE call of
+    // the value form: bind it to a local first, so the struct is built once
+    // per delivery rather than once per field.
+    let vf = format_ident!("__vf");
+    let mut stmts = match &plan.root_call {
+        Some(f) => {
+            let m = qualify(f);
+            let base = if by_ref {
+                value.clone()
+            } else {
+                quote!(&#value)
+            };
+            quote! { let #vf = #m::#f(#base); }
+        }
+        None => TokenStream::new(),
     };
+    // Leaves that go through the value form reach off that local with the
+    // shared `Call` step already consumed; a sibling `.field()` / `.field_self()`
+    // leaf still reaches from the value itself.
+    let rebase =
+        |leaf: &crate::api::core::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>) {
+            match (&plan.root_call, leaf.path.split_first()) {
+                (Some(rc), Some((PathStep::Call { ident, .. }, rest)))
+                    if ident == rc && !rest.is_empty() =>
+                {
+                    (quote!(#vf), false, rest.to_vec())
+                }
+                _ => (value.clone(), by_ref, leaf.path.clone()),
+            }
+        };
 
-    let mut stmts = TokenStream::new();
     let mut order: Vec<usize> = (0..n).filter(|&i| !plan.leaves[i].identity).collect();
     order.extend((0..n).filter(|&i| plan.leaves[i].identity));
 
     for idx in order {
         let leaf = &plan.leaves[idx];
         let obj_ident = &obj_idents[idx];
+        let (value, by_ref, path) = rebase(leaf);
+        let value = &value;
         let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
                 "jnigen unfold: leaf `{}` has no registered output converter",
@@ -513,7 +546,7 @@ pub(crate) fn encode_plan_leaves(
             match proj.kind {
                 ProjectionKind::Handle => {
                     let handle_ident = format_ident!("__h{}", idx);
-                    if leaf.path.is_empty() && !by_ref {
+                    if path.is_empty() && !by_ref {
                         // Owned root, non-nullable by construction (nullable
                         // comes from path nesting): move into a Box, raw jlong.
                         stmts.extend(quote! {
@@ -527,8 +560,7 @@ pub(crate) fn encode_plan_leaves(
                         // raw jlong (no Option steps on the path).
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -551,8 +583,7 @@ pub(crate) fn encode_plan_leaves(
                         let box_fail = fail(quote!(__e.to_string()));
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -582,14 +613,13 @@ pub(crate) fn encode_plan_leaves(
                             jni::sys::jvalue { j: #enc_ident }
                         }}
                     };
-                    if leaf.path.is_empty() && !by_ref {
+                    if path.is_empty() && !by_ref {
                         let expr = encode(value.clone());
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else if !leaf.nullable {
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -601,8 +631,7 @@ pub(crate) fn encode_plan_leaves(
                         let box_fail = fail(quote!(__e.to_string()));
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -637,20 +666,28 @@ pub(crate) fn encode_plan_leaves(
         use crate::api::core::unfold::LeafSource;
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
             match &leaf.source {
-                LeafSource::Accessor => reach_leaf(
+                LeafSource::Accessor => {
+                    reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body)
+                }
+                LeafSource::Field if path.iter().all(PathStep::is_plain_field) => {
+                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                    body(quote!(#value #(.#segs)*.clone()))
+                }
+                // A `.fields()` leaf reaches its field through the value-form
+                // accessor, so the path can be mixed: compose it like an
+                // accessor leaf — the final step composes directly, since the
+                // converter takes the field type as written (`Option` and all)
+                // — and clone the reached borrow, which is what a field leaf
+                // delivers.
+                LeafSource::Field => reach_leaf(
                     &qualify,
-                    &leaf.path,
-                    &returns_option,
+                    &path,
                     value.clone(),
                     by_ref,
                     false,
                     0,
-                    body,
+                    &|reached| body(quote!((#reached).clone())),
                 ),
-                LeafSource::Field => {
-                    let segs = &leaf.path;
-                    body(quote!(#value #(.#segs)*.clone()))
-                }
                 // Group leaves never reach this walk: a plan carrying them is
                 // routed to `encode_sum_leaves` at the top of this function,
                 // because a variant payload has no path — it is bound by a

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -387,22 +387,29 @@ pub(crate) fn reach_leaf_flat(
          shape needs callback delivery",
         leaf.name,
     );
-    // Under a CONSUMING value form the leaf OWNS what it reaches, so it is
-    // moved out rather than cloned — a field leaf like `reach`'s
-    // `LeafSource::Field` arm on the multi-leaf path, and an IDENTITY leaf
-    // (a handle field decomposed by `.field_self()`) whose `out_ty` the plan
-    // resolved to the owned type precisely so the owning converter boxes the
-    // move instead of the borrowed one cloning it.
+    // Whether what this leaf reaches is OURS, and so is moved rather than
+    // borrowed or cloned. The two leaf kinds say it differently:
+    //
+    // * an IDENTITY leaf carries the answer in its `out_ty` — the plan resolved
+    //   it to the owned type exactly when the value is the plan's to give away
+    //   (`place_is_owned`: an owned root, or a field of a CONSUMING value form),
+    //   and that is also what selected the owning converter, which boxes the
+    //   move rather than cloning a borrow;
+    // * a FIELD leaf's `out_ty` is the field type as written, owned either way,
+    //   so ownership is the enclosing form's: only a consuming one gives its
+    //   fields away.
     //
     // A trailing `Option` step cannot arrive here at all: return delivery has
     // no `None` arm for the absent case, so a nullable leaf is routed to
     // callback delivery when the plan picks its `Delivery` — see
     // `single_return` in `core/unfold.rs`. `is_plain_field` is what that rules
     // out, and it stays as the local statement of the same fact.
-    if consuming
-        && !matches!(leaf.out_ty, syn::Type::Reference(_))
-        && path.iter().all(PathStep::is_plain_field)
-    {
+    let reached_is_ours = if leaf.identity {
+        !matches!(leaf.out_ty, syn::Type::Reference(_))
+    } else {
+        consuming
+    };
+    if reached_is_ours && path.iter().all(PathStep::is_plain_field) {
         let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
         return quote!(#base #(.#segs)*);
     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -1,7 +1,7 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
 
 use super::*;
-use crate::api::core::unfold::PathStep;
+use crate::api::core::unfold::{steps_are_movable, PathStep};
 
 /// Emit the output-expansion delivery body (output phase) for a function
 /// marked `.expand_output()`. The return value (`__out`) is decomposed by the
@@ -387,10 +387,21 @@ pub(crate) fn reach_leaf_flat(
          shape needs callback delivery",
         leaf.name,
     );
-    // Under a CONSUMING value form the leaf OWNS its field, so it is moved out
-    // rather than cloned — the same rule `reach`'s `LeafSource::Field` arm
-    // applies on the multi-leaf path, and the reason both live in this file.
-    if leaf.source == LeafSource::Field && consuming && path.iter().all(PathStep::is_plain_field) {
+    // Under a CONSUMING value form the leaf OWNS what it reaches, so it is
+    // moved out rather than cloned — a field leaf like `reach`'s
+    // `LeafSource::Field` arm on the multi-leaf path, and an IDENTITY leaf
+    // (a handle field decomposed by `.field_self()`) whose `out_ty` the plan
+    // resolved to the owned type precisely so the owning converter boxes the
+    // move instead of the borrowed one cloning it.
+    //
+    // A trailing `Option` step is excluded here, not by `steps_are_movable`:
+    // return delivery has no `None` arm to put the absent case in, so the whole
+    // `Option` would have to reach the converter — which is what the callback
+    // path's nullable branch does with a `match`.
+    if consuming
+        && !matches!(leaf.out_ty, syn::Type::Reference(_))
+        && path.iter().all(PathStep::is_plain_field)
+    {
         let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
         return quote!(#base #(.#segs)*);
     }
@@ -742,34 +753,62 @@ pub(crate) fn encode_plan_leaves(
                     TypeKey::from_type(&leaf.out_ty)
                 )
             });
-            // The place this handle lives, when it is OURS to give away: the
-            // owned root, or a field of a CONSUMING value form — that form
-            // handed its value over, so its handle fields move out like every
-            // other field rather than being cloned through the converter (which
-            // would also demand a `Clone` the type need not have). Reached by a
-            // plain-field run, so nothing borrows the local as a whole; an
-            // `Option` step would make the leaf nullable and is excluded by the
-            // same test.
-            let owned_place: Option<TokenStream> = if path.is_empty() && !by_ref {
-                Some(value.clone())
-            } else if consuming && path.iter().all(PathStep::is_plain_field) {
-                let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                Some(quote!(#value #(.#segs)*))
-            } else {
-                None
-            };
+            // The place this handle lives, when it is OURS to give away — the
+            // owned root, or a field of a CONSUMING value form, which handed its
+            // value over so its handle fields move out like every other field
+            // rather than being cloned through the borrowed converter (which
+            // would also demand a `Clone` the type need not have).
+            //
+            // Which it is was decided in the plan, not here: an owned `out_ty`
+            // IS the statement that this leaf owns what it reaches, and it is
+            // what selected the owning converter. `steps_are_movable` then says
+            // how to project it — a plain-field run directly, a trailing
+            // `Option` through the nullable branch's `match`, which moves the
+            // whole `Option` in rather than borrowing it.
+            let owned_place: Option<TokenStream> =
+                if !matches!(leaf.out_ty, syn::Type::Reference(_)) && steps_are_movable(&path) {
+                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                    Some(quote!(#value #(.#segs)*))
+                } else {
+                    None
+                };
             match proj.kind {
                 ProjectionKind::Handle => {
                     let handle_ident = format_ident!("__h{}", idx);
-                    if let Some(place) = &owned_place {
-                        // Non-nullable by construction (nullable comes from path
-                        // nesting): move into a Box, raw jlong.
+                    if let (Some(place), false) = (&owned_place, leaf.nullable) {
+                        // Ours, and always present: move into a Box, raw jlong.
                         stmts.extend(quote! {
                             let #obj_ident: jni::sys::jvalue = jni::sys::jvalue {
                                 j: std::boxed::Box::into_raw(std::boxed::Box::new(#place))
                                     as jni::sys::jlong,
                             };
                         });
+                    } else if let Some(place) = &owned_place {
+                        // Ours, behind an `Option`: match the option BY VALUE so
+                        // the present handle is moved into its Box, boxed
+                        // `java.lang.Long` when present / JVM null when absent.
+                        // Matching `&place` here is what used to clone it back
+                        // through the borrowed converter.
+                        let box_fail = fail(quote!(__e.to_string()));
+                        stmts.extend(bind_obj(
+                            obj_ident,
+                            quote! {{
+                                match #place {
+                                    ::core::option::Option::Some(__n) => {
+                                        let #handle_ident: jni::sys::jlong =
+                                            std::boxed::Box::into_raw(std::boxed::Box::new(__n))
+                                                as jni::sys::jlong;
+                                        match ::prebindgen::lang::box_jlong(&mut env, #handle_ident) {
+                                            ::core::result::Result::Ok(__o) => __o,
+                                            ::core::result::Result::Err(__e) => {
+                                                #box_fail
+                                            }
+                                        }
+                                    }
+                                    ::core::option::Option::None => jni::objects::JObject::null(),
+                                }
+                            }},
+                        ));
                     } else if !leaf.nullable {
                         // Reached non-null handle: clone via the converter,
                         // raw jlong (no Option steps on the path).

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -83,11 +83,11 @@ pub(crate) fn synth_value_struct_leaves(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
-    path_prefix: &[syn::Ident],
+    path_prefix: &[crate::api::core::unfold::PathStep],
     name_prefix: &str,
     depth: usize,
 ) -> Option<Vec<crate::api::core::unfold::UnfoldLeaf>> {
-    use crate::api::core::unfold::{LeafSource, UnfoldLeaf};
+    use crate::api::core::unfold::{LeafSource, PathStep, UnfoldLeaf};
     if depth > 16 {
         return None;
     }
@@ -105,7 +105,10 @@ pub(crate) fn synth_value_struct_leaves(
             format!("{name_prefix}__{camel}")
         };
         let mut path = path_prefix.to_vec();
-        path.push(fname);
+        // The synthesizer declines `Option`-wrapped nesting below, so an
+        // intermediate step is never optional; a TERMINAL `Option` field is not
+        // a nesting step either (its own converter carries the nullability).
+        path.push(PathStep::field(fname, false));
 
         // A projection field (opaque handle) or an enum field
         // is delivered with a transform the fixed builder can't forward yet.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -50,14 +50,17 @@ pub(crate) fn synth_sum_leaves(
     };
 
     let spec = SumSpec::from_item_enum(item_enum);
-    // The selector rides ahead of the groups it chooses between. Its `out_ty`
-    // documents the wire (`i32` → `jint` → Kotlin `Int`); nothing looks up a
-    // converter for it, because there is no value to convert — the emitter
-    // assigns the tag literal per arm.
+    // The selector rides ahead of the groups it chooses between, and carries
+    // **which sum** it selects over as its `out_ty` — that is how the emitter
+    // finds the enum to `match` when the sum is a field rather than the whole
+    // returned value. Nothing looks up a converter for it (`has_converter()` is
+    // false for a `SumTag`): there is no value to convert, the emitter assigns
+    // the tag literal per arm. Its wire is a `jint` by definition.
+    let enum_ident = &item_enum.ident;
     let mut leaves = vec![UnfoldLeaf {
         name: SUM_TAG_LEAF.to_string(),
         path: Vec::new(),
-        out_ty: syn::parse_quote!(i32),
+        out_ty: syn::parse_quote!(#enum_ident),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,
@@ -96,27 +99,38 @@ pub(crate) fn is_sum_leaves(leaves: &[crate::api::core::unfold::UnfoldLeaf]) -> 
 /// pattern's payload bindings, every other group from the same wire defaults an
 /// absent `Option<nested>` uses.
 ///
+/// `leaves` is ONE sum's segment — its [`LeafSource::SumTag`] selector followed
+/// by that selector's group leaves — with `obj_idents` the matching slice of
+/// slot locals. `matched` is the expression to `match` on (a reference to the
+/// value), which is the whole returned value when the sum IS the return, and
+/// the reached field when a value form carries it.
+///
 /// The signature mirrors [`encode_plan_leaves`](super::encode_plan_leaves), and
 /// the two are interchangeable at the call site: both bind `obj_idents` and
 /// return the per-leaf `jvalue` argument expressions in leaf order. What differs
 /// is that a leaf here is not an independent expression — its slot exists in
 /// every arm and only one arm computes it.
-pub(crate) fn encode_sum_leaves(
+pub(crate) fn encode_sum_group(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
-    plan: &crate::api::core::unfold::UnfoldPlan,
+    leaves: &[crate::api::core::unfold::UnfoldLeaf],
     obj_idents: &[syn::Ident],
-    value: &TokenStream,
+    matched: TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
     use crate::api::core::unfold::LeafSource;
 
-    let leaves = &plan.leaves;
-    // Qualified path of the source enum, for the arm patterns.
-    let ident = bare_path_ident(&plan.source).unwrap_or_else(|| {
+    // Which sum this is comes from the selector leaf, not from the plan's
+    // source: the plan's source is the *containing* value when the sum is a
+    // field of a value form.
+    let tag_leaf = leaves
+        .iter()
+        .find(|l| l.source == LeafSource::SumTag)
+        .expect("a sum segment carries its selector leaf");
+    let ident = bare_path_ident(&tag_leaf.out_ty).unwrap_or_else(|| {
         panic!(
-            "jnigen sum unfold: source `{}` is not a path type",
-            TypeKey::from_type(&plan.source)
+            "jnigen sum unfold: selector type `{}` is not a path type",
+            TypeKey::from_type(&tag_leaf.out_ty)
         )
     });
     let module = ext.fn_module(registry, &ident);
@@ -268,14 +282,6 @@ pub(crate) fn encode_sum_leaves(
         })
         .collect();
 
-    // A borrowed value is matched as-is; an owned one is matched by reference
-    // so each payload can be cloned out of it (the same reach a struct field
-    // leaf uses).
-    let matched = if plan.by_ref {
-        value.clone()
-    } else {
-        quote!(&#value)
-    };
     let stmts = quote! {
         #decls
         match #matched { #(#arms)* }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -210,30 +210,13 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let uplan = unfold_plan.expect("is_convert ⇒ plan");
         let leaf = &uplan.leaves[0];
         let by_ref = uplan.by_ref;
+        // One derivation, shared with the multi-leaf encoder — see
+        // [`reach_leaf_flat`]. Deriving it a second time here is what let the
+        // two drift apart, so the reach lives beside `reach_leaf` and both
+        // callers read the same code.
+        let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
-            use crate::api::core::unfold::{LeafSource, PathStep};
-            let mut e = if base_is_ref { base } else { quote!(&#base) };
-            for step in &leaf.path {
-                let a = step.ident();
-                e = match step {
-                    PathStep::Call { .. } => {
-                        let m = ext.fn_module(registry, a);
-                        quote!(#m::#a(#e))
-                    }
-                    PathStep::Field { .. } => quote!(&(#e).#a),
-                };
-            }
-            // A field leaf's converter takes the field type as WRITTEN (owned),
-            // so the reached place is cloned out — the same treatment
-            // `encode_plan_leaves` gives it. Without this the single-leaf
-            // shortcut hands `&F` to an `F` converter, and a non-`Copy` field
-            // additionally borrows out of the temporary the value-form call
-            // returned. An identity leaf stays borrowed: its own converter is
-            // the borrowed-opaque clone.
-            if leaf.source == LeafSource::Field {
-                e = quote!((#e).clone());
-            }
-            e
+            reach_leaf_flat(&qualify, leaf, base, base_is_ref)
         };
         match &uplan.shape {
             UnfoldShape::Optional((), _) => {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -212,9 +212,15 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let by_ref = uplan.by_ref;
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
             let mut e = if base_is_ref { base } else { quote!(&#base) };
-            for a in &leaf.path {
-                let m = ext.fn_module(registry, a);
-                e = quote!(#m::#a(#e));
+            for step in &leaf.path {
+                let a = step.ident();
+                e = match step {
+                    crate::api::core::unfold::PathStep::Call { .. } => {
+                        let m = ext.fn_module(registry, a);
+                        quote!(#m::#a(#e))
+                    }
+                    crate::api::core::unfold::PathStep::Field { .. } => quote!(&(#e).#a),
+                };
             }
             e
         };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -210,13 +210,23 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let uplan = unfold_plan.expect("is_convert ⇒ plan");
         let leaf = &uplan.leaves[0];
         let by_ref = uplan.by_ref;
-        // One derivation, shared with the multi-leaf encoder — see
-        // [`reach_leaf_flat`]. Deriving it a second time here is what let the
-        // two drift apart, so the reach lives beside `reach_leaf` and both
-        // callers read the same code.
+        // One derivation, shared with the multi-leaf encoder — the value forms
+        // are bound by the same [`bind_hoists`] and the leaf reached by the
+        // same [`reach_leaf_flat`]. Deriving either a second time here is what
+        // let the two drift apart: this shortcut used to compose its reach
+        // straight off the raw value, which for a value form declared with
+        // `.fields_into(..)` emitted `f(&v)` against a by-value receiver.
         let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
-            reach_leaf_flat(&qualify, leaf, base, base_is_ref)
+            let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
+            let stmts = &hoisted.stmts;
+            let reached = match hoisted.rebase(&leaf.path) {
+                Some((local, rest, consuming)) => {
+                    reach_leaf_flat(&qualify, leaf, &rest, quote!(#local), false, consuming)
+                }
+                None => reach_leaf_flat(&qualify, leaf, &leaf.path, base, base_is_ref, false),
+            };
+            quote!({ #stmts #reached })
         };
         match &uplan.shape {
             UnfoldShape::Optional((), _) => {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -211,16 +211,27 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let leaf = &uplan.leaves[0];
         let by_ref = uplan.by_ref;
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
+            use crate::api::core::unfold::{LeafSource, PathStep};
             let mut e = if base_is_ref { base } else { quote!(&#base) };
             for step in &leaf.path {
                 let a = step.ident();
                 e = match step {
-                    crate::api::core::unfold::PathStep::Call { .. } => {
+                    PathStep::Call { .. } => {
                         let m = ext.fn_module(registry, a);
                         quote!(#m::#a(#e))
                     }
-                    crate::api::core::unfold::PathStep::Field { .. } => quote!(&(#e).#a),
+                    PathStep::Field { .. } => quote!(&(#e).#a),
                 };
+            }
+            // A field leaf's converter takes the field type as WRITTEN (owned),
+            // so the reached place is cloned out — the same treatment
+            // `encode_plan_leaves` gives it. Without this the single-leaf
+            // shortcut hands `&F` to an `F` converter, and a non-`Copy` field
+            // additionally borrows out of the temporary the value-form call
+            // returned. An identity leaf stays borrowed: its own converter is
+            // the borrowed-opaque clone.
+            if leaf.source == LeafSource::Field {
+                e = quote!((#e).clone());
             }
             e
         };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -215,7 +215,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // same [`reach_leaf_flat`]. Deriving either a second time here is what
         // let the two drift apart: this shortcut used to compose its reach
         // straight off the raw value, which for a value form declared with
-        // `.fields_into(..)` emitted `f(&v)` against a by-value receiver.
+        // `.fields_self_into(..)` emitted `f(&v)` against a by-value receiver.
         let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
             let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -22,7 +22,7 @@
 //! determinism is a checked invariant rather than a convention.
 
 use super::*;
-use crate::api::core::unfold::{dedup_names, DeconId, UnfoldPlan};
+use crate::api::core::unfold::{dedup_names, DeconId, LeafSource, UnfoldPlan};
 
 /// The JVM-visible single method name of every generated callback interface.
 pub(crate) const IFACE_METHOD: &str = "run";
@@ -1141,15 +1141,54 @@ pub(crate) fn callback_iface_spec(
                 });
             } else {
                 // Accessor-plan arg: each leaf is its own passthrough group, so
-                // the user callback still sees the flattened leaves (unchanged).
-                for n in &leaf_names {
-                    groups.push(GroupDesc {
-                        name: n.clone(),
-                        typed: None,
-                        reassemble: None,
-                        imports: Vec::new(),
-                        leaf_count: 1,
-                    });
+                // the user callback still sees the flattened leaves (unchanged)
+                // — EXCEPT a sum segment, whose selector and group slots are one
+                // value and collapse into a single typed parameter rebuilt by a
+                // `when` over the tag. Handing those slots over raw would defeat
+                // the `sealed_class!` the sum was declared as.
+                let mut k = 0usize;
+                while k < plan.leaves.len() {
+                    let leaf = &plan.leaves[k];
+                    let seg = if leaf.source == LeafSource::SumTag {
+                        (k + 1..plan.leaves.len())
+                            .take_while(|&j| plan.leaves[j].group.is_some())
+                            .last()
+                            .map_or(k + 1, |j| j + 1)
+                    } else {
+                        k + 1
+                    };
+                    if leaf.source == LeafSource::SumTag {
+                        any_fixed = true;
+                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(&leaf.out_ty))?;
+                        let (reassemble, imports) = fixed_reassembly(
+                            ext,
+                            registry,
+                            &leaf.out_ty,
+                            &plan.leaves[k..seg],
+                            &fqn,
+                        );
+                        groups.push(GroupDesc {
+                            // The tag leaf is named `<field>__tag`; the value it
+                            // selects over is that field.
+                            name: leaf_names[k]
+                                .strip_suffix(&format!("__{SUM_TAG_LEAF}"))
+                                .unwrap_or(&leaf_names[k])
+                                .to_string(),
+                            typed: Some(kt::KtType::cls(fqn.to_string())),
+                            reassemble: Some(reassemble),
+                            imports,
+                            leaf_count: seg - k,
+                        });
+                    } else {
+                        groups.push(GroupDesc {
+                            name: leaf_names[k].clone(),
+                            typed: None,
+                            reassemble: None,
+                            imports: Vec::new(),
+                            leaf_count: 1,
+                        });
+                    }
+                    k = seg;
                 }
             }
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -33,6 +33,7 @@ mod niches;
 mod sealed;
 mod snapshots;
 mod symbols;
+mod value_form;
 mod values;
 
 /// Build a `TypeEntry` for use in tests. The function body is not

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1125,6 +1125,115 @@ fn sum_return_group_can_own_a_handle() {
     );
 }
 
+/// The same handle payload as a **data-class field** — the position the
+/// return/callback coverage above does not reach, and the one
+/// `ReplyStruct { result: ReplyResult, .. }` needs (both `ReplyResult`
+/// alternatives carry handles).
+///
+/// The group slot stays the raw `jlong` and the live arm wraps it into the
+/// typed handle class, exactly as in return position — the parent's own
+/// `fromParts` inlining the `when`.
+///
+/// Two consequences of this position, both asserted below so they cannot
+/// change silently:
+///
+/// * The container is **not** `AutoCloseable` — `destructible()` matches only
+///   a `Projection` field, never a `Sum` one. That follows the documented
+///   ownership rule for sum payloads ("who closes a handle payload: the
+///   receiver"), but it does differ from a plain handle field, which *does*
+///   make its class closeable and cascades. The handle stays reachable and
+///   closeable through the variant (`(h.outcome as Lookup.Found).v0.close()`);
+///   what is absent is the cascade.
+/// * A sum field takes its parent off the fixed-builder path onto the
+///   whole-value `fromParts` bridge (`synth_value_struct_leaves` declines
+///   `TypeKind::Sum`), so the value costs a JVM object — a slower shape, not a
+///   broken one.
+#[test]
+fn a_data_class_field_may_be_a_sum_carrying_a_handle() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub id: i64,
+                    pub outcome: Lookup,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_new(id: i64) -> Holder {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::ptr_class!(Probe))
+            .class(crate::sealed_class!(Lookup))
+            .class(crate::data_class!(Holder))
+            .fun(crate::fun!(holder_new)),
+    );
+    let dir = unique_test_dir("jnigen_sum_handle_field");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // The tag keeps the `__` marker; a group slot is prefixed with its field
+    // by the single-underscore nesting convention (`mode_periodicQueries_period`).
+    assert!(
+        kotlin.contains("outcome__tag: Int") && kotlin.contains("outcome_found_v0: Long"),
+        "the selector plus a raw-pointer group slot, both prefixed by the field:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("Lookup.Found(Probe(outcome_found_v0))"),
+        "the parent's fromParts inlines the `when` and wraps the pointer:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("public data class Holder(val id: Long, val outcome: Lookup)"),
+        "the field surfaces as the typed sum:\n{kotlin}"
+    );
+    assert!(
+        !kotlin.contains("Holder(val id: Long, val outcome: Lookup) : AutoCloseable"),
+        "a sum-carried handle is the RECEIVER's to close — the container does \
+         not cascade, unlike a plain handle field:\n{kotlin}"
+    );
+    assert!(
+        rust.contains("Lookup::Found") && rust.contains("Lookup::Absent"),
+        "Rust matches the field's sum, filling every group's slots:\n{rust}"
+    );
+}
+
 /// TWO sums in one callback signature: each contributes its own selector, so
 /// the signature-wide dedup renames the second to `tag2` — and the reassembly
 /// expressions must follow it, including the `$tag` Kotlin string template in

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -985,6 +985,62 @@ fn a_sole_optional_handle_field_takes_callback_delivery() {
     );
 }
 
+/// A ROOT identity leaf owns its value with no value form in sight — a plain
+/// `-> ZChild` return under the type-level `expand_return!(ZChild).field_self()`
+/// that exists so the same boundary can be spliced as a value-form field. The
+/// flat return path tied its move to the rebased hoist's `consuming` flag,
+/// which is `false` when there is no hoist, so it emitted `&__cvsrc` into the
+/// owning `ZChild`-to-jlong converter.
+///
+/// Ownership is not "a consuming form gave it to me" — that is one of its two
+/// sources. For an identity leaf the plan already states it in `out_ty`, so the
+/// emitter reads it there rather than re-deriving it from the hoist. The
+/// `Option` return is the same value inside a `map` closure.
+#[test]
+fn an_owned_root_identity_moves_without_any_value_form() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_root_child_make() -> ZChild {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_root_child_maybe() -> Option<ZChild> {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_root_child_make))
+                .fun(crate::fun!(z_root_child_maybe)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self());
+    let dir = unique_test_dir("jnigen_vf_root_identity");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        !rust.contains("&__cvsrc") && !rust.contains("&__inner"),
+        "an owned root is MOVED into its converter, not borrowed — the owning \
+         converter takes `ZChild`, not `&ZChild`:\n{rust}"
+    );
+}
+
 /// A per-field `.field(name, expand_return!(T))` override states the field's
 /// type, so it has to be checked against the field. Otherwise the override
 /// silently survives an upstream field-type change — which is exactly the drift

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -913,6 +913,78 @@ fn an_optional_handle_field_of_a_consuming_value_form_moves() {
     );
 }
 
+/// The cross-product of the two above: a value form whose SOLE field is an
+/// `Option<Handle>`. Delivery was chosen on leaf COUNT alone, so this landed on
+/// the flat `Delivery::Return` path — which has no `None` arm, and whose
+/// `convert_out_ty` names the leaf's own type rather than an optional of it, so
+/// it composed `&(&__vf0).child` into a converter typed for `ZChild`.
+///
+/// A nullable leaf now goes to callback delivery, which has that arm already.
+/// Absence is a delivery question, not an ownership one — making `out_ty` owned
+/// says who frees the handle, not whether there is one.
+#[test]
+fn a_sole_optional_handle_field_takes_callback_delivery() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOptionalSingleStruct {
+                    pub child: Option<ZChild>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_single_into_struct(e: ZOptionalSingle) -> ZOptionalSingleStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_single_make() -> ZOptionalSingle {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOptionalSingle))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_optional_single_make)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZOptionalSingle)
+                .fields_into(crate::fields!(z_optional_single_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_sole_optional_handle");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        !rust.contains("&(&__vf0).child") && !rust.contains("&__vf0.child"),
+        "the optional field is never composed as a borrow — that is what the \
+         flat return path did, handing `&Option<ZChild>` to a `ZChild` \
+         converter:\n{rust}"
+    );
+    assert!(
+        rust.contains("match __vf0.child") && rust.contains("Box::new(__n)"),
+        "it takes callback delivery, whose `None` arm exists, and the present \
+         handle still moves:\n{rust}"
+    );
+}
+
 /// A per-field `.field(name, expand_return!(T))` override states the field's
 /// type, so it has to be checked against the field. Otherwise the override
 /// silently survives an upstream field-type change — which is exactly the drift

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -782,3 +782,117 @@ fn a_nested_value_form_is_hoisted_too() {
         );
     }
 }
+
+// A compact fixture shared by the two follow-up review regressions.
+fn nested_review_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = myflat_loc();
+    vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReviewInnerStruct {
+                    pub value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReviewOuterStruct {
+                    pub optional: Option<ZReviewInner>,
+                    pub items: Vec<ZReviewInner>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_review_inner_to_struct(i: &ZReviewInner) -> ZReviewInnerStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_review_outer_to_struct(o: &ZReviewOuter) -> ZReviewOuterStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_review_outer_sub(cb: impl Fn(ZReviewOuter) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ]
+}
+
+fn nested_review_jni(outer: crate::lang::ExpandReturnDecl) -> JniGen {
+    JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZReviewOuter))
+                .class(crate::ptr_class!(ZReviewInner))
+                .fun(crate::fun!(z_review_outer_sub)),
+        )
+        .expand(
+            crate::expand_return!(ZReviewInner).fields(crate::fields!(z_review_inner_to_struct)),
+        )
+        .expand(outer)
+}
+
+/// A nested value form below an `Option` cannot be emitted as an
+/// unconditional hoist: its accessor takes `&Inner`, not `&Option<Inner>`.
+/// Reject it during planning until conditional hoists can share one `Some`
+/// scope across every descendant leaf.
+#[test]
+fn an_optional_nested_value_form_is_rejected_before_emission() {
+    let registry = Registry::<KotlinMeta>::from_items(nested_review_items()).expect("index items");
+    let jni = nested_review_jni(
+        crate::expand_return!(ZReviewOuter).fields(crate::fields!(z_review_outer_to_struct)),
+    );
+    let err = match registry.resolve(jni) {
+        Ok(_) => panic!("an optional nested value form must be rejected"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("z_review_inner_to_struct") && msg.contains("Option"),
+        "the error names the unsupported conditional hoist: {msg}"
+    );
+}
+
+/// Override records are applied to a `Vec<T>` field as a whole; a fixed leaf
+/// list cannot apply `T`'s deconstructor once per element. The declaration
+/// check must compare against `Vec<T>`, not peel it to `T`.
+#[test]
+fn a_vec_field_override_must_name_the_whole_vec_type() {
+    let build = || {
+        let registry =
+            Registry::<KotlinMeta>::from_items(nested_review_items()).expect("index items");
+        let jni = nested_review_jni(
+            crate::expand_return!(ZReviewOuter).fields(
+                crate::fields!(z_review_outer_to_struct)
+                    .field("items", crate::expand_return!(ZReviewInner).field_self()),
+            ),
+        );
+        let _ = registry.resolve(jni);
+    };
+
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(build))
+        .expect_err("an element-typed override on a Vec field must be rejected");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("items") && msg.contains("Vec") && msg.contains("ZReviewInner"),
+        "the error names the field, its whole Vec type, and the declared element type: {msg}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -896,3 +896,192 @@ fn a_vec_field_override_must_name_the_whole_vec_type() {
         "the error names the field, its whole Vec type, and the declared element type: {msg}"
     );
 }
+
+// ── Consuming value forms ────────────────────────────────────────────────────
+
+/// A value form whose accessor takes its receiver **by value** destroys the
+/// object into its parts, so nothing needs cloning. Fixture mirrors the
+/// borrowing one; `zc_owned` / `zc_borrowed` give an owned and a `&T` plan of
+/// the same type, since one declaration serves both.
+fn consuming_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = myflat_loc();
+    vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZCarrierStruct {
+                    pub label: String,
+                    pub count: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn zc_into_struct(c: ZCarrier) -> ZCarrierStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn zc_to_struct(c: &ZCarrier) -> ZCarrierStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn zc_sub(cb: impl Fn(ZCarrier) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ]
+}
+
+fn consuming_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> String {
+    let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZCarrier))
+                .fun(crate::fun!(zc_sub)),
+        )
+        .expand(decl);
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust")
+}
+
+/// The headline: a consuming value form is handed the value itself, and each
+/// field is **moved** into its leaf. The clones the borrowing form pays — one
+/// per field, on a value it is about to drop — simply are not emitted.
+#[test]
+fn a_consuming_value_form_moves_its_fields() {
+    let rust = consuming_gen(
+        "jnigen_vf_consume",
+        crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)),
+    );
+    assert!(
+        rust.contains("zc_into_struct(__cb_arg0)"),
+        "the value is passed BY MOVE, not borrowed:\n{rust}"
+    );
+    assert!(
+        rust.contains("__vf0.label") && rust.contains("__vf0.count"),
+        "each field is read off the one hoisted local:\n{rust}"
+    );
+    assert!(
+        !rust.contains("__vf0.label.clone()") && !rust.contains("__vf0.count.clone()"),
+        "and MOVED out of it — a consuming form exists precisely to drop these \
+         clones:\n{rust}"
+    );
+}
+
+/// The borrowing form is untouched: same declaration shape, still borrows, still
+/// clones. Consuming-ness is inferred per accessor, so one does not disturb the
+/// other.
+#[test]
+fn the_borrowing_value_form_still_clones() {
+    let rust = consuming_gen(
+        "jnigen_vf_borrow",
+        crate::expand_return!(ZCarrier).fields(crate::fields!(zc_to_struct)),
+    );
+    assert!(
+        rust.contains("zc_to_struct(&__cb_arg0)"),
+        "a `&T` accessor is still handed a borrow:\n{rust}"
+    );
+    assert!(
+        rust.contains("__vf0.label.clone()"),
+        "and its fields are still cloned out:\n{rust}"
+    );
+}
+
+/// One declaration is reached by BOTH owned and borrowed plans of the same type
+/// (records are type-level, `by_ref` is per-function). A borrowed plan has no
+/// value to give up, so it clones once up front rather than being rejected —
+/// the same cost the borrowing form of the accessor would have paid.
+#[test]
+fn a_borrowed_plan_clones_before_consuming() {
+    let loc = myflat_loc();
+    let mut items = consuming_items();
+    items.push((
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn zc_borrowed(v: &ZVault) -> Option<&ZCarrier> {
+                unimplemented!()
+            }
+        )),
+        loc,
+    ));
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZCarrier))
+                .class(crate::ptr_class!(ZVault))
+                .fun(crate::fun!(zc_sub))
+                .fun(crate::fun!(zc_borrowed)),
+        )
+        .expand(crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)));
+    let dir = unique_test_dir("jnigen_vf_consume_ref");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    assert!(
+        rust.contains("zc_into_struct(__inner.clone())"),
+        "a borrowed plan clones the value, then consumes the clone:\n{rust}"
+    );
+}
+
+/// A consuming form moves the value, so anything else reading it is broken by
+/// construction — refused at declaration time rather than emitted as Rust that
+/// cannot compile in the consumer's crate.
+#[test]
+fn a_consuming_value_form_rejects_shapes_that_outlive_the_move() {
+    let build = |decl: crate::lang::ExpandReturnDecl| -> String {
+        let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZCarrier))
+                    .fun(crate::fun!(zc_sub)),
+            )
+            .expand(decl);
+        match registry.resolve(jni) {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        }
+    };
+
+    // `.field_self()` beside it would deliver the handle the form just consumed.
+    let msg = build(
+        crate::expand_return!(ZCarrier)
+            .fields(crate::fields!(zc_into_struct))
+            .field_self(),
+    );
+    assert!(
+        msg.contains("only record") && msg.contains("zc_into_struct"),
+        "a sibling record must be refused, naming the rule and the accessor: {msg:?}"
+    );
+
+    // A plain `.field()` sibling has the same problem.
+    let msg = build(
+        crate::expand_return!(ZCarrier)
+            .fields(crate::fields!(zc_into_struct))
+            .field(crate::fun!(zc_to_struct)),
+    );
+    assert!(
+        msg.contains("only record"),
+        "any sibling record is refused, not just the identity one: {msg:?}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -772,6 +772,147 @@ fn a_handle_field_of_a_consuming_value_form_moves() {
     );
 }
 
+/// The cross-product of the two above: a value form whose SOLE field is a
+/// handle. That takes the single-leaf `Delivery::Return` shortcut with an
+/// *identity* leaf, so neither the multi-leaf handle test (which is a callback
+/// plan) nor the single-leaf `String` test (a `Field` leaf) covered it, and the
+/// shortcut handed the borrowed converter `&__vf0.child`.
+///
+/// The fix is in the PLAN, not in the shortcut: an identity leaf under a
+/// consuming form resolves its `out_ty` to the OWNED type, which both selects
+/// the owning converter and tells every emitter it may move.
+#[test]
+fn a_sole_handle_field_of_a_consuming_value_form_moves() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZSingleEnvelopeStruct {
+                    pub child: ZChild,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_single_envelope_into_struct(e: ZSingleEnvelope) -> ZSingleEnvelopeStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_single_envelope_make() -> ZSingleEnvelope {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZSingleEnvelope))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_single_envelope_make)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZSingleEnvelope)
+                .fields_into(crate::fields!(z_single_envelope_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_sole_handle_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("z_single_envelope_into_struct(__cvsrc)"),
+        "the by-value accessor is handed the value:\n{rust}"
+    );
+    assert!(
+        rust.contains("__vf0.child") && !rust.contains("&__vf0.child"),
+        "and the sole handle field is MOVED out, not borrowed into the \
+         cloning converter:\n{rust}"
+    );
+}
+
+/// An `Option<Handle>` field is the same claim behind an `Option` — and the
+/// commonest shape there is (`SampleStruct.attachment`). The consuming form
+/// owns the whole `Option`, so it is matched BY VALUE and the present handle
+/// moves into its Box; only the *reach* differs from the non-optional case, not
+/// the ownership.
+#[test]
+fn an_optional_handle_field_of_a_consuming_value_form_moves() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOptionalEnvelopeStruct {
+                    pub child: Option<ZChild>,
+                    pub tag: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_envelope_into_struct(
+                    e: ZOptionalEnvelope,
+                ) -> ZOptionalEnvelopeStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_envelope_sub(
+                    cb: impl Fn(ZOptionalEnvelope) + Send + Sync + 'static,
+                ) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOptionalEnvelope))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_optional_envelope_sub)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZOptionalEnvelope)
+                .fields_into(crate::fields!(z_optional_envelope_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_optional_handle_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("match __vf0.child") && !rust.contains("&__vf0.child"),
+        "the `Option` is matched BY VALUE, not borrowed:\n{rust}"
+    );
+    assert!(
+        rust.contains("Box::new(__n)"),
+        "and the present handle is MOVED into its Box rather than cloned \
+         through the borrowed converter:\n{rust}"
+    );
+}
+
 /// A per-field `.field(name, expand_return!(T))` override states the field's
 /// type, so it has to be checked against the field. Otherwise the override
 /// silently survives an upstream field-type change — which is exactly the drift

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -783,6 +783,119 @@ fn a_nested_value_form_is_hoisted_too() {
     }
 }
 
+/// A consuming value form reached **through another one** is handed the
+/// parent's field by MOVE. A hoisted value form is an owned struct and its
+/// fields are disjoint, so giving one field away leaves every sibling leaf
+/// readable — which is why this shape needs no clone and is not refused.
+///
+/// Checked under both parents: what makes the move legal is that the hoist
+/// local is owned, and a borrowing form's returned struct is owned just as much
+/// as a consuming one's.
+#[test]
+fn a_nested_consuming_value_form_moves_the_parent_s_field() {
+    let loc = myflat_loc();
+    let items = |outer_by_value: bool| -> Vec<(syn::Item, crate::SourceLocation)> {
+        let outer: syn::Item = if outer_by_value {
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_into_struct(o: ZOuter) -> ZOuterStruct {
+                    unimplemented!()
+                }
+            ))
+        } else {
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_to_struct(o: &ZOuter) -> ZOuterStruct {
+                    unimplemented!()
+                }
+            ))
+        };
+        vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZInnerStruct {
+                        pub a: i64,
+                        pub b: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZOuterStruct {
+                        pub inner: ZInner,
+                        pub tag: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_inner_into_struct(i: ZInner) -> ZInnerStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (outer, loc.clone()),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_outer_sub(cb: impl Fn(ZOuter) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ]
+    };
+
+    for (tag, outer_by_value, outer) in [
+        (
+            "borrow",
+            false,
+            crate::expand_return!(ZOuter).fields(crate::fields!(z_outer_to_struct)),
+        ),
+        (
+            "consume",
+            true,
+            crate::expand_return!(ZOuter).fields_into(crate::fields!(z_outer_into_struct)),
+        ),
+    ] {
+        let registry =
+            Registry::<KotlinMeta>::from_items(items(outer_by_value)).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZOuter))
+                    .class(crate::ptr_class!(ZInner))
+                    .fun(crate::fun!(z_outer_sub)),
+            )
+            .expand(crate::expand_return!(ZInner).fields_into(crate::fields!(z_inner_into_struct)))
+            .expand(outer);
+        let dir = unique_test_dir(&format!("jnigen_vf_nested_consume_{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let gen = registry.resolve(jni).expect("resolve");
+        let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+            .expect("read rust");
+
+        assert!(
+            rust.contains("z_inner_into_struct(__vf0.inner)"),
+            "[{tag}] the parent's field is MOVED into the nested form, not borrowed \
+             or cloned:\n{rust}"
+        );
+        assert!(
+            rust.contains("__vf0.tag") && !rust.contains("(&__vf0)"),
+            "[{tag}] and a sibling leaf still reads its own field off the parent local, \
+             projected directly — borrowing the partially-moved local as a whole would \
+             not compile:\n{rust}"
+        );
+        assert!(
+            !rust.contains("__vf1.a.clone()"),
+            "[{tag}] the nested form's own fields move out too:\n{rust}"
+        );
+    }
+}
+
 // A compact fixture shared by the two follow-up review regressions.
 fn nested_review_items() -> Vec<(syn::Item, crate::SourceLocation)> {
     let loc = myflat_loc();
@@ -967,7 +1080,7 @@ fn consuming_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> String {
 fn a_consuming_value_form_moves_its_fields() {
     let rust = consuming_gen(
         "jnigen_vf_consume",
-        crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)),
+        crate::expand_return!(ZCarrier).fields_into(crate::fields!(zc_into_struct)),
     );
     assert!(
         rust.contains("zc_into_struct(__cb_arg0)"),
@@ -1029,7 +1142,7 @@ fn a_borrowed_plan_clones_before_consuming() {
                 .fun(crate::fun!(zc_sub))
                 .fun(crate::fun!(zc_borrowed)),
         )
-        .expand(crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)));
+        .expand(crate::expand_return!(ZCarrier).fields_into(crate::fields!(zc_into_struct)));
     let dir = unique_test_dir("jnigen_vf_consume_ref");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -1042,11 +1155,44 @@ fn a_borrowed_plan_clones_before_consuming() {
     );
 }
 
-/// A consuming form moves the value, so anything else reading it is broken by
-/// construction — refused at declaration time rather than emitted as Rust that
-/// cannot compile in the consumer's crate.
+/// `.fields_into(..)` gives the value away, so anything else reading it is
+/// broken by construction. Refused **where it is declared** — the collision is
+/// visible in the decl itself, so it does not need a resolve to be found.
+///
+/// `.field_self()` beside it would deliver the handle the form just consumed.
 #[test]
-fn a_consuming_value_form_rejects_shapes_that_outlive_the_move() {
+#[should_panic(expected = "only record")]
+fn a_consuming_value_form_rejects_a_following_sibling() {
+    let _ = crate::expand_return!(ZCarrier)
+        .fields_into(crate::fields!(zc_into_struct))
+        .field_self();
+}
+
+/// And the other way round — the decl is a builder, so both orders must be
+/// caught or the rule holds only for the order someone happened to write.
+#[test]
+#[should_panic(expected = "only record")]
+fn a_consuming_value_form_rejects_a_preceding_sibling() {
+    let _ = crate::expand_return!(ZCarrier)
+        .field_self()
+        .fields_into(crate::fields!(zc_into_struct));
+}
+
+/// Any sibling record, not just the identity one.
+#[test]
+#[should_panic(expected = "only record")]
+fn a_consuming_value_form_rejects_a_plain_field_sibling() {
+    let _ = crate::expand_return!(ZCarrier)
+        .fields_into(crate::fields!(zc_into_struct))
+        .field(crate::fun!(zc_to_struct));
+}
+
+/// The declarator states whether the value is given away and the accessor's
+/// signature has to agree — otherwise the emitted call would not compile in the
+/// consumer's crate, and a boundary would silently stop being the one declared.
+/// Both directions are errors; the fixture has one accessor of each kind.
+#[test]
+fn the_declarator_and_the_accessor_s_receiver_must_agree() {
     let build = |decl: crate::lang::ExpandReturnDecl| -> String {
         let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index");
         let jni = JniGen::new()
@@ -1063,25 +1209,15 @@ fn a_consuming_value_form_rejects_shapes_that_outlive_the_move() {
         }
     };
 
-    // `.field_self()` beside it would deliver the handle the form just consumed.
-    let msg = build(
-        crate::expand_return!(ZCarrier)
-            .fields(crate::fields!(zc_into_struct))
-            .field_self(),
-    );
+    let msg = build(crate::expand_return!(ZCarrier).fields_into(crate::fields!(zc_to_struct)));
     assert!(
-        msg.contains("only record") && msg.contains("zc_into_struct"),
-        "a sibling record must be refused, naming the rule and the accessor: {msg:?}"
+        msg.contains("CONSUMING") && msg.contains("zc_to_struct"),
+        "`.fields_into` on a borrowing accessor must be refused, naming it: {msg:?}"
     );
 
-    // A plain `.field()` sibling has the same problem.
-    let msg = build(
-        crate::expand_return!(ZCarrier)
-            .fields(crate::fields!(zc_into_struct))
-            .field(crate::fun!(zc_to_struct)),
-    );
+    let msg = build(crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)));
     assert!(
-        msg.contains("only record"),
-        "any sibling record is refused, not just the identity one: {msg:?}"
+        msg.contains("BORROWING") && msg.contains("zc_into_struct"),
+        "`.fields` on a by-value accessor must be refused, naming it: {msg:?}"
     );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -684,7 +684,7 @@ fn a_single_leaf_consuming_value_form_moves_its_field() {
                 .class(crate::ptr_class!(ZOne))
                 .fun(crate::fun!(z_one_make)),
         )
-        .expand(crate::expand_return!(ZOne).fields_into(crate::fields!(z_one_into_struct)));
+        .expand(crate::expand_return!(ZOne).fields_self_into(crate::fields!(z_one_into_struct)));
     let dir = unique_test_dir("jnigen_vf_single_consume");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -705,7 +705,7 @@ fn a_single_leaf_consuming_value_form_moves_its_field() {
 /// A handle field of a consuming value form is the value form's field like any
 /// other: the form gave its value away, so the handle **moves** into its Box
 /// rather than being cloned through the borrowed-opaque converter — which also
-/// stops `.fields_into(..)` from silently requiring a `Clone` the handle type
+/// stops `.fields_self_into(..)` from silently requiring a `Clone` the handle type
 /// need not have.
 ///
 /// The identity branch computed `consuming` and then returned before using it,
@@ -752,7 +752,8 @@ fn a_handle_field_of_a_consuming_value_form_moves() {
         )
         .expand(crate::expand_return!(ZChild).field_self())
         .expand(
-            crate::expand_return!(ZEnvelope).fields_into(crate::fields!(z_envelope_into_struct)),
+            crate::expand_return!(ZEnvelope)
+                .fields_self_into(crate::fields!(z_envelope_into_struct)),
         );
     let dir = unique_test_dir("jnigen_vf_handle_field_consume");
     let _ = std::fs::remove_dir_all(&dir);
@@ -822,7 +823,7 @@ fn a_sole_handle_field_of_a_consuming_value_form_moves() {
         .expand(crate::expand_return!(ZChild).field_self())
         .expand(
             crate::expand_return!(ZSingleEnvelope)
-                .fields_into(crate::fields!(z_single_envelope_into_struct)),
+                .fields_self_into(crate::fields!(z_single_envelope_into_struct)),
         );
     let dir = unique_test_dir("jnigen_vf_sole_handle_consume");
     let _ = std::fs::remove_dir_all(&dir);
@@ -893,7 +894,7 @@ fn an_optional_handle_field_of_a_consuming_value_form_moves() {
         .expand(crate::expand_return!(ZChild).field_self())
         .expand(
             crate::expand_return!(ZOptionalEnvelope)
-                .fields_into(crate::fields!(z_optional_envelope_into_struct)),
+                .fields_self_into(crate::fields!(z_optional_envelope_into_struct)),
         );
     let dir = unique_test_dir("jnigen_vf_optional_handle_consume");
     let _ = std::fs::remove_dir_all(&dir);
@@ -963,7 +964,7 @@ fn a_sole_optional_handle_field_takes_callback_delivery() {
         .expand(crate::expand_return!(ZChild).field_self())
         .expand(
             crate::expand_return!(ZOptionalSingle)
-                .fields_into(crate::fields!(z_optional_single_into_struct)),
+                .fields_self_into(crate::fields!(z_optional_single_into_struct)),
         );
     let dir = unique_test_dir("jnigen_vf_sole_optional_handle");
     let _ = std::fs::remove_dir_all(&dir);
@@ -1256,7 +1257,7 @@ fn a_nested_consuming_value_form_moves_the_parent_s_field() {
         (
             "consume",
             true,
-            crate::expand_return!(ZOuter).fields_into(crate::fields!(z_outer_into_struct)),
+            crate::expand_return!(ZOuter).fields_self_into(crate::fields!(z_outer_into_struct)),
         ),
     ] {
         let registry =
@@ -1269,7 +1270,9 @@ fn a_nested_consuming_value_form_moves_the_parent_s_field() {
                     .class(crate::ptr_class!(ZInner))
                     .fun(crate::fun!(z_outer_sub)),
             )
-            .expand(crate::expand_return!(ZInner).fields_into(crate::fields!(z_inner_into_struct)))
+            .expand(
+                crate::expand_return!(ZInner).fields_self_into(crate::fields!(z_inner_into_struct)),
+            )
             .expand(outer);
         let dir = unique_test_dir(&format!("jnigen_vf_nested_consume_{tag}"));
         let _ = std::fs::remove_dir_all(&dir);
@@ -1480,7 +1483,7 @@ fn consuming_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> String {
 fn a_consuming_value_form_moves_its_fields() {
     let rust = consuming_gen(
         "jnigen_vf_consume",
-        crate::expand_return!(ZCarrier).fields_into(crate::fields!(zc_into_struct)),
+        crate::expand_return!(ZCarrier).fields_self_into(crate::fields!(zc_into_struct)),
     );
     assert!(
         rust.contains("zc_into_struct(__cb_arg0)"),
@@ -1542,7 +1545,7 @@ fn a_borrowed_plan_clones_before_consuming() {
                 .fun(crate::fun!(zc_sub))
                 .fun(crate::fun!(zc_borrowed)),
         )
-        .expand(crate::expand_return!(ZCarrier).fields_into(crate::fields!(zc_into_struct)));
+        .expand(crate::expand_return!(ZCarrier).fields_self_into(crate::fields!(zc_into_struct)));
     let dir = unique_test_dir("jnigen_vf_consume_ref");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -1555,7 +1558,7 @@ fn a_borrowed_plan_clones_before_consuming() {
     );
 }
 
-/// `.fields_into(..)` gives the value away, so anything else reading it is
+/// `.fields_self_into(..)` gives the value away, so anything else reading it is
 /// broken by construction. Refused **where it is declared** — the collision is
 /// visible in the decl itself, so it does not need a resolve to be found.
 ///
@@ -1564,7 +1567,7 @@ fn a_borrowed_plan_clones_before_consuming() {
 #[should_panic(expected = "only record")]
 fn a_consuming_value_form_rejects_a_following_sibling() {
     let _ = crate::expand_return!(ZCarrier)
-        .fields_into(crate::fields!(zc_into_struct))
+        .fields_self_into(crate::fields!(zc_into_struct))
         .field_self();
 }
 
@@ -1575,7 +1578,7 @@ fn a_consuming_value_form_rejects_a_following_sibling() {
 fn a_consuming_value_form_rejects_a_preceding_sibling() {
     let _ = crate::expand_return!(ZCarrier)
         .field_self()
-        .fields_into(crate::fields!(zc_into_struct));
+        .fields_self_into(crate::fields!(zc_into_struct));
 }
 
 /// Any sibling record, not just the identity one.
@@ -1583,7 +1586,7 @@ fn a_consuming_value_form_rejects_a_preceding_sibling() {
 #[should_panic(expected = "only record")]
 fn a_consuming_value_form_rejects_a_plain_field_sibling() {
     let _ = crate::expand_return!(ZCarrier)
-        .fields_into(crate::fields!(zc_into_struct))
+        .fields_self_into(crate::fields!(zc_into_struct))
         .field(crate::fun!(zc_to_struct));
 }
 
@@ -1609,10 +1612,10 @@ fn the_declarator_and_the_accessor_s_receiver_must_agree() {
         }
     };
 
-    let msg = build(crate::expand_return!(ZCarrier).fields_into(crate::fields!(zc_to_struct)));
+    let msg = build(crate::expand_return!(ZCarrier).fields_self_into(crate::fields!(zc_to_struct)));
     assert!(
         msg.contains("CONSUMING") && msg.contains("zc_to_struct"),
-        "`.fields_into` on a borrowing accessor must be refused, naming it: {msg:?}"
+        "`.fields_self_into` on a borrowing accessor must be refused, naming it: {msg:?}"
     );
 
     let msg = build(crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)));

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -1,0 +1,404 @@
+//! `expand_return!(T).fields(fields!(t_to_struct))` — deriving a type's output
+//! boundary from its **value form** (the struct gathering its own accessors)
+//! instead of restating the field list, which is how the two drift apart.
+//!
+//! The contract each test below pins down: `.fields()` is `.field()` applied to
+//! every struct field, so a field still crosses by **its own type's** default
+//! output boundary.
+
+use super::*;
+
+/// The value-form fixture: a `ZSample` handle whose fields cover the shapes
+/// that decide behaviour — a handle field with its own `expand_return!`
+/// (decomposed, not handed over raw), a scalar, an `Option<data class>`, a
+/// non-optional nested data class (inlined), and an `Option<handle>`.
+fn value_form_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = myflat_loc();
+    vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZStamp {
+                    pub secs: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOrigin {
+                    pub node: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZSampleStruct {
+                    pub key_expr: ZKeyExpr,
+                    pub payload: ZBytes,
+                    pub express: bool,
+                    pub stamp: Option<ZStamp>,
+                    pub origin: ZOrigin,
+                    pub attachment: Option<ZBytes>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ]
+}
+
+/// Build the fixture through `JniGen`, letting the caller adjust the
+/// `ZSample` boundary decl. Returns the generated Rust + the joined Kotlin.
+fn value_form_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> (String, String) {
+    let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZSample))
+                .class(crate::ptr_class!(ZKeyExpr))
+                .class(crate::ptr_class!(ZBytes))
+                .class(crate::data_class!(ZStamp))
+                .class(crate::data_class!(ZOrigin))
+                .fun(crate::fun!(z_sample_sub)),
+        )
+        // A KeyExpr crosses as its string, never as a handle — the rule a
+        // `.fields()` expansion has to keep honouring for the `key_expr` field.
+        .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+        .expand(decl);
+
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (rust, kotlin)
+}
+
+/// The headline: `.fields(fields!(f))` produces the leaves the fields' own
+/// boundaries dictate, NOT one leaf per field.
+///
+/// Read the expected signature field by field — each is a different rule:
+/// `key_expr` splices `ZKeyExpr`'s own decl (a String, not a handle);
+/// `express` is a scalar; `stamp` behind `Option` stays one data-class leaf;
+/// `origin` is a non-optional data class and INLINES (`origin__node`);
+/// `payload` / `attachment` have no decl of their own, so they stay handles.
+#[test]
+fn fields_expand_by_each_field_s_own_boundary() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_basic",
+        crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)),
+    );
+    assert!(
+        kotlin.contains("keyExpr__zKeyexprAsStr: String"),
+        "a field whose type has its own expand_return! is decomposed by it, \
+         not handed over as a handle:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("express: Boolean"),
+        "a scalar field is one leaf:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("stamp: ZStamp?"),
+        "an Option<data class> field stays ONE leaf (its converter builds it):\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("origin__node: Long"),
+        "a non-optional nested data class INLINES into its own fields:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("payload: ZBytes") && kotlin.contains("attachment: ZBytes?"),
+        "a handle field with no boundary decl stays a handle, nullable under Option:\n{kotlin}"
+    );
+}
+
+/// The value form is called ONCE per delivery. Without the hoist each field
+/// would rebuild the whole struct — cloning every field once per leaf — which
+/// is exactly the per-message cost `expand_return` exists to avoid.
+#[test]
+fn the_value_form_accessor_is_called_once() {
+    let (rust, _) = value_form_gen(
+        "jnigen_vf_hoist",
+        crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)),
+    );
+    let calls = rust.matches("z_sample_to_struct").count();
+    assert_eq!(
+        calls, 1,
+        "the value form is bound to one local and every leaf reaches off it; \
+         found {calls} calls in:\n{rust}"
+    );
+}
+
+/// An `Option` field with nothing decomposed below it crosses **whole** — its
+/// own converter takes the `Option`. Unwrapping it to reach the inner value
+/// would hand `ZStamp` to a converter typed `Option<ZStamp>`: a mismatch the
+/// Kotlin signature cannot show, because it reads `ZStamp?` either way.
+#[test]
+fn an_optional_field_reaches_its_converter_whole() {
+    let (rust, _) = value_form_gen(
+        "jnigen_vf_opt",
+        crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)),
+    );
+    for field in ["stamp", "attachment"] {
+        assert!(
+            rust.contains(&format!("__vf.{field}.clone()")),
+            "`{field}` must be cloned whole, not matched open:\n{rust}"
+        );
+        assert!(
+            !rust.contains(&format!("match &(&__vf).{field}")),
+            "`{field}` has nothing decomposed below it, so it is not a nesting \
+             step:\n{rust}"
+        );
+    }
+}
+
+/// A hand-written field list and the derived one are the SAME leaves — the
+/// property that makes adopting `.fields()` a no-op on the wire, and the whole
+/// reason it can be trusted to replace a list that has drifted.
+#[test]
+fn deriving_matches_the_equivalent_hand_written_list() {
+    let items = value_form_items();
+    let accessors: Vec<(syn::Item, crate::SourceLocation)> = {
+        let loc = myflat_loc();
+        vec![
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_express(s: &ZSample) -> bool {
+                        unimplemented!()
+                    }
+                )),
+                loc,
+            ),
+        ]
+    };
+
+    let leaves_of = |decl: crate::lang::ExpandReturnDecl,
+                     extra: Vec<(syn::Item, crate::SourceLocation)>|
+     -> Vec<(String, String)> {
+        let mut all = items.clone();
+        all.extend(extra);
+        let registry = Registry::<KotlinMeta>::from_items(all).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .class(crate::ptr_class!(ZBytes))
+                    .class(crate::data_class!(ZStamp))
+                    .class(crate::data_class!(ZOrigin))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(decl);
+        let gen = registry.resolve(jni).expect("resolve");
+        gen.registry()
+            .callback_arg_plans
+            .values()
+            .flat_map(|p| p.leaves.iter())
+            .map(|l| (l.name.clone(), l.out_ty.to_token_stream().to_string()))
+            .collect()
+    };
+
+    // The two fields the hand-written list can state with real accessors.
+    let derived = leaves_of(
+        crate::expand_return!(ZSample).fields(
+            crate::fields!(z_sample_to_struct)
+                .name("key_expr", "keyExpr")
+                .name("express", "express"),
+        ),
+        vec![],
+    );
+    let by_hand = leaves_of(
+        crate::expand_return!(ZSample)
+            .field(crate::fun!(z_sample_key_expr).name("keyExpr"))
+            .field(crate::fun!(z_sample_express).name("express")),
+        accessors,
+    );
+
+    let take = |v: &[(String, String)], n: &str| -> Option<(String, String)> {
+        v.iter().find(|(name, _)| name.starts_with(n)).cloned()
+    };
+    for prefix in ["keyExpr", "express"] {
+        assert_eq!(
+            take(&derived, prefix).map(|(n, _)| n),
+            take(&by_hand, prefix).map(|(n, _)| n),
+            "derived and hand-written leaves must agree on `{prefix}`\n\
+             derived: {derived:?}\nby hand: {by_hand:?}"
+        );
+    }
+}
+
+/// A per-field override replaces that field's type default wholesale — here
+/// keeping the raw `ZKeyExpr` handle instead of its declared string form.
+#[test]
+fn a_per_field_override_replaces_the_type_default() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_override",
+        crate::expand_return!(ZSample).fields(
+            crate::fields!(z_sample_to_struct)
+                .field("key_expr", crate::expand_return!(ZKeyExpr).field_self()),
+        ),
+    );
+    assert!(
+        kotlin.contains("keyExpr: ZKeyExpr"),
+        "the override wins over ZKeyExpr's type-level decl:\n{kotlin}"
+    );
+    assert!(
+        !kotlin.contains("keyExpr__zKeyexprAsStr"),
+        "the overridden field must NOT also carry the type default:\n{kotlin}"
+    );
+}
+
+/// A rename keys on the Rust field ident and reaches an inlined nested field
+/// through its dotted path.
+#[test]
+fn a_field_can_be_renamed_including_a_nested_one() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_rename",
+        crate::expand_return!(ZSample).fields(
+            crate::fields!(z_sample_to_struct)
+                .name("express", "fast")
+                .name("origin.node", "nodeId"),
+        ),
+    );
+    assert!(
+        kotlin.contains("fast: Boolean"),
+        "a renamed field uses the literal name:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("origin__nodeId: Long"),
+        "a nested field is renamed through its dotted path, keeping the prefix:\n{kotlin}"
+    );
+}
+
+/// `.fields()` mixes with the other declarators — the value form's fields
+/// *and* the live handle, which is the `Query`-style shape.
+#[test]
+fn fields_mixes_with_field_self() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_mixed",
+        crate::expand_return!(ZSample)
+            .fields(crate::fields!(z_sample_to_struct))
+            .field_self(),
+    );
+    assert!(
+        kotlin.contains("express: Boolean") && kotlin.contains("handle: ZSample"),
+        "the derived fields and the identity leaf are delivered together:\n{kotlin}"
+    );
+}
+
+/// Naming a field the value form does not have is the very drift this
+/// declarator exists to catch, so it is an error rather than a silent no-op.
+#[test]
+fn an_adjustment_naming_an_unknown_field_is_an_error() {
+    let build = |decl: crate::lang::FieldsDecl| {
+        let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .class(crate::ptr_class!(ZBytes))
+                    .class(crate::data_class!(ZStamp))
+                    .class(crate::data_class!(ZOrigin))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(crate::expand_return!(ZSample).fields(decl));
+        let dir = unique_test_dir("jnigen_vf_unknown");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+
+    for decl in [
+        crate::fields!(z_sample_to_struct).name("kex", "kex"),
+        crate::fields!(z_sample_to_struct)
+            .field("kex", crate::expand_return!(ZKeyExpr).field_self()),
+    ] {
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build(decl)))
+            .expect_err("an unknown field name must be rejected");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(msg.contains("kex"), "the message names the field: {msg}");
+        assert!(
+            msg.contains("ZSampleStruct"),
+            "the message names the value form: {msg}"
+        );
+    }
+}
+
+/// One value form states the whole field set: a second `.fields()` would make
+/// the leaf order depend on declaration order for no gain.
+#[test]
+#[should_panic(expected = "already expands a value form")]
+fn a_second_value_form_is_an_error() {
+    let _ = crate::expand_return!(ZSample)
+        .fields(crate::fields!(z_sample_to_struct))
+        .fields(crate::fields!(z_sample_to_struct));
+}
+
+/// Repeating an adjustment for one field is a declaration bug — the complete
+/// set rule, same as `.expand_param` / `.field`.
+#[test]
+#[should_panic(expected = "already has an override")]
+fn a_repeated_override_is_an_error() {
+    let _ = crate::fields!(z_sample_to_struct)
+        .field("key_expr", crate::expand_return!(ZKeyExpr).field_self())
+        .field("key_expr", crate::expand_return!(ZKeyExpr).field_self());
+}
+
+/// `"__"` is the reserved chain separator, so an author-supplied rename may
+/// not smuggle one in and forge a nesting that isn't there.
+#[test]
+#[should_panic(expected = "reserved")]
+fn a_rename_may_not_contain_the_chain_separator() {
+    let _ = crate::fields!(z_sample_to_struct).name("express", "a__b");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -641,6 +641,137 @@ fn a_single_leaf_value_form_delivers_an_owned_field() {
     );
 }
 
+/// The same shortcut with a CONSUMING form. It composed its reach straight off
+/// the raw value and never looked at the plan's hoists, so it emitted
+/// `z_one_into_struct(&__cvsrc)` against a by-value receiver — Rust that does
+/// not compile in the consumer's crate — and then cloned a field it owns. Both
+/// paths now bind hoists with the same `bind_hoists`, so neither can drift from
+/// the other again.
+#[test]
+fn a_single_leaf_consuming_value_form_moves_its_field() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOneStruct {
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_into_struct(o: ZOne) -> ZOneStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_make(n: i64) -> ZOne {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOne))
+                .fun(crate::fun!(z_one_make)),
+        )
+        .expand(crate::expand_return!(ZOne).fields_into(crate::fields!(z_one_into_struct)));
+    let dir = unique_test_dir("jnigen_vf_single_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("z_one_into_struct(__cvsrc)") && !rust.contains("z_one_into_struct(&"),
+        "the by-value accessor is handed the value, not a borrow of it:\n{rust}"
+    );
+    assert!(
+        rust.contains(".label") && !rust.contains(".label).clone()"),
+        "and the field it owns is MOVED out, not cloned:\n{rust}"
+    );
+}
+
+/// A handle field of a consuming value form is the value form's field like any
+/// other: the form gave its value away, so the handle **moves** into its Box
+/// rather than being cloned through the borrowed-opaque converter — which also
+/// stops `.fields_into(..)` from silently requiring a `Clone` the handle type
+/// need not have.
+///
+/// The identity branch computed `consuming` and then returned before using it,
+/// so every reached handle took the clone arm; only a handle at the owned ROOT
+/// (empty path) moved.
+#[test]
+fn a_handle_field_of_a_consuming_value_form_moves() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZEnvelopeStruct {
+                    pub child: ZChild,
+                    pub tag: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_envelope_into_struct(e: ZEnvelope) -> ZEnvelopeStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_envelope_sub(cb: impl Fn(ZEnvelope) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZEnvelope))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_envelope_sub)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZEnvelope).fields_into(crate::fields!(z_envelope_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_handle_field_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("Box::new(__vf0.child)"),
+        "the handle field is MOVED into its Box:\n{rust}"
+    );
+    assert!(
+        !rust.contains("&__vf0.child"),
+        "and is not handed to the borrowed-opaque converter, which would clone \
+         it:\n{rust}"
+    );
+}
+
 /// A per-field `.field(name, expand_return!(T))` override states the field's
 /// type, so it has to be checked against the field. Otherwise the override
 /// silently survives an upstream field-type change — which is exactly the drift

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -328,6 +328,183 @@ fn fields_mixes_with_field_self() {
     );
 }
 
+/// A **sum** field decomposes into its selector plus one group per
+/// alternative, right there among its sibling fields — a sum has no
+/// whole-value converter, so this is the only way it can cross at all. The
+/// `ReplyStruct { result: ReplyResult, .. }` shape.
+fn sum_field_gen(tag: &str) -> (String, String) {
+    let loc = myflat_loc();
+    let mut items = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum ZOutcome {
+                    Empty,
+                    Ok(ZBytes),
+                    Failed(String),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReplyStruct {
+                    pub result: ZOutcome,
+                    pub seq: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_reply_to_struct(r: &ZReply) -> ZReplyStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    items.push((
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn z_reply_sub(cb: impl Fn(ZReply) + Send + Sync + 'static) {
+                unimplemented!()
+            }
+        )),
+        loc,
+    ));
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZReply))
+                .class(crate::ptr_class!(ZBytes))
+                .class(crate::sealed_class!(ZOutcome))
+                .fun(crate::fun!(z_reply_sub)),
+        )
+        .expand(crate::expand_return!(ZReply).fields(crate::fields!(z_reply_to_struct)));
+
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (rust, kotlin)
+}
+
+#[test]
+fn a_sum_field_crosses_as_its_selector_and_groups() {
+    let (rust, kotlin) = sum_field_gen("jnigen_vf_sum");
+    assert!(
+        kotlin.contains("result__tag: Int"),
+        "the sum field contributes its selector, prefixed by the field:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("result__ok_v0: Long") && kotlin.contains("result__failed_v0: String?"),
+        "one group slot per alternative payload, object slots nullable \
+         (an inert group arrives as null):\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("seq: Long"),
+        "a sibling field is unaffected:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("ZOutcome.Ok(") && kotlin.contains("ZOutcome.Failed("),
+        "the receiver rebuilds the live alternative from the tag:\n{kotlin}"
+    );
+    assert!(
+        rust.contains("myflat::ZOutcome::Ok") && rust.contains("myflat::ZOutcome::Failed"),
+        "Rust matches the sum once, filling every group's slots:\n{rust}"
+    );
+}
+
+/// A sum's slots sit at a FIXED position in the leaf list, so the two shapes
+/// that would move or repeat them are refused by name rather than mis-emitted:
+/// `Vec<sum>` has variable arity, and `Option<sum>` would need a present flag
+/// beside the tag that an output leaf list cannot carry.
+#[test]
+fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| {
+        let items = vec![
+            (
+                syn::Item::Enum(syn::parse_quote!(
+                    pub enum ZOutcome {
+                        Empty,
+                        Failed(String),
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZReplyStruct {
+                        pub result: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_reply_to_struct(r: &ZReply) -> ZReplyStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_reply_sub(cb: impl Fn(ZReply) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZReply))
+                    .class(crate::sealed_class!(ZOutcome))
+                    .fun(crate::fun!(z_reply_sub)),
+            )
+            .expand(crate::expand_return!(ZReply).fields(crate::fields!(z_reply_to_struct)));
+        let dir = unique_test_dir("jnigen_vf_sum_reject");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+
+    for (ty, want) in [
+        (syn::parse_quote!(Vec<ZOutcome>), "variable arity"),
+        (syn::parse_quote!(Option<ZOutcome>), "present flag"),
+    ] {
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build(ty)))
+            .expect_err("a sum behind Option/Vec must be rejected");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(msg.contains(want), "expected `{want}` in: {msg}");
+        assert!(
+            msg.contains("ZReplyStruct.result"),
+            "the message names the offending field: {msg}"
+        );
+    }
+}
+
 /// Naming a field the value form does not have is the very drift this
 /// declarator exists to catch, so it is an error rather than a silent no-op.
 #[test]

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -173,13 +173,13 @@ fn an_optional_field_reaches_its_converter_whole() {
     );
     for field in ["stamp", "attachment"] {
         assert!(
-            rust.contains(&format!("__vf.{field}.clone()")),
+            rust.contains(&format!(".{field}.clone()")),
             "`{field}` must be cloned whole, not matched open:\n{rust}"
         );
         assert!(
-            !rust.contains(&format!("match &(&__vf).{field}")),
+            !rust.contains(&format!(".{field} {{")),
             "`{field}` has nothing decomposed below it, so it is not a nesting \
-             step:\n{rust}"
+             step — no `match` on it:\n{rust}"
         );
     }
 }
@@ -578,4 +578,207 @@ fn a_repeated_override_is_an_error() {
 #[should_panic(expected = "reserved")]
 fn a_rename_may_not_contain_the_chain_separator() {
     let _ = crate::fields!(z_sample_to_struct).name("express", "a__b");
+}
+
+// ── Review findings on #221 ──────────────────────────────────────────────────
+
+/// A **single-leaf** value form takes the `Delivery::Return` shortcut, whose
+/// reach is composed separately from the multi-leaf encoder
+/// (`emit/wrapper.rs`'s `is_convert` path). That path must still give a plain
+/// field leaf the owned value its converter is typed for: composing the field
+/// as a borrow feeds `&i64` to the `i64` converter, and for a non-`Copy` field
+/// borrows out of the temporary the value-form call returned.
+#[test]
+fn a_single_leaf_value_form_delivers_an_owned_field() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOneStruct {
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_to_struct(o: &ZOne) -> ZOneStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_make(n: i64) -> ZOne {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOne))
+                .fun(crate::fun!(z_one_make)),
+        )
+        .expand(crate::expand_return!(ZOne).fields(crate::fields!(z_one_to_struct)));
+    let dir = unique_test_dir("jnigen_vf_single");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains(".label).clone()"),
+        "the single leaf is CLONED out of the value form, matching the owned \
+         `String` its converter takes — composing it as a borrow would feed \
+         `&String` to a `String` converter:\n{rust}"
+    );
+}
+
+/// A per-field `.field(name, expand_return!(T))` override states the field's
+/// type, so it has to be checked against the field. Otherwise the override
+/// silently survives an upstream field-type change — which is exactly the drift
+/// this declarator exists to catch — and two same-shaped handle types are
+/// interchangeable by accident.
+#[test]
+fn a_per_field_override_must_name_the_field_s_own_type() {
+    let build = || {
+        let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .class(crate::ptr_class!(ZBytes))
+                    .class(crate::data_class!(ZStamp))
+                    .class(crate::data_class!(ZOrigin))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(
+                crate::expand_return!(ZSample).fields(
+                    // `key_expr` is a `ZKeyExpr`, not a `ZBytes`.
+                    crate::fields!(z_sample_to_struct)
+                        .field("key_expr", crate::expand_return!(ZBytes).field_self()),
+                ),
+            );
+        let dir = unique_test_dir("jnigen_vf_ovr_ty");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(build))
+        .expect_err("a mistyped override must be rejected");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("key_expr"),
+        "the message names the field: {msg}"
+    );
+    assert!(
+        msg.contains("ZBytes") && msg.contains("ZKeyExpr"),
+        "the message names the declared type and the real one: {msg}"
+    );
+}
+
+/// The "called once per delivery" contract has to survive **composition**: when
+/// a value form's field splices a child type whose own boundary is also derived
+/// from a value form, the child accessor is a second hoist, not a call repeated
+/// once per child leaf.
+#[test]
+fn a_nested_value_form_is_hoisted_too() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZInnerStruct {
+                    pub a: i64,
+                    pub b: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOuterStruct {
+                    pub inner: ZInner,
+                    pub tag: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_inner_to_struct(i: &ZInner) -> ZInnerStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_to_struct(o: &ZOuter) -> ZOuterStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_sub(cb: impl Fn(ZOuter) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOuter))
+                .class(crate::ptr_class!(ZInner))
+                .fun(crate::fun!(z_outer_sub)),
+        )
+        .expand(crate::expand_return!(ZInner).fields(crate::fields!(z_inner_to_struct)))
+        .expand(crate::expand_return!(ZOuter).fields(crate::fields!(z_outer_to_struct)));
+    let dir = unique_test_dir("jnigen_vf_nested");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        kotlin.contains("inner__a: Long") && kotlin.contains("inner__b: Long"),
+        "the child value form's fields splice in, prefixed:\n{kotlin}"
+    );
+    for f in ["z_outer_to_struct", "z_inner_to_struct"] {
+        let calls = rust.matches(f).count();
+        assert_eq!(
+            calls, 1,
+            "`{f}` is bound to one local and every leaf below it reaches off \
+             that local; found {calls} calls in:\n{rust}"
+        );
+    }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -967,8 +967,11 @@ impl Prebindgen for JniGen {
     /// Assembled on demand — field names (member inheritance) resolve here,
     /// against the complete declaration set (see
     /// [`JniGen::build_deconstructors`]).
-    fn deconstructors(&self) -> Option<crate::api::core::unfold::Deconstructors> {
-        Some(self.build_deconstructors())
+    fn deconstructors(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> Option<crate::api::core::unfold::Deconstructors> {
+        Some(self.build_deconstructors(registry))
     }
 
     /// Synthesize a field-decomposition for every `.data_class` type whose

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -42,8 +42,9 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, ConvertSourceDecl,
-    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
-    IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl,
+    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FieldsDecl,
+    FunctionDecl, IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, SealedClassDecl,
+    VariantDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -142,7 +142,7 @@
 //!   [`try_from!`](crate::try_from), [`into!`](crate::into),
 //!   [`try_into!`](crate::try_into)
 //! - Boundary expansion: [`expand_param!`](crate::expand_param),
-//!   [`expand_return!`](crate::expand_return)
+//!   [`expand_return!`](crate::expand_return), [`fields!`](crate::fields)
 //!
 //! **Syntax helpers** produce a bare `syn` node — `Type` / `Path` / `Expr` /
 //! `Signature` / `Ident` — to hand to a declaration method that requires one.
@@ -322,8 +322,8 @@ pub mod lang {
         box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string, matching,
         null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl,
         ConvertSourceDecl, DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl,
-        ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen, KotlinFile,
-        PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl, WriteKotlinError,
+        ExpandReturnDecl, FieldsDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen,
+        KotlinFile, PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl, WriteKotlinError,
     };
 }
 


### PR DESCRIPTION
Closes #213 (Gap A). Gaps B and C were "confirm, or state why it cannot" — both
are answered in [this comment](https://github.com/milyin/prebindgen/issues/213#issuecomment-5108600146),
with follow-ups filed as #217, #218, #219, #220.

## The problem

zenoh-flat publishes a **value form** for each handle type — `SampleStruct`,
`HelloStruct`, `EncodingStruct`, `ReplyStruct`, `ReplyErrorStruct` — reached via
`<type>_to_struct`. Each is literally "the type's own accessors gathered into
one struct". A JniGen consumer that wants a decomposed callback has to restate
that field list by hand, and the two copies drift: of zenoh-flat-jni's five
`expand_return!` blocks, **two had already fallen behind** the struct they
mirror (both missing `timestamp_stack`). Nothing caught it.

## The declaration

```rust
expand_return!(Sample).fields(fields!(sample_to_struct))
```

`.fields()` is the plural of the existing `.field()` — it is exactly `.field()`
applied to each struct field, so it keeps the same rule: **each field crosses by
its own type's default output boundary**. A field type with its own
`expand_return!` splices it (a `KeyExpr` field still crosses as its string, not
as a handle), a declared `data_class!` inlines, a field behind `Option`/`Vec`
stays one leaf.

That is what makes adoption safe: the derived list reproduces the boundary a
hand-written one already had. What changes is that it can no longer drift.

Per-field adjustments live on the `FieldsDecl` and key on the **Rust field
ident**, mirroring `FunctionDecl::expand_param(<param name>, decl)`:

```rust
expand_return!(Sample)
    .fields(fields!(sample_to_struct)
        .field("key_expr", expand_return!(KeyExpr).field_self())  // replace one field's decomposition
        .name("origin.node", "nodeId"))                            // rename; dotted for an inlined field
```

Naming a field the struct does not have is a hard error — that is the drift this
declarator exists to catch. `.fields()` mixes with `.field()` / `.field_self()`;
at most one per decl.

## What it generates

For a value form covering every rule (the `Report` fixture added to
`perftest-flat`):

```kotlin
public fun interface ReportCallback {          // what the user writes against
    public fun run(
        summary__count: Long, summary__total: Double,   // spliced by Summary's own decl
        taken: Stamp?,                                  // Option<data class> — one leaf
        origin__secs: Long, origin__nanos: Long,        // non-optional data class — inlined
        outcome: Lookup,                                // a sum, typed
        label: String,
    )
}

public fun interface ReportCallbackRaw {       // the wire — still ONE crossing
    public fun run(
        summary__count: Long, summary__total: Double,
        taken: Stamp?,
        origin__secs: Long, origin__nanos: Long,
        outcome__tag: Int, outcome__found_v0: Long, outcome__failed_v0: String?,
        label: String,
    )
}
```

```rust
let __vf = perftest_flat::report_to_struct(&__cb_arg0);   // called ONCE
// … each leaf reached off __vf
```

## Implementation

**Core.** `UnfoldLeaf.path` becomes `Vec<PathStep>` (`Call` / `Field`, each
carrying its own optionality) so one path can mix accessor calls and field reads
— `sample_to_struct(v)` → `.key_expr` → `keyexpr_as_str(..)`. `DeconRecord::Fields`
+ `FieldRecord` describe a value form; the adapter walks the struct (only it
knows which are declared classes) and core decides per field whether to splice,
riding the existing `visited` / `UnfoldError::Cycle` guard.
`UnfoldPlan.root_call` hoists the value-form call to one local — without it each
field would rebuild the whole struct, cloning all of it once per leaf.
`Prebindgen::deconstructors` now takes `&Registry`, matching
`value_struct_decons`.

**Sums.** A `sealed_class!` field decomposes in place into its selector and one
group per alternative — a sum has no whole-value converter by construction, so
this is the only shape in which it can cross. The user-facing callback still
receives one typed value: the tag and group slots collapse into a single
parameter rebuilt by an inlined `when`, reusing the `GroupDesc` collapsing a
fixed-builder arg already uses. Two generalizations, both behaviour-preserving
for a sum in whole-return position: the selector leaf carries the sum's own type
as its `out_ty` (so the emitter finds the enum from the leaf, not from
`plan.source`, which names the *containing* value once a sum is a field), and
`encode_sum_leaves` becomes `encode_sum_group` over one leaf segment, with
`encode_plan_leaves` segmenting the list instead of handing the whole plan over.

`Vec<sum>` and `Option<sum>` **fields** are refused by name (#220 tracks the
latter).

## Verification

- 425 lib tests (13 new for `.fields()`, 1 for #213 Gap B), `cargo test` and
  `cargo test --all --all-features`
- `clippy --all-targets --no-default-features --all-features --deny warnings`, `cargo fmt --check`
- `examples/regen-check.sh` clean
- `examples/covertest-kotlin$ ./gradlew run` — **47 sections**, including the new
  `output boundary derived from a value form`, whose callback signature is itself
  the assertion (it would not compile if a field had been derived wrongly) and
  which pins the ownership contract for a handle reached through a value form
  and a sum group

One bug found and fixed mid-way, worth calling out because the Kotlin signature
cannot show it: a terminal `Option` field was being unwrapped, handing `ZStamp`
to a converter typed `Option<ZStamp>` (`ZStamp?` on the Kotlin side either way).
`an_optional_field_reaches_its_converter_whole` asserts the Rust shape.

Commit `a92659d` restores the `example-cbindgen` goldens, which an earlier
`git add -A` here picked up from an `--all-features` regeneration — the generator
output is unchanged; only the committed artifact was wrong. That footgun is #219.

## Downstream

Not in this PR (separate repo): replacing zenoh-flat-jni's `Sample` / `Hello` /
`Encoding` / `ReplyError` blocks with `.fields(fields!(<type>_to_struct))` should
bring back the same callback signatures **with `timestamp_stack` added** — the
two drifted decls closing by themselves — after which zenoh-java's
`FlatCallbacks.kt` needs one more lambda parameter, since it consumes the leaves
positionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
