### PR TITLE
Let Registry read prebindgen output directly

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -118,20 +118,6 @@ fn strip_flat_class_prefix(class: &str, name: &str) -> String {
 }
 
 fn main() {
-    // Two prebindgen sources: the flat crate plus the binding-side helper
-    // crate (conversion fns for `convert!`). The registry records each fn's
-    // origin from the stream's `SourceLocation` stamps so generated calls
-    // qualify with the defining crate (`perftest_flat::…` vs
-    // `cov_helpers::…`). The helper dependency is RENAMED in Cargo.toml
-    // (`cov_helpers = { package = "covertest-helpers", .. }`), so the stamp
-    // recorded at capture time (`covertest-helpers`) would not resolve from
-    // this crate — `.crate_name()` overrides it with the name this crate
-    // actually uses.
-    let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
-    let helpers = prebindgen::Source::builder(cov_helpers::PREBINDGEN_OUT_DIR)
-        .crate_name("cov_helpers")
-        .build();
-
     let jni = JniGen::new()
         .set_package_prefix("io.prebindgen.covertest")
         .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")
@@ -706,7 +692,18 @@ fn main() {
         .ignore(matching(|name| name.starts_with("storage_get_into_")))
         .ignore(fun!(storage_put_by_read_and_update));
 
-    let registry = Registry::from_items(source.items_all().chain(helpers.items_all()))
+    // Two prebindgen sources: the flat crate plus the binding-side helper crate
+    // (conversion fns for `convert!`). The registry records each fn's origin from
+    // the `SourceLocation` stamps so generated calls qualify with the defining
+    // crate (`perftest_flat::…` vs `cov_helpers::…`). The helper dependency is
+    // RENAMED in Cargo.toml (`cov_helpers = { package = "covertest-helpers", .. }`),
+    // so the stamp recorded at capture time (`covertest-helpers`) would not
+    // resolve from this crate — `source_named` overrides it with the name this
+    // crate actually uses, per directory.
+    let registry = Registry::builder()
+        .source(perftest_flat::PREBINDGEN_OUT_DIR)
+        .source_named(cov_helpers::PREBINDGEN_OUT_DIR, "cov_helpers")
+        .build()
         .expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -38,8 +38,6 @@ fn main() {
 /// Generate the Rust FFI bindings from `example-flat`'s prebindgen output via the
 /// `lang::Cbindgen` adapter, and publish the result to `generated/example_flat.rs`.
 fn generate_ffi_bindings() -> PathBuf {
-    // Reader over the data emitted by example-flat's `#[prebindgen]` macro.
-    let source = prebindgen::Source::new(example_flat::PREBINDGEN_OUT_DIR);
     let unstable = std::env::var("CARGO_FEATURE_UNSTABLE").is_ok();
 
     // The C / cbindgen adapter. Name-mangling rules turn each Rust type/function
@@ -184,8 +182,11 @@ fn generate_ffi_bindings() -> PathBuf {
         cbindgen = cbindgen.function(function).panic();
     }
 
-    let registry =
-        prebindgen::core::Registry::from_items(source.items_all()).expect("scan prebindgen items");
+    // Reads example-flat's `#[prebindgen]` output straight from its directory.
+    let registry = prebindgen::core::Registry::builder()
+        .source(example_flat::PREBINDGEN_OUT_DIR)
+        .build()
+        .expect("scan prebindgen items");
     // Always written to OUT_DIR under a stable name too, so the commented-out
     // `include!(OUT_DIR ...)` alternative in `lib.rs` works for any target.
     let out_file = registry

--- a/examples/perftest-c/build.rs
+++ b/examples/perftest-c/build.rs
@@ -28,9 +28,6 @@ fn main() {
 /// Generate the Rust FFI bindings from `perftest-flat`'s prebindgen output via the
 /// `lang::Cbindgen` adapter, and publish the result to `generated/perftest_<arch>.rs`.
 fn generate_ffi_bindings() -> PathBuf {
-    // Reader over the data emitted by perftest-flat's `#[prebindgen]` macro.
-    let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
-
     // The C / cbindgen adapter. Name-mangling rules turn each Rust type/function
     // into its C name (e.g. `Payload` -> `payload_t`, `String` -> `string_t`).
     let mut cbindgen = prebindgen::lang::Cbindgen::new()
@@ -130,8 +127,11 @@ fn generate_ffi_bindings() -> PathBuf {
     cbindgen = cbindgen.function(pq!(payload_vec_handler_new));
     cbindgen = cbindgen.function(pq!(storage_callback_vec)).panic();
 
-    let registry =
-        prebindgen::core::Registry::from_items(source.items_all()).expect("scan prebindgen items");
+    // Reads perftest-flat's `#[prebindgen]` output straight from its directory.
+    let registry = prebindgen::core::Registry::builder()
+        .source(perftest_flat::PREBINDGEN_OUT_DIR)
+        .build()
+        .expect("scan prebindgen items");
     let out_file = registry
         .resolve(cbindgen)
         .expect("resolve prebindgen items")

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -24,8 +24,6 @@
 use prebindgen::{core::Registry, data_class, fun, lang::JniGen, package, ptr_class};
 
 fn main() {
-    let source = prebindgen::Source::new(perftest_flat::PREBINDGEN_OUT_DIR);
-
     let jni = JniGen::new()
         .set_package_prefix("io.prebindgen.perftest")
         // Trigger native-library loading from the generated `JNINative` static
@@ -115,7 +113,11 @@ fn main() {
                 .fun(fun!(storage_callback_vec)),
         );
 
-    let registry = Registry::from_items(source.items_all()).expect("scan prebindgen items");
+    // Reads perftest-flat's `#[prebindgen]` output straight from its directory.
+    let registry = Registry::builder()
+        .source(perftest_flat::PREBINDGEN_OUT_DIR)
+        .build()
+        .expect("scan prebindgen items");
 
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -36,5 +36,8 @@ pub use self::{
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},
-    registry::{Direction, Generation, Registry, ScanError, TypeEntry, TypeKey, WriteRustError},
+    registry::{
+        Direction, Generation, Registry, RegistryBuilder, ScanError, TypeEntry, TypeKey,
+        WriteRustError,
+    },
 };

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -15,6 +15,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt,
+    marker::PhantomData,
 };
 
 use quote::ToTokens;
@@ -597,14 +598,108 @@ impl DeclaredItems {
     }
 }
 
+/// Collects what a [`Registry`] will index, then hands over the registry.
+///
+/// The same shape [`Flat`](crate::core::flat) reads prebindgen data with — name a
+/// directory, or feed a stream, then `build()` — so there is one way to say where
+/// captured items come from, whoever consumes them.
+///
+/// Feeders accumulate, so mix them freely.
+pub struct RegistryBuilder<M> {
+    items: Vec<(syn::Item, SourceLocation)>,
+    /// `M` is fixed by the adapter a caller eventually `resolve`s with, and is
+    /// carried through so `Registry::builder()` needs no turbofish: it threads
+    /// from here to [`Self::build`] and is inferred at the `resolve` call.
+    _metadata: PhantomData<M>,
+}
+
+impl<M> RegistryBuilder<M> {
+    /// Every `#[prebindgen]` item captured in `dir` — pass
+    /// `<source_crate>::PREBINDGEN_OUT_DIR`.
+    ///
+    /// Panics the way [`Source::new`](crate::Source::new) does if `dir` is not
+    /// readable prebindgen output: a build script has nothing to recover with.
+    pub fn source<P: AsRef<std::path::Path>>(self, dir: P) -> Self {
+        let source = crate::Source::new(dir);
+        self.items(source.items_all())
+    }
+
+    /// The same, for a dependency this crate **renames** in `Cargo.toml`.
+    ///
+    /// The origin recorded at capture time is the dependency's real package name,
+    /// which will not resolve from a crate that refers to it by another name.
+    /// `crate_name` is the name *this* crate uses.
+    ///
+    /// Per directory, deliberately: a registry-level override could only fix one
+    /// module, and a registry may layer several sources.
+    pub fn source_named<P: AsRef<std::path::Path>>(
+        self,
+        dir: P,
+        crate_name: impl Into<String>,
+    ) -> Self {
+        let source = crate::Source::builder(dir).crate_name(crate_name).build();
+        self.items(source.items_all())
+    }
+
+    /// Add a captured item stream — a group selection, an otherwise-configured
+    /// [`Source`](crate::Source), or synthetic items in a test.
+    pub fn items<I>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = (syn::Item, SourceLocation)>,
+    {
+        self.items.extend(items);
+        self
+    }
+
+    /// Index everything collected so far.
+    ///
+    /// Sugar over [`Registry::from_items`], which stays the primitive: one place
+    /// decides what a stream of items means.
+    pub fn build(self) -> Result<Registry<M>, ScanError> {
+        Registry::from_items(self.items)
+    }
+}
+
 impl<M> Registry<M> {
+    /// Start collecting what to index.
+    ///
+    /// The way a build script reads prebindgen output: name the directory and get
+    /// a registry, with no [`Source`](crate::Source) in between.
+    ///
+    /// ```
+    /// # prebindgen::Source::init_doctest_simulate();
+    /// use prebindgen::core::Registry;
+    ///
+    /// // Annotated only because nothing here resolves: in a build script `M` is
+    /// // fixed by the adapter passed to `resolve`, so no call site names it.
+    /// let registry: Registry<()> = Registry::builder().source("source_ffi").build()?;
+    /// assert!(registry.functions.contains_key(&quote::format_ident!("test_function")));
+    /// # Ok::<_, prebindgen::core::ScanError>(())
+    /// ```
+    ///
+    /// Several directories compose, including one this crate renames:
+    ///
+    /// ```ignore
+    /// let registry = Registry::builder()
+    ///     .source(flat_crate::PREBINDGEN_OUT_DIR)
+    ///     .source_named(helpers::PREBINDGEN_OUT_DIR, "helpers")
+    ///     .build()?;
+    /// ```
+    pub fn builder() -> RegistryBuilder<M> {
+        RegistryBuilder {
+            items: Vec::new(),
+            _metadata: PhantomData,
+        }
+    }
+
     /// Construct a `Registry` by indexing a stream of source items.
     ///
-    /// Callers feed any `(syn::Item, SourceLocation)` iterator — typically
-    /// `source.items_all()`, `source.items_except_groups(...)`, or a
-    /// hand-rolled filter chain — so item-level selection happens upstream
-    /// of the registry rather than inside it. Streams from several sources
-    /// combine with plain iterator composition:
+    /// The primitive: [`Self::builder`] is sugar over this, and is what a build
+    /// script reading a directory should reach for. Callers feed any
+    /// `(syn::Item, SourceLocation)` iterator — typically `source.items_all()`,
+    /// `source.items_except_groups(...)`, or a hand-rolled filter chain — so
+    /// item-level selection happens upstream of the registry rather than inside
+    /// it. Streams from several sources combine with plain iterator composition:
     ///
     /// ```ignore
     /// let registry = Registry::from_items(

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -611,3 +611,159 @@ fn foreign_qualified_declared_type_stays_supported() {
     assert!(reg.required_inputs_scan.contains(&foreign));
     assert!(reg.required_outputs_scan.contains(&foreign));
 }
+
+// ── The directory-reading builder ──────────────────────────────────────
+
+/// Write a real prebindgen output directory holding one marked fn, stamped with
+/// `crate_name` at capture time — the same fixture shape
+/// `duplicate_name_across_sources_names_both_crates` builds.
+fn write_source_dir(tag: &str, crate_name: &str, fn_name: &str) -> std::path::PathBuf {
+    use crate::{
+        api::record::{Record, RecordKind},
+        SourceLocation,
+    };
+
+    let dir = crate::api::test_util::unique_test_dir(&format!("builder_{tag}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("crate_name.txt"), crate_name).unwrap();
+    let record = Record::new(
+        RecordKind::Function,
+        fn_name.to_string(),
+        format!("pub fn {fn_name}() -> i32 {{ 1 }}"),
+        SourceLocation {
+            file: "src/lib.rs".to_string(),
+            line: 1,
+            column: 1,
+            crate_name: None,
+        },
+        None,
+    );
+    crate::api::utils::jsonl::write_to_jsonl_file(dir.join("default_1.jsonl"), &[&record]).unwrap();
+    dir
+}
+
+/// Render a module path the way the other origin tests in this file do.
+fn module(p: syn::Path) -> String {
+    p.to_token_stream().to_string()
+}
+
+fn fn_ident(name: &str) -> syn::Ident {
+    syn::parse_str(name).unwrap()
+}
+
+/// A build script names a directory and gets a registry — no `Source` in between.
+/// The captured crate becomes the default module, exactly as it does through a
+/// hand-built stream.
+#[test]
+fn builder_reads_a_source_directory() {
+    let dir = write_source_dir("plain", "flat-crate", "marked_fn");
+    let registry: Registry<()> = Registry::builder().source(&dir).build().expect("indexes");
+
+    assert!(registry.functions.contains_key(&fn_ident("marked_fn")));
+    // Dashes normalize to underscores, as they must to be a Rust module path.
+    assert_eq!(
+        registry.default_module().map(module),
+        Some("flat_crate".to_string())
+    );
+    assert_eq!(
+        registry.origin_module(&fn_ident("marked_fn")).map(module),
+        Some("flat_crate".to_string())
+    );
+}
+
+/// `source_named` overrides the capture-time stamp, which is what a dependency
+/// renamed in `Cargo.toml` needs: the recorded package name would not resolve
+/// from the crate that refers to it by another name.
+#[test]
+fn builder_source_named_overrides_the_captured_crate() {
+    let dir = write_source_dir("renamed", "real-package-name", "helper_fn");
+
+    // Without the override, the registry believes the package name.
+    let plain: Registry<()> = Registry::builder().source(&dir).build().expect("indexes");
+    assert_eq!(
+        plain.origin_module(&fn_ident("helper_fn")).map(module),
+        Some("real_package_name".to_string())
+    );
+
+    let renamed: Registry<()> = Registry::builder()
+        .source_named(&dir, "as_renamed")
+        .build()
+        .expect("indexes");
+    assert_eq!(
+        renamed.origin_module(&fn_ident("helper_fn")).map(module),
+        Some("as_renamed".to_string())
+    );
+    assert_eq!(
+        renamed.default_module().map(module),
+        Some("as_renamed".to_string())
+    );
+}
+
+/// Feeders accumulate, and the override stays **per directory** — a
+/// registry-level one could only fix a single module, which is the whole reason
+/// it lives on the source.
+#[test]
+fn builder_composes_directories_and_streams() {
+    let flat = write_source_dir("multi_flat", "flat-crate", "flat_fn");
+    let helper = write_source_dir("multi_helper", "real-helper-name", "helper_fn");
+
+    let registry: Registry<()> = Registry::builder()
+        .source(&flat)
+        .source_named(&helper, "renamed_helper")
+        .items(vec![(
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn synthetic() -> i32 {
+                    2
+                }
+            )),
+            crate::SourceLocation::default(),
+        )])
+        .build()
+        .expect("indexes");
+
+    for name in ["flat_fn", "helper_fn", "synthetic"] {
+        assert!(registry.functions.contains_key(&fn_ident(name)), "{name}");
+    }
+    // Each directory keeps its own origin; the stream item has none to keep.
+    assert_eq!(
+        registry.origin_module(&fn_ident("flat_fn")).map(module),
+        Some("flat_crate".to_string())
+    );
+    assert_eq!(
+        registry.origin_module(&fn_ident("helper_fn")).map(module),
+        Some("renamed_helper".to_string())
+    );
+    assert_eq!(
+        registry.origin_module(&fn_ident("synthetic")).map(module),
+        None
+    );
+
+    // First-seen order, which is what makes the first entry the default module.
+    assert_eq!(
+        registry
+            .all_source_modules()
+            .into_iter()
+            .map(module)
+            .collect::<Vec<_>>(),
+        vec!["flat_crate".to_string(), "renamed_helper".to_string()]
+    );
+}
+
+/// The builder is sugar: it reaches the same indexing as the primitive, so the
+/// whole-stream rules cannot differ between the two entry points.
+#[test]
+fn builder_and_from_items_agree() {
+    let dir = write_source_dir("agree", "flat-crate", "marked_fn");
+
+    let built: Registry<()> = Registry::builder().source(&dir).build().expect("indexes");
+    let streamed: Registry<()> =
+        Registry::from_items(crate::Source::new(&dir).items_all()).expect("indexes");
+
+    assert_eq!(built.functions.len(), streamed.functions.len());
+    assert_eq!(
+        built.default_module().map(module),
+        streamed.default_module().map(module)
+    );
+    assert_eq!(built.passthrough.len(), streamed.passthrough.len());
+}

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -288,8 +288,8 @@ macro_rules! ident {
 pub mod core {
     pub use crate::api::core::{
         ConverterImpl, Direction, DomainScalar, Generation, Gravestone, NicheSlot, Niches,
-        Prebindgen, Registry, RepresentationDomain, ScalarValue, ScanError, Stage, Transmute,
-        TypeEntry, TypeKey, WriteRustError,
+        Prebindgen, Registry, RegistryBuilder, RepresentationDomain, ScalarValue, ScanError, Stage,
+        Transmute, TypeEntry, TypeKey, WriteRustError,
     };
 }
 


### PR DESCRIPTION
`Flat` (on `language-integration`) reads a prebindgen directory with
`builder().source(dir).build()`. `Registry` could not: every build script had to
stand up a `Source` first and hand over the item stream.

```rust
// before
let source = prebindgen::Source::new(example_flat::PREBINDGEN_OUT_DIR);
let registry = Registry::from_items(source.items_all())?;

// after
let registry = Registry::builder()
    .source(example_flat::PREBINDGEN_OUT_DIR)
    .build()?;
```

Same method names as `FlatBuilder`, deliberately — one shape for saying where
captured items come from, whoever consumes them.

## `source_named` for a renamed dependency

A dependency renamed in `Cargo.toml` has a capture-time origin of its *real*
package name, which will not resolve from a crate that refers to it by another.
`source_named(dir, name)` overrides it, **per directory**: a registry-level
override could only fix one module, and a registry may layer several sources.

covertest-kotlin is the only real user and now names both its sources in one
expression:

```rust
let registry = Registry::builder()
    .source(perftest_flat::PREBINDGEN_OUT_DIR)
    .source_named(cov_helpers::PREBINDGEN_OUT_DIR, "cov_helpers")
    .build()?;
```

The other `Source` knobs — group selection, feature and target filtering — have no
callers anywhere in the workspace outside their own doctests, so they stay on
`Source` and remain reachable through `.items()`.

## Purely additive

`from_items` stays the **primitive** and `build()` is sugar over it. So the five
things it does with `SourceLocation`s — `source_modules` gathering in stream order,
`normalize_item_types` against those modules, `item_origins`, the duplicate-name
check with its `first_crate`/`second_crate` enrichment, and the stored locations —
stay in one place, unchanged.

Consequences: the 230 tests that build registries from synthetic items are
untouched, and `zenoh-flat-c` / `zenoh-flat-jni` keep building. They can each drop
a `Source` in a one-line change, in their own repos, whenever suits.

## Why this shape now

It is the seam for what comes next. When `Registry` starts consuming `Flat` instead
of indexing a stream itself, only `from_items`' body changes — the API callers
already write is the final one, so no consumer moves twice.

`M` threads from `builder()` to `build()` through a `PhantomData`, so no call site
names it: it is fixed by the adapter passed to `resolve`, and inference already
carries that across statements at all six production sites. Only the doctest
annotates it, because nothing there resolves.

## Tests

Four new tests over real on-disk prebindgen directories, reusing the fixture
pattern `duplicate_name_across_sources_names_both_crates` already uses:

- `.source(dir)` indexes the directory and records the captured crate as the
  default module (dashes normalized);
- `.source_named` overrides the capture-time stamp, asserted both ways round;
- directories and a synthetic stream compose in one builder, each directory keeping
  its own origin, `source_modules` in first-seen order;
- `builder_and_from_items_agree` — the sugar reaches the same indexing, so the
  whole-stream rules cannot drift between the two entry points.

Plus a **runnable** doctest on `Registry::builder`, via
`Source::init_doctest_simulate()`. Every existing example of constructing a
`Registry` is an `ignore` fence, so this is the first one actually checked.

## Verification

457 tests and 14 doctests on `--all --all-features`; default features clean; clippy
clean on all three configurations CI runs; `examples/regen-check.sh` byte-identical
— so migrating four build scripts changed no generated output. The JVM covertest
passes all 48 sections, which is what exercises the two-source path including the
rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)