### PR TITLE
jnigen: generated code passes the consumer's own lints

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3111,22 +3111,10 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Ledger_Send_Sync_static_c76008cc<'env, '
                         String,
                     >>::from(format!("push local frame for {}: {}", "Fn(Ledger)", e)))?;
                 let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    let __vf0 = match perftest_flat::ledger_filed(&__cb_arg0) {
-                        ::core::option::Option::Some(__hb0) => {
-                            ::core::option::Option::Some(
-                                perftest_flat::report_into_struct((__hb0).clone()),
-                            )
-                        }
-                        ::core::option::Option::None => ::core::option::Option::None,
-                    };
-                    let __vf1 = match perftest_flat::ledger_archived(&__cb_arg0) {
-                        ::core::option::Option::Some(__hb0) => {
-                            ::core::option::Option::Some(
-                                perftest_flat::report_into_struct(__hb0),
-                            )
-                        }
-                        ::core::option::Option::None => ::core::option::Option::None,
-                    };
+                    let __vf0 = perftest_flat::ledger_filed(&__cb_arg0)
+                        .map(|__hb0| perftest_flat::report_into_struct((__hb0).clone()));
+                    let __vf1 = perftest_flat::ledger_archived(&__cb_arg0)
+                        .map(|__hb0| perftest_flat::report_into_struct(__hb0));
                     let (
                         __cb0_obj0,
                         __cb0_obj1,
@@ -13113,20 +13101,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ledgerNew<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/LedgerBuilderRaw";
     const __CB_DESCR: &str = "(Ljava/lang/Long;Ljava/lang/Double;Lio/prebindgen/covertest/model/Stamp;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Double;Lio/prebindgen/covertest/model/Stamp;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::ledger_new(n);
-    let __vf0 = match perftest_flat::ledger_filed(&__out) {
-        ::core::option::Option::Some(__hb0) => {
-            ::core::option::Option::Some(
-                perftest_flat::report_into_struct((__hb0).clone()),
-            )
-        }
-        ::core::option::Option::None => ::core::option::Option::None,
-    };
-    let __vf1 = match perftest_flat::ledger_archived(&__out) {
-        ::core::option::Option::Some(__hb0) => {
-            ::core::option::Option::Some(perftest_flat::report_into_struct(__hb0))
-        }
-        ::core::option::Option::None => ::core::option::Option::None,
-    };
+    let __vf0 = perftest_flat::ledger_filed(&__out)
+        .map(|__hb0| perftest_flat::report_into_struct((__hb0).clone()));
+    let __vf1 = perftest_flat::ledger_archived(&__out)
+        .map(|__hb0| perftest_flat::report_into_struct(__hb0));
     let (
         __obj0,
         __obj1,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -565,9 +565,10 @@ impl Hoisted {
 }
 
 /// Fold `path` over `base` the way [`reach_leaf`] does, but yielding an
-/// `Option<…>` rather than a `JObject`: every optional step short-circuits to
-/// `None` instead of to a null object. `body` renders the innermost reached
-/// expression and must itself produce the `Some`.
+/// `Option<…>` rather than a `JObject`: the optional steps become a
+/// `map`/`and_then` chain, so an absent value short-circuits to `None` instead
+/// of to a null object. `body` renders the innermost reached expression as a
+/// BARE value — the chain's last link wraps it.
 ///
 /// This is how a CONDITIONAL value form is bound — the accessor runs only where
 /// the value it decomposes is actually present.
@@ -607,11 +608,18 @@ fn reach_optional(
                 depth + 1,
                 body,
             );
+            // `map` when this is the LAST optional step (the body yields a bare
+            // value) and `and_then` when another follows (the recursion yields
+            // an `Option` that must not nest). The equivalent `match` reads the
+            // same but generated code runs through the consumer's lints, where
+            // `clippy::manual_map` is a denial.
+            let combinator = if rest.iter().any(PathStep::is_optional) {
+                format_ident!("and_then")
+            } else {
+                format_ident!("map")
+            };
             quote! {
-                match #opt_e {
-                    ::core::option::Option::Some(#bind) => { #inner }
-                    ::core::option::Option::None => ::core::option::Option::None,
-                }
+                #opt_e.#combinator(|#bind| #inner)
             }
         }
     }
