### PR TITLE
Parse the record stream into elements that keep their syntax (#211)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -40,8 +40,8 @@ pub struct ReplyStruct {
 
 A caller who sets both `RecoveryConfig` fields gets `heartbeat` ignored with no diagnostic; a caller
 who checks only `ReplyStruct::sample` reads an error reply as an empty success. These are
-[zenoh-flat #31](https://github.com/ZettaScaleLabs/zenoh-flat/issues/31) and
-[#30](https://github.com/ZettaScaleLabs/zenoh-flat/issues/30). flat's README already forbids bending
+[zenoh-flat #31](https://github.com/eclipse-zenoh/zenoh-flat/issues/31) and
+[#30](https://github.com/eclipse-zenoh/zenoh-flat/issues/30). flat's README already forbids bending
 its shapes to generator limits (§*Bindings choose; flat stays neutral*), so the fix belongs here.
 
 Sum types are also not exotic: Kotlin, Swift, Rust, TypeScript and Python (tagged unions) all express

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -34,6 +34,8 @@
 //! | split × builder-delivered return (#87) | `summaryMerge` — cartesian split + generic `<R>` wrapper; every overload re-declares `<R>` |
 //! | JNI native-symbol escaping (#86)      | `esc_pkg.Esc_Probe` — underscored subpackage + class (escaped `freePtr` symbol) + hook-mangled `escape_probe_value` harness extern |
 //! | `expand_return!` `.field()` (+`_self`) | `Summary` fields + `StorageError` `message` + self (error handle → `onError`) |
+//! | `expand_return!` `.fields(fields!(…))` (#213) | `Report` — boundary DERIVED from the value form instead of restated; covers every per-field rule (spliced `Summary`, inlined `Stamp`, `Option<data class>`, a sum with a handle payload, a plain leaf) |
+//! | `expand_return!` `.fields_self_into(fields!(…))` | `report_into_struct(r: Report)` — the CONSUMING value form: the value is given away and its fields MOVED out, so the clones the borrowing `report_to_struct` pays are not emitted at all |
 //! | `PackageDecl::fun` / `FunctionDecl::name`| every free function; `.name` renames `millis_add` → `addMillis` |
 //! | `Generation::report()` (C7)           | `kotlin/REPORT.md` — the resolved surface, committed next to the regen |
 //! | contextual method names               | method hook strips `storage`/`stamp` class prefixes; `summary_new`→`.name("of")` still overrides |
@@ -97,8 +99,8 @@
 
 use prebindgen::{
     constant, convert, core::Registry, data_class, enum_class, expand_param, expand_return, expr,
-    from, fun, into, lang::JniGen, matching, package, path, ptr_class, sealed_class, sig, try_from,
-    ty, variant,
+    fields, from, fun, into, lang::JniGen, matching, package, path, ptr_class, sealed_class, sig,
+    try_from, ty, variant,
 };
 
 fn strip_flat_class_prefix(class: &str, name: &str) -> String {
@@ -239,6 +241,11 @@ fn main() {
                 // resources: one alternative carries an opaque handle, one
                 // carries nothing at all.
                 .class(sealed_class!(Lookup))
+                // `Report`'s output boundary is DERIVED from its value form
+                // (`.fields_self_into(fields!(report_into_struct))` below) instead of
+                // being restated field by field — #213. The form it names is
+                // the CONSUMING one, so the fields are moved, not cloned.
+                .class(ptr_class!(Report))
                 // `Hold`'s payload is a CONVERTED type, so its leaf crosses
                 // through the `convert!(Duration)` chain; `HoldPolicy` puts
                 // that same payload in the data-class-field position.
@@ -378,6 +385,14 @@ fn main() {
                 .field(fun!(summary_count))
                 .field(fun!(summary_total)),
         )
+        // `Report` default output DERIVED from its value form (#213): the
+        // leaves come from `ReportStruct`'s fields, so the list cannot drift
+        // from the struct the way a restated one does. Each field still crosses
+        // by ITS OWN type's boundary — `summary` splices `Summary`'s decl above
+        // into `(count, total)` rather than becoming a handle, `origin` inlines
+        // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
+        // decomposes into a selector plus one group per alternative.
+        .expand(expand_return!(Report).fields_self_into(fields!(report_into_struct)))
         // ── Base-package handle type: `Storage` + scalar members ────────────
         // Back in the base package so the typed handle classes live alongside
         // `Payload`.
@@ -490,6 +505,11 @@ fn main() {
                 // handle-carrying sum arriving through a CALLBACK, and a sum
                 // returned BORROWED (`&E` / `Option<&E>`).
                 .fun(fun!(lookup_each))
+                // #213: the output boundary DERIVED from the type's value form
+                // rather than restated. `report_each` delivers the decomposed
+                // `Report` in one crossing; the leaf list comes from
+                // `ReportStruct`'s fields, so it cannot drift from it.
+                .fun(fun!(report_each))
                 .fun(fun!(archive_set_reading))
                 .fun(fun!(archive_reading))
                 .fun(fun!(archive_reading_maybe))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -96,6 +96,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `report_each` — `fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>)`
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
@@ -202,6 +203,7 @@ Base package: `io.prebindgen.covertest`
 - `Priority`: enum_class → `io.prebindgen.covertest.model.Priority` (wire `jni :: sys :: jint`)
 - `Reading`: sealed_class → `io.prebindgen.covertest.model.Reading` (wire `?`)
 - `RepliesConfig`: data_class → `io.prebindgen.covertest.model.RepliesConfig` (wire `jni :: objects :: JObject`)
+- `Report`: ptr_class → `io.prebindgen.covertest.model.Report` (wire `jni :: sys :: jlong`)
 - `Stamp`: data_class → `io.prebindgen.covertest.model.Stamp` (wire `jni :: objects :: JObject`)
 - `Storage`: ptr_class → `io.prebindgen.covertest.Storage` (wire `jni :: sys :: jlong`)
 - `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -832,6 +832,8 @@ internal object CovNative {
 
     external fun readingSeries(n: Int, acc: Any?, fold: Any, errorSink: Any): Any?
 
+    external fun reportEach(n: Long, sink: Any, errorSink: Any)
+
     external fun stampNanos(sSecs: Long, sNanos: Long, errorSink: Any): Long
 
     external fun stampNew(secs: Long, nanos: Long, build: Any, errorSink: Any): Any?

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -5,6 +5,7 @@ import io.prebindgen.covertest.CovNative
 import io.prebindgen.covertest.DurationCallback
 import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
+import io.prebindgen.covertest.NativeHandle
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.__u64FolderRawHolder
@@ -858,6 +859,30 @@ public data class Unsigned(val byte: Int, val short: Int, val int: Long, val lon
     }
 }
 
+/** Typed handle for a native Zenoh `Report`. */
+public class Report(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): Report {
+        val p = ptr
+        ptr = p or 1L
+        return Report(p)
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+    }
+}
+
 public fun interface LookupCallback {
     public fun run(lookup: Lookup)
 }
@@ -903,6 +928,54 @@ public fun ReadingCallback.asRaw(): ReadingCallbackRaw =
         companion_v0 ->
         run(
             when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
+        )
+    }
+
+public fun interface ReportCallback {
+    public fun run(
+        summary__count: Long,
+        summary__total: Double,
+        taken: Stamp?,
+        origin__secs: Long,
+        origin__nanos: Long,
+        outcome: Lookup,
+        label: String,
+    )
+}
+
+public fun interface ReportCallbackRaw {
+    public fun run(
+        summary__count: Long,
+        summary__total: Double,
+        taken: Stamp?,
+        origin__secs: Long,
+        origin__nanos: Long,
+        outcome__tag: Int,
+        outcome__found_v0: Long,
+        outcome__failed_v0: String?,
+        label: String,
+    )
+}
+
+public fun ReportCallback.asRaw(): ReportCallbackRaw =
+    ReportCallbackRaw {
+        summary__count,
+        summary__total,
+        taken,
+        origin__secs,
+        origin__nanos,
+        outcome__tag,
+        outcome__found_v0,
+        outcome__failed_v0,
+        label ->
+        run(
+            summary__count,
+            summary__total,
+            taken,
+            origin__secs,
+            origin__nanos,
+            when (outcome__tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(outcome__found_v0)); 2 -> Lookup.Failed(outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $outcome__tag") },
+            label
         )
     }
 
@@ -1476,6 +1549,17 @@ public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>
 public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>) {
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.lookupEach(n, total, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Deliver a [`Report`] to a callback — the decomposed value form arriving in
+ * ONE crossing, which is the whole point of deriving the boundary rather than
+ * handing over a handle the receiver must then query field by field.
+ */
+public fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.reportEach(n, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -67,6 +67,7 @@ import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.observationNew
 import io.prebindgen.covertest.model.observationWhich
 import io.prebindgen.covertest.model.lookupEach
+import io.prebindgen.covertest.model.reportEach
 import io.prebindgen.covertest.model.lookupOf
 import io.prebindgen.covertest.model.archiveReading
 import io.prebindgen.covertest.model.archiveReadingMaybe
@@ -569,6 +570,58 @@ fun main() {
         check(s.count(boom) == 1L)
         s.close()
         check(s.isClosed())
+    }
+
+    // An output boundary DERIVED from the type's value form
+    // (`expand_return!(Report).fields(fields!(report_to_struct))`) instead of a
+    // restated field list — #213. The point is that deriving changes NOTHING
+    // about the wire: each field still crosses by its own type's boundary, all
+    // in ONE crossing, so a binding can swap a hand-written list (which drifts
+    // when the struct gains a field) for the derived one and keep its shape.
+    //
+    // Each parameter below lands on a different rule, and the signature itself
+    // is the assertion — it would not compile if a field had been derived
+    // wrongly:
+    //   summary__count/total  the field's type has its own expand_return! and
+    //                         is spliced by it — NOT handed over as a handle
+    //   taken                 Option<data class> stays ONE leaf
+    //   origin__secs/nanos    a non-optional data class INLINES
+    //   outcome               a sum, typed here, tag + groups on the wire
+    //   label                 a plain leaf
+    section("output boundary derived from a value form") {
+        val rows = mutableListOf<String>()
+        val kept = mutableListOf<Summary>()
+        reportEach(3L, { sCount, sTotal, taken, oSecs, oNanos, outcome, label ->
+            // The value form is called ONCE per delivery, so every leaf below
+            // comes from the same snapshot.
+            check(oSecs == 1L && oNanos == 2L)
+            val stamped = if (taken != null) "@${taken.secs}" else "-"
+            val which = when (outcome) {
+                is Lookup.Failed -> "failed"
+                Lookup.Absent -> "absent"
+                is Lookup.Found -> {
+                    val s = outcome.v0
+                    // A handle carried by a sum group, reached through a value
+                    // form: live, and the receiver's to close.
+                    check(!s.isClosed())
+                    kept.add(s)
+                    "found:${s.count(boom)}"
+                }
+            }
+            rows.add("$label|$sCount|$sTotal|$stamped|$which")
+        }, boom)
+
+        check(
+            rows == listOf(
+                "r0|0|0.0|@7|failed",
+                "r1|0|10.0|-|absent",
+                "r2|1|20.0|@7|found:1",
+            )
+        ) { "derived value-form leaves: $rows" }
+
+        check(kept.size == 1)
+        kept[0].close()
+        check(kept[0].isClosed())
     }
 
     // A sum returned BORROWED (`&Reading` / `Option<&Reading>`). The value stays

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -211,6 +211,22 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_model_Report_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::Report));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Report>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecFree(
     _env: jni::JNIEnv,
     _class: jni::objects::JClass,
@@ -3869,6 +3885,255 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Report) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Report)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(
+                &__invoke_class,
+                "run",
+                "(JDLio/prebindgen/covertest/model/Stamp;JJIJLjava/lang/String;Ljava/lang/String;)V",
+            )
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Report)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Report| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Report)", e)))?;
+                env.push_local_frame(24)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Report)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __vf0 = perftest_flat::report_into_struct(__cb_arg0);
+                    let __cb0_obj5: jni::sys::jvalue;
+                    let __cb0_obj6: jni::sys::jvalue;
+                    let __cb0_obj7: jni::objects::JObject;
+                    match &__vf0.outcome {
+                        perftest_flat::Lookup::Absent => {
+                            __cb0_obj5 = jni::sys::jvalue { i: 0 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                            __cb0_obj7 = jni::objects::JObject::null();
+                        }
+                        perftest_flat::Lookup::Found(__sv0) => {
+                            let __enc___cb0_obj6 = match Summary_to_jlong_3cb103b9(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj6 = jni::sys::jvalue {
+                                j: __enc___cb0_obj6,
+                            };
+                            __cb0_obj5 = jni::sys::jvalue { i: 1 };
+                            __cb0_obj7 = jni::objects::JObject::null();
+                        }
+                        perftest_flat::Lookup::Failed(__sv0) => {
+                            let __enc___cb0_obj7 = match String_to_JString_c7f3ca43(
+                                &mut env,
+                                __sv0.clone(),
+                            ) {
+                                ::core::result::Result::Ok(__w) => __w,
+                                ::core::result::Result::Err(__e) => {
+                                    return ::core::result::Result::Err(
+                                        <__JniErr as ::core::convert::From<
+                                            String,
+                                        >>::from(__e.to_string()),
+                                    );
+                                }
+                            };
+                            __cb0_obj7 = __enc___cb0_obj7.into();
+                            __cb0_obj5 = jni::sys::jvalue { i: 2 };
+                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                        }
+                    }
+                    let __cb0_obj0: jni::sys::jvalue = {
+                        let __enc0 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            perftest_flat::summary_count(&__vf0.summary),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc0 }
+                    };
+                    let __cb0_obj1: jni::sys::jvalue = {
+                        let __enc1 = match f64_to_jdouble_9e4a8f70(
+                            &mut env,
+                            perftest_flat::summary_total(&__vf0.summary),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { d: __enc1 }
+                    };
+                    let __cb0_obj2: jni::objects::JObject = {
+                        let __enc2 = match Option_Stamp_to_JObject_6375b503(
+                            &mut env,
+                            __vf0.taken,
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc2
+                    };
+                    let __cb0_obj3: jni::sys::jvalue = {
+                        let __enc3 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            __vf0.origin.secs,
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc3 }
+                    };
+                    let __cb0_obj4: jni::sys::jvalue = {
+                        let __enc4 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            __vf0.origin.nanos,
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc4 }
+                    };
+                    let __cb0_obj8: jni::objects::JObject = {
+                        let __enc8 = match String_to_JString_c7f3ca43(
+                            &mut env,
+                            __vf0.label,
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc8.into()
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj2.as_raw(),
+                                },
+                                __cb0_obj3,
+                                __cb0_obj4,
+                                __cb0_obj5,
+                                __cb0_obj6,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj7.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj8.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Report)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_Storage_Send_Sync_static_2f26edcf<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -6787,6 +7052,28 @@ pub(crate) unsafe fn Option_Priority_to_JObject_ad5cbb32<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_Stamp_to_JObject_6375b503<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Stamp>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        match v {
+            Some(value) => Stamp_to_JObject_f6b1e942(env, value)?,
+            None => jni::objects::JObject::null().into(),
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<&perftest_flat::Summary>,
@@ -7100,6 +7387,23 @@ pub(crate) unsafe fn RepliesConfig_to_JObject_eb8e9079<'a>(
             >>::from(format!("encode struct via fromParts: {}", e)))?;
         __obj
     })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Report_to_jlong_eaed4ba1<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Report,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
 }
 #[allow(
     non_snake_case,
@@ -8208,6 +8512,30 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    dead_code,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_Report_eaed4ba1<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::Report>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Report) })
 }
 #[allow(
     non_snake_case,
@@ -14197,6 +14525,66 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingSeries<'a
         };
     }
     __acc
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_reportEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::report_each(n, sink);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1382,6 +1382,109 @@ pub fn escape_probe_value(p: &EscapeProbe) -> i64 {
     p.value
 }
 
+// ── Value form: a type's own accessors gathered into one struct (#213) ──────
+
+/// An opaque handle whose output boundary is declared from its **value form**
+/// ([`report_to_struct`]) instead of a restated field list — the
+/// `expand_return!(Report).fields(fields!(report_to_struct))` exercise.
+///
+/// Its fields are chosen so each one lands on a different rule of the
+/// expansion, and so the derived boundary is the same one a hand-written
+/// `.field()` list would have produced:
+///
+/// | field | rule |
+/// |---|---|
+/// | `summary` | its type has its own `expand_return!` ⇒ spliced into `(count, total)`, NOT handed over as a handle |
+/// | `taken` | `Option<data class>` ⇒ stays ONE leaf, its converter builds the object |
+/// | `origin` | a non-optional declared `data class` ⇒ INLINES into its own fields |
+/// | `outcome` | a `sealed_class!` ⇒ its selector plus one group per alternative, with a handle payload |
+/// | `label` | a plain leaf |
+pub struct Report {
+    summary: Summary,
+    taken: Option<Stamp>,
+    origin: Stamp,
+    outcome: Lookup,
+    label: String,
+}
+
+/// The value form of [`Report`]: its fields as data, handles staying handles.
+#[prebindgen]
+pub struct ReportStruct {
+    /// Decomposed by `Summary`'s own boundary decl, not delivered as a handle.
+    pub summary: Summary,
+    /// Absent when the report was never stamped.
+    pub taken: Option<Stamp>,
+    /// Always present, so it inlines into `origin_secs` / `origin_nanos`.
+    pub origin: Stamp,
+    /// A tag-gated group set, one alternative live, carrying a handle.
+    pub outcome: Lookup,
+    /// A plain string leaf beside the rest.
+    pub label: String,
+}
+
+/// Build a [`Report`]. `count < 0` makes the outcome a failure, `0` absent.
+#[prebindgen]
+pub fn report_new(count: i64, total: f64, taken: bool, label: String) -> Report {
+    Report {
+        summary: summary_new(count.max(0), total),
+        taken: taken.then(|| stamp_new(7, 8)),
+        origin: stamp_new(1, 2),
+        outcome: lookup_of(count, total),
+        label,
+    }
+}
+
+/// Decompose a [`Report`] into its value form — the accessor
+/// `expand_return!(Report).fields(fields!(...))` names. Cloning the fields is
+/// what makes this a *value* form; the generated code calls it ONCE per
+/// delivery and reads every leaf off that one result.
+#[prebindgen]
+pub fn report_to_struct(r: &Report) -> ReportStruct {
+    ReportStruct {
+        summary: r.summary.clone(),
+        taken: r.taken,
+        origin: r.origin,
+        outcome: r.outcome.clone(),
+        label: r.label.clone(),
+    }
+}
+
+/// The **consuming** value form of [`Report`] — the same fields, reached by
+/// destroying the report instead of cloning out of a borrow.
+///
+/// This is the shape a hot receive path wants. Every callback hands its value
+/// over **owned** (`impl Fn(Report)`), so there is nothing to preserve: moving
+/// the fields out costs nothing, while [`report_to_struct`] pays a clone per
+/// handle field for a value it is about to drop. The binding picks whichever
+/// form it declares; `expand_return!(Report).fields(fields!(report_into_struct))`
+/// selects this one and the generated code then **moves** each field into its
+/// leaf rather than cloning it.
+#[prebindgen]
+pub fn report_into_struct(r: Report) -> ReportStruct {
+    ReportStruct {
+        summary: r.summary,
+        taken: r.taken,
+        origin: r.origin,
+        outcome: r.outcome,
+        label: r.label,
+    }
+}
+
+/// Deliver a [`Report`] to a callback — the decomposed value form arriving in
+/// ONE crossing, which is the whole point of deriving the boundary rather than
+/// handing over a handle the receiver must then query field by field.
+#[prebindgen]
+pub fn report_each(n: i64, sink: impl Fn(Report) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(report_new(
+            i - 1,
+            10.0 * i as f64,
+            i % 2 == 0,
+            format!("r{i}"),
+        ));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/prebindgen/src/api/core/language/array_len.rs
+++ b/prebindgen/src/api/core/language/array_len.rs
@@ -130,41 +130,53 @@ impl fmt::Display for UnsupportedArrayLen {
 
 impl std::error::Error for UnsupportedArrayLen {}
 
-/// A fixed-size array's extent: the number, and the const identity when the
-/// source named one.
+/// A fixed-size array's extent: the number, the const identity when the source
+/// named one, and the spelling it was written with.
 ///
-/// Both halves belong to **different consumers**:
+/// # Three facts, three consumers — and no `==`
 ///
-/// * `value` is the semantic length. It is what makes `[u8; A]` and `[u8; 4]`
-///   one Rust type and one converter, and what a destination language needs when
-///   it has no way to reference a Rust const.
-/// * `source` is the identity a C header re-states as `uint8_t tag[TAG_LEN]`,
-///   so changing the size stays one edit rather than a hunt through literals.
+/// The three answer different questions, and **deliberately no equality is
+/// provided**, because there is no single one that could be right. A consumer
+/// projects the fact it actually needs:
+///
+/// | Question | Projection |
+/// |---|---|
+/// | is this the same type / the same converter? | [`Self::value`] |
+/// | how does a C declaration spell it? | [`Self::origin`]`.syntax`, per occurrence |
+/// | which consts must reach the header as a `#define`? | [`Self::const_id`] |
+///
+/// A blanket `==` mixes them and is wrong under either reading: comparing
+/// `source` makes `[u8; A]` differ from `[u8; 4]` when `A == 4` — one Rust type
+/// reported as two — while ignoring the spelling makes `[u8; 4]` equal
+/// `[u8; 0x04]`, whose retained syntax differs. Neither is type identity and
+/// neither is spelling identity, so the choice belongs to whoever is asking.
+///
+/// # Note for a converter table
+///
+/// `value` being the type identity means several occurrences share one
+/// converter, and their spellings differ. A shared converter therefore needs a
+/// **canonical** Rust spelling chosen on purpose — the evaluated literal is the
+/// obvious one — rather than whichever occurrence happened to populate a
+/// deduplicated entry.
 ///
 /// This lives on the **use site** — a field's or parameter's type — and never on
-/// anything keyed by type. Three fields whose extents are equal are one type, so
-/// a type-keyed table could only report whichever was stored last.
-///
-/// Equality is over the length only: `[u8; A]` and `[u8; 4]` are one type
-/// wherever they are written, so [`Self::origin`] — which differs per use site
-/// by construction — is deliberately not compared.
+/// anything keyed by type, for the same reason: two occurrences of one type may
+/// name the length differently, so a type-keyed table could only report
+/// whichever was stored last.
 #[derive(Clone, Debug)]
 pub struct ArrayExtent {
+    /// The evaluated length. The type identity: `[u8; A]` and `[u8; 4]` are one
+    /// Rust type when `A == 4`, and a destination language with no way to name a
+    /// Rust const needs the number.
     pub value: usize,
+    /// How the length was addressed, so a C header can re-state
+    /// `uint8_t tag[TAG_LEN]` and know `TAG_LEN` must reach it.
     pub source: ExtentSource,
-    /// The length expression as written — `4`, `TAG_LEN` — and where it came
-    /// from. So a C header emitting `uint8_t x[TAG_LEN]` spells the length off
-    /// its own slice rather than digging into the enclosing array type.
+    /// The length expression as written — `4`, `0x04`, `TAG_LEN` — and where it
+    /// came from. The spelling of *this* occurrence, which is what a declaration
+    /// re-emits; two occurrences of one type may differ here.
     pub origin: Origin<syn::Expr>,
 }
-
-impl PartialEq for ArrayExtent {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value && self.source == other.source
-    }
-}
-
-impl Eq for ArrayExtent {}
 
 /// How an [`ArrayExtent`] was addressed at its use site.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/prebindgen/src/api/core/language/array_len.rs
+++ b/prebindgen/src/api/core/language/array_len.rs
@@ -1,0 +1,303 @@
+//! The fixed-size-array length subgrammar: one closed representation and one
+//! fallible walk that produces it.
+//!
+//! A length must reduce to a **known number** — a generator runs in `build.rs`,
+//! where it cannot evaluate arbitrary Rust. Two spellings reach one, and nothing
+//! else does: an integer literal, or the bare name of a `#[prebindgen]` const
+//! whose own initializer is an integer literal.
+//!
+//! Both the number and the const identity travel, as an [`ArrayExtent`]: the
+//! value is the semantic length that makes `[u8; A]` and `[u8; 4]` one type, and
+//! the identity is what lets a C header emit `uint8_t x[NAME]`. The *spelling*
+//! travels separately and always — it is in the [`Type::syntax`](super::Type)
+//! slice of the array type itself — so this carries only what a destination
+//! language cannot read off the source.
+//!
+//! Ported from #212, which introduced it for issue #210.
+
+use std::{collections::HashMap, fmt};
+
+use quote::ToTokens;
+
+/// A length the prebindgen source language does not accept.
+///
+/// Names the offending sub-expression, not just the array: the point of the
+/// single walk is that it knows exactly which part it could not lower.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedArrayLen {
+    /// The array type as written, for context — `[u8 ; A + 1]`.
+    pub array: String,
+    /// The sub-expression that could not be lowered — `A + 1`.
+    pub offending: String,
+    /// Why it could not be lowered.
+    pub reason: ArrayLenReason,
+}
+
+/// Why [`lower_array_len`] refused a length.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArrayLenReason {
+    /// Not a literal and not a plain name: arithmetic, a cast, a call, a block,
+    /// a `match`, a closure — anything with structure the grammar lacks.
+    NotLiteralOrName,
+    /// A literal that is not a non-negative integer.
+    NotAnIntegerLiteral,
+    /// An integer literal too large for `usize`.
+    IntegerOutOfRange,
+    /// A path with more than one segment, a qualified self, or a leading `::` —
+    /// `crate::limits::MAX`, `usize::MAX`, `<Holder>::N`, `::MAX`.
+    ///
+    /// A length names a `#[prebindgen]` const, and those live in one flat,
+    /// uniquely-named namespace, so the bare name is the complete address. Any
+    /// longer path either restates that (`crate::limits::MAX`) or reaches
+    /// somewhere the frontend cannot follow — a module it does not index, an
+    /// associated const it never captured, a foreign crate. Neither can be
+    /// reduced to a number, and guessing between them is how a length silently
+    /// becomes the wrong one.
+    NotABareName,
+    /// A bare name that is not a `#[prebindgen]` const.
+    ///
+    /// The generated crate sees **only** what the macro exposed, so an unmarked
+    /// const is not merely unqualifiable — it does not exist downstream.
+    NotAMarkedConst,
+    /// A `#[prebindgen]` const whose own initializer is not an integer literal.
+    ///
+    /// `build.rs` cannot evaluate it, and a destination language that needs the
+    /// count cannot either. Hoist the arithmetic into the value the const is
+    /// computed FROM, or write the number.
+    ConstIsNotALiteral,
+    /// A `#[prebindgen]` const from a different source crate than the item
+    /// using it.
+    ///
+    /// Uniqueness holds across the *marked* namespace only, so a bare name in
+    /// one source crate can collide with an unmarked name of its own — the
+    /// frontend would silently bind to the other crate's value. Requiring the
+    /// length's const to come from the item's own crate makes that
+    /// unrepresentable.
+    ForeignSourceConst {
+        /// Crate the const was marked in.
+        const_crate: String,
+        /// Crate the item using it came from.
+        item_crate: String,
+    },
+}
+
+impl fmt::Display for UnsupportedArrayLen {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let what = match &self.reason {
+            ArrayLenReason::NotLiteralOrName => {
+                "is neither an integer literal nor the name of a const".to_string()
+            }
+            ArrayLenReason::NotAnIntegerLiteral => {
+                "is not a non-negative integer literal".to_string()
+            }
+            ArrayLenReason::IntegerOutOfRange => "does not fit in a `usize`".to_string(),
+            ArrayLenReason::NotABareName => {
+                "is a path rather than a bare name; `#[prebindgen]` items live in one flat \
+                 namespace, so the bare name is the whole address"
+                    .to_string()
+            }
+            ArrayLenReason::NotAMarkedConst => {
+                "names no `#[prebindgen]` const — the generated crate sees only what the macro \
+                 exposed, so mark it `#[prebindgen]`"
+                    .to_string()
+            }
+            ArrayLenReason::ConstIsNotALiteral => {
+                "names a const whose value is not an integer literal, so `build.rs` cannot \
+                 evaluate it"
+                    .to_string()
+            }
+            ArrayLenReason::ForeignSourceConst {
+                const_crate,
+                item_crate,
+            } => format!(
+                "names a const marked in `{const_crate}`, but the item using it comes from \
+                 `{item_crate}` — a length must name a const from its own source crate"
+            ),
+        };
+        write!(
+            f,
+            "fixed-size array `{}`: the length `{}` {what}. A length must be an integer literal, \
+             or the bare name of a `#[prebindgen]` const that is itself an integer literal \
+             (`pub const N: usize = 4;`) — a generator runs in `build.rs` and cannot evaluate \
+             anything else, and some destination languages need the count as a number.",
+            self.array, self.offending
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedArrayLen {}
+
+/// A fixed-size array's extent: the number, and the const identity when the
+/// source named one.
+///
+/// Both halves belong to **different consumers**:
+///
+/// * `value` is the semantic length. It is what makes `[u8; A]` and `[u8; 4]`
+///   one Rust type and one converter, and what a destination language needs when
+///   it has no way to reference a Rust const.
+/// * `source` is the identity a C header re-states as `uint8_t tag[TAG_LEN]`,
+///   so changing the size stays one edit rather than a hunt through literals.
+///
+/// This lives on the **use site** — a field's or parameter's type — and never on
+/// anything keyed by type. Three fields whose extents are equal are one type, so
+/// a type-keyed table could only report whichever was stored last.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArrayExtent {
+    pub value: usize,
+    pub source: ExtentSource,
+}
+
+/// How an [`ArrayExtent`] was addressed at its use site.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExtentSource {
+    /// Written as an integer literal — `[u8; 4]`.
+    Literal,
+    /// Written as the name of a `#[prebindgen]` const — `[u8; TAG_LEN]`.
+    Const(ConstId),
+}
+
+/// A `#[prebindgen]` const, identified the way the flat namespace identifies
+/// everything: by name, plus the crate it was marked in.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConstId {
+    pub name: String,
+    /// Crate the const was marked in; `None` for an origin-less stream.
+    pub origin: Option<String>,
+}
+
+impl ArrayExtent {
+    /// The const this extent named, if it named one.
+    pub fn const_id(&self) -> Option<&ConstId> {
+        match &self.source {
+            ExtentSource::Literal => None,
+            ExtentSource::Const(id) => Some(id),
+        }
+    }
+}
+
+/// One `#[prebindgen]` const, as a length sees it.
+struct ConstEntry {
+    /// The literal value, or `None` when the initializer is not one. Present
+    /// either way, so "not a const" and "not a usable const" stay distinct
+    /// diagnostics.
+    value: Option<usize>,
+    /// Crate the const was marked in; `None` for an origin-less stream.
+    origin: Option<String>,
+}
+
+/// The `#[prebindgen]` consts a length may name.
+///
+/// Built once per parse, before any type is lowered, so a const may be declared
+/// after the item that uses it. Deliberately holds **only consts**: nothing else
+/// can be a length now that the grammar is a bare name, so there is no item-kind
+/// enumeration here to drift.
+pub(crate) struct ConstIndex {
+    consts: HashMap<String, ConstEntry>,
+}
+
+impl ConstIndex {
+    /// `consts` maps each `#[prebindgen]` const's name to its initializer and
+    /// the crate it was marked in.
+    pub(crate) fn new<I>(consts: I) -> Self
+    where
+        I: IntoIterator<Item = (String, syn::Expr, Option<String>)>,
+    {
+        Self {
+            consts: consts
+                .into_iter()
+                .map(|(name, expr, origin)| {
+                    let entry = ConstEntry {
+                        value: int_literal(&expr),
+                        origin,
+                    };
+                    (name, entry)
+                })
+                .collect(),
+        }
+    }
+}
+
+/// The `usize` an expression denotes, if it is plainly an integer literal.
+fn int_literal(expr: &syn::Expr) -> Option<usize> {
+    let syn::Expr::Lit(lit) = expr else {
+        return None;
+    };
+    let syn::Lit::Int(int) = &lit.lit else {
+        return None;
+    };
+    int.base10_parse::<usize>().ok()
+}
+
+/// Lower one array length to its closed representation.
+///
+/// **The contract**: `Ok` means the length was fully understood AND reduced to a
+/// number. There is no separate acceptance check to drift from this — a form
+/// this function does not lower is, by construction, a form the language does
+/// not accept. That is the fix for the validator/rewriter pair this replaces
+/// (issue #210), where eight defects in a row were two walks disagreeing about
+/// one input.
+///
+/// `array` is the array type's rendered form and `item_crate` the origin of the
+/// item the length was written in; both are used for diagnostics, and
+/// `item_crate` additionally pins provenance.
+pub(crate) fn lower_array_len(
+    len: &syn::Expr,
+    array: &str,
+    item_crate: Option<&str>,
+    consts: &ConstIndex,
+) -> Result<ArrayExtent, UnsupportedArrayLen> {
+    let fail = |reason| UnsupportedArrayLen {
+        array: array.to_string(),
+        offending: len.to_token_stream().to_string(),
+        reason,
+    };
+    match len {
+        syn::Expr::Lit(_) => match int_literal(len) {
+            Some(value) => Ok(ArrayExtent {
+                value,
+                source: ExtentSource::Literal,
+            }),
+            None => Err(fail(match len {
+                // Told apart so an out-of-range integer does not report as
+                // "not an integer".
+                syn::Expr::Lit(l) if matches!(l.lit, syn::Lit::Int(_)) => {
+                    ArrayLenReason::IntegerOutOfRange
+                }
+                _ => ArrayLenReason::NotAnIntegerLiteral,
+            })),
+        },
+        syn::Expr::Path(ep) => {
+            // A bare name, and nothing longer. See `NotABareName` for why the
+            // flat namespace makes every longer path either redundant or
+            // unfollowable.
+            if ep.qself.is_some() || ep.path.leading_colon.is_some() || ep.path.segments.len() != 1
+            {
+                return Err(fail(ArrayLenReason::NotABareName));
+            }
+            let name = ep.path.segments[0].ident.to_string();
+            let Some(entry) = consts.consts.get(&name) else {
+                return Err(fail(ArrayLenReason::NotAMarkedConst));
+            };
+            // Provenance before value: a same-named const from another source
+            // may well be a literal, and using it would be the silent wrong
+            // answer rather than an error.
+            if entry.origin.as_deref() != item_crate {
+                return Err(fail(ArrayLenReason::ForeignSourceConst {
+                    const_crate: entry.origin.clone().unwrap_or_else(|| "<unstamped>".into()),
+                    item_crate: item_crate.unwrap_or("<unstamped>").to_string(),
+                }));
+            }
+            let Some(value) = entry.value else {
+                return Err(fail(ArrayLenReason::ConstIsNotALiteral));
+            };
+            Ok(ArrayExtent {
+                value,
+                source: ExtentSource::Const(ConstId {
+                    name,
+                    origin: entry.origin.clone(),
+                }),
+            })
+        }
+        _ => Err(fail(ArrayLenReason::NotLiteralOrName)),
+    }
+}

--- a/prebindgen/src/api/core/language/array_len.rs
+++ b/prebindgen/src/api/core/language/array_len.rs
@@ -15,9 +15,12 @@
 //!
 //! Ported from #212, which introduced it for issue #210.
 
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, rc::Rc};
 
 use quote::ToTokens;
+
+use super::origin::Origin;
+use crate::SourceLocation;
 
 /// A length the prebindgen source language does not accept.
 ///
@@ -141,11 +144,27 @@ impl std::error::Error for UnsupportedArrayLen {}
 /// This lives on the **use site** — a field's or parameter's type — and never on
 /// anything keyed by type. Three fields whose extents are equal are one type, so
 /// a type-keyed table could only report whichever was stored last.
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// Equality is over the length only: `[u8; A]` and `[u8; 4]` are one type
+/// wherever they are written, so [`Self::origin`] — which differs per use site
+/// by construction — is deliberately not compared.
+#[derive(Clone, Debug)]
 pub struct ArrayExtent {
     pub value: usize,
     pub source: ExtentSource,
+    /// The length expression as written — `4`, `TAG_LEN` — and where it came
+    /// from. So a C header emitting `uint8_t x[TAG_LEN]` spells the length off
+    /// its own slice rather than digging into the enclosing array type.
+    pub origin: Origin<syn::Expr>,
 }
+
+impl PartialEq for ArrayExtent {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value && self.source == other.source
+    }
+}
+
+impl Eq for ArrayExtent {}
 
 /// How an [`ArrayExtent`] was addressed at its use site.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -161,8 +180,13 @@ pub enum ExtentSource {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConstId {
     pub name: String,
-    /// Crate the const was marked in; `None` for an origin-less stream.
-    pub origin: Option<String>,
+    /// Crate the const was **declared** in, resolved by looking the name up
+    /// among the captured consts — never assumed from the use site. That is
+    /// what lets an extent refuse a const from another source crate.
+    ///
+    /// A bare crate name, not an [`Origin`]: it describes a *different* item
+    /// than the one being lowered, so it is not that node's provenance.
+    pub crate_name: Option<String>,
 }
 
 impl ArrayExtent {
@@ -181,8 +205,10 @@ struct ConstEntry {
     /// either way, so "not a const" and "not a usable const" stay distinct
     /// diagnostics.
     value: Option<usize>,
-    /// Crate the const was marked in; `None` for an origin-less stream.
-    origin: Option<String>,
+    /// Crate the const was marked in; `None` for an unstamped stream. Named
+    /// for what it is — a crate, not an [`Origin`], which belongs to the node
+    /// being lowered rather than to some other item it names.
+    crate_name: Option<String>,
 }
 
 /// The `#[prebindgen]` consts a length may name.
@@ -205,10 +231,10 @@ impl ConstIndex {
         Self {
             consts: consts
                 .into_iter()
-                .map(|(name, expr, origin)| {
+                .map(|(name, expr, crate_name)| {
                     let entry = ConstEntry {
                         value: int_literal(&expr),
-                        origin,
+                        crate_name,
                     };
                     (name, entry)
                 })
@@ -237,15 +263,17 @@ fn int_literal(expr: &syn::Expr) -> Option<usize> {
 /// (issue #210), where eight defects in a row were two walks disagreeing about
 /// one input.
 ///
-/// `array` is the array type's rendered form and `item_crate` the origin of the
-/// item the length was written in; both are used for diagnostics, and
-/// `item_crate` additionally pins provenance.
+/// `array` is the array type's rendered form, for diagnostics, and `at` the
+/// origin of the item the length was written in — which both becomes the
+/// extent's own origin and pins which crate a named const may come from.
 pub(crate) fn lower_array_len(
     len: &syn::Expr,
     array: &str,
-    item_crate: Option<&str>,
+    at: &Rc<SourceLocation>,
     consts: &ConstIndex,
 ) -> Result<ArrayExtent, UnsupportedArrayLen> {
+    let item_crate = at.crate_name.as_deref();
+    let origin = || Origin::new(len.clone(), Rc::clone(at));
     let fail = |reason| UnsupportedArrayLen {
         array: array.to_string(),
         offending: len.to_token_stream().to_string(),
@@ -256,6 +284,7 @@ pub(crate) fn lower_array_len(
             Some(value) => Ok(ArrayExtent {
                 value,
                 source: ExtentSource::Literal,
+                origin: origin(),
             }),
             None => Err(fail(match len {
                 // Told apart so an out-of-range integer does not report as
@@ -281,9 +310,12 @@ pub(crate) fn lower_array_len(
             // Provenance before value: a same-named const from another source
             // may well be a literal, and using it would be the silent wrong
             // answer rather than an error.
-            if entry.origin.as_deref() != item_crate {
+            if entry.crate_name.as_deref() != item_crate {
                 return Err(fail(ArrayLenReason::ForeignSourceConst {
-                    const_crate: entry.origin.clone().unwrap_or_else(|| "<unstamped>".into()),
+                    const_crate: entry
+                        .crate_name
+                        .clone()
+                        .unwrap_or_else(|| "<unstamped>".into()),
                     item_crate: item_crate.unwrap_or("<unstamped>").to_string(),
                 }));
             }
@@ -294,8 +326,9 @@ pub(crate) fn lower_array_len(
                 value,
                 source: ExtentSource::Const(ConstId {
                     name,
-                    origin: entry.origin.clone(),
+                    crate_name: entry.crate_name.clone(),
                 }),
+                origin: origin(),
             })
         }
         _ => Err(fail(ArrayLenReason::NotLiteralOrName)),

--- a/prebindgen/src/api/core/language/boundary.ledger
+++ b/prebindgen/src/api/core/language/boundary.ledger
@@ -42,7 +42,7 @@
 # gaps are listed here rather than implied away.
 
 4	api/core/expand.rs
-13	api/core/registry.rs
+12	api/core/registry.rs
 40	api/core/types_util.rs
 15	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
@@ -70,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 202
+# total: 201

--- a/prebindgen/src/api/core/language/boundary.ledger
+++ b/prebindgen/src/api/core/language/boundary.ledger
@@ -44,7 +44,7 @@
 4	api/core/expand.rs
 12	api/core/registry.rs
 40	api/core/types_util.rs
-15	api/core/unfold.rs
+16	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
@@ -53,7 +53,7 @@
 13	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 4	api/lang/jnigen/jni/emit/convert.rs
-1	api/lang/jnigen/jni/emit/delivery.rs
+2	api/lang/jnigen/jni/emit/delivery.rs
 10	api/lang/jnigen/jni/emit/flat_input.rs
 17	api/lang/jnigen/jni/emit/names.rs
 2	api/lang/jnigen/jni/emit/vec_build.rs
@@ -70,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 201
+# total: 203

--- a/prebindgen/src/api/core/language/boundary.ledger
+++ b/prebindgen/src/api/core/language/boundary.ledger
@@ -1,0 +1,73 @@
+# prebindgen source-syntax boundary ledger — issue #211.
+#
+# One line per file OUTSIDE `api/core/language/`, counting how many times a
+# variant of a watched syn syntax enum is named in production code:
+#
+#     syn::Type::Reference(r) => ...        <- one site
+#     matches!(ty, syn::Expr::Lit(_))       <- one site
+#
+# Watched enums: syn::Type, syn::Expr. Test code is excluded.
+#
+# Every one of these is a place that independently decides what captured Rust
+# MEANS. #211 says only `core::language` may do that, so this file freezes the
+# population: any change fails `cargo test -p prebindgen boundary_ledger`.
+#
+# This is the CLASSIFY half of the rule, and only that half. Spelling the source
+# — handing an element's `syntax` slice to `quote!` — names no variant and is
+# not counted, because re-emitting what the source wrote is what generated Rust
+# is for. Deciding what the source MEANT from that syntax is what it is not for.
+#
+# To change it deliberately:
+#
+#     UPDATE_BOUNDARY_LEDGER=1 cargo test -p prebindgen boundary_ledger
+#     git diff prebindgen/src/api/core/language/boundary.ledger
+#
+# A count going DOWN is the goal (a classifier reads elements instead) and is
+# still a ledger edit, so the win shows up in the diff.
+#
+# KNOWN BLIND SPOTS — classification this check cannot see, because it never
+# writes a `syn::` path. Each is a candidate addition to WATCHED:
+#
+#   * token-string classification, e.g. `core/domain.rs` matching
+#     `ty.to_token_stream().to_string()` against "i8" / "f32";
+#   * ident-name classification, e.g. `seg.ident == "Option"`;
+#   * helper delegation — `jnigen/jni/classify.rs` is a whole classifier with
+#     zero watched sites;
+#   * syn enums outside WATCHED: Item, Fields, FnArg, ReturnType,
+#     GenericArgument, Pat, ...;
+#   * `types_util::match_pattern` unification against `parse_quote!(_)`
+#     patterns, which adds a shape rule with no watched site at all.
+#
+# A check that silently under-reports is worse than no check, which is why the
+# gaps are listed here rather than implied away.
+
+4	api/core/expand.rs
+13	api/core/registry.rs
+40	api/core/types_util.rs
+15	api/core/unfold.rs
+8	api/lang/cbindgen/builder.rs
+1	api/lang/cbindgen/convert.rs
+5	api/lang/cbindgen/emit.rs
+5	api/lang/cbindgen/mod.rs
+6	api/lang/cbindgen/trait_impl.rs
+13	api/lang/jnigen/jni/builder.rs
+1	api/lang/jnigen/jni/emit/callback.rs
+4	api/lang/jnigen/jni/emit/convert.rs
+1	api/lang/jnigen/jni/emit/delivery.rs
+10	api/lang/jnigen/jni/emit/flat_input.rs
+17	api/lang/jnigen/jni/emit/names.rs
+2	api/lang/jnigen/jni/emit/vec_build.rs
+11	api/lang/jnigen/jni/emit/wrapper.rs
+3	api/lang/jnigen/jni/fold.rs
+5	api/lang/jnigen/jni/iface.rs
+2	api/lang/jnigen/jni/kotlin_emit.rs
+2	api/lang/jnigen/jni/overloads.rs
+1	api/lang/jnigen/jni/prim.rs
+3	api/lang/jnigen/jni/prim_array.rs
+8	api/lang/jnigen/jni/render.rs
+7	api/lang/jnigen/jni/selector.rs
+11	api/lang/jnigen/jni/trait_impl.rs
+2	api/lang/jnigen/jni/wire_access.rs
+2	api/lang/jnigen/util.rs
+
+# total: 202

--- a/prebindgen/src/api/core/language/boundary.rs
+++ b/prebindgen/src/api/core/language/boundary.rs
@@ -1,0 +1,464 @@
+//! The mechanical boundary check: a committed ledger of every place outside
+//! this module that classifies captured Rust syntax.
+//!
+//! Issue #211's sixth completion criterion is that a mechanical check must
+//! prevent new source-syntax classifiers from appearing outside the frontend.
+//! This is that check. It is test-only; it ships no production code.
+//!
+//! It measures exactly the rule the [element model](super) states — **classify
+//! off `kind`, spell off `syntax`** — and it can, because it counts *variant
+//! mentions* of a syn syntax enum rather than uses of syn values. Handing a
+//! `syntax` slice to `quote!` names no variant and is invisible here; asking
+//! `matches!(ty, syn::Type::Reference(_))` names one and is counted. So the
+//! check needed no adaptation to the design: spelling was never what it saw.
+//!
+//! ## What a site is
+//!
+//! A place that looks at captured Rust syntax and asks *what shape is this*:
+//!
+//! ```ignore
+//! syn::Type::Reference(r) => vec![(*r.elem).clone()],          // core/types_util.rs
+//! if !matches!(arg_ty, syn::Type::Reference(_)) => { .. }      // jnigen emit/wrapper.rs
+//! let syn::Type::Slice(s) = &*r.elem else { .. };              // cbindgen builder.rs
+//! ```
+//!
+//! Each is an independent decision about what the source Rust *means* — the
+//! decisions #211 says belong to this module alone. #210 was two such places,
+//! in one file, disagreeing about `[u8; <Holder>::N]`.
+//!
+//! So [`scan_tree`] counts, per file, how many times a variant of a [`WATCHED`]
+//! syn syntax enum is named, and [`boundary_ledger`] fails if any count moved.
+//! Up means a new classifier landed outside the language. Down means one was
+//! migrated — the goal, but it still edits the ledger, so the progress of the
+//! adapter migrations shows as a diff instead of being invisible.
+//!
+//! The seed count is therefore high: nothing consumes elements yet, so this
+//! freezes the population as it stands and every later PR pays it down.
+//!
+//! The number's job is to not move, not to be a precise census: a few counted
+//! occurrences *build* syntax rather than classify it (`cbindgen/builder.rs`
+//! returns a `syn::Type::Path`, which is emission). Separating build from match
+//! mechanically costs real code, and those sites are few and stable.
+//!
+//! ## Why the count is read off disk
+//!
+//! The crate has no default features and `unstable-cbindgen` gates the whole
+//! cbindgen suite, so CI runs both `cargo test` and `cargo test --all
+//! --all-features`. A check that inspected the *compiled* crate would count a
+//! different population in each, i.e. give two answers in one CI run — the
+//! failure mode of #219. Reading the source files makes the count
+//! feature-independent, so both invocations agree.
+//!
+//! ## Why tokens, not a grep and not an AST visit
+//!
+//! A `grep -c` counts lines rather than occurrences, counts the inline
+//! `#[cfg(test)] mod` blocks (so *adding a test* would fail the check, which is
+//! how these ledgers die), and is defeated by one line: `use syn::Type;` then
+//! `Type::Reference(_)` greps as zero. A `syn::visit::Visit` walk fixes those
+//! and opens a worse hole — it cannot see inside macro invocations, and a large
+//! share of the sites live in `matches!(..)`. A token walk sees patterns,
+//! expressions, types and macro bodies alike, and is immune to line wrapping.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use proc_macro2::{Delimiter, TokenStream, TokenTree};
+
+/// The syn syntax enums whose variants count as a classification site.
+///
+/// Deliberately minimal. It is the population #211 and `docs/source-frontend.md`
+/// already track, and the low-noise one: emitters construct `syn::Item::Fn`
+/// constantly but rarely construct a `syn::Type` or `syn::Expr`, so adding
+/// `Item` here would churn the ledger on every emission change.
+///
+/// Extending this list is one line, plus a regenerated ledger whose diff is the
+/// classification decision.
+const WATCHED: &[&str] = &["Type", "Expr"];
+
+/// Ledger location, relative to `src/`.
+const LEDGER: &str = "api/core/language/boundary.ledger";
+
+/// Regenerated verbatim on every write, so the contract cannot drift from the
+/// numbers underneath it.
+const HEADER: &str = "\
+# prebindgen source-syntax boundary ledger — issue #211.
+#
+# One line per file OUTSIDE `api/core/language/`, counting how many times a
+# variant of a watched syn syntax enum is named in production code:
+#
+#     syn::Type::Reference(r) => ...        <- one site
+#     matches!(ty, syn::Expr::Lit(_))       <- one site
+#
+# Watched enums: syn::Type, syn::Expr. Test code is excluded.
+#
+# Every one of these is a place that independently decides what captured Rust
+# MEANS. #211 says only `core::language` may do that, so this file freezes the
+# population: any change fails `cargo test -p prebindgen boundary_ledger`.
+#
+# This is the CLASSIFY half of the rule, and only that half. Spelling the source
+# — handing an element's `syntax` slice to `quote!` — names no variant and is
+# not counted, because re-emitting what the source wrote is what generated Rust
+# is for. Deciding what the source MEANT from that syntax is what it is not for.
+#
+# To change it deliberately:
+#
+#     UPDATE_BOUNDARY_LEDGER=1 cargo test -p prebindgen boundary_ledger
+#     git diff prebindgen/src/api/core/language/boundary.ledger
+#
+# A count going DOWN is the goal (a classifier reads elements instead) and is
+# still a ledger edit, so the win shows up in the diff.
+#
+# KNOWN BLIND SPOTS — classification this check cannot see, because it never
+# writes a `syn::` path. Each is a candidate addition to WATCHED:
+#
+#   * token-string classification, e.g. `core/domain.rs` matching
+#     `ty.to_token_stream().to_string()` against \"i8\" / \"f32\";
+#   * ident-name classification, e.g. `seg.ident == \"Option\"`;
+#   * helper delegation — `jnigen/jni/classify.rs` is a whole classifier with
+#     zero watched sites;
+#   * syn enums outside WATCHED: Item, Fields, FnArg, ReturnType,
+#     GenericArgument, Pat, ...;
+#   * `types_util::match_pattern` unification against `parse_quote!(_)`
+#     patterns, which adds a shape rule with no watched site at all.
+#
+# A check that silently under-reports is worse than no check, which is why the
+# gaps are listed here rather than implied away.
+";
+
+/// Every classification site in the crate's own sources, keyed by path relative
+/// to `src/` with `/` separators so the ledger is identical on every platform.
+///
+/// Excluded: this module's own directory (the language is where classification
+/// is *supposed* to live), and test code — `tests.rs`, anything under a `tests/`
+/// directory, and any item carrying `#[cfg(test)]`.
+fn scan_tree(src_root: &Path) -> BTreeMap<String, usize> {
+    let mut out = BTreeMap::new();
+    let mut stack = vec![src_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = fs::read_dir(&dir).expect("src/ is readable");
+        for entry in entries {
+            let path = entry.expect("readable dir entry").path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "tests") {
+                    continue;
+                }
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs")
+                || path.file_name().is_some_and(|n| n == "tests.rs")
+            {
+                continue;
+            }
+            let rel = rel_key(src_root, &path);
+            if rel.starts_with("api/core/language/") {
+                continue;
+            }
+            let text = fs::read_to_string(&path).expect("source file is UTF-8");
+            let n = scan_file(&text);
+            if n > 0 {
+                out.insert(rel, n);
+            }
+        }
+    }
+    out
+}
+
+fn rel_key(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .expect("path came from walking root")
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Sites in one file's text.
+fn scan_file(text: &str) -> usize {
+    let stream = TokenStream::from_str(text).expect("source file parses as tokens");
+    let aliases = collect_aliases(stream.clone());
+    let mut n = 0;
+    count(stream, &aliases, &mut n);
+    n
+}
+
+/// Idents bound to a watched enum by a `use` in this file — `use syn::Type` or
+/// `use syn::Type as T`.
+///
+/// Without this the check is defeated by a one-line import, and CI's
+/// `imports_granularity=Crate` makes such an import more likely over time, not
+/// less. No file does this today; the point is that none can start.
+fn collect_aliases(stream: TokenStream) -> Vec<String> {
+    let mut out = Vec::new();
+    for run in use_runs(stream) {
+        // `use syn::...` only; `use crate::Type` binds something else entirely.
+        if run.first().map(String::as_str) != Some("syn") {
+            continue;
+        }
+        let mut i = 1;
+        while i < run.len() {
+            if WATCHED.contains(&run[i].as_str()) {
+                let renamed = run.get(i + 1).map(String::as_str) == Some("as");
+                match (renamed, run.get(i + 2)) {
+                    (true, Some(alias)) => {
+                        out.push(alias.clone());
+                        i += 3;
+                        continue;
+                    }
+                    _ => out.push(run[i].clone()),
+                }
+            }
+            i += 1;
+        }
+    }
+    out
+}
+
+/// The idents of every `use` statement, flattened through brace groups so
+/// `use syn::{Type, Expr as E}` reads as one run.
+fn use_runs(stream: TokenStream) -> Vec<Vec<String>> {
+    let mut out = Vec::new();
+    let toks: Vec<TokenTree> = stream.into_iter().collect();
+    let mut i = 0;
+    while i < toks.len() {
+        match &toks[i] {
+            TokenTree::Ident(id) if *id == "use" => {
+                let mut run = Vec::new();
+                i += 1;
+                while i < toks.len() && !is_punct(&toks[i], ';') {
+                    flatten_idents(&toks[i], &mut run);
+                    i += 1;
+                }
+                out.push(run);
+            }
+            // A `use` can be nested in a module body or a function.
+            TokenTree::Group(g) => {
+                out.extend(use_runs(g.stream()));
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    out
+}
+
+fn flatten_idents(tt: &TokenTree, out: &mut Vec<String>) {
+    match tt {
+        TokenTree::Ident(id) => out.push(id.to_string()),
+        TokenTree::Group(g) => {
+            for inner in g.stream() {
+                flatten_idents(&inner, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn count(stream: TokenStream, aliases: &[String], n: &mut usize) {
+    let toks: Vec<TokenTree> = stream.into_iter().collect();
+    let mut i = 0;
+    while i < toks.len() {
+        // `#[cfg(test)] <item>` — skip the item wholesale. Five inline test
+        // modules exist and one is named `replace_ident_tests`, so a rule keyed
+        // on the module name would miss it.
+        if is_punct(&toks[i], '#') {
+            if let Some(TokenTree::Group(g)) = toks.get(i + 1) {
+                if g.delimiter() == Delimiter::Bracket && is_cfg_test(g.stream()) {
+                    i += 2;
+                    skip_item(&toks, &mut i);
+                    continue;
+                }
+            }
+            i += 1;
+            continue;
+        }
+        // An import is not a classifier, and counting one would churn the ledger
+        // whenever rustfmt regroups imports.
+        if matches!(&toks[i], TokenTree::Ident(id) if *id == "use") {
+            while i < toks.len() && !is_punct(&toks[i], ';') {
+                i += 1;
+            }
+            i += 1;
+            continue;
+        }
+        // `syn :: <watched> :: <variant>`
+        if matches!(&toks[i], TokenTree::Ident(id) if *id == "syn")
+            && is_sep(&toks, i + 1)
+            && matches!(toks.get(i + 3), Some(TokenTree::Ident(id)) if WATCHED.contains(&id.to_string().as_str()))
+            && is_sep(&toks, i + 4)
+            && matches!(toks.get(i + 6), Some(TokenTree::Ident(_)))
+        {
+            *n += 1;
+            i += 7;
+            continue;
+        }
+        // `<alias> :: <variant>`
+        if matches!(&toks[i], TokenTree::Ident(id) if aliases.contains(&id.to_string()))
+            && is_sep(&toks, i + 1)
+            && matches!(toks.get(i + 3), Some(TokenTree::Ident(_)))
+        {
+            *n += 1;
+            i += 4;
+            continue;
+        }
+        if let TokenTree::Group(g) = &toks[i] {
+            count(g.stream(), aliases, n);
+        }
+        i += 1;
+    }
+}
+
+/// Consume the item an attribute was attached to: everything up to and including
+/// its first brace-delimited body, or its terminating `;`, whichever comes first.
+/// That covers `mod x { .. }`, `mod x;`, `fn f() -> T { .. }`, `use ..;` and
+/// `impl T { .. }` alike, and steps over any further attributes on the way.
+fn skip_item(toks: &[TokenTree], i: &mut usize) {
+    while *i < toks.len() {
+        let tt = &toks[*i];
+        *i += 1;
+        match tt {
+            TokenTree::Group(g) if g.delimiter() == Delimiter::Brace => return,
+            _ if is_punct(tt, ';') => return,
+            _ => {}
+        }
+    }
+}
+
+fn is_cfg_test(stream: TokenStream) -> bool {
+    let mut idents = Vec::new();
+    for tt in stream {
+        flatten_idents(&tt, &mut idents);
+    }
+    idents.first().map(String::as_str) == Some("cfg") && idents.iter().any(|s| s == "test")
+}
+
+/// A `::` is two `Punct` tokens, so a path separator spans `i` and `i + 1`.
+fn is_sep(toks: &[TokenTree], i: usize) -> bool {
+    toks.get(i).is_some_and(|t| is_punct(t, ':'))
+        && toks.get(i + 1).is_some_and(|t| is_punct(t, ':'))
+}
+
+fn is_punct(tt: &TokenTree, c: char) -> bool {
+    matches!(tt, TokenTree::Punct(p) if p.as_char() == c)
+}
+
+fn render(sites: &BTreeMap<String, usize>) -> String {
+    let mut s = String::from(HEADER);
+    s.push('\n');
+    for (path, n) in sites {
+        s.push_str(&format!("{n}\t{path}\n"));
+    }
+    s.push_str(&format!("\n# total: {}\n", sites.values().sum::<usize>()));
+    s
+}
+
+fn parse(text: &str) -> BTreeMap<String, usize> {
+    text.lines()
+        .filter(|l| !l.starts_with('#') && !l.trim().is_empty())
+        .map(|l| {
+            let (n, path) = l
+                .split_once('\t')
+                .expect("ledger line is `<count>\\t<path>`");
+            (
+                path.to_string(),
+                n.parse().expect("ledger count is a number"),
+            )
+        })
+        .collect()
+}
+
+fn src_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+#[test]
+fn boundary_ledger() {
+    let root = src_root();
+    let found = scan_tree(&root);
+    let ledger_path = root.join(LEDGER);
+
+    if std::env::var_os("UPDATE_BOUNDARY_LEDGER").is_some() {
+        fs::write(&ledger_path, render(&found)).expect("ledger is writable");
+        return;
+    }
+
+    let committed = parse(&fs::read_to_string(&ledger_path).expect("ledger is committed"));
+    if committed == found {
+        return;
+    }
+
+    let mut drift = String::new();
+    let paths: std::collections::BTreeSet<_> = committed.keys().chain(found.keys()).collect();
+    for path in paths {
+        let (was, now) = (committed.get(path), found.get(path));
+        if was != now {
+            let fmt = |v: Option<&usize>| v.map_or("-".to_string(), usize::to_string);
+            drift.push_str(&format!("  {path}: {} -> {}\n", fmt(was), fmt(now)));
+        }
+    }
+    panic!(
+        "BOUNDARY LEDGER DRIFT — source-syntax classification sites changed:\n\
+         {drift}\n\
+         A new classifier outside core::language needs one of:\n\
+         \x20 * move it into core::language (see #211), or\n\
+         \x20 * regenerate and justify the change in review:\n\
+         \x20     UPDATE_BOUNDARY_LEDGER=1 cargo test -p prebindgen boundary_ledger\n\
+         \x20     git diff prebindgen/src/{LEDGER}\n"
+    );
+}
+
+#[test]
+fn scanner_recognizes_the_shapes_that_matter() {
+    // A match arm, and a `matches!` body — invisible to an AST visitor, which is
+    // why this walks tokens.
+    assert_eq!(
+        scan_file("fn f(t: &syn::Type) { match t { syn::Type::Slice(s) => g(s), _ => {} } }"),
+        1
+    );
+    assert_eq!(
+        scan_file("fn f() -> bool { matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty()) }"),
+        1
+    );
+    assert_eq!(
+        scan_file("fn f() { let syn::Expr::Lit(l) = e else { return; }; }"),
+        1
+    );
+    // Two on one line: a line count would report one.
+    assert_eq!(
+        scan_file("fn f() { if let (syn::Type::Path(a), syn::Type::Path(b)) = p {} }"),
+        2
+    );
+
+    // The one-line defeat the alias handling closes.
+    assert_eq!(
+        scan_file("use syn::Type;\nfn f() { if let Type::Reference(r) = t {} }"),
+        1
+    );
+    assert_eq!(
+        scan_file(
+            "use syn::{Expr, Type as T};\nfn f() { if let T::Ptr(p) = t { h(Expr::Lit(l)) } }"
+        ),
+        2
+    );
+    // An import is not a site, and neither is a non-syn `Type`.
+    assert_eq!(scan_file("use syn::Type;\nfn f() {}"), 0);
+    assert_eq!(scan_file("fn f() { if let Type::Reference(r) = t {} }"), 0);
+
+    // Outside WATCHED — emitters construct these constantly.
+    assert_eq!(scan_file("fn f() { let i = syn::Item::Fn(f); }"), 0);
+
+    // Test code does not count, whatever the module is called.
+    assert_eq!(
+        scan_file(
+            "fn f() { match t { syn::Type::Slice(s) => (), _ => () } }\n\
+             #[cfg(test)]\n\
+             mod replace_ident_tests { fn g() { let _ = syn::Type::Ptr(p); } }"
+        ),
+        1
+    );
+    assert_eq!(scan_file("#[cfg(test)]\nmod tests;"), 0);
+}

--- a/prebindgen/src/api/core/language/boundary.rs
+++ b/prebindgen/src/api/core/language/boundary.rs
@@ -328,12 +328,24 @@ fn skip_item(toks: &[TokenTree], i: &mut usize) {
     }
 }
 
+/// True only for the exact predicate `cfg(test)`.
+///
+/// Deliberately conservative: this check's job is to stop a classifier hiding, so
+/// anything it cannot *prove* is test-only gets counted. Looking for the ident
+/// `test` anywhere in the predicate got that backwards — `cfg(not(test))` and
+/// `cfg(any(test, feature = "x"))` both compile in a production build, and both
+/// were treated as test-only, so a classifier under either evaded the ledger
+/// entirely.
+///
+/// `cfg(all(test, …))` is genuinely test-only and is nonetheless counted. That is
+/// the safe direction to err in, and nothing in the tree writes one; if that
+/// changes, widening this is a deliberate edit with a ledger diff attached.
 fn is_cfg_test(stream: TokenStream) -> bool {
     let mut idents = Vec::new();
     for tt in stream {
         flatten_idents(&tt, &mut idents);
     }
-    idents.first().map(String::as_str) == Some("cfg") && idents.iter().any(|s| s == "test")
+    idents == ["cfg", "test"]
 }
 
 /// A `::` is two `Punct` tokens, so a path separator spans `i` and `i + 1`.
@@ -461,4 +473,23 @@ fn scanner_recognizes_the_shapes_that_matter() {
         1
     );
     assert_eq!(scan_file("#[cfg(test)]\nmod tests;"), 0);
+
+    // But ONLY code proven test-only. Both of these compile in a production
+    // build, and a rule that looked for the ident `test` anywhere let a
+    // classifier under either evade the count.
+    assert_eq!(
+        scan_file("#[cfg(not(test))]\nfn g() { let _ = syn::Type::Ptr(p); }"),
+        1,
+        "cfg(not(test)) is production code"
+    );
+    assert_eq!(
+        scan_file("#[cfg(any(test, feature = \"x\"))]\nfn g() { let _ = syn::Type::Ptr(p); }"),
+        1,
+        "cfg(any(test, ..)) compiles whenever the other arm holds"
+    );
+    // A feature literally named "test" is not the test predicate either.
+    assert_eq!(
+        scan_file("#[cfg(feature = \"test\")]\nfn g() { let _ = syn::Type::Ptr(p); }"),
+        1
+    );
 }

--- a/prebindgen/src/api/core/language/element.rs
+++ b/prebindgen/src/api/core/language/element.rs
@@ -4,9 +4,10 @@
 //! Every component — a parameter, a field, a variant, a type — keeps its own
 //! slice, so generated Rust names the source by re-emitting what the source
 //! wrote, and nothing re-parses a whole item to find a part of it.
-
-use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+//!
+//! **Structure only.** Everything that turns an element back into Rust tokens
+//! lives in [`spell`](super::spell), so the shape of an element says nothing
+//! about the language it came from.
 
 use super::ty::Type;
 use crate::SourceLocation;
@@ -80,11 +81,11 @@ pub struct Function {
     pub name: syn::Ident,
     /// Parameters in declaration order.
     pub params: Vec<Param>,
-    /// The return type, or `None` when the source wrote no `->` at all. A
-    /// written `-> ()` is `Some`, with [`TypeKind::Unit`](super::TypeKind) —
-    /// the two mean the same thing and are spelled differently, and only the
-    /// spelling side cares.
-    pub ret: Option<Type>,
+    /// What the function returns. An elided return is
+    /// [`TypeKind::Unit`](super::TypeKind), exactly as a written `-> ()` is:
+    /// they mean the same thing, differ only in spelling, and every consumer
+    /// today already normalizes one to the other on the spot.
+    pub ret: Type,
     pub location: SourceLocation,
     /// The whole item: attributes, `cfg`, doc comments, body.
     pub syntax: syn::ItemFn,
@@ -99,36 +100,32 @@ pub struct Param {
     pub syntax: syn::PatType,
 }
 
-/// A `#[prebindgen]` struct.
+/// A `#[prebindgen]` struct: a product of fields, or an opaque one.
 #[derive(Clone, Debug)]
 pub struct Struct {
     pub name: syn::Ident,
-    pub fields: StructFields,
+    /// The fields, when they are a boundary surface — `Some(vec![])` for a
+    /// struct with none.
+    ///
+    /// `None` means **opaque**: the contents are not part of the boundary and
+    /// are deliberately not lowered, so a field type outside the grammar is not
+    /// an error. That is today's tuple struct — usable as a handle, its fields
+    /// never crossed by any adapter — and lowering them would turn types that
+    /// are ignored now into refusals.
+    ///
+    /// Whether a shape has named or positional fields is not recorded here: a
+    /// [`Field`] already knows its own address, and the delimiters are
+    /// spelling, read off `syntax` by
+    /// [`spell::fields`](super::spell::fields).
+    pub fields: Option<Vec<Field>>,
     pub location: SourceLocation,
     pub syntax: syn::ItemStruct,
 }
 
-/// The three struct shapes, and which of them has a modelled field list.
-#[derive(Clone, Debug)]
-pub enum StructFields {
-    /// `struct S { a: A }` — the one shape whose fields are a boundary surface,
-    /// so they are lowered and a type the language cannot express is an error.
-    Named(Vec<Field>),
-    /// `struct S(A, B);` — indexed, fields **not** modelled. A tuple struct is
-    /// usable as an opaque handle, and no adapter has ever crossed its fields,
-    /// so lowering them would turn types that are ignored today into errors.
-    Unnamed,
-    /// `struct S;`
-    Unit,
-}
-
-impl StructFields {
-    /// The modelled fields — empty for the shapes that have none.
-    pub fn named(&self) -> &[Field] {
-        match self {
-            StructFields::Named(f) => f,
-            StructFields::Unnamed | StructFields::Unit => &[],
-        }
+impl Struct {
+    /// The modelled fields — empty when the struct is opaque.
+    pub fn fields(&self) -> &[Field] {
+        self.fields.as_deref().unwrap_or(&[])
     }
 }
 
@@ -204,38 +201,7 @@ pub struct Variant {
     pub syntax: syn::Variant,
 }
 
-impl Variant {
-    /// True when this variant carries no payload.
-    ///
-    /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
-    /// unit by this test, and [`Self::spell`] is what keeps their delimiters
-    /// apart.
-    pub fn is_unit(&self) -> bool {
-        self.fields.is_empty()
-    }
-
-    /// Spell this variant: `head`, `head(parts…)` or `head { parts… }`,
-    /// following the delimiters the source wrote.
-    ///
-    /// The one place a variant's delimiters are chosen, for match patterns and
-    /// constructors alike and in either direction. It reads them off
-    /// [`Self::syntax`] rather than a modelled shape, because they are spelling
-    /// and nothing else: `B()` carries no payload and still must be written
-    /// `E::B()` wherever Rust names it, while no destination language can tell
-    /// it from `B`.
-    ///
-    /// `head` is the variant's path and each part is an already-rendered `bind`
-    /// or `member: bind` — see [`Field::member`].
-    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        match &self.syntax.fields {
-            syn::Fields::Unit => head,
-            syn::Fields::Unnamed(_) => quote!(#head(#(#parts),*)),
-            syn::Fields::Named(_) => quote!(#head { #(#parts),* }),
-        }
-    }
-}
-
-/// One field of a [`StructFields::Named`] struct or of a [`Variant`].
+/// One field of a [`Struct`] or of a [`Variant`].
 #[derive(Clone, Debug)]
 pub struct Field {
     /// The field's name, or `None` for a positional one.
@@ -248,24 +214,15 @@ pub struct Field {
     pub syntax: syn::Field,
 }
 
-impl Field {
-    /// How the field is addressed in a pattern or an initializer: by name when
-    /// it has one, else by position.
-    pub fn member(&self) -> syn::Member {
-        match &self.name {
-            Some(id) => syn::Member::Named(id.clone()),
-            None => syn::Member::Unnamed(syn::Index::from(self.index)),
-        }
-    }
-
-    /// The field bound to `bind`, shaped for whichever address it uses —
-    /// `id: __f0` for a named field, `__f0` for a positional one. The part
-    /// [`Variant::spell`] takes.
-    pub fn bind(&self, bind: &impl ToTokens) -> TokenStream {
-        match &self.name {
-            Some(id) => quote!(#id: #bind),
-            None => quote!(#bind),
-        }
+impl Variant {
+    /// True when this variant carries no payload.
+    ///
+    /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
+    /// unit by this test, and
+    /// [`spell::fields`](super::spell::fields) is what keeps their delimiters
+    /// apart.
+    pub fn is_unit(&self) -> bool {
+        self.fields.is_empty()
     }
 }
 

--- a/prebindgen/src/api/core/language/element.rs
+++ b/prebindgen/src/api/core/language/element.rs
@@ -1,15 +1,15 @@
-//! The elements: one variant per structure the source language allows, each
-//! carrying the exact syntax it was built from.
+//! The elements: one variant per structure the source language allows.
 //!
-//! Every component — a parameter, a field, a variant, a type — keeps its own
-//! slice, so generated Rust names the source by re-emitting what the source
-//! wrote, and nothing re-parses a whole item to find a part of it.
+//! Every node — an item, a parameter, a field, a variant, a type — carries one
+//! [`Origin`], so generated Rust names the source by re-emitting what the source
+//! wrote, nothing re-parses a whole item to find a part of it, and no level has
+//! to copy a piece of provenance down from the level above.
 //!
 //! **Structure only.** Everything that turns an element back into Rust tokens
 //! lives in [`spell`](super::spell), so the shape of an element says nothing
 //! about the language it came from.
 
-use super::ty::Type;
+use super::{origin::Origin, ty::Type};
 use crate::SourceLocation;
 
 /// One structure of the prebindgen source language.
@@ -55,24 +55,27 @@ impl Element {
     }
 
     /// Where the item was captured, including the crate that marked it.
+    ///
+    /// The same location every component of this item carries — they share one
+    /// [`Origin::location`], because one captured record is one item.
     pub fn location(&self) -> &SourceLocation {
         match self {
-            Element::Function(f) => &f.location,
-            Element::Struct(s) => &s.location,
-            Element::Enum(e) => &e.location,
-            Element::Const(c) => &c.location,
-            Element::Unsupported(u) => &u.location,
+            Element::Function(f) => &f.origin.location,
+            Element::Struct(s) => &s.origin.location,
+            Element::Enum(e) => &e.origin.location,
+            Element::Const(c) => &c.origin.location,
+            Element::Unsupported(u) => &u.origin.location,
         }
     }
 
     /// The whole item as the source wrote it.
     pub fn syntax(&self) -> syn::Item {
         match self {
-            Element::Function(f) => syn::Item::Fn(f.syntax.clone()),
-            Element::Struct(s) => syn::Item::Struct(s.syntax.clone()),
-            Element::Enum(e) => syn::Item::Enum(e.syntax.clone()),
-            Element::Const(c) => syn::Item::Const(c.syntax.clone()),
-            Element::Unsupported(u) => u.syntax.clone(),
+            Element::Function(f) => syn::Item::Fn(f.origin.syntax.clone()),
+            Element::Struct(s) => syn::Item::Struct(s.origin.syntax.clone()),
+            Element::Enum(e) => syn::Item::Enum(e.origin.syntax.clone()),
+            Element::Const(c) => syn::Item::Const(c.origin.syntax.clone()),
+            Element::Unsupported(u) => u.origin.syntax.clone(),
         }
     }
 }
@@ -88,9 +91,8 @@ pub struct Function {
     /// they mean the same thing, differ only in spelling, and every consumer
     /// today already normalizes one to the other on the spot.
     pub ret: Type,
-    pub location: SourceLocation,
     /// The whole item: attributes, `cfg`, doc comments, body.
-    pub syntax: syn::ItemFn,
+    pub origin: Origin<syn::ItemFn>,
 }
 
 /// One parameter of a [`Function`].
@@ -99,7 +101,7 @@ pub struct Param {
     pub name: syn::Ident,
     pub ty: Type,
     /// The parameter as written — `mode: Mode`.
-    pub syntax: syn::PatType,
+    pub origin: Origin<syn::PatType>,
 }
 
 /// A `#[prebindgen]` struct: a product of fields, or an opaque one.
@@ -120,8 +122,7 @@ pub struct Struct {
     /// spelling, read off `syntax` by
     /// [`spell::fields`](super::spell::fields).
     pub fields: Option<Vec<Field>>,
-    pub location: SourceLocation,
-    pub syntax: syn::ItemStruct,
+    pub origin: Origin<syn::ItemStruct>,
 }
 
 impl Struct {
@@ -142,8 +143,7 @@ pub struct Enum {
     pub name: syn::Ident,
     /// Variants in declaration order; `variants[i].tag == i as i32`.
     pub variants: Vec<Variant>,
-    pub location: SourceLocation,
-    pub syntax: syn::ItemEnum,
+    pub origin: Origin<syn::ItemEnum>,
 }
 
 impl Enum {
@@ -200,7 +200,7 @@ pub struct Variant {
     /// The variant's payload, in declaration order.
     pub fields: Vec<Field>,
     /// The variant as written: delimiters, `= 0x07`, attributes, doc comments.
-    pub syntax: syn::Variant,
+    pub origin: Origin<syn::Variant>,
 }
 
 /// One field of a [`Struct`] or of a [`Variant`].
@@ -213,7 +213,7 @@ pub struct Field {
     pub index: usize,
     pub ty: Type,
     /// The field as written — `pub id: u64`, attributes and docs included.
-    pub syntax: syn::Field,
+    pub origin: Origin<syn::Field>,
 }
 
 impl Variant {
@@ -237,10 +237,9 @@ impl Variant {
 pub struct Const {
     pub name: syn::Ident,
     pub ty: Type,
-    pub location: SourceLocation,
     /// The whole item — the initializer expression included, which is where a
     /// consumer that re-emits the value reads it from.
-    pub syntax: syn::ItemConst,
+    pub origin: Origin<syn::ItemConst>,
 }
 
 /// An item the language cannot express.
@@ -248,11 +247,10 @@ pub struct Const {
 pub struct Unsupported {
     /// The item's identifier, or `None` for an item kind that has none.
     pub name: Option<syn::Ident>,
-    pub location: SourceLocation,
     /// What could not be expressed, ready to be raised by whatever declares
     /// this item. Boxed: it is the size outlier among the elements, and this
     /// one is the rare variant.
     pub error: Box<super::ItemError>,
-    /// The item as written, so it can still be re-emitted verbatim.
-    pub syntax: syn::Item,
+    /// The item as written, so a diagnosis can quote the source.
+    pub origin: Origin<syn::Item>,
 }

--- a/prebindgen/src/api/core/language/element.rs
+++ b/prebindgen/src/api/core/language/element.rs
@@ -14,40 +14,44 @@ use crate::SourceLocation;
 
 /// One structure of the prebindgen source language.
 ///
-/// The variants are the accepted item kinds: anything else is
-/// [`Element::Passthrough`], emitted verbatim and never interpreted.
+/// The four modelled kinds, plus [`Element::Unsupported`] for anything the
+/// language cannot express. There is no verbatim-passthrough variant: a
+/// `#[prebindgen]` crate marks the items that cross the boundary, and the
+/// supporting code around them is the consumer crate's job — the proc-macro
+/// enforces that already, refusing to mark a `use`, `mod`, `impl` or
+/// `macro_rules!` at all.
 #[derive(Clone, Debug)]
 pub enum Element {
     Function(Function),
     Struct(Struct),
     Enum(Enum),
     Const(Const),
-    /// A named item of a kind the language models, whose contents it cannot
-    /// express — a parameter type outside the grammar, a `self` receiver.
+    /// An item the language cannot express — a parameter type outside the
+    /// grammar, a `self` receiver, or a whole item kind it does not model such
+    /// as a `union`.
     ///
     /// Inert: it is indexed under its name so nothing else can claim it, and
     /// the diagnosis rides along, to be raised by whatever declares it. See the
     /// [module docs](super) on where acceptance is enforced.
     Unsupported(Unsupported),
-    /// An item the language does not interpret — `use`, `mod`, `macro_rules!`,
-    /// `union`, a type alias. It is carried so generation can re-emit it, and
-    /// nothing else.
-    Passthrough(Passthrough),
 }
 
 impl Element {
     /// The item's name, which is also its address: `#[prebindgen]` names live
-    /// in one flat namespace across every ingested source crate. `None` for a
-    /// passthrough, which is never addressed by name.
+    /// in one flat namespace across every ingested source crate.
+    ///
+    /// `None` when the item has no address — an unnamed `const _` (each
+    /// source's injected feature guard, so several may coexist), or an item
+    /// kind with no identifier at all.
     pub fn name(&self) -> Option<&syn::Ident> {
-        match self {
+        let named = match self {
             Element::Function(f) => Some(&f.name),
             Element::Struct(s) => Some(&s.name),
             Element::Enum(e) => Some(&e.name),
             Element::Const(c) => Some(&c.name),
-            Element::Unsupported(u) => Some(&u.name),
-            Element::Passthrough(_) => None,
-        }
+            Element::Unsupported(u) => u.name.as_ref(),
+        };
+        named.filter(|id| *id != "_")
     }
 
     /// Where the item was captured, including the crate that marked it.
@@ -58,7 +62,6 @@ impl Element {
             Element::Enum(e) => &e.location,
             Element::Const(c) => &c.location,
             Element::Unsupported(u) => &u.location,
-            Element::Passthrough(p) => &p.location,
         }
     }
 
@@ -70,7 +73,6 @@ impl Element {
             Element::Enum(e) => syn::Item::Enum(e.syntax.clone()),
             Element::Const(c) => syn::Item::Const(c.syntax.clone()),
             Element::Unsupported(u) => u.syntax.clone(),
-            Element::Passthrough(p) => p.syntax.clone(),
         }
     }
 }
@@ -227,6 +229,10 @@ impl Variant {
 }
 
 /// A `#[prebindgen]` const.
+///
+/// Also the home of the unnamed `const _` feature guard each source injects: it
+/// is a const, so it is modelled as one, and [`Element::name`] returning `None`
+/// for `_` is what keeps several of them from colliding in the flat namespace.
 #[derive(Clone, Debug)]
 pub struct Const {
     pub name: syn::Ident,
@@ -237,22 +243,16 @@ pub struct Const {
     pub syntax: syn::ItemConst,
 }
 
-/// A named item the language recognises but cannot express.
+/// An item the language cannot express.
 #[derive(Clone, Debug)]
 pub struct Unsupported {
-    pub name: syn::Ident,
+    /// The item's identifier, or `None` for an item kind that has none.
+    pub name: Option<syn::Ident>,
     pub location: SourceLocation,
     /// What could not be expressed, ready to be raised by whatever declares
     /// this item. Boxed: it is the size outlier among the elements, and this
     /// one is the rare variant.
     pub error: Box<super::ItemError>,
     /// The item as written, so it can still be re-emitted verbatim.
-    pub syntax: syn::Item,
-}
-
-/// An item the language does not interpret.
-#[derive(Clone, Debug)]
-pub struct Passthrough {
-    pub location: SourceLocation,
     pub syntax: syn::Item,
 }

--- a/prebindgen/src/api/core/language/element.rs
+++ b/prebindgen/src/api/core/language/element.rs
@@ -14,7 +14,7 @@ use crate::SourceLocation;
 
 /// One structure of the prebindgen source language.
 ///
-/// The four modelled kinds, plus [`Element::Unsupported`] for anything the
+/// The five modelled kinds, plus [`Element::Unsupported`] for anything the
 /// language cannot express. There is no verbatim-passthrough variant: a
 /// `#[prebindgen]` crate marks the items that cross the boundary, and the
 /// supporting code around them is the consumer crate's job — the proc-macro
@@ -24,6 +24,9 @@ use crate::SourceLocation;
 pub enum Element {
     Function(Function),
     Struct(Struct),
+    /// An enum whose alternatives carry payloads — a sum type.
+    Variant(Variant),
+    /// An enum whose every alternative is fieldless — a named set of integers.
     Enum(Enum),
     Const(Const),
     /// An item the language cannot express — a parameter type outside the
@@ -47,6 +50,7 @@ impl Element {
         let named = match self {
             Element::Function(f) => Some(&f.name),
             Element::Struct(s) => Some(&s.name),
+            Element::Variant(v) => Some(&v.name),
             Element::Enum(e) => Some(&e.name),
             Element::Const(c) => Some(&c.name),
             Element::Unsupported(u) => u.name.as_ref(),
@@ -62,6 +66,7 @@ impl Element {
         match self {
             Element::Function(f) => &f.origin.location,
             Element::Struct(s) => &s.origin.location,
+            Element::Variant(v) => &v.origin.location,
             Element::Enum(e) => &e.origin.location,
             Element::Const(c) => &c.origin.location,
             Element::Unsupported(u) => &u.origin.location,
@@ -73,6 +78,7 @@ impl Element {
         match self {
             Element::Function(f) => syn::Item::Fn(f.origin.syntax.clone()),
             Element::Struct(s) => syn::Item::Struct(s.origin.syntax.clone()),
+            Element::Variant(v) => syn::Item::Enum(v.origin.syntax.clone()),
             Element::Enum(e) => syn::Item::Enum(e.origin.syntax.clone()),
             Element::Const(c) => syn::Item::Const(c.origin.syntax.clone()),
             Element::Unsupported(u) => u.origin.syntax.clone(),
@@ -132,43 +138,82 @@ impl Struct {
     }
 }
 
-/// A `#[prebindgen]` enum: a choice of one alternative, each with its own field
-/// group.
+/// A `#[prebindgen]` enum whose alternatives carry payloads — a sum type.
 ///
-/// One model covers both enum shapes on purpose. A fieldless enum is the
-/// degenerate sum whose every group is empty, so a lowering written for the
-/// general case collapses to "just the selector" for it.
+/// Distinct from [`Enum`], which is the fieldless shape, because the two are
+/// consumed as different constructs and **numbered differently**. A sum's
+/// alternatives are identified by position: the mirror an adapter builds carries
+/// no `repr` and numbers its own arms, so a Rust discriminant would be the wrong
+/// answer here — which is why there is no slot for one.
+///
+/// Both shapes are spelled `enum` in Rust and both keep a `syn::ItemEnum` in
+/// their origin. Which one an item *is* is the classification, and it is decided
+/// once: any alternative with a field makes it a `Variant`.
+#[derive(Clone, Debug)]
+pub struct Variant {
+    pub name: syn::Ident,
+    /// Alternatives in declaration order; `alternatives[i].index == i`.
+    pub alternatives: Vec<Alternative>,
+    pub origin: Origin<syn::ItemEnum>,
+}
+
+/// One alternative of a [`Variant`].
+#[derive(Clone, Debug)]
+pub struct Alternative {
+    pub name: syn::Ident,
+    /// Position within its sum, `0..N-1` — the same fact a [`Field`] carries,
+    /// for the same reason: a node handed out on its own still knows where it
+    /// sits.
+    ///
+    /// This is the *only* numbering a sum has. What a destination language does
+    /// with it is its own business: one may transmit it to say which alternative
+    /// is live, another may send a name instead.
+    pub index: usize,
+    /// The alternative's payload, in declaration order. May be empty — a sum can
+    /// mix payload-carrying and payload-free alternatives, and only the presence
+    /// of *some* payload makes the type a `Variant`.
+    pub fields: Vec<Field>,
+    /// The alternative as written: delimiters, attributes, doc comments.
+    pub origin: Origin<syn::Variant>,
+}
+
+impl Alternative {
+    /// True when this alternative carries no payload.
+    ///
+    /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
+    /// empty by this test, and [`spell::fields`](super::spell::fields) is what
+    /// keeps their delimiters apart.
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+/// A `#[prebindgen]` enum whose every alternative is fieldless — the C-style
+/// shape, a named set of integers.
+///
+/// Distinct from [`Variant`] because the identity of a member here is the value
+/// Rust **assigns** it, not where it sits: a C header re-states each `= expr`
+/// and a Kotlin `enum class` entry is `NAME(7)`. A sum has no such value, which
+/// is why the two are separate entities rather than one with a dead field each.
 #[derive(Clone, Debug)]
 pub struct Enum {
     pub name: syn::Ident,
-    /// Variants in declaration order; `variants[i].index == i`.
-    pub variants: Vec<Variant>,
+    /// Values in declaration order; `values[i].index == i`.
+    pub values: Vec<EnumValue>,
     pub origin: Origin<syn::ItemEnum>,
 }
 
 impl Enum {
-    /// True when every variant is fieldless, i.e. the value is exactly its
-    /// discriminant.
-    pub fn is_unit(&self) -> bool {
-        self.variants.iter().all(Variant::is_unit)
-    }
-
-    /// The first payload-carrying variant — the offender an adapter names when
-    /// refusing a sum where only a fieldless enum is accepted.
-    pub fn first_payload_variant(&self) -> Option<&Variant> {
-        self.variants.iter().find(|v| !v.is_unit())
-    }
-
-    /// Every variant paired with the value Rust assigns it, or the first
-    /// variant whose discriminant could not be evaluated.
+    /// Every value paired with the number Rust assigns it, or the first value
+    /// whose discriminant could not be evaluated.
     ///
     /// This is the numbering a destination language needs when it has no way to
     /// reference a Rust constant: a Kotlin `enum class` entry is `NAME(3)`, and
-    /// the generated `int → variant` decode matches on the same numbers, so both
+    /// the generated `int → value` decode matches on the same numbers, so both
     /// come from here and cannot drift. An `Err` is a refusal for *that*
     /// consumer only — one that re-emits the source spelling never asks.
     pub fn discriminant_values(&self) -> Result<Vec<(&syn::Ident, i64)>, &syn::Ident> {
-        self.variants
+        self.values
             .iter()
             .map(|v| match v.discriminant {
                 Some(n) => Ok((&v.name, n)),
@@ -178,24 +223,17 @@ impl Enum {
     }
 }
 
-/// One alternative of an [`Enum`].
+/// One named value of an [`Enum`].
 #[derive(Clone, Debug)]
-pub struct Variant {
+pub struct EnumValue {
     pub name: syn::Ident,
-    /// Position within its enum, `0..N-1` — the same fact a [`Field`] carries,
-    /// for the same reason: a node handed out on its own still knows where it
-    /// sits.
-    ///
-    /// This is **not** the discriminant. A position is what the source *wrote*;
-    /// a discriminant is the value Rust *assigns*, and the two are independent
-    /// — see [`Self::discriminant`].
-    ///
-    /// What a destination language does with the position is its own business:
-    /// one may transmit it to say which alternative is live, another may send a
-    /// name instead. The language says only where the variant sits.
+    /// Position within its enum, `0..N-1`. Not the identity — see
+    /// [`Self::discriminant`] — but the same "where it sits" fact every node in
+    /// an ordered list carries, and what a consumer falls back to when a
+    /// discriminant cannot be evaluated.
     pub index: usize,
-    /// The value Rust assigns this variant — an explicit `= N` sets it, an
-    /// implicit variant takes the previous value plus one, starting at 0.
+    /// The value Rust assigns — an explicit `= N` sets it, an implicit value
+    /// takes the previous plus one, starting at 0. **This shape's identity.**
     ///
     /// `None` once a spelling the frontend cannot evaluate (a `const`, a `cfg`,
     /// arithmetic) has broken the chain, or once the chain has run out of `i64`.
@@ -203,19 +241,19 @@ pub struct Variant {
     /// affected, and one that re-emits the *spelling* reads
     /// [`Self::origin`]`.syntax.discriminant` instead.
     pub discriminant: Option<i64>,
-    /// The variant's payload, in declaration order.
-    pub fields: Vec<Field>,
-    /// The variant as written: delimiters, `= 0x07`, attributes, doc comments.
+    /// The value as written: `= 0x07`, attributes, doc comments — and its
+    /// delimiters, since `B` and `B()` are both fieldless and still spelled
+    /// differently.
     pub origin: Origin<syn::Variant>,
 }
 
-/// One field of a [`Struct`] or of a [`Variant`].
+/// One field of a [`Struct`] or of an [`Alternative`].
 #[derive(Clone, Debug)]
 pub struct Field {
     /// The field's name, or `None` for a positional one.
     pub name: Option<syn::Ident>,
-    /// Position within its struct or variant, `0..N-1` — the same fact a
-    /// [`Variant`] carries.
+    /// Position within its struct or alternative, `0..N-1` — the same fact an
+    /// [`Alternative`] carries.
     ///
     /// The address of a positional field. A named field has one too, and simply
     /// does not need it: it is addressed by name, so this is available rather
@@ -224,18 +262,6 @@ pub struct Field {
     pub ty: Type,
     /// The field as written — `pub id: u64`, attributes and docs included.
     pub origin: Origin<syn::Field>,
-}
-
-impl Variant {
-    /// True when this variant carries no payload.
-    ///
-    /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
-    /// unit by this test, and
-    /// [`spell::fields`](super::spell::fields) is what keeps their delimiters
-    /// apart.
-    pub fn is_unit(&self) -> bool {
-        self.fields.is_empty()
-    }
 }
 
 /// A `#[prebindgen]` const.

--- a/prebindgen/src/api/core/language/element.rs
+++ b/prebindgen/src/api/core/language/element.rs
@@ -1,0 +1,301 @@
+//! The elements: one variant per structure the source language allows, each
+//! carrying the exact syntax it was built from.
+//!
+//! Every component — a parameter, a field, a variant, a type — keeps its own
+//! slice, so generated Rust names the source by re-emitting what the source
+//! wrote, and nothing re-parses a whole item to find a part of it.
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+use super::ty::Type;
+use crate::SourceLocation;
+
+/// One structure of the prebindgen source language.
+///
+/// The variants are the accepted item kinds: anything else is
+/// [`Element::Passthrough`], emitted verbatim and never interpreted.
+#[derive(Clone, Debug)]
+pub enum Element {
+    Function(Function),
+    Struct(Struct),
+    Enum(Enum),
+    Const(Const),
+    /// A named item of a kind the language models, whose contents it cannot
+    /// express — a parameter type outside the grammar, a `self` receiver.
+    ///
+    /// Inert: it is indexed under its name so nothing else can claim it, and
+    /// the diagnosis rides along, to be raised by whatever declares it. See the
+    /// [module docs](super) on where acceptance is enforced.
+    Unsupported(Unsupported),
+    /// An item the language does not interpret — `use`, `mod`, `macro_rules!`,
+    /// `union`, a type alias. It is carried so generation can re-emit it, and
+    /// nothing else.
+    Passthrough(Passthrough),
+}
+
+impl Element {
+    /// The item's name, which is also its address: `#[prebindgen]` names live
+    /// in one flat namespace across every ingested source crate. `None` for a
+    /// passthrough, which is never addressed by name.
+    pub fn name(&self) -> Option<&syn::Ident> {
+        match self {
+            Element::Function(f) => Some(&f.name),
+            Element::Struct(s) => Some(&s.name),
+            Element::Enum(e) => Some(&e.name),
+            Element::Const(c) => Some(&c.name),
+            Element::Unsupported(u) => Some(&u.name),
+            Element::Passthrough(_) => None,
+        }
+    }
+
+    /// Where the item was captured, including the crate that marked it.
+    pub fn location(&self) -> &SourceLocation {
+        match self {
+            Element::Function(f) => &f.location,
+            Element::Struct(s) => &s.location,
+            Element::Enum(e) => &e.location,
+            Element::Const(c) => &c.location,
+            Element::Unsupported(u) => &u.location,
+            Element::Passthrough(p) => &p.location,
+        }
+    }
+
+    /// The whole item as the source wrote it.
+    pub fn syntax(&self) -> syn::Item {
+        match self {
+            Element::Function(f) => syn::Item::Fn(f.syntax.clone()),
+            Element::Struct(s) => syn::Item::Struct(s.syntax.clone()),
+            Element::Enum(e) => syn::Item::Enum(e.syntax.clone()),
+            Element::Const(c) => syn::Item::Const(c.syntax.clone()),
+            Element::Unsupported(u) => u.syntax.clone(),
+            Element::Passthrough(p) => p.syntax.clone(),
+        }
+    }
+}
+
+/// A `#[prebindgen]` free function.
+#[derive(Clone, Debug)]
+pub struct Function {
+    pub name: syn::Ident,
+    /// Parameters in declaration order.
+    pub params: Vec<Param>,
+    /// The return type, or `None` when the source wrote no `->` at all. A
+    /// written `-> ()` is `Some`, with [`TypeKind::Unit`](super::TypeKind) —
+    /// the two mean the same thing and are spelled differently, and only the
+    /// spelling side cares.
+    pub ret: Option<Type>,
+    pub location: SourceLocation,
+    /// The whole item: attributes, `cfg`, doc comments, body.
+    pub syntax: syn::ItemFn,
+}
+
+/// One parameter of a [`Function`].
+#[derive(Clone, Debug)]
+pub struct Param {
+    pub name: syn::Ident,
+    pub ty: Type,
+    /// The parameter as written — `mode: Mode`.
+    pub syntax: syn::PatType,
+}
+
+/// A `#[prebindgen]` struct.
+#[derive(Clone, Debug)]
+pub struct Struct {
+    pub name: syn::Ident,
+    pub fields: StructFields,
+    pub location: SourceLocation,
+    pub syntax: syn::ItemStruct,
+}
+
+/// The three struct shapes, and which of them has a modelled field list.
+#[derive(Clone, Debug)]
+pub enum StructFields {
+    /// `struct S { a: A }` — the one shape whose fields are a boundary surface,
+    /// so they are lowered and a type the language cannot express is an error.
+    Named(Vec<Field>),
+    /// `struct S(A, B);` — indexed, fields **not** modelled. A tuple struct is
+    /// usable as an opaque handle, and no adapter has ever crossed its fields,
+    /// so lowering them would turn types that are ignored today into errors.
+    Unnamed,
+    /// `struct S;`
+    Unit,
+}
+
+impl StructFields {
+    /// The modelled fields — empty for the shapes that have none.
+    pub fn named(&self) -> &[Field] {
+        match self {
+            StructFields::Named(f) => f,
+            StructFields::Unnamed | StructFields::Unit => &[],
+        }
+    }
+}
+
+/// A `#[prebindgen]` enum: a **tag** — which alternative is live — plus one
+/// field group per variant.
+///
+/// One model covers both enum shapes on purpose. A fieldless enum is the
+/// degenerate sum whose every group is empty, so a lowering written for the
+/// general case collapses to "just a tag" for it.
+#[derive(Clone, Debug)]
+pub struct Enum {
+    pub name: syn::Ident,
+    /// Variants in declaration order; `variants[i].tag == i as i32`.
+    pub variants: Vec<Variant>,
+    pub location: SourceLocation,
+    pub syntax: syn::ItemEnum,
+}
+
+impl Enum {
+    /// True when every variant is fieldless, i.e. the value is exactly its
+    /// discriminant.
+    pub fn is_unit(&self) -> bool {
+        self.variants.iter().all(Variant::is_unit)
+    }
+
+    /// The first payload-carrying variant — the offender an adapter names when
+    /// refusing a sum where only a fieldless enum is accepted.
+    pub fn first_payload_variant(&self) -> Option<&Variant> {
+        self.variants.iter().find(|v| !v.is_unit())
+    }
+
+    /// Every variant paired with the value Rust assigns it, or the first
+    /// variant whose discriminant could not be evaluated.
+    ///
+    /// This is the numbering a destination language needs when it has no way to
+    /// reference a Rust constant: a Kotlin `enum class` entry is `NAME(3)`, and
+    /// the generated `int → variant` decode matches on the same numbers, so both
+    /// come from here and cannot drift. An `Err` is a refusal for *that*
+    /// consumer only — one that re-emits the source spelling never asks.
+    pub fn discriminant_values(&self) -> Result<Vec<(&syn::Ident, i64)>, &syn::Ident> {
+        self.variants
+            .iter()
+            .map(|v| match v.discriminant {
+                Some(n) => Ok((&v.name, n)),
+                None => Err(&v.name),
+            })
+            .collect()
+    }
+}
+
+/// One alternative of an [`Enum`].
+#[derive(Clone, Debug)]
+pub struct Variant {
+    pub name: syn::Ident,
+    /// Declaration-order tag, `0..N-1`.
+    ///
+    /// This is **not** the discriminant. A sum's alternatives are identified by
+    /// position, because the payload mirror an adapter builds carries no `repr`
+    /// and numbers its arms itself.
+    pub tag: i32,
+    /// The value Rust assigns this variant — an explicit `= N` sets it, an
+    /// implicit variant takes the previous value plus one, starting at 0.
+    ///
+    /// `None` once a spelling the frontend cannot evaluate (a `const`, a `cfg`,
+    /// arithmetic) has broken the chain, or once the chain has run out of `i64`.
+    /// That is not a failure: only a consumer that needs the *number* is
+    /// affected, and one that re-emits the *spelling* reads
+    /// [`Self::syntax`]`.discriminant` instead.
+    pub discriminant: Option<i64>,
+    /// The variant's payload, in declaration order.
+    pub fields: Vec<Field>,
+    /// The variant as written: delimiters, `= 0x07`, attributes, doc comments.
+    pub syntax: syn::Variant,
+}
+
+impl Variant {
+    /// True when this variant carries no payload.
+    ///
+    /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
+    /// unit by this test, and [`Self::spell`] is what keeps their delimiters
+    /// apart.
+    pub fn is_unit(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Spell this variant: `head`, `head(parts…)` or `head { parts… }`,
+    /// following the delimiters the source wrote.
+    ///
+    /// The one place a variant's delimiters are chosen, for match patterns and
+    /// constructors alike and in either direction. It reads them off
+    /// [`Self::syntax`] rather than a modelled shape, because they are spelling
+    /// and nothing else: `B()` carries no payload and still must be written
+    /// `E::B()` wherever Rust names it, while no destination language can tell
+    /// it from `B`.
+    ///
+    /// `head` is the variant's path and each part is an already-rendered `bind`
+    /// or `member: bind` — see [`Field::member`].
+    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
+        match &self.syntax.fields {
+            syn::Fields::Unit => head,
+            syn::Fields::Unnamed(_) => quote!(#head(#(#parts),*)),
+            syn::Fields::Named(_) => quote!(#head { #(#parts),* }),
+        }
+    }
+}
+
+/// One field of a [`StructFields::Named`] struct or of a [`Variant`].
+#[derive(Clone, Debug)]
+pub struct Field {
+    /// The field's name, or `None` for a positional one.
+    pub name: Option<syn::Ident>,
+    /// Position within its struct or variant, `0..N-1`. The address of a
+    /// positional field, and the tie-breaker for a named one.
+    pub index: usize,
+    pub ty: Type,
+    /// The field as written — `pub id: u64`, attributes and docs included.
+    pub syntax: syn::Field,
+}
+
+impl Field {
+    /// How the field is addressed in a pattern or an initializer: by name when
+    /// it has one, else by position.
+    pub fn member(&self) -> syn::Member {
+        match &self.name {
+            Some(id) => syn::Member::Named(id.clone()),
+            None => syn::Member::Unnamed(syn::Index::from(self.index)),
+        }
+    }
+
+    /// The field bound to `bind`, shaped for whichever address it uses —
+    /// `id: __f0` for a named field, `__f0` for a positional one. The part
+    /// [`Variant::spell`] takes.
+    pub fn bind(&self, bind: &impl ToTokens) -> TokenStream {
+        match &self.name {
+            Some(id) => quote!(#id: #bind),
+            None => quote!(#bind),
+        }
+    }
+}
+
+/// A `#[prebindgen]` const.
+#[derive(Clone, Debug)]
+pub struct Const {
+    pub name: syn::Ident,
+    pub ty: Type,
+    pub location: SourceLocation,
+    /// The whole item — the initializer expression included, which is where a
+    /// consumer that re-emits the value reads it from.
+    pub syntax: syn::ItemConst,
+}
+
+/// A named item the language recognises but cannot express.
+#[derive(Clone, Debug)]
+pub struct Unsupported {
+    pub name: syn::Ident,
+    pub location: SourceLocation,
+    /// What could not be expressed, ready to be raised by whatever declares
+    /// this item. Boxed: it is the size outlier among the elements, and this
+    /// one is the rare variant.
+    pub error: Box<super::ItemError>,
+    /// The item as written, so it can still be re-emitted verbatim.
+    pub syntax: syn::Item,
+}
+
+/// An item the language does not interpret.
+#[derive(Clone, Debug)]
+pub struct Passthrough {
+    pub location: SourceLocation,
+    pub syntax: syn::Item,
+}

--- a/prebindgen/src/api/core/language/element.rs
+++ b/prebindgen/src/api/core/language/element.rs
@@ -132,16 +132,16 @@ impl Struct {
     }
 }
 
-/// A `#[prebindgen]` enum: a **tag** — which alternative is live — plus one
-/// field group per variant.
+/// A `#[prebindgen]` enum: a choice of one alternative, each with its own field
+/// group.
 ///
 /// One model covers both enum shapes on purpose. A fieldless enum is the
 /// degenerate sum whose every group is empty, so a lowering written for the
-/// general case collapses to "just a tag" for it.
+/// general case collapses to "just the selector" for it.
 #[derive(Clone, Debug)]
 pub struct Enum {
     pub name: syn::Ident,
-    /// Variants in declaration order; `variants[i].tag == i as i32`.
+    /// Variants in declaration order; `variants[i].index == i`.
     pub variants: Vec<Variant>,
     pub origin: Origin<syn::ItemEnum>,
 }
@@ -182,12 +182,18 @@ impl Enum {
 #[derive(Clone, Debug)]
 pub struct Variant {
     pub name: syn::Ident,
-    /// Declaration-order tag, `0..N-1`.
+    /// Position within its enum, `0..N-1` — the same fact a [`Field`] carries,
+    /// for the same reason: a node handed out on its own still knows where it
+    /// sits.
     ///
-    /// This is **not** the discriminant. A sum's alternatives are identified by
-    /// position, because the payload mirror an adapter builds carries no `repr`
-    /// and numbers its arms itself.
-    pub tag: i32,
+    /// This is **not** the discriminant. A position is what the source *wrote*;
+    /// a discriminant is the value Rust *assigns*, and the two are independent
+    /// — see [`Self::discriminant`].
+    ///
+    /// What a destination language does with the position is its own business:
+    /// one may transmit it to say which alternative is live, another may send a
+    /// name instead. The language says only where the variant sits.
+    pub index: usize,
     /// The value Rust assigns this variant — an explicit `= N` sets it, an
     /// implicit variant takes the previous value plus one, starting at 0.
     ///
@@ -195,7 +201,7 @@ pub struct Variant {
     /// arithmetic) has broken the chain, or once the chain has run out of `i64`.
     /// That is not a failure: only a consumer that needs the *number* is
     /// affected, and one that re-emits the *spelling* reads
-    /// [`Self::syntax`]`.discriminant` instead.
+    /// [`Self::origin`]`.syntax.discriminant` instead.
     pub discriminant: Option<i64>,
     /// The variant's payload, in declaration order.
     pub fields: Vec<Field>,
@@ -208,8 +214,12 @@ pub struct Variant {
 pub struct Field {
     /// The field's name, or `None` for a positional one.
     pub name: Option<syn::Ident>,
-    /// Position within its struct or variant, `0..N-1`. The address of a
-    /// positional field, and the tie-breaker for a named one.
+    /// Position within its struct or variant, `0..N-1` — the same fact a
+    /// [`Variant`] carries.
+    ///
+    /// The address of a positional field. A named field has one too, and simply
+    /// does not need it: it is addressed by name, so this is available rather
+    /// than used — the same way it carries its item's location.
     pub index: usize,
     pub ty: Type,
     /// The field as written — `pub id: u64`, attributes and docs included.

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -93,6 +93,24 @@
 //! `macro_rules!` cannot be marked at all — so an item kind this module does
 //! not model is a `union` or a type alias, and it is diagnosed like any other
 //! thing the language cannot express.
+//!
+//! # Shapes that must be refused rather than approximated
+//!
+//! An [`Element`] holds what it holds: ordinary parameters, a direct return, no
+//! generic binder. A shape with no slot in that structure cannot be *partly*
+//! accepted — the missing piece would simply be dropped, and silently:
+//!
+//! | Shape | Would become | So |
+//! |---|---|---|
+//! | `async fn` | a function returning `()` | the future is dropped and the export's body never runs |
+//! | `fn f(a: u8, ...)` | a function without the tail | the variadic arguments vanish |
+//! | `struct S<T>`, `fn f<T>()`, `struct S<const N: usize>` | `T` as a nominal reference | a parameter is indistinguishable from an item named `T` |
+//!
+//! All three are [`ItemError`]s, inert until declared, like any other refusal. A
+//! **lifetime** binder is not among them: lifetimes are spelling, and the
+//! spelling already travels. Nor is `impl Trait` in argument position — Rust
+//! calls it an anonymous type parameter, but it is not a binder in the syntax,
+//! so the callback form is untouched.
 
 use std::{fmt, rc::Rc};
 
@@ -327,6 +345,33 @@ pub enum ItemError {
     },
     /// A const's type is not in the language.
     ConstType { source: UnsupportedType },
+    /// An `async fn`.
+    ///
+    /// The most dangerous shape to accept quietly: [`Function`] has a direct
+    /// return, so an `async fn ping()` lowers as one returning `()`, and a
+    /// generated wrapper calls it, drops the future and exports a function whose
+    /// body never runs.
+    UnsupportedAsync,
+    /// A C-variadic tail — `fn f(a: u8, ...)`.
+    ///
+    /// [`Function`] holds ordinary parameters only, so the tail would simply be
+    /// dropped from the signature.
+    UnsupportedVariadic,
+    /// A type or const generic parameter on the item.
+    ///
+    /// The elements have no generic binder, so a `T` in a field or parameter
+    /// would lower as [`TypeKind::Named`] — an ordinary nominal reference into
+    /// the flat namespace, indistinguishable from a real item called `T`. That
+    /// loses the scoping every downstream resolver needs, and no destination
+    /// language can express an uninstantiated parameter anyway.
+    ///
+    /// A lifetime parameter is *not* this: lifetimes are spelling and already
+    /// travel in the syntax.
+    UnsupportedGenericParam {
+        param: String,
+        /// `a type parameter` / `a const generic parameter`.
+        kind: &'static str,
+    },
     /// A whole item kind the language does not model — a `union`, a type alias.
     ///
     /// The proc-macro refuses to mark a `use`, `mod`, `impl` or `macro_rules!`
@@ -357,6 +402,24 @@ impl fmt::Display for ItemError {
                 source,
             } => write!(f, "variant `{variant}` field `{field}`: {source}"),
             ItemError::ConstType { source } => write!(f, "const type: {source}"),
+            ItemError::UnsupportedAsync => write!(
+                f,
+                "is an `async fn`; the boundary has no way to drive a future, and the generated \
+                 wrapper would drop it and export a function whose body never runs — expose a \
+                 blocking wrapper instead"
+            ),
+            ItemError::UnsupportedVariadic => write!(
+                f,
+                "has a C-variadic tail, which the prebindgen source language does not model — \
+                 take a slice, or one parameter per value"
+            ),
+            ItemError::UnsupportedGenericParam { param, kind } => write!(
+                f,
+                "declares `{param}`, {kind}: the prebindgen source language has no generic \
+                 binder, so an uninstantiated parameter is indistinguishable from a nominal type \
+                 of the same name and no destination language can express it — write the \
+                 concrete types, one marked item per instantiation (a newtype is the usual way)"
+            ),
             ItemError::UnsupportedItemKind { kind } => write!(
                 f,
                 "is {kind}; the prebindgen source language models functions, structs, enums and \
@@ -434,11 +497,36 @@ fn unsupported(
     })
 }
 
+/// Refuse a type or const generic parameter, naming the first one found.
+///
+/// Lifetimes pass: they say nothing a destination language can act on, and the
+/// spelling that needs them is already in the syntax — the same call
+/// [`lower_type`] makes for a lifetime *argument*.
+fn reject_generic_params(generics: &syn::Generics) -> Result<(), ItemError> {
+    for param in &generics.params {
+        let (name, kind) = match param {
+            syn::GenericParam::Lifetime(_) => continue,
+            syn::GenericParam::Type(t) => (t.ident.to_string(), "a type parameter"),
+            syn::GenericParam::Const(c) => (c.ident.to_string(), "a const generic parameter"),
+        };
+        return Err(ItemError::UnsupportedGenericParam { param: name, kind });
+    }
+    Ok(())
+}
+
 fn lower_fn(
     f: &syn::ItemFn,
     at: &Rc<SourceLocation>,
     consts: &ConstIndex,
 ) -> Result<Function, ItemError> {
+    // Shapes `Function` has no slot for, and would therefore drop in silence.
+    if f.sig.asyncness.is_some() {
+        return Err(ItemError::UnsupportedAsync);
+    }
+    if f.sig.variadic.is_some() {
+        return Err(ItemError::UnsupportedVariadic);
+    }
+    reject_generic_params(&f.sig.generics)?;
     let mut params = Vec::with_capacity(f.sig.inputs.len());
     for input in &f.sig.inputs {
         let pt = match input {
@@ -486,6 +574,7 @@ fn lower_struct(
     at: &Rc<SourceLocation>,
     consts: &ConstIndex,
 ) -> Result<Struct, ItemError> {
+    reject_generic_params(&s.generics)?;
     let fields = match &s.fields {
         syn::Fields::Named(named) => {
             let mut out = Vec::with_capacity(named.named.len());
@@ -521,6 +610,7 @@ fn lower_enum(
     at: &Rc<SourceLocation>,
     consts: &ConstIndex,
 ) -> Result<Enum, ItemError> {
+    reject_generic_params(&e.generics)?;
     let mut variants = Vec::with_capacity(e.variants.len());
     // Rust's own numbering rule: an explicit `= N` sets the value, an implicit
     // variant takes the previous plus one, starting at 0.

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -73,6 +73,13 @@
 //! until something declares it. Only whole-stream rules — a duplicate name in
 //! the flat namespace — are [`ParseError`]s, because no declaration can make
 //! two items with one name unambiguous.
+//!
+//! There is **no verbatim passthrough**, because a `#[prebindgen]` crate marks
+//! the items that cross the boundary and leaves the supporting code to the
+//! consumer. The proc-macro already enforces that — a `use`, `mod`, `impl` or
+//! `macro_rules!` cannot be marked at all — so an item kind this module does
+//! not model is a `union` or a type alias, and it is diagnosed like any other
+//! thing the language cannot express.
 
 use std::fmt;
 
@@ -91,9 +98,7 @@ mod tests;
 use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
-    element::{
-        Const, Element, Enum, Field, Function, Param, Passthrough, Struct, Unsupported, Variant,
-    },
+    element::{Const, Element, Enum, Field, Function, Param, Struct, Unsupported, Variant},
     ty::{ScalarKind, Type, TypeId, TypeKind, UnsupportedType, UnsupportedTypeReason},
 };
 use crate::SourceLocation;
@@ -158,8 +163,8 @@ impl Language {
         }
 
         // Pass 1: the consts an array length may name. Unnamed `const _` items
-        // are excluded here for the same reason they are passed through below —
-        // they are not addressable.
+        // are excluded for the same reason `Element::name` skips them — they
+        // are not addressable, so no length can name one.
         let consts = ConstIndex::new(items.iter().filter_map(|(item, loc)| match item {
             syn::Item::Const(c) if c.ident != "_" => Some((
                 c.ident.to_string(),
@@ -296,6 +301,11 @@ pub enum ItemError {
     },
     /// A const's type is not in the language.
     ConstType { source: UnsupportedType },
+    /// A whole item kind the language does not model — a `union`, a type alias.
+    ///
+    /// The proc-macro refuses to mark a `use`, `mod`, `impl` or `macro_rules!`
+    /// at all, so only the kinds it accepts can reach here.
+    UnsupportedItemKind { kind: &'static str },
 }
 
 impl fmt::Display for ItemError {
@@ -321,6 +331,11 @@ impl fmt::Display for ItemError {
                 source,
             } => write!(f, "variant `{variant}` field `{field}`: {source}"),
             ItemError::ConstType { source } => write!(f, "const type: {source}"),
+            ItemError::UnsupportedItemKind { kind } => write!(
+                f,
+                "is {kind}; the prebindgen source language models functions, structs, enums and \
+                 consts — everything else belongs in the consumer crate"
+            ),
         }
     }
 }
@@ -346,13 +361,10 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
             Ok(en) => Element::Enum(en),
             Err(error) => unsupported(e.ident.clone(), syn::Item::Enum(e), loc, error),
         },
-        // Unnamed `const _` items (each source's injected `konst` feature
-        // guard) live outside the flat namespace: several sources may each
-        // carry one, all passed through verbatim.
-        syn::Item::Const(c) if c.ident == "_" => Element::Passthrough(Passthrough {
-            location: loc,
-            syntax: syn::Item::Const(c),
-        }),
+        // Including the unnamed `const _` each source injects as its feature
+        // guard: it is a const, so it is one here. `Element::name` returns
+        // `None` for `_`, which is what keeps several sources' guards from
+        // colliding in the flat namespace.
         syn::Item::Const(c) => match lower_type(&c.ty, consts, crate_ref) {
             Ok(ty) => Element::Const(Const {
                 name: c.ident.clone(),
@@ -367,21 +379,30 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
                 ItemError::ConstType { source },
             ),
         },
-        other => Element::Passthrough(Passthrough {
-            location: loc,
-            syntax: other,
-        }),
+        // An item kind the language does not model. The proc-macro accepts
+        // only six kinds, so in practice this is a `union` or a type alias —
+        // both named, neither ever written by a source crate. It is diagnosed
+        // rather than carried: a `#[prebindgen]` crate marks what crosses the
+        // boundary, and the code around that belongs to the consumer.
+        other => {
+            let (name, kind) = match &other {
+                syn::Item::Union(u) => (Some(u.ident.clone()), "a union"),
+                syn::Item::Type(t) => (Some(t.ident.clone()), "a type alias"),
+                _ => (None, "an item kind"),
+            };
+            unsupported(name, other, loc, ItemError::UnsupportedItemKind { kind })
+        }
     }
 }
 
 fn unsupported(
-    name: syn::Ident,
+    name: impl Into<Option<syn::Ident>>,
     syntax: syn::Item,
     location: SourceLocation,
     error: ItemError,
 ) -> Element {
     Element::Unsupported(Unsupported {
-        name,
+        name: name.into(),
         location,
         error: Box::new(error),
         syntax,

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -19,9 +19,9 @@
 //!
 //! Two things at once, and that pairing is the whole design:
 //!
-//! * a **closed classification** — [`TypeKind`], the field list, the variant
-//!   list — that says what the source *means*, in terms every destination
-//!   language shares;
+//! * a **closed classification** — [`TypeKind`], the field list, which of the two
+//!   enum shapes an item is — that says what the source *means*, in terms every
+//!   destination language shares;
 //! * one [`Origin`], carrying the **exact syntax** the node was built from and
 //!   the source it arrived in.
 //!
@@ -54,8 +54,20 @@
 //! | `Vec<T>`, `[T]` | [`TypeKind::Sequence`] | a run of `T`; owned vs borrowed is the [`Ref`](TypeKind::Ref) layer's fact |
 //! | `Box<T>` | whatever `T` is | an owned `T` either way |
 //! | `struct S;`, `struct S {}` | zero fields | the delimiters are spelling |
+//! | `enum E { A(u8) }` | [`Variant`] | a sum, identified by position |
+//! | `enum E { A = 7 }` | [`Enum`] | a named integer, identified by its value |
 //! | no `->`, `-> ()` | [`TypeKind::Unit`] | the same function |
 //! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
+//!
+//! The two enum shapes are the clearest case of a *concept* splitting where Rust
+//! has one spelling. Both are `enum` and both keep a `syn::ItemEnum`, but a sum's
+//! alternatives are identified by **position** — the mirror an adapter builds
+//! carries no `repr` and numbers its own arms — while a fieldless enum's members
+//! are identified by the **value Rust assigns**, which a C header re-states and a
+//! Kotlin `enum class` entry carries. Neither numbering means anything for the
+//! other shape, so one model covering both would carry a field that is dead in
+//! each direction, and worse than dead: Rust does assign a discriminant to a
+//! sum's alternatives, and using it would be wrong.
 //!
 //! The identities follow the same rule: a nominal type is a [`TypeId`] — a
 //! name — not a `syn::Path`, so nothing downstream has to take a path apart to
@@ -134,7 +146,10 @@ mod tests;
 use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
-    element::{Const, Element, Enum, Field, Function, Param, Struct, Unsupported, Variant},
+    element::{
+        Alternative, Const, Element, Enum, EnumValue, Field, Function, Param, Struct, Unsupported,
+        Variant,
+    },
     origin::Origin,
     ty::{ScalarKind, Type, TypeId, TypeKind, UnsupportedType, UnsupportedTypeReason},
 };
@@ -537,7 +552,7 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
             Err(error) => unsupported(s.ident.clone(), syn::Item::Struct(s), &at, error),
         },
         syn::Item::Enum(e) => match lower_enum(&e, &at, consts) {
-            Ok(en) => Element::Enum(en),
+            Ok(element) => element,
             Err(error) => unsupported(e.ident.clone(), syn::Item::Enum(e), &at, error),
         },
         // Including the unnamed `const _` each source injects as its feature
@@ -694,17 +709,79 @@ fn lower_struct(
     })
 }
 
+/// Lower an `enum` item to whichever of the two shapes it is.
+///
+/// **The classification**: any alternative with a field makes it a [`Variant`] —
+/// a sum, numbered by position. Otherwise it is an [`Enum`] — a named set of
+/// integers, identified by the value Rust assigns. Both are spelled `enum` in
+/// Rust and both keep the `syn::ItemEnum`; only what a destination language can
+/// do with them differs, and that is what the model records.
+///
+/// `enum E {}` has no alternative carrying anything, so it is the degenerate
+/// `Enum`.
 fn lower_enum(
     e: &syn::ItemEnum,
     at: &Rc<SourceLocation>,
     consts: &ConstIndex,
-) -> Result<Enum, ItemError> {
+) -> Result<Element, ItemError> {
     reject_generic_params(&e.generics)?;
-    let mut variants = Vec::with_capacity(e.variants.len());
+
+    if e.variants.iter().any(|v| !v.fields.is_empty()) {
+        return Ok(Element::Variant(lower_variant(e, at, consts)?));
+    }
+    Ok(Element::Enum(lower_c_enum(e, at)))
+}
+
+/// The payload-carrying shape. Position is the only numbering a sum has, so no
+/// discriminant is evaluated: the mirror an adapter builds numbers its own arms.
+fn lower_variant(
+    e: &syn::ItemEnum,
+    at: &Rc<SourceLocation>,
+    consts: &ConstIndex,
+) -> Result<Variant, ItemError> {
+    let mut alternatives = Vec::with_capacity(e.variants.len());
+    for (index, v) in e.variants.iter().enumerate() {
+        let mut fields = Vec::with_capacity(v.fields.len());
+        for (field_index, f) in v.fields.iter().enumerate() {
+            let ty =
+                lower_type(&f.ty, consts, at).map_err(|source| ItemError::VariantFieldType {
+                    variant: v.ident.clone(),
+                    field: match &f.ident {
+                        Some(id) => id.to_string(),
+                        None => field_index.to_string(),
+                    },
+                    source,
+                })?;
+            fields.push(Field {
+                name: f.ident.clone(),
+                index: field_index,
+                ty,
+                origin: Origin::new(f.clone(), Rc::clone(at)),
+            });
+        }
+        alternatives.push(Alternative {
+            name: v.ident.clone(),
+            index,
+            fields,
+            origin: Origin::new(v.clone(), Rc::clone(at)),
+        });
+    }
+    Ok(Variant {
+        name: e.ident.clone(),
+        alternatives,
+        origin: Origin::new(e.clone(), Rc::clone(at)),
+    })
+}
+
+/// The fieldless shape. Nothing here can fail to lower — there are no field
+/// types — so an unevaluable discriminant ends the numeric chain rather than
+/// refusing the item.
+fn lower_c_enum(e: &syn::ItemEnum, at: &Rc<SourceLocation>) -> Enum {
+    let mut values = Vec::with_capacity(e.variants.len());
     // Rust's own numbering rule: an explicit `= N` sets the value, an implicit
-    // variant takes the previous plus one, starting at 0.
+    // one takes the previous plus one, starting at 0.
     let mut next: Option<i64> = Some(0);
-    for (variant_index, v) in e.variants.iter().enumerate() {
+    for (index, v) in e.variants.iter().enumerate() {
         let discriminant = match v.discriminant.as_ref() {
             Some((_, expr)) => int_literal(expr),
             None => next,
@@ -712,40 +789,21 @@ fn lower_enum(
         // `checked_add`: a discriminant at the top of the range is valid Rust
         // (`#[repr(u64)] enum E { A = i64::MAX as u64, B }`), so running out of
         // `i64` ends the numeric chain exactly as an unevaluable spelling does.
-        // The spelling is untouched either way — it is in `Variant::origin`.
+        // The spelling is untouched either way — it is in `EnumValue::origin`.
         next = discriminant.and_then(|n| n.checked_add(1));
 
-        let mut fields = Vec::with_capacity(v.fields.len());
-        for (index, f) in v.fields.iter().enumerate() {
-            let ty =
-                lower_type(&f.ty, consts, at).map_err(|source| ItemError::VariantFieldType {
-                    variant: v.ident.clone(),
-                    field: match &f.ident {
-                        Some(id) => id.to_string(),
-                        None => index.to_string(),
-                    },
-                    source,
-                })?;
-            fields.push(Field {
-                name: f.ident.clone(),
-                index,
-                ty,
-                origin: Origin::new(f.clone(), Rc::clone(at)),
-            });
-        }
-        variants.push(Variant {
+        values.push(EnumValue {
             name: v.ident.clone(),
-            index: variant_index,
+            index,
             discriminant,
-            fields,
             origin: Origin::new(v.clone(), Rc::clone(at)),
         });
     }
-    Ok(Enum {
+    Enum {
         name: e.ident.clone(),
-        variants,
+        values,
         origin: Origin::new(e.clone(), Rc::clone(at)),
-    })
+    }
 }
 
 /// Pull a signed integer out of a literal expression (`5`, `-3`, `0x07`).

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -11,6 +11,10 @@
 //!   (syn::Item)          validate              elements      spell off `origin`
 //! ```
 //!
+//! [`Language::source`] folds the first arrow in for the common case, so a build
+//! script names one directory and gets elements; [`Language::items`] keeps the
+//! arrow itself, for a stream that needs shaping first.
+//!
 //! # What an element is
 //!
 //! Two things at once, and that pairing is the whole design:
@@ -138,39 +142,124 @@ use crate::SourceLocation;
 
 /// The parser for the prebindgen source language.
 ///
-/// Carries no configuration: what the language accepts is a property of the
-/// language, not of the call site. See the [module docs](self) for the contract.
+/// Carries no configuration about what it *accepts* — that is a property of the
+/// language, not of the call site. What it does carry is **what to parse**:
+/// collect the inputs, then [`parse`](Self::parse) once.
 ///
-/// ```ignore
-/// let elements = Language::new().parse(
-///     flat.items_all().chain(helpers.items_in_groups(&["api"])),
-/// )?;
+/// # Reading a source directory
+///
+/// A build script's whole job, in one expression — the
+/// [`Source`](crate::Source) step included. Pass
+/// `<source_crate>::PREBINDGEN_OUT_DIR`:
+///
 /// ```
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Language;
+/// # prebindgen::Source::init_doctest_simulate();
+/// use prebindgen::core::Language;
+///
+/// let elements = Language::new().source("source_ffi").parse()?;
+/// assert_eq!(elements.len(), 2);
+/// # Ok::<_, prebindgen::core::language::ParseError>(())
+/// ```
+///
+/// # Reading a stream
+///
+/// [`Self::items`] takes any `(syn::Item, SourceLocation)` iterator, so
+/// everything a [`Source`](crate::Source) can express still composes — a group
+/// selection, a renamed dependency, several sources at once. The feeders
+/// accumulate, so mix them freely:
+///
+/// ```
+/// # prebindgen::Source::init_doctest_simulate();
+/// use prebindgen::{core::Language, Source};
+///
+/// // A dependency renamed in Cargo.toml needs the name THIS crate uses, so it
+/// // is configured rather than named by directory.
+/// let helpers = Source::builder("source_ffi").crate_name("helpers").build();
+/// let elements = Language::new()
+///     .items(helpers.items_in_groups(&["functions"]))
+///     .parse()?;
+/// assert_eq!(elements.len(), 1);
+/// # Ok::<_, prebindgen::core::language::ParseError>(())
+/// ```
+///
+/// # Why accumulate, rather than parse each input
+///
+/// The rules that make a parse fail are **whole-stream** rules: one flat
+/// namespace across every ingested crate, one const index an array length may
+/// reach into, one set of source modules to normalize paths against. None can be
+/// decided per input, so every input is in hand before any of it is classified.
+#[derive(Debug, Default)]
+pub struct Language {
+    items: Vec<(syn::Item, SourceLocation)>,
+}
 
 impl Language {
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 
-    /// Parse a captured item stream into elements.
+    /// Every `#[prebindgen]` item captured in `dir`.
     ///
-    /// Takes any `(syn::Item, SourceLocation)` iterator — typically
-    /// `source.items_all()` — so item-level selection and multi-source
-    /// composition stay upstream, where they already are.
+    /// Sugar for [`Self::items`] over [`Source::items_all`](crate::Source::items_all),
+    /// which is the whole of what a build script normally needs — pass
+    /// `<source_crate>::PREBINDGEN_OUT_DIR`. Reach for a
+    /// [`Source`](crate::Source) directly, and feed it through [`Self::items`],
+    /// only when it needs configuring.
+    ///
+    /// Panics the way [`Source::new`](crate::Source::new) does if `dir` is not
+    /// readable prebindgen output: a build script has nothing to recover with.
+    ///
+    /// ```
+    /// # prebindgen::Source::init_doctest_simulate();
+    /// use prebindgen::core::Language;
+    ///
+    /// let elements = Language::new().source("source_ffi").parse().unwrap();
+    /// let mut names: Vec<String> =
+    ///     elements.iter().filter_map(|e| e.name()).map(|n| n.to_string()).collect();
+    /// names.sort();
+    /// assert_eq!(names, ["TestStruct", "test_function"]);
+    /// ```
+    pub fn source<P: AsRef<std::path::Path>>(self, dir: P) -> Self {
+        let source = crate::Source::new(dir);
+        self.items(source.items_all())
+    }
+
+    /// Add a captured item stream.
+    ///
+    /// The general feeder: any `(syn::Item, SourceLocation)` iterator, so
+    /// item-level selection and multi-source composition stay upstream where
+    /// they already are. Call it as often as needed; the streams accumulate.
+    ///
+    /// ```
+    /// # prebindgen::Source::init_doctest_simulate();
+    /// use prebindgen::{core::Language, Source};
+    ///
+    /// let source = Source::new("source_ffi");
+    /// let elements = Language::new()
+    ///     .items(source.items_in_groups(&["structs"]))
+    ///     .parse()
+    ///     .unwrap();
+    /// assert_eq!(elements.len(), 1);
+    /// ```
+    pub fn items<I>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = (syn::Item, SourceLocation)>,
+    {
+        self.items.extend(items);
+        self
+    }
+
+    /// Parse everything collected so far into elements.
     ///
     /// **Transactional**: an `Err` yields no elements at all, so a refused
     /// stream cannot leave a half-built model behind.
     ///
     /// Order-independent: source modules are gathered, and consts indexed,
     /// before anything is lowered — so a cross-source type reference and an
-    /// array length may both name something declared later in the stream.
-    pub fn parse<I>(&self, items: I) -> Result<Vec<Element>, ParseError>
-    where
-        I: IntoIterator<Item = (syn::Item, SourceLocation)>,
-    {
-        let mut items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
+    /// array length may both name something declared later, in this input or
+    /// another.
+    pub fn parse(self) -> Result<Vec<Element>, ParseError> {
+        let mut items = self.items;
 
         // Pass 0: normalize every item's types to the canonical flat spelling
         // before a single one is classified. `std::option::Option<T>` is an

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -213,6 +213,12 @@ impl Language {
 /// If `ty` is `impl Fn(T1, T2, ...) + Send + Sync + 'static`, return the `Fn`
 /// argument types in declaration order. Otherwise `None`.
 ///
+/// A callback **returns nothing**, and that is checked, not assumed: a written
+/// `-> ()` is the same thing spelled out, and any other return is refused.
+/// [`TypeKind::Callback`] has no slot for one, so accepting `impl Fn() -> u8`
+/// would drop a fact a destination language needs — and drop it silently, which
+/// is worse than the refusal.
+///
 /// The callback grammar, and the language's alone: [`TypeKind::Callback`] is
 /// exactly what this accepts, so acceptance cannot drift from classification.
 /// The registry re-exports it for the consumers that have not migrated yet.
@@ -234,6 +240,11 @@ pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
                         let syn::PathArguments::Parenthesized(p) = &last.arguments else {
                             return None;
                         };
+                        match &p.output {
+                            syn::ReturnType::Default => {}
+                            syn::ReturnType::Type(_, t) if ty::is_unit_type(t) => {}
+                            syn::ReturnType::Type(..) => return None,
+                        }
                         args = Some(p.inputs.iter().cloned().collect());
                     }
                     "Send" => has_send = true,
@@ -561,16 +572,28 @@ fn lower_enum(
 /// Pull a signed integer out of a literal expression (`5`, `-3`, `0x07`).
 /// `None` for anything else — a `const`, a path, arithmetic.
 fn int_literal(expr: &syn::Expr) -> Option<i64> {
+    i64::try_from(int_literal_wide(expr)?).ok()
+}
+
+/// [`int_literal`] before the range check.
+///
+/// The magnitude is parsed **wider than the result** so the sign can be applied
+/// first: `-9223372036854775808` is `i64::MIN` and a valid Rust discriminant,
+/// but its magnitude is one past `i64::MAX`, so parsing the digits as `i64`
+/// would reject the whole literal. A magnitude too large for `i128` fails here
+/// and is reported as an unevaluable discriminant, which is the existing
+/// contract for anything the frontend cannot reduce to a number.
+fn int_literal_wide(expr: &syn::Expr) -> Option<i128> {
     match expr {
         syn::Expr::Lit(lit) => match &lit.lit {
-            syn::Lit::Int(int) => int.base10_parse::<i64>().ok(),
+            syn::Lit::Int(int) => int.base10_parse::<i128>().ok(),
             _ => None,
         },
         syn::Expr::Unary(syn::ExprUnary {
             op: syn::UnOp::Neg(_),
             expr,
             ..
-        }) => int_literal(expr).map(|v| -v),
+        }) => int_literal_wide(expr).map(|v| -v),
         _ => None,
     }
 }

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! Two things at once, and that pairing is the whole design:
 //!
-//! * a **closed classification** — [`TypeKind`], [`StructFields`], the variant
+//! * a **closed classification** — [`TypeKind`], the field list, the variant
 //!   list — that says what the source *means*, in terms every destination
 //!   language shares;
 //! * the **exact syntax** each part was built from, sliced down to the
@@ -28,7 +28,26 @@
 //! Matching a `syn::Type` or `syn::Expr` variant outside this module is a
 //! classifier, and issue #211 says classification lives here alone. Passing a
 //! `syntax` slice into `quote!` is spelling, and spelling the source is exactly
-//! what generated Rust must do.
+//! what generated Rust must do — see [`spell`] for the helpers that do it.
+//!
+//! # What earns a variant
+//!
+//! A concept, not a Rust spelling. The test is whether a *destination* language
+//! would act on the distinction; if only Rust can see it, it is spelling, and
+//! the slice already carries it:
+//!
+//! | Rust writes | The model says | Because |
+//! |---|---|---|
+//! | `String`, `str` | [`TypeKind::Str`] | one concept, two Rust types |
+//! | `Vec<T>`, `[T]` | [`TypeKind::Sequence`] | a run of `T`; owned vs borrowed is the [`Ref`](TypeKind::Ref) layer's fact |
+//! | `Box<T>` | whatever `T` is | an owned `T` either way |
+//! | `struct S;`, `struct S {}` | zero fields | the delimiters are spelling |
+//! | no `->`, `-> ()` | [`TypeKind::Unit`] | the same function |
+//! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
+//!
+//! The identities follow the same rule: a nominal type is a [`TypeId`] — a
+//! name — not a `syn::Path`, so nothing downstream has to take a path apart to
+//! learn what a type is.
 //!
 //! # Why the syntax rides along
 //!
@@ -63,6 +82,7 @@ mod array_len;
 #[cfg(test)]
 mod boundary;
 mod element;
+pub mod spell;
 mod ty;
 
 #[cfg(test)]
@@ -72,10 +92,9 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{
-        Const, Element, Enum, Field, Function, Param, Passthrough, Struct, StructFields,
-        Unsupported, Variant,
+        Const, Element, Enum, Field, Function, Param, Passthrough, Struct, Unsupported, Variant,
     },
-    ty::{ScalarKind, Type, TypeKind, UnsupportedType, UnsupportedTypeReason},
+    ty::{ScalarKind, Type, TypeId, TypeKind, UnsupportedType, UnsupportedTypeReason},
 };
 use crate::SourceLocation;
 
@@ -106,13 +125,37 @@ impl Language {
     /// **Transactional**: an `Err` yields no elements at all, so a refused
     /// stream cannot leave a half-built model behind.
     ///
-    /// Order-independent: consts are indexed before anything is lowered, so an
-    /// array length may name a const declared later in the stream.
+    /// Order-independent: source modules are gathered, and consts indexed,
+    /// before anything is lowered — so a cross-source type reference and an
+    /// array length may both name something declared later in the stream.
     pub fn parse<I>(&self, items: I) -> Result<Vec<Element>, ParseError>
     where
         I: IntoIterator<Item = (syn::Item, SourceLocation)>,
     {
-        let items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
+        let mut items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
+
+        // Pass 0: normalize every item's types to the canonical flat spelling
+        // before a single one is classified. `std::option::Option<T>` is an
+        // `Option`, and `source_a::TypeA` is `TypeA` — decisions this module
+        // owns, so it must be the one to see the reduced form. Gathering EVERY
+        // module name first is what makes a cross-source reference in an
+        // earlier item normalize the same as in a later one.
+        //
+        // The consequence is deliberate and stated in `Type::syntax`: a slice
+        // is the spelling generation must EMIT, which is the normalized one —
+        // the flat namespace is what the generated crate can actually name.
+        let mut modules: Vec<String> = Vec::new();
+        for (_, loc) in &items {
+            if let Some(crate_name) = &loc.crate_name {
+                let module = crate_name.replace('-', "_");
+                if !modules.contains(&module) {
+                    modules.push(module);
+                }
+            }
+        }
+        for (item, _) in &mut items {
+            crate::api::core::types_util::normalize_item_types(item, &modules);
+        }
 
         // Pass 1: the consts an array length may name. Unnamed `const _` items
         // are excluded here for the same reason they are passed through below —
@@ -144,6 +187,48 @@ impl Language {
             out.push(element);
         }
         Ok(out)
+    }
+}
+
+/// If `ty` is `impl Fn(T1, T2, ...) + Send + Sync + 'static`, return the `Fn`
+/// argument types in declaration order. Otherwise `None`.
+///
+/// The callback grammar, and the language's alone: [`TypeKind::Callback`] is
+/// exactly what this accepts, so acceptance cannot drift from classification.
+/// The registry re-exports it for the consumers that have not migrated yet.
+pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
+    let syn::Type::ImplTrait(it) = ty else {
+        return None;
+    };
+    let mut args: Option<Vec<syn::Type>> = None;
+    let mut has_send = false;
+    let mut has_sync = false;
+    let mut has_static = false;
+    for bound in &it.bounds {
+        match bound {
+            syn::TypeParamBound::Trait(tb) => {
+                let last = tb.path.segments.last()?;
+                let name = last.ident.to_string();
+                match name.as_str() {
+                    "Fn" => {
+                        let syn::PathArguments::Parenthesized(p) = &last.arguments else {
+                            return None;
+                        };
+                        args = Some(p.inputs.iter().cloned().collect());
+                    }
+                    "Send" => has_send = true,
+                    "Sync" => has_sync = true,
+                    _ => return None,
+                }
+            }
+            syn::TypeParamBound::Lifetime(lt) if lt.ident == "static" => has_static = true,
+            _ => return None,
+        }
+    }
+    if has_send && has_sync && has_static {
+        args
+    } else {
+        None
     }
 }
 
@@ -331,11 +416,17 @@ fn lower_fn(
             syntax: pt.clone(),
         });
     }
+    // An elided return and a written `-> ()` are the same function. The model
+    // says so once, here, instead of leaving every consumer to normalize one to
+    // the other — which is what they all do today, in eight separate copies.
     let ret = match &f.sig.output {
-        syn::ReturnType::Default => None,
-        syn::ReturnType::Type(_, t) => Some(
-            lower_type(t, consts, item_crate).map_err(|source| ItemError::ReturnType { source })?,
-        ),
+        syn::ReturnType::Default => Type {
+            kind: TypeKind::Unit,
+            syntax: syn::parse_quote!(()),
+        },
+        syn::ReturnType::Type(_, t) => {
+            lower_type(t, consts, item_crate).map_err(|source| ItemError::ReturnType { source })?
+        }
     };
     Ok(Function {
         name: f.sig.ident.clone(),
@@ -370,10 +461,12 @@ fn lower_struct(
                     syntax: f.clone(),
                 });
             }
-            StructFields::Named(out)
+            Some(out)
         }
-        syn::Fields::Unnamed(_) => StructFields::Unnamed,
-        syn::Fields::Unit => StructFields::Unit,
+        // Opaque: a tuple struct's contents are not a boundary surface, so they
+        // are not lowered and a field type outside the grammar is not an error.
+        syn::Fields::Unnamed(_) => None,
+        syn::Fields::Unit => Some(Vec::new()),
     };
     Ok(Struct {
         name: s.ident.clone(),

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -514,7 +514,7 @@ fn lower_enum(
     // Rust's own numbering rule: an explicit `= N` sets the value, an implicit
     // variant takes the previous plus one, starting at 0.
     let mut next: Option<i64> = Some(0);
-    for (tag, v) in e.variants.iter().enumerate() {
+    for (variant_index, v) in e.variants.iter().enumerate() {
         let discriminant = match v.discriminant.as_ref() {
             Some((_, expr)) => int_literal(expr),
             None => next,
@@ -522,7 +522,7 @@ fn lower_enum(
         // `checked_add`: a discriminant at the top of the range is valid Rust
         // (`#[repr(u64)] enum E { A = i64::MAX as u64, B }`), so running out of
         // `i64` ends the numeric chain exactly as an unevaluable spelling does.
-        // The spelling is untouched either way — it is in `Variant::syntax`.
+        // The spelling is untouched either way — it is in `Variant::origin`.
         next = discriminant.and_then(|n| n.checked_add(1));
 
         let mut fields = Vec::with_capacity(v.fields.len());
@@ -545,7 +545,7 @@ fn lower_enum(
         }
         variants.push(Variant {
             name: v.ident.clone(),
-            tag: tag as i32,
+            index: variant_index,
             discriminant,
             fields,
             origin: Origin::new(v.clone(), Rc::clone(at)),

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -8,7 +8,7 @@
 //! ```text
 //! Source(s) ──items──> Language ──Elements──> Registry ──> adapters
 //!   raw records          parse +               indexes       classify off `kind`
-//!   (syn::Item)          validate              elements      spell off `syntax`
+//!   (syn::Item)          validate              elements      spell off `origin`
 //! ```
 //!
 //! # What an element is
@@ -18,17 +18,25 @@
 //! * a **closed classification** — [`TypeKind`], the field list, the variant
 //!   list — that says what the source *means*, in terms every destination
 //!   language shares;
-//! * the **exact syntax** each part was built from, sliced down to the
-//!   parameter, field, variant and type.
+//! * one [`Origin`], carrying the **exact syntax** the node was built from and
+//!   the source it arrived in.
+//!
+//! The `Origin` is uniform: every node has one, at every level — item,
+//! parameter, field, variant, type, array extent. Some levels know less than
+//! others (a field has no line of its own, so it shares its item's), but the
+//! shape does not change with the level, and no level copies a piece of
+//! provenance down from the one above. That copying is what previously let the
+//! same crate name appear under three field names with two meanings.
 //!
 //! So the rule for every consumer is:
 //!
-//! > **Classify off `kind`, spell off `syntax`.**
+//! > **Classify off `kind`, spell off `origin.syntax`.**
 //!
 //! Matching a `syn::Type` or `syn::Expr` variant outside this module is a
 //! classifier, and issue #211 says classification lives here alone. Passing a
-//! `syntax` slice into `quote!` is spelling, and spelling the source is exactly
-//! what generated Rust must do — see [`spell`] for the helpers that do it.
+//! node's [`Origin`] into `quote!` is spelling, and spelling the source is
+//! exactly what generated Rust must do — see [`spell`] for the helpers that do
+//! it.
 //!
 //! # What earns a variant
 //!
@@ -47,7 +55,12 @@
 //!
 //! The identities follow the same rule: a nominal type is a [`TypeId`] — a
 //! name — not a `syn::Path`, so nothing downstream has to take a path apart to
-//! learn what a type is.
+//! learn what a type is. And a name is *all* it is: **a reference carries a
+//! name, the declaration carries the origin**, so the same type never compares
+//! unequal to itself because two source crates mentioned it. The one place a
+//! crate name rides with an identity is [`ConstId`], and that is the const's
+//! *declaring* crate, resolved by lookup — which is exactly what lets an array
+//! extent refuse a const from another source.
 //!
 //! # Why the syntax rides along
 //!
@@ -81,7 +94,7 @@
 //! not model is a `union` or a type alias, and it is diagnosed like any other
 //! thing the language cannot express.
 
-use std::fmt;
+use std::{fmt, rc::Rc};
 
 use quote::ToTokens;
 
@@ -89,6 +102,7 @@ mod array_len;
 #[cfg(test)]
 mod boundary;
 mod element;
+mod origin;
 pub mod spell;
 mod ty;
 
@@ -99,6 +113,7 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{Const, Element, Enum, Field, Function, Param, Struct, Unsupported, Variant},
+    origin::Origin,
     ty::{ScalarKind, Type, TypeId, TypeKind, UnsupportedType, UnsupportedTypeReason},
 };
 use crate::SourceLocation;
@@ -146,7 +161,7 @@ impl Language {
         // module name first is what makes a cross-source reference in an
         // earlier item normalize the same as in a later one.
         //
-        // The consequence is deliberate and stated in `Type::syntax`: a slice
+        // The consequence is deliberate and stated on `Origin`: a slice
         // is the spelling generation must EMIT, which is the normalized one —
         // the flat namespace is what the generated crate can actually name.
         let mut modules: Vec<String> = Vec::new();
@@ -346,36 +361,36 @@ impl std::error::Error for ItemError {}
 /// whose contents the language cannot express becomes [`Element::Unsupported`]
 /// rather than failing the parse.
 fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Element {
-    let item_crate = loc.crate_name.clone();
-    let crate_ref = item_crate.as_deref();
+    // One captured record is one item, so this is allocated once and shared by
+    // the item and every node lowered out of it.
+    let at = Rc::new(loc);
     match item {
-        syn::Item::Fn(f) => match lower_fn(&f, &loc, consts, crate_ref) {
+        syn::Item::Fn(f) => match lower_fn(&f, &at, consts) {
             Ok(func) => Element::Function(func),
-            Err(error) => unsupported(f.sig.ident.clone(), syn::Item::Fn(f), loc, error),
+            Err(error) => unsupported(f.sig.ident.clone(), syn::Item::Fn(f), &at, error),
         },
-        syn::Item::Struct(s) => match lower_struct(&s, &loc, consts, crate_ref) {
+        syn::Item::Struct(s) => match lower_struct(&s, &at, consts) {
             Ok(st) => Element::Struct(st),
-            Err(error) => unsupported(s.ident.clone(), syn::Item::Struct(s), loc, error),
+            Err(error) => unsupported(s.ident.clone(), syn::Item::Struct(s), &at, error),
         },
-        syn::Item::Enum(e) => match lower_enum(&e, &loc, consts, crate_ref) {
+        syn::Item::Enum(e) => match lower_enum(&e, &at, consts) {
             Ok(en) => Element::Enum(en),
-            Err(error) => unsupported(e.ident.clone(), syn::Item::Enum(e), loc, error),
+            Err(error) => unsupported(e.ident.clone(), syn::Item::Enum(e), &at, error),
         },
         // Including the unnamed `const _` each source injects as its feature
         // guard: it is a const, so it is one here. `Element::name` returns
         // `None` for `_`, which is what keeps several sources' guards from
         // colliding in the flat namespace.
-        syn::Item::Const(c) => match lower_type(&c.ty, consts, crate_ref) {
+        syn::Item::Const(c) => match lower_type(&c.ty, consts, &at) {
             Ok(ty) => Element::Const(Const {
                 name: c.ident.clone(),
                 ty,
-                location: loc,
-                syntax: c,
+                origin: Origin::new(c, at),
             }),
             Err(source) => unsupported(
                 c.ident.clone(),
                 syn::Item::Const(c),
-                loc,
+                &at,
                 ItemError::ConstType { source },
             ),
         },
@@ -390,7 +405,7 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
                 syn::Item::Type(t) => (Some(t.ident.clone()), "a type alias"),
                 _ => (None, "an item kind"),
             };
-            unsupported(name, other, loc, ItemError::UnsupportedItemKind { kind })
+            unsupported(name, other, &at, ItemError::UnsupportedItemKind { kind })
         }
     }
 }
@@ -398,22 +413,20 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
 fn unsupported(
     name: impl Into<Option<syn::Ident>>,
     syntax: syn::Item,
-    location: SourceLocation,
+    at: &Rc<SourceLocation>,
     error: ItemError,
 ) -> Element {
     Element::Unsupported(Unsupported {
         name: name.into(),
-        location,
         error: Box::new(error),
-        syntax,
+        origin: Origin::new(syntax, Rc::clone(at)),
     })
 }
 
 fn lower_fn(
     f: &syn::ItemFn,
-    loc: &SourceLocation,
+    at: &Rc<SourceLocation>,
     consts: &ConstIndex,
-    item_crate: Option<&str>,
 ) -> Result<Function, ItemError> {
     let mut params = Vec::with_capacity(f.sig.inputs.len());
     for input in &f.sig.inputs {
@@ -427,14 +440,14 @@ fn lower_fn(
             });
         };
         let name = pat.ident.clone();
-        let ty = lower_type(&pt.ty, consts, item_crate).map_err(|source| ItemError::ParamType {
+        let ty = lower_type(&pt.ty, consts, at).map_err(|source| ItemError::ParamType {
             param: name.clone(),
             source,
         })?;
         params.push(Param {
             name,
             ty,
-            syntax: pt.clone(),
+            origin: Origin::new(pt.clone(), Rc::clone(at)),
         });
     }
     // An elided return and a written `-> ()` are the same function. The model
@@ -443,43 +456,39 @@ fn lower_fn(
     let ret = match &f.sig.output {
         syn::ReturnType::Default => Type {
             kind: TypeKind::Unit,
-            syntax: syn::parse_quote!(()),
+            origin: Origin::new(syn::parse_quote!(()), Rc::clone(at)),
         },
         syn::ReturnType::Type(_, t) => {
-            lower_type(t, consts, item_crate).map_err(|source| ItemError::ReturnType { source })?
+            lower_type(t, consts, at).map_err(|source| ItemError::ReturnType { source })?
         }
     };
     Ok(Function {
         name: f.sig.ident.clone(),
         params,
         ret,
-        location: loc.clone(),
-        syntax: f.clone(),
+        origin: Origin::new(f.clone(), Rc::clone(at)),
     })
 }
 
 fn lower_struct(
     s: &syn::ItemStruct,
-    loc: &SourceLocation,
+    at: &Rc<SourceLocation>,
     consts: &ConstIndex,
-    item_crate: Option<&str>,
 ) -> Result<Struct, ItemError> {
     let fields = match &s.fields {
         syn::Fields::Named(named) => {
             let mut out = Vec::with_capacity(named.named.len());
             for (index, f) in named.named.iter().enumerate() {
                 let name = f.ident.clone().expect("named fields have idents");
-                let ty = lower_type(&f.ty, consts, item_crate).map_err(|source| {
-                    ItemError::FieldType {
-                        field: name.clone(),
-                        source,
-                    }
+                let ty = lower_type(&f.ty, consts, at).map_err(|source| ItemError::FieldType {
+                    field: name.clone(),
+                    source,
                 })?;
                 out.push(Field {
                     name: Some(name),
                     index,
                     ty,
-                    syntax: f.clone(),
+                    origin: Origin::new(f.clone(), Rc::clone(at)),
                 });
             }
             Some(out)
@@ -492,16 +501,14 @@ fn lower_struct(
     Ok(Struct {
         name: s.ident.clone(),
         fields,
-        location: loc.clone(),
-        syntax: s.clone(),
+        origin: Origin::new(s.clone(), Rc::clone(at)),
     })
 }
 
 fn lower_enum(
     e: &syn::ItemEnum,
-    loc: &SourceLocation,
+    at: &Rc<SourceLocation>,
     consts: &ConstIndex,
-    item_crate: Option<&str>,
 ) -> Result<Enum, ItemError> {
     let mut variants = Vec::with_capacity(e.variants.len());
     // Rust's own numbering rule: an explicit `= N` sets the value, an implicit
@@ -520,21 +527,20 @@ fn lower_enum(
 
         let mut fields = Vec::with_capacity(v.fields.len());
         for (index, f) in v.fields.iter().enumerate() {
-            let ty = lower_type(&f.ty, consts, item_crate).map_err(|source| {
-                ItemError::VariantFieldType {
+            let ty =
+                lower_type(&f.ty, consts, at).map_err(|source| ItemError::VariantFieldType {
                     variant: v.ident.clone(),
                     field: match &f.ident {
                         Some(id) => id.to_string(),
                         None => index.to_string(),
                     },
                     source,
-                }
-            })?;
+                })?;
             fields.push(Field {
                 name: f.ident.clone(),
                 index,
                 ty,
-                syntax: f.clone(),
+                origin: Origin::new(f.clone(), Rc::clone(at)),
             });
         }
         variants.push(Variant {
@@ -542,14 +548,13 @@ fn lower_enum(
             tag: tag as i32,
             discriminant,
             fields,
-            syntax: v.clone(),
+            origin: Origin::new(v.clone(), Rc::clone(at)),
         });
     }
     Ok(Enum {
         name: e.ident.clone(),
         variants,
-        location: loc.clone(),
-        syntax: e.clone(),
+        origin: Origin::new(e.clone(), Rc::clone(at)),
     })
 }
 

--- a/prebindgen/src/api/core/language/mod.rs
+++ b/prebindgen/src/api/core/language/mod.rs
@@ -1,0 +1,457 @@
+//! The prebindgen **source language**: one parser from captured records to
+//! [`Element`]s.
+//!
+//! > Naming: `core::language` is the *source* language — the Rust subset a
+//! > `#[prebindgen]` crate may write. `api::lang` is the *destination* adapters
+//! > (C, JNI). They are opposite ends of the pipeline.
+//!
+//! ```text
+//! Source(s) ──items──> Language ──Elements──> Registry ──> adapters
+//!   raw records          parse +               indexes       classify off `kind`
+//!   (syn::Item)          validate              elements      spell off `syntax`
+//! ```
+//!
+//! # What an element is
+//!
+//! Two things at once, and that pairing is the whole design:
+//!
+//! * a **closed classification** — [`TypeKind`], [`StructFields`], the variant
+//!   list — that says what the source *means*, in terms every destination
+//!   language shares;
+//! * the **exact syntax** each part was built from, sliced down to the
+//!   parameter, field, variant and type.
+//!
+//! So the rule for every consumer is:
+//!
+//! > **Classify off `kind`, spell off `syntax`.**
+//!
+//! Matching a `syn::Type` or `syn::Expr` variant outside this module is a
+//! classifier, and issue #211 says classification lives here alone. Passing a
+//! `syntax` slice into `quote!` is spelling, and spelling the source is exactly
+//! what generated Rust must do.
+//!
+//! # Why the syntax rides along
+//!
+//! The generated Rust glue is itself a destination artifact, and the only one
+//! that needs syntax fidelity: `B()` must not be re-spelled `B`, `= 0x07` must
+//! not become `= 7`, `Foo<'a>` is not `Foo`. A model that carries no syntax has
+//! to become *lossless* to serve it — which is how a language-neutral IR turns
+//! back into a second `syn`. Carrying the original slice costs nothing and lets
+//! the classification stay small: a lifetime, a delimiter and a literal's base
+//! are simply not modelled facts.
+//!
+//! # Where acceptance is enforced
+//!
+//! Lowering is **total over the accepted grammar**: a form with no variant in
+//! [`TypeKind`] is a form the language does not accept, so there is no second
+//! acceptance list to drift from it.
+//!
+//! But an item the language cannot express is not automatically a build failure.
+//! A source crate may mark items no binding uses, and those have never been
+//! required to be expressible — the pipeline scans a signature only once an
+//! adapter *declares* it. So parsing diagnoses per item and defers the raising:
+//! such an item becomes [`Element::Unsupported`], carrying the diagnosis, inert
+//! until something declares it. Only whole-stream rules — a duplicate name in
+//! the flat namespace — are [`ParseError`]s, because no declaration can make
+//! two items with one name unambiguous.
+
+use std::fmt;
+
+use quote::ToTokens;
+
+mod array_len;
+#[cfg(test)]
+mod boundary;
+mod element;
+mod ty;
+
+#[cfg(test)]
+mod tests;
+
+use self::{array_len::ConstIndex, ty::lower_type};
+pub use self::{
+    array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
+    element::{
+        Const, Element, Enum, Field, Function, Param, Passthrough, Struct, StructFields,
+        Unsupported, Variant,
+    },
+    ty::{ScalarKind, Type, TypeKind, UnsupportedType, UnsupportedTypeReason},
+};
+use crate::SourceLocation;
+
+/// The parser for the prebindgen source language.
+///
+/// Carries no configuration: what the language accepts is a property of the
+/// language, not of the call site. See the [module docs](self) for the contract.
+///
+/// ```ignore
+/// let elements = Language::new().parse(
+///     flat.items_all().chain(helpers.items_in_groups(&["api"])),
+/// )?;
+/// ```
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Language;
+
+impl Language {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Parse a captured item stream into elements.
+    ///
+    /// Takes any `(syn::Item, SourceLocation)` iterator — typically
+    /// `source.items_all()` — so item-level selection and multi-source
+    /// composition stay upstream, where they already are.
+    ///
+    /// **Transactional**: an `Err` yields no elements at all, so a refused
+    /// stream cannot leave a half-built model behind.
+    ///
+    /// Order-independent: consts are indexed before anything is lowered, so an
+    /// array length may name a const declared later in the stream.
+    pub fn parse<I>(&self, items: I) -> Result<Vec<Element>, ParseError>
+    where
+        I: IntoIterator<Item = (syn::Item, SourceLocation)>,
+    {
+        let items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
+
+        // Pass 1: the consts an array length may name. Unnamed `const _` items
+        // are excluded here for the same reason they are passed through below —
+        // they are not addressable.
+        let consts = ConstIndex::new(items.iter().filter_map(|(item, loc)| match item {
+            syn::Item::Const(c) if c.ident != "_" => Some((
+                c.ident.to_string(),
+                (*c.expr).clone(),
+                loc.crate_name.clone(),
+            )),
+            _ => None,
+        }));
+
+        // Pass 2: lower, checking the flat namespace as we go.
+        let mut out: Vec<Element> = Vec::with_capacity(items.len());
+        let mut seen: Vec<(syn::Ident, SourceLocation)> = Vec::new();
+        for (item, loc) in items {
+            let element = lower_item(item, loc, &consts);
+            if let Some(name) = element.name() {
+                if let Some((first_name, first)) = seen.iter().find(|(n, _)| n == name) {
+                    return Err(ParseError::DuplicateName(Box::new(DuplicateName {
+                        name: first_name.clone(),
+                        first: first.clone(),
+                        second: element.location().clone(),
+                    })));
+                }
+                seen.push((name.clone(), element.location().clone()));
+            }
+            out.push(element);
+        }
+        Ok(out)
+    }
+}
+
+/// A rule of the language that no single item can satisfy on its own, and that
+/// no adapter declaration can excuse.
+#[derive(Clone, Debug)]
+pub enum ParseError {
+    /// Two `#[prebindgen]` items share a name. Names live in one flat namespace
+    /// across every ingested source crate, so this is ambiguous however the
+    /// crates are arranged.
+    DuplicateName(Box<DuplicateName>),
+}
+
+/// The two items of a [`ParseError::DuplicateName`].
+#[derive(Clone, Debug)]
+pub struct DuplicateName {
+    pub name: syn::Ident,
+    pub first: SourceLocation,
+    pub second: SourceLocation,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::DuplicateName(d) => write!(
+                f,
+                "duplicate `#[prebindgen]` name `{}`: first at {}, again at {} — marked items \
+                 share one flat namespace across all source crates",
+                d.name, d.first, d.second
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Why one item could not be expressed in the language.
+///
+/// Carried by [`Element::Unsupported`] rather than raised at parse time: see
+/// the [module docs](self) on where acceptance is enforced.
+#[derive(Clone, Debug)]
+pub enum ItemError {
+    /// A `self` receiver. `#[prebindgen]` captures free functions only.
+    UnsupportedReceiver,
+    /// A parameter pattern that is not a plain name — `(a, b): (u8, u8)`.
+    UnsupportedParamPattern { pattern: String },
+    /// A parameter's type is not in the language.
+    ParamType {
+        param: syn::Ident,
+        source: UnsupportedType,
+    },
+    /// A return type is not in the language.
+    ReturnType { source: UnsupportedType },
+    /// A named struct field's type is not in the language.
+    FieldType {
+        field: syn::Ident,
+        source: UnsupportedType,
+    },
+    /// A variant payload's type is not in the language.
+    VariantFieldType {
+        variant: syn::Ident,
+        /// The field's name, or its position for a tuple variant.
+        field: String,
+        source: UnsupportedType,
+    },
+    /// A const's type is not in the language.
+    ConstType { source: UnsupportedType },
+}
+
+impl fmt::Display for ItemError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ItemError::UnsupportedReceiver => write!(
+                f,
+                "takes a `self` receiver; `#[prebindgen]` captures free functions only"
+            ),
+            ItemError::UnsupportedParamPattern { pattern } => write!(
+                f,
+                "parameter pattern `{pattern}` is not a plain name — bind each parameter to one \
+                 identifier"
+            ),
+            ItemError::ParamType { param, source } => {
+                write!(f, "parameter `{param}`: {source}")
+            }
+            ItemError::ReturnType { source } => write!(f, "return type: {source}"),
+            ItemError::FieldType { field, source } => write!(f, "field `{field}`: {source}"),
+            ItemError::VariantFieldType {
+                variant,
+                field,
+                source,
+            } => write!(f, "variant `{variant}` field `{field}`: {source}"),
+            ItemError::ConstType { source } => write!(f, "const type: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for ItemError {}
+
+/// Lower one captured item. Total: every item becomes an element, and an item
+/// whose contents the language cannot express becomes [`Element::Unsupported`]
+/// rather than failing the parse.
+fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Element {
+    let item_crate = loc.crate_name.clone();
+    let crate_ref = item_crate.as_deref();
+    match item {
+        syn::Item::Fn(f) => match lower_fn(&f, &loc, consts, crate_ref) {
+            Ok(func) => Element::Function(func),
+            Err(error) => unsupported(f.sig.ident.clone(), syn::Item::Fn(f), loc, error),
+        },
+        syn::Item::Struct(s) => match lower_struct(&s, &loc, consts, crate_ref) {
+            Ok(st) => Element::Struct(st),
+            Err(error) => unsupported(s.ident.clone(), syn::Item::Struct(s), loc, error),
+        },
+        syn::Item::Enum(e) => match lower_enum(&e, &loc, consts, crate_ref) {
+            Ok(en) => Element::Enum(en),
+            Err(error) => unsupported(e.ident.clone(), syn::Item::Enum(e), loc, error),
+        },
+        // Unnamed `const _` items (each source's injected `konst` feature
+        // guard) live outside the flat namespace: several sources may each
+        // carry one, all passed through verbatim.
+        syn::Item::Const(c) if c.ident == "_" => Element::Passthrough(Passthrough {
+            location: loc,
+            syntax: syn::Item::Const(c),
+        }),
+        syn::Item::Const(c) => match lower_type(&c.ty, consts, crate_ref) {
+            Ok(ty) => Element::Const(Const {
+                name: c.ident.clone(),
+                ty,
+                location: loc,
+                syntax: c,
+            }),
+            Err(source) => unsupported(
+                c.ident.clone(),
+                syn::Item::Const(c),
+                loc,
+                ItemError::ConstType { source },
+            ),
+        },
+        other => Element::Passthrough(Passthrough {
+            location: loc,
+            syntax: other,
+        }),
+    }
+}
+
+fn unsupported(
+    name: syn::Ident,
+    syntax: syn::Item,
+    location: SourceLocation,
+    error: ItemError,
+) -> Element {
+    Element::Unsupported(Unsupported {
+        name,
+        location,
+        error: Box::new(error),
+        syntax,
+    })
+}
+
+fn lower_fn(
+    f: &syn::ItemFn,
+    loc: &SourceLocation,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<Function, ItemError> {
+    let mut params = Vec::with_capacity(f.sig.inputs.len());
+    for input in &f.sig.inputs {
+        let pt = match input {
+            syn::FnArg::Receiver(_) => return Err(ItemError::UnsupportedReceiver),
+            syn::FnArg::Typed(pt) => pt,
+        };
+        let syn::Pat::Ident(pat) = &*pt.pat else {
+            return Err(ItemError::UnsupportedParamPattern {
+                pattern: pt.pat.to_token_stream().to_string(),
+            });
+        };
+        let name = pat.ident.clone();
+        let ty = lower_type(&pt.ty, consts, item_crate).map_err(|source| ItemError::ParamType {
+            param: name.clone(),
+            source,
+        })?;
+        params.push(Param {
+            name,
+            ty,
+            syntax: pt.clone(),
+        });
+    }
+    let ret = match &f.sig.output {
+        syn::ReturnType::Default => None,
+        syn::ReturnType::Type(_, t) => Some(
+            lower_type(t, consts, item_crate).map_err(|source| ItemError::ReturnType { source })?,
+        ),
+    };
+    Ok(Function {
+        name: f.sig.ident.clone(),
+        params,
+        ret,
+        location: loc.clone(),
+        syntax: f.clone(),
+    })
+}
+
+fn lower_struct(
+    s: &syn::ItemStruct,
+    loc: &SourceLocation,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<Struct, ItemError> {
+    let fields = match &s.fields {
+        syn::Fields::Named(named) => {
+            let mut out = Vec::with_capacity(named.named.len());
+            for (index, f) in named.named.iter().enumerate() {
+                let name = f.ident.clone().expect("named fields have idents");
+                let ty = lower_type(&f.ty, consts, item_crate).map_err(|source| {
+                    ItemError::FieldType {
+                        field: name.clone(),
+                        source,
+                    }
+                })?;
+                out.push(Field {
+                    name: Some(name),
+                    index,
+                    ty,
+                    syntax: f.clone(),
+                });
+            }
+            StructFields::Named(out)
+        }
+        syn::Fields::Unnamed(_) => StructFields::Unnamed,
+        syn::Fields::Unit => StructFields::Unit,
+    };
+    Ok(Struct {
+        name: s.ident.clone(),
+        fields,
+        location: loc.clone(),
+        syntax: s.clone(),
+    })
+}
+
+fn lower_enum(
+    e: &syn::ItemEnum,
+    loc: &SourceLocation,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<Enum, ItemError> {
+    let mut variants = Vec::with_capacity(e.variants.len());
+    // Rust's own numbering rule: an explicit `= N` sets the value, an implicit
+    // variant takes the previous plus one, starting at 0.
+    let mut next: Option<i64> = Some(0);
+    for (tag, v) in e.variants.iter().enumerate() {
+        let discriminant = match v.discriminant.as_ref() {
+            Some((_, expr)) => int_literal(expr),
+            None => next,
+        };
+        // `checked_add`: a discriminant at the top of the range is valid Rust
+        // (`#[repr(u64)] enum E { A = i64::MAX as u64, B }`), so running out of
+        // `i64` ends the numeric chain exactly as an unevaluable spelling does.
+        // The spelling is untouched either way — it is in `Variant::syntax`.
+        next = discriminant.and_then(|n| n.checked_add(1));
+
+        let mut fields = Vec::with_capacity(v.fields.len());
+        for (index, f) in v.fields.iter().enumerate() {
+            let ty = lower_type(&f.ty, consts, item_crate).map_err(|source| {
+                ItemError::VariantFieldType {
+                    variant: v.ident.clone(),
+                    field: match &f.ident {
+                        Some(id) => id.to_string(),
+                        None => index.to_string(),
+                    },
+                    source,
+                }
+            })?;
+            fields.push(Field {
+                name: f.ident.clone(),
+                index,
+                ty,
+                syntax: f.clone(),
+            });
+        }
+        variants.push(Variant {
+            name: v.ident.clone(),
+            tag: tag as i32,
+            discriminant,
+            fields,
+            syntax: v.clone(),
+        });
+    }
+    Ok(Enum {
+        name: e.ident.clone(),
+        variants,
+        location: loc.clone(),
+        syntax: e.clone(),
+    })
+}
+
+/// Pull a signed integer out of a literal expression (`5`, `-3`, `0x07`).
+/// `None` for anything else — a `const`, a path, arithmetic.
+fn int_literal(expr: &syn::Expr) -> Option<i64> {
+    match expr {
+        syn::Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Int(int) => int.base10_parse::<i64>().ok(),
+            _ => None,
+        },
+        syn::Expr::Unary(syn::ExprUnary {
+            op: syn::UnOp::Neg(_),
+            expr,
+            ..
+        }) => int_literal(expr).map(|v| -v),
+        _ => None,
+    }
+}

--- a/prebindgen/src/api/core/language/origin.rs
+++ b/prebindgen/src/api/core/language/origin.rs
@@ -1,0 +1,88 @@
+//! Where a node came from: the syntax it was built from, and the source that
+//! syntax arrived in.
+//!
+//! One uniform property of **every** node in the model — item, parameter,
+//! field, variant, type, array extent alike. Some levels know less than others
+//! (a field has no line of its own), but the shape does not change with the
+//! level, so nothing has to copy a piece of provenance downward by hand.
+
+use std::rc::Rc;
+
+use quote::ToTokens;
+
+use crate::SourceLocation;
+
+/// The syntax a node was built from, plus where that syntax came from.
+///
+/// # Why the two travel together
+///
+/// `syn` tokens normally carry spans, so in principle the syntax alone could
+/// answer "where was this written". Not here: the proc-macro serializes each
+/// marked item as a **string** into JSONL, and `build.rs` re-parses it, so every
+/// span in [`Self::syntax`] points into an anonymous buffer.
+/// [`SourceLocation::from_span`] captures file, line and column at
+/// macro-expansion time — while real rustc spans still exist — precisely because
+/// they cannot survive that trip.
+///
+/// # Why the location is shared
+///
+/// One captured record is one item, so there is exactly one location per item
+/// and none of its own for any component. An item and everything inside it —
+/// parameters, fields, variants, types, extents — therefore point at the *same*
+/// [`SourceLocation`], which is both the honest answer and the cheap one: a
+/// struct with twenty fields keeps one location, not twenty copies of a path.
+///
+/// `Rc` rather than `Arc`: this holds `syn` values, which are `!Send`, so the
+/// model can never cross a thread boundary and an atomic refcount would only
+/// cost. [`TypeKey`](crate::api::core::registry::TypeKey) made the same call for
+/// the same reason.
+///
+/// # The rule about origins
+///
+/// > A reference carries a name; the declaration carries the origin.
+///
+/// `location.crate_name` here is the crate whose source this node was written
+/// *in* — the use site. It is never part of a referenced item's identity:
+/// [`TypeId`](super::TypeId) is a name alone, because `#[prebindgen]` names live
+/// in one flat namespace. [`ConstId`](super::ConstId) is not an exception — the
+/// crate it records is the const's *declaring* crate, obtained by lookup, and
+/// that is exactly what lets an array extent refuse a const from another source.
+#[derive(Clone, Debug)]
+pub struct Origin<S> {
+    /// The exact tokens this node was built from. Feed it to `quote!` when
+    /// generated Rust has to spell the node; never `match` on it to decide what
+    /// the node is — see the [module docs](super) on classifying off `kind`.
+    pub syntax: S,
+    /// The captured item this node belongs to, shared with every sibling.
+    pub location: Rc<SourceLocation>,
+}
+
+impl<S> Origin<S> {
+    pub fn new(syntax: S, location: Rc<SourceLocation>) -> Self {
+        Self { syntax, location }
+    }
+
+    /// The crate this node's source was written in.
+    ///
+    /// The **use site**, not the declaring crate of anything it names.
+    pub fn crate_name(&self) -> Option<&str> {
+        self.location.crate_name.as_deref()
+    }
+
+    /// The same location over different syntax — for building a component's
+    /// origin from the item's.
+    pub fn with<T>(&self, syntax: T) -> Origin<T> {
+        Origin {
+            syntax,
+            location: Rc::clone(&self.location),
+        }
+    }
+}
+
+/// Spelling a node emits its syntax, so a site that re-states a whole node
+/// needs no `.syntax` hop.
+impl<S: ToTokens> ToTokens for Origin<S> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.syntax.to_tokens(tokens)
+    }
+}

--- a/prebindgen/src/api/core/language/spell.rs
+++ b/prebindgen/src/api/core/language/spell.rs
@@ -37,7 +37,7 @@ pub fn fields(shape: &syn::Fields, head: TokenStream, parts: &[TokenStream]) -> 
 impl Variant {
     /// [`fields`] over this variant's own delimiters.
     pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.syntax.fields, head, parts)
+        fields(&self.origin.syntax.fields, head, parts)
     }
 }
 
@@ -45,7 +45,7 @@ impl Struct {
     /// [`fields`] over this struct's own delimiters — the dual of
     /// [`Variant::spell`], and the reason neither needs a modelled shape.
     pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.syntax.fields, head, parts)
+        fields(&self.origin.syntax.fields, head, parts)
     }
 }
 

--- a/prebindgen/src/api/core/language/spell.rs
+++ b/prebindgen/src/api/core/language/spell.rs
@@ -1,0 +1,71 @@
+//! Spelling an element back as Rust: the one place the model turns into tokens.
+//!
+//! The other half of **classify off `kind`, spell off `syntax`**. Every helper
+//! here reads an element's retained syntax and emits Rust; none of them decides
+//! what anything *means*. Keeping them out of [`element`](super::element) is
+//! what lets that module describe structure alone — a `Field` is a name, a
+//! position and a type, and whether Rust writes it `id: v` or `v` is answered
+//! here.
+//!
+//! Nothing outside generated Rust reads any of this: a destination language
+//! cannot tell `E::B` from `E::B()`, which is exactly why the delimiters are
+//! spelling rather than a modelled shape.
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+use super::element::{Field, Struct, Variant};
+
+/// Spell a field group: `head`, `head(parts…)` or `head { parts… }`, following
+/// the delimiters the source wrote.
+///
+/// The one place those delimiters are chosen — for match patterns and
+/// constructors alike, in either direction, for a struct and a variant alike.
+/// `B()` carries no payload and still must be written `E::B()` wherever Rust
+/// names it.
+///
+/// `head` is the type's or variant's path, and each part is an already-rendered
+/// [`Field::bind`].
+pub fn fields(shape: &syn::Fields, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
+    match shape {
+        syn::Fields::Unit => head,
+        syn::Fields::Unnamed(_) => quote!(#head(#(#parts),*)),
+        syn::Fields::Named(_) => quote!(#head { #(#parts),* }),
+    }
+}
+
+impl Variant {
+    /// [`fields`] over this variant's own delimiters.
+    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
+        fields(&self.syntax.fields, head, parts)
+    }
+}
+
+impl Struct {
+    /// [`fields`] over this struct's own delimiters — the dual of
+    /// [`Variant::spell`], and the reason neither needs a modelled shape.
+    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
+        fields(&self.syntax.fields, head, parts)
+    }
+}
+
+impl Field {
+    /// How the field is addressed in a pattern or an initializer: by name when
+    /// it has one, else by position.
+    pub fn member(&self) -> syn::Member {
+        match &self.name {
+            Some(id) => syn::Member::Named(id.clone()),
+            None => syn::Member::Unnamed(syn::Index::from(self.index)),
+        }
+    }
+
+    /// The field bound to `bind`, shaped for whichever address it uses —
+    /// `id: __f0` for a named field, `__f0` for a positional one. The part
+    /// [`fields`] takes.
+    pub fn bind(&self, bind: &impl ToTokens) -> TokenStream {
+        match &self.name {
+            Some(id) => quote!(#id: #bind),
+            None => quote!(#bind),
+        }
+    }
+}

--- a/prebindgen/src/api/core/language/spell.rs
+++ b/prebindgen/src/api/core/language/spell.rs
@@ -14,7 +14,7 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
-use super::element::{Field, Struct, Variant};
+use super::element::{Alternative, EnumValue, Field, Struct};
 
 /// Spell a field group: `head`, `head(parts…)` or `head { parts… }`, following
 /// the delimiters the source wrote.
@@ -34,8 +34,20 @@ pub fn fields(shape: &syn::Fields, head: TokenStream, parts: &[TokenStream]) -> 
     }
 }
 
-impl Variant {
-    /// [`fields`] over this variant's own delimiters.
+impl Alternative {
+    /// [`fields`] over this alternative's own delimiters.
+    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
+        fields(&self.origin.syntax.fields, head, parts)
+    }
+}
+
+impl EnumValue {
+    /// [`fields`] over this value's own delimiters.
+    ///
+    /// A fieldless alternative still has them: `A`, `B()` and `C {}` carry no
+    /// payload alike, and Rust demands the delimiters wherever the last two are
+    /// named. `parts` is therefore always empty — the signature matches
+    /// [`Alternative::spell`] so one caller can spell either.
     pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
         fields(&self.origin.syntax.fields, head, parts)
     }

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -15,7 +15,7 @@ fn lower(ty: proc_macro2::TokenStream) -> Result<Type, UnsupportedType> {
         }
     );
     match parse(vec![tag_len_const(), item]).remove(1) {
-        Element::Struct(s) => Ok(s.fields.named()[0].ty.clone()),
+        Element::Struct(s) => Ok(s.fields()[0].ty.clone()),
         Element::Unsupported(u) => match *u.error {
             ItemError::FieldType { source, .. } => Err(source),
             other => panic!("expected a field-type diagnosis, got {other}"),
@@ -52,6 +52,22 @@ fn scalars_and_strings() {
     assert!(matches!(kind(quote::quote!(())), TypeKind::Unit));
 }
 
+/// `String` and `str` are one concept, and the borrow is the `Ref` layer's
+/// fact. Every adapter already treats `&str` as a borrowed string by hand;
+/// classifying `str` as a nominal type would send them all looking for an item
+/// named `str` to resolve.
+#[test]
+fn a_string_is_a_string_however_it_is_spelled() {
+    assert!(matches!(kind(quote::quote!(str)), TypeKind::Str));
+    for spelling in [quote::quote!(&str), quote::quote!(&String)] {
+        let TypeKind::Ref { mutable, inner } = kind(spelling) else {
+            panic!("a borrow");
+        };
+        assert!(!mutable);
+        assert!(matches!(inner.kind, TypeKind::Str));
+    }
+}
+
 #[test]
 fn the_builtin_generics() {
     assert!(matches!(
@@ -63,28 +79,48 @@ fn the_builtin_generics() {
         TypeKind::Sequence(_)
     ));
     assert!(matches!(
-        kind(quote::quote!(Box<Sample>)),
-        TypeKind::Boxed(_)
-    ));
-    assert!(matches!(
         kind(quote::quote!(Result<u8, Error>)),
         TypeKind::Fallible { .. }
     ));
 }
 
-/// A builtin must be spelled BARE: a path-qualified `Option` is a foreign type
+/// `Box<T>` **is** `T` — an owned value either way, and no destination language
+/// can tell them apart, so it carries no kind of its own. The `Box` survives
+/// where it matters: in the syntax generated Rust spells.
+#[test]
+fn a_box_classifies_as_what_it_wraps() {
+    let ty = lower(quote::quote!(Box<String>)).expect("in the language");
+    assert!(matches!(ty.kind, TypeKind::Str));
+    assert_eq!(tokens(&ty.syntax), "Box < String >");
+
+    // And it composes: the nullable heap string of a `#[repr(C)]` struct field
+    // is an optional string, spelled with its `Box`.
+    let ty = lower(quote::quote!(Option<Box<String>>)).expect("in the language");
+    let TypeKind::Optional(inner) = &ty.kind else {
+        panic!("an option");
+    };
+    assert!(matches!(inner.kind, TypeKind::Str));
+    assert_eq!(tokens(&inner.syntax), "Box < String >");
+}
+
+/// A builtin must be spelled BARE **after normalization**: the real std path
+/// reduces and classifies, while a path-qualified lookalike is a foreign type
 /// that merely shares the name, and collapsing it would silently retype the
 /// field.
 #[test]
 fn a_qualified_builtin_is_a_named_type() {
     assert!(matches!(
-        kind(quote::quote!(foreign::Option<u8>)),
-        TypeKind::Named { .. }
+        kind(quote::quote!(std::option::Option<u8>)),
+        TypeKind::Optional(_)
     ));
+    let TypeKind::Named { id, .. } = kind(quote::quote!(foreign::Option<u8>)) else {
+        panic!("a named type");
+    };
+    assert_eq!(id.name, "foreign::Option");
 }
 
 #[test]
-fn references_slices_and_pointers() {
+fn references() {
     assert!(matches!(
         kind(quote::quote!(&Sample)),
         TypeKind::Ref { mutable: false, .. }
@@ -93,14 +129,40 @@ fn references_slices_and_pointers() {
         kind(quote::quote!(&mut Sample)),
         TypeKind::Ref { mutable: true, .. }
     ));
+}
+
+/// `Vec<T>` and `[T]` are one concept — a run of `T` — and ownership is the
+/// `Ref` layer's fact, not a second variant. That is already how the pipeline
+/// behaves: one `Shape::Iterable` covers both, and jnigen rewrites a `&[T]`
+/// input into the `Vec<_>` pattern outright.
+#[test]
+fn a_sequence_is_a_sequence_borrowed_or_owned() {
     assert!(matches!(
-        kind(quote::quote!(*const u8)),
-        TypeKind::Ptr { mutable: false, .. }
+        kind(quote::quote!(Vec<u8>)),
+        TypeKind::Sequence(_)
     ));
+    // Bare, as a callback argument is written: `impl Fn([T])`.
+    assert!(matches!(kind(quote::quote!([u8])), TypeKind::Sequence(_)));
     let TypeKind::Ref { inner, .. } = kind(quote::quote!(&[u8])) else {
         panic!("a reference");
     };
-    assert!(matches!(inner.kind, TypeKind::Slice(_)));
+    assert!(matches!(inner.kind, TypeKind::Sequence(_)));
+}
+
+/// A raw pointer is not in the language. A `#[prebindgen]` crate is idiomatic
+/// Rust and the adapter owns the lowering to pointers — no adapter has a
+/// selection arm for one, so accepting it would only defer the failure to a
+/// late "unresolved type".
+#[test]
+fn a_raw_pointer_is_not_in_the_language() {
+    assert_eq!(
+        reason(quote::quote!(*const u8)),
+        UnsupportedTypeReason::UnsupportedForm
+    );
+    assert_eq!(
+        reason(quote::quote!(*mut Sample)),
+        UnsupportedTypeReason::UnsupportedForm
+    );
 }
 
 /// A lifetime argument is accepted and not modelled — `Foo<'a, T>` classifies
@@ -108,10 +170,10 @@ fn references_slices_and_pointers() {
 #[test]
 fn a_lifetime_argument_is_spelling_only() {
     let ty = lower(quote::quote!(Foo<'a, u8>)).expect("in the language");
-    let TypeKind::Named { path, args } = &ty.kind else {
+    let TypeKind::Named { id, args } = &ty.kind else {
         panic!("a named type");
     };
-    assert_eq!(tokens(path), "Foo");
+    assert_eq!(id.name, "Foo");
     assert_eq!(args.len(), 1);
     assert_eq!(tokens(&ty.syntax), "Foo < 'a , u8 >");
 }
@@ -200,7 +262,7 @@ fn an_extent_may_name_a_const_declared_later() {
         tag_len_const(),
     ]);
     assert_eq!(
-        as_struct(&elements[0]).fields.named()[0]
+        as_struct(&elements[0]).fields()[0]
             .ty
             .array_extent()
             .expect("an extent")
@@ -239,10 +301,11 @@ fn a_computed_const_is_indexed_but_is_not_a_length() {
 
 // ── Item kinds ─────────────────────────────────────────────────────────
 
-/// Only a named-field struct has a modelled field list. A tuple struct is
-/// indexable as an opaque handle, and its fields are deliberately not lowered:
-/// no adapter has ever crossed them, so lowering would turn types that are
-/// ignored today into errors.
+/// A struct is a product of fields, or opaque. A tuple struct is the opaque
+/// one: usable as a handle, its fields deliberately not lowered, because no
+/// adapter has ever crossed them and lowering would turn types that are ignored
+/// today into errors. A unit struct is the empty product, not a third shape —
+/// the delimiters are spelling, and `spell` reads them off the syntax.
 #[test]
 fn struct_shapes() {
     let named = parse_one(syn::parse_quote!(
@@ -250,18 +313,19 @@ fn struct_shapes() {
             pub x: u8,
         }
     ));
-    assert!(matches!(as_struct(&named).fields, StructFields::Named(_)));
+    assert_eq!(as_struct(&named).fields().len(), 1);
 
     let tuple = parse_one(syn::parse_quote!(
         pub struct B(SomethingUnexpressible<'_, dyn Trait>);
     ));
-    assert!(matches!(as_struct(&tuple).fields, StructFields::Unnamed));
-    assert!(as_struct(&tuple).fields.named().is_empty());
+    assert!(as_struct(&tuple).fields.is_none(), "opaque");
+    assert!(as_struct(&tuple).fields().is_empty());
 
     let unit = parse_one(syn::parse_quote!(
         pub struct C;
     ));
-    assert!(matches!(as_struct(&unit).fields, StructFields::Unit));
+    assert!(as_struct(&unit).fields.is_some(), "empty, not opaque");
+    assert!(as_struct(&unit).fields().is_empty());
 }
 
 /// Tags are declaration order and are never the discriminant. The two
@@ -403,10 +467,25 @@ fn function_signatures() {
             .collect::<Vec<_>>(),
         vec!["key", "payload"]
     );
-    assert!(matches!(
-        f.ret.as_ref().expect("a return").kind,
-        TypeKind::Fallible { .. }
-    ));
+    assert!(matches!(f.ret.kind, TypeKind::Fallible { .. }));
+}
+
+/// An elided return and a written `-> ()` are the same function. Nothing in the
+/// pipeline distinguishes them — every consumer normalizes one to the other on
+/// the spot — so the model does it once instead.
+#[test]
+fn an_elided_return_is_the_unit() {
+    for sig in [
+        quote::quote!(
+            pub fn f() {}
+        ),
+        quote::quote!(
+            pub fn f() -> () {}
+        ),
+    ] {
+        let element = parse_one(syn::parse_quote!(#sig));
+        assert!(matches!(as_fn(&element).ret.kind, TypeKind::Unit));
+    }
 }
 
 #[test]

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -433,7 +433,7 @@ fn tags_are_declaration_order() {
     ));
     let e = as_enum(&element);
     assert_eq!(
-        e.variants.iter().map(|v| v.index).collect::<Vec<_>>(),
+        e.values.iter().map(|v| v.index).collect::<Vec<_>>(),
         vec![0, 1]
     );
     assert_eq!(
@@ -446,19 +446,37 @@ fn tags_are_declaration_order() {
     );
 }
 
-/// A fieldless enum is the degenerate sum, and `is_unit` is the question the
-/// declarators ask.
+/// The two enum shapes are two entities, and the classification is decided once:
+/// any alternative with a field makes it a sum.
+///
+/// They are not one model with a dead field each. A sum has no discriminant slot,
+/// because its alternatives are identified by position — the mirror an adapter
+/// builds numbers its own arms — and a fieldless enum's identity is exactly the
+/// value Rust assigns.
 #[test]
-fn unit_and_payload_enums() {
-    let unit = parse_one(syn::parse_quote!(
+fn the_two_enum_shapes_are_two_entities() {
+    let fieldless = parse_one(syn::parse_quote!(
         pub enum E {
             A,
             B = 7,
         }
     ));
-    assert!(as_enum(&unit).is_unit());
-    assert!(as_enum(&unit).first_payload_variant().is_none());
+    let e = as_enum(&fieldless);
+    assert_eq!(e.values.len(), 2);
+    assert_eq!(e.values[1].discriminant, Some(7));
 
+    // Empty delimiters are still fieldless — the group question, not the syntax
+    // one — so this is an enum, and `spell` keeps the delimiters.
+    let empty_groups = parse_one(syn::parse_quote!(
+        pub enum E {
+            A,
+            B(),
+            C {},
+        }
+    ));
+    assert_eq!(as_enum(&empty_groups).values.len(), 3);
+
+    // One field anywhere makes it a sum.
     let sum = parse_one(syn::parse_quote!(
         pub enum E {
             A,
@@ -466,14 +484,21 @@ fn unit_and_payload_enums() {
             C { x: u8 },
         }
     ));
-    assert!(!as_enum(&sum).is_unit());
+    let v = as_variant(&sum);
+    assert_eq!(v.alternatives.len(), 3);
+    assert!(v.alternatives[0].is_empty(), "a sum may mix");
+    assert_eq!(v.alternatives[1].fields.len(), 1);
     assert_eq!(
-        as_enum(&sum)
-            .first_payload_variant()
-            .expect("a payload")
-            .name,
-        "B"
+        v.alternatives.iter().map(|a| a.index).collect::<Vec<_>>(),
+        vec![0, 1, 2]
     );
+
+    // No alternatives at all: nothing carries a payload, so it is the degenerate
+    // enum rather than an empty sum.
+    let empty = parse_one(syn::parse_quote!(
+        pub enum E {}
+    ));
+    assert!(as_enum(&empty).values.is_empty());
 }
 
 /// A field is addressed by name or by position, and the model says which
@@ -486,13 +511,13 @@ fn field_members_follow_the_addressing() {
             Range { low: i64 },
         }
     ));
-    let e = as_enum(&element);
+    let v = as_variant(&element);
     assert!(matches!(
-        e.variants[0].fields[1].member(),
+        v.alternatives[0].fields[1].member(),
         syn::Member::Unnamed(i) if i.index == 1
     ));
     assert!(matches!(
-        e.variants[1].fields[0].member(),
+        v.alternatives[1].fields[0].member(),
         syn::Member::Named(id) if id == "low"
     ));
 }

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -413,10 +413,11 @@ fn consts_carry_their_type_and_value() {
     assert_eq!(tokens(&c.syntax.expr), "4");
 }
 
-/// An unnamed `const _` — each source's injected feature guard — lives outside
-/// the flat namespace, so several sources may each carry one.
+/// An unnamed `const _` — each source's injected feature guard — is a const
+/// like any other, and simply has no address, so several sources may each carry
+/// one without colliding in the flat namespace.
 #[test]
-fn unnamed_consts_pass_through_ungated() {
+fn an_unnamed_const_is_a_const_without_an_address() {
     let elements = parse(vec![
         syn::parse_quote!(
             const _: () = ();
@@ -425,27 +426,39 @@ fn unnamed_consts_pass_through_ungated() {
             const _: () = ();
         ),
     ]);
-    assert!(elements
-        .iter()
-        .all(|e| matches!(e, Element::Passthrough(_))));
+    assert!(elements.iter().all(|e| matches!(e, Element::Const(_))));
+    assert!(elements.iter().all(|e| e.name().is_none()));
 }
 
+/// An item kind the language does not model is diagnosed, not carried: a
+/// `#[prebindgen]` crate marks what crosses the boundary and leaves the code
+/// around it to the consumer. The proc-macro refuses to mark a `use` at all, so
+/// only a `union` or a type alias can reach here — and both keep their name, so
+/// nothing else can claim it.
 #[test]
-fn item_kinds_the_language_does_not_interpret() {
-    for item in [
-        syn::parse_quote!(
-            pub use foo::Bar;
+fn an_unmodelled_item_kind_is_diagnosed() {
+    for (item, expected) in [
+        (
+            syn::parse_quote!(
+                pub union U {
+                    a: u8,
+                }
+            ),
+            "a union",
         ),
-        syn::parse_quote!(
-            pub union U {
-                a: u8,
-            }
-        ),
-        syn::parse_quote!(
-            pub type Alias = u32;
+        (
+            syn::parse_quote!(
+                pub type Alias = u32;
+            ),
+            "a type alias",
         ),
     ] {
-        assert!(matches!(parse_one(item), Element::Passthrough(_)));
+        let element = parse_one(item);
+        assert!(element.name().is_some(), "keeps its address");
+        assert!(matches!(
+            as_unsupported(&element),
+            ItemError::UnsupportedItemKind { kind } if *kind == expected
+        ));
     }
 }
 

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -188,6 +188,33 @@ fn the_callback_form() {
     assert_eq!(args.len(), 2);
 }
 
+/// A callback returns nothing, and that is **checked**. `TypeKind::Callback` has
+/// no slot for a return, so accepting `impl Fn() -> u8` would drop a fact a
+/// destination language needs — silently, which is worse than the refusal.
+#[test]
+fn a_callback_must_return_nothing() {
+    // Written out, `-> ()` is the same callback.
+    let TypeKind::Callback { args } =
+        kind(quote::quote!(impl Fn(u32) -> () + Send + Sync + 'static))
+    else {
+        panic!("a callback");
+    };
+    assert_eq!(args.len(), 1);
+
+    // Anything else is not the accepted `impl Trait` form.
+    for spelling in [
+        quote::quote!(impl Fn() -> u8 + Send + Sync + 'static),
+        quote::quote!(impl Fn(u32) -> Sample + Send + Sync + 'static),
+        quote::quote!(impl Fn() -> Option<u8> + Send + Sync + 'static),
+    ] {
+        assert_eq!(
+            reason(spelling),
+            UnsupportedTypeReason::DisallowedImplTrait,
+            "a returning callback is refused, not silently truncated"
+        );
+    }
+}
+
 #[test]
 fn types_outside_the_language() {
     assert_eq!(
@@ -268,6 +295,71 @@ fn an_extent_may_name_a_const_declared_later() {
             .expect("an extent")
             .value,
         4
+    );
+}
+
+/// An extent carries three facts for three questions, and they come apart. No
+/// blanket equality could serve all three, which is why the type provides none:
+/// a consumer projects the one it needs.
+#[test]
+fn the_three_extent_projections_are_independent() {
+    // `A` and `TAG_LEN` are both 4; `0x04` and `4` are the same literal value
+    // spelled differently.
+    let elements = parse(vec![
+        syn::parse_quote!(
+            pub struct Marker {
+                pub by_const: [u8; TAG_LEN],
+                pub by_other_const: [u8; ALSO_FOUR],
+                pub by_literal: [u8; 4],
+                pub by_hex_literal: [u8; 0x04],
+                pub longer: [u8; 8],
+            }
+        ),
+        tag_len_const(),
+        syn::parse_quote!(
+            pub const ALSO_FOUR: usize = 4;
+        ),
+    ]);
+    let fields = as_struct(&elements[0]).fields();
+    let at = |i: usize| fields[i].ty.array_extent().expect("an extent");
+    let (by_const, by_other_const, by_literal, by_hex, longer) =
+        (at(0), at(1), at(2), at(3), at(4));
+
+    // Type identity is the evaluated value: all four fours are ONE type and one
+    // converter, however they were addressed or spelled.
+    for e in [by_const, by_other_const, by_literal, by_hex] {
+        assert_eq!(e.value, 4);
+    }
+    assert_ne!(longer.value, by_literal.value);
+
+    // Declaration spelling is per occurrence, and distinguishes cases the value
+    // cannot: `4` is not `0x04`, and neither is `TAG_LEN`.
+    assert_eq!(tokens(&by_literal.origin.syntax), "4");
+    assert_eq!(tokens(&by_hex.origin.syntax), "0x04");
+    assert_eq!(tokens(&by_const.origin.syntax), "TAG_LEN");
+
+    // Header dependency is the named const, and distinguishes cases the
+    // spelling groups together and the value does not see at all.
+    assert_eq!(
+        by_const.const_id().expect("a const dependency").name,
+        "TAG_LEN"
+    );
+    assert_eq!(
+        by_other_const.const_id().expect("a const dependency").name,
+        "ALSO_FOUR"
+    );
+    assert!(by_literal.const_id().is_none());
+    assert!(by_hex.const_id().is_none());
+
+    // The three really are orthogonal: each pair below agrees on one projection
+    // and differs on another.
+    assert!(by_const.value == by_literal.value && by_const.const_id() != by_literal.const_id());
+    assert!(
+        by_literal.value == by_hex.value
+            && tokens(&by_literal.origin.syntax) != tokens(&by_hex.origin.syntax)
+    );
+    assert!(
+        by_const.const_id() != by_other_const.const_id() && by_const.value == by_other_const.value
     );
 }
 

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -594,6 +594,118 @@ fn an_elided_return_is_the_unit() {
     }
 }
 
+/// Function shapes `Function` has no slot for, and would therefore drop in
+/// silence.
+///
+/// `async` is the one that bites: the future would be dropped and the export
+/// would be a function whose body never runs.
+#[test]
+fn function_shapes_outside_the_language() {
+    let element = parse_one(syn::parse_quote!(
+        pub async fn ping() {}
+    ));
+    assert!(matches!(
+        as_unsupported(&element),
+        ItemError::UnsupportedAsync
+    ));
+    // Named, so nothing else can claim the address while it sits inert.
+    assert_eq!(element.name().expect("named"), "ping");
+
+    let element = parse_one(syn::parse_quote!(
+        pub unsafe extern "C" fn log(fmt: u8, ...) {}
+    ));
+    assert!(matches!(
+        as_unsupported(&element),
+        ItemError::UnsupportedVariadic
+    ));
+}
+
+/// A generic binder is refused on every item kind. The elements have no binder,
+/// so a `T` would lower as an ordinary nominal reference into the flat namespace
+/// — indistinguishable from a real item named `T`.
+#[test]
+fn a_generic_parameter_is_outside_the_language() {
+    let cases: Vec<(syn::Item, &str, &str)> = vec![
+        (
+            syn::parse_quote!(
+                pub struct Wrapper<T> {
+                    pub value: T,
+                }
+            ),
+            "T",
+            "a type parameter",
+        ),
+        (
+            syn::parse_quote!(
+                pub fn first<T>(items: Vec<T>) -> T {
+                    unimplemented!()
+                }
+            ),
+            "T",
+            "a type parameter",
+        ),
+        (
+            syn::parse_quote!(
+                pub enum Either<L, R> {
+                    Left(L),
+                    Right(R),
+                }
+            ),
+            "L",
+            "a type parameter",
+        ),
+        (
+            // Unused, and still a binder.
+            syn::parse_quote!(
+                pub struct Padded<const N: usize> {
+                    pub value: u8,
+                }
+            ),
+            "N",
+            "a const generic parameter",
+        ),
+    ];
+    for (item, expected_param, expected_kind) in cases {
+        let element = parse_one(item);
+        let ItemError::UnsupportedGenericParam { param, kind } = as_unsupported(&element) else {
+            panic!(
+                "expected a generic-parameter diagnosis, got {}",
+                describe(&element)
+            );
+        };
+        assert_eq!(param, expected_param);
+        assert_eq!(*kind, expected_kind);
+    }
+}
+
+/// A **lifetime** binder is not a generic parameter for this purpose: lifetimes
+/// say nothing a destination language can act on, and the spelling that needs
+/// them is already in the syntax — the same call made for a lifetime argument.
+#[test]
+fn a_lifetime_binder_is_accepted() {
+    let element = parse_one(syn::parse_quote!(
+        pub struct Borrowed<'a> {
+            pub key: &'a str,
+        }
+    ));
+    let s = as_struct(&element);
+    assert_eq!(s.fields().len(), 1);
+    assert_eq!(tokens(&s.fields()[0].ty.origin.syntax), "& 'a str");
+}
+
+/// `impl Trait` in argument position is an anonymous type parameter in Rust, but
+/// `syn` does not desugar it into the binder list — so the callback form, which
+/// every callback-taking source function uses, is untouched by the generic
+/// refusal. This is the test that says so.
+#[test]
+fn a_callback_parameter_is_not_a_generic_binder() {
+    let element = parse_one(syn::parse_quote!(
+        pub fn for_each(f: impl Fn(u64) + Send + Sync + 'static) {}
+    ));
+    let func = as_fn(&element);
+    assert!(matches!(func.params[0].ty.kind, TypeKind::Callback { .. }));
+}
+
 #[test]
 fn a_receiver_is_not_a_free_function() {
     let element = parse_one(syn::parse_quote!(

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -91,7 +91,7 @@ fn the_builtin_generics() {
 fn a_box_classifies_as_what_it_wraps() {
     let ty = lower(quote::quote!(Box<String>)).expect("in the language");
     assert!(matches!(ty.kind, TypeKind::Str));
-    assert_eq!(tokens(&ty.syntax), "Box < String >");
+    assert_eq!(tokens(&ty.origin.syntax), "Box < String >");
 
     // And it composes: the nullable heap string of a `#[repr(C)]` struct field
     // is an optional string, spelled with its `Box`.
@@ -100,7 +100,7 @@ fn a_box_classifies_as_what_it_wraps() {
         panic!("an option");
     };
     assert!(matches!(inner.kind, TypeKind::Str));
-    assert_eq!(tokens(&inner.syntax), "Box < String >");
+    assert_eq!(tokens(&inner.origin.syntax), "Box < String >");
 }
 
 /// A builtin must be spelled BARE **after normalization**: the real std path
@@ -175,7 +175,7 @@ fn a_lifetime_argument_is_spelling_only() {
     };
     assert_eq!(id.name, "Foo");
     assert_eq!(args.len(), 1);
-    assert_eq!(tokens(&ty.syntax), "Foo < 'a , u8 >");
+    assert_eq!(tokens(&ty.origin.syntax), "Foo < 'a , u8 >");
 }
 
 #[test]
@@ -410,7 +410,7 @@ fn consts_carry_their_type_and_value() {
     let c = as_const(&element);
     assert_eq!(c.name, "TAG_LEN");
     assert!(matches!(c.ty.kind, TypeKind::Scalar(ScalarKind::Usize)));
-    assert_eq!(tokens(&c.syntax.expr), "4");
+    assert_eq!(tokens(&c.origin.syntax.expr), "4");
 }
 
 /// An unnamed `const _` — each source's injected feature guard — is a const

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -328,8 +328,9 @@ fn struct_shapes() {
     assert!(as_struct(&unit).fields().is_empty());
 }
 
-/// Tags are declaration order and are never the discriminant. The two
-/// numberings are independent, and this is the pair that proves it.
+/// A variant's index is its declaration order and is never its discriminant:
+/// one is where the source *put* it, the other is the value Rust *assigns* it.
+/// The two numberings are independent, and this is the pair that proves it.
 #[test]
 fn tags_are_declaration_order() {
     let element = parse_one(syn::parse_quote!(
@@ -340,7 +341,7 @@ fn tags_are_declaration_order() {
     ));
     let e = as_enum(&element);
     assert_eq!(
-        e.variants.iter().map(|v| v.tag).collect::<Vec<_>>(),
+        e.variants.iter().map(|v| v.index).collect::<Vec<_>>(),
         vec![0, 1]
     );
     assert_eq!(

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -789,6 +789,45 @@ fn an_unsupported_item_is_indexed_not_refused() {
 
 // ── The flat namespace ─────────────────────────────────────────────────
 
+/// The feeders accumulate, and the whole-stream rules span them.
+///
+/// This is why inputs are collected before anything is classified rather than
+/// parsed one at a time: a duplicate name is only visible with every input in
+/// hand, and so is a const that an array length in another input reaches for.
+#[test]
+fn the_feeders_accumulate_and_whole_stream_rules_span_them() {
+    let marker: syn::Item = syn::parse_quote!(
+        pub struct Marker {
+            pub tag: [u8; TAG_LEN],
+        }
+    );
+
+    // A length in the first feeder naming a const from the second.
+    let elements = Language::new()
+        .items(vec![(marker.clone(), loc())])
+        .items(vec![(tag_len_const(), loc())])
+        .parse()
+        .expect("the const is found across feeders");
+    assert_eq!(elements.len(), 2);
+    assert_eq!(
+        as_struct(&elements[0]).fields()[0]
+            .ty
+            .array_extent()
+            .expect("an extent")
+            .value,
+        4
+    );
+
+    // And a name colliding across feeders is still the one hard failure.
+    let err = Language::new()
+        .items(vec![(marker.clone(), loc())])
+        .items(vec![(marker, loc())])
+        .parse()
+        .expect_err("a duplicate across feeders is still a duplicate");
+    let ParseError::DuplicateName(d) = err;
+    assert_eq!(d.name, "Marker");
+}
+
 /// Two marked items with one name are ambiguous however the crates are
 /// arranged, so this is the one thing a parse refuses outright.
 #[test]

--- a/prebindgen/src/api/core/language/tests/acceptance.rs
+++ b/prebindgen/src/api/core/language/tests/acceptance.rs
@@ -1,0 +1,530 @@
+//! The acceptance matrix: source spelling → element, or a diagnosis naming the
+//! item and the component that could not be expressed.
+//!
+//! Ported from #212/#226 and extended to functions, consts and item kinds.
+
+use super::*;
+
+/// Lower one type by putting it in a struct field, and report what the language
+/// made of it. The field path is used because a field is the position every
+/// consumer already agrees is a boundary surface.
+fn lower(ty: proc_macro2::TokenStream) -> Result<Type, UnsupportedType> {
+    let item: syn::Item = syn::parse_quote!(
+        pub struct S {
+            pub f: #ty,
+        }
+    );
+    match parse(vec![tag_len_const(), item]).remove(1) {
+        Element::Struct(s) => Ok(s.fields.named()[0].ty.clone()),
+        Element::Unsupported(u) => match *u.error {
+            ItemError::FieldType { source, .. } => Err(source),
+            other => panic!("expected a field-type diagnosis, got {other}"),
+        },
+        other => panic!("expected a struct, got {}", describe(&other)),
+    }
+}
+
+fn kind(ty: proc_macro2::TokenStream) -> TypeKind {
+    lower(ty).expect("in the language").kind
+}
+
+fn reason(ty: proc_macro2::TokenStream) -> UnsupportedTypeReason {
+    lower(ty).expect_err("outside the language").reason
+}
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+#[test]
+fn scalars_and_strings() {
+    assert!(matches!(
+        kind(quote::quote!(u8)),
+        TypeKind::Scalar(ScalarKind::U8)
+    ));
+    assert!(matches!(
+        kind(quote::quote!(bool)),
+        TypeKind::Scalar(ScalarKind::Bool)
+    ));
+    assert!(matches!(
+        kind(quote::quote!(f64)),
+        TypeKind::Scalar(ScalarKind::F64)
+    ));
+    assert!(matches!(kind(quote::quote!(String)), TypeKind::Str));
+    assert!(matches!(kind(quote::quote!(())), TypeKind::Unit));
+}
+
+#[test]
+fn the_builtin_generics() {
+    assert!(matches!(
+        kind(quote::quote!(Option<u8>)),
+        TypeKind::Optional(_)
+    ));
+    assert!(matches!(
+        kind(quote::quote!(Vec<u8>)),
+        TypeKind::Sequence(_)
+    ));
+    assert!(matches!(
+        kind(quote::quote!(Box<Sample>)),
+        TypeKind::Boxed(_)
+    ));
+    assert!(matches!(
+        kind(quote::quote!(Result<u8, Error>)),
+        TypeKind::Fallible { .. }
+    ));
+}
+
+/// A builtin must be spelled BARE: a path-qualified `Option` is a foreign type
+/// that merely shares the name, and collapsing it would silently retype the
+/// field.
+#[test]
+fn a_qualified_builtin_is_a_named_type() {
+    assert!(matches!(
+        kind(quote::quote!(foreign::Option<u8>)),
+        TypeKind::Named { .. }
+    ));
+}
+
+#[test]
+fn references_slices_and_pointers() {
+    assert!(matches!(
+        kind(quote::quote!(&Sample)),
+        TypeKind::Ref { mutable: false, .. }
+    ));
+    assert!(matches!(
+        kind(quote::quote!(&mut Sample)),
+        TypeKind::Ref { mutable: true, .. }
+    ));
+    assert!(matches!(
+        kind(quote::quote!(*const u8)),
+        TypeKind::Ptr { mutable: false, .. }
+    ));
+    let TypeKind::Ref { inner, .. } = kind(quote::quote!(&[u8])) else {
+        panic!("a reference");
+    };
+    assert!(matches!(inner.kind, TypeKind::Slice(_)));
+}
+
+/// A lifetime argument is accepted and not modelled — `Foo<'a, T>` classifies
+/// as `Foo` with one type argument, and the spelling keeps the rest.
+#[test]
+fn a_lifetime_argument_is_spelling_only() {
+    let ty = lower(quote::quote!(Foo<'a, u8>)).expect("in the language");
+    let TypeKind::Named { path, args } = &ty.kind else {
+        panic!("a named type");
+    };
+    assert_eq!(tokens(path), "Foo");
+    assert_eq!(args.len(), 1);
+    assert_eq!(tokens(&ty.syntax), "Foo < 'a , u8 >");
+}
+
+#[test]
+fn the_callback_form() {
+    let TypeKind::Callback { args } =
+        kind(quote::quote!(impl Fn(&Sample, u32) + Send + Sync + 'static))
+    else {
+        panic!("a callback");
+    };
+    assert_eq!(args.len(), 2);
+}
+
+#[test]
+fn types_outside_the_language() {
+    assert_eq!(
+        reason(quote::quote!((u8, u8))),
+        UnsupportedTypeReason::UnsupportedTuple
+    );
+    assert_eq!(
+        reason(quote::quote!(<Holder as Trait>::Assoc)),
+        UnsupportedTypeReason::AssociatedType
+    );
+    assert_eq!(
+        reason(quote::quote!(Option<u8, u16>)),
+        UnsupportedTypeReason::WrongGenericArity { expected: 1 }
+    );
+    assert_eq!(
+        reason(quote::quote!(Result<u8>)),
+        UnsupportedTypeReason::WrongGenericArity { expected: 2 }
+    );
+    assert_eq!(
+        reason(quote::quote!(impl Iterator<Item = u8>)),
+        UnsupportedTypeReason::DisallowedImplTrait
+    );
+    assert_eq!(
+        reason(quote::quote!(dyn Fn(u8))),
+        UnsupportedTypeReason::UnsupportedForm
+    );
+    assert_eq!(
+        reason(quote::quote!(!)),
+        UnsupportedTypeReason::UnsupportedForm
+    );
+}
+
+// ── Array extents ──────────────────────────────────────────────────────
+
+fn extent_reason(ty: proc_macro2::TokenStream) -> ArrayLenReason {
+    match reason(ty) {
+        UnsupportedTypeReason::BadArrayExtent(e) => e.reason,
+        other => panic!("expected an extent diagnosis, got {other:?}"),
+    }
+}
+
+#[test]
+fn extents_outside_the_subgrammar() {
+    assert_eq!(
+        extent_reason(quote::quote!([u8; TAG_LEN + 1])),
+        ArrayLenReason::NotLiteralOrName
+    );
+    assert_eq!(
+        extent_reason(quote::quote!([u8; crate::limits::MAX])),
+        ArrayLenReason::NotABareName
+    );
+    assert_eq!(
+        extent_reason(quote::quote!([u8; UNMARKED])),
+        ArrayLenReason::NotAMarkedConst
+    );
+    assert_eq!(
+        extent_reason(quote::quote!([u8; 'c'])),
+        ArrayLenReason::NotAnIntegerLiteral
+    );
+}
+
+/// A const may be declared after the item that uses it: the const index is
+/// built before anything is lowered.
+#[test]
+fn an_extent_may_name_a_const_declared_later() {
+    let elements = parse(vec![
+        syn::parse_quote!(
+            pub struct Marker {
+                pub tag: [u8; TAG_LEN],
+            }
+        ),
+        tag_len_const(),
+    ]);
+    assert_eq!(
+        as_struct(&elements[0]).fields.named()[0]
+            .ty
+            .array_extent()
+            .expect("an extent")
+            .value,
+        4
+    );
+}
+
+/// A const whose own initializer is not a literal cannot be a length —
+/// `build.rs` cannot evaluate it — but it is still a perfectly good const.
+#[test]
+fn a_computed_const_is_indexed_but_is_not_a_length() {
+    let elements = parse(vec![
+        syn::parse_quote!(
+            pub const COMPUTED: usize = 2 * 2;
+        ),
+        syn::parse_quote!(
+            pub struct Marker {
+                pub tag: [u8; COMPUTED],
+            }
+        ),
+    ]);
+    assert_eq!(as_const(&elements[0]).name, "COMPUTED");
+    match as_unsupported(&elements[1]) {
+        ItemError::FieldType {
+            source:
+                UnsupportedType {
+                    reason: UnsupportedTypeReason::BadArrayExtent(e),
+                    ..
+                },
+            ..
+        } => assert_eq!(e.reason, ArrayLenReason::ConstIsNotALiteral),
+        other => panic!("expected an extent diagnosis, got {other}"),
+    }
+}
+
+// ── Item kinds ─────────────────────────────────────────────────────────
+
+/// Only a named-field struct has a modelled field list. A tuple struct is
+/// indexable as an opaque handle, and its fields are deliberately not lowered:
+/// no adapter has ever crossed them, so lowering would turn types that are
+/// ignored today into errors.
+#[test]
+fn struct_shapes() {
+    let named = parse_one(syn::parse_quote!(
+        pub struct A {
+            pub x: u8,
+        }
+    ));
+    assert!(matches!(as_struct(&named).fields, StructFields::Named(_)));
+
+    let tuple = parse_one(syn::parse_quote!(
+        pub struct B(SomethingUnexpressible<'_, dyn Trait>);
+    ));
+    assert!(matches!(as_struct(&tuple).fields, StructFields::Unnamed));
+    assert!(as_struct(&tuple).fields.named().is_empty());
+
+    let unit = parse_one(syn::parse_quote!(
+        pub struct C;
+    ));
+    assert!(matches!(as_struct(&unit).fields, StructFields::Unit));
+}
+
+/// Tags are declaration order and are never the discriminant. The two
+/// numberings are independent, and this is the pair that proves it.
+#[test]
+fn tags_are_declaration_order() {
+    let element = parse_one(syn::parse_quote!(
+        pub enum E {
+            A = 5,
+            B = 9,
+        }
+    ));
+    let e = as_enum(&element);
+    assert_eq!(
+        e.variants.iter().map(|v| v.tag).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    assert_eq!(
+        e.discriminant_values()
+            .expect("literals")
+            .into_iter()
+            .map(|(_, v)| v)
+            .collect::<Vec<_>>(),
+        vec![5, 9]
+    );
+}
+
+/// A fieldless enum is the degenerate sum, and `is_unit` is the question the
+/// declarators ask.
+#[test]
+fn unit_and_payload_enums() {
+    let unit = parse_one(syn::parse_quote!(
+        pub enum E {
+            A,
+            B = 7,
+        }
+    ));
+    assert!(as_enum(&unit).is_unit());
+    assert!(as_enum(&unit).first_payload_variant().is_none());
+
+    let sum = parse_one(syn::parse_quote!(
+        pub enum E {
+            A,
+            B(u32),
+            C { x: u8 },
+        }
+    ));
+    assert!(!as_enum(&sum).is_unit());
+    assert_eq!(
+        as_enum(&sum)
+            .first_payload_variant()
+            .expect("a payload")
+            .name,
+        "B"
+    );
+}
+
+/// A field is addressed by name or by position, and the model says which
+/// without anyone reading `syn::Fields`.
+#[test]
+fn field_members_follow_the_addressing() {
+    let element = parse_one(syn::parse_quote!(
+        pub enum Reading {
+            Exact(i64, i64),
+            Range { low: i64 },
+        }
+    ));
+    let e = as_enum(&element);
+    assert!(matches!(
+        e.variants[0].fields[1].member(),
+        syn::Member::Unnamed(i) if i.index == 1
+    ));
+    assert!(matches!(
+        e.variants[1].fields[0].member(),
+        syn::Member::Named(id) if id == "low"
+    ));
+}
+
+#[test]
+fn consts_carry_their_type_and_value() {
+    let element = parse_one(tag_len_const());
+    let c = as_const(&element);
+    assert_eq!(c.name, "TAG_LEN");
+    assert!(matches!(c.ty.kind, TypeKind::Scalar(ScalarKind::Usize)));
+    assert_eq!(tokens(&c.syntax.expr), "4");
+}
+
+/// An unnamed `const _` — each source's injected feature guard — lives outside
+/// the flat namespace, so several sources may each carry one.
+#[test]
+fn unnamed_consts_pass_through_ungated() {
+    let elements = parse(vec![
+        syn::parse_quote!(
+            const _: () = ();
+        ),
+        syn::parse_quote!(
+            const _: () = ();
+        ),
+    ]);
+    assert!(elements
+        .iter()
+        .all(|e| matches!(e, Element::Passthrough(_))));
+}
+
+#[test]
+fn item_kinds_the_language_does_not_interpret() {
+    for item in [
+        syn::parse_quote!(
+            pub use foo::Bar;
+        ),
+        syn::parse_quote!(
+            pub union U {
+                a: u8,
+            }
+        ),
+        syn::parse_quote!(
+            pub type Alias = u32;
+        ),
+    ] {
+        assert!(matches!(parse_one(item), Element::Passthrough(_)));
+    }
+}
+
+// ── Functions ──────────────────────────────────────────────────────────
+
+#[test]
+fn function_signatures() {
+    let element = parse_one(syn::parse_quote!(
+        pub fn put(key: &KeyExpr, payload: Vec<u8>) -> Result<(), Error> {
+            unimplemented!()
+        }
+    ));
+    let f = as_fn(&element);
+    assert_eq!(f.name, "put");
+    assert_eq!(
+        f.params
+            .iter()
+            .map(|p| p.name.to_string())
+            .collect::<Vec<_>>(),
+        vec!["key", "payload"]
+    );
+    assert!(matches!(
+        f.ret.as_ref().expect("a return").kind,
+        TypeKind::Fallible { .. }
+    ));
+}
+
+#[test]
+fn a_receiver_is_not_a_free_function() {
+    let element = parse_one(syn::parse_quote!(
+        pub fn get(self) -> u8 {
+            unimplemented!()
+        }
+    ));
+    assert!(matches!(
+        as_unsupported(&element),
+        ItemError::UnsupportedReceiver
+    ));
+}
+
+#[test]
+fn a_parameter_must_be_bound_to_one_name() {
+    let element = parse_one(syn::parse_quote!(
+        pub fn f((a, b): (u8, u8)) {}
+    ));
+    assert!(matches!(
+        as_unsupported(&element),
+        ItemError::UnsupportedParamPattern { .. }
+    ));
+}
+
+/// The diagnosis names the component, not just the item — the whole point of
+/// lowering each part separately.
+#[test]
+fn a_diagnosis_names_the_component() {
+    let element = parse_one(syn::parse_quote!(
+        pub fn f(ok: u8, bad: (u8, u8)) {}
+    ));
+    match as_unsupported(&element) {
+        ItemError::ParamType { param, source } => {
+            assert_eq!(param, "bad");
+            assert_eq!(source.reason, UnsupportedTypeReason::UnsupportedTuple);
+        }
+        other => panic!("expected a parameter diagnosis, got {other}"),
+    }
+
+    let element = parse_one(syn::parse_quote!(
+        pub fn f() -> (u8, u8) {
+            unimplemented!()
+        }
+    ));
+    assert!(matches!(
+        as_unsupported(&element),
+        ItemError::ReturnType { .. }
+    ));
+
+    let element = parse_one(syn::parse_quote!(
+        pub enum E {
+            V { bad: (u8, u8) },
+        }
+    ));
+    match as_unsupported(&element) {
+        ItemError::VariantFieldType { variant, field, .. } => {
+            assert_eq!(variant, "V");
+            assert_eq!(field, "bad");
+        }
+        other => panic!("expected a variant diagnosis, got {other}"),
+    }
+}
+
+/// An item the language cannot express is inert, not fatal: a source crate may
+/// mark items no binding uses, and those have never had to be expressible. It
+/// keeps its name (so nothing else can claim it) and its syntax.
+#[test]
+fn an_unsupported_item_is_indexed_not_refused() {
+    let elements = parse(vec![
+        syn::parse_quote!(
+            pub fn unusable(pair: (u8, u8)) {}
+        ),
+        syn::parse_quote!(
+            pub fn usable(x: u8) {}
+        ),
+    ]);
+    assert_eq!(elements[0].name().expect("named"), "unusable");
+    assert!(matches!(elements[0], Element::Unsupported(_)));
+    assert!(matches!(elements[1], Element::Function(_)));
+}
+
+// ── The flat namespace ─────────────────────────────────────────────────
+
+/// Two marked items with one name are ambiguous however the crates are
+/// arranged, so this is the one thing a parse refuses outright.
+#[test]
+fn duplicate_names_are_a_hard_error() {
+    let err = try_parse(vec![
+        syn::parse_quote!(
+            pub struct Sample {
+                pub x: u8,
+            }
+        ),
+        syn::parse_quote!(
+            pub fn Sample() {}
+        ),
+    ])
+    .expect_err("a duplicate");
+    let ParseError::DuplicateName(d) = err;
+    assert_eq!(d.name, "Sample");
+}
+
+/// Even an item the language could not express holds its name against the
+/// namespace: it is still a marked item, and a second one would still be
+/// ambiguous.
+#[test]
+fn an_unsupported_item_still_holds_its_name() {
+    assert!(try_parse(vec![
+        syn::parse_quote!(
+            pub fn Thing(pair: (u8, u8)) {}
+        ),
+        syn::parse_quote!(
+            pub struct Thing {
+                pub x: u8,
+            }
+        ),
+    ])
+    .is_err());
+}

--- a/prebindgen/src/api/core/language/tests/mod.rs
+++ b/prebindgen/src/api/core/language/tests/mod.rs
@@ -98,7 +98,9 @@ fn describe(e: &Element) -> String {
         Element::Struct(s) => format!("struct `{}`", s.name),
         Element::Enum(en) => format!("enum `{}`", en.name),
         Element::Const(c) => format!("const `{}`", c.name),
-        Element::Unsupported(u) => format!("unsupported `{}` ({})", u.name, u.error),
-        Element::Passthrough(p) => format!("passthrough `{}`", tokens(&p.syntax)),
+        Element::Unsupported(u) => match &u.name {
+            Some(name) => format!("unsupported `{name}` ({})", u.error),
+            None => format!("unsupported ({})", u.error),
+        },
     }
 }

--- a/prebindgen/src/api/core/language/tests/mod.rs
+++ b/prebindgen/src/api/core/language/tests/mod.rs
@@ -1,0 +1,104 @@
+//! The language's own test suite, in two halves:
+//!
+//! * [`roundtrip`] — every element's syntax slices re-emit what the source
+//!   wrote. This is the property the whole design rests on: if a slice were
+//!   rebuilt rather than kept, the classification would have to be lossless and
+//!   would grow back into a second `syn`.
+//! * [`acceptance`] — source spelling → element, or a diagnosis naming the item
+//!   and the component. The matrix issue #211 asks for.
+
+use quote::ToTokens;
+
+use super::*;
+
+mod acceptance;
+mod roundtrip;
+
+/// Parse one item, stamped with an origin crate so array extents can name
+/// `#[prebindgen]` consts from "their own" crate.
+fn parse_one(item: syn::Item) -> Element {
+    let mut out = parse(vec![item]);
+    assert_eq!(out.len(), 1);
+    out.remove(0)
+}
+
+/// Parse a whole stream, all items stamped with the same origin crate.
+fn parse(items: Vec<syn::Item>) -> Vec<Element> {
+    try_parse(items).expect("stream parses")
+}
+
+fn try_parse(items: Vec<syn::Item>) -> Result<Vec<Element>, ParseError> {
+    Language::new().parse(items.into_iter().map(|i| (i, loc())))
+}
+
+fn loc() -> SourceLocation {
+    SourceLocation {
+        file: "src/lib.rs".to_string(),
+        line: 1,
+        column: 1,
+        crate_name: Some("myflat".to_string()),
+    }
+}
+
+/// `pub const TAG_LEN: usize = 4;` — the const an array extent may name.
+fn tag_len_const() -> syn::Item {
+    syn::parse_quote!(
+        pub const TAG_LEN: usize = 4;
+    )
+}
+
+/// Whitespace-insensitive token comparison, so a test states what the tokens
+/// are rather than how they were spaced.
+fn tokens(t: &impl ToTokens) -> String {
+    t.to_token_stream().to_string()
+}
+
+/// The element as a [`Function`], or a panic naming what it actually is.
+fn as_fn(e: &Element) -> &Function {
+    match e {
+        Element::Function(f) => f,
+        other => panic!("expected a function, got {}", describe(other)),
+    }
+}
+
+fn as_struct(e: &Element) -> &Struct {
+    match e {
+        Element::Struct(s) => s,
+        other => panic!("expected a struct, got {}", describe(other)),
+    }
+}
+
+fn as_enum(e: &Element) -> &Enum {
+    match e {
+        Element::Enum(en) => en,
+        other => panic!("expected an enum, got {}", describe(other)),
+    }
+}
+
+fn as_const(e: &Element) -> &Const {
+    match e {
+        Element::Const(c) => c,
+        other => panic!("expected a const, got {}", describe(other)),
+    }
+}
+
+/// The diagnosis of an [`Element::Unsupported`], or a panic naming what the
+/// element actually is — so a test that expected a refusal and got an
+/// acceptance says so.
+fn as_unsupported(e: &Element) -> &ItemError {
+    match e {
+        Element::Unsupported(u) => &u.error,
+        other => panic!("expected an unsupported item, got {}", describe(other)),
+    }
+}
+
+fn describe(e: &Element) -> String {
+    match e {
+        Element::Function(f) => format!("function `{}`", f.name),
+        Element::Struct(s) => format!("struct `{}`", s.name),
+        Element::Enum(en) => format!("enum `{}`", en.name),
+        Element::Const(c) => format!("const `{}`", c.name),
+        Element::Unsupported(u) => format!("unsupported `{}` ({})", u.name, u.error),
+        Element::Passthrough(p) => format!("passthrough `{}`", tokens(&p.syntax)),
+    }
+}

--- a/prebindgen/src/api/core/language/tests/mod.rs
+++ b/prebindgen/src/api/core/language/tests/mod.rs
@@ -75,7 +75,14 @@ fn as_struct(e: &Element) -> &Struct {
 fn as_enum(e: &Element) -> &Enum {
     match e {
         Element::Enum(en) => en,
-        other => panic!("expected an enum, got {}", describe(other)),
+        other => panic!("expected a fieldless enum, got {}", describe(other)),
+    }
+}
+
+fn as_variant(e: &Element) -> &Variant {
+    match e {
+        Element::Variant(v) => v,
+        other => panic!("expected a sum, got {}", describe(other)),
     }
 }
 
@@ -100,6 +107,7 @@ fn describe(e: &Element) -> String {
     match e {
         Element::Function(f) => format!("function `{}`", f.name),
         Element::Struct(s) => format!("struct `{}`", s.name),
+        Element::Variant(v) => format!("sum `{}`", v.name),
         Element::Enum(en) => format!("enum `{}`", en.name),
         Element::Const(c) => format!("const `{}`", c.name),
         Element::Unsupported(u) => match &u.name {

--- a/prebindgen/src/api/core/language/tests/mod.rs
+++ b/prebindgen/src/api/core/language/tests/mod.rs
@@ -7,6 +7,8 @@
 //! * [`acceptance`] — source spelling → element, or a diagnosis naming the item
 //!   and the component. The matrix issue #211 asks for.
 
+use std::rc::Rc;
+
 use quote::ToTokens;
 
 use super::*;

--- a/prebindgen/src/api/core/language/tests/mod.rs
+++ b/prebindgen/src/api/core/language/tests/mod.rs
@@ -30,7 +30,9 @@ fn parse(items: Vec<syn::Item>) -> Vec<Element> {
 }
 
 fn try_parse(items: Vec<syn::Item>) -> Result<Vec<Element>, ParseError> {
-    Language::new().parse(items.into_iter().map(|i| (i, loc())))
+    Language::new()
+        .items(items.into_iter().map(|i| (i, loc())))
+        .parse()
 }
 
 fn loc() -> SourceLocation {

--- a/prebindgen/src/api/core/language/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/language/tests/roundtrip.rs
@@ -40,27 +40,36 @@ fn function_parts_are_the_source_tokens() {
     assert_eq!(tokens(&func.params[0].ty.syntax), "& 'a KeyExpr");
     assert!(matches!(func.params[0].ty.kind, TypeKind::Ref { .. }));
 
-    assert_eq!(
-        tokens(&func.ret.as_ref().expect("a return type").syntax),
-        "Result < () , Error >"
-    );
+    assert_eq!(tokens(&func.ret.syntax), "Result < () , Error >");
 }
 
-/// A defaulted return is distinguishable from a written `-> ()`: the first has
-/// no tokens to keep, the second is a modelled unit whose slice is `()`.
+/// A defaulted return and a written `-> ()` are the same function, and both
+/// spell as `()`. The one thing that separates them — whether the source typed
+/// an arrow — is in `Function::syntax.sig.output`, where the only consumer that
+/// could care (one re-emitting the signature verbatim) already looks.
 #[test]
-fn a_defaulted_return_is_not_a_written_unit() {
+fn a_defaulted_return_spells_as_the_unit() {
+    for item in [
+        syn::parse_quote!(
+            pub fn a() {}
+        ),
+        syn::parse_quote!(
+            pub fn b() -> () {}
+        ),
+    ] {
+        let element = parse_one(item);
+        let ret = &as_fn(&element).ret;
+        assert!(matches!(ret.kind, TypeKind::Unit));
+        assert_eq!(tokens(&ret.syntax), "()");
+    }
+
     let defaulted = parse_one(syn::parse_quote!(
         pub fn a() {}
     ));
-    assert!(as_fn(&defaulted).ret.is_none());
-
-    let written = parse_one(syn::parse_quote!(
-        pub fn b() -> () {}
+    assert!(matches!(
+        as_fn(&defaulted).syntax.sig.output,
+        syn::ReturnType::Default
     ));
-    let ret = as_fn(&written).ret.as_ref().expect("a written return");
-    assert!(matches!(ret.kind, TypeKind::Unit));
-    assert_eq!(tokens(&ret.syntax), "()");
 }
 
 /// A field's slice keeps its attributes and visibility, so an emitter can
@@ -75,7 +84,7 @@ fn struct_field_slices_keep_attributes() {
             pub(crate) seq: u64,
         }
     ));
-    let fields = as_struct(&element).fields.named();
+    let fields = as_struct(&element).fields();
     assert_eq!(fields.len(), 2);
     assert!(tokens(&fields[0].syntax).contains("The key it was published on."));
     assert_eq!(
@@ -135,6 +144,64 @@ fn empty_delimiters_survive_and_spell() {
     assert_eq!(
         bind(&e.variants[1]),
         "Reading :: Range { low : __f0 , high : __f1 }"
+    );
+}
+
+/// The same property for a struct, which is why it needs no modelled shape
+/// either. `struct S;` and `struct S {}` hold zero fields alike and are still
+/// spelled differently wherever Rust names them — one `spell` off the syntax
+/// covers a struct and a variant, in either direction.
+#[test]
+fn struct_delimiters_survive_and_spell() {
+    let spell = |item: syn::Item, parts: &[proc_macro2::TokenStream]| {
+        let element = parse_one(item);
+        let s = as_struct(&element);
+        let name = &s.name;
+        (
+            s.fields.is_some(),
+            s.fields().len(),
+            s.spell(quote::quote!(#name), parts).to_string(),
+        )
+    };
+
+    assert_eq!(
+        spell(
+            syn::parse_quote!(
+                pub struct A;
+            ),
+            &[]
+        ),
+        (true, 0, "A".to_string())
+    );
+    assert_eq!(
+        spell(
+            syn::parse_quote!(
+                pub struct B {}
+            ),
+            &[]
+        ),
+        (true, 0, "B { }".to_string())
+    );
+    assert_eq!(
+        spell(
+            syn::parse_quote!(
+                pub struct C {
+                    pub x: u8,
+                }
+            ),
+            &[quote::quote!(x: __f0)]
+        ),
+        (true, 1, "C { x : __f0 }".to_string())
+    );
+    // Opaque: no modelled fields, and still spellable.
+    assert_eq!(
+        spell(
+            syn::parse_quote!(
+                pub struct D(Whatever<'_, dyn Trait>);
+            ),
+            &[quote::quote!(__f0)]
+        ),
+        (false, 0, "D (__f0)".to_string())
     );
 }
 
@@ -229,7 +296,7 @@ fn array_extent_carries_number_const_and_spelling() {
             }
         ),
     ]);
-    let fields = as_struct(&elements[1]).fields.named();
+    let fields = as_struct(&elements[1]).fields();
 
     let named = fields[0].ty.array_extent().expect("an extent");
     assert_eq!(named.value, 4);

--- a/prebindgen/src/api/core/language/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/language/tests/roundtrip.rs
@@ -351,6 +351,45 @@ fn a_discriminant_at_the_top_of_the_range_does_not_overflow() {
     );
 }
 
+/// The bottom of the range too. `i64::MIN` is a valid Rust discriminant, and its
+/// magnitude is one past `i64::MAX` — so the sign has to be applied before the
+/// range check, not after.
+#[test]
+fn a_discriminant_at_the_bottom_of_the_range_evaluates() {
+    let element = parse_one(syn::parse_quote!(
+        #[repr(i64)]
+        pub enum E {
+            A = -9223372036854775808,
+            B,
+        }
+    ));
+    let e = as_enum(&element);
+    assert_eq!(e.variants[0].discriminant, Some(i64::MIN));
+    assert_eq!(e.variants[1].discriminant, Some(i64::MIN + 1));
+    // And the spelling is still the source's, as for any other discriminant.
+    let (_, expr) = e.variants[0]
+        .origin
+        .syntax
+        .discriminant
+        .as_ref()
+        .expect("explicit");
+    assert_eq!(tokens(expr), "- 9223372036854775808");
+
+    // One step further out is not a number, and ends the chain rather than
+    // panicking — the same contract as an unevaluable spelling.
+    let element = parse_one(syn::parse_quote!(
+        #[repr(i128)]
+        pub enum E {
+            A = -9223372036854775809,
+            B,
+        }
+    ));
+    let e = as_enum(&element);
+    assert_eq!(e.variants[0].discriminant, None);
+    assert_eq!(e.variants[1].discriminant, None);
+    assert_eq!(e.discriminant_values().expect_err("no numbers"), "A");
+}
+
 /// An array's extent is modelled as a number AND the const it named, while the
 /// type's slice keeps the symbolic spelling — the three-way split that lets one
 /// consumer emit `[u8; 4]` and another `uint8_t tag[TAG_LEN]`.

--- a/prebindgen/src/api/core/language/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/language/tests/roundtrip.rs
@@ -28,7 +28,7 @@ fn function_parts_are_the_source_tokens() {
     assert_eq!(
         func.params
             .iter()
-            .map(|p| tokens(&p.syntax))
+            .map(|p| tokens(&p.origin.syntax))
             .collect::<Vec<_>>(),
         vec![
             "key : & 'a KeyExpr",
@@ -37,10 +37,10 @@ fn function_parts_are_the_source_tokens() {
         ]
     );
     // The lifetime is nowhere in the classification, and still survives.
-    assert_eq!(tokens(&func.params[0].ty.syntax), "& 'a KeyExpr");
+    assert_eq!(tokens(&func.params[0].ty.origin.syntax), "& 'a KeyExpr");
     assert!(matches!(func.params[0].ty.kind, TypeKind::Ref { .. }));
 
-    assert_eq!(tokens(&func.ret.syntax), "Result < () , Error >");
+    assert_eq!(tokens(&func.ret.origin.syntax), "Result < () , Error >");
 }
 
 /// A defaulted return and a written `-> ()` are the same function, and both
@@ -60,14 +60,14 @@ fn a_defaulted_return_spells_as_the_unit() {
         let element = parse_one(item);
         let ret = &as_fn(&element).ret;
         assert!(matches!(ret.kind, TypeKind::Unit));
-        assert_eq!(tokens(&ret.syntax), "()");
+        assert_eq!(tokens(&ret.origin.syntax), "()");
     }
 
     let defaulted = parse_one(syn::parse_quote!(
         pub fn a() {}
     ));
     assert!(matches!(
-        as_fn(&defaulted).syntax.sig.output,
+        as_fn(&defaulted).origin.syntax.sig.output,
         syn::ReturnType::Default
     ));
 }
@@ -86,11 +86,78 @@ fn struct_field_slices_keep_attributes() {
     ));
     let fields = as_struct(&element).fields();
     assert_eq!(fields.len(), 2);
-    assert!(tokens(&fields[0].syntax).contains("The key it was published on."));
+    assert!(tokens(&fields[0].origin.syntax).contains("The key it was published on."));
     assert_eq!(
-        tokens(&fields[1].syntax),
+        tokens(&fields[1].origin.syntax),
         "# [allow (dead_code)] pub (crate) seq : u64"
     );
+}
+
+/// One captured record is one item, so an item and every node lowered out of it
+/// point at the **same** location — not equal copies, the same allocation.
+///
+/// That is the model, not an optimisation: a field has no location of its own,
+/// and the honest answer to "where is this field" is "wherever its item is".
+#[test]
+fn an_item_and_its_components_share_one_location() {
+    let element = parse_one(syn::parse_quote!(
+        pub struct Sample {
+            pub key: String,
+            pub tags: Vec<u8>,
+        }
+    ));
+    let s = as_struct(&element);
+    let item = &s.origin.location;
+    for field in s.fields() {
+        assert!(Rc::ptr_eq(item, &field.origin.location), "field");
+        assert!(Rc::ptr_eq(item, &field.ty.origin.location), "field type");
+    }
+    // And down through a nested type's arguments.
+    let TypeKind::Sequence(elem) = &s.fields()[1].ty.kind else {
+        panic!("a sequence");
+    };
+    assert!(Rc::ptr_eq(item, &elem.origin.location), "element type");
+
+    // Variants, their fields, parameters and extents alike.
+    let element = parse_one(syn::parse_quote!(
+        pub enum E {
+            A { x: [u8; 4] },
+        }
+    ));
+    let e = as_enum(&element);
+    let item = &e.origin.location;
+    let v = &e.variants[0];
+    assert!(Rc::ptr_eq(item, &v.origin.location), "variant");
+    let f = &v.fields[0];
+    assert!(Rc::ptr_eq(item, &f.origin.location), "variant field");
+    let extent = f.ty.array_extent().expect("an extent");
+    assert!(Rc::ptr_eq(item, &extent.origin.location), "extent");
+    assert_eq!(tokens(&extent.origin.syntax), "4");
+
+    let element = parse_one(syn::parse_quote!(
+        pub fn f(a: u8) {}
+    ));
+    let func = as_fn(&element);
+    let item = &func.origin.location;
+    assert!(Rc::ptr_eq(item, &func.params[0].origin.location), "param");
+    assert!(Rc::ptr_eq(item, &func.ret.origin.location), "elided return");
+}
+
+/// A component's diagnosis carries the item's location, which is the only one
+/// there is — the record is per-item, so nothing finer was ever captured.
+#[test]
+fn a_component_diagnosis_carries_the_items_location() {
+    let element = parse_one(syn::parse_quote!(
+        pub struct Sample {
+            pub bad: (u8, u8),
+        }
+    ));
+    let Element::Unsupported(u) = &element else {
+        panic!("a tuple field is outside the language");
+    };
+    assert!(matches!(*u.error, ItemError::FieldType { .. }));
+    // The item's own location, reachable the same way as for any other element.
+    assert!(std::ptr::eq(element.location(), &*u.origin.location));
 }
 
 /// The case that motivated the design. `B()` and `C {}` carry no payload and
@@ -223,12 +290,13 @@ fn discriminant_number_and_spelling_both_survive() {
         vec![(&e.variants[0].name, 7), (&e.variants[1].name, 8)]
     );
     let (_, expr) = e.variants[0]
+        .origin
         .syntax
         .discriminant
         .as_ref()
         .expect("an explicit discriminant");
     assert_eq!(tokens(expr), "0x07");
-    assert!(e.variants[1].syntax.discriminant.is_none());
+    assert!(e.variants[1].origin.syntax.discriminant.is_none());
 }
 
 /// A discriminant the frontend cannot evaluate breaks the *numeric* chain and
@@ -246,6 +314,7 @@ fn an_unevaluable_discriminant_keeps_its_spelling() {
     assert!(e.variants.iter().all(|v| v.discriminant.is_none()));
     assert_eq!(e.discriminant_values().expect_err("no numbers"), "A");
     let (_, expr) = e.variants[0]
+        .origin
         .syntax
         .discriminant
         .as_ref()
@@ -301,7 +370,7 @@ fn array_extent_carries_number_const_and_spelling() {
     let named = fields[0].ty.array_extent().expect("an extent");
     assert_eq!(named.value, 4);
     assert_eq!(named.const_id().expect("a const").name, "TAG_LEN");
-    assert_eq!(tokens(&fields[0].ty.syntax), "[u8 ; TAG_LEN]");
+    assert_eq!(tokens(&fields[0].ty.origin.syntax), "[u8 ; TAG_LEN]");
 
     let literal = fields[1].ty.array_extent().expect("an extent");
     assert_eq!(literal.value, 2);
@@ -320,7 +389,7 @@ fn the_whole_item_survives() {
         }
     );
     let element = parse_one(syn::Item::Fn(source.clone()));
-    assert_eq!(tokens(&as_fn(&element).syntax), tokens(&source));
+    assert_eq!(tokens(&as_fn(&element).origin.syntax), tokens(&source));
     assert_eq!(tokens(&element.syntax()), tokens(&syn::Item::Fn(source)));
 }
 

--- a/prebindgen/src/api/core/language/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/language/tests/roundtrip.rs
@@ -1,0 +1,271 @@
+//! The round-trip property: an element's syntax slices are the source's own
+//! tokens, sliced — never a reconstruction.
+//!
+//! Every test here would also pass against a model that rebuilt syntax from its
+//! classification *for the easy cases*. The ones that matter are the cases where
+//! a reconstruction loses: an empty tuple variant, a hex discriminant, a
+//! lifetime, an aliased path, a doc comment. Those are the reason the slices
+//! ride along at all.
+
+use super::*;
+
+/// Each parameter and the return type re-emit exactly what was written —
+/// including a lifetime, which the classification does not model.
+#[test]
+fn function_parts_are_the_source_tokens() {
+    let f = syn::parse_quote!(
+        pub fn publish(
+            key: &'a KeyExpr,
+            payload: Vec<u8>,
+            count: Option<i32>,
+        ) -> Result<(), Error> {
+            unimplemented!()
+        }
+    );
+    let element = parse_one(syn::Item::Fn(f));
+    let func = as_fn(&element);
+
+    assert_eq!(
+        func.params
+            .iter()
+            .map(|p| tokens(&p.syntax))
+            .collect::<Vec<_>>(),
+        vec![
+            "key : & 'a KeyExpr",
+            "payload : Vec < u8 >",
+            "count : Option < i32 >",
+        ]
+    );
+    // The lifetime is nowhere in the classification, and still survives.
+    assert_eq!(tokens(&func.params[0].ty.syntax), "& 'a KeyExpr");
+    assert!(matches!(func.params[0].ty.kind, TypeKind::Ref { .. }));
+
+    assert_eq!(
+        tokens(&func.ret.as_ref().expect("a return type").syntax),
+        "Result < () , Error >"
+    );
+}
+
+/// A defaulted return is distinguishable from a written `-> ()`: the first has
+/// no tokens to keep, the second is a modelled unit whose slice is `()`.
+#[test]
+fn a_defaulted_return_is_not_a_written_unit() {
+    let defaulted = parse_one(syn::parse_quote!(
+        pub fn a() {}
+    ));
+    assert!(as_fn(&defaulted).ret.is_none());
+
+    let written = parse_one(syn::parse_quote!(
+        pub fn b() -> () {}
+    ));
+    let ret = as_fn(&written).ret.as_ref().expect("a written return");
+    assert!(matches!(ret.kind, TypeKind::Unit));
+    assert_eq!(tokens(&ret.syntax), "()");
+}
+
+/// A field's slice keeps its attributes and visibility, so an emitter can
+/// re-state the field rather than rebuild it from name and type.
+#[test]
+fn struct_field_slices_keep_attributes() {
+    let element = parse_one(syn::parse_quote!(
+        pub struct Sample {
+            /// The key it was published on.
+            pub key: String,
+            #[allow(dead_code)]
+            pub(crate) seq: u64,
+        }
+    ));
+    let fields = as_struct(&element).fields.named();
+    assert_eq!(fields.len(), 2);
+    assert!(tokens(&fields[0].syntax).contains("The key it was published on."));
+    assert_eq!(
+        tokens(&fields[1].syntax),
+        "# [allow (dead_code)] pub (crate) seq : u64"
+    );
+}
+
+/// The case that motivated the design. `B()` and `C {}` carry no payload and
+/// are still not unit variants: Rust demands the delimiters wherever the variant
+/// is named. The classification calls all three unit *groups*; `spell` keeps
+/// them apart, off the syntax.
+#[test]
+fn empty_delimiters_survive_and_spell() {
+    let element = parse_one(syn::parse_quote!(
+        pub enum E {
+            A,
+            B(),
+            C {},
+            D(u32),
+        }
+    ));
+    let e = as_enum(&element);
+
+    // All four groups, and which of them are empty.
+    assert_eq!(
+        e.variants.iter().map(|v| v.is_unit()).collect::<Vec<_>>(),
+        vec![true, true, true, false]
+    );
+
+    let spell = |v: &Variant| {
+        let name = &v.name;
+        v.spell(quote::quote!(E::#name), &[]).to_string()
+    };
+    assert_eq!(spell(&e.variants[0]), "E :: A");
+    assert_eq!(spell(&e.variants[1]), "E :: B ()");
+    assert_eq!(spell(&e.variants[2]), "E :: C { }");
+
+    // And with payloads, in both addressing modes.
+    let element = parse_one(syn::parse_quote!(
+        pub enum Reading {
+            Exact(i64),
+            Range { low: i64, high: i64 },
+        }
+    ));
+    let e = as_enum(&element);
+    let bind = |v: &Variant| {
+        let parts: Vec<_> = v
+            .fields
+            .iter()
+            .map(|f| f.bind(&quote::format_ident!("__f{}", f.index)))
+            .collect();
+        let name = &v.name;
+        v.spell(quote::quote!(Reading::#name), &parts).to_string()
+    };
+    assert_eq!(bind(&e.variants[0]), "Reading :: Exact (__f0)");
+    assert_eq!(
+        bind(&e.variants[1]),
+        "Reading :: Range { low : __f0 , high : __f1 }"
+    );
+}
+
+/// A discriminant is two facts with two homes: the number is modelled, the
+/// spelling stays in the variant's slice. `0x07` must reach a C header as
+/// `0x07`, and no reconstruction from `7` can do that.
+#[test]
+fn discriminant_number_and_spelling_both_survive() {
+    let element = parse_one(syn::parse_quote!(
+        pub enum Priority {
+            Low = 0x07,
+            High,
+        }
+    ));
+    let e = as_enum(&element);
+
+    assert_eq!(
+        e.discriminant_values().expect("literal discriminants"),
+        vec![(&e.variants[0].name, 7), (&e.variants[1].name, 8)]
+    );
+    let (_, expr) = e.variants[0]
+        .syntax
+        .discriminant
+        .as_ref()
+        .expect("an explicit discriminant");
+    assert_eq!(tokens(expr), "0x07");
+    assert!(e.variants[1].syntax.discriminant.is_none());
+}
+
+/// A discriminant the frontend cannot evaluate breaks the *numeric* chain and
+/// nothing else: the spelling is still there, so a consumer that re-emits it
+/// carries on while one that needs the number is told which variant to blame.
+#[test]
+fn an_unevaluable_discriminant_keeps_its_spelling() {
+    let element = parse_one(syn::parse_quote!(
+        pub enum E {
+            A = OTHER,
+            B,
+        }
+    ));
+    let e = as_enum(&element);
+    assert!(e.variants.iter().all(|v| v.discriminant.is_none()));
+    assert_eq!(e.discriminant_values().expect_err("no numbers"), "A");
+    let (_, expr) = e.variants[0]
+        .syntax
+        .discriminant
+        .as_ref()
+        .expect("explicit");
+    assert_eq!(tokens(expr), "OTHER");
+}
+
+/// A discriminant at the top of the range is valid Rust, so running out of
+/// `i64` ends the numeric chain the way an unevaluable spelling does — it does
+/// not panic during ingest, which would take down every consumer including the
+/// ones that only re-emit.
+#[test]
+fn a_discriminant_at_the_top_of_the_range_does_not_overflow() {
+    let element = parse_one(syn::parse_quote!(
+        #[repr(u64)]
+        pub enum E {
+            A = 9223372036854775807,
+            B,
+        }
+    ));
+    let e = as_enum(&element);
+    assert_eq!(e.variants[0].discriminant, Some(i64::MAX));
+    assert_eq!(e.variants[1].discriminant, None);
+
+    // The last variant needs no successor, so it must not fail either.
+    let element = parse_one(syn::parse_quote!(
+        pub enum E {
+            A = 9223372036854775807,
+        }
+    ));
+    assert_eq!(
+        as_enum(&element).discriminant_values().expect("a number")[0].1,
+        i64::MAX
+    );
+}
+
+/// An array's extent is modelled as a number AND the const it named, while the
+/// type's slice keeps the symbolic spelling — the three-way split that lets one
+/// consumer emit `[u8; 4]` and another `uint8_t tag[TAG_LEN]`.
+#[test]
+fn array_extent_carries_number_const_and_spelling() {
+    let elements = parse(vec![
+        tag_len_const(),
+        syn::parse_quote!(
+            pub struct Marker {
+                pub tag: [u8; TAG_LEN],
+                pub pad: [u8; 2],
+            }
+        ),
+    ]);
+    let fields = as_struct(&elements[1]).fields.named();
+
+    let named = fields[0].ty.array_extent().expect("an extent");
+    assert_eq!(named.value, 4);
+    assert_eq!(named.const_id().expect("a const").name, "TAG_LEN");
+    assert_eq!(tokens(&fields[0].ty.syntax), "[u8 ; TAG_LEN]");
+
+    let literal = fields[1].ty.array_extent().expect("an extent");
+    assert_eq!(literal.value, 2);
+    assert!(literal.const_id().is_none());
+}
+
+/// The whole item is kept too, so anything the element model does not describe
+/// — attributes, `cfg`, the function body — is still emittable.
+#[test]
+fn the_whole_item_survives() {
+    let source: syn::ItemFn = syn::parse_quote!(
+        /// Adds two numbers.
+        #[inline]
+        pub fn add(a: i32, b: i32) -> i32 {
+            a + b
+        }
+    );
+    let element = parse_one(syn::Item::Fn(source.clone()));
+    assert_eq!(tokens(&as_fn(&element).syntax), tokens(&source));
+    assert_eq!(tokens(&element.syntax()), tokens(&syn::Item::Fn(source)));
+}
+
+/// An item the language does not interpret is carried verbatim and classified
+/// as nothing at all.
+#[test]
+fn passthrough_is_verbatim() {
+    let source: syn::Item = syn::parse_quote!(
+        pub type Alias = u32;
+    );
+    let element = parse_one(source.clone());
+    assert!(matches!(element, Element::Passthrough(_)));
+    assert_eq!(tokens(&element.syntax()), tokens(&source));
+    assert!(element.name().is_none());
+}

--- a/prebindgen/src/api/core/language/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/language/tests/roundtrip.rs
@@ -324,15 +324,14 @@ fn the_whole_item_survives() {
     assert_eq!(tokens(&element.syntax()), tokens(&syn::Item::Fn(source)));
 }
 
-/// An item the language does not interpret is carried verbatim and classified
-/// as nothing at all.
+/// An item the language cannot express still keeps its tokens, so a diagnosis
+/// can quote the source and nothing is lost by refusing it.
 #[test]
-fn passthrough_is_verbatim() {
+fn an_unsupported_item_keeps_its_tokens() {
     let source: syn::Item = syn::parse_quote!(
         pub type Alias = u32;
     );
     let element = parse_one(source.clone());
-    assert!(matches!(element, Element::Passthrough(_)));
+    assert!(matches!(element, Element::Unsupported(_)));
     assert_eq!(tokens(&element.syntax()), tokens(&source));
-    assert!(element.name().is_none());
 }

--- a/prebindgen/src/api/core/language/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/language/tests/roundtrip.rs
@@ -118,18 +118,18 @@ fn an_item_and_its_components_share_one_location() {
     };
     assert!(Rc::ptr_eq(item, &elem.origin.location), "element type");
 
-    // Variants, their fields, parameters and extents alike.
+    // Alternatives, their fields, parameters and extents alike.
     let element = parse_one(syn::parse_quote!(
         pub enum E {
             A { x: [u8; 4] },
         }
     ));
-    let e = as_enum(&element);
-    let item = &e.origin.location;
-    let v = &e.variants[0];
-    assert!(Rc::ptr_eq(item, &v.origin.location), "variant");
-    let f = &v.fields[0];
-    assert!(Rc::ptr_eq(item, &f.origin.location), "variant field");
+    let v = as_variant(&element);
+    let item = &v.origin.location;
+    let a = &v.alternatives[0];
+    assert!(Rc::ptr_eq(item, &a.origin.location), "alternative");
+    let f = &a.fields[0];
+    assert!(Rc::ptr_eq(item, &f.origin.location), "alternative field");
     let extent = f.ty.array_extent().expect("an extent");
     assert!(Rc::ptr_eq(item, &extent.origin.location), "extent");
     assert_eq!(tokens(&extent.origin.syntax), "4");
@@ -174,21 +174,42 @@ fn empty_delimiters_survive_and_spell() {
             D(u32),
         }
     ));
-    let e = as_enum(&element);
+    let v = as_variant(&element);
 
     // All four groups, and which of them are empty.
     assert_eq!(
-        e.variants.iter().map(|v| v.is_unit()).collect::<Vec<_>>(),
+        v.alternatives
+            .iter()
+            .map(|a| a.is_empty())
+            .collect::<Vec<_>>(),
         vec![true, true, true, false]
     );
 
-    let spell = |v: &Variant| {
-        let name = &v.name;
-        v.spell(quote::quote!(E::#name), &[]).to_string()
+    let spell = |a: &Alternative| {
+        let name = &a.name;
+        a.spell(quote::quote!(E::#name), &[]).to_string()
     };
-    assert_eq!(spell(&e.variants[0]), "E :: A");
-    assert_eq!(spell(&e.variants[1]), "E :: B ()");
-    assert_eq!(spell(&e.variants[2]), "E :: C { }");
+    assert_eq!(spell(&v.alternatives[0]), "E :: A");
+    assert_eq!(spell(&v.alternatives[1]), "E :: B ()");
+    assert_eq!(spell(&v.alternatives[2]), "E :: C { }");
+
+    // The same in a FIELDLESS enum, where every group is empty and the whole
+    // item is the other shape: the delimiters still have to survive.
+    let element = parse_one(syn::parse_quote!(
+        pub enum F {
+            A,
+            B(),
+            C {},
+        }
+    ));
+    let e = as_enum(&element);
+    let spell = |v: &EnumValue| {
+        let name = &v.name;
+        v.spell(quote::quote!(F::#name), &[]).to_string()
+    };
+    assert_eq!(spell(&e.values[0]), "F :: A");
+    assert_eq!(spell(&e.values[1]), "F :: B ()");
+    assert_eq!(spell(&e.values[2]), "F :: C { }");
 
     // And with payloads, in both addressing modes.
     let element = parse_one(syn::parse_quote!(
@@ -197,19 +218,19 @@ fn empty_delimiters_survive_and_spell() {
             Range { low: i64, high: i64 },
         }
     ));
-    let e = as_enum(&element);
-    let bind = |v: &Variant| {
-        let parts: Vec<_> = v
+    let v = as_variant(&element);
+    let bind = |a: &Alternative| {
+        let parts: Vec<_> = a
             .fields
             .iter()
             .map(|f| f.bind(&quote::format_ident!("__f{}", f.index)))
             .collect();
-        let name = &v.name;
-        v.spell(quote::quote!(Reading::#name), &parts).to_string()
+        let name = &a.name;
+        a.spell(quote::quote!(Reading::#name), &parts).to_string()
     };
-    assert_eq!(bind(&e.variants[0]), "Reading :: Exact (__f0)");
+    assert_eq!(bind(&v.alternatives[0]), "Reading :: Exact (__f0)");
     assert_eq!(
-        bind(&e.variants[1]),
+        bind(&v.alternatives[1]),
         "Reading :: Range { low : __f0 , high : __f1 }"
     );
 }
@@ -287,16 +308,16 @@ fn discriminant_number_and_spelling_both_survive() {
 
     assert_eq!(
         e.discriminant_values().expect("literal discriminants"),
-        vec![(&e.variants[0].name, 7), (&e.variants[1].name, 8)]
+        vec![(&e.values[0].name, 7), (&e.values[1].name, 8)]
     );
-    let (_, expr) = e.variants[0]
+    let (_, expr) = e.values[0]
         .origin
         .syntax
         .discriminant
         .as_ref()
         .expect("an explicit discriminant");
     assert_eq!(tokens(expr), "0x07");
-    assert!(e.variants[1].origin.syntax.discriminant.is_none());
+    assert!(e.values[1].origin.syntax.discriminant.is_none());
 }
 
 /// A discriminant the frontend cannot evaluate breaks the *numeric* chain and
@@ -311,9 +332,9 @@ fn an_unevaluable_discriminant_keeps_its_spelling() {
         }
     ));
     let e = as_enum(&element);
-    assert!(e.variants.iter().all(|v| v.discriminant.is_none()));
+    assert!(e.values.iter().all(|v| v.discriminant.is_none()));
     assert_eq!(e.discriminant_values().expect_err("no numbers"), "A");
-    let (_, expr) = e.variants[0]
+    let (_, expr) = e.values[0]
         .origin
         .syntax
         .discriminant
@@ -336,8 +357,8 @@ fn a_discriminant_at_the_top_of_the_range_does_not_overflow() {
         }
     ));
     let e = as_enum(&element);
-    assert_eq!(e.variants[0].discriminant, Some(i64::MAX));
-    assert_eq!(e.variants[1].discriminant, None);
+    assert_eq!(e.values[0].discriminant, Some(i64::MAX));
+    assert_eq!(e.values[1].discriminant, None);
 
     // The last variant needs no successor, so it must not fail either.
     let element = parse_one(syn::parse_quote!(
@@ -364,10 +385,10 @@ fn a_discriminant_at_the_bottom_of_the_range_evaluates() {
         }
     ));
     let e = as_enum(&element);
-    assert_eq!(e.variants[0].discriminant, Some(i64::MIN));
-    assert_eq!(e.variants[1].discriminant, Some(i64::MIN + 1));
+    assert_eq!(e.values[0].discriminant, Some(i64::MIN));
+    assert_eq!(e.values[1].discriminant, Some(i64::MIN + 1));
     // And the spelling is still the source's, as for any other discriminant.
-    let (_, expr) = e.variants[0]
+    let (_, expr) = e.values[0]
         .origin
         .syntax
         .discriminant
@@ -385,8 +406,8 @@ fn a_discriminant_at_the_bottom_of_the_range_evaluates() {
         }
     ));
     let e = as_enum(&element);
-    assert_eq!(e.variants[0].discriminant, None);
-    assert_eq!(e.variants[1].discriminant, None);
+    assert_eq!(e.values[0].discriminant, None);
+    assert_eq!(e.values[1].discriminant, None);
     assert_eq!(e.discriminant_values().expect_err("no numbers"), "A");
 }
 

--- a/prebindgen/src/api/core/language/ty.rs
+++ b/prebindgen/src/api/core/language/ty.rs
@@ -346,7 +346,7 @@ pub(crate) fn lower_type(
         },
         // `[T]` is the borrowed spelling of the same concept `Vec<T>` owns.
         syn::Type::Slice(s) => TypeKind::Sequence(Box::new(lower_type(&s.elem, consts, at)?)),
-        syn::Type::Tuple(t) if t.elems.is_empty() => TypeKind::Unit,
+        _ if is_unit_type(ty) => TypeKind::Unit,
         // Only the unit is in the language. Refusing here names the type;
         // accepting would defer the failure to an "unresolved type" much later.
         syn::Type::Tuple(_) => return Err(fail(UnsupportedTypeReason::UnsupportedTuple)),
@@ -487,6 +487,21 @@ fn lower_path(
         }
     }
     Ok(named(tp, args))
+}
+
+/// True when `ty` is the unit type `()`.
+///
+/// The language's one answer to that question: [`lower_type`] classifies it as
+/// [`TypeKind::Unit`], and the callback grammar uses it to insist a callback
+/// returns nothing.
+pub(crate) fn is_unit_type(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Tuple(t) => t.elems.is_empty(),
+        // A parenthesized or grouped `()` is still `()`.
+        syn::Type::Paren(p) => is_unit_type(&p.elem),
+        syn::Type::Group(g) => is_unit_type(&g.elem),
+        _ => false,
+    }
 }
 
 /// `Named` with the identity read off the path: every segment joined, minus the

--- a/prebindgen/src/api/core/language/ty.rs
+++ b/prebindgen/src/api/core/language/ty.rs
@@ -10,31 +10,35 @@
 //! lowering rather than a second list that can drift from it. Same contract, and
 //! for the same reason, as [`lower_array_len`].
 
-use std::fmt;
+use std::{fmt, rc::Rc};
 
 use quote::ToTokens;
 
-use super::array_len::{lower_array_len, ArrayExtent, ConstIndex, UnsupportedArrayLen};
+use super::{
+    array_len::{lower_array_len, ArrayExtent, ConstIndex, UnsupportedArrayLen},
+    origin::Origin,
+};
+use crate::SourceLocation;
 
 /// A type as the language decided it, plus the exact syntax it came from.
 ///
-/// The `syntax` slice is what removes the pressure to make `kind` lossless: a
-/// lifetime, an elided argument, a `Box` that changes nothing outside Rust all
-/// survive here at zero modelling cost, so `kind` can stay language-neutral and
-/// small.
+/// The [`Origin::syntax`] slice is what removes the pressure to make `kind`
+/// lossless: a lifetime, an elided argument, a `Box` that changes nothing
+/// outside Rust all survive there at zero modelling cost, so `kind` can stay
+/// language-neutral and small.
 #[derive(Clone, Debug)]
 pub struct Type {
     /// What the type means — the closed, destination-neutral classification.
     pub kind: TypeKind,
-    /// The type as generated Rust must spell it: the source's own tokens,
+    /// The type as generated Rust must spell it — the source's own tokens,
     /// normalized to the flat namespace the generated crate can name (see
-    /// [`Language::parse`](super::Language::parse)). Feed this to `quote!`;
-    /// never `match` on it to decide what the type is.
+    /// [`Language::parse`](super::Language::parse)) — plus the source they came
+    /// from.
     ///
-    /// It can say strictly more than `kind` does — `Box<String>` is a `Str`
-    /// here — which is the point: what Rust needs and no destination language
-    /// can see lives in the tokens, not in the classification.
-    pub syntax: syn::Type,
+    /// The syntax can say strictly more than `kind` does — `Box<String>` is a
+    /// `Str` here — which is the point: what Rust needs and no destination
+    /// language can see lives in the tokens, not in the classification.
+    pub origin: Origin<syn::Type>,
 }
 
 impl Type {
@@ -144,12 +148,14 @@ pub enum TypeKind {
     Unit,
 }
 
-/// A nominal type's identity.
+/// A nominal type's identity: a name, and nothing else.
 ///
 /// `#[prebindgen]` names live in one flat namespace — a duplicate is a
-/// [`ParseError`](super::ParseError) — so the name is the whole address, and
-/// `origin` records which crate wrote it for the same reason
-/// [`ConstId`](super::ConstId) does.
+/// [`ParseError`](super::ParseError) — so the name is the whole address. It
+/// deliberately carries **no crate**: a reference carries a name, and the
+/// declaring crate belongs to the declaration, reachable by looking the name up
+/// among the elements. Putting the use site's crate here would make the same
+/// type compare unequal to itself across two source crates.
 ///
 /// A name rather than a `syn::Path` on purpose: an identity kept as syntax
 /// makes every consumer take a path apart to learn what a type is, which is the
@@ -161,9 +167,6 @@ pub struct TypeId {
     /// `foreign::Option`. Normalized, so a reducible std or source-module path
     /// has already collapsed to its final segment.
     pub name: String,
-    /// Crate the item using this type was captured from; `None` for an
-    /// origin-less stream.
-    pub origin: Option<String>,
 }
 
 /// The primitives the source language accepts. Mirrors the set every adapter
@@ -318,42 +321,41 @@ impl std::error::Error for UnsupportedType {}
 /// understood, so a form this function does not lower is a form the language
 /// does not accept.
 ///
-/// `item_crate` is the origin of the item the type was written in; an extent
-/// must name a const from that same crate.
+/// `at` is the origin of the item this type was written in — the location every
+/// node lowered from that item shares, and the crate an array extent's const
+/// must come from.
 pub(crate) fn lower_type(
     ty: &syn::Type,
     consts: &ConstIndex,
-    item_crate: Option<&str>,
+    at: &Rc<SourceLocation>,
 ) -> Result<Type, UnsupportedType> {
     let fail = |reason| UnsupportedType {
         offending: ty.to_token_stream().to_string(),
         reason,
     };
-    // Every arm builds `kind` only; the syntax slice is attached once, here, so
-    // no arm can forget it or attach a rebuilt approximation.
+    // Every arm builds `kind` only; the origin is attached once, here, so no arm
+    // can forget it or attach a rebuilt approximation.
     let kind = match ty {
         // A group or paren wraps the same type. Its inner node keeps the inner
         // spelling, which is the one a consumer wants to emit.
-        syn::Type::Group(g) => return lower_type(&g.elem, consts, item_crate),
-        syn::Type::Paren(p) => return lower_type(&p.elem, consts, item_crate),
+        syn::Type::Group(g) => return lower_type(&g.elem, consts, at),
+        syn::Type::Paren(p) => return lower_type(&p.elem, consts, at),
         syn::Type::Reference(r) => TypeKind::Ref {
             mutable: r.mutability.is_some(),
-            inner: Box::new(lower_type(&r.elem, consts, item_crate)?),
+            inner: Box::new(lower_type(&r.elem, consts, at)?),
         },
         // `[T]` is the borrowed spelling of the same concept `Vec<T>` owns.
-        syn::Type::Slice(s) => {
-            TypeKind::Sequence(Box::new(lower_type(&s.elem, consts, item_crate)?))
-        }
+        syn::Type::Slice(s) => TypeKind::Sequence(Box::new(lower_type(&s.elem, consts, at)?)),
         syn::Type::Tuple(t) if t.elems.is_empty() => TypeKind::Unit,
         // Only the unit is in the language. Refusing here names the type;
         // accepting would defer the failure to an "unresolved type" much later.
         syn::Type::Tuple(_) => return Err(fail(UnsupportedTypeReason::UnsupportedTuple)),
         syn::Type::Array(a) => {
             let rendered = a.to_token_stream().to_string();
-            let extent = lower_array_len(&a.len, &rendered, item_crate, consts)
+            let extent = lower_array_len(&a.len, &rendered, at, consts)
                 .map_err(|e| fail(UnsupportedTypeReason::BadArrayExtent(Box::new(e))))?;
             TypeKind::Array {
-                elem: Box::new(lower_type(&a.elem, consts, item_crate)?),
+                elem: Box::new(lower_type(&a.elem, consts, at)?),
                 extent,
             }
         }
@@ -363,17 +365,17 @@ pub(crate) fn lower_type(
             Some(args) => TypeKind::Callback {
                 args: args
                     .iter()
-                    .map(|a| lower_type(a, consts, item_crate))
+                    .map(|a| lower_type(a, consts, at))
                     .collect::<Result<_, _>>()?,
             },
             None => return Err(fail(UnsupportedTypeReason::DisallowedImplTrait)),
         },
-        syn::Type::Path(tp) => lower_path(ty, tp, consts, item_crate)?,
+        syn::Type::Path(tp) => lower_path(ty, tp, consts, at)?,
         _ => return Err(fail(UnsupportedTypeReason::UnsupportedForm)),
     };
     Ok(Type {
         kind,
-        syntax: ty.clone(),
+        origin: Origin::new(ty.clone(), Rc::clone(at)),
     })
 }
 
@@ -381,7 +383,7 @@ fn lower_path(
     ty: &syn::Type,
     tp: &syn::TypePath,
     consts: &ConstIndex,
-    item_crate: Option<&str>,
+    at: &Rc<SourceLocation>,
 ) -> Result<TypeKind, UnsupportedType> {
     let fail = |reason| UnsupportedType {
         offending: ty.to_token_stream().to_string(),
@@ -410,7 +412,7 @@ fn lower_path(
             for a in &ab.args {
                 match a {
                     syn::GenericArgument::Type(t) => {
-                        out.push(lower_type(t, consts, item_crate)?);
+                        out.push(lower_type(t, consts, at)?);
                     }
                     syn::GenericArgument::Lifetime(_) => has_lifetime_arg = true,
                     _ => return Err(fail(UnsupportedTypeReason::UnsupportedGenericArgument)),
@@ -480,16 +482,16 @@ fn lower_path(
                     let ok = Box::new(args.remove(0));
                     return Ok(TypeKind::Fallible { ok, err });
                 }
-                _ => return Ok(named(tp, args, item_crate)),
+                _ => return Ok(named(tp, args)),
             }
         }
     }
-    Ok(named(tp, args, item_crate))
+    Ok(named(tp, args))
 }
 
 /// `Named` with the identity read off the path: every segment joined, minus the
 /// generic arguments, which are already in `args`.
-fn named(tp: &syn::TypePath, args: Vec<Type>, item_crate: Option<&str>) -> TypeKind {
+fn named(tp: &syn::TypePath, args: Vec<Type>) -> TypeKind {
     let name = tp
         .path
         .segments
@@ -498,10 +500,7 @@ fn named(tp: &syn::TypePath, args: Vec<Type>, item_crate: Option<&str>) -> TypeK
         .collect::<Vec<_>>()
         .join("::");
     TypeKind::Named {
-        id: TypeId {
-            name,
-            origin: item_crate.map(str::to_string),
-        },
+        id: TypeId { name },
         args,
     }
 }

--- a/prebindgen/src/api/core/language/ty.rs
+++ b/prebindgen/src/api/core/language/ty.rs
@@ -19,16 +19,21 @@ use super::array_len::{lower_array_len, ArrayExtent, ConstIndex, UnsupportedArra
 /// A type as the language decided it, plus the exact syntax it came from.
 ///
 /// The `syntax` slice is what removes the pressure to make `kind` lossless: a
-/// lifetime, the spelling `0x07`, a `crate::`-qualified path or an elided
-/// argument all survive here at zero modelling cost, so `kind` can stay
-/// language-neutral and small.
+/// lifetime, an elided argument, a `Box` that changes nothing outside Rust all
+/// survive here at zero modelling cost, so `kind` can stay language-neutral and
+/// small.
 #[derive(Clone, Debug)]
 pub struct Type {
     /// What the type means — the closed, destination-neutral classification.
     pub kind: TypeKind,
-    /// The type exactly as the source wrote it. Feed this to `quote!` when
-    /// generated Rust has to name the type; never `match` on it to decide what
-    /// the type is.
+    /// The type as generated Rust must spell it: the source's own tokens,
+    /// normalized to the flat namespace the generated crate can name (see
+    /// [`Language::parse`](super::Language::parse)). Feed this to `quote!`;
+    /// never `match` on it to decide what the type is.
+    ///
+    /// It can say strictly more than `kind` does — `Box<String>` is a `Str`
+    /// here — which is the point: what Rust needs and no destination language
+    /// can see lives in the tokens, not in the classification.
     pub syntax: syn::Type,
 }
 
@@ -58,12 +63,9 @@ impl Type {
                 out.push(extent);
                 elem.collect_extents(out);
             }
-            TypeKind::Optional(t)
-            | TypeKind::Sequence(t)
-            | TypeKind::Boxed(t)
-            | TypeKind::Slice(t)
-            | TypeKind::Ref { inner: t, .. }
-            | TypeKind::Ptr { inner: t, .. } => t.collect_extents(out),
+            TypeKind::Optional(t) | TypeKind::Sequence(t) | TypeKind::Ref { inner: t, .. } => {
+                t.collect_extents(out)
+            }
             TypeKind::Fallible { ok, err } => {
                 ok.collect_extents(out);
                 err.collect_extents(out);
@@ -77,45 +79,91 @@ impl Type {
 }
 
 /// What a [`Type`] means. The variants are the accepted type grammar.
+///
+/// One Rust spelling per concept is **not** the rule here — several are. A
+/// concept earns a variant when a destination language would act on it; a
+/// spelling that changes nothing outside Rust folds into the concept it carries
+/// and survives in [`Type::syntax`]:
+///
+/// | Spelling | Kind | Why |
+/// |---|---|---|
+/// | `String`, `str` | [`Str`](TypeKind::Str) | one concept, two Rust types |
+/// | `Vec<T>`, `[T]` | [`Sequence`](TypeKind::Sequence) | a run of `T`; owned vs borrowed is the [`Ref`](TypeKind::Ref) layer's fact, not a second variant |
+/// | `Box<T>` | *whatever `T` is* | an owned `T` either way; nothing outside Rust can tell |
 #[derive(Clone, Debug)]
 pub enum TypeKind {
     /// A primitive with a fixed C/JVM counterpart.
     Scalar(ScalarKind),
-    /// `String` — an owned, heap-allocated UTF-8 string.
+    /// A UTF-8 string — `String` owned, `str` behind a [`Ref`](TypeKind::Ref).
+    ///
+    /// Both spellings are one concept: `&str` and `&String` are each a borrowed
+    /// string and classify identically, which is what every adapter already
+    /// does by hand.
     Str,
     /// `Option<T>`.
     Optional(Box<Type>),
-    /// `Vec<T>`.
+    /// A run of `T` — `Vec<T>` owned, `[T]` behind a [`Ref`](TypeKind::Ref).
+    ///
+    /// One variant, because ownership is already the [`Ref`](TypeKind::Ref)
+    /// layer's fact: `&[T]` is `Ref(Sequence)`, `Vec<T>` is `Sequence`. A
+    /// second variant would encode ownership twice and let the two copies
+    /// disagree. `[T; N]` is *not* this — a fixed extent is a different
+    /// concept, see [`Array`](TypeKind::Array).
     Sequence(Box<Type>),
-    /// `Box<T>`.
-    Boxed(Box<Type>),
     /// `Result<T, E>`.
     Fallible { ok: Box<Type>, err: Box<Type> },
     /// Any other named type: a `#[prebindgen]` struct or enum, or a foreign
     /// path.
     ///
-    /// `path` is the type's **identity**, with the last segment's generic
-    /// arguments stripped out into `args` so one fact has one representation.
-    /// `args` holds the *type* arguments only — a lifetime argument says nothing
-    /// a destination language can act on, and the full spelling is in
-    /// [`Type::syntax`] for whoever has to re-emit it.
-    Named { path: syn::Path, args: Vec<Type> },
-    /// `[T; N]`.
+    /// `id` is the type's **identity** — a name, not syntax, so nothing outside
+    /// this module has to take a path apart to learn what a type is. The last
+    /// segment's generic arguments live in `args`, and only the *type*
+    /// arguments: a lifetime argument says nothing a destination language can
+    /// act on. The full spelling is in [`Type::syntax`] for whoever re-emits it.
+    Named { id: TypeId, args: Vec<Type> },
+    /// `[T; N]` — a run of `T` whose length is known at compile time.
+    ///
+    /// Deliberately not a [`Sequence`](TypeKind::Sequence) with an optional
+    /// extent: a fixed array crosses by value as a primitive array, a `Vec`
+    /// crosses as a heap collection, and every adapter branches between the two
+    /// at every site.
     Array {
         elem: Box<Type>,
         extent: ArrayExtent,
     },
-    /// `&T` / `&'a T` / `&mut T`. The lifetime is spelling, so it lives in
-    /// [`Type::syntax`] rather than here.
+    /// A borrow — `&T` / `&'a T` / `&mut T`. The lifetime is spelling, so it
+    /// lives in [`Type::syntax`] rather than here.
+    ///
+    /// This is the ownership layer for every concept underneath it: `&str` is
+    /// `Ref(Str)`, `&[T]` is `Ref(Sequence)`. A shared-ownership handle
+    /// (`Arc<T>`, `Rc<T>`) belongs here too when the language accepts one.
     Ref { mutable: bool, inner: Box<Type> },
-    /// `[T]`, only ever behind a [`TypeKind::Ref`].
-    Slice(Box<Type>),
-    /// `*const T` / `*mut T`.
-    Ptr { mutable: bool, inner: Box<Type> },
     /// `impl Fn(A, B, …) + Send + Sync + 'static` — the callback form.
     Callback { args: Vec<Type> },
     /// `()`.
     Unit,
+}
+
+/// A nominal type's identity.
+///
+/// `#[prebindgen]` names live in one flat namespace — a duplicate is a
+/// [`ParseError`](super::ParseError) — so the name is the whole address, and
+/// `origin` records which crate wrote it for the same reason
+/// [`ConstId`](super::ConstId) does.
+///
+/// A name rather than a `syn::Path` on purpose: an identity kept as syntax
+/// makes every consumer take a path apart to learn what a type is, which is the
+/// re-classification issue #211 exists to stop — and one the boundary ledger
+/// would not even see, since it watches `syn::Type` and `syn::Expr`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeId {
+    /// The path as written, minus any generic arguments — `Foo`,
+    /// `foreign::Option`. Normalized, so a reducible std or source-module path
+    /// has already collapsed to its final segment.
+    pub name: String,
+    /// Crate the item using this type was captured from; `None` for an
+    /// origin-less stream.
+    pub origin: Option<String>,
 }
 
 /// The primitives the source language accepts. Mirrors the set every adapter
@@ -188,8 +236,14 @@ pub struct UnsupportedType {
 /// Why [`lower_type`] refused a type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UnsupportedTypeReason {
-    /// A syntactic form with no place in the language: a bare trait object, a
-    /// closure type, a macro, `Self`, a never type, an inferred type.
+    /// A syntactic form with no place in the language: a raw pointer, a bare
+    /// trait object, a closure type, a macro, `Self`, a never type, an inferred
+    /// type.
+    ///
+    /// A `#[prebindgen]` crate is idiomatic Rust — the adapter owns the lowering
+    /// to pointers — so `*const T` / `*mut T` are refused here rather than
+    /// modelled. No adapter has a selection arm for one, so accepting them would
+    /// only defer the failure to a late "unresolved type".
     UnsupportedForm,
     /// `impl Trait` that is not the accepted callback form — anything but
     /// `impl Fn(..) + Send + Sync + 'static` returning `()`.
@@ -286,11 +340,10 @@ pub(crate) fn lower_type(
             mutable: r.mutability.is_some(),
             inner: Box::new(lower_type(&r.elem, consts, item_crate)?),
         },
-        syn::Type::Slice(s) => TypeKind::Slice(Box::new(lower_type(&s.elem, consts, item_crate)?)),
-        syn::Type::Ptr(p) => TypeKind::Ptr {
-            mutable: p.mutability.is_some(),
-            inner: Box::new(lower_type(&p.elem, consts, item_crate)?),
-        },
+        // `[T]` is the borrowed spelling of the same concept `Vec<T>` owns.
+        syn::Type::Slice(s) => {
+            TypeKind::Sequence(Box::new(lower_type(&s.elem, consts, item_crate)?))
+        }
         syn::Type::Tuple(t) if t.elems.is_empty() => TypeKind::Unit,
         // Only the unit is in the language. Refusing here names the type;
         // accepting would defer the failure to an "unresolved type" much later.
@@ -304,9 +357,9 @@ pub(crate) fn lower_type(
                 extent,
             }
         }
-        // The callback shape is decided by `extract_fn_trait_args`, which is
-        // also what the registry accepts today — ONE authority for the form.
-        syn::Type::ImplTrait(_) => match crate::api::core::registry::extract_fn_trait_args(ty) {
+        // The callback shape is decided by `extract_fn_trait_args`, this
+        // module's own — and the pipeline's only — authority for the form.
+        syn::Type::ImplTrait(_) => match super::extract_fn_trait_args(ty) {
             Some(args) => TypeKind::Callback {
                 args: args
                     .iter()
@@ -381,7 +434,11 @@ fn lower_path(
             if let Some(kind) = ScalarKind::from_name(&name) {
                 return Ok(TypeKind::Scalar(kind));
             }
-            if name == "String" {
+            // `String` and `str` are one concept. `str` is unsized and so only
+            // ever appears behind a `&`, which the `Ref` layer already records
+            // — classifying it as a nominal type instead would send every
+            // adapter looking for an item named `str` to resolve.
+            if name == "String" || name == "str" {
                 return Ok(TypeKind::Str);
             }
         }
@@ -407,9 +464,15 @@ fn lower_path(
                     arity(1)?;
                     return Ok(TypeKind::Sequence(Box::new(args.remove(0))));
                 }
+                // `Box<T>` **is** `T`: an owned value either way, and no
+                // destination language can tell the two apart. So it carries no
+                // kind of its own and classifies as whatever it wraps — the
+                // `Box` survives in `Type::syntax`, which is what generated
+                // Rust spells. (A shared-ownership handle would classify as a
+                // `Ref` for the same reason, when the language accepts one.)
                 "Box" => {
                     arity(1)?;
-                    return Ok(TypeKind::Boxed(Box::new(args.remove(0))));
+                    return Ok(args.remove(0).kind);
                 }
                 "Result" => {
                     arity(2)?;
@@ -417,18 +480,28 @@ fn lower_path(
                     let ok = Box::new(args.remove(0));
                     return Ok(TypeKind::Fallible { ok, err });
                 }
-                _ => return Ok(named(tp, args)),
+                _ => return Ok(named(tp, args, item_crate)),
             }
         }
     }
-    Ok(named(tp, args))
+    Ok(named(tp, args, item_crate))
 }
 
-/// `Named` with the last segment's arguments stripped out of the identity path.
-fn named(tp: &syn::TypePath, args: Vec<Type>) -> TypeKind {
-    let mut path = tp.path.clone();
-    if let Some(last) = path.segments.last_mut() {
-        last.arguments = syn::PathArguments::None;
+/// `Named` with the identity read off the path: every segment joined, minus the
+/// generic arguments, which are already in `args`.
+fn named(tp: &syn::TypePath, args: Vec<Type>, item_crate: Option<&str>) -> TypeKind {
+    let name = tp
+        .path
+        .segments
+        .iter()
+        .map(|s| s.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+    TypeKind::Named {
+        id: TypeId {
+            name,
+            origin: item_crate.map(str::to_string),
+        },
+        args,
     }
-    TypeKind::Named { path, args }
 }

--- a/prebindgen/src/api/core/language/ty.rs
+++ b/prebindgen/src/api/core/language/ty.rs
@@ -1,0 +1,434 @@
+//! Types: a closed classification paired with the syntax it was read from.
+//!
+//! [`Type`] is the pattern the whole element model follows — `kind` says what
+//! the type *means*, `syntax` is the tokens the source wrote. Consumers
+//! **classify off `kind` and spell off `syntax`**; see the [module docs](super)
+//! for why that split is the point.
+//!
+//! [`TypeKind`] is total over the accepted grammar: a form with no variant here
+//! is a form the language does not accept, so acceptance is a consequence of
+//! lowering rather than a second list that can drift from it. Same contract, and
+//! for the same reason, as [`lower_array_len`].
+
+use std::fmt;
+
+use quote::ToTokens;
+
+use super::array_len::{lower_array_len, ArrayExtent, ConstIndex, UnsupportedArrayLen};
+
+/// A type as the language decided it, plus the exact syntax it came from.
+///
+/// The `syntax` slice is what removes the pressure to make `kind` lossless: a
+/// lifetime, the spelling `0x07`, a `crate::`-qualified path or an elided
+/// argument all survive here at zero modelling cost, so `kind` can stay
+/// language-neutral and small.
+#[derive(Clone, Debug)]
+pub struct Type {
+    /// What the type means — the closed, destination-neutral classification.
+    pub kind: TypeKind,
+    /// The type exactly as the source wrote it. Feed this to `quote!` when
+    /// generated Rust has to name the type; never `match` on it to decide what
+    /// the type is.
+    pub syntax: syn::Type,
+}
+
+impl Type {
+    /// The extent of this type when it is an array, else `None`.
+    pub fn array_extent(&self) -> Option<&ArrayExtent> {
+        match &self.kind {
+            TypeKind::Array { extent, .. } => Some(extent),
+            _ => None,
+        }
+    }
+
+    /// Every extent reachable from this type, outermost first — so a nested
+    /// `[[u8; A]; B]` yields `B` then `A`.
+    ///
+    /// Used to find which consts an emitted C type may name, and therefore which
+    /// must reach the header as a `#define`.
+    pub fn extents(&self) -> Vec<&ArrayExtent> {
+        let mut out = Vec::new();
+        self.collect_extents(&mut out);
+        out
+    }
+
+    fn collect_extents<'a>(&'a self, out: &mut Vec<&'a ArrayExtent>) {
+        match &self.kind {
+            TypeKind::Array { elem, extent } => {
+                out.push(extent);
+                elem.collect_extents(out);
+            }
+            TypeKind::Optional(t)
+            | TypeKind::Sequence(t)
+            | TypeKind::Boxed(t)
+            | TypeKind::Slice(t)
+            | TypeKind::Ref { inner: t, .. }
+            | TypeKind::Ptr { inner: t, .. } => t.collect_extents(out),
+            TypeKind::Fallible { ok, err } => {
+                ok.collect_extents(out);
+                err.collect_extents(out);
+            }
+            TypeKind::Callback { args } | TypeKind::Named { args, .. } => {
+                args.iter().for_each(|t| t.collect_extents(out))
+            }
+            TypeKind::Scalar(_) | TypeKind::Str | TypeKind::Unit => {}
+        }
+    }
+}
+
+/// What a [`Type`] means. The variants are the accepted type grammar.
+#[derive(Clone, Debug)]
+pub enum TypeKind {
+    /// A primitive with a fixed C/JVM counterpart.
+    Scalar(ScalarKind),
+    /// `String` — an owned, heap-allocated UTF-8 string.
+    Str,
+    /// `Option<T>`.
+    Optional(Box<Type>),
+    /// `Vec<T>`.
+    Sequence(Box<Type>),
+    /// `Box<T>`.
+    Boxed(Box<Type>),
+    /// `Result<T, E>`.
+    Fallible { ok: Box<Type>, err: Box<Type> },
+    /// Any other named type: a `#[prebindgen]` struct or enum, or a foreign
+    /// path.
+    ///
+    /// `path` is the type's **identity**, with the last segment's generic
+    /// arguments stripped out into `args` so one fact has one representation.
+    /// `args` holds the *type* arguments only — a lifetime argument says nothing
+    /// a destination language can act on, and the full spelling is in
+    /// [`Type::syntax`] for whoever has to re-emit it.
+    Named { path: syn::Path, args: Vec<Type> },
+    /// `[T; N]`.
+    Array {
+        elem: Box<Type>,
+        extent: ArrayExtent,
+    },
+    /// `&T` / `&'a T` / `&mut T`. The lifetime is spelling, so it lives in
+    /// [`Type::syntax`] rather than here.
+    Ref { mutable: bool, inner: Box<Type> },
+    /// `[T]`, only ever behind a [`TypeKind::Ref`].
+    Slice(Box<Type>),
+    /// `*const T` / `*mut T`.
+    Ptr { mutable: bool, inner: Box<Type> },
+    /// `impl Fn(A, B, …) + Send + Sync + 'static` — the callback form.
+    Callback { args: Vec<Type> },
+    /// `()`.
+    Unit,
+}
+
+/// The primitives the source language accepts. Mirrors the set every adapter
+/// already treats as directly representable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScalarKind {
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+    F32,
+    F64,
+}
+
+impl ScalarKind {
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "bool" => Self::Bool,
+            "i8" => Self::I8,
+            "i16" => Self::I16,
+            "i32" => Self::I32,
+            "i64" => Self::I64,
+            "isize" => Self::Isize,
+            "u8" => Self::U8,
+            "u16" => Self::U16,
+            "u32" => Self::U32,
+            "u64" => Self::U64,
+            "usize" => Self::Usize,
+            "f32" => Self::F32,
+            "f64" => Self::F64,
+            _ => return None,
+        })
+    }
+
+    /// The Rust spelling — the identity this was lowered from.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::I8 => "i8",
+            Self::I16 => "i16",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::Isize => "isize",
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::Usize => "usize",
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+}
+
+/// A type the prebindgen source language does not accept.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnsupportedType {
+    /// The offending type as written.
+    pub offending: String,
+    pub reason: UnsupportedTypeReason,
+}
+
+/// Why [`lower_type`] refused a type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnsupportedTypeReason {
+    /// A syntactic form with no place in the language: a bare trait object, a
+    /// closure type, a macro, `Self`, a never type, an inferred type.
+    UnsupportedForm,
+    /// `impl Trait` that is not the accepted callback form — anything but
+    /// `impl Fn(..) + Send + Sync + 'static` returning `()`.
+    DisallowedImplTrait,
+    /// A generic that takes a fixed arity and did not get it — `Option` with no
+    /// argument, `Result` with one.
+    WrongGenericArity { expected: usize },
+    /// A non-empty tuple. Only `()` is in the language: no adapter has ever
+    /// lowered a tuple, so accepting one would defer the failure to a late
+    /// "unresolved type" instead of naming it here.
+    UnsupportedTuple,
+    /// A path with a qualified self — `<T as Trait>::Assoc`.
+    ///
+    /// The frontend never captures `impl` blocks, so it cannot know what an
+    /// associated type resolves to; carrying the spelling would only move the
+    /// failure downstream.
+    AssociatedType,
+    /// A generic argument that is neither a type nor a lifetime — a const
+    /// generic, an associated-type binding.
+    UnsupportedGenericArgument,
+    /// The array's extent — see [`ArrayLenReason`](super::ArrayLenReason).
+    BadArrayExtent(Box<UnsupportedArrayLen>),
+}
+
+impl fmt::Display for UnsupportedType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.reason {
+            UnsupportedTypeReason::BadArrayExtent(e) => return write!(f, "{e}"),
+            UnsupportedTypeReason::UnsupportedForm => write!(
+                f,
+                "type `{}` is a form the prebindgen source language does not accept",
+                self.offending
+            ),
+            UnsupportedTypeReason::DisallowedImplTrait => write!(
+                f,
+                "type `{}` is not an accepted callback — the only `impl Trait` in the language is \
+                 `impl Fn(..) + Send + Sync + 'static` returning `()`",
+                self.offending
+            ),
+            UnsupportedTypeReason::WrongGenericArity { expected } => write!(
+                f,
+                "type `{}` needs exactly {expected} type argument(s)",
+                self.offending
+            ),
+            UnsupportedTypeReason::UnsupportedTuple => write!(
+                f,
+                "type `{}` is a tuple; only the unit `()` is supported — return the \
+                 components separately, or wrap them in a `#[prebindgen]` struct",
+                self.offending
+            ),
+            UnsupportedTypeReason::AssociatedType => write!(
+                f,
+                "type `{}` is an associated type; `#[prebindgen]` never captures `impl` \
+                 blocks, so its resolution is unknowable here — name the concrete type",
+                self.offending
+            ),
+            UnsupportedTypeReason::UnsupportedGenericArgument => write!(
+                f,
+                "type `{}` has a generic argument that is neither a type nor a lifetime",
+                self.offending
+            ),
+        }?;
+        write!(f, " — see docs/source-language.md for the accepted grammar")
+    }
+}
+
+impl std::error::Error for UnsupportedType {}
+
+/// Lower one captured type.
+///
+/// **Total over the accepted grammar**: `Ok` means every part of the type was
+/// understood, so a form this function does not lower is a form the language
+/// does not accept.
+///
+/// `item_crate` is the origin of the item the type was written in; an extent
+/// must name a const from that same crate.
+pub(crate) fn lower_type(
+    ty: &syn::Type,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<Type, UnsupportedType> {
+    let fail = |reason| UnsupportedType {
+        offending: ty.to_token_stream().to_string(),
+        reason,
+    };
+    // Every arm builds `kind` only; the syntax slice is attached once, here, so
+    // no arm can forget it or attach a rebuilt approximation.
+    let kind = match ty {
+        // A group or paren wraps the same type. Its inner node keeps the inner
+        // spelling, which is the one a consumer wants to emit.
+        syn::Type::Group(g) => return lower_type(&g.elem, consts, item_crate),
+        syn::Type::Paren(p) => return lower_type(&p.elem, consts, item_crate),
+        syn::Type::Reference(r) => TypeKind::Ref {
+            mutable: r.mutability.is_some(),
+            inner: Box::new(lower_type(&r.elem, consts, item_crate)?),
+        },
+        syn::Type::Slice(s) => TypeKind::Slice(Box::new(lower_type(&s.elem, consts, item_crate)?)),
+        syn::Type::Ptr(p) => TypeKind::Ptr {
+            mutable: p.mutability.is_some(),
+            inner: Box::new(lower_type(&p.elem, consts, item_crate)?),
+        },
+        syn::Type::Tuple(t) if t.elems.is_empty() => TypeKind::Unit,
+        // Only the unit is in the language. Refusing here names the type;
+        // accepting would defer the failure to an "unresolved type" much later.
+        syn::Type::Tuple(_) => return Err(fail(UnsupportedTypeReason::UnsupportedTuple)),
+        syn::Type::Array(a) => {
+            let rendered = a.to_token_stream().to_string();
+            let extent = lower_array_len(&a.len, &rendered, item_crate, consts)
+                .map_err(|e| fail(UnsupportedTypeReason::BadArrayExtent(Box::new(e))))?;
+            TypeKind::Array {
+                elem: Box::new(lower_type(&a.elem, consts, item_crate)?),
+                extent,
+            }
+        }
+        // The callback shape is decided by `extract_fn_trait_args`, which is
+        // also what the registry accepts today — ONE authority for the form.
+        syn::Type::ImplTrait(_) => match crate::api::core::registry::extract_fn_trait_args(ty) {
+            Some(args) => TypeKind::Callback {
+                args: args
+                    .iter()
+                    .map(|a| lower_type(a, consts, item_crate))
+                    .collect::<Result<_, _>>()?,
+            },
+            None => return Err(fail(UnsupportedTypeReason::DisallowedImplTrait)),
+        },
+        syn::Type::Path(tp) => lower_path(ty, tp, consts, item_crate)?,
+        _ => return Err(fail(UnsupportedTypeReason::UnsupportedForm)),
+    };
+    Ok(Type {
+        kind,
+        syntax: ty.clone(),
+    })
+}
+
+fn lower_path(
+    ty: &syn::Type,
+    tp: &syn::TypePath,
+    consts: &ConstIndex,
+    item_crate: Option<&str>,
+) -> Result<TypeKind, UnsupportedType> {
+    let fail = |reason| UnsupportedType {
+        offending: ty.to_token_stream().to_string(),
+        reason,
+    };
+    // An associated type is refused rather than carried: the frontend never
+    // captures `impl` blocks, so what `<T as Trait>::Assoc` resolves to is
+    // unknowable here, and keeping the spelling would only move the failure
+    // downstream.
+    if tp.qself.is_some() {
+        return Err(fail(UnsupportedTypeReason::AssociatedType));
+    }
+    let Some(last) = tp.path.segments.last() else {
+        return Err(fail(UnsupportedTypeReason::UnsupportedForm));
+    };
+    let name = last.ident.to_string();
+
+    // Type arguments only. A lifetime argument is accepted and dropped: it is
+    // part of the spelling (`Foo<'a>` is not `Foo`), and the spelling is in
+    // `Type::syntax`, so modelling it would be a second copy of one fact.
+    let mut has_lifetime_arg = false;
+    let args: Vec<Type> = match &last.arguments {
+        syn::PathArguments::None => Vec::new(),
+        syn::PathArguments::AngleBracketed(ab) => {
+            let mut out = Vec::new();
+            for a in &ab.args {
+                match a {
+                    syn::GenericArgument::Type(t) => {
+                        out.push(lower_type(t, consts, item_crate)?);
+                    }
+                    syn::GenericArgument::Lifetime(_) => has_lifetime_arg = true,
+                    _ => return Err(fail(UnsupportedTypeReason::UnsupportedGenericArgument)),
+                }
+            }
+            out
+        }
+        syn::PathArguments::Parenthesized(_) => {
+            return Err(fail(UnsupportedTypeReason::UnsupportedForm))
+        }
+    };
+
+    // A builtin must be spelled BARE. `normalize_type` has already reduced the
+    // real std paths (`std::option::Option` → `Option`) at ingest and
+    // deliberately leaves unknown crate paths alone, so anything still carrying
+    // a prefix is a foreign type that merely shares a name — `foreign::Option`
+    // is not `Option`, and collapsing it would silently retype the field.
+    let is_bare = tp.path.leading_colon.is_none() && tp.path.segments.len() == 1;
+    if is_bare {
+        if args.is_empty() && !has_lifetime_arg {
+            if let Some(kind) = ScalarKind::from_name(&name) {
+                return Ok(TypeKind::Scalar(kind));
+            }
+            if name == "String" {
+                return Ok(TypeKind::Str);
+            }
+        }
+        // A builtin generic takes types only; a lifetime argument on one is not
+        // a shape this language has.
+        if !has_lifetime_arg {
+            let mut args = args;
+            let arity = |n: usize| {
+                if args.len() == n {
+                    Ok(())
+                } else {
+                    Err(fail(UnsupportedTypeReason::WrongGenericArity {
+                        expected: n,
+                    }))
+                }
+            };
+            match name.as_str() {
+                "Option" => {
+                    arity(1)?;
+                    return Ok(TypeKind::Optional(Box::new(args.remove(0))));
+                }
+                "Vec" => {
+                    arity(1)?;
+                    return Ok(TypeKind::Sequence(Box::new(args.remove(0))));
+                }
+                "Box" => {
+                    arity(1)?;
+                    return Ok(TypeKind::Boxed(Box::new(args.remove(0))));
+                }
+                "Result" => {
+                    arity(2)?;
+                    let err = Box::new(args.remove(1));
+                    let ok = Box::new(args.remove(0));
+                    return Ok(TypeKind::Fallible { ok, err });
+                }
+                _ => return Ok(named(tp, args)),
+            }
+        }
+    }
+    Ok(named(tp, args))
+}
+
+/// `Named` with the last segment's arguments stripped out of the identity path.
+fn named(tp: &syn::TypePath, args: Vec<Type>) -> TypeKind {
+    let mut path = tp.path.clone();
+    if let Some(last) = path.segments.last_mut() {
+        last.arguments = syn::PathArguments::None;
+    }
+    TypeKind::Named { path, args }
+}

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod write;
 pub use self::{
     domain::{DomainScalar, RepresentationDomain, ScalarValue},
     gravestone::{Gravestone, Transmute},
+    language::{Element, Language},
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},
     registry::{Direction, Generation, Registry, ScanError, TypeEntry, TypeKey, WriteRustError},

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -22,6 +22,7 @@
 pub mod domain;
 pub mod expand;
 pub mod gravestone;
+pub mod language;
 pub mod niches;
 pub mod prebindgen;
 pub mod registry;

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -196,10 +196,17 @@ pub trait Prebindgen {
     /// [`crate::api::core::unfold::UnfoldPlan`] on the registry and its leaf
     /// types are registered as required outputs.
     ///
-    /// Returned by value, same as [`Self::expansions`].
+    /// Returned by value, same as [`Self::expansions`]. The registry is
+    /// available because a declaration may name a **value form** (an accessor
+    /// returning "this type's fields in one struct") whose fields have to be
+    /// read off the indexed struct to become records.
     ///
     /// Default: `None`.
-    fn deconstructors(&self) -> Option<crate::api::core::unfold::Deconstructors> {
+    fn deconstructors(
+        &self,
+        registry: &Registry<Self::Metadata>,
+    ) -> Option<crate::api::core::unfold::Deconstructors> {
+        let _ = registry;
         None
     }
 

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1395,7 +1395,7 @@ impl<M> Registry<M> {
                 &declared.method_receivers,
             )?;
         }
-        if let Some(dec) = ext.deconstructors() {
+        if let Some(dec) = ext.deconstructors(self) {
             crate::api::core::unfold::apply(self, &dec, &declared.functions, &declared.accessors)?;
         }
         // Synthesized by-value `data_class` decompositions: build the leaves

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -1483,43 +1483,9 @@ pub fn immediate_subtype_positions(ty: &syn::Type) -> Vec<syn::Type> {
     }
 }
 
-/// If `ty` is `impl Fn(T1, T2, ...) + Send + Sync + 'static`, return the
-/// `Fn` argument types in declaration order. Otherwise None.
-pub fn extract_fn_trait_args(ty: &syn::Type) -> Option<Vec<syn::Type>> {
-    let syn::Type::ImplTrait(it) = ty else {
-        return None;
-    };
-    let mut args: Option<Vec<syn::Type>> = None;
-    let mut has_send = false;
-    let mut has_sync = false;
-    let mut has_static = false;
-    for bound in &it.bounds {
-        match bound {
-            syn::TypeParamBound::Trait(tb) => {
-                let last = tb.path.segments.last()?;
-                let name = last.ident.to_string();
-                match name.as_str() {
-                    "Fn" => {
-                        let syn::PathArguments::Parenthesized(p) = &last.arguments else {
-                            return None;
-                        };
-                        args = Some(p.inputs.iter().cloned().collect());
-                    }
-                    "Send" => has_send = true,
-                    "Sync" => has_sync = true,
-                    _ => return None,
-                }
-            }
-            syn::TypeParamBound::Lifetime(lt) if lt.ident == "static" => has_static = true,
-            _ => return None,
-        }
-    }
-    if has_send && has_sync && has_static {
-        args
-    } else {
-        None
-    }
-}
+/// The callback grammar, which the source language owns — re-exported here for
+/// the existing call sites until they consume elements (stages L2–L4 of #229).
+pub use crate::api::core::language::extract_fn_trait_args;
 
 /// A **resolved** binding generation: the [`Registry`] after
 /// [`Registry::resolve`] ran the adapter's scan, plans, and type

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -37,7 +37,10 @@ mod plan;
 
 pub use self::{
     error::{UnfoldDeclError, UnfoldError},
-    plan::{DeconId, DeconSpec, LeafSource, UnfoldLeaf, UnfoldPlan, UnfoldShape},
+    plan::{
+        steps_are_movable, DeconId, DeconSpec, Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan,
+        UnfoldShape,
+    },
 };
 
 // ──────────────────────────────────────────────────────────────────────
@@ -73,6 +76,58 @@ pub enum DeconRecord {
     /// moved for an owned `T`). At most one per
     /// deconstructor.
     Identity,
+    /// Read the fields of the type's **value form**: call `func` once
+    /// (`f(&T) -> TStruct`) and contribute one record per [`FieldRecord`],
+    /// reached by field access on the returned struct. The language adapter
+    /// builds the field list (it knows which structs are declared classes and
+    /// therefore inline); this record only says how to get there.
+    ///
+    /// Each field then decomposes exactly like an [`Acc`](Self::Acc) record's
+    /// return does — its own [`records`](FieldRecord::records) if the
+    /// declaration overrode it, else its type's own deconstructor if it has
+    /// one, else one leaf — so a value form and a hand-written field list
+    /// produce the same leaves.
+    Fields {
+        func: syn::Ident,
+        /// The accessor **consumes** its receiver (`f(T) -> TStruct`): the
+        /// value is moved in and each field moved *out* into its leaf, instead
+        /// of being cloned out of a borrow. Declared by the adapter rather than
+        /// read off the signature — giving the value away is a boundary
+        /// decision — and cross-checked against the signature when the records
+        /// are flattened, so the two cannot drift.
+        consuming: bool,
+        fields: Vec<FieldRecord>,
+    },
+}
+
+/// One field of a value form (see [`DeconRecord::Fields`]).
+#[derive(Clone)]
+pub struct FieldRecord {
+    /// Field-access chain from the value form's returned struct. More than one
+    /// element when the adapter inlined a nested declared class.
+    pub members: Vec<syn::Ident>,
+    /// The leaf name (already `__`-joined across inlined nesting).
+    pub name: String,
+    /// The field's type as written, `Option` / `Vec` layers included.
+    pub ty: syn::Type,
+    /// How this field decomposes.
+    pub decon: FieldDecon,
+}
+
+/// How one [`FieldRecord`] decomposes.
+#[derive(Clone)]
+pub enum FieldDecon {
+    /// By the field type's own deconstructor if it has one, else one leaf —
+    /// the same default a [`DeconRecord::Acc`] record's return follows.
+    Default,
+    /// Explicit records, replacing the type default wholesale (the declaration
+    /// stated this field's complete leaf set).
+    Records(Vec<DeconRecord>),
+    /// Leaves the **adapter** built, appended with this field's path and name
+    /// prefixed onto each. For shapes whose leaf structure only the adapter
+    /// knows — a decomposed sum, which is a selector plus one group per
+    /// alternative rather than a product of records.
+    Leaves(Vec<UnfoldLeaf>),
 }
 
 impl DeconRecord {
@@ -230,23 +285,7 @@ pub fn apply<M>(
     // Binding-local records skip the gate — there is no `#[prebindgen]` item
     // behind them — but keep the reserved-separator name check.
     for d in &acc.deconstructors {
-        for rec in &d.records {
-            let (func, name) = match rec {
-                DeconRecord::Acc { func, name } => (Some(func), name),
-                DeconRecord::LocalAcc { name, .. } => (None, name),
-                DeconRecord::Identity => continue,
-            };
-            // `"__"` is the reserved nesting/chain separator — author leaf names
-            // must not contain it.
-            if name.contains("__") {
-                return Err(UnfoldError::ReservedSeparator { name: name.clone() });
-            }
-            if let Some(func) = func {
-                if !accessor_fns.contains(func) {
-                    return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
-                }
-            }
-        }
+        check_records(&d.records, accessor_fns)?;
     }
 
     // Explicit decls first; they take precedence over (and suppress) a default
@@ -624,6 +663,7 @@ fn wire_fixed_returns<M>(
             delivery: Delivery::Callback,
             convert_out_ty: None,
             fixed_builder: true,
+            hoists: Vec::new(),
         };
         registry.unfold_plans.insert(func.clone(), plan);
     }
@@ -690,6 +730,7 @@ fn wire_fixed_callbacks<M>(
                     delivery: Delivery::Callback,
                     convert_out_ty: None,
                     fixed_builder: true,
+                    hoists: Vec::new(),
                 };
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -804,11 +845,57 @@ fn whole_leaf_fold_plan(vec_elem: &syn::Type, shape: UnfoldShape) -> UnfoldPlan 
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
+        hoists: Vec::new(),
     }
 }
 
+/// The deconstructor gate: every accessor-function record must be a declared
+/// `.fun_accessor` (the single source of truth for "accessor"), and no author
+/// leaf name may contain the reserved `"__"` chain separator. Binding-local
+/// records skip the accessor check — there is no `#[prebindgen]` item behind
+/// them — but keep the name check.
+///
+/// Recurses into a value form's per-field override records, so an override is
+/// held to the same rules as the declaration it replaces.
+fn check_records(
+    records: &[DeconRecord],
+    accessor_fns: &HashSet<syn::Ident>,
+) -> Result<(), UnfoldError> {
+    for rec in records {
+        let (func, name) = match rec {
+            DeconRecord::Acc { func, name } => (Some(func), name),
+            DeconRecord::LocalAcc { name, .. } => (None, name),
+            DeconRecord::Identity => continue,
+            // A value form's field names come from struct idents, not from the
+            // author, so the `"__"` in an inlined nested name is the separator
+            // doing its job. An author-supplied rename is checked where it is
+            // declared.
+            DeconRecord::Fields { func, fields, .. } => {
+                if !accessor_fns.contains(func) {
+                    return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
+                }
+                for fr in fields {
+                    if let FieldDecon::Records(recs) = &fr.decon {
+                        check_records(recs, accessor_fns)?;
+                    }
+                }
+                continue;
+            }
+        };
+        if name.contains("__") {
+            return Err(UnfoldError::ReservedSeparator { name: name.clone() });
+        }
+        if let Some(func) = func {
+            if !accessor_fns.contains(func) {
+                return Err(UnfoldError::RecordNotAccessor { func: func.clone() });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Strip a single leading `&` (one level) from a type.
-fn peel_ref(ty: &syn::Type) -> syn::Type {
+pub(crate) fn peel_ref(ty: &syn::Type) -> syn::Type {
     match ty {
         syn::Type::Reference(r) => (*r.elem).clone(),
         other => other.clone(),
@@ -949,6 +1036,7 @@ fn process_decl<M>(
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
+                    hoists: Vec::new(),
                 }
             }
         } else {
@@ -982,16 +1070,28 @@ fn process_decl<M>(
             plan
         };
         // Delivery is by **leaf count**, not a per-decl flag:
-        //   * Output, single leaf, non-Iterable ⇒ Return (wrapper returns the
-        //     value via its ordinary output converter — `convert_out_ty`).
+        //   * Output, single non-nullable leaf, non-Iterable ⇒ Return (wrapper
+        //     returns the value via its ordinary output converter —
+        //     `convert_out_ty`).
         //   * Output, multiple leaves or Iterable (at any layer — an
         //     `Optional(Iterable)` fold has no single value to return) ⇒
         //     Callback (builder / fold).
         //   * Error ⇒ always Callback-shaped: every leaf is a `ze` arg after the
         //     fixed `je` (no return-value path; `convert_out_ty` stays None).
+        //
+        // A NULLABLE leaf is one whose path passes through an `Option` that
+        // something is decomposed below (`Option<Handle>` reached by
+        // `.field_self()`, a nested value form behind an `Option`). Returning it
+        // has nowhere to put the absent case: a return value is one expression,
+        // so there is no `None` arm, and `convert_out_ty` names the leaf's own
+        // type rather than an optional of it. Callback delivery has that arm
+        // already — the leaf crosses as a boxed `Long` / JVM null — so the
+        // shape goes there instead of being composed into Rust that hands
+        // `&Option<T>` to a converter typed for `T`.
         let single_return = ed.target == DeconTarget::Output
             && !plan.shape.has_iterable_layer()
-            && plan.leaves.len() == 1;
+            && plan.leaves.len() == 1
+            && !plan.leaves[0].nullable;
         let plan = if single_return {
             let leaf_ty = plan.leaves[0].out_ty.clone();
             let cv_ty: syn::Type = if matches!(plan.shape, UnfoldShape::Optional((), _)) {
@@ -1052,6 +1152,9 @@ fn register_decon_spec<M>(
         false,
         &mut visited,
         &mut leaves,
+        // A `DeconSpec` describes the leaf list only — signature artifacts are
+        // derived from it, never emitted code — so its hoists are discarded.
+        &mut Vec::new(),
     )?;
     require_unique_leaf_names(source, &leaves)?;
     registry.decon_plans.insert(
@@ -1116,6 +1219,7 @@ fn build_plan<M>(
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     let mut visited: HashSet<TypeKey> = HashSet::new();
     visited.insert(TypeKey::from_type(source));
+    let mut hoists: Vec<Hoist> = Vec::new();
     flatten(
         acc,
         registry,
@@ -1127,6 +1231,7 @@ fn build_plan<M>(
         false,
         &mut visited,
         &mut leaves,
+        &mut hoists,
     )?;
     require_unique_leaf_names(source, &leaves)?;
     require_root_identity_last(by_ref, source, &leaves)?;
@@ -1141,6 +1246,7 @@ fn build_plan<M>(
         delivery: ed.delivery,
         convert_out_ty: None,
         fixed_builder: false,
+        hoists,
     })
 }
 
@@ -1194,12 +1300,13 @@ fn flatten<M>(
     registry: &Registry<M>,
     records: &[DeconRecord],
     source: &syn::Type,
-    path_prefix: &[syn::Ident],
+    path_prefix: &[PathStep],
     name_prefix: &[String],
     by_ref: bool,
     nullable: bool,
     visited: &mut HashSet<TypeKey>,
     leaves: &mut Vec<UnfoldLeaf>,
+    hoists: &mut Vec<Hoist>,
 ) -> Result<(), UnfoldError> {
     let source_key = TypeKey::from_type(source);
     // The author-supplied (literal) leaf-name segment at this level, appended
@@ -1222,11 +1329,15 @@ fn flatten<M>(
                     });
                 }
                 seen_identity = true;
-                // Owned at the root of an owned value (a `Copy` blob copies /
-                // an opaque handle moves); borrowed (clone) otherwise. The
-                // adapter-side type + projection come from this `out_ty`'s
-                // output converter.
-                let out_ty: syn::Type = if path_prefix.is_empty() && !by_ref {
+                // Owned where the value is OURS to give: the root of an owned
+                // plan (a `Copy` blob copies / an opaque handle moves), or a
+                // field of a value form that CONSUMED its value — that form was
+                // handed the value, so its fields move out like every other
+                // field of it. Borrowed (clone) otherwise. The adapter-side type
+                // + projection come from this `out_ty`'s output converter, so
+                // this is what decides whether the leaf is boxed by move or
+                // cloned through the borrowed-opaque one.
+                let out_ty: syn::Type = if place_is_owned(hoists, path_prefix, by_ref) {
                     source.clone()
                 } else {
                     syn::parse_quote!(&#source)
@@ -1245,6 +1356,179 @@ fn flatten<M>(
                     group: None,
                 });
             }
+            DeconRecord::Fields {
+                func,
+                consuming,
+                fields,
+            } => {
+                let consuming = *consuming;
+                // The value form is called once; every field hangs off that one
+                // call, so the whole record shares a single `Call` step and the
+                // emitter can hoist it.
+                let (takes, _ret) = accessor_signature(registry, func)?;
+                check_takes(func, &takes, source)?;
+                // The declarator states whether the value is given away; the
+                // signature has to agree, or the emitted call would not compile
+                // in the consumer's crate. Checked rather than inferred so that
+                // declaring `.fields_self_into(..)` on a borrowing accessor is a
+                // named error instead of a silently downgraded boundary.
+                if consuming != accessor_consumes(registry, func) {
+                    return Err(UnfoldError::Unsupported {
+                        func: func.clone(),
+                        reason: if consuming {
+                            "declared as a CONSUMING value form (`.fields_self_into(..)`) but the \
+                             accessor borrows its receiver — declare it with `.fields(..)`, or \
+                             name the by-value accessor"
+                        } else {
+                            "declared as a BORROWING value form (`.fields(..)`) but the accessor \
+                             takes its receiver by value — declare it with `.fields_self_into(..)`, or \
+                             name the `&Self` accessor"
+                        },
+                    });
+                }
+                let mut root_path = path_prefix.to_vec();
+                root_path.push(PathStep::call(func.clone(), false));
+                // A hoist below an optional step cannot be emitted as an
+                // unconditional local: composing the path directly would pass
+                // `&Option<T>` to the child value-form accessor. The current
+                // flat leaf emitter has no conditional-hoist representation,
+                // so reject the shape instead of generating ill-typed Rust.
+                // A top-level `Option<T>` is represented by
+                // `UnfoldShape::Optional`, not by a path step, and is unaffected.
+                if root_path.iter().any(PathStep::is_optional) {
+                    return Err(UnfoldError::Unsupported {
+                        func: func.clone(),
+                        reason: "a nested value form reached through `Option` — conditional \
+                                 value-form hoisting is not implemented",
+                    });
+                }
+                // A consuming value form DESTROYS the value into its parts, so
+                // a sibling record — `.field_self()` or another `.field()` —
+                // would read what it just gave away. jnigen refuses this in the
+                // declarator, where the author can see it; this is the backstop
+                // for records built directly against core.
+                //
+                // Being reached through ANOTHER value form is fine: a hoisted
+                // value form is an owned struct and its fields are disjoint, so
+                // the parent's field is handed over by move.
+                if consuming && records.len() > 1 {
+                    return Err(UnfoldError::Unsupported {
+                        func: func.clone(),
+                        reason: "a consuming value form must be the only record of its \
+                                 declaration — it moves the value, so `.field_self()` or \
+                                 a sibling `.field()` would read a moved value",
+                    });
+                }
+                // Evaluate this value form ONCE. Recorded at the prefix it sits
+                // at rather than as a lone accessor, so a nested value form
+                // (this record reached through another one's field) gets its own
+                // hoist instead of being rebuilt per child leaf. `path_prefix`
+                // grows as `flatten` descends, so the list comes out
+                // outermost-first.
+                hoists.push(Hoist {
+                    prefix: root_path.clone(),
+                    consuming,
+                });
+
+                for fr in fields {
+                    // A field's own `Option` makes everything under it nullable,
+                    // exactly as an `Option`-returning accessor step does.
+                    let (opt, core) = match option_inner_type(&fr.ty) {
+                        Some(inner) => (true, inner),
+                        None => (false, fr.ty.clone()),
+                    };
+                    let child_ty = peel_ref(&core);
+                    let child_key = TypeKey::from_type(&child_ty);
+
+                    // Same three-way choice a `.field()` record makes: declared
+                    // override, else the field type's own deconstructor, else
+                    // one leaf — with the adapter able to pre-build the leaves
+                    // for a shape only it can describe.
+                    let child_records = match &fr.decon {
+                        FieldDecon::Records(recs) => Some(recs.clone()),
+                        FieldDecon::Leaves(_) => None,
+                        FieldDecon::Default => match find_deconstructor_by_type(acc, &child_key) {
+                            Some(child_decl) if !visited.contains(&child_key) => {
+                                Some(child_decl.records.clone())
+                            }
+                            Some(_) => {
+                                return Err(UnfoldError::Cycle {
+                                    target: child_key.to_string(),
+                                });
+                            }
+                            None => None,
+                        },
+                    };
+                    let decomposed =
+                        child_records.is_some() || matches!(fr.decon, FieldDecon::Leaves(_));
+
+                    // The field's own `Option` is a nullable NESTING step only
+                    // when something is decomposed below it. For a plain leaf
+                    // the whole `Option<F>` is what the converter takes — the
+                    // same rule that makes a terminal accessor's `Option` ride
+                    // its converter instead of being unwrapped.
+                    let mut field_path = root_path.clone();
+                    let (last, lead) = fr
+                        .members
+                        .split_last()
+                        .expect("a field record addresses at least one member");
+                    // Only the LAST member can be optional — an inlined nested
+                    // class is reached directly, never through an `Option`.
+                    field_path.extend(lead.iter().map(|m| PathStep::field(m.clone(), false)));
+                    field_path.push(PathStep::field(last.clone(), opt && decomposed));
+
+                    // Adapter-built leaves: rebase each onto this field's path
+                    // and name. Their internal structure (a selector plus its
+                    // groups) is opaque here and passes through untouched.
+                    if let FieldDecon::Leaves(built) = &fr.decon {
+                        for l in built {
+                            let mut path = field_path.clone();
+                            path.extend(l.path.iter().cloned());
+                            let mut name = seg_name(&fr.name);
+                            name.push(l.name.clone());
+                            leaves.push(UnfoldLeaf {
+                                name: name.join("__"),
+                                path,
+                                nullable: l.nullable || nullable || opt,
+                                ..l.clone()
+                            });
+                        }
+                        continue;
+                    }
+
+                    if let Some(child_records) = child_records {
+                        visited.insert(child_key.clone());
+                        flatten(
+                            acc,
+                            registry,
+                            &child_records,
+                            &child_ty,
+                            &field_path,
+                            &seg_name(&fr.name),
+                            by_ref,
+                            nullable || opt,
+                            visited,
+                            leaves,
+                            hoists,
+                        )?;
+                        visited.remove(&child_key);
+                    } else {
+                        // A plain field leaf: the value is CLONED out of the
+                        // struct, so its converter takes the owned field type as
+                        // written — `Option` and all, which is why a terminal
+                        // `Option` step is not a nesting step for it.
+                        leaves.push(UnfoldLeaf {
+                            name: seg_name(&fr.name).join("__"),
+                            path: field_path,
+                            out_ty: fr.ty.clone(),
+                            identity: false,
+                            nullable,
+                            source: LeafSource::Field,
+                            group: None,
+                        });
+                    }
+                }
+            }
             DeconRecord::Acc { name, .. } | DeconRecord::LocalAcc { name, .. } => {
                 // A binding-local record resolves through its synthesized
                 // registry entry (see `synthesize_local_accessors`), so both
@@ -1253,7 +1537,7 @@ fn flatten<M>(
                 let (func, local) = match rec {
                     DeconRecord::Acc { func, .. } => (func.clone(), false),
                     DeconRecord::LocalAcc { path, .. } => (DeconRecord::local_ident(path), true),
-                    DeconRecord::Identity => unreachable!(),
+                    DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
                 let (takes, ret) = accessor_signature(registry, &func)?;
                 check_takes(&func, &takes, source)?;
@@ -1288,7 +1572,7 @@ fn flatten<M>(
                     visited.insert(child_key.clone());
                     let child_records = child_decl.records.clone();
                     let mut child_path = path_prefix.to_vec();
-                    child_path.push(func.clone());
+                    child_path.push(PathStep::call(func.clone(), opt));
                     flatten(
                         acc,
                         registry,
@@ -1300,6 +1584,7 @@ fn flatten<M>(
                         nullable || opt,
                         visited,
                         leaves,
+                        hoists,
                     )?;
                     visited.remove(&child_key);
                 } else {
@@ -1332,7 +1617,7 @@ fn flatten<M>(
                         (ret, nullable, false)
                     };
                     let mut path = path_prefix.to_vec();
-                    path.push(func.clone());
+                    path.push(PathStep::call(func.clone(), opt));
                     leaves.push(UnfoldLeaf {
                         name: seg_name(name).join("__"),
                         path,
@@ -1413,6 +1698,45 @@ fn accessor_signature<M>(
         syn::ReturnType::Type(_, t) => (**t).clone(),
     };
     Ok((takes, ret))
+}
+
+/// Whether the value sitting at `path_prefix` is the plan's **to give away**:
+/// the root of an owned plan, or a field of a value form that consumed its
+/// value and is reached by a movable run of field steps.
+///
+/// Consulted where a leaf's `out_ty` is chosen, so the ownership decision is
+/// made ONCE, in the plan, rather than re-derived by each emitter — a leaf
+/// whose `out_ty` is the owned type is boxed by move, one whose `out_ty` is a
+/// borrow is cloned through the borrowed-opaque converter.
+fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> bool {
+    if path_prefix.is_empty() {
+        return !by_ref;
+    }
+    hoists
+        .iter()
+        .filter(|h| h.prefix.len() <= path_prefix.len() && path_prefix.starts_with(&h.prefix))
+        .max_by_key(|h| h.prefix.len())
+        .is_some_and(|h| h.consuming && steps_are_movable(&path_prefix[h.prefix.len()..]))
+}
+
+/// Whether an accessor takes its receiver **by value** — a *consuming* value
+/// form, which destroys the object into its parts instead of cloning them out
+/// of a borrow.
+///
+/// Asked separately because [`accessor_signature`] peels the `&` in order to
+/// compare target types, so `f(v: T)` and `f(v: &T)` are indistinguishable
+/// there by design.
+fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
+    registry.functions.get(func).is_some_and(|(f, _)| {
+        f.sig
+            .inputs
+            .iter()
+            .find_map(|input| match input {
+                syn::FnArg::Typed(pt) => Some(!matches!(*pt.ty, syn::Type::Reference(_))),
+                _ => None,
+            })
+            .unwrap_or(false)
+    })
 }
 
 fn check_takes(

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -58,6 +58,93 @@ pub struct DeconSpec {
     pub leaves: Vec<UnfoldLeaf>,
 }
 
+/// One step of a leaf's [`UnfoldLeaf::path`] — how to get from the value
+/// reached so far to the next one.
+///
+/// A step is typed rather than a bare ident because a single path may **mix**
+/// the two: an `expand_return!(T).fields(fields!(t_to_struct))` leaf calls the
+/// value-form accessor, reads a struct field, and may then call that field
+/// type's own accessor — `Call(t_to_struct)`, `Field(key_expr)`,
+/// `Call(keyexpr_as_str)`. [`LeafSource`] still says what *kind* of leaf sits
+/// at the end of the path; the steps say how it is reached.
+///
+/// Each step also records whether it is **optional** — its accessor returns
+/// `Option<…>`, or its field is typed `Option<…>`. A `true` on a step *before*
+/// the last makes it a nullable nesting step: the emitter matches on it and the
+/// `None` arm short-circuits the whole leaf to null. The flag is carried rather
+/// than re-derived so both kinds answer the question the same way and the
+/// emitter needs no type walk (an accessor's `Option` was already peeled where
+/// the step was built).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum PathStep {
+    /// Call a `#[prebindgen]` accessor on the value reached so far:
+    /// `source_module::f(&value)`.
+    Call { ident: syn::Ident, optional: bool },
+    /// Read a struct field of the value reached so far: `value.f`.
+    Field { ident: syn::Ident, optional: bool },
+}
+
+impl PathStep {
+    /// An accessor call step.
+    pub fn call(ident: syn::Ident, optional: bool) -> Self {
+        Self::Call { ident, optional }
+    }
+
+    /// A struct-field read step.
+    pub fn field(ident: syn::Ident, optional: bool) -> Self {
+        Self::Field { ident, optional }
+    }
+
+    /// The step's ident, whichever kind it is.
+    pub fn ident(&self) -> &syn::Ident {
+        match self {
+            Self::Call { ident, .. } | Self::Field { ident, .. } => ident,
+        }
+    }
+
+    /// Whether the step yields an `Option` — a nullable nesting step when it is
+    /// not the last on the path.
+    pub fn is_optional(&self) -> bool {
+        match self {
+            Self::Call { optional, .. } | Self::Field { optional, .. } => *optional,
+        }
+    }
+
+    /// Whether the step is a plain (non-optional) field read — a path made only
+    /// of these renders as `value.a.b`, needing no nesting `match`.
+    pub fn is_plain_field(&self) -> bool {
+        matches!(
+            self,
+            Self::Field {
+                optional: false,
+                ..
+            }
+        )
+    }
+
+    /// Whether the step is a field read, `Option` or not.
+    pub fn is_field(&self) -> bool {
+        matches!(self, Self::Field { .. })
+    }
+}
+
+/// Whether a run of steps can be **moved** out of the value it hangs off:
+/// field reads only, with an `Option` allowed on the last one — a `None` arm
+/// still hands over the whole `Option` by value, while an `Option` in the
+/// middle would have to be unwrapped and so can only be borrowed through.
+///
+/// This is the one place the rule is written: the resolver uses it to decide
+/// whether a leaf OWNS what it reaches (its `out_ty` then being the owned type
+/// rather than a borrow), and the emitters use it to project that place. Two
+/// readings of it would drift, and the disagreement would be a borrow handed to
+/// an owning converter.
+pub fn steps_are_movable(steps: &[PathStep]) -> bool {
+    steps
+        .iter()
+        .enumerate()
+        .all(|(i, s)| s.is_field() && (!s.is_optional() || i + 1 == steps.len()))
+}
+
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum LeafSource {
@@ -140,6 +227,34 @@ pub struct UnfoldPlan {
     /// generic over `R`/`A` — it returns the concrete type). `false` for the
     /// accessor-declared deconstructors, whose builder is caller-supplied.
     pub fixed_builder: bool,
+    /// Value forms that must be evaluated **once** and bound to a local. Every
+    /// leaf below one reaches off that local — otherwise each field would
+    /// rebuild the whole struct, cloning all of it once per leaf.
+    ///
+    /// A list rather than a single accessor because value forms **compose**: a
+    /// field may splice a child type whose own boundary is derived from *its*
+    /// value form, and that child call is a second hoist nested under the
+    /// first. Ordered outermost-first, so a hoist can be composed from the
+    /// longest already-bound prefix of itself.
+    pub hoists: Vec<Hoist>,
+}
+
+/// One hoisted value form: where it sits, and whether it **consumes** the value
+/// it decomposes.
+#[derive(Clone)]
+pub struct Hoist {
+    /// The path prefix to bind, ending in the value form's
+    /// [`PathStep::Call`] (`DeconRecord::Fields`).
+    pub prefix: Vec<PathStep>,
+    /// `true` when the accessor takes its receiver **by value**
+    /// (`f(v: T) -> TStruct`), so the value is moved in and each field can be
+    /// moved *out* into its leaf instead of cloned — the whole point of a
+    /// consuming value form.
+    ///
+    /// Carried on the hoist rather than on [`PathStep::Call`] because only a
+    /// value-form root can consume: the ordinary accessor-chain steps are
+    /// always borrows.
+    pub consuming: bool,
 }
 
 /// One flattened output leaf of a decomposed return value.
@@ -151,9 +266,10 @@ pub struct UnfoldLeaf {
     /// `"keyExpr"` → `"sample__keyExpr"`); a root identity leaf is `"handle"`.
     /// Names are unique within a deconstructor (a duplicate is a hard error).
     pub name: String,
-    /// Accessor-call chain from the root value (`[]` = the identity/root
-    /// itself; `[f]` = `f(&root)`; longer = nested records, M3).
-    pub path: Vec<syn::Ident>,
+    /// Reach chain from the root value (`[]` = the identity/root itself;
+    /// `[Call(f)]` = `f(&root)`; longer = nested records, M3). Steps of both
+    /// kinds may mix — see [`PathStep`].
+    pub path: Vec<PathStep>,
     /// Type whose resolved **output** converter encodes this leaf — a
     /// reference type for accessors (`&str`, `&F`), `&Source` for the identity
     /// leaf (so the borrowed-opaque clone converter / projection is reused).

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -88,7 +88,10 @@ fn accessor_optional_primitive() {
     );
     assert_eq!(plan.leaves.len(), 1);
     assert!(!plan.leaves[0].identity);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_timestamp_ntp64");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_timestamp_ntp64"
+    );
     assert_eq!(plan.leaves[0].out_ty.to_token_stream().to_string(), "i64");
     assert!(reg
         .required_outputs_scan
@@ -150,7 +153,10 @@ fn accessor_plan_byref() {
     // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
     assert!(!plan.leaves[1].identity);
     assert_eq!(plan.leaves[1].path.len(), 1);
-    assert_eq!(plan.leaves[1].path[0].to_string(), "z_keyexpr_as_str");
+    assert_eq!(
+        plan.leaves[1].path[0].ident().to_string(),
+        "z_keyexpr_as_str"
+    );
     assert_eq!(plan.leaves[1].out_ty.to_token_stream().to_string(), "& str");
 
     // Leaf out_tys registered as required outputs so the resolver builds
@@ -484,7 +490,7 @@ fn nested_accessor_flatten() {
     let path = |l: &UnfoldLeaf| {
         l.path
             .iter()
-            .map(|i| i.to_string())
+            .map(|i| i.ident().to_string())
             .collect::<Vec<_>>()
             .join(".")
     };
@@ -627,7 +633,7 @@ fn reply_product_double_option_flatten() {
     let path = |l: &UnfoldLeaf| {
         l.path
             .iter()
-            .map(|i| i.to_string())
+            .map(|i| i.ident().to_string())
             .collect::<Vec<_>>()
             .join(".")
     };
@@ -797,7 +803,10 @@ fn iterable_decomposed_plan() {
     assert!(matches!(&plan.shape, UnfoldShape::Iterable(_)));
     assert!(plan.element.is_none(), "decomposed: element not used");
     assert_eq!(plan.leaves.len(), 2);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_zenoh_id_to_string");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_zenoh_id_to_string"
+    );
     assert_eq!(
         plan.leaves[0].out_ty.to_token_stream().to_string(),
         "String"
@@ -1067,7 +1076,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         reg_with(&["fn storage_get_vec(s: &Storage) -> Option<Vec<Payload>> { todo!() }"]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
-        path: vec![ident(name)],
+        path: vec![PathStep::field(ident(name), false)],
         out_ty: ty,
         identity: false,
         nullable: false,
@@ -1120,7 +1129,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     ]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
-        path: vec![ident(name)],
+        path: vec![PathStep::field(ident(name), false)],
         out_ty: ty,
         identity: false,
         nullable: false,
@@ -1328,13 +1337,16 @@ fn callback_arg_plan_derived() {
     assert_eq!(plan.leaves.len(), 3);
     // Nested keyexpr identity (borrowed: non-root) + string + direct enum.
     assert!(plan.leaves[0].identity);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_sample_key_expr");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_sample_key_expr"
+    );
     assert_eq!(
         plan.leaves[0].out_ty.to_token_stream().to_string(),
         "& ZKeyExpr"
     );
     assert_eq!(
-        plan.leaves[1].path.last().unwrap().to_string(),
+        plan.leaves[1].path.last().unwrap().ident().to_string(),
         "z_keyexpr_as_str"
     );
     assert_eq!(
@@ -1412,7 +1424,10 @@ fn callback_arg_borrowed_decomposed() {
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 3);
     assert!(plan.leaves[0].identity);
-    assert_eq!(plan.leaves[0].path[0].to_string(), "z_sample_key_expr");
+    assert_eq!(
+        plan.leaves[0].path[0].ident().to_string(),
+        "z_sample_key_expr"
+    );
     assert_eq!(
         plan.leaves[2].out_ty.to_token_stream().to_string(),
         "SampleKind"
@@ -1561,6 +1576,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
         delivery: Delivery::Return,
         convert_out_ty: None,
         fixed_builder: false,
+        hoists: Vec::new(),
     };
     reg.unfold_plans.insert(ident("strings"), sentinel);
     apply_leaf_vec_folds(&mut reg, vec![syn::parse_quote!(String)], &declared)

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -748,6 +748,7 @@ impl JniGen {
     /// once, on the member), else the camel-cased Rust name.
     fn lower_fields(
         &self,
+        registry: &Registry<KotlinMeta>,
         key: &TypeKey,
         fields: &[LocalField],
     ) -> Vec<crate::api::core::unfold::DeconRecord> {
@@ -755,6 +756,11 @@ impl JniGen {
         fields
             .iter()
             .map(|f| match f {
+                LocalField::Fields(decl) => DeconRecord::Fields {
+                    func: decl.func.clone(),
+                    consuming: decl.consuming,
+                    fields: self.lower_value_form(registry, key, decl),
+                },
                 LocalField::Named(func, name_override) => {
                     let name = name_override
                         .clone()
@@ -782,6 +788,276 @@ impl JniGen {
             .collect()
     }
 
+    /// Expand a `.fields(fields!(f))` declaration into one
+    /// [`FieldRecord`](crate::api::core::unfold::FieldRecord) per field of the
+    /// struct `f` returns — the value form.
+    ///
+    /// The walk is the adapter's job because only it knows which structs are
+    /// declared `data_class!`es: a **non-optional** nested one is inlined (its
+    /// own fields become records with `__`-joined names), matching what
+    /// `synth_value_struct_leaves` does for a by-value data class; everything
+    /// else is one record and core decides whether that record's type splices
+    /// its own `expand_return!`.
+    ///
+    /// Per-field `.field(...)` overrides and `.name(...)` renames key on the
+    /// **Rust field ident**, and both are checked against the struct: naming a
+    /// field the value form doesn't have is a hard error, which is the point —
+    /// a field renamed upstream must not silently lose its adjustment.
+    fn lower_value_form(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        key: &TypeKey,
+        decl: &FieldsDecl,
+    ) -> Vec<crate::api::core::unfold::FieldRecord> {
+        let func = &decl.func;
+        let (item_fn, _) = registry.functions.get(func).unwrap_or_else(|| {
+            panic!(
+                "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
+                 `{func}` — a value form is an accessor `fn {func}(v: &{}) -> {}Struct`",
+                key.as_str(),
+                key.as_str(),
+                key.as_str(),
+            )
+        });
+        let ret: syn::Type = match &item_fn.sig.output {
+            syn::ReturnType::Type(_, t) => crate::api::core::unfold::peel_ref(t),
+            syn::ReturnType::Default => panic!(
+                "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
+                 value form returns the struct holding this type's fields",
+                key.as_str()
+            ),
+        };
+        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, &ret) else {
+            panic!(
+                "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
+                 not a struct — a value form returns a struct whose fields become the leaves",
+                key.as_str(),
+                ret.to_token_stream(),
+            )
+        };
+        let st = st.clone();
+
+        let mut out = Vec::new();
+        self.walk_value_form(registry, key, decl, &st, &[], "", 0, &mut out);
+
+        // Every adjustment must have found its field. An unknown name is the
+        // drift this whole declarator exists to catch, so it is an error rather
+        // than a no-op.
+        let named: std::collections::HashSet<String> = out
+            .iter()
+            .map(|r: &crate::api::core::unfold::FieldRecord| {
+                r.members
+                    .iter()
+                    .map(|m| m.to_string())
+                    .collect::<Vec<_>>()
+                    .join(".")
+            })
+            .collect();
+        for (field, _) in decl.overrides.iter() {
+            assert!(
+                named.contains(field),
+                "fields!({func}).field(\"{field}\", ...): `{}` has no field `{field}` \
+                 (fields: {})",
+                st.ident,
+                named.iter().cloned().collect::<Vec<_>>().join(", "),
+            );
+        }
+        for (field, _) in decl.names.iter() {
+            assert!(
+                named.contains(field),
+                "fields!({func}).name(\"{field}\", ...): `{}` has no field `{field}` \
+                 (fields: {})",
+                st.ident,
+                named.iter().cloned().collect::<Vec<_>>().join(", "),
+            );
+        }
+        out
+    }
+
+    /// One level of [`Self::lower_value_form`]'s struct walk. `members` /
+    /// `name_prefix` accumulate through inlined nested data classes; an
+    /// override or rename keys on the dotted member path, so a nested field is
+    /// addressed as `"outer.inner"`.
+    #[allow(clippy::too_many_arguments)]
+    fn walk_value_form(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        key: &TypeKey,
+        decl: &FieldsDecl,
+        st: &syn::ItemStruct,
+        members: &[syn::Ident],
+        name_prefix: &str,
+        depth: usize,
+        out: &mut Vec<crate::api::core::unfold::FieldRecord>,
+    ) {
+        use crate::api::core::unfold::{FieldDecon, FieldRecord};
+        let syn::Fields::Named(named) = &st.fields else {
+            panic!(
+                "expand_return!({}).fields(fields!({})): `{}` has no named fields — a value \
+                 form is a plain struct whose fields become the leaves",
+                key.as_str(),
+                decl.func,
+                st.ident,
+            )
+        };
+        // A value form holding itself would expand forever; the cycle rule for
+        // everything reachable BELOW a field is core's `visited` check.
+        assert!(
+            depth <= 16,
+            "expand_return!({}).fields(fields!({})): `{}` nests data classes more than 16 \
+             deep — is a value form holding itself?",
+            key.as_str(),
+            decl.func,
+            st.ident,
+        );
+        for field in &named.named {
+            let Some(fname) = field.ident.as_ref() else {
+                continue;
+            };
+            let mut member_path = members.to_vec();
+            member_path.push(fname.clone());
+            let dotted = member_path
+                .iter()
+                .map(|m| m.to_string())
+                .collect::<Vec<_>>()
+                .join(".");
+            let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
+            let name = decl
+                .names
+                .iter()
+                .find(|(f, _)| *f == dotted)
+                .map(|(_, n)| n.clone())
+                .unwrap_or(camel);
+            let name = if name_prefix.is_empty() {
+                name
+            } else {
+                format!("{name_prefix}__{name}")
+            };
+
+            // An explicit override replaces the field type's default
+            // decomposition wholesale — including any nesting it would have had.
+            if let Some((_, ovr)) = decl.overrides.iter().find(|(f, _)| *f == dotted) {
+                // The override states the field's type, so it is cross-checked
+                // against the field the same way a per-fn `.expand_param` /
+                // `.expand_return` decl is checked against its parameter or
+                // return. Without this an override outlives an upstream
+                // field-type change — the very drift `.fields()` exists to
+                // catch — and two same-shaped handle types silently swap.
+                // Core applies override records to the whole field after
+                // peeling only an outer `Option`: a `Vec<T>` remains `Vec<T>`.
+                // Mirror that exact normalization here; peeling `Vec` would
+                // accept `expand_return!(T)` and only fail later when core
+                // applies its records to `Vec<T>`.
+                let peeled = option_inner_type(&field.ty)
+                    .map(|t| crate::api::core::unfold::peel_ref(&t))
+                    .unwrap_or_else(|| crate::api::core::unfold::peel_ref(&field.ty));
+                let actual = TypeKey::from_type(&peeled);
+                assert!(
+                    actual == ovr.key,
+                    "fields!({}).field(\"{dotted}\", expand_return!({})): `{}.{dotted}` is \
+                     `{}`, not `{}` — a per-field override names the field's own type",
+                    decl.func,
+                    ovr.key.as_str(),
+                    st.ident,
+                    actual.as_str(),
+                    ovr.key.as_str(),
+                );
+                out.push(FieldRecord {
+                    members: member_path,
+                    name,
+                    ty: field.ty.clone(),
+                    decon: FieldDecon::Records(self.lower_fields(registry, &ovr.key, &ovr.fields)),
+                });
+                continue;
+            }
+
+            // A nested `data_class!` inlines when it is reached directly; behind
+            // `Option` / `Vec` it stays one leaf, whose own converter builds the
+            // object (the rule `synth_value_struct_leaves` already follows).
+            // A `sealed_class!` field has no whole-value converter at all, so it
+            // must decompose into its selector and groups wherever it appears.
+            let bare = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
+            let probe = vec_inner_type(&bare).unwrap_or_else(|| bare.clone());
+            match self.type_kind(registry, &probe) {
+                TypeKind::DataStruct { st, cfg: Some(_) }
+                    if option_inner_type(&field.ty).is_none()
+                        && vec_inner_type(&field.ty).is_none() =>
+                {
+                    let child = st.clone();
+                    self.walk_value_form(
+                        registry,
+                        key,
+                        decl,
+                        &child,
+                        &member_path,
+                        &name,
+                        depth + 1,
+                        out,
+                    );
+                    continue;
+                }
+                TypeKind::Sum => {
+                    // A sum's leaves are a selector plus one group per
+                    // alternative, laid out side by side at a FIXED position.
+                    // A `Vec` of them has variable arity; an `Option` of one
+                    // needs a present flag the unfold leaf list has no notion of
+                    // (the `fromParts` bridge's `PlanFieldKind::Sum` does — a
+                    // data-class field can be `Option<sum>`).
+                    assert!(
+                        vec_inner_type(&bare).is_none(),
+                        "expand_return!({}).fields(fields!({})): field `{}.{}` is a \
+                         `Vec<{}>` — a sequence of tag-gated groups has variable arity and \
+                         cannot be laid out in a fixed leaf list",
+                        key.as_str(),
+                        decl.func,
+                        st.ident,
+                        dotted,
+                        probe.to_token_stream(),
+                    );
+                    assert!(
+                        option_inner_type(&field.ty).is_none(),
+                        "expand_return!({}).fields(fields!({})): field `{}.{}` is an \
+                         `Option<{}>` — an optional sum would need a present flag beside its \
+                         tag, which an output leaf list cannot carry. Give the field a \
+                         payload-less alternative instead of wrapping the sum in `Option`, \
+                         or override it with .field(\"{}\", ...)",
+                        key.as_str(),
+                        decl.func,
+                        st.ident,
+                        dotted,
+                        probe.to_token_stream(),
+                        dotted,
+                    );
+                    let ident = bare_path_ident(&probe).expect("a sum type is a path type");
+                    let (item_enum, _) = registry
+                        .enums
+                        .get(&ident)
+                        .expect("TypeKind::Sum implies an indexed enum");
+                    let sum_cfg = self.types[&TypeKey::from_type(&probe)]
+                        .sum()
+                        .expect("TypeKind::Sum implies a sealed-class config");
+                    out.push(FieldRecord {
+                        members: member_path,
+                        name,
+                        ty: field.ty.clone(),
+                        decon: FieldDecon::Leaves(crate::api::lang::jnigen::jni::synth_sum_leaves(
+                            self, sum_cfg, item_enum,
+                        )),
+                    });
+                    continue;
+                }
+                _ => {}
+            }
+
+            out.push(FieldRecord {
+                members: member_path,
+                name,
+                ty: field.ty.clone(),
+                decon: FieldDecon::Default,
+            });
+        }
+    }
+
     /// Lower the raw [`ExpandReturnDecl`]s into the core's immutable
     /// [`Deconstructors`] record set — the output-side peer of
     /// [`Self::build_expansions`], a pure declaration → record mapping.
@@ -789,7 +1065,10 @@ impl JniGen {
     /// them. `skip_output` is derived from the class members: a
     /// `.constructor()` member's return is a factory, never
     /// output-flattened.
-    pub(crate) fn build_deconstructors(&self) -> crate::api::core::unfold::Deconstructors {
+    pub(crate) fn build_deconstructors(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> crate::api::core::unfold::Deconstructors {
         use crate::api::core::unfold::{
             DeconSel, DeconTarget, DeconstructorDecl, Deconstructors, Delivery, OutputDecl,
         };
@@ -817,7 +1096,7 @@ impl JniGen {
             );
             dec.deconstructors.push(DeconstructorDecl {
                 target: decl.key.to_type(),
-                records: self.lower_fields(&decl.key, &decl.fields),
+                records: self.lower_fields(registry, &decl.key, &decl.fields),
                 default: Some((DeconTarget::Output, Delivery::Callback)),
             });
         }
@@ -838,7 +1117,7 @@ impl JniGen {
             );
             dec.outputs.push(OutputDecl {
                 func: func.clone(),
-                sel: DeconSel::Inline(self.lower_fields(&decl.key, &decl.fields)),
+                sel: DeconSel::Inline(self.lower_fields(registry, &decl.key, &decl.fields)),
                 target: DeconTarget::Output,
                 delivery: Delivery::Callback,
                 declared_source: Some(decl.key.to_type()),
@@ -1001,26 +1280,10 @@ impl JniGen {
                 LocalVariant::Ctor(f) => Some(f.clone()),
                 LocalVariant::SelfIdentity => None,
             });
-        let accessors = self
-            .return_expand_decls
-            .iter()
-            .map(|d| &d.fields)
-            .chain(self.fn_return_expands.iter().map(|(_, d)| &d.fields))
-            .flatten()
-            .filter_map(|f| match f {
-                LocalField::Named(func, _) => Some(func.clone()),
-                // A binding-local field's synthesized fn is helper-only too:
-                // called by the generated code, never externed, and its
-                // synthesized registry entry must not trip the warning.
-                LocalField::Local { path, .. } => Some(
-                    path.segments
-                        .last()
-                        .expect("validated non-empty at decl time")
-                        .ident
-                        .clone(),
-                ),
-                LocalField::SelfField => None,
-            });
+        // Includes a binding-local field's synthesized fn (called by the
+        // generated code, never externed, so its synthesized registry entry
+        // must not trip the warning) and a value form's accessor.
+        let accessors = self.field_referenced_fns().into_iter();
         // Synthesized binding-local fns from every entry form (path-built
         // fun! at fun/method/constructor/convert sites): their registry
         // entries exist only for signature reads — helper-only unless also
@@ -1037,26 +1300,52 @@ impl JniGen {
     /// from parameter composition. Derived from *usage* — a function need not
     /// also be a `.method()` class member to be referenced this way.
     pub(crate) fn field_accessor_fns(&self) -> std::collections::HashSet<syn::Ident> {
-        self.return_expand_decls
+        self.field_referenced_fns().into_iter().collect()
+    }
+
+    /// Every function ident referenced as a field by any `expand_return!` decl
+    /// (type-level or per-fn), recursing into a value form's per-field
+    /// overrides. The one walk behind both [`Self::field_accessor_fns`] and the
+    /// helper-only set in [`Self::boundary_referenced_fns`] — they ask the same
+    /// question of the same declarations, so a new field kind is taught to both
+    /// at once.
+    fn field_referenced_fns(&self) -> Vec<syn::Ident> {
+        fn walk(fields: &[LocalField], out: &mut Vec<syn::Ident>) {
+            for f in fields {
+                match f {
+                    LocalField::Named(func, _) => out.push(func.clone()),
+                    // A binding-local field's synthesized fn IS an accessor —
+                    // excluded from parameter composition, and acknowledged so
+                    // the registry's "skipping undeclared" warning stays quiet.
+                    LocalField::Local { path, .. } => out.push(
+                        path.segments
+                            .last()
+                            .expect("validated non-empty at decl time")
+                            .ident
+                            .clone(),
+                    ),
+                    LocalField::SelfField => {}
+                    // The value form's own accessor, plus whatever its
+                    // per-field overrides reference.
+                    LocalField::Fields(d) => {
+                        out.push(d.func.clone());
+                        for (_, ovr) in &d.overrides {
+                            walk(&ovr.fields, out);
+                        }
+                    }
+                }
+            }
+        }
+        let mut out = Vec::new();
+        for fields in self
+            .return_expand_decls
             .iter()
             .map(|d| &d.fields)
             .chain(self.fn_return_expands.iter().map(|(_, d)| &d.fields))
-            .flatten()
-            .filter_map(|f| match f {
-                LocalField::Named(func, _) => Some(func.clone()),
-                // A binding-local field's synthesized fn IS an accessor —
-                // excluded from parameter composition, and acknowledged so
-                // the registry's "skipping undeclared" warning stays quiet.
-                LocalField::Local { path, .. } => Some(
-                    path.segments
-                        .last()
-                        .expect("validated non-empty at decl time")
-                        .ident
-                        .clone(),
-                ),
-                LocalField::SelfField => None,
-            })
-            .collect()
+        {
+            walk(fields, &mut out);
+        }
+        out
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -51,6 +51,11 @@ pub(crate) enum LocalField {
         sig: syn::Signature,
         name_override: Option<String>,
     },
+    /// Include **every field of the type's value form** — the struct returned
+    /// by the named accessor — each as its own field. Expands to the same
+    /// records the fields would produce if named one by one; see
+    /// [`ExpandReturnDecl::fields`].
+    Fields(FieldsDecl),
 }
 
 // Class members are stored as the full `(FunctionDecl, MemberKind)` pair —
@@ -289,6 +294,16 @@ macro_rules! try_into {
 macro_rules! expand_return {
     ($t:ty) => {
         $crate::lang::ExpandReturnDecl::new($crate::__macro_support::parse_type(stringify!($t)))
+    };
+}
+
+/// Build a [`FieldsDecl`] from the ident of a **value-form accessor** —
+/// `fields!(sample_to_struct)` is `FieldsDecl::new(prebindgen::ident!(sample_to_struct))`.
+/// The argument of [`ExpandReturnDecl::fields`](crate::lang::ExpandReturnDecl::fields).
+#[macro_export]
+macro_rules! fields {
+    ($name:ident) => {
+        $crate::lang::FieldsDecl::new($crate::ident!($name))
     };
 }
 
@@ -682,6 +697,7 @@ impl ExpandReturnDecl {
     /// decomposition comes from ITS type's boundary decl, not from the
     /// accessor).
     pub fn field(mut self, accessor: FunctionDecl) -> Self {
+        self.reject_beside_consuming("field(..)");
         assert!(
             accessor.param_expands.is_empty() && accessor.return_expand.is_none(),
             "expand_return!({}).field(fun!({})): expand overrides don't apply to a \
@@ -717,7 +733,204 @@ impl ExpandReturnDecl {
     /// Declare it **last**, after any field that decomposes a nested handle,
     /// so the generated Rust moves the value only after those borrows.
     pub fn field_self(mut self) -> Self {
+        self.reject_beside_consuming("field_self()");
         self.fields.push(LocalField::SelfField);
+        self
+    }
+
+    /// The one rule [`Self::fields_self_into`] adds: it hands the value **itself**
+    /// over, so nothing else in the decl can still read it.
+    fn reject_beside_consuming(&self, what: &str) {
+        if let Some(f) = self.fields.iter().find_map(|f| match f {
+            LocalField::Fields(d) if d.consuming => Some(&d.func),
+            _ => None,
+        }) {
+            panic!(
+                "expand_return!({k}).fields_self_into(fields!({f})).{what}: `.fields_self_into(..)` hands \
+                 the value ITSELF over as its fields, so nothing else can read it afterwards — \
+                 it must be the decl's only record. Use `.fields(fields!(..))` with the \
+                 borrowing form of the accessor if you need both.",
+                k = self.key.as_str(),
+                f = f,
+            );
+        }
+    }
+
+    /// Take the fields from the type's **value form** — a `#[prebindgen]`
+    /// accessor returning "this type's own accessors gathered into one struct"
+    /// — instead of restating them.
+    ///
+    /// `.fields(fields!(f))` is exactly `.field(...)` applied to each field of
+    /// that struct, so it has the same configurability (per-field overrides and
+    /// renames live on the [`FieldsDecl`]) and, crucially, the same
+    /// decomposition rule: **each field crosses by its own type's default
+    /// output boundary**. A field whose type has its own `expand_return!` is
+    /// decomposed by it (a `KeyExpr` field still crosses as its string, not as
+    /// a handle); a declared `data_class!` field expands into its fields; a
+    /// field behind `Option` / `Vec` stays one leaf. So swapping a hand-written
+    /// field list for `.fields(...)` keeps the boundary shape it already had —
+    /// what changes is that the list can no longer drift from the struct.
+    ///
+    /// ```
+    /// // Instead of restating SampleStruct's fields one by one:
+    /// let _ = prebindgen::expand_return!(Sample)
+    ///     .fields(prebindgen::fields!(sample_to_struct));
+    /// ```
+    ///
+    /// The accessor **borrows** its receiver (`f(v: &Self) -> SelfStruct`):
+    /// the struct is built from a borrow, so each field is cloned into it and
+    /// the leaves clone again out of it, and the value survives. It therefore
+    /// mixes freely — `.fields(...).field_self()` delivers the value form's
+    /// fields *and* the live handle. At most one value form per decl.
+    ///
+    /// Where the value is delivered **owned** — a callback argument
+    /// (`impl Fn(Sample)`), an owned return — and nothing else needs it, use
+    /// [`fields_self_into`](Self::fields_self_into) instead: those clones are being paid
+    /// on a value that is about to be dropped.
+    pub fn fields(mut self, decl: FieldsDecl) -> Self {
+        self.reject_beside_consuming("fields(..)");
+        self.reject_second_value_form(&decl);
+        self.fields.push(LocalField::Fields(decl));
+        self
+    }
+
+    /// Like [`fields`](Self::fields), but the accessor **consumes** its
+    /// receiver (`f(v: Self) -> SelfStruct`): the value is moved in and each
+    /// field is moved *out* into its leaf. No clones at all.
+    ///
+    /// This is the same decision [`field_self`](Self::field_self) makes, one
+    /// step further: `.field_self()` hands the value over whole,
+    /// `.fields_self_into(...)` hands *the value itself* over as its parts, and
+    /// `.fields(...)` hands over a copy of its parts. Use it wherever the value
+    /// arrives owned and is not needed afterwards — the hot receive path this
+    /// whole declarator exists to make cheap.
+    ///
+    /// ```
+    /// let _ = prebindgen::expand_return!(Sample)
+    ///     .fields_self_into(prebindgen::fields!(sample_into_struct));
+    /// ```
+    ///
+    /// Because it gives the value away it must be the decl's **only** record —
+    /// a `.field_self()` or a sibling `.field(...)` would read a value that is
+    /// gone — which is a declaration-time panic either way round. It may still
+    /// be reached through *another* value form: the parent's field is handed to
+    /// it by move, since a hoisted value form is an owned struct and its fields
+    /// are disjoint.
+    ///
+    /// The declarator and the accessor's signature must agree; naming a
+    /// `&Self` accessor here (or a by-value one on [`fields`](Self::fields)) is
+    /// an error, so the declared intent cannot drift from the function it
+    /// names. At a **borrowed** delivery position there is no value to give up,
+    /// so the emitter clones once up front and consumes the clone — the same
+    /// cost the borrowing form would have paid, which keeps one declaration
+    /// usable by both owned and `&T` returns of the type.
+    pub fn fields_self_into(mut self, decl: FieldsDecl) -> Self {
+        self.reject_second_value_form(&decl);
+        assert!(
+            self.fields.is_empty(),
+            "expand_return!({k}).fields_self_into(fields!({f})): `.fields_self_into(..)` hands the value \
+             ITSELF over as its fields, so it must be the decl's only record — the records \
+             already declared would read a value that is gone. Use `.fields(fields!(..))` with \
+             the borrowing form of the accessor if you need both.",
+            k = self.key.as_str(),
+            f = decl.func,
+        );
+        self.fields.push(LocalField::Fields(decl.consuming()));
+        self
+    }
+
+    fn reject_second_value_form(&self, decl: &FieldsDecl) {
+        assert!(
+            !self
+                .fields
+                .iter()
+                .any(|f| matches!(f, LocalField::Fields(_))),
+            "expand_return!({}): the decl already expands a value form (fields!({})) — \
+             one value form states the whole field set",
+            self.key.as_str(),
+            decl.func
+        );
+    }
+}
+
+/// A **value-form expansion**: the accessor whose returned struct supplies the
+/// fields, plus the per-field adjustments. Built with
+/// [`fields!`](crate::fields) and handed to
+/// [`ExpandReturnDecl::fields`].
+///
+/// Both adjusters key on the **Rust struct field name**, mirroring
+/// [`FunctionDecl::expand_param`]'s Rust-parameter-name key: an unknown field
+/// name or a repeated one is a hard error, so a field renamed upstream is
+/// caught rather than silently ignored.
+#[derive(Clone)]
+pub struct FieldsDecl {
+    pub(crate) func: syn::Ident,
+    pub(crate) overrides: Vec<(String, ExpandReturnDecl)>,
+    pub(crate) names: Vec<(String, String)>,
+    /// Set by [`ExpandReturnDecl::fields_self_into`] — the accessor consumes its
+    /// receiver. Declared rather than read off the signature, because giving
+    /// the value away is a boundary decision; the two are cross-checked when
+    /// the records are resolved.
+    pub(crate) consuming: bool,
+}
+
+impl FieldsDecl {
+    pub fn new(func: syn::Ident) -> Self {
+        Self {
+            func,
+            overrides: Vec::new(),
+            names: Vec::new(),
+            consuming: false,
+        }
+    }
+
+    pub(crate) fn consuming(mut self) -> Self {
+        self.consuming = true;
+        self
+    }
+
+    /// Replace **one** field's decomposition, with the same
+    /// [`ExpandReturnDecl`] a type-level default uses — so the complete-set
+    /// rule applies here too: the decl states that field's entire leaf set.
+    /// Use it where the field's type default is not what this boundary wants
+    /// (a lone `.field_self()` keeps the raw handle instead of decomposing it).
+    pub fn field(mut self, field: impl AsRef<str>, decl: ExpandReturnDecl) -> Self {
+        let field = field.as_ref().to_string();
+        assert!(
+            !self.overrides.iter().any(|(f, _)| *f == field),
+            "fields!({}).field(\"{}\", ...): field already has an override — declare its \
+             complete field set in ONE decl",
+            self.func,
+            field
+        );
+        self.overrides.push((field, decl));
+        self
+    }
+
+    /// Rename **one** field's leaf, overriding the name derived from the struct
+    /// field ident. The literal Kotlin name, like `fun!(f).name(...)`.
+    pub fn name(mut self, field: impl AsRef<str>, kotlin_name: impl Into<String>) -> Self {
+        let field = field.as_ref().to_string();
+        let kotlin_name = kotlin_name.into();
+        assert!(
+            !self.names.iter().any(|(f, _)| *f == field),
+            "fields!({}).name(\"{}\", ...): field is already renamed",
+            self.func,
+            field
+        );
+        // The derived names of inlined nested fields are joined with `"__"`, so
+        // an author name carrying one would forge a nesting that isn't there.
+        // (Core rejects it for a `.field()` name; here the name never reaches
+        // that check, so it is made at the point of declaration.)
+        assert!(
+            !kotlin_name.contains("__"),
+            "fields!({}).name(\"{}\", \"{}\"): `__` is the reserved chain separator \
+             and cannot appear in a leaf name",
+            self.func,
+            field,
+            kotlin_name,
+        );
+        self.names.push((field, kotlin_name));
         self
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -1,6 +1,7 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
 
 use super::*;
+use crate::api::core::unfold::{steps_are_movable, PathStep};
 
 /// Emit the output-expansion delivery body (output phase) for a function
 /// marked `.expand_output()`. The return value (`__out`) is decomposed by the
@@ -310,21 +311,227 @@ pub(crate) fn cast_wire_to_jobject(
     }
 }
 
-/// Reach a leaf's input by folding its accessor `path` over `base`, then hand
-/// the reached expression to `body` (which renders the encode and yields
-/// `JObject`). Every `Option`-returning nesting step becomes a `match`: its
-/// `None` arm short-circuits the whole leaf to `JObject::null()` (the value is
-/// absent ⇒ the leaf is null) — any number of `Option` steps on the path nest.
+/// Compose one [`PathStep`] onto the reference expression reached so far.
+/// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
+/// and re-borrows, so the result is a reference either way and steps chain
+/// uniformly.
+pub(crate) fn compose_step(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    step: &PathStep,
+    e: TokenStream,
+) -> TokenStream {
+    match step {
+        PathStep::Call { ident, .. } => {
+            let m = qualify(ident);
+            quote!(#m::#ident(#e))
+        }
+        PathStep::Field { ident, .. } => quote!(&(#e).#ident),
+    }
+}
+
+/// Start a reach from `base`, projecting the **leading run of plain field
+/// steps** directly (`&base.a.b`) instead of through a borrow of the base
+/// (`&(&base).a.b`). Returns the expression and how many steps it consumed.
+///
+/// The two forms name the same value, but the second borrows the base **as a
+/// whole**, which the borrow checker rejects once a sibling leaf has moved a
+/// different field out of it. Projecting directly makes each leaf's borrow
+/// disjoint, so a consuming value form's field moves are order-independent
+/// rather than compiling only while the borrowing leaves happen to be declared
+/// first.
+fn project_leading_fields(
+    base: &TokenStream,
+    base_is_ref: bool,
+    path: &[PathStep],
+) -> (TokenStream, usize) {
+    if base_is_ref {
+        return (base.clone(), 0);
+    }
+    let n = path.iter().take_while(|s| s.is_plain_field()).count();
+    if n == 0 {
+        return (quote!(&#base), 0);
+    }
+    let segs: Vec<&syn::Ident> = path[..n].iter().map(PathStep::ident).collect();
+    (quote!(&#base #(.#segs)*), n)
+}
+
+/// Fold a leaf's whole `path` over `base` with no optional-step handling, then
+/// apply the terminal treatment its [`LeafSource`] calls for: a `Field` leaf is
+/// **cloned** out of the place it reached, because its converter takes the field
+/// type as written (owned); every other leaf keeps the borrow its converter
+/// expects.
+///
+/// This is the derivation the single-leaf [`Delivery::Return`] shortcut uses
+/// (`emit/wrapper.rs`). It exists here, beside [`reach_leaf`], so the two are
+/// read and changed together: they drifted once already — the shortcut was
+/// missing the `Field` clone and handed `&F` to an `F` converter.
+///
+/// [`Delivery::Return`]: crate::api::core::unfold::Delivery::Return
+pub(crate) fn reach_leaf_flat(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    leaf: &crate::api::core::unfold::UnfoldLeaf,
+    path: &[PathStep],
+    base: TokenStream,
+    base_is_ref: bool,
+    consuming: bool,
+) -> TokenStream {
+    use crate::api::core::unfold::LeafSource;
+    // An optional step BEFORE the last one needs a `match` whose `None` arm has
+    // somewhere to go. This derivation has none — it yields a plain Rust value,
+    // not a `JObject` that could be null — so the shape is refused here rather
+    // than composed into code that cannot type-check in the consumer's crate.
+    assert!(
+        !path.iter().rev().skip(1).any(PathStep::is_optional),
+        "jnigen unfold: leaf `{}` reaches through an optional step but is \
+         delivered as a single return value, which has no `None` arm — this \
+         shape needs callback delivery",
+        leaf.name,
+    );
+    // Whether what this leaf reaches is OURS, and so is moved rather than
+    // borrowed or cloned. The two leaf kinds say it differently:
+    //
+    // * an IDENTITY leaf carries the answer in its `out_ty` — the plan resolved
+    //   it to the owned type exactly when the value is the plan's to give away
+    //   (`place_is_owned`: an owned root, or a field of a CONSUMING value form),
+    //   and that is also what selected the owning converter, which boxes the
+    //   move rather than cloning a borrow;
+    // * a FIELD leaf's `out_ty` is the field type as written, owned either way,
+    //   so ownership is the enclosing form's: only a consuming one gives its
+    //   fields away.
+    //
+    // A trailing `Option` step cannot arrive here at all: return delivery has
+    // no `None` arm for the absent case, so a nullable leaf is routed to
+    // callback delivery when the plan picks its `Delivery` — see
+    // `single_return` in `core/unfold.rs`. `is_plain_field` is what that rules
+    // out, and it stays as the local statement of the same fact.
+    let reached_is_ours = if leaf.identity {
+        !matches!(leaf.out_ty, syn::Type::Reference(_))
+    } else {
+        consuming
+    };
+    if reached_is_ours && path.iter().all(PathStep::is_plain_field) {
+        let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+        return quote!(#base #(.#segs)*);
+    }
+    let (mut e, lead) = project_leading_fields(&base, base_is_ref, path);
+    for step in &path[lead..] {
+        e = compose_step(qualify, step, e);
+    }
+    if leaf.source == LeafSource::Field {
+        quote!((#e).clone())
+    } else {
+        e
+    }
+}
+
+/// Every value form on a plan, evaluated **once** and bound to a local
+/// (`__vf0`, `__vf1`, …), so a struct is built once per delivery rather than
+/// once per field. The bound prefixes come back with the statements, since
+/// reaching a leaf means starting from the innermost local it sits under.
+///
+/// Shared by both delivery paths — the multi-leaf encoder below and the
+/// single-leaf `Delivery::Return` shortcut in `emit/wrapper.rs`. The shortcut
+/// used to compose its reach straight off the raw value, which for a consuming
+/// value form emitted `f(&v)` against a by-value receiver: ill-typed Rust in
+/// the consumer's crate. One binder, so the two cannot disagree about what a
+/// hoist is or who owns it.
+pub(crate) struct Hoisted {
+    /// The `let __vfN = …;` bindings, outermost-first.
+    pub(crate) stmts: TokenStream,
+    /// Each hoist's path prefix and the local it was bound to.
+    bound: Vec<(Vec<PathStep>, syn::Ident)>,
+    /// Whether each bound hoist consumed the value it decomposed.
+    consuming: Vec<bool>,
+}
+
+impl Hoisted {
+    /// The innermost bound local `path` sits under, with that prefix already
+    /// consumed, and whether that hoist gave its value away. `None` for a leaf
+    /// under no value form at all — a sibling `.field()` / `.field_self()`,
+    /// which still reaches from the value itself.
+    pub(crate) fn rebase(&self, path: &[PathStep]) -> Option<(syn::Ident, Vec<PathStep>, bool)> {
+        self.bound
+            .iter()
+            .enumerate()
+            .filter(|(_, (p, _))| p.len() < path.len() && path.starts_with(p))
+            .max_by_key(|(_, (p, _))| p.len())
+            .map(|(i, (p, id))| (id.clone(), path[p.len()..].to_vec(), self.consuming[i]))
+    }
+}
+
+pub(crate) fn bind_hoists(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    hoists: &[crate::api::core::unfold::Hoist],
+    value: &TokenStream,
+    by_ref: bool,
+) -> Hoisted {
+    let mut out = Hoisted {
+        stmts: TokenStream::new(),
+        bound: Vec::new(),
+        consuming: Vec::new(),
+    };
+    // Value forms COMPOSE, so each hoist is built from the longest hoist that
+    // is already a proper prefix of it (they arrive outermost-first), and from
+    // `value` otherwise.
+    for (i, h) in hoists.iter().enumerate() {
+        let local = format_ident!("__vf{}", i);
+        let (from, mut expr) = match out.rebase(&h.prefix) {
+            // A NESTED consuming form is handed the parent's field by MOVE: a
+            // hoisted value form is an owned struct and its fields are
+            // disjoint, so moving one out leaves every sibling leaf readable.
+            // `compose_step` borrows (`&(e).f`), so the field run to that field
+            // is projected here instead of going through it.
+            Some((outer, rest, _)) if h.consuming => {
+                let last = h.prefix.len() - 1;
+                let lead = &rest[..rest.len() - 1];
+                if lead.iter().all(PathStep::is_plain_field) {
+                    let segs: Vec<&syn::Ident> = lead.iter().map(PathStep::ident).collect();
+                    (last, quote!(#outer #(.#segs)*))
+                } else {
+                    // Reached through an accessor call, so what is in hand is a
+                    // borrow with nothing to give up — clone once and consume
+                    // the clone, exactly as a borrowed root does below.
+                    let mut e = quote!(&#outer);
+                    for step in lead {
+                        e = compose_step(qualify, step, e);
+                    }
+                    (last, quote!((#e).clone()))
+                }
+            }
+            Some((outer, rest, _)) => (h.prefix.len() - rest.len(), quote!(&#outer)),
+            // A CONSUMING value form is handed the value itself, so its fields
+            // move out instead of being cloned out of a borrow. A borrowed plan
+            // has no value to give up, so it clones first — the same cost the
+            // borrowing form of the accessor would have paid, which keeps one
+            // declaration usable by both owned and `&T` returns of the type.
+            None if h.consuming && by_ref => (0, quote!(#value.clone())),
+            None if h.consuming => (0, value.clone()),
+            None if by_ref => (0, value.clone()),
+            None => (0, quote!(&#value)),
+        };
+        for step in &h.prefix[from..] {
+            expr = compose_step(qualify, step, expr);
+        }
+        out.stmts.extend(quote! { let #local = #expr; });
+        out.bound.push((h.prefix.clone(), local));
+        out.consuming.push(h.consuming);
+    }
+    out
+}
+
+/// Reach a leaf's input by folding its `path` over `base`, then hand the
+/// reached expression to `body` (which renders the encode and yields
+/// `JObject`). Every optional nesting step becomes a `match`: its `None` arm
+/// short-circuits the whole leaf to `JObject::null()` (the value is absent ⇒
+/// the leaf is null) — any number of optional steps on the path nest.
 /// With `unwrap_last == false` the final path element composes directly — a
-/// non-identity leaf's converter takes the final accessor's **full** return
-/// type (`Option` included), so only the steps *before* it are nesting. An
+/// non-identity leaf's converter takes the final step's **full** type
+/// (`Option` included), so only the steps *before* it are nesting. An
 /// identity leaf (`unwrap_last == true`) delivers the reached value itself, so
 /// a final `Option` step unwraps too.
-#[allow(clippy::too_many_arguments)]
 fn reach_leaf(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    path: &[syn::Ident],
-    returns_option: &dyn Fn(&syn::Ident) -> bool,
+    path: &[PathStep],
     base: TokenStream,
     base_is_ref: bool,
     unwrap_last: bool,
@@ -336,28 +543,24 @@ fn reach_leaf(
     } else {
         path.len().saturating_sub(1)
     };
-    let mut e = if base_is_ref { base } else { quote!(&#base) };
-    match (0..limit).find(|&i| returns_option(&path[i])) {
-        // No (more) `Option` nesting steps: compose the rest plainly.
+    let (mut e, lead) = project_leading_fields(&base, base_is_ref, path);
+    match (lead..limit).find(|&i| path[i].is_optional()) {
+        // No (more) optional nesting steps: compose the rest plainly.
         None => {
-            for a in path {
-                let m = qualify(a);
-                e = quote!(#m::#a(#e));
+            for step in &path[lead..] {
+                e = compose_step(qualify, step, e);
             }
             body(e)
         }
         Some(k) => {
-            for a in &path[..k] {
-                let m = qualify(a);
-                e = quote!(#m::#a(#e));
+            for step in &path[lead..k] {
+                e = compose_step(qualify, step, e);
             }
-            let opt_acc = &path[k];
-            let opt_m = qualify(opt_acc);
+            let opt_e = compose_step(qualify, &path[k], e);
             let nested = format_ident!("__n{}", depth);
             let inner = reach_leaf(
                 qualify,
                 &path[k + 1..],
-                returns_option,
                 quote!(#nested),
                 true,
                 unwrap_last,
@@ -365,7 +568,7 @@ fn reach_leaf(
                 body,
             );
             quote! {
-                match #opt_m::#opt_acc(#e) {
+                match #opt_e {
                     ::core::option::Option::Some(#nested) => { #inner }
                     ::core::option::Option::None => jni::objects::JObject::null(),
                 }
@@ -394,13 +597,6 @@ pub(crate) fn encode_plan_leaves(
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
-    // A decomposed **sum** is the one plan whose leaves are not independent:
-    // only one group is live per value, so the whole list is emitted as ONE
-    // `match` rather than per-leaf expressions. Same contract, different
-    // emitter — see [`encode_sum_leaves`].
-    if is_sum_leaves(&plan.leaves) {
-        return encode_sum_leaves(ext, registry, plan, obj_idents, value, fail);
-    }
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
@@ -422,25 +618,80 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    // True when accessor `acc`'s return type is `Option<…>` (a nullable nesting
-    // step on a leaf's path).
-    let returns_option = |acc: &syn::Ident| -> bool {
-        registry.functions.get(acc).is_some_and(|(f, _)| match &f.sig.output {
-            syn::ReturnType::Type(_, t) => matches!(
-                &**t,
-                syn::Type::Path(tp) if tp.path.segments.last().is_some_and(|s| s.ident == "Option")
-            ),
-            _ => false,
-        })
-    };
+    let hoisted = bind_hoists(&qualify, &plan.hoists, value, by_ref);
+    let mut stmts = hoisted.stmts.clone();
 
-    let mut stmts = TokenStream::new();
-    let mut order: Vec<usize> = (0..n).filter(|&i| !plan.leaves[i].identity).collect();
-    order.extend((0..n).filter(|&i| plan.leaves[i].identity));
+    // Reach a leaf off the innermost value form it sits under, with that
+    // prefix's steps already consumed, and say whether that form CONSUMED its
+    // value — so the leaf owns its field and may move it out rather than clone
+    // it. A leaf under no value form at all (a sibling `.field()` /
+    // `.field_self()`) still reaches from the value itself.
+    let rebase =
+        |leaf: &crate::api::core::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>, bool) {
+            match hoisted.rebase(&leaf.path) {
+                Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
+                None => (value.clone(), by_ref, leaf.path.clone(), false),
+            }
+        };
+
+    // A decomposed **sum** is the one shape whose leaves are not independent:
+    // only one group is live per value, so its whole segment — the selector
+    // leaf plus the group leaves that follow it — is emitted as ONE `match`
+    // instead of per-leaf expressions. A plan may carry several: a sum that IS
+    // the returned value is the degenerate case of one segment covering
+    // everything, while a value form contributes one per sum-typed field.
+    let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
+        .filter(|&i| plan.leaves[i].source == crate::api::core::unfold::LeafSource::SumTag)
+        .map(|start| {
+            let end = (start + 1..n)
+                .take_while(|&i| plan.leaves[i].group.is_some())
+                .last()
+                .map_or(start + 1, |i| i + 1);
+            start..end
+        })
+        .collect();
+    for seg in &sum_segments {
+        let leaf = &plan.leaves[seg.start];
+        let (base, base_is_ref, path, _) = rebase(leaf);
+        // The value to `match` on. The selector's own path reaches the sum
+        // (empty when the sum IS the value); no step on it is optional, since
+        // an optional sum is refused where the leaves are built.
+        //
+        // A plain field chain is borrowed DIRECTLY (`&base.a.b`) rather than
+        // through the base (`&(&base).a.b`). The two are the same value, but
+        // the second borrows the base as a whole, which the borrow checker
+        // rejects once a sibling leaf has moved another field out of it — and
+        // borrowing this field while sibling fields move is exactly what a
+        // consuming value form does.
+        let (mut matched, lead) = project_leading_fields(&base, base_is_ref, &path);
+        for step in &path[lead..] {
+            matched = compose_step(&qualify, step, matched);
+        }
+        let (group_stmts, group_args) = encode_sum_group(
+            ext,
+            registry,
+            &plan.leaves[seg.clone()],
+            &obj_idents[seg.clone()],
+            matched,
+            fail,
+        );
+        stmts.extend(group_stmts);
+        for (k, e) in group_args.into_iter().enumerate() {
+            arg_exprs[seg.start + k] = e;
+        }
+    }
+
+    let in_sum = |i: usize| sum_segments.iter().any(|s| s.contains(&i));
+    let mut order: Vec<usize> = (0..n)
+        .filter(|&i| !plan.leaves[i].identity && !in_sum(i))
+        .collect();
+    order.extend((0..n).filter(|&i| plan.leaves[i].identity && !in_sum(i)));
 
     for idx in order {
         let leaf = &plan.leaves[idx];
         let obj_ident = &obj_idents[idx];
+        let (value, by_ref, path, consuming) = rebase(leaf);
+        let value = &value;
         let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
                 "jnigen unfold: leaf `{}` has no registered output converter",
@@ -510,25 +761,68 @@ pub(crate) fn encode_plan_leaves(
                     TypeKey::from_type(&leaf.out_ty)
                 )
             });
+            // The place this handle lives, when it is OURS to give away — the
+            // owned root, or a field of a CONSUMING value form, which handed its
+            // value over so its handle fields move out like every other field
+            // rather than being cloned through the borrowed converter (which
+            // would also demand a `Clone` the type need not have).
+            //
+            // Which it is was decided in the plan, not here: an owned `out_ty`
+            // IS the statement that this leaf owns what it reaches, and it is
+            // what selected the owning converter. `steps_are_movable` then says
+            // how to project it — a plain-field run directly, a trailing
+            // `Option` through the nullable branch's `match`, which moves the
+            // whole `Option` in rather than borrowing it.
+            let owned_place: Option<TokenStream> =
+                if !matches!(leaf.out_ty, syn::Type::Reference(_)) && steps_are_movable(&path) {
+                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                    Some(quote!(#value #(.#segs)*))
+                } else {
+                    None
+                };
             match proj.kind {
                 ProjectionKind::Handle => {
                     let handle_ident = format_ident!("__h{}", idx);
-                    if leaf.path.is_empty() && !by_ref {
-                        // Owned root, non-nullable by construction (nullable
-                        // comes from path nesting): move into a Box, raw jlong.
+                    if let (Some(place), false) = (&owned_place, leaf.nullable) {
+                        // Ours, and always present: move into a Box, raw jlong.
                         stmts.extend(quote! {
                             let #obj_ident: jni::sys::jvalue = jni::sys::jvalue {
-                                j: std::boxed::Box::into_raw(std::boxed::Box::new(#value))
+                                j: std::boxed::Box::into_raw(std::boxed::Box::new(#place))
                                     as jni::sys::jlong,
                             };
                         });
+                    } else if let Some(place) = &owned_place {
+                        // Ours, behind an `Option`: match the option BY VALUE so
+                        // the present handle is moved into its Box, boxed
+                        // `java.lang.Long` when present / JVM null when absent.
+                        // Matching `&place` here is what used to clone it back
+                        // through the borrowed converter.
+                        let box_fail = fail(quote!(__e.to_string()));
+                        stmts.extend(bind_obj(
+                            obj_ident,
+                            quote! {{
+                                match #place {
+                                    ::core::option::Option::Some(__n) => {
+                                        let #handle_ident: jni::sys::jlong =
+                                            std::boxed::Box::into_raw(std::boxed::Box::new(__n))
+                                                as jni::sys::jlong;
+                                        match ::prebindgen::lang::box_jlong(&mut env, #handle_ident) {
+                                            ::core::result::Result::Ok(__o) => __o,
+                                            ::core::result::Result::Err(__e) => {
+                                                #box_fail
+                                            }
+                                        }
+                                    }
+                                    ::core::option::Option::None => jni::objects::JObject::null(),
+                                }
+                            }},
+                        ));
                     } else if !leaf.nullable {
                         // Reached non-null handle: clone via the converter,
                         // raw jlong (no Option steps on the path).
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -551,8 +845,7 @@ pub(crate) fn encode_plan_leaves(
                         let box_fail = fail(quote!(__e.to_string()));
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -582,14 +875,13 @@ pub(crate) fn encode_plan_leaves(
                             jni::sys::jvalue { j: #enc_ident }
                         }}
                     };
-                    if leaf.path.is_empty() && !by_ref {
+                    if path.is_empty() && !by_ref {
                         let expr = encode(value.clone());
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else if !leaf.nullable {
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -601,8 +893,7 @@ pub(crate) fn encode_plan_leaves(
                         let box_fail = fail(quote!(__e.to_string()));
                         let expr = reach_leaf(
                             &qualify,
-                            &leaf.path,
-                            &returns_option,
+                            &path,
                             value.clone(),
                             by_ref,
                             true,
@@ -637,20 +928,38 @@ pub(crate) fn encode_plan_leaves(
         use crate::api::core::unfold::LeafSource;
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
             match &leaf.source {
-                LeafSource::Accessor => reach_leaf(
+                LeafSource::Accessor => {
+                    reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body)
+                }
+                // Under a CONSUMING value form the leaf owns its field, so it
+                // is **moved** out; the whole point of consuming is that this
+                // clone disappears. Each field is read by exactly one leaf, so
+                // the partial moves are disjoint — but nothing may then borrow
+                // the local as a whole, which is why the reach below projects
+                // the field directly rather than through `&(&local)`.
+                LeafSource::Field if consuming && path.iter().all(PathStep::is_plain_field) => {
+                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                    body(quote!(#value #(.#segs)*))
+                }
+                LeafSource::Field if path.iter().all(PathStep::is_plain_field) => {
+                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                    body(quote!(#value #(.#segs)*.clone()))
+                }
+                // A `.fields()` leaf reaches its field through the value-form
+                // accessor, so the path can be mixed: compose it like an
+                // accessor leaf — the final step composes directly, since the
+                // converter takes the field type as written (`Option` and all)
+                // — and clone the reached borrow, which is what a field leaf
+                // delivers.
+                LeafSource::Field => reach_leaf(
                     &qualify,
-                    &leaf.path,
-                    &returns_option,
+                    &path,
                     value.clone(),
                     by_ref,
                     false,
                     0,
-                    body,
+                    &|reached| body(quote!((#reached).clone())),
                 ),
-                LeafSource::Field => {
-                    let segs = &leaf.path;
-                    body(quote!(#value #(.#segs)*.clone()))
-                }
                 // Group leaves never reach this walk: a plan carrying them is
                 // routed to `encode_sum_leaves` at the top of this function,
                 // because a variant payload has no path — it is bound by a

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -83,11 +83,11 @@ pub(crate) fn synth_value_struct_leaves(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
-    path_prefix: &[syn::Ident],
+    path_prefix: &[crate::api::core::unfold::PathStep],
     name_prefix: &str,
     depth: usize,
 ) -> Option<Vec<crate::api::core::unfold::UnfoldLeaf>> {
-    use crate::api::core::unfold::{LeafSource, UnfoldLeaf};
+    use crate::api::core::unfold::{LeafSource, PathStep, UnfoldLeaf};
     if depth > 16 {
         return None;
     }
@@ -105,7 +105,10 @@ pub(crate) fn synth_value_struct_leaves(
             format!("{name_prefix}__{camel}")
         };
         let mut path = path_prefix.to_vec();
-        path.push(fname);
+        // The synthesizer declines `Option`-wrapped nesting below, so an
+        // intermediate step is never optional; a TERMINAL `Option` field is not
+        // a nesting step either (its own converter carries the nullability).
+        path.push(PathStep::field(fname, false));
 
         // A projection field (opaque handle) or an enum field
         // is delivered with a transform the fixed builder can't forward yet.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -50,14 +50,17 @@ pub(crate) fn synth_sum_leaves(
     };
 
     let spec = SumSpec::from_item_enum(item_enum);
-    // The selector rides ahead of the groups it chooses between. Its `out_ty`
-    // documents the wire (`i32` → `jint` → Kotlin `Int`); nothing looks up a
-    // converter for it, because there is no value to convert — the emitter
-    // assigns the tag literal per arm.
+    // The selector rides ahead of the groups it chooses between, and carries
+    // **which sum** it selects over as its `out_ty` — that is how the emitter
+    // finds the enum to `match` when the sum is a field rather than the whole
+    // returned value. Nothing looks up a converter for it (`has_converter()` is
+    // false for a `SumTag`): there is no value to convert, the emitter assigns
+    // the tag literal per arm. Its wire is a `jint` by definition.
+    let enum_ident = &item_enum.ident;
     let mut leaves = vec![UnfoldLeaf {
         name: SUM_TAG_LEAF.to_string(),
         path: Vec::new(),
-        out_ty: syn::parse_quote!(i32),
+        out_ty: syn::parse_quote!(#enum_ident),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,
@@ -96,27 +99,38 @@ pub(crate) fn is_sum_leaves(leaves: &[crate::api::core::unfold::UnfoldLeaf]) -> 
 /// pattern's payload bindings, every other group from the same wire defaults an
 /// absent `Option<nested>` uses.
 ///
+/// `leaves` is ONE sum's segment — its [`LeafSource::SumTag`] selector followed
+/// by that selector's group leaves — with `obj_idents` the matching slice of
+/// slot locals. `matched` is the expression to `match` on (a reference to the
+/// value), which is the whole returned value when the sum IS the return, and
+/// the reached field when a value form carries it.
+///
 /// The signature mirrors [`encode_plan_leaves`](super::encode_plan_leaves), and
 /// the two are interchangeable at the call site: both bind `obj_idents` and
 /// return the per-leaf `jvalue` argument expressions in leaf order. What differs
 /// is that a leaf here is not an independent expression — its slot exists in
 /// every arm and only one arm computes it.
-pub(crate) fn encode_sum_leaves(
+pub(crate) fn encode_sum_group(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,
-    plan: &crate::api::core::unfold::UnfoldPlan,
+    leaves: &[crate::api::core::unfold::UnfoldLeaf],
     obj_idents: &[syn::Ident],
-    value: &TokenStream,
+    matched: TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> (TokenStream, Vec<TokenStream>) {
     use crate::api::core::unfold::LeafSource;
 
-    let leaves = &plan.leaves;
-    // Qualified path of the source enum, for the arm patterns.
-    let ident = bare_path_ident(&plan.source).unwrap_or_else(|| {
+    // Which sum this is comes from the selector leaf, not from the plan's
+    // source: the plan's source is the *containing* value when the sum is a
+    // field of a value form.
+    let tag_leaf = leaves
+        .iter()
+        .find(|l| l.source == LeafSource::SumTag)
+        .expect("a sum segment carries its selector leaf");
+    let ident = bare_path_ident(&tag_leaf.out_ty).unwrap_or_else(|| {
         panic!(
-            "jnigen sum unfold: source `{}` is not a path type",
-            TypeKey::from_type(&plan.source)
+            "jnigen sum unfold: selector type `{}` is not a path type",
+            TypeKey::from_type(&tag_leaf.out_ty)
         )
     });
     let module = ext.fn_module(registry, &ident);
@@ -268,14 +282,6 @@ pub(crate) fn encode_sum_leaves(
         })
         .collect();
 
-    // A borrowed value is matched as-is; an owned one is matched by reference
-    // so each payload can be cloned out of it (the same reach a struct field
-    // leaf uses).
-    let matched = if plan.by_ref {
-        value.clone()
-    } else {
-        quote!(&#value)
-    };
     let stmts = quote! {
         #decls
         match #matched { #(#arms)* }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -210,13 +210,23 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let uplan = unfold_plan.expect("is_convert ⇒ plan");
         let leaf = &uplan.leaves[0];
         let by_ref = uplan.by_ref;
+        // One derivation, shared with the multi-leaf encoder — the value forms
+        // are bound by the same [`bind_hoists`] and the leaf reached by the
+        // same [`reach_leaf_flat`]. Deriving either a second time here is what
+        // let the two drift apart: this shortcut used to compose its reach
+        // straight off the raw value, which for a value form declared with
+        // `.fields_self_into(..)` emitted `f(&v)` against a by-value receiver.
+        let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
         let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
-            let mut e = if base_is_ref { base } else { quote!(&#base) };
-            for a in &leaf.path {
-                let m = ext.fn_module(registry, a);
-                e = quote!(#m::#a(#e));
-            }
-            e
+            let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
+            let stmts = &hoisted.stmts;
+            let reached = match hoisted.rebase(&leaf.path) {
+                Some((local, rest, consuming)) => {
+                    reach_leaf_flat(&qualify, leaf, &rest, quote!(#local), false, consuming)
+                }
+                None => reach_leaf_flat(&qualify, leaf, &leaf.path, base, base_is_ref, false),
+            };
+            quote!({ #stmts #reached })
         };
         match &uplan.shape {
             UnfoldShape::Optional((), _) => {

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -22,7 +22,7 @@
 //! determinism is a checked invariant rather than a convention.
 
 use super::*;
-use crate::api::core::unfold::{dedup_names, DeconId, UnfoldPlan};
+use crate::api::core::unfold::{dedup_names, DeconId, LeafSource, UnfoldPlan};
 
 /// The JVM-visible single method name of every generated callback interface.
 pub(crate) const IFACE_METHOD: &str = "run";
@@ -1141,15 +1141,54 @@ pub(crate) fn callback_iface_spec(
                 });
             } else {
                 // Accessor-plan arg: each leaf is its own passthrough group, so
-                // the user callback still sees the flattened leaves (unchanged).
-                for n in &leaf_names {
-                    groups.push(GroupDesc {
-                        name: n.clone(),
-                        typed: None,
-                        reassemble: None,
-                        imports: Vec::new(),
-                        leaf_count: 1,
-                    });
+                // the user callback still sees the flattened leaves (unchanged)
+                // — EXCEPT a sum segment, whose selector and group slots are one
+                // value and collapse into a single typed parameter rebuilt by a
+                // `when` over the tag. Handing those slots over raw would defeat
+                // the `sealed_class!` the sum was declared as.
+                let mut k = 0usize;
+                while k < plan.leaves.len() {
+                    let leaf = &plan.leaves[k];
+                    let seg = if leaf.source == LeafSource::SumTag {
+                        (k + 1..plan.leaves.len())
+                            .take_while(|&j| plan.leaves[j].group.is_some())
+                            .last()
+                            .map_or(k + 1, |j| j + 1)
+                    } else {
+                        k + 1
+                    };
+                    if leaf.source == LeafSource::SumTag {
+                        any_fixed = true;
+                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(&leaf.out_ty))?;
+                        let (reassemble, imports) = fixed_reassembly(
+                            ext,
+                            registry,
+                            &leaf.out_ty,
+                            &plan.leaves[k..seg],
+                            &fqn,
+                        );
+                        groups.push(GroupDesc {
+                            // The tag leaf is named `<field>__tag`; the value it
+                            // selects over is that field.
+                            name: leaf_names[k]
+                                .strip_suffix(&format!("__{SUM_TAG_LEAF}"))
+                                .unwrap_or(&leaf_names[k])
+                                .to_string(),
+                            typed: Some(kt::KtType::cls(fqn.to_string())),
+                            reassemble: Some(reassemble),
+                            imports,
+                            leaf_count: seg - k,
+                        });
+                    } else {
+                        groups.push(GroupDesc {
+                            name: leaf_names[k].clone(),
+                            typed: None,
+                            reassemble: None,
+                            imports: Vec::new(),
+                            leaf_count: 1,
+                        });
+                    }
+                    k = seg;
                 }
             }
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -33,6 +33,7 @@ mod niches;
 mod sealed;
 mod snapshots;
 mod symbols;
+mod value_form;
 mod values;
 
 /// Build a `TypeEntry` for use in tests. The function body is not

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1125,6 +1125,115 @@ fn sum_return_group_can_own_a_handle() {
     );
 }
 
+/// The same handle payload as a **data-class field** — the position the
+/// return/callback coverage above does not reach, and the one
+/// `ReplyStruct { result: ReplyResult, .. }` needs (both `ReplyResult`
+/// alternatives carry handles).
+///
+/// The group slot stays the raw `jlong` and the live arm wraps it into the
+/// typed handle class, exactly as in return position — the parent's own
+/// `fromParts` inlining the `when`.
+///
+/// Two consequences of this position, both asserted below so they cannot
+/// change silently:
+///
+/// * The container is **not** `AutoCloseable` — `destructible()` matches only
+///   a `Projection` field, never a `Sum` one. That follows the documented
+///   ownership rule for sum payloads ("who closes a handle payload: the
+///   receiver"), but it does differ from a plain handle field, which *does*
+///   make its class closeable and cascades. The handle stays reachable and
+///   closeable through the variant (`(h.outcome as Lookup.Found).v0.close()`);
+///   what is absent is the cascade.
+/// * A sum field takes its parent off the fixed-builder path onto the
+///   whole-value `fromParts` bridge (`synth_value_struct_leaves` declines
+///   `TypeKind::Sum`), so the value costs a JVM object — a slower shape, not a
+///   broken one.
+#[test]
+fn a_data_class_field_may_be_a_sum_carrying_a_handle() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub id: i64,
+                    pub outcome: Lookup,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_new(id: i64) -> Holder {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
+        crate::package!()
+            .class(crate::ptr_class!(Probe))
+            .class(crate::sealed_class!(Lookup))
+            .class(crate::data_class!(Holder))
+            .fun(crate::fun!(holder_new)),
+    );
+    let dir = unique_test_dir("jnigen_sum_handle_field");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // The tag keeps the `__` marker; a group slot is prefixed with its field
+    // by the single-underscore nesting convention (`mode_periodicQueries_period`).
+    assert!(
+        kotlin.contains("outcome__tag: Int") && kotlin.contains("outcome_found_v0: Long"),
+        "the selector plus a raw-pointer group slot, both prefixed by the field:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("Lookup.Found(Probe(outcome_found_v0))"),
+        "the parent's fromParts inlines the `when` and wraps the pointer:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("public data class Holder(val id: Long, val outcome: Lookup)"),
+        "the field surfaces as the typed sum:\n{kotlin}"
+    );
+    assert!(
+        !kotlin.contains("Holder(val id: Long, val outcome: Lookup) : AutoCloseable"),
+        "a sum-carried handle is the RECEIVER's to close — the container does \
+         not cascade, unlike a plain handle field:\n{kotlin}"
+    );
+    assert!(
+        rust.contains("Lookup::Found") && rust.contains("Lookup::Absent"),
+        "Rust matches the field's sum, filling every group's slots:\n{rust}"
+    );
+}
+
 /// TWO sums in one callback signature: each contributes its own selector, so
 /// the signature-wide dedup renames the second to `tag2` — and the reassembly
 /// expressions must follow it, including the `$tag` Kotlin string template in

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -1,0 +1,1626 @@
+//! `expand_return!(T).fields(fields!(t_to_struct))` — deriving a type's output
+//! boundary from its **value form** (the struct gathering its own accessors)
+//! instead of restating the field list, which is how the two drift apart.
+//!
+//! The contract each test below pins down: `.fields()` is `.field()` applied to
+//! every struct field, so a field still crosses by **its own type's** default
+//! output boundary.
+
+use super::*;
+
+/// The value-form fixture: a `ZSample` handle whose fields cover the shapes
+/// that decide behaviour — a handle field with its own `expand_return!`
+/// (decomposed, not handed over raw), a scalar, an `Option<data class>`, a
+/// non-optional nested data class (inlined), and an `Option<handle>`.
+fn value_form_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = myflat_loc();
+    vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZStamp {
+                    pub secs: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOrigin {
+                    pub node: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZSampleStruct {
+                    pub key_expr: ZKeyExpr,
+                    pub payload: ZBytes,
+                    pub express: bool,
+                    pub stamp: Option<ZStamp>,
+                    pub origin: ZOrigin,
+                    pub attachment: Option<ZBytes>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ]
+}
+
+/// Build the fixture through `JniGen`, letting the caller adjust the
+/// `ZSample` boundary decl. Returns the generated Rust + the joined Kotlin.
+fn value_form_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> (String, String) {
+    let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZSample))
+                .class(crate::ptr_class!(ZKeyExpr))
+                .class(crate::ptr_class!(ZBytes))
+                .class(crate::data_class!(ZStamp))
+                .class(crate::data_class!(ZOrigin))
+                .fun(crate::fun!(z_sample_sub)),
+        )
+        // A KeyExpr crosses as its string, never as a handle — the rule a
+        // `.fields()` expansion has to keep honouring for the `key_expr` field.
+        .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+        .expand(decl);
+
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (rust, kotlin)
+}
+
+/// The headline: `.fields(fields!(f))` produces the leaves the fields' own
+/// boundaries dictate, NOT one leaf per field.
+///
+/// Read the expected signature field by field — each is a different rule:
+/// `key_expr` splices `ZKeyExpr`'s own decl (a String, not a handle);
+/// `express` is a scalar; `stamp` behind `Option` stays one data-class leaf;
+/// `origin` is a non-optional data class and INLINES (`origin__node`);
+/// `payload` / `attachment` have no decl of their own, so they stay handles.
+#[test]
+fn fields_expand_by_each_field_s_own_boundary() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_basic",
+        crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)),
+    );
+    assert!(
+        kotlin.contains("keyExpr__zKeyexprAsStr: String"),
+        "a field whose type has its own expand_return! is decomposed by it, \
+         not handed over as a handle:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("express: Boolean"),
+        "a scalar field is one leaf:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("stamp: ZStamp?"),
+        "an Option<data class> field stays ONE leaf (its converter builds it):\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("origin__node: Long"),
+        "a non-optional nested data class INLINES into its own fields:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("payload: ZBytes") && kotlin.contains("attachment: ZBytes?"),
+        "a handle field with no boundary decl stays a handle, nullable under Option:\n{kotlin}"
+    );
+}
+
+/// The value form is called ONCE per delivery. Without the hoist each field
+/// would rebuild the whole struct — cloning every field once per leaf — which
+/// is exactly the per-message cost `expand_return` exists to avoid.
+#[test]
+fn the_value_form_accessor_is_called_once() {
+    let (rust, _) = value_form_gen(
+        "jnigen_vf_hoist",
+        crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)),
+    );
+    let calls = rust.matches("z_sample_to_struct").count();
+    assert_eq!(
+        calls, 1,
+        "the value form is bound to one local and every leaf reaches off it; \
+         found {calls} calls in:\n{rust}"
+    );
+}
+
+/// An `Option` field with nothing decomposed below it crosses **whole** — its
+/// own converter takes the `Option`. Unwrapping it to reach the inner value
+/// would hand `ZStamp` to a converter typed `Option<ZStamp>`: a mismatch the
+/// Kotlin signature cannot show, because it reads `ZStamp?` either way.
+#[test]
+fn an_optional_field_reaches_its_converter_whole() {
+    let (rust, _) = value_form_gen(
+        "jnigen_vf_opt",
+        crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)),
+    );
+    for field in ["stamp", "attachment"] {
+        assert!(
+            rust.contains(&format!(".{field}.clone()")),
+            "`{field}` must be cloned whole, not matched open:\n{rust}"
+        );
+        assert!(
+            !rust.contains(&format!(".{field} {{")),
+            "`{field}` has nothing decomposed below it, so it is not a nesting \
+             step — no `match` on it:\n{rust}"
+        );
+    }
+}
+
+/// A hand-written field list and the derived one are the SAME leaves — the
+/// property that makes adopting `.fields()` a no-op on the wire, and the whole
+/// reason it can be trusted to replace a list that has drifted.
+#[test]
+fn deriving_matches_the_equivalent_hand_written_list() {
+    let items = value_form_items();
+    let accessors: Vec<(syn::Item, crate::SourceLocation)> = {
+        let loc = myflat_loc();
+        vec![
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_express(s: &ZSample) -> bool {
+                        unimplemented!()
+                    }
+                )),
+                loc,
+            ),
+        ]
+    };
+
+    let leaves_of = |decl: crate::lang::ExpandReturnDecl,
+                     extra: Vec<(syn::Item, crate::SourceLocation)>|
+     -> Vec<(String, String)> {
+        let mut all = items.clone();
+        all.extend(extra);
+        let registry = Registry::<KotlinMeta>::from_items(all).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .class(crate::ptr_class!(ZBytes))
+                    .class(crate::data_class!(ZStamp))
+                    .class(crate::data_class!(ZOrigin))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(decl);
+        let gen = registry.resolve(jni).expect("resolve");
+        gen.registry()
+            .callback_arg_plans
+            .values()
+            .flat_map(|p| p.leaves.iter())
+            .map(|l| (l.name.clone(), l.out_ty.to_token_stream().to_string()))
+            .collect()
+    };
+
+    // The two fields the hand-written list can state with real accessors.
+    let derived = leaves_of(
+        crate::expand_return!(ZSample).fields(
+            crate::fields!(z_sample_to_struct)
+                .name("key_expr", "keyExpr")
+                .name("express", "express"),
+        ),
+        vec![],
+    );
+    let by_hand = leaves_of(
+        crate::expand_return!(ZSample)
+            .field(crate::fun!(z_sample_key_expr).name("keyExpr"))
+            .field(crate::fun!(z_sample_express).name("express")),
+        accessors,
+    );
+
+    let take = |v: &[(String, String)], n: &str| -> Option<(String, String)> {
+        v.iter().find(|(name, _)| name.starts_with(n)).cloned()
+    };
+    for prefix in ["keyExpr", "express"] {
+        assert_eq!(
+            take(&derived, prefix).map(|(n, _)| n),
+            take(&by_hand, prefix).map(|(n, _)| n),
+            "derived and hand-written leaves must agree on `{prefix}`\n\
+             derived: {derived:?}\nby hand: {by_hand:?}"
+        );
+    }
+}
+
+/// A per-field override replaces that field's type default wholesale — here
+/// keeping the raw `ZKeyExpr` handle instead of its declared string form.
+#[test]
+fn a_per_field_override_replaces_the_type_default() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_override",
+        crate::expand_return!(ZSample).fields(
+            crate::fields!(z_sample_to_struct)
+                .field("key_expr", crate::expand_return!(ZKeyExpr).field_self()),
+        ),
+    );
+    assert!(
+        kotlin.contains("keyExpr: ZKeyExpr"),
+        "the override wins over ZKeyExpr's type-level decl:\n{kotlin}"
+    );
+    assert!(
+        !kotlin.contains("keyExpr__zKeyexprAsStr"),
+        "the overridden field must NOT also carry the type default:\n{kotlin}"
+    );
+}
+
+/// A rename keys on the Rust field ident and reaches an inlined nested field
+/// through its dotted path.
+#[test]
+fn a_field_can_be_renamed_including_a_nested_one() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_rename",
+        crate::expand_return!(ZSample).fields(
+            crate::fields!(z_sample_to_struct)
+                .name("express", "fast")
+                .name("origin.node", "nodeId"),
+        ),
+    );
+    assert!(
+        kotlin.contains("fast: Boolean"),
+        "a renamed field uses the literal name:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("origin__nodeId: Long"),
+        "a nested field is renamed through its dotted path, keeping the prefix:\n{kotlin}"
+    );
+}
+
+/// `.fields()` mixes with the other declarators — the value form's fields
+/// *and* the live handle, which is the `Query`-style shape.
+#[test]
+fn fields_mixes_with_field_self() {
+    let (_, kotlin) = value_form_gen(
+        "jnigen_vf_mixed",
+        crate::expand_return!(ZSample)
+            .fields(crate::fields!(z_sample_to_struct))
+            .field_self(),
+    );
+    assert!(
+        kotlin.contains("express: Boolean") && kotlin.contains("handle: ZSample"),
+        "the derived fields and the identity leaf are delivered together:\n{kotlin}"
+    );
+}
+
+/// A **sum** field decomposes into its selector plus one group per
+/// alternative, right there among its sibling fields — a sum has no
+/// whole-value converter, so this is the only way it can cross at all. The
+/// `ReplyStruct { result: ReplyResult, .. }` shape.
+fn sum_field_gen(tag: &str) -> (String, String) {
+    let loc = myflat_loc();
+    let mut items = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum ZOutcome {
+                    Empty,
+                    Ok(ZBytes),
+                    Failed(String),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReplyStruct {
+                    pub result: ZOutcome,
+                    pub seq: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_reply_to_struct(r: &ZReply) -> ZReplyStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    items.push((
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn z_reply_sub(cb: impl Fn(ZReply) + Send + Sync + 'static) {
+                unimplemented!()
+            }
+        )),
+        loc,
+    ));
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZReply))
+                .class(crate::ptr_class!(ZBytes))
+                .class(crate::sealed_class!(ZOutcome))
+                .fun(crate::fun!(z_reply_sub)),
+        )
+        .expand(crate::expand_return!(ZReply).fields(crate::fields!(z_reply_to_struct)));
+
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (rust, kotlin)
+}
+
+#[test]
+fn a_sum_field_crosses_as_its_selector_and_groups() {
+    let (rust, kotlin) = sum_field_gen("jnigen_vf_sum");
+    assert!(
+        kotlin.contains("result__tag: Int"),
+        "the sum field contributes its selector, prefixed by the field:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("result__ok_v0: Long") && kotlin.contains("result__failed_v0: String?"),
+        "one group slot per alternative payload, object slots nullable \
+         (an inert group arrives as null):\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("seq: Long"),
+        "a sibling field is unaffected:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("ZOutcome.Ok(") && kotlin.contains("ZOutcome.Failed("),
+        "the receiver rebuilds the live alternative from the tag:\n{kotlin}"
+    );
+    assert!(
+        rust.contains("myflat::ZOutcome::Ok") && rust.contains("myflat::ZOutcome::Failed"),
+        "Rust matches the sum once, filling every group's slots:\n{rust}"
+    );
+}
+
+/// A sum's slots sit at a FIXED position in the leaf list, so the two shapes
+/// that would move or repeat them are refused by name rather than mis-emitted:
+/// `Vec<sum>` has variable arity, and `Option<sum>` would need a present flag
+/// beside the tag that an output leaf list cannot carry.
+#[test]
+fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| {
+        let items = vec![
+            (
+                syn::Item::Enum(syn::parse_quote!(
+                    pub enum ZOutcome {
+                        Empty,
+                        Failed(String),
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZReplyStruct {
+                        pub result: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_reply_to_struct(r: &ZReply) -> ZReplyStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_reply_sub(cb: impl Fn(ZReply) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZReply))
+                    .class(crate::sealed_class!(ZOutcome))
+                    .fun(crate::fun!(z_reply_sub)),
+            )
+            .expand(crate::expand_return!(ZReply).fields(crate::fields!(z_reply_to_struct)));
+        let dir = unique_test_dir("jnigen_vf_sum_reject");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+
+    for (ty, want) in [
+        (syn::parse_quote!(Vec<ZOutcome>), "variable arity"),
+        (syn::parse_quote!(Option<ZOutcome>), "present flag"),
+    ] {
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build(ty)))
+            .expect_err("a sum behind Option/Vec must be rejected");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(msg.contains(want), "expected `{want}` in: {msg}");
+        assert!(
+            msg.contains("ZReplyStruct.result"),
+            "the message names the offending field: {msg}"
+        );
+    }
+}
+
+/// Naming a field the value form does not have is the very drift this
+/// declarator exists to catch, so it is an error rather than a silent no-op.
+#[test]
+fn an_adjustment_naming_an_unknown_field_is_an_error() {
+    let build = |decl: crate::lang::FieldsDecl| {
+        let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .class(crate::ptr_class!(ZBytes))
+                    .class(crate::data_class!(ZStamp))
+                    .class(crate::data_class!(ZOrigin))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(crate::expand_return!(ZSample).fields(decl));
+        let dir = unique_test_dir("jnigen_vf_unknown");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+
+    for decl in [
+        crate::fields!(z_sample_to_struct).name("kex", "kex"),
+        crate::fields!(z_sample_to_struct)
+            .field("kex", crate::expand_return!(ZKeyExpr).field_self()),
+    ] {
+        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build(decl)))
+            .expect_err("an unknown field name must be rejected");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(msg.contains("kex"), "the message names the field: {msg}");
+        assert!(
+            msg.contains("ZSampleStruct"),
+            "the message names the value form: {msg}"
+        );
+    }
+}
+
+/// One value form states the whole field set: a second `.fields()` would make
+/// the leaf order depend on declaration order for no gain.
+#[test]
+#[should_panic(expected = "already expands a value form")]
+fn a_second_value_form_is_an_error() {
+    let _ = crate::expand_return!(ZSample)
+        .fields(crate::fields!(z_sample_to_struct))
+        .fields(crate::fields!(z_sample_to_struct));
+}
+
+/// Repeating an adjustment for one field is a declaration bug — the complete
+/// set rule, same as `.expand_param` / `.field`.
+#[test]
+#[should_panic(expected = "already has an override")]
+fn a_repeated_override_is_an_error() {
+    let _ = crate::fields!(z_sample_to_struct)
+        .field("key_expr", crate::expand_return!(ZKeyExpr).field_self())
+        .field("key_expr", crate::expand_return!(ZKeyExpr).field_self());
+}
+
+/// `"__"` is the reserved chain separator, so an author-supplied rename may
+/// not smuggle one in and forge a nesting that isn't there.
+#[test]
+#[should_panic(expected = "reserved")]
+fn a_rename_may_not_contain_the_chain_separator() {
+    let _ = crate::fields!(z_sample_to_struct).name("express", "a__b");
+}
+
+// ── Review findings on #221 ──────────────────────────────────────────────────
+
+/// A **single-leaf** value form takes the `Delivery::Return` shortcut, whose
+/// reach is composed separately from the multi-leaf encoder
+/// (`emit/wrapper.rs`'s `is_convert` path). That path must still give a plain
+/// field leaf the owned value its converter is typed for: composing the field
+/// as a borrow feeds `&i64` to the `i64` converter, and for a non-`Copy` field
+/// borrows out of the temporary the value-form call returned.
+#[test]
+fn a_single_leaf_value_form_delivers_an_owned_field() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOneStruct {
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_to_struct(o: &ZOne) -> ZOneStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_make(n: i64) -> ZOne {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOne))
+                .fun(crate::fun!(z_one_make)),
+        )
+        .expand(crate::expand_return!(ZOne).fields(crate::fields!(z_one_to_struct)));
+    let dir = unique_test_dir("jnigen_vf_single");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains(".label).clone()"),
+        "the single leaf is CLONED out of the value form, matching the owned \
+         `String` its converter takes — composing it as a borrow would feed \
+         `&String` to a `String` converter:\n{rust}"
+    );
+}
+
+/// The same shortcut with a CONSUMING form. It composed its reach straight off
+/// the raw value and never looked at the plan's hoists, so it emitted
+/// `z_one_into_struct(&__cvsrc)` against a by-value receiver — Rust that does
+/// not compile in the consumer's crate — and then cloned a field it owns. Both
+/// paths now bind hoists with the same `bind_hoists`, so neither can drift from
+/// the other again.
+#[test]
+fn a_single_leaf_consuming_value_form_moves_its_field() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOneStruct {
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_into_struct(o: ZOne) -> ZOneStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_one_make(n: i64) -> ZOne {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOne))
+                .fun(crate::fun!(z_one_make)),
+        )
+        .expand(crate::expand_return!(ZOne).fields_self_into(crate::fields!(z_one_into_struct)));
+    let dir = unique_test_dir("jnigen_vf_single_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("z_one_into_struct(__cvsrc)") && !rust.contains("z_one_into_struct(&"),
+        "the by-value accessor is handed the value, not a borrow of it:\n{rust}"
+    );
+    assert!(
+        rust.contains(".label") && !rust.contains(".label).clone()"),
+        "and the field it owns is MOVED out, not cloned:\n{rust}"
+    );
+}
+
+/// A handle field of a consuming value form is the value form's field like any
+/// other: the form gave its value away, so the handle **moves** into its Box
+/// rather than being cloned through the borrowed-opaque converter — which also
+/// stops `.fields_self_into(..)` from silently requiring a `Clone` the handle type
+/// need not have.
+///
+/// The identity branch computed `consuming` and then returned before using it,
+/// so every reached handle took the clone arm; only a handle at the owned ROOT
+/// (empty path) moved.
+#[test]
+fn a_handle_field_of_a_consuming_value_form_moves() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZEnvelopeStruct {
+                    pub child: ZChild,
+                    pub tag: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_envelope_into_struct(e: ZEnvelope) -> ZEnvelopeStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_envelope_sub(cb: impl Fn(ZEnvelope) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZEnvelope))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_envelope_sub)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZEnvelope)
+                .fields_self_into(crate::fields!(z_envelope_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_handle_field_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("Box::new(__vf0.child)"),
+        "the handle field is MOVED into its Box:\n{rust}"
+    );
+    assert!(
+        !rust.contains("&__vf0.child"),
+        "and is not handed to the borrowed-opaque converter, which would clone \
+         it:\n{rust}"
+    );
+}
+
+/// The cross-product of the two above: a value form whose SOLE field is a
+/// handle. That takes the single-leaf `Delivery::Return` shortcut with an
+/// *identity* leaf, so neither the multi-leaf handle test (which is a callback
+/// plan) nor the single-leaf `String` test (a `Field` leaf) covered it, and the
+/// shortcut handed the borrowed converter `&__vf0.child`.
+///
+/// The fix is in the PLAN, not in the shortcut: an identity leaf under a
+/// consuming form resolves its `out_ty` to the OWNED type, which both selects
+/// the owning converter and tells every emitter it may move.
+#[test]
+fn a_sole_handle_field_of_a_consuming_value_form_moves() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZSingleEnvelopeStruct {
+                    pub child: ZChild,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_single_envelope_into_struct(e: ZSingleEnvelope) -> ZSingleEnvelopeStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_single_envelope_make() -> ZSingleEnvelope {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZSingleEnvelope))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_single_envelope_make)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZSingleEnvelope)
+                .fields_self_into(crate::fields!(z_single_envelope_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_sole_handle_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("z_single_envelope_into_struct(__cvsrc)"),
+        "the by-value accessor is handed the value:\n{rust}"
+    );
+    assert!(
+        rust.contains("__vf0.child") && !rust.contains("&__vf0.child"),
+        "and the sole handle field is MOVED out, not borrowed into the \
+         cloning converter:\n{rust}"
+    );
+}
+
+/// An `Option<Handle>` field is the same claim behind an `Option` — and the
+/// commonest shape there is (`SampleStruct.attachment`). The consuming form
+/// owns the whole `Option`, so it is matched BY VALUE and the present handle
+/// moves into its Box; only the *reach* differs from the non-optional case, not
+/// the ownership.
+#[test]
+fn an_optional_handle_field_of_a_consuming_value_form_moves() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOptionalEnvelopeStruct {
+                    pub child: Option<ZChild>,
+                    pub tag: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_envelope_into_struct(
+                    e: ZOptionalEnvelope,
+                ) -> ZOptionalEnvelopeStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_envelope_sub(
+                    cb: impl Fn(ZOptionalEnvelope) + Send + Sync + 'static,
+                ) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOptionalEnvelope))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_optional_envelope_sub)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZOptionalEnvelope)
+                .fields_self_into(crate::fields!(z_optional_envelope_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_optional_handle_consume");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        rust.contains("match __vf0.child") && !rust.contains("&__vf0.child"),
+        "the `Option` is matched BY VALUE, not borrowed:\n{rust}"
+    );
+    assert!(
+        rust.contains("Box::new(__n)"),
+        "and the present handle is MOVED into its Box rather than cloned \
+         through the borrowed converter:\n{rust}"
+    );
+}
+
+/// The cross-product of the two above: a value form whose SOLE field is an
+/// `Option<Handle>`. Delivery was chosen on leaf COUNT alone, so this landed on
+/// the flat `Delivery::Return` path — which has no `None` arm, and whose
+/// `convert_out_ty` names the leaf's own type rather than an optional of it, so
+/// it composed `&(&__vf0).child` into a converter typed for `ZChild`.
+///
+/// A nullable leaf now goes to callback delivery, which has that arm already.
+/// Absence is a delivery question, not an ownership one — making `out_ty` owned
+/// says who frees the handle, not whether there is one.
+#[test]
+fn a_sole_optional_handle_field_takes_callback_delivery() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOptionalSingleStruct {
+                    pub child: Option<ZChild>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_single_into_struct(e: ZOptionalSingle) -> ZOptionalSingleStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_optional_single_make() -> ZOptionalSingle {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOptionalSingle))
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_optional_single_make)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self())
+        .expand(
+            crate::expand_return!(ZOptionalSingle)
+                .fields_self_into(crate::fields!(z_optional_single_into_struct)),
+        );
+    let dir = unique_test_dir("jnigen_vf_sole_optional_handle");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        !rust.contains("&(&__vf0).child") && !rust.contains("&__vf0.child"),
+        "the optional field is never composed as a borrow — that is what the \
+         flat return path did, handing `&Option<ZChild>` to a `ZChild` \
+         converter:\n{rust}"
+    );
+    assert!(
+        rust.contains("match __vf0.child") && rust.contains("Box::new(__n)"),
+        "it takes callback delivery, whose `None` arm exists, and the present \
+         handle still moves:\n{rust}"
+    );
+}
+
+/// A ROOT identity leaf owns its value with no value form in sight — a plain
+/// `-> ZChild` return under the type-level `expand_return!(ZChild).field_self()`
+/// that exists so the same boundary can be spliced as a value-form field. The
+/// flat return path tied its move to the rebased hoist's `consuming` flag,
+/// which is `false` when there is no hoist, so it emitted `&__cvsrc` into the
+/// owning `ZChild`-to-jlong converter.
+///
+/// Ownership is not "a consuming form gave it to me" — that is one of its two
+/// sources. For an identity leaf the plan already states it in `out_ty`, so the
+/// emitter reads it there rather than re-deriving it from the hoist. The
+/// `Option` return is the same value inside a `map` closure.
+#[test]
+fn an_owned_root_identity_moves_without_any_value_form() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_root_child_make() -> ZChild {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_root_child_maybe() -> Option<ZChild> {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZChild))
+                .fun(crate::fun!(z_root_child_make))
+                .fun(crate::fun!(z_root_child_maybe)),
+        )
+        .expand(crate::expand_return!(ZChild).field_self());
+    let dir = unique_test_dir("jnigen_vf_root_identity");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+
+    assert!(
+        !rust.contains("&__cvsrc") && !rust.contains("&__inner"),
+        "an owned root is MOVED into its converter, not borrowed — the owning \
+         converter takes `ZChild`, not `&ZChild`:\n{rust}"
+    );
+}
+
+/// A per-field `.field(name, expand_return!(T))` override states the field's
+/// type, so it has to be checked against the field. Otherwise the override
+/// silently survives an upstream field-type change — which is exactly the drift
+/// this declarator exists to catch — and two same-shaped handle types are
+/// interchangeable by accident.
+#[test]
+fn a_per_field_override_must_name_the_field_s_own_type() {
+    let build = || {
+        let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .class(crate::ptr_class!(ZBytes))
+                    .class(crate::data_class!(ZStamp))
+                    .class(crate::data_class!(ZOrigin))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(
+                crate::expand_return!(ZSample).fields(
+                    // `key_expr` is a `ZKeyExpr`, not a `ZBytes`.
+                    crate::fields!(z_sample_to_struct)
+                        .field("key_expr", crate::expand_return!(ZBytes).field_self()),
+                ),
+            );
+        let dir = unique_test_dir("jnigen_vf_ovr_ty");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = registry
+            .resolve(jni)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(build))
+        .expect_err("a mistyped override must be rejected");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("key_expr"),
+        "the message names the field: {msg}"
+    );
+    assert!(
+        msg.contains("ZBytes") && msg.contains("ZKeyExpr"),
+        "the message names the declared type and the real one: {msg}"
+    );
+}
+
+/// The "called once per delivery" contract has to survive **composition**: when
+/// a value form's field splices a child type whose own boundary is also derived
+/// from a value form, the child accessor is a second hoist, not a call repeated
+/// once per child leaf.
+#[test]
+fn a_nested_value_form_is_hoisted_too() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZInnerStruct {
+                    pub a: i64,
+                    pub b: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZOuterStruct {
+                    pub inner: ZInner,
+                    pub tag: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_inner_to_struct(i: &ZInner) -> ZInnerStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_to_struct(o: &ZOuter) -> ZOuterStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_sub(cb: impl Fn(ZOuter) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZOuter))
+                .class(crate::ptr_class!(ZInner))
+                .fun(crate::fun!(z_outer_sub)),
+        )
+        .expand(crate::expand_return!(ZInner).fields(crate::fields!(z_inner_to_struct)))
+        .expand(crate::expand_return!(ZOuter).fields(crate::fields!(z_outer_to_struct)));
+    let dir = unique_test_dir("jnigen_vf_nested");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        kotlin.contains("inner__a: Long") && kotlin.contains("inner__b: Long"),
+        "the child value form's fields splice in, prefixed:\n{kotlin}"
+    );
+    for f in ["z_outer_to_struct", "z_inner_to_struct"] {
+        let calls = rust.matches(f).count();
+        assert_eq!(
+            calls, 1,
+            "`{f}` is bound to one local and every leaf below it reaches off \
+             that local; found {calls} calls in:\n{rust}"
+        );
+    }
+}
+
+/// A consuming value form reached **through another one** is handed the
+/// parent's field by MOVE. A hoisted value form is an owned struct and its
+/// fields are disjoint, so giving one field away leaves every sibling leaf
+/// readable — which is why this shape needs no clone and is not refused.
+///
+/// Checked under both parents: what makes the move legal is that the hoist
+/// local is owned, and a borrowing form's returned struct is owned just as much
+/// as a consuming one's.
+#[test]
+fn a_nested_consuming_value_form_moves_the_parent_s_field() {
+    let loc = myflat_loc();
+    let items = |outer_by_value: bool| -> Vec<(syn::Item, crate::SourceLocation)> {
+        let outer: syn::Item = if outer_by_value {
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_into_struct(o: ZOuter) -> ZOuterStruct {
+                    unimplemented!()
+                }
+            ))
+        } else {
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_outer_to_struct(o: &ZOuter) -> ZOuterStruct {
+                    unimplemented!()
+                }
+            ))
+        };
+        vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZInnerStruct {
+                        pub a: i64,
+                        pub b: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZOuterStruct {
+                        pub inner: ZInner,
+                        pub tag: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_inner_into_struct(i: ZInner) -> ZInnerStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (outer, loc.clone()),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_outer_sub(cb: impl Fn(ZOuter) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ]
+    };
+
+    for (tag, outer_by_value, outer) in [
+        (
+            "borrow",
+            false,
+            crate::expand_return!(ZOuter).fields(crate::fields!(z_outer_to_struct)),
+        ),
+        (
+            "consume",
+            true,
+            crate::expand_return!(ZOuter).fields_self_into(crate::fields!(z_outer_into_struct)),
+        ),
+    ] {
+        let registry =
+            Registry::<KotlinMeta>::from_items(items(outer_by_value)).expect("index items");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZOuter))
+                    .class(crate::ptr_class!(ZInner))
+                    .fun(crate::fun!(z_outer_sub)),
+            )
+            .expand(
+                crate::expand_return!(ZInner).fields_self_into(crate::fields!(z_inner_into_struct)),
+            )
+            .expand(outer);
+        let dir = unique_test_dir(&format!("jnigen_vf_nested_consume_{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let gen = registry.resolve(jni).expect("resolve");
+        let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+            .expect("read rust");
+
+        assert!(
+            rust.contains("z_inner_into_struct(__vf0.inner)"),
+            "[{tag}] the parent's field is MOVED into the nested form, not borrowed \
+             or cloned:\n{rust}"
+        );
+        assert!(
+            rust.contains("__vf0.tag") && !rust.contains("(&__vf0)"),
+            "[{tag}] and a sibling leaf still reads its own field off the parent local, \
+             projected directly — borrowing the partially-moved local as a whole would \
+             not compile:\n{rust}"
+        );
+        assert!(
+            !rust.contains("__vf1.a.clone()"),
+            "[{tag}] the nested form's own fields move out too:\n{rust}"
+        );
+    }
+}
+
+// A compact fixture shared by the two follow-up review regressions.
+fn nested_review_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = myflat_loc();
+    vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReviewInnerStruct {
+                    pub value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReviewOuterStruct {
+                    pub optional: Option<ZReviewInner>,
+                    pub items: Vec<ZReviewInner>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_review_inner_to_struct(i: &ZReviewInner) -> ZReviewInnerStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_review_outer_to_struct(o: &ZReviewOuter) -> ZReviewOuterStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_review_outer_sub(cb: impl Fn(ZReviewOuter) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ]
+}
+
+fn nested_review_jni(outer: crate::lang::ExpandReturnDecl) -> JniGen {
+    JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZReviewOuter))
+                .class(crate::ptr_class!(ZReviewInner))
+                .fun(crate::fun!(z_review_outer_sub)),
+        )
+        .expand(
+            crate::expand_return!(ZReviewInner).fields(crate::fields!(z_review_inner_to_struct)),
+        )
+        .expand(outer)
+}
+
+/// A nested value form below an `Option` cannot be emitted as an
+/// unconditional hoist: its accessor takes `&Inner`, not `&Option<Inner>`.
+/// Reject it during planning until conditional hoists can share one `Some`
+/// scope across every descendant leaf.
+#[test]
+fn an_optional_nested_value_form_is_rejected_before_emission() {
+    let registry = Registry::<KotlinMeta>::from_items(nested_review_items()).expect("index items");
+    let jni = nested_review_jni(
+        crate::expand_return!(ZReviewOuter).fields(crate::fields!(z_review_outer_to_struct)),
+    );
+    let err = match registry.resolve(jni) {
+        Ok(_) => panic!("an optional nested value form must be rejected"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("z_review_inner_to_struct") && msg.contains("Option"),
+        "the error names the unsupported conditional hoist: {msg}"
+    );
+}
+
+/// Override records are applied to a `Vec<T>` field as a whole; a fixed leaf
+/// list cannot apply `T`'s deconstructor once per element. The declaration
+/// check must compare against `Vec<T>`, not peel it to `T`.
+#[test]
+fn a_vec_field_override_must_name_the_whole_vec_type() {
+    let build = || {
+        let registry =
+            Registry::<KotlinMeta>::from_items(nested_review_items()).expect("index items");
+        let jni = nested_review_jni(
+            crate::expand_return!(ZReviewOuter).fields(
+                crate::fields!(z_review_outer_to_struct)
+                    .field("items", crate::expand_return!(ZReviewInner).field_self()),
+            ),
+        );
+        let _ = registry.resolve(jni);
+    };
+
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(build))
+        .expect_err("an element-typed override on a Vec field must be rejected");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("items") && msg.contains("Vec") && msg.contains("ZReviewInner"),
+        "the error names the field, its whole Vec type, and the declared element type: {msg}"
+    );
+}
+
+// ── Consuming value forms ────────────────────────────────────────────────────
+
+/// A value form whose accessor takes its receiver **by value** destroys the
+/// object into its parts, so nothing needs cloning. Fixture mirrors the
+/// borrowing one; `zc_owned` / `zc_borrowed` give an owned and a `&T` plan of
+/// the same type, since one declaration serves both.
+fn consuming_items() -> Vec<(syn::Item, crate::SourceLocation)> {
+    let loc = myflat_loc();
+    vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZCarrierStruct {
+                    pub label: String,
+                    pub count: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn zc_into_struct(c: ZCarrier) -> ZCarrierStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn zc_to_struct(c: &ZCarrier) -> ZCarrierStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn zc_sub(cb: impl Fn(ZCarrier) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ]
+}
+
+fn consuming_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> String {
+    let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZCarrier))
+                .fun(crate::fun!(zc_sub)),
+        )
+        .expand(decl);
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust")
+}
+
+/// The headline: a consuming value form is handed the value itself, and each
+/// field is **moved** into its leaf. The clones the borrowing form pays — one
+/// per field, on a value it is about to drop — simply are not emitted.
+#[test]
+fn a_consuming_value_form_moves_its_fields() {
+    let rust = consuming_gen(
+        "jnigen_vf_consume",
+        crate::expand_return!(ZCarrier).fields_self_into(crate::fields!(zc_into_struct)),
+    );
+    assert!(
+        rust.contains("zc_into_struct(__cb_arg0)"),
+        "the value is passed BY MOVE, not borrowed:\n{rust}"
+    );
+    assert!(
+        rust.contains("__vf0.label") && rust.contains("__vf0.count"),
+        "each field is read off the one hoisted local:\n{rust}"
+    );
+    assert!(
+        !rust.contains("__vf0.label.clone()") && !rust.contains("__vf0.count.clone()"),
+        "and MOVED out of it — a consuming form exists precisely to drop these \
+         clones:\n{rust}"
+    );
+}
+
+/// The borrowing form is untouched: same declaration shape, still borrows, still
+/// clones. Consuming-ness is inferred per accessor, so one does not disturb the
+/// other.
+#[test]
+fn the_borrowing_value_form_still_clones() {
+    let rust = consuming_gen(
+        "jnigen_vf_borrow",
+        crate::expand_return!(ZCarrier).fields(crate::fields!(zc_to_struct)),
+    );
+    assert!(
+        rust.contains("zc_to_struct(&__cb_arg0)"),
+        "a `&T` accessor is still handed a borrow:\n{rust}"
+    );
+    assert!(
+        rust.contains("__vf0.label.clone()"),
+        "and its fields are still cloned out:\n{rust}"
+    );
+}
+
+/// One declaration is reached by BOTH owned and borrowed plans of the same type
+/// (records are type-level, `by_ref` is per-function). A borrowed plan has no
+/// value to give up, so it clones once up front rather than being rejected —
+/// the same cost the borrowing form of the accessor would have paid.
+#[test]
+fn a_borrowed_plan_clones_before_consuming() {
+    let loc = myflat_loc();
+    let mut items = consuming_items();
+    items.push((
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn zc_borrowed(v: &ZVault) -> Option<&ZCarrier> {
+                unimplemented!()
+            }
+        )),
+        loc,
+    ));
+    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let jni = JniGen::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZCarrier))
+                .class(crate::ptr_class!(ZVault))
+                .fun(crate::fun!(zc_sub))
+                .fun(crate::fun!(zc_borrowed)),
+        )
+        .expand(crate::expand_return!(ZCarrier).fields_self_into(crate::fields!(zc_into_struct)));
+    let dir = unique_test_dir("jnigen_vf_consume_ref");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = registry.resolve(jni).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read rust");
+    assert!(
+        rust.contains("zc_into_struct(__inner.clone())"),
+        "a borrowed plan clones the value, then consumes the clone:\n{rust}"
+    );
+}
+
+/// `.fields_self_into(..)` gives the value away, so anything else reading it is
+/// broken by construction. Refused **where it is declared** — the collision is
+/// visible in the decl itself, so it does not need a resolve to be found.
+///
+/// `.field_self()` beside it would deliver the handle the form just consumed.
+#[test]
+#[should_panic(expected = "only record")]
+fn a_consuming_value_form_rejects_a_following_sibling() {
+    let _ = crate::expand_return!(ZCarrier)
+        .fields_self_into(crate::fields!(zc_into_struct))
+        .field_self();
+}
+
+/// And the other way round — the decl is a builder, so both orders must be
+/// caught or the rule holds only for the order someone happened to write.
+#[test]
+#[should_panic(expected = "only record")]
+fn a_consuming_value_form_rejects_a_preceding_sibling() {
+    let _ = crate::expand_return!(ZCarrier)
+        .field_self()
+        .fields_self_into(crate::fields!(zc_into_struct));
+}
+
+/// Any sibling record, not just the identity one.
+#[test]
+#[should_panic(expected = "only record")]
+fn a_consuming_value_form_rejects_a_plain_field_sibling() {
+    let _ = crate::expand_return!(ZCarrier)
+        .fields_self_into(crate::fields!(zc_into_struct))
+        .field(crate::fun!(zc_to_struct));
+}
+
+/// The declarator states whether the value is given away and the accessor's
+/// signature has to agree — otherwise the emitted call would not compile in the
+/// consumer's crate, and a boundary would silently stop being the one declared.
+/// Both directions are errors; the fixture has one accessor of each kind.
+#[test]
+fn the_declarator_and_the_accessor_s_receiver_must_agree() {
+    let build = |decl: crate::lang::ExpandReturnDecl| -> String {
+        let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index");
+        let jni = JniGen::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZCarrier))
+                    .fun(crate::fun!(zc_sub)),
+            )
+            .expand(decl);
+        match registry.resolve(jni) {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        }
+    };
+
+    let msg = build(crate::expand_return!(ZCarrier).fields_self_into(crate::fields!(zc_to_struct)));
+    assert!(
+        msg.contains("CONSUMING") && msg.contains("zc_to_struct"),
+        "`.fields_self_into` on a borrowing accessor must be refused, naming it: {msg:?}"
+    );
+
+    let msg = build(crate::expand_return!(ZCarrier).fields(crate::fields!(zc_into_struct)));
+    assert!(
+        msg.contains("BORROWING") && msg.contains("zc_into_struct"),
+        "`.fields` on a by-value accessor must be refused, naming it: {msg:?}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -967,8 +967,11 @@ impl Prebindgen for JniGen {
     /// Assembled on demand — field names (member inheritance) resolve here,
     /// against the complete declaration set (see
     /// [`JniGen::build_deconstructors`]).
-    fn deconstructors(&self) -> Option<crate::api::core::unfold::Deconstructors> {
-        Some(self.build_deconstructors())
+    fn deconstructors(
+        &self,
+        registry: &Registry<KotlinMeta>,
+    ) -> Option<crate::api::core::unfold::Deconstructors> {
+        Some(self.build_deconstructors(registry))
     }
 
     /// Synthesize a field-decomposition for every `.data_class` type whose

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -42,8 +42,9 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, ConvertSourceDecl,
-    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FunctionDecl,
-    IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl,
+    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FieldsDecl,
+    FunctionDecl, IgnoreDecl, JniBindingError, JniGen, PackageDecl, PtrClassDecl, SealedClassDecl,
+    VariantDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -142,7 +142,7 @@
 //!   [`try_from!`](crate::try_from), [`into!`](crate::into),
 //!   [`try_into!`](crate::try_into)
 //! - Boundary expansion: [`expand_param!`](crate::expand_param),
-//!   [`expand_return!`](crate::expand_return)
+//!   [`expand_return!`](crate::expand_return), [`fields!`](crate::fields)
 //!
 //! **Syntax helpers** produce a bare `syn` node — `Type` / `Path` / `Expr` /
 //! `Signature` / `Ident` — to hand to a declaration method that requires one.
@@ -322,8 +322,8 @@ pub mod lang {
         box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string, matching,
         null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl,
         ConvertSourceDecl, DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl,
-        ExpandReturnDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen, KotlinFile,
-        PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl, WriteKotlinError,
+        ExpandReturnDecl, FieldsDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen,
+        KotlinFile, PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl, WriteKotlinError,
     };
 }
 

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -286,6 +286,11 @@ macro_rules! ident {
 /// [`lang::JniGen`]. The C / cbindgen proof of concept is available separately
 /// with the `unstable-cbindgen` feature.
 pub mod core {
+    /// The prebindgen **source language**: the parser from captured
+    /// `#[prebindgen]` records to [`language::Element`]s, and the element model
+    /// itself. Not to be confused with [`crate::lang`], the *destination*
+    /// adapters.
+    pub use crate::api::core::language;
     pub use crate::api::core::{
         ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot, Niches,
         Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage, Transmute,

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -291,10 +291,13 @@ pub mod core {
     /// itself. Not to be confused with [`crate::lang`], the *destination*
     /// adapters.
     pub use crate::api::core::language;
+    /// [`Language`] and [`Element`] sit here too, next to [`Registry`]: they are
+    /// what a build script names, and the rest of the element model stays in
+    /// [`mod@language`] where an adapter reaches for it.
     pub use crate::api::core::{
-        ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot, Niches,
-        Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage, Transmute,
-        TypeEntry, TypeKey, WriteRustError,
+        ConverterImpl, Direction, DomainScalar, Element, Generation, Gravestone, Language,
+        NicheSlot, Niches, Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError,
+        Stage, Transmute, TypeEntry, TypeKey, WriteRustError,
     };
 }
 


### PR DESCRIPTION
**Stage L0 of #229** — the umbrella for making every prebindgen component consume
`Element`s instead of parsing captured Rust itself. The stage map, the measured
size of the problem and the completion criteria live there.

A new direction for #211, developed separately from the `source-frontend`
branch (#215) and integrable with it later.

## Why

#211 asks for one frontend that decides what captured `#[prebindgen]` Rust
means, so adapters stop re-reading syntax. #215 built that as a **syn-free
semantic model**, and it kept hitting one wall: the generated Rust glue is
itself a destination artifact, and it is the only consumer that needs syntax
fidelity. Each time it did, the answer was to model the syntax —
`DiscriminantSource::Explicit(syn::Expr)`, `syn::Member`, `syn::Lifetime`,
`to_syn()`, and most recently a `VariantShape` whose only job was to make
generated Rust spell `E::B()` instead of `E::B`. The model was becoming a
second `syn`.

The cause is one layer earlier: the raw record stream is never parsed. `Source`
hands out `syn::Item`s, `Registry` indexes `syn::Item`s, and every consumer
re-derives structure from whole items — so a model that wants to displace that
has to be *lossless*, not merely decisive.

## What

`Language::parse` turns the item stream into `Element`s. Every node — item,
parameter, field, variant, type, array extent — pairs its classification with
one `Origin`: the exact syntax it was built from, and the source that syntax
arrived in.

```rust
pub struct Origin<S> { pub syntax: S, pub location: Rc<SourceLocation> }

pub struct Type    { pub kind: TypeKind, pub origin: Origin<syn::Type> }
pub struct Param   { pub name: syn::Ident, pub ty: Type, pub origin: Origin<syn::PatType> }
pub struct Variant { pub index: usize, pub discriminant: Option<i64>, pub fields: Vec<Field>,
                     pub origin: Origin<syn::Variant> }
```

So the classification carries only what a destination language needs, and the
spelling is the source's own tokens — already sliced to the parameter, field and
variant, so nothing re-parses a whole item to find a part of it.

The provenance is uniform for the same reason the syntax is. `syn` tokens
normally carry spans, but the proc-macro serializes each item as a **string**
into JSONL and `build.rs` re-parses it, so every span in a slice points into an
anonymous buffer; `SourceLocation::from_span` captures file/line/column while
real rustc spans still exist, precisely because they cannot survive that trip.
One captured record is one item, so an item and every node lowered out of it
share one `Rc` — the honest answer to "where is this field", and the cheap one.
(`Rc`, not `Arc`: the model holds `syn`, so it is `!Send` regardless — the call
`TypeKey` already made.)

Uniformity is not tidiness here. Before it, provenance was reachable at item
level only, so its one load-bearing part — the crate name — was copied downward
by hand under a third field name with drifting meaning: `ConstId.origin` is the
crate a const was *declared* in, while `TypeId.origin` was the crate of the item
*using* the type, and it sat inside `TypeId`'s derived `Eq` — so `Sample`
referenced from two source crates compared unequal. The rule the model now
states: **a reference carries a name, the declaration carries the origin.**
`TypeId` is a name alone; `ConstId.origin` becomes `ConstId.crate_name`, because
it describes a *different* item than the node holding it.

Consequences, all covered by tests:

* `B()` is a unit **group** and still spells `E::B()` — `spell` reads the
  delimiters off `origin.syntax`. No `VariantShape`.
* `= 0x07` reaches a C header as `0x07` while Kotlin gets `7`. No
  `DiscriminantSource`.
* `Foo<'a, T>` classifies as `Foo` with one type argument and re-emits with its
  lifetime. No modelled lifetimes.
* An array extent is a number **and** the const it named **and** the spelling —
  three consumers, three homes, no `to_syn()`.

## The rule, and how it is enforced

> **Classify off `kind`, spell off `syntax`.**

#224's boundary ledger measures exactly this with no adaptation: it counts
*variant mentions* of `syn::Type` / `syn::Expr`, so `quote!(#slice)` is
invisible to it while `matches!(ty, syn::Type::Reference(_))` is counted. Ported
and seeded at **203 sites** — the population the adapter migrations pay down,
one ledger diff at a time.

## What earns a variant

A concept, not a Rust spelling. The test is whether a *destination* language
would act on the distinction; if only Rust can see it, it is spelling, and the
slice already carries it. That is what keeps the classification from becoming a
second `syn` by a different route — one where the variants are Rust's type
constructors rather than its syntax nodes.

| Rust writes | The model says | Because |
|---|---|---|
| `String`, `str` | `TypeKind::Str` | one concept, two Rust types |
| `Vec<T>`, `[T]` | `TypeKind::Sequence` | a run of `T`; owned vs borrowed is the `Ref` layer's fact |
| `Box<T>` | whatever `T` is | an owned `T` either way |
| `struct S;`, `struct S {}` | zero fields | the delimiters are spelling |
| no `->`, `-> ()` | `TypeKind::Unit` | the same function |
| `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |

Each of those is what the pipeline already does by hand, now said once:

* **Sequence.** One `Shape::Iterable` covers `Vec` and slice alike
  (`core/shape.rs:27`); jnigen rewrites a `&[T]` input into the `Vec<_>` pattern
  outright (`jni/selector.rs:88-95`) and collapses both through
  `slice_or_vec_elem → (elem, by_ref)`. cbindgen's asymmetry (Vec output-only,
  `&[T]` input-only) is direction + ownership, both already modelled.
* **Box.** There is no generic Box handling anywhere: jnigen matches the literal
  key string `"Box < String >"`, cbindgen's `box_inner` serves two field shapes,
  and `Branch(Box<Node>)` is unresolvable. It classifies as what it wraps; the
  `Box` survives in `Type::syntax`. The one place that behaves as though `Box`
  changes the *meaning* — cbindgen's differing wire for `Option<Box<String>>` vs
  `Option<String>` — is filed as suspected generator incorrectness (#230), not
  modelled around.
* **`str`.** The most common non-scalar parameter in the ecosystem (26 in
  zenoh-flat, plus every example crate). Both adapters special-case it by name
  and register a *stub* rank-0 entry purely to satisfy resolution. Classifying
  it as a nominal type would guarantee they keep doing so after migrating.
* **Raw pointers.** Zero uses in any source crate; neither adapter has a
  `Type::Ptr` selection arm, so one reaches `ResolveError::Unresolved` today.
  Accepting them would have *widened* acceptance, which this stage is not
  allowed to do.

The identities follow the same rule: a nominal type is a `TypeId` — a name —
not a `syn::Path`. An identity kept as syntax makes every consumer take a path
apart to learn what a type is, and `Path` is not in the ledger's watch list, so
that classifier would never have been counted.

Applied to the elements themselves:

* `Function::ret` is a `Type`, unit when elided. Nothing distinguishes that from
  a written `-> ()`; eight consumers normalize one to the other on the spot.
* `Struct::fields` is `Option<Vec<Field>>` — a product, or opaque. Named /
  unnamed / unit were three Rust shapes where `Variant` already modelled the
  same idea as a field list plus delimiters read off the syntax. `None` is the
  tuple struct, whose contents no adapter has ever crossed.
* `spell.rs` holds everything that turns an element back into Rust tokens, so
  `element.rs` describes structure alone.
* `item_crate: Option<&str>` stops being threaded through six lowering
  functions, since the location now arrives with the syntax.
* A variant's position is an `index: usize`, the same fact a field carries. It
  was a `tag: i32`, sized that way because cbindgen writes `c_int` and jnigen
  writes `jint` — a frontend field shaped by two generators' wire types, which
  is the coupling this module exists to prevent. Sum versus product is carried
  by *which* list the node sits in, not by the number; transmitting the position
  to say which alternative is live is one destination's choice, and another may
  send a name. What stays distinct is `discriminant`: a position is where the
  source *put* a variant, a discriminant is the value Rust *assigns* it.
* **There is no passthrough element.** A `#[prebindgen]` crate marks the items
  that cross the boundary and leaves the supporting code to the consumer — the
  proc-macro enforces exactly that, refusing to mark a `use`, `mod`, `impl` or
  `macro_rules!` at all, so the variant's doc listed items that could never
  arrive. What actually reached it was the `const _` feature guard, which is not
  a source item: `CfgFilter` synthesizes it and prepends it to the stream. It is
  a const, so it is modelled as one, and `Element::name` returning `None` for
  `_` is the real fact — the one that lets several sources' guards coexist in
  the flat namespace. `write.rs` already had that rule for consts, dead until
  now because `const _` never reached the consts map.

## Scope

Self-contained: nothing consumes elements yet, so no generation path changes and
no artifact can move — `examples/regen-check.sh` is byte-identical.
`Registry::from_elements` is stage L1, with the registry's `syn`-keyed maps
rebuilt from each element's retained syntax so both adapters compile untouched;
`api/core` (L2), `Cbindgen` (L3) and `JniGen` (L4) migrate after that, each
paying down its share of the 203 ledger sites this PR seeds. See #229 for the
full order.

Two things move to where they belong on the way: `Language::parse` normalizes
before lowering (the type lowering already assumed it had, so a qualified
`std::option::Option` would have classified as a foreign named type), and the
callback grammar `extract_fn_trait_args` lives in the language rather than the
registry — the first ledger site paid down, 202 to 201.

Acceptance is **preserved** except where it was demonstrably wrong, and never
widened. An item the language cannot express becomes `Element::Unsupported`
carrying its diagnosis, because the pipeline has always scanned a signature only
once an adapter declared it, and a source crate may mark items no binding uses.
Only a duplicate name — which no declaration can disambiguate — fails the parse.
Tuple-struct fields stay unmodelled for the same reason.

Two deliberate narrowings, both of forms no source crate writes: a raw pointer is
refused rather than modelled (it was unresolvable downstream anyway), and a
`union` or type alias is diagnosed rather than copied verbatim into generated
code that would name source types without qualification. The proc-macro still
accepts those two kinds, so the mark site and the frontend now disagree about
exactly two item kinds — loudly, instead of silently.

## Tests

All green: the **round-trip** half (syntax slices are the source's tokens,
including the cases a reconstruction loses — empty delimiters, `0x07`,
lifetimes, docs, and now struct delimiters) and the **acceptance matrix** half
(spelling → element, or a diagnosis naming the item *and* the component). The
model changes are locked by their own rows: `str`/`&str`/`&String` → `Str`,
`Box<String>` → `Str` with its syntax intact, `Vec<T>`/`[T]`/`&[T]` → one
sequence concept, `*const T` → refused, `std::option::Option<u8>` → `Optional`,
an elided return → `Unit`.

Ported from #215: the array-length subgrammar (#212), the type grammar and its
acceptance tests, enum tag/discriminant numbering (#226), the ledger (#224).

Refs #211. Umbrella: #229. Follow-up: #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


