### PR TITLE
F5: cbindgen's struct-field classification reads the model, not the projection (#211)

### DIFF
--- a/docs/source-frontend.md
+++ b/docs/source-frontend.md
@@ -37,8 +37,8 @@ i.e. places that classify source shape today:
 |---|---|---|---|
 | `api/core` | 67 | 67 | 74 |
 | `api/lang/jnigen` | 97 | 97 | 96 |
-| `api/lang/cbindgen` | 25 | 26 | 26 |
-| **total** | 189 | 190 | **196** |
+| `api/lang/cbindgen` | 25 | 26 | 26 → 25 |
+| **total** | 189 | 190 | **196 → 195** |
 
 The first two columns were counted by hand and are wrong in both directions — a
 recount gives 69/96/26, a token-level count a third answer. **The `After F8`
@@ -69,7 +69,7 @@ number.
 | F2 | `SourceModel` — the language-neutral item model | **partial** — types complete, items structs-only |
 | F3 | Move the type-shape classifiers into the frontend | not started |
 | F4 | `Registry` consumes `SourceModel` | not started |
-| F5 | Migrate `Cbindgen` | not started |
+| F5 | Migrate `Cbindgen` | **partial** — struct fields classify off the model; params/returns blocked on F2 |
 | F6 | Migrate `JniGen` *(the long pole — 97 sites)* | not started |
 | F7 | Close the open-syntax boundary in the `Prebindgen` trait | not started |
 | F8 | Mechanical boundary check | **done** — landed early, on purpose (see below) |
@@ -153,9 +153,15 @@ what syntax reaches the adapter.
 
 - [x] Cbindgen gains array support — `[T; N]` of non-`bool` scalars is its own C wire; `[bool; N]` is refused for the restricted-validity reason (#212)
 - [x] The struct-field path reads `SourceType` from `Registry::source_struct` (#212)
-- [ ] The per-field **classification** still runs on `SourceType::to_syn()`: `is_scalar` / `is_string` / `is_vec` / `box_inner` are re-derived from the projection instead of matching the model. This is the duplicate F5 exists to delete
-- [ ] `lang/cbindgen/{trait_impl,convert,emit,builder,mod}.rs` consume `SourceModel` for parameters and returns too, not only struct fields
-- [ ] Generated C artifacts byte-identical, except where previously-accepted ambiguous syntax becomes an intentional frontend error
+- [x] The per-field **classification** now matches the model: `c_field_wire`, `is_scalar_array`, `data_field_wire`, `data_field_owns`, `restricted_validity_field`, and the `in_data_struct` / `out_data_struct` field loops take a `SourceType` and match it, instead of re-deriving the shape from `to_syn()`
+
+  The rule this established, and the one later stages should follow: **shape from the model, identity from the registry.** "Is this field a `String`, a `bool`, an array of scalars?" is a source fact the frontend already decided, so asking it again of syntax is the duplicate authority #211 forbids. "Is this the type the binding declared as a `tagged_union`?" is a registry lookup that happens to be keyed by `TypeKey`, i.e. by a `syn::Type` — that key is F4's to change, not F5's, so those call sites project and say why.
+
+  Effect on the ledger: `api/lang/cbindgen/mod.rs` 6 → 5, the first entry to come off it. The other predicates in that file (`is_string`, `is_bool`, `is_scalar`) were never *in* it — they classify by ident name, one of the blind spots the header lists — which is precisely why a count alone is not the measure.
+
+- [ ] `mirror_field_wire` still classifies syntax (`is_scalar` / `box_inner` / `is_option`). It is one policy shared by the `repr_c_struct` mirror path, which has a model, and the tagged-union payload path, whose **variant** fields the frontend does not model yet. Splitting it in two would duplicate the policy — the exact thing #211 forbids — so it waits on F2 modeling enums
+- [ ] `lang/cbindgen/{trait_impl,convert,emit,builder,mod}.rs` consume `SourceModel` for parameters and returns too, not only struct fields — also blocked on F2 (functions are still `syn` items)
+- [x] Generated C artifacts byte-identical, except where previously-accepted ambiguous syntax becomes an intentional frontend error — `regen-check.sh` clean across the field-classification migration
 
 ### F6 — migrate `JniGen`
 

--- a/prebindgen/src/api/core/frontend/boundary.ledger
+++ b/prebindgen/src/api/core/frontend/boundary.ledger
@@ -43,7 +43,7 @@
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
-6	api/lang/cbindgen/mod.rs
+5	api/lang/cbindgen/mod.rs
 6	api/lang/cbindgen/trait_impl.rs
 13	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/emit/callback.rs
@@ -65,4 +65,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total: 196
+# total: 195

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -315,9 +315,25 @@ impl Cbindgen {
     /// `syn` item could only have recovered that by parsing source syntax,
     /// which is what issue #211 exists to stop.
     ///
-    /// The per-field *classification* (is it a `String`, a declared enum, an
-    /// opaque pointer) still runs on [`SourceType::to_syn`]; migrating that off
-    /// `syn` is stage F5 of the umbrella, not this change.
+    /// What callers may and may not do with a field, the split stage F5
+    /// established:
+    ///
+    /// * **Shape comes from the model.** Is this field a `String`, a `bool`, an
+    ///   array of scalars? The frontend decided that already, so match the
+    ///   [`SourceType`] — see [`c_field_wire`], [`Self::data_field_wire`],
+    ///   [`Self::restricted_validity_field`]. Re-deriving it from
+    ///   [`SourceType::to_syn`] would make the projection a second authority on
+    ///   one fact, which is the drift #211 exists to stop.
+    /// * **Identity may still project.** Is this the type the binding declared
+    ///   as a `tagged_union` / `enum_type` / `opaque_ptr`? That is a registry
+    ///   lookup keyed by [`TypeKey`], i.e. by a `syn::Type`. Rekeying the
+    ///   registry is stage F4; until then those sites call `to_syn()` and say so.
+    ///
+    /// One shape consumer is deliberately still on syntax:
+    /// [`Self::mirror_field_wire`] is a single policy shared with the
+    /// tagged-union payload path, whose **variant** fields the frontend does not
+    /// model yet. Splitting it in two would duplicate the policy rather than
+    /// remove it, so it waits on F2 modeling enums.
     pub(super) fn struct_fields(
         &self,
         registry: &Registry<()>,

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -175,9 +175,18 @@ impl Cbindgen {
     /// [`::core::mem::MaybeUninit`]: one mirror struct serves both directions,
     /// and on the way in its bytes are C's, so the field may not be a Rust enum
     /// until its tag has been validated. Invisible in C either way.
-    pub(super) fn data_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
-        if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(fty);
+    ///
+    /// The `tagged_union` test is an **identity** question — is this the type
+    /// the binding declared? — so it stays a `TypeKey` lookup on the projection
+    /// until the registry itself is keyed by the model (F4). Everything below it
+    /// is a shape question and is answered by [`c_field_wire`] from the model.
+    pub(super) fn data_field_wire(&self, fty: &SourceType) -> Option<syn::Type> {
+        let syn_ty = fty.to_syn();
+        if self
+            .tagged_unions
+            .contains_key(&TypeKey::from_type(&syn_ty))
+        {
+            let c = self.c_type_ident(&syn_ty);
             return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         c_field_wire(fty)
@@ -238,8 +247,8 @@ impl Cbindgen {
         self.struct_fields(registry, fty)
             .unwrap_or_default()
             .into_iter()
-            .map(|(name, fty)| (name, fty.to_syn()))
             .filter(|(_, fty)| self.data_field_owns(fty, registry))
+            .map(|(name, fty)| (name, fty.to_syn()))
             .collect()
     }
 
@@ -247,11 +256,11 @@ impl Cbindgen {
     /// is a pointer (`String` → `char *`), or it is a declared
     /// [`Cbindgen::tagged_union`] with an owning arm — which crosses by value,
     /// so the pointer it owns is one level further down.
-    fn data_field_owns(&self, fty: &syn::Type, registry: &Registry<()>) -> bool {
+    fn data_field_owns(&self, fty: &SourceType, registry: &Registry<()>) -> bool {
         if matches!(self.data_field_wire(fty), Some(syn::Type::Ptr(_))) {
             return true;
         }
-        self.tagged_union_has_drop(fty, registry)
+        self.tagged_union_has_drop(&fty.to_syn(), registry)
     }
 
     /// Whether a declared `tagged_union` gets a typed `<base>_drop` — i.e. it is
@@ -408,11 +417,11 @@ impl Cbindgen {
     /// value already exists. Wrapping the mirror field in `MaybeUninit` moves
     /// the problem rather than solving it — the transmute's *output* still has
     /// the real field.
-    pub(super) fn restricted_validity_field(&self, fty: &syn::Type) -> Option<&'static str> {
-        if is_bool(fty) {
+    pub(super) fn restricted_validity_field(&self, fty: &SourceType) -> Option<&'static str> {
+        if matches!(fty, SourceType::Scalar(ScalarKind::Bool)) {
             return Some("`bool` — only `0` and `1` are valid");
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+        if self.enums.contains_key(&TypeKey::from_type(&fty.to_syn())) {
             return Some("a declared `enum_type` — only its declared discriminants are valid");
         }
         None
@@ -430,7 +439,7 @@ impl Cbindgen {
             .unwrap_or_default()
             .into_iter()
             .filter_map(|(fname, fty)| {
-                self.restricted_validity_field(&fty.to_syn())
+                self.restricted_validity_field(&fty)
                     .map(|reason| (fname, reason))
             })
             .collect()

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -108,7 +108,7 @@ pub(crate) use crate::api::core::types_util::{
 };
 use crate::api::{
     core::{
-        frontend::model::SourceType,
+        frontend::model::{ScalarKind, SourceType},
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen},
         registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
@@ -720,24 +720,26 @@ fn route_result(call: TokenStream, route: &ErrRoute<'_>) -> TokenStream {
 /// C-ABI wire type for a struct field. `String` → `*mut c_char`; `bool` →
 /// [`bool_wire`]; the remaining FFI-safe scalars pass through. `None` for
 /// anything else (unsupported this increment).
-fn c_field_wire(ty: &syn::Type) -> Option<syn::Type> {
-    if is_string(ty) {
-        return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
-    }
-    // #170 instance 2: the field arrives from C by value, so it may not be a
-    // Rust `bool` until the byte has been normalised.
-    if is_bool(ty) {
-        return Some(bool_wire());
-    }
-    if is_scalar(ty) {
-        return Some(ty.clone());
-    }
-    if is_scalar_array(ty) {
+///
+/// The question asked here is a **shape** question, so it is asked of the
+/// frontend's [`SourceType`] rather than of a `syn::Type`: the model already
+/// decided that this field is a `String`, a `bool`, or an array of scalars, and
+/// re-deriving that from `to_syn()` would be a second authority on the same
+/// fact — the drift #211 exists to stop. Contrast the *identity* questions the
+/// callers still ask (`is this type a declared tagged_union?`), which are
+/// registry lookups keyed by `TypeKey` and stay on `syn` until F4.
+fn c_field_wire(ty: &SourceType) -> Option<syn::Type> {
+    match ty {
+        SourceType::Str => Some(syn::parse_quote!(*mut ::core::ffi::c_char)),
+        // #170 instance 2: the field arrives from C by value, so it may not be
+        // a Rust `bool` until the byte has been normalised.
+        SourceType::Scalar(ScalarKind::Bool) => Some(bool_wire()),
+        SourceType::Scalar(_) => Some(ty.to_syn()),
         // `[T; N]` is already `#[repr(C)]`-compatible and C sees `T x[N]`, so
         // the array IS its own wire and the field copies with no conversion.
-        return Some(ty.clone());
+        SourceType::Array { .. } if is_scalar_array(ty) => Some(ty.to_syn()),
+        _ => None,
     }
-    None
 }
 
 /// `true` for `[T; N]` (nested included) whose element is a scalar **other than
@@ -748,12 +750,13 @@ fn c_field_wire(ty: &syn::Type) -> Option<syn::Type> {
 /// with no per-element hook, so a byte C wrote could become an invalid Rust
 /// `bool` before any generated code could look. Every other scalar holds any
 /// bit pattern legally.
-fn is_scalar_array(ty: &syn::Type) -> bool {
-    let syn::Type::Array(a) = ty else {
+fn is_scalar_array(ty: &SourceType) -> bool {
+    let SourceType::Array { elem, .. } = ty else {
         return false;
     };
-    if is_bool(&a.elem) {
-        return false;
+    match &**elem {
+        SourceType::Scalar(ScalarKind::Bool) => false,
+        SourceType::Scalar(_) => true,
+        nested => is_scalar_array(nested),
     }
-    is_scalar(&a.elem) || is_scalar_array(&a.elem)
 }

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -59,22 +59,28 @@ impl Cbindgen {
         let mut subs: Vec<syn::Type> = Vec::new();
         let mut fallible = false;
         for (fname, fty) in &fields {
-            let fty = &fty.to_syn();
-            if is_string(fty) {
+            // Shape from the model; identity (`is this a declared tagged_union`)
+            // from the projection's `TypeKey`, which is the registry's key until
+            // F4 rekeys it.
+            if matches!(fty, SourceType::Str) {
                 inits.push(quote!(#fname: if v.#fname.is_null() {
                     ::std::string::String::new()
                 } else {
                     ::std::ffi::CStr::from_ptr(v.#fname).to_string_lossy().into_owned()
                 }));
-            } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
+            } else if self
+                .tagged_unions
+                .contains_key(&TypeKey::from_type(&fty.to_syn()))
+            {
                 // A sum field crosses by value as its mirror; its own converter
                 // validates the tag and rebuilds the live arm, which is what
                 // makes this whole decode fallible.
-                let conv = Self::in_name(fty);
-                subs.push(fty.clone());
+                let fty = fty.to_syn();
+                let conv = Self::in_name(&fty);
+                subs.push(fty);
                 fallible = true;
                 inits.push(quote!(#fname: #conv(v.#fname)?));
-            } else if is_bool(fty) {
+            } else if matches!(fty, SourceType::Scalar(ScalarKind::Bool)) {
                 // #170 instance 2: the field's wire is `MaybeUninit<bool>`, so
                 // the byte C wrote is normalised here — a Rust `bool` never
                 // holds it unchecked.
@@ -130,11 +136,16 @@ impl Cbindgen {
         }
         let mut idents = Vec::new();
         for (fname, fty) in self.struct_fields(registry, ty)? {
-            let fty = fty.to_syn();
             // An owned-pointer field is one whose mirror wire is a raw pointer
             // (`Option<Box<T>>` / `Box<T>` → `*mut t_t`); scalars/enums are not.
-            if matches!(self.mirror_field_wire(&fty), Some(syn::Type::Ptr(_))) {
-                if !is_option(&fty) {
+            // `mirror_field_wire` still takes syntax: it is shared with the
+            // tagged-union payload path, whose variant fields the frontend does
+            // not model yet (F2 covers structs only).
+            if matches!(
+                self.mirror_field_wire(&fty.to_syn()),
+                Some(syn::Type::Ptr(_))
+            ) {
+                if !matches!(fty, SourceType::Optional(_)) {
                     return None; // bare `Box<T>`: cannot be nulled (invalid `Box`)
                 }
                 idents.push(fname);
@@ -574,13 +585,12 @@ impl Cbindgen {
             let c_struct = self.c_type_ident(&ty);
             let mut field_defs: Vec<TokenStream> = Vec::new();
             for (fname, fty) in &fields {
-                let sty = fty.to_syn();
-                let wire = self.data_field_wire(&sty).unwrap_or_else(|| {
+                let wire = self.data_field_wire(fty).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
                         fname,
                         type_short(&ty),
-                        sty.to_token_stream()
+                        fty.to_syn().to_token_stream()
                     )
                 });
                 // An array extent that named a const keeps the NAME here — see
@@ -1837,14 +1847,17 @@ impl Cbindgen {
             let mut inits: Vec<TokenStream> = Vec::new();
             let mut subs: Vec<syn::Type> = Vec::new();
             for (fname, fty) in &fields {
-                let fty = &fty.to_syn();
-                if is_string(fty) {
+                if matches!(fty, SourceType::Str) {
                     inits.push(quote!(#fname: __cbg_alloc_cstr(v.#fname)));
-                } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
-                    let conv = Self::out_name(fty);
-                    subs.push(fty.clone());
+                } else if self
+                    .tagged_unions
+                    .contains_key(&TypeKey::from_type(&fty.to_syn()))
+                {
+                    let fty = fty.to_syn();
+                    let conv = Self::out_name(&fty);
+                    subs.push(fty);
                     inits.push(quote!(#fname: #conv(v.#fname)));
-                } else if is_bool(fty) {
+                } else if matches!(fty, SourceType::Scalar(ScalarKind::Bool)) {
                     let wrap = bool_out_expr(quote!(v.#fname));
                     inits.push(quote!(#fname: #wrap));
                 } else {


### PR DESCRIPTION
Stage **F5** of #215 (umbrella for #211) — the struct-field half.

## The duplicate

#212 made cbindgen's struct-field path read `SourceType` from `Registry::source_struct`. It then threw the model away:

```rust
for (fname, fty) in &fields {
    let fty = &fty.to_syn();          // model discarded
    if is_string(fty) { .. }          // re-decided from syntax
    else if is_bool(fty) { .. }
```

The frontend had already decided that this field is a `String`, a `bool`, or an array of scalars. Projecting back to `syn` and asking again made the projection a second authority on one fact — the drift #211 exists to stop, and the exact shape #210 took.

`c_field_wire`, `is_scalar_array`, `data_field_wire`, `data_field_owns`, `restricted_validity_field`, and the `in_data_struct` / `out_data_struct` field loops now take a `SourceType` and match it:

```rust
fn c_field_wire(ty: &SourceType) -> Option<syn::Type> {
    match ty {
        SourceType::Str => Some(syn::parse_quote!(*mut ::core::ffi::c_char)),
        SourceType::Scalar(ScalarKind::Bool) => Some(bool_wire()),
        SourceType::Scalar(_) => Some(ty.to_syn()),
        SourceType::Array { .. } if is_scalar_array(ty) => Some(ty.to_syn()),
        _ => None,
    }
}
```

## The rule this establishes

**Shape from the model, identity from the registry.**

*"Is this field a `String`, a `bool`, an array of scalars?"* is a source fact the frontend decided. Asking syntax again is the duplicate.

*"Is this the type the binding declared as a `tagged_union`?"* is a registry lookup that happens to be keyed by `TypeKey`, i.e. by a `syn::Type`. Rekeying the registry is **F4's** job, not this stage's, so those call sites project deliberately and say so in a comment rather than pretending to be migrated.

Later stages should follow the same split; without it, "migrate to the model" degenerates into churning every lookup that touches a type.

## What stays on syntax, and why

`mirror_field_wire` (`is_scalar` / `box_inner` / `is_option`) is **not** migrated. It is one policy serving two callers: the `repr_c_struct` mirror path, which has a model, and the tagged-union payload path, whose **variant** fields the frontend does not model yet (F2 covers structs only). Splitting it into a model version and a syntax version would duplicate the policy — precisely the thing this PR deletes. It waits on F2 modeling enums.

Same for parameters and returns: functions are still `syn` items, so that F5 bullet is blocked on F2 too. Both are recorded as such in `docs/source-frontend.md` rather than left as open boxes with no stated blocker.

## The ledger caught it

First real use of #224's boundary check, and it fired on the *decrease*:

```
BOUNDARY LEDGER DRIFT — source-syntax classification sites changed:
  api/lang/cbindgen/mod.rs: 6 -> 5
```

`is_scalar_array` no longer matches `syn::Type::Array`. Total 196 → 195, and the regenerated ledger is in the diff — which is the point of requiring an edit in both directions.

**Note what that number does not capture.** `is_string`, `is_bool` and `is_scalar` were never *in* the ledger: they classify by ident name (`type_path_tail(ty) == "String"`), one of the blind spots the ledger header lists. The count moved by one; the duplication deleted was larger. That is the ledger working exactly as documented — a tripwire against growth, not a measure of progress — and it is worth seeing on the first stage that uses it rather than discovering later.

## Verification

- `cargo test --all --all-features` — green (428 lib tests + the workspace suite).
- `./examples/regen-check.sh` — **byte-identical**. Per the branch's review protocol this stage is *must not move*: this is a pure re-sourcing of the same decisions, so any generated diff would be a bug.
- clippy `--deny warnings`, fmt — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