@@ -648,8 +656,7 @@ pub(crate) fn bind_hoists(
             // borrow, so what arrives is a reference either way.
             let owned = lead.last().is_some_and(PathStep::yields_owned);
             let expr = reach_optional(qualify, lead, value.clone(), by_ref, 0, &|reached| {
-                let call = compose_value_form_call(qualify, last, reached, owned, consuming);
-                quote!(::core::option::Option::Some(#call))
+                compose_value_form_call(qualify, last, reached, owned, consuming)
             });
             out.stmts.extend(quote! { let #local = #expr; });
             out.bound.push((h.prefix.clone(), local));

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -217,32 +217,44 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // straight off the raw value, which for a value form declared with
         // `.fields_self_into(..)` emitted `f(&v)` against a by-value receiver.
         let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
-        let compose = |base: TokenStream, base_is_ref: bool| -> TokenStream {
+        // `None` when the reach is the IDENTITY of `base` and no value form had
+        // to be bound — the leaf IS the value, so there is nothing to compose.
+        // Reported separately from the composed form because the two want
+        // different code: wrapping identity in a block emits `{ __cvsrc }`
+        // (`unused_braces`), and mapping it over an `Option` emits
+        // `.map(|__inner| __inner)` (`clippy::map_identity`). Generated code
+        // runs through the consumer's own lints, where both are denials.
+        let compose = |base: TokenStream, base_is_ref: bool| -> Option<TokenStream> {
             let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
             let stmts = &hoisted.stmts;
             let reached = match hoisted.rebase(&leaf.path) {
                 Some((local, rest, consuming)) => {
                     reach_leaf_flat(&qualify, leaf, &rest, quote!(#local), false, consuming)
                 }
-                None => reach_leaf_flat(&qualify, leaf, &leaf.path, base, base_is_ref, false),
+                None => {
+                    reach_leaf_flat(&qualify, leaf, &leaf.path, base.clone(), base_is_ref, false)
+                }
             };
-            quote!({ #stmts #reached })
+            if stmts.is_empty() && reached.to_string() == base.to_string() {
+                return None;
+            }
+            Some(quote!({ #stmts #reached }))
         };
         match &uplan.shape {
-            UnfoldShape::Optional((), _) => {
-                let inner = compose(quote!(__inner), by_ref);
-                quote!({
+            UnfoldShape::Optional((), _) => match compose(quote!(__inner), by_ref) {
+                Some(inner) => quote!({
                     let __cvsrc = #raw_call;
                     __cvsrc.map(|__inner| #inner)
-                })
-            }
-            _ => {
-                let v = compose(quote!(__cvsrc), by_ref);
-                quote!({
+                }),
+                None => raw_call.clone(),
+            },
+            _ => match compose(quote!(__cvsrc), by_ref) {
+                Some(v) => quote!({
                     let __cvsrc = #raw_call;
                     #v
-                })
-            }
+                }),
+                None => raw_call.clone(),
+            },
         }
     } else if let Some(ep) = error_plan {
         // `Result<T, E>` peel (the automatic `?`): success ⇒ `T`; on `Err(e)`,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -1459,8 +1459,10 @@ fn a_value_form_under_an_optional_accessor_is_hoisted_conditionally() {
         "the value form runs ONCE, not once per leaf:\n{rust}"
     );
     assert!(
-        rust.contains("zh_get_carrier(&__cb_arg0)") && rust.contains("Some(__hb0)"),
-        "the hoist is built inside the `Some` arm of the optional step:\n{rust}"
+        rust.contains("zh_get_carrier(&__cb_arg0)") && rust.contains(".map(|__hb0|"),
+        "the hoist is built only where the optional step has a value — as a \
+         `map`, since the equivalent `match` trips `clippy::manual_map` in the \
+         consumer:\n{rust}"
     );
     assert!(
         rust.contains("zc_into_struct((__hb0).clone())"),


### PR DESCRIPTION
## Why

A binding crate runs its own `cargo clippy --all-targets --all-features -- -D warnings` over the file this generator writes. A lint there is a build failure the consumer cannot fix — they did not write the code.

The conditional hoist merged in #231 shipped three. Found by building [zenoh-flat-jni](https://github.com/eclipse-zenoh/zenoh-flat-jni/pull/18) against merged `main`; its `Lint` job denies warnings and went red on generated output that prebindgen's own tests were perfectly happy with.

## What

**`clippy::manual_map`** — the optional steps of a conditional hoist were emitted as `match opt { Some(x) => Some(f(x)), None => None }`. Now a `map` / `and_then` chain:

```rust
let __vf0 = myflat::zh_get_carrier(&__cb_arg0)
    .map(|__hb0| myflat::zc_into_struct((__hb0).clone()));
```

`map` at the **last** optional step, where the body yields a bare value; `and_then` before it, where the recursion yields an `Option` that must not nest. `reach_optional`'s `body` contract changes accordingly — it renders the bare value and the chain's last link wraps it.

**`clippy::map_identity` + `unused_braces`** — the single-leaf `Delivery::Return` shortcut wrapped its reach in a block and mapped it over the `Option` even when the reach was the *identity* of the value and no value form had to be bound:

```rust
let __out = { let __cvsrc = zenoh_flat::sample_get_attachment(&s); __cvsrc.map(|__inner| { __inner }) };
```

`compose` now reports that case (`Option<TokenStream>`) and the caller returns the raw call untouched.

## Verification

- 381 lib tests, clippy clean, regen-check byte-identical after regenerating covertest's goldens (the identity simplification removes 30 lines of wrapper noise)
- covertest `gradlew run` green at 48 sections
- **zenoh-flat-jni: `cargo clippy --all-targets --all-features -- -D warnings` now passes** — exactly what its CI runs, and the check that failed before this

## Note

This class of defect is invisible to prebindgen's own tests, which assert on emitted text and compile the output only under this workspace's lint settings. The consumer's `-D warnings` is the real contract. Worth considering whether covertest should adopt `-D warnings` over its generated file so the next one is caught here rather than downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)