### PR TITLE
A prelude, Extern instead of Opaque, and no args

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -43,7 +43,7 @@
 
 4	api/core/expand.rs
 12	api/core/registry.rs
-40	api/core/types_util.rs
+41	api/core/types_util.rs
 18	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
@@ -70,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 205
+# total: 206

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -43,7 +43,7 @@
 
 4	api/core/expand.rs
 12	api/core/registry.rs
-41	api/core/types_util.rs
+40	api/core/types_util.rs
 18	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
@@ -70,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 206
+# total: 205

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -133,9 +133,13 @@ impl Type {
 /// rather than the Rust shape that carried it:
 ///
 /// * `#[prebindgen] pub type X = path::To<Thing>;` — how a foreign or
-///   crate-private type gets a name here. That name is also what teaches the
-///   language to recognise the path: see
-///   [`normalize_type`](crate::api::core::types_util::normalize_type)'s rule list.
+///   crate-private type gets a name here. That name usually also teaches the
+///   language to recognise the path (see
+///   [`normalize_type`](crate::api::core::types_util::normalize_type)'s rule list),
+///   but the two are not the same thing: an alias is an `Extern` **always** and a
+///   reduction rule only when its target is a path the grammar does not already
+///   model. `type Error = Box<dyn Error>` is an `Extern` with no reduction rule at
+///   all — nobody spells a trait object in a signature, they write `Error`.
 /// * `#[prebindgen] pub struct X(..);` — a tuple struct, whose fields no adapter
 ///   has ever crossed.
 ///

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -89,7 +89,7 @@ pub enum Type {
     Variant(Variant),
     /// An enum whose every alternative is fieldless — a named set of integers.
     Enum(Enum),
-    Opaque(Opaque),
+    Extern(Extern),
 }
 
 impl Type {
@@ -98,7 +98,7 @@ impl Type {
             Type::Struct(s) => &s.name,
             Type::Variant(v) => &v.name,
             Type::Enum(e) => &e.name,
-            Type::Opaque(o) => &o.name,
+            Type::Extern(e) => &e.name,
         }
     }
 
@@ -112,7 +112,7 @@ impl Type {
             Type::Struct(s) => &s.origin.location,
             Type::Variant(v) => &v.origin.location,
             Type::Enum(e) => &e.origin.location,
-            Type::Opaque(o) => &o.origin.location,
+            Type::Extern(e) => &e.origin.location,
         }
     }
 
@@ -122,27 +122,41 @@ impl Type {
             Type::Struct(s) => syn::Item::Struct(s.origin.syntax.clone()),
             Type::Variant(v) => syn::Item::Enum(v.origin.syntax.clone()),
             Type::Enum(e) => syn::Item::Enum(e.origin.syntax.clone()),
-            Type::Opaque(o) => o.origin.syntax.clone(),
+            Type::Extern(e) => e.origin.syntax.clone(),
         }
     }
 }
 
-/// A type whose contents do not cross the boundary — a handle.
+/// A type the flat API **names** but whose contents it does not model.
 ///
-/// Two spellings declare one thing, because the model records the *fact* rather
-/// than the Rust shape that carried it:
+/// Two spellings declare one thing, because what the frontend records is the fact
+/// rather than the Rust shape that carried it:
 ///
-/// * `#[prebindgen] pub type X = path::To<Thing>;` — the way to give a foreign or
-///   crate-private type a name in the flat API. This is how a handle is declared
-///   deliberately.
+/// * `#[prebindgen] pub type X = path::To<Thing>;` — how a foreign or
+///   crate-private type gets a name here. That name is also what teaches the
+///   language to recognise the path: see
+///   [`normalize_type`](crate::api::core::types_util::normalize_type)'s rule list.
 /// * `#[prebindgen] pub struct X(..);` — a tuple struct, whose fields no adapter
 ///   has ever crossed.
 ///
-/// Either way the adapter decides what the handle becomes: an opaque pointer, a
-/// `ptr_class`, a `convert!` target.
+/// Not necessarily a *handle*: `#[prebindgen] pub type Duration =
+/// std::time::Duration;` crosses by value through a `convert!`, erased to a plain
+/// integer. What it becomes — an opaque pointer, a `ptr_class`, a conversion — is
+/// the adapter's decision, and this says only that the frontend does not model the
+/// contents.
 #[derive(Clone, Debug)]
-pub struct Opaque {
+pub struct Extern {
     pub name: syn::Ident,
+    /// What the declaration points at, for an alias — `std::time::Duration`,
+    /// `zenoh::Session`, `handles::Storage`. `None` for a tuple struct, which is
+    /// itself the definition.
+    ///
+    /// Informational, and deliberately **not** classified. `Error` is
+    /// `Box<dyn std::error::Error + Send + Sync>` behind a `zenoh::` alias in one
+    /// crate and spelled openly in another, so being "a std type" is a property of
+    /// the spelling, not of the type. An adapter that wants to recognise a target
+    /// may; the frontend does not decide for it.
+    pub target: Option<String>,
     /// The declaring item — a type alias or a tuple struct.
     pub origin: Origin<syn::Item>,
 }
@@ -173,7 +187,7 @@ pub struct Param {
 
 /// A `#[prebindgen]` struct: a product of fields that cross the boundary.
 ///
-/// A struct whose contents do *not* cross is an [`Opaque`], not a `Struct` with
+/// A struct whose contents do *not* cross is an [`Extern`], not a `Struct` with
 /// nothing in it — so `fields` is a plain list, and empty means the source wrote
 /// a struct with no fields.
 ///

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -133,13 +133,12 @@ impl Type {
 /// rather than the Rust shape that carried it:
 ///
 /// * `#[prebindgen] pub type X = path::To<Thing>;` — how a foreign or
-///   crate-private type gets a name here. That name usually also teaches the
-///   language to recognise the path (see
-///   [`normalize_type`](crate::api::core::types_util::normalize_type)'s rule list),
-///   but the two are not the same thing: an alias is an `Extern` **always** and a
-///   reduction rule only when its target is a path the grammar does not already
-///   model. `type Error = Box<dyn Error>` is an `Extern` with no reduction rule at
-///   all — nobody spells a trait object in a signature, they write `Error`.
+///   crate-private type gets a name here. A **one-way road**: the name is
+///   thereafter the only way to spell that type inside the flat API, and the
+///   qualified path stays refused. This declares a name; it is not an equivalence
+///   between spellings — see
+///   [`normalize_type`](crate::api::core::types_util::normalize_type)'s rule 4 for
+///   why treating it as one is a category error.
 /// * `#[prebindgen] pub struct X(..);` — a tuple struct, whose fields no adapter
 ///   has ever crossed.
 ///

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -56,7 +56,7 @@
 //! | `struct S;`, `struct S {}` | zero fields | the delimiters are spelling |
 //! | `enum E { A(u8) }` | [`Variant`] | a sum, identified by position |
 //! | `enum E { A = 7 }` | [`Enum`] | a named integer, identified by its value |
-//! | `type X = ..`, `struct X(..)` | [`Opaque`] | a handle; contents do not cross |
+//! | `type X = ..`, `struct X(..)` | [`Extern`] | named here; contents not modelled |
 //! | `&mut MaybeUninit<T>` | [`RefMode::Out`] | an out-param slot the caller supplies |
 //! | no `->`, `-> ()` | [`TypeKind::Unit`] | the same function |
 //! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
@@ -114,7 +114,7 @@
 //!
 //! # Declaring a handle
 //!
-//! `#[prebindgen] pub type X = path::To<Thing>;` declares an [`Opaque`]: it gives
+//! `#[prebindgen] pub type X = path::To<Thing>;` declares an [`Extern`]: it gives
 //! a foreign or crate-private type a **name in the flat API** without claiming
 //! anything about its contents. That is what makes the API closable — a handle
 //! enters it deliberately rather than by being mentioned — and it is why a
@@ -158,7 +158,7 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{
-        Alternative, Constant, Element, Enum, EnumValue, Field, Function, Opaque, Param, Struct,
+        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Param, Struct,
         Type, Unsupported, Variant,
     },
     origin::Origin,
@@ -303,25 +303,18 @@ impl FlatBuilder {
 
         // Pass 0: normalize every item's types to the canonical flat spelling
         // before a single one is classified. `std::option::Option<T>` is an
-        // `Option`, and `source_a::TypeA` is `TypeA` — decisions this module
-        // owns, so it must be the one to see the reduced form. Gathering EVERY
-        // module name first is what makes a cross-source reference in an
-        // earlier item normalize the same as in a later one.
+        // `Option`, `source_a::TypeA` is `TypeA`, and `zenoh::Session` is whatever
+        // an alias named it — decisions this module owns, so it must be the one to
+        // see the reduced form. Gathering EVERY module and alias first is what
+        // makes a reference in an earlier item normalize the same as in a later
+        // one.
         //
         // The consequence is deliberate and stated on `Origin`: a slice
         // is the spelling generation must EMIT, which is the normalized one —
         // the flat namespace is what the generated crate can actually name.
-        let mut modules: Vec<String> = Vec::new();
-        for (_, loc) in &items {
-            if let Some(crate_name) = &loc.crate_name {
-                let module = crate_name.replace('-', "_");
-                if !modules.contains(&module) {
-                    modules.push(module);
-                }
-            }
-        }
+        let normalization = crate::api::core::types_util::Normalization::from_items(&items);
         for (item, _) in &mut items {
-            crate::api::core::types_util::normalize_item_types(item, &modules);
+            crate::api::core::types_util::normalize_item_types(item, &normalization);
         }
 
         // Pass 1: the consts an array length may name. Unnamed `const _` items
@@ -575,7 +568,7 @@ fn first_unresolved(
         ),
         // An enum names nothing, an opaque hides what it names, and an
         // unsupported item already has a diagnosis worth keeping.
-        Element::Type(Type::Enum(_) | Type::Opaque(_)) | Element::Unsupported(_) => {}
+        Element::Type(Type::Enum(_) | Type::Extern(_)) | Element::Unsupported(_) => {}
     }
     refs.into_iter().find_map(|r| r.first_unresolved(declared))
 }
@@ -828,16 +821,20 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
         // anything about its contents. That is the only way a handle enters the
         // API deliberately, and the reason references can be required to resolve.
         syn::Item::Type(t) => match reject_generic_params(&t.generics) {
-            // `Opaque` has no binder and no arity, so a generic alias would be
+            // `Extern` has no binder and no arity, so a generic alias would be
             // accepted as one declaration that `Handle<u8>` then resolves against
             // — losing exactly the scoped-parameter distinction every other item
             // kind refuses. It is also why `MaybeUninit` needed grammar support
             // rather than an alias.
             Err(error) => unsupported(t.ident.clone(), syn::Item::Type(t), &at, error),
-            Ok(()) => Element::Type(Type::Opaque(Opaque {
-                name: t.ident.clone(),
-                origin: Origin::new(syn::Item::Type(t), at),
-            })),
+            Ok(()) => {
+                let target = Some(t.ty.to_token_stream().to_string());
+                Element::Type(Type::Extern(Extern {
+                    name: t.ident.clone(),
+                    target,
+                    origin: Origin::new(syn::Item::Type(t), at),
+                }))
+            }
         },
         // Including the unnamed `const _` each source injects as its feature
         // guard: it is a const, so it is one here. `Element::name` returns
@@ -958,7 +955,7 @@ fn lower_fn(
 
 /// Lower a `struct` item to whichever of the two shapes it is.
 ///
-/// A **tuple struct** is an [`Opaque`]: no adapter has ever crossed its fields,
+/// A **tuple struct** is an [`Extern`]: no adapter has ever crossed its fields,
 /// so they are deliberately not lowered and a field type outside the grammar is
 /// not an error. Anything else is a product of fields that do cross.
 fn lower_struct(
@@ -987,10 +984,12 @@ fn lower_struct(
         }
         // Its contents are not a boundary surface, so nothing is lowered.
         syn::Fields::Unnamed(_) => {
-            return Ok(Type::Opaque(Opaque {
+            return Ok(Type::Extern(Extern {
                 name: s.ident.clone(),
+                // A tuple struct IS the definition; it points at nothing.
+                target: None,
                 origin: Origin::new(syn::Item::Struct(s.clone()), Rc::clone(at)),
-            }))
+            }));
         }
         syn::Fields::Unit => Vec::new(),
     };

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -169,18 +169,22 @@ fn the_prelude_reaches_every_builtin_by_either_spelling() {
     assert_eq!(mode, RefMode::Out);
 }
 
-/// A declared alias IS a reduction rule: the flat API naming a foreign path is what
-/// teaches the language to recognise that path. So both spellings reach the one
-/// declaration, and the alias's own target is left alone — rewriting it with its
-/// own rule would make it `pub type Session = Session`.
+/// A `#[prebindgen] pub type` is a **one-way road**: it brings a foreign type into
+/// the flat API under a name, and that name is thereafter the only way to spell it.
+///
+/// It is a *declaration*, not an equivalence. Treating it as a reduction rule broke
+/// the contract normalization actually has — choose among spellings of one type,
+/// never change what a type is — because `type Bytes = Vec<u8>` would make `Vec<u8>`
+/// an extern. So a qualified spelling stays refused even when an alias names exactly
+/// that type.
 #[test]
-fn a_declared_alias_reduces_the_path_it_names() {
+fn an_alias_is_a_declaration_not_an_equivalence() {
     let items: Vec<syn::Item> = vec![
         syn::parse_quote!(
             pub type Session = zenoh::Session;
         ),
         syn::parse_quote!(
-            pub fn by_alias(s: &Session) {}
+            pub fn by_name(s: &Session) {}
         ),
         syn::parse_quote!(
             pub fn by_path(s: &zenoh::Session) {}
@@ -189,41 +193,58 @@ fn a_declared_alias_reduces_the_path_it_names() {
     let flat = Flat::builder()
         .items(items.into_iter().map(|i| (i, loc())))
         .build()
-        .expect("both spellings reach the declaration");
+        .expect("a refusal is deferred, not fatal");
 
-    // Neither is refused, so both resolved.
-    assert_eq!(flat.unsupported().count(), 0);
-    for name in ["by_alias", "by_path"] {
-        let f = flat.function(name).expect(name);
-        let TypeKind::Ref { inner, .. } = &f.params[0].ty.kind else {
-            panic!("a borrow");
-        };
-        let TypeKind::Named { id } = &inner.kind else {
-            panic!("a nominal type");
-        };
-        assert_eq!(id.name, "Session", "{name}");
-    }
+    // The declared name works.
+    let f = flat.function("by_name").expect("declared");
+    let TypeKind::Ref { inner, .. } = &f.params[0].ty.kind else {
+        panic!("a borrow");
+    };
+    let TypeKind::Named { id } = &inner.kind else {
+        panic!("a nominal type");
+    };
+    assert_eq!(id.name, "Session");
 
-    // The declaration is not rewritten by the rule it defines.
-    let ty = flat.declared_type("Session").expect("declared");
-    let Type::Extern(e) = ty else {
+    // The path it aliases does NOT, and the diagnosis says to use the name.
+    assert!(flat.function("by_path").is_none());
+    let u = flat.unsupported().next().expect("one refusal");
+    assert!(matches!(
+        &*u.error,
+        ItemError::UnresolvedType { name } if name == "zenoh::Session"
+    ));
+    assert!(
+        u.error.to_string().contains("refer to that"),
+        "the diagnosis must point at the declared name: {}",
+        u.error
+    );
+
+    // And the declaration itself still records what it points at.
+    let Type::Extern(e) = flat.declared_type("Session").expect("declared") else {
         panic!("an extern");
     };
     assert_eq!(e.target.as_deref(), Some("zenoh :: Session"));
 }
 
-/// A concrete alias must not capture other instantiations, nor the constructor.
+/// An alias cannot retype anything, whatever its target's arguments — the property
+/// that made key-shape bugs possible in the first place, now unreachable because an
+/// alias is not an equivalence at all.
 ///
-/// `type Bytes = Vec<u8>` and `Vec<String>` are unrelated types. An arg-blind key
-/// conflated them *and* shadowed the prelude, so the parameter below stopped being a
-/// sequence — an unrelated declaration retyping a spelling elsewhere in the API.
+/// Covers the reported cases: a concrete generic target (`Vec<u8>`, which shadowed
+/// the prelude), and a const-generic pair (`Wrap<4>` / `Wrap<8>`, which collided
+/// because a key kept only type arguments).
 #[test]
-fn a_concrete_alias_captures_nothing_else() {
+fn an_alias_never_retypes_a_spelling() {
     let flat = Flat::builder()
         .items(
             vec![
                 syn::parse_quote!(
                     pub type Bytes = std::vec::Vec<u8>;
+                ),
+                syn::parse_quote!(
+                    pub type Small = zenoh::Wrap<4>;
+                ),
+                syn::parse_quote!(
+                    pub type Big = zenoh::Wrap<8>;
                 ),
                 syn::parse_quote!(
                     pub fn strings(xs: std::vec::Vec<String>) {}
@@ -233,6 +254,12 @@ fn a_concrete_alias_captures_nothing_else() {
                 ),
                 syn::parse_quote!(
                     pub fn by_name(b: Bytes) {}
+                ),
+                syn::parse_quote!(
+                    pub fn small(w: Small) {}
+                ),
+                syn::parse_quote!(
+                    pub fn big(w: Big) {}
                 ),
             ]
             .into_iter()
@@ -250,69 +277,26 @@ fn a_concrete_alias_captures_nothing_else() {
             .clone()
     };
 
-    // The reported case: a different instantiation is untouched.
-    assert!(
-        matches!(param("strings"), TypeKind::Sequence(_)),
-        "`Vec<String>` is a sequence, whatever `Bytes` aliases"
-    );
+    // A prelude type keeps its grammar meaning at every instantiation, whatever an
+    // unrelated alias happens to target.
+    for f in ["strings", "bytes"] {
+        assert!(
+            matches!(param(f), TypeKind::Sequence(_)),
+            "`{f}`: the grammar's spelling stays canonical"
+        );
+    }
 
-    // And the alias's OWN instantiation keeps its grammar meaning: the language
-    // models `Vec<u8>`, so the prelude owns that path and the alias is not a
-    // reduction rule for it. Otherwise declaring `Bytes` would retype every
-    // `Vec<u8>` in the flat API.
-    assert!(
-        matches!(param("bytes"), TypeKind::Sequence(_)),
-        "the grammar's spelling stays canonical"
-    );
-
-    // The alias is still perfectly usable by name — a bare path is never reduced.
-    let TypeKind::Named { id } = param("by_name") else {
-        panic!("a nominal type");
-    };
-    assert_eq!(id.name, "Bytes");
-    assert!(matches!(
-        flat.declared_type("Bytes").expect("declared"),
-        Type::Extern(_)
-    ));
-}
-
-/// Two aliases over one foreign constructor stay distinct, which is what keeping
-/// type arguments in the key buys.
-#[test]
-fn concrete_aliases_over_one_constructor_stay_distinct() {
-    let flat = Flat::builder()
-        .items(
-            vec![
-                syn::parse_quote!(
-                    pub type Small = zenoh::Wrap<u8>;
-                ),
-                syn::parse_quote!(
-                    pub type Big = zenoh::Wrap<String>;
-                ),
-                syn::parse_quote!(
-                    pub fn small(w: zenoh::Wrap<u8>) {}
-                ),
-                syn::parse_quote!(
-                    pub fn big(w: zenoh::Wrap<String>) {}
-                ),
-            ]
-            .into_iter()
-            .map(|i: syn::Item| (i, loc())),
-        )
-        .build()
-        .expect("parses");
-
-    for (func, expected) in [("small", "Small"), ("big", "Big")] {
-        let f = flat
-            .function(func)
-            .unwrap_or_else(|| panic!("{func} survives"));
-        let TypeKind::Named { id } = &f.params[0].ty.kind else {
-            panic!("a nominal type");
+    // Each alias is usable by its own name, and they cannot collide: a bare path is
+    // never reduced, so the name IS the identity.
+    for (f, expected) in [("by_name", "Bytes"), ("small", "Small"), ("big", "Big")] {
+        let TypeKind::Named { id } = param(f) else {
+            panic!("{f}: a nominal type");
         };
-        // Each use site reaches its own alias, and the reduced type carries no
-        // arguments — the alias name IS the whole type.
-        assert_eq!(id.name, expected, "{func}");
-        assert_eq!(tokens(&f.params[0].ty.origin.syntax), expected, "{func}");
+        assert_eq!(id.name, expected, "{f}");
+        assert!(matches!(
+            flat.declared_type(expected).expect(expected),
+            Type::Extern(_)
+        ));
     }
 }
 

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -212,6 +212,110 @@ fn a_declared_alias_reduces_the_path_it_names() {
     assert_eq!(e.target.as_deref(), Some("zenoh :: Session"));
 }
 
+/// A concrete alias must not capture other instantiations, nor the constructor.
+///
+/// `type Bytes = Vec<u8>` and `Vec<String>` are unrelated types. An arg-blind key
+/// conflated them *and* shadowed the prelude, so the parameter below stopped being a
+/// sequence — an unrelated declaration retyping a spelling elsewhere in the API.
+#[test]
+fn a_concrete_alias_captures_nothing_else() {
+    let flat = Flat::builder()
+        .items(
+            vec![
+                syn::parse_quote!(
+                    pub type Bytes = std::vec::Vec<u8>;
+                ),
+                syn::parse_quote!(
+                    pub fn strings(xs: std::vec::Vec<String>) {}
+                ),
+                syn::parse_quote!(
+                    pub fn bytes(xs: std::vec::Vec<u8>) {}
+                ),
+                syn::parse_quote!(
+                    pub fn by_name(b: Bytes) {}
+                ),
+            ]
+            .into_iter()
+            .map(|i: syn::Item| (i, loc())),
+        )
+        .build()
+        .expect("parses");
+
+    let param = |name: &str| {
+        flat.function(name)
+            .unwrap_or_else(|| panic!("{name} survives"))
+            .params[0]
+            .ty
+            .kind
+            .clone()
+    };
+
+    // The reported case: a different instantiation is untouched.
+    assert!(
+        matches!(param("strings"), TypeKind::Sequence(_)),
+        "`Vec<String>` is a sequence, whatever `Bytes` aliases"
+    );
+
+    // And the alias's OWN instantiation keeps its grammar meaning: the language
+    // models `Vec<u8>`, so the prelude owns that path and the alias is not a
+    // reduction rule for it. Otherwise declaring `Bytes` would retype every
+    // `Vec<u8>` in the flat API.
+    assert!(
+        matches!(param("bytes"), TypeKind::Sequence(_)),
+        "the grammar's spelling stays canonical"
+    );
+
+    // The alias is still perfectly usable by name — a bare path is never reduced.
+    let TypeKind::Named { id } = param("by_name") else {
+        panic!("a nominal type");
+    };
+    assert_eq!(id.name, "Bytes");
+    assert!(matches!(
+        flat.declared_type("Bytes").expect("declared"),
+        Type::Extern(_)
+    ));
+}
+
+/// Two aliases over one foreign constructor stay distinct, which is what keeping
+/// type arguments in the key buys.
+#[test]
+fn concrete_aliases_over_one_constructor_stay_distinct() {
+    let flat = Flat::builder()
+        .items(
+            vec![
+                syn::parse_quote!(
+                    pub type Small = zenoh::Wrap<u8>;
+                ),
+                syn::parse_quote!(
+                    pub type Big = zenoh::Wrap<String>;
+                ),
+                syn::parse_quote!(
+                    pub fn small(w: zenoh::Wrap<u8>) {}
+                ),
+                syn::parse_quote!(
+                    pub fn big(w: zenoh::Wrap<String>) {}
+                ),
+            ]
+            .into_iter()
+            .map(|i: syn::Item| (i, loc())),
+        )
+        .build()
+        .expect("parses");
+
+    for (func, expected) in [("small", "Small"), ("big", "Big")] {
+        let f = flat
+            .function(func)
+            .unwrap_or_else(|| panic!("{func} survives"));
+        let TypeKind::Named { id } = &f.params[0].ty.kind else {
+            panic!("a nominal type");
+        };
+        // Each use site reaches its own alias, and the reduced type carries no
+        // arguments — the alias name IS the whole type.
+        assert_eq!(id.name, expected, "{func}");
+        assert_eq!(tokens(&f.params[0].ty.origin.syntax), expected, "{func}");
+    }
+}
+
 #[test]
 fn a_qualified_builtin_is_a_named_type() {
     assert!(matches!(

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -114,6 +114,104 @@ fn a_box_classifies_as_what_it_wraps() {
 /// reduces and classifies, while a path-qualified lookalike is a foreign type
 /// that merely shares the name, and collapsing it would silently retype the
 /// field.
+/// The prelude: every name the language pre-declares reaches the same kind however
+/// it is spelled. This is the drift guard — adding a builtin arm to `lower_path`
+/// and forgetting its prelude entry fails here, which is exactly how `MaybeUninit`
+/// slipped through and worked only when the source happened to `use` it.
+#[test]
+fn the_prelude_reaches_every_builtin_by_either_spelling() {
+    use crate::api::core::types_util::Normalization;
+
+    // Each entry, bare against fully qualified. `MaybeUninit` needs a `&mut` to
+    // mean anything, so it is checked separately below.
+    for (path, name) in Normalization::PRELUDE {
+        if *name == "MaybeUninit" {
+            continue;
+        }
+        let bare: proc_macro2::TokenStream = match *name {
+            "Result" => quote::quote!(Result<u8, Error>),
+            "String" => quote::quote!(String),
+            _ => {
+                let n = quote::format_ident!("{name}");
+                quote::quote!(#n<u8>)
+            }
+        };
+        let qualified: proc_macro2::TokenStream = {
+            let p: syn::Path = syn::parse_str(path).expect("a prelude path");
+            match *name {
+                "Result" => quote::quote!(#p<u8, Error>),
+                "String" => quote::quote!(#p),
+                _ => quote::quote!(#p<u8>),
+            }
+        };
+        assert_eq!(
+            format!("{:?}", kind(bare)),
+            format!("{:?}", kind(qualified)),
+            "`{name}` must classify the same as `{path}`"
+        );
+    }
+
+    // `core` and `alloc` are re-exports of the same items, so either root works.
+    assert!(matches!(
+        kind(quote::quote!(core::option::Option<u8>)),
+        TypeKind::Optional(_)
+    ));
+    assert!(matches!(
+        kind(quote::quote!(alloc::string::String)),
+        TypeKind::Str
+    ));
+
+    // The bug: qualified `MaybeUninit` used to fall through to an unresolvable
+    // nominal type, so an out-parameter worked only if the source `use`d it.
+    let TypeKind::Ref { mode, .. } = kind(quote::quote!(&mut std::mem::MaybeUninit<Sample>)) else {
+        panic!("a borrow");
+    };
+    assert_eq!(mode, RefMode::Out);
+}
+
+/// A declared alias IS a reduction rule: the flat API naming a foreign path is what
+/// teaches the language to recognise that path. So both spellings reach the one
+/// declaration, and the alias's own target is left alone — rewriting it with its
+/// own rule would make it `pub type Session = Session`.
+#[test]
+fn a_declared_alias_reduces_the_path_it_names() {
+    let items: Vec<syn::Item> = vec![
+        syn::parse_quote!(
+            pub type Session = zenoh::Session;
+        ),
+        syn::parse_quote!(
+            pub fn by_alias(s: &Session) {}
+        ),
+        syn::parse_quote!(
+            pub fn by_path(s: &zenoh::Session) {}
+        ),
+    ];
+    let flat = Flat::builder()
+        .items(items.into_iter().map(|i| (i, loc())))
+        .build()
+        .expect("both spellings reach the declaration");
+
+    // Neither is refused, so both resolved.
+    assert_eq!(flat.unsupported().count(), 0);
+    for name in ["by_alias", "by_path"] {
+        let f = flat.function(name).expect(name);
+        let TypeKind::Ref { inner, .. } = &f.params[0].ty.kind else {
+            panic!("a borrow");
+        };
+        let TypeKind::Named { id } = &inner.kind else {
+            panic!("a nominal type");
+        };
+        assert_eq!(id.name, "Session", "{name}");
+    }
+
+    // The declaration is not rewritten by the rule it defines.
+    let ty = flat.declared_type("Session").expect("declared");
+    let Type::Extern(e) = ty else {
+        panic!("an extern");
+    };
+    assert_eq!(e.target.as_deref(), Some("zenoh :: Session"));
+}
+
 #[test]
 fn a_qualified_builtin_is_a_named_type() {
     assert!(matches!(
@@ -191,17 +289,26 @@ fn a_raw_pointer_is_not_in_the_language() {
     );
 }
 
-/// A lifetime argument is accepted and not modelled — `Foo<'a, T>` classifies
-/// as `Foo` with one type argument, and the spelling keeps the rest.
+/// Generic arguments are accepted and not modelled — a reference is a *name*, and
+/// the spelling keeps the rest.
+///
+/// Nothing could read retained arguments: a surviving reference resolves to a
+/// declared type, and no declaration takes type parameters. They are still lowered,
+/// so a bad type inside one is diagnosed.
 #[test]
-fn a_lifetime_argument_is_spelling_only() {
+fn generic_arguments_are_spelling_only() {
     let ty = lower(quote::quote!(Foo<'a, u8>)).expect("in the language");
-    let TypeKind::Named { id, args } = &ty.kind else {
+    let TypeKind::Named { id } = &ty.kind else {
         panic!("a named type");
     };
     assert_eq!(id.name, "Foo");
-    assert_eq!(args.len(), 1);
     assert_eq!(tokens(&ty.origin.syntax), "Foo < 'a , u8 >");
+
+    // Lowered, so still checked: a tuple inside a generic argument is refused.
+    assert_eq!(
+        reason(quote::quote!(Foo<(u8, u8)>)),
+        UnsupportedTypeReason::UnsupportedTuple
+    );
 }
 
 #[test]
@@ -438,7 +545,7 @@ fn struct_shapes() {
     let tuple = parse_one(syn::parse_quote!(
         pub struct B(SomethingUnexpressible<'_, dyn Trait>);
     ));
-    assert_eq!(as_opaque(&tuple).name, "B");
+    assert_eq!(as_extern(&tuple).name, "B");
 
     let unit = parse_one(syn::parse_quote!(
         pub struct C;
@@ -600,17 +707,38 @@ fn an_unmodelled_item_kind_is_diagnosed() {
 /// crate-private type gets a name in the flat API. That is what lets references
 /// be required to resolve, so it is the keystone of the whole model.
 #[test]
-fn a_marked_alias_declares_an_opaque() {
+fn a_marked_alias_declares_an_extern() {
     let element = parse_one(syn::parse_quote!(
         pub type Session = zenoh::Session;
     ));
-    let o = as_opaque(&element);
-    assert_eq!(o.name, "Session");
+    let e = as_extern(&element);
+    assert_eq!(e.name, "Session");
+    // What it points at is a modelled fact, so an adapter can recognise a target
+    // without taking the syntax apart. Not classified: a std type may hide behind a
+    // foreign alias, as `Error = zenoh::Error` does.
+    assert_eq!(e.target.as_deref(), Some("zenoh :: Session"));
     // The whole item survives, so a consumer can still read what it aliased.
     assert_eq!(
-        tokens(&o.origin.syntax),
+        tokens(&e.origin.syntax),
         "pub type Session = zenoh :: Session ;"
     );
+
+    // A std target is recorded the same way — nothing here decides it is special.
+    let element = parse_one(syn::parse_quote!(
+        pub type Duration = std::time::Duration;
+    ));
+    assert_eq!(
+        as_extern(&element).target.as_deref(),
+        Some("std :: time :: Duration")
+    );
+
+    // A tuple struct points at nothing: it IS the definition.
+    let element = parse_one(syn::parse_quote!(
+        pub struct Handle(Whatever);
+    ));
+    let e = as_extern(&element);
+    assert_eq!(e.name, "Handle");
+    assert_eq!(e.target, None);
 
     // And it satisfies a reference, which is the point.
     let mut items = fixture_types();
@@ -930,7 +1058,7 @@ fn a_reference_resolves_to_its_declaration() {
         panic!("a nominal type");
     };
     let target = flat.resolve(id).expect("resolves");
-    assert!(matches!(target, Type::Opaque(_)));
+    assert!(matches!(target, Type::Extern(_)));
     assert_eq!(target.name(), "Session");
 }
 
@@ -1008,12 +1136,14 @@ fn an_undeclared_reference_refuses_the_referencing_item() {
         quote::quote!(Result<Session, Error>),
         quote::quote!(impl Fn(Session) + Send + Sync + 'static),
         quote::quote!([Session; 4]),
-        quote::quote!(Wrapper<Session>),
+        // NOT `Wrapper<Session>`: a declared type takes no type parameters, so a
+        // source writing that would not compile. Generic arguments are lowered and
+        // discarded — `generic_arguments_are_spelling_only` covers that they are
+        // still checked.
     ] {
         let flat = Flat::builder()
             .items(vec![
                 (opaque("Error"), loc()),
-                (opaque("Wrapper"), loc()),
                 (
                     syn::parse_quote!(
                         pub fn f(s: #ty) {}
@@ -1244,7 +1374,7 @@ fn every_surviving_reference_resolves() {
     assert!(flat.function("takes_broken").is_none());
 }
 
-/// A generic alias is a generic binder like any other item's, and `Opaque` has no
+/// A generic alias is a generic binder like any other item's, and `Extern` has no
 /// binder or arity — so accepting one would let `Handle<u8>` resolve against a
 /// declaration that says nothing about its parameter. It is also why
 /// `MaybeUninit` needed grammar support rather than an alias.
@@ -1283,7 +1413,7 @@ fn a_generic_alias_is_refused() {
     let element = parse_one(syn::parse_quote!(
         pub type Borrowed<'a> = hidden::Borrowed<'a>;
     ));
-    assert_eq!(as_opaque(&element).name, "Borrowed");
+    assert_eq!(as_extern(&element).name, "Borrowed");
 }
 
 // ── The flat namespace ─────────────────────────────────────────────────

--- a/prebindgen/src/api/core/flat/tests/mod.rs
+++ b/prebindgen/src/api/core/flat/tests/mod.rs
@@ -128,10 +128,10 @@ fn as_variant(e: &Element) -> &Variant {
     }
 }
 
-fn as_opaque(e: &Element) -> &Opaque {
+fn as_extern(e: &Element) -> &Extern {
     match as_type(e) {
-        Type::Opaque(o) => o,
-        other => panic!("expected an opaque, got {}", describe_type(other)),
+        Type::Extern(e) => e,
+        other => panic!("expected an extern, got {}", describe_type(other)),
     }
 }
 
@@ -169,7 +169,7 @@ fn describe_type(t: &Type) -> String {
         Type::Struct(_) => "struct",
         Type::Variant(_) => "sum",
         Type::Enum(_) => "enum",
-        Type::Opaque(_) => "opaque",
+        Type::Extern(_) => "extern",
     };
     format!("{kind} `{}`", t.name())
 }

--- a/prebindgen/src/api/core/flat/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/flat/tests/roundtrip.rs
@@ -281,12 +281,12 @@ fn struct_delimiters_survive_and_spell() {
         (1, "C { x : __f0 }".to_string())
     );
 
-    // A tuple struct is a handle, so it is an `Opaque` and has no field list to
+    // A tuple struct is named-only, so it is an `Extern` and has no field list to
     // spell from — the delimiters still survive in its retained syntax.
     let element = parse_one(syn::parse_quote!(
         pub struct D(Whatever<'_, dyn Trait>);
     ));
-    let o = as_opaque(&element);
+    let o = as_extern(&element);
     assert_eq!(o.name, "D");
     assert!(tokens(&o.origin.syntax).contains("Whatever"));
 }

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -71,12 +71,7 @@ impl TypeRef {
         declared: &std::collections::HashSet<String>,
     ) -> Option<String> {
         match &self.kind {
-            TypeKind::Named { id, args } => {
-                if !declared.contains(&id.name) {
-                    return Some(id.name.clone());
-                }
-                args.iter().find_map(|a| a.first_unresolved(declared))
-            }
+            TypeKind::Named { id } => (!declared.contains(&id.name)).then(|| id.name.clone()),
             TypeKind::Optional(t) | TypeKind::Sequence(t) | TypeKind::Ref { inner: t, .. } => {
                 t.first_unresolved(declared)
             }
@@ -102,9 +97,8 @@ impl TypeRef {
                 ok.collect_extents(out);
                 err.collect_extents(out);
             }
-            TypeKind::Callback { args } | TypeKind::Named { args, .. } => {
-                args.iter().for_each(|t| t.collect_extents(out))
-            }
+            TypeKind::Callback { args } => args.iter().for_each(|t| t.collect_extents(out)),
+            TypeKind::Named { .. } => {}
             TypeKind::Scalar(_) | TypeKind::Str | TypeKind::Unit => {}
         }
     }
@@ -152,7 +146,7 @@ pub enum TypeKind {
     /// segment's generic arguments live in `args`, and only the *type*
     /// arguments: a lifetime argument says nothing a destination language can
     /// act on. The full spelling is in [`TypeRef::origin`] for whoever re-emits it.
-    Named { id: TypeId, args: Vec<TypeRef> },
+    Named { id: TypeId },
     /// `[T; N]` — a run of `T` whose length is known at compile time.
     ///
     /// Deliberately not a [`Sequence`](TypeKind::Sequence) with an optional
@@ -579,11 +573,11 @@ fn lower_path(
                     let ok = Box::new(args.remove(0));
                     return Ok(TypeKind::Fallible { ok, err });
                 }
-                _ => return Ok(named(tp, args)),
+                _ => return Ok(named(tp)),
             }
         }
     }
-    Ok(named(tp, args))
+    Ok(named(tp))
 }
 
 /// If `ty` is a bare `MaybeUninit<T>`, the `T` it holds storage for.
@@ -626,7 +620,16 @@ pub(crate) fn is_unit_type(ty: &syn::Type) -> bool {
 
 /// `Named` with the identity read off the path: every segment joined, minus the
 /// generic arguments, which are already in `args`.
-fn named(tp: &syn::TypePath, args: Vec<TypeRef>) -> TypeKind {
+/// `Named` with the identity read off the path: every segment joined, minus the
+/// generic arguments.
+///
+/// The arguments are **lowered but not retained** — a bad type inside one is still
+/// diagnosed, it just leaves no trace. Nothing could read them: a surviving
+/// reference resolves to a declared type, and no declaration takes type parameters,
+/// so `Foo<u8>` against a declared `Foo` would not compile in the source crate.
+/// Accepting *instantiated* generics — `Wrapper<u8>` as its own declared type — is
+/// what would bring the field back.
+fn named(tp: &syn::TypePath) -> TypeKind {
     let name = tp
         .path
         .segments
@@ -636,6 +639,5 @@ fn named(tp: &syn::TypePath, args: Vec<TypeRef>) -> TypeKind {
         .join("::");
     TypeKind::Named {
         id: TypeId { name },
-        args,
     }
 }

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -155,7 +155,10 @@ pub enum TypeKind {
     /// at every site.
     Array {
         elem: Box<TypeRef>,
-        extent: ArrayExtent,
+        /// Boxed: an extent carries an [`Origin`] over the length expression, which
+        /// makes it the size outlier among the kinds, and an array is the rare one.
+        /// The same trade-off [`Unsupported::error`](super::Unsupported) makes.
+        extent: Box<ArrayExtent>,
     },
     /// A borrow — `&T`, `&mut T`, or `&mut MaybeUninit<T>`. The lifetime is
     /// spelling, so it lives in [`TypeRef::origin`] rather than here.
@@ -443,7 +446,7 @@ pub(crate) fn lower_type(
                 .map_err(|e| fail(UnsupportedTypeReason::BadArrayExtent(Box::new(e))))?;
             TypeKind::Array {
                 elem: Box::new(lower_type(&a.elem, consts, at)?),
-                extent,
+                extent: Box::new(extent),
             }
         }
         // The callback shape is decided by `extract_fn_trait_args`, this

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -103,7 +103,10 @@ impl TypeKey {
     /// input is not modified).
     pub fn from_type(ty: &syn::Type) -> Self {
         let mut t = ty.clone();
-        crate::api::core::types_util::normalize_type(&mut t, &[]);
+        crate::api::core::types_util::normalize_type(
+            &mut t,
+            &crate::api::core::types_util::Normalization::prelude(),
+        );
         Self {
             canon: t.to_token_stream().to_string().into(),
             ty: std::rc::Rc::new(t),
@@ -730,25 +733,22 @@ impl<M> Registry<M> {
         let mut registry = Registry::default();
         // Pass 1: collect and gather EVERY source module name first, so
         // cross-source type references (`source_a::TypeA` in a later-chained
-        // source's signature) normalize order-independently in pass 2.
+        // source's signature) normalize order-independently in pass 2 — and so do
+        // alias-named paths, whose declaration may arrive later or in another
+        // source.
         let items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
-        for (_, loc) in &items {
-            if let Some(crate_name) = &loc.crate_name {
-                let module = crate_name.replace('-', "_");
-                if !registry.source_modules.contains(&module) {
-                    registry.source_modules.push(module);
-                }
-            }
-        }
+        let normalization = crate::api::core::types_util::Normalization::from_items(&items);
+        registry
+            .source_modules
+            .clone_from(&normalization.source_modules);
         // Pass 2: normalize each item's types to the canonical flat spelling
-        // (`crate::`/source-module paths reduce to the bare indexed name —
-        // see `normalize_type`'s rule list), then index. Every downstream
-        // `TypeKey::from_type` over a signature type therefore sees the
-        // normalized form, so bare adapter declarations match qualified
-        // captured spellings (issue #95).
-        let modules = registry.source_modules.clone();
+        // (`crate::`/source-module paths reduce to the bare indexed name, and an
+        // aliased path to the name its alias gives it — see `normalize_type`'s
+        // rule list), then index. Every downstream `TypeKey::from_type` over a
+        // signature type therefore sees the normalized form, so bare adapter
+        // declarations match qualified captured spellings (issue #95).
         for (mut item, loc) in items {
-            crate::api::core::types_util::normalize_item_types(&mut item, &modules);
+            crate::api::core::types_util::normalize_item_types(&mut item, &normalization);
             let crate_name = loc.crate_name.clone();
             let named: Option<syn::Ident> = match &item {
                 syn::Item::Fn(f) => Some(f.sig.ident.clone()),

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -33,32 +33,23 @@ pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
 ///    `#[prebindgen]` source crates chained into the registry,
 ///    hyphens-as-underscores) reduces the same way (`myflat::Foo` ≡ `Foo`).
 ///    Pure callers pass `&[]`.
-/// 4. A path that some **alias** names reduces to that alias's name. Two
-///    sources of aliases, and they **partition** the targets rather than
-///    competing, because a target either has a grammar meaning or it does
-///    not:
+/// 4. A **prelude** path reduces to the bare name the language knows it by —
+///    exactly [`Normalization::PRELUDE`], with `core`/`alloc` read as `std`.
+///    Each entry names a *constructor*, so arguments are preserved:
+///    `std::vec::Vec<Foo>` ≡ `Vec<Foo>`.
 ///
-///    * [`Normalization::PRELUDE`], which the language pre-declares, over
-///      targets the grammar **models**. Each names a *constructor*, so
-///      arguments are ignored when matching and preserved when rewriting:
-///      `std::vec::Vec<Foo>` ≡ `Vec<Foo>`.
-///    * every `#[prebindgen] pub type X = path;` an ingested crate wrote,
-///      over targets the grammar does **not** model. Each names one
-///      *complete type*, so the key includes its type arguments and a match
-///      replaces the whole type: given `pub type Session = zenoh::Session`,
-///      `zenoh::Session` ≡ `Session`.
+///    Nothing else. `std::ffi::CString` stays qualified, and so does a
+///    foreign path (`zenoh::KeyExpr`) **even when an alias names that
+///    type**: a `#[prebindgen] pub type` is a one-way road, bringing a
+///    foreign type into the flat API under a name that is thereafter the
+///    only way to spell it. It declares
+///    an [`Extern`](crate::core::flat::Extern); it is not an equivalence.
 ///
-///    An alias whose target the grammar already models is therefore NOT a
-///    reduction rule — the prelude owns that path. `type Bytes = Vec<u8>`
-///    is a perfectly good name for an [`Extern`](crate::core::flat::Extern),
-///    but it must not make `Vec<u8>` stop being a sequence, and it must not
-///    capture `Vec<String>`.
-///
-///    Nothing else: `std::ffi::CString` stays qualified, and a foreign path
-///    nobody aliased (`zenoh::KeyExpr` with no such declaration) is NEVER
-///    touched — the registry has no index of a foreign namespace, so
-///    `a::KeyExpr` and `b::KeyExpr` may be genuinely distinct types and
-///    their spelling is their identity.
+///    That keeps the rule meaning-preserving, which is the whole contract
+///    here: reduction may choose among spellings of ONE type, never change
+///    what a type is. Treating an alias as an equivalence broke that —
+///    `Vec<u8>` ≡ `Bytes` turns a sequence into an extern — and no
+///    key-shape refinement fixes the category error.
 /// 5. Lifetimes are NOT normalized (`&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`)
 ///    — [`match_pattern`] treats lifetimes as fixed structure and
 ///    foreign-type declarations (`ptr_class!(ZKeyExpr<'static>)`) rely on
@@ -79,13 +70,14 @@ pub struct Normalization {
     /// Module name per ingested source, first-seen order. The first doubles as the
     /// default module for references with no recorded origin.
     pub source_modules: Vec<String>,
-    /// Constructor path → name, from [`Self::PRELUDE`] alone. Matched with the use
-    /// site's type arguments **ignored and preserved**, because a prelude entry
-    /// names a constructor: `std::vec::Vec` is every `Vec<T>`.
+    /// Constructor path → the bare name the language knows it by, from
+    /// [`Self::PRELUDE`] alone. Matched with the use site's type arguments ignored
+    /// and preserved, because a prelude entry names a constructor:
+    /// `std::vec::Vec` is every `Vec<T>`.
+    ///
+    /// A crate's `#[prebindgen] pub type` is deliberately **not** here — see
+    /// [`normalize_type`]'s rule 4.
     constructors: HashMap<String, String>,
-    /// Complete type → name, from the aliases the ingested crates declared. Matched
-    /// exactly, arguments included, because an alias names one whole type.
-    aliases: HashMap<String, String>,
 }
 
 impl Normalization {
@@ -118,7 +110,6 @@ impl Normalization {
                 .iter()
                 .map(|(path, name)| ((*path).to_string(), (*name).to_string()))
                 .collect(),
-            aliases: HashMap::new(),
         }
     }
 
@@ -138,42 +129,7 @@ impl Normalization {
                 }
             }
         }
-        for (item, _) in items {
-            // A marked `type X = path;` declares `X` as the name for `path`. Only a
-            // path-shaped target can be a reduction key: `Box<dyn Error>` never
-            // appears *as a path* in a signature — it is still an `Extern`, just not
-            // a spelling anyone writes.
-            let syn::Item::Type(t) = item else { continue };
-            let syn::Type::Path(tp) = &*t.ty else {
-                continue;
-            };
-            if tp.qself.is_some() {
-                continue;
-            }
-            // The language's aliases and a crate's PARTITION the targets: a target
-            // either has a grammar meaning or it does not. So an alias to something
-            // the grammar already models is not a reduction rule — the prelude owns
-            // that path, and `Vec<u8>` must keep meaning a sequence rather than be
-            // retyped by an unrelated declaration. A single-segment target is a bare
-            // builtin or scalar, and dead as a key anyway, since `reduce_flat_path`
-            // bails below two segments.
-            if tp.path.segments.len() < 2
-                || out.constructors.contains_key(&constructor_key(&tp.path))
-            {
-                continue;
-            }
-            // First declaration wins, so two names for one target reduce
-            // deterministically rather than by stream order.
-            out.aliases
-                .entry(alias_key(&tp.path))
-                .or_insert_with(|| t.ident.to_string());
-        }
         out
-    }
-
-    /// The name a crate's alias gives this exact type, arguments included.
-    fn alias_of(&self, path: &syn::Path) -> Option<&str> {
-        self.aliases.get(&alias_key(path)).map(String::as_str)
     }
 
     /// The bare name the language knows this constructor by, arguments ignored.
@@ -181,13 +137,6 @@ impl Normalization {
         self.constructors
             .get(&constructor_key(path))
             .map(String::as_str)
-    }
-
-    /// True when `ident` is an alias this collected — so its own declaration is not
-    /// rewritten by the rule it defines.
-    fn declares(&self, ident: &syn::Ident) -> bool {
-        let name = ident.to_string();
-        self.aliases.values().any(|n| *n == name)
     }
 }
 
@@ -197,19 +146,12 @@ impl Default for Normalization {
     }
 }
 
-/// A path as an alias-map key: segments joined, **type** arguments kept, lifetimes
-/// dropped, and a leading `core`/`alloc` read as `std` since they re-export the
-/// same items.
+/// A path as a key: segments joined, arguments dropped, and a leading
+/// `core`/`alloc` read as `std` since they re-export the same items.
 ///
-/// Type arguments are part of the key because they are part of the type:
-/// `Vec<u8>`, `Vec<String>` and the bare constructor `Vec` are three different
-/// things, and conflating them lets a concrete alias capture every other
-/// instantiation.
-///
-/// Lifetimes are dropped, so a target `zenoh::key_expr::KeyExpr<'static>` and a use
-/// site's `KeyExpr<'a>` share a key — a lifetime is spelling, as everywhere else in
-/// the model.
-fn alias_key(path: &syn::Path) -> String {
+/// Only [`Normalization::constructors`] is keyed this way, and a constructor is
+/// exactly a path without arguments — `std::vec::Vec` matches every `Vec<T>`.
+fn constructor_key(path: &syn::Path) -> String {
     let mut out = String::new();
     for (i, seg) in path.segments.iter().enumerate() {
         if i > 0 {
@@ -221,44 +163,7 @@ fn alias_key(path: &syn::Path) -> String {
         }
         out.push_str(&ident);
     }
-    let args = type_args(path);
-    if !args.is_empty() {
-        out.push('<');
-        out.push_str(&args.join(","));
-        out.push('>');
-    }
     out
-}
-
-/// The last segment's **type** arguments, rendered; lifetimes and anything else
-/// excluded. Empty for a path with no arguments, or with only lifetimes.
-fn type_args(path: &syn::Path) -> Vec<String> {
-    let Some(seg) = path.segments.last() else {
-        return Vec::new();
-    };
-    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
-        return Vec::new();
-    };
-    ab.args
-        .iter()
-        .filter_map(|a| match a {
-            syn::GenericArgument::Type(t) => Some(t.to_token_stream().to_string()),
-            _ => None,
-        })
-        .collect()
-}
-
-/// The path a prelude entry is keyed under: the same, minus type arguments.
-///
-/// A prelude entry names a **constructor** — `std::vec::Vec` matches every `Vec<T>`
-/// — which is the one asymmetry between the language's aliases and a crate's. A
-/// crate's alias names a complete type, so its key keeps the arguments.
-fn constructor_key(path: &syn::Path) -> String {
-    let mut path = path.clone();
-    if let Some(last) = path.segments.last_mut() {
-        last.arguments = syn::PathArguments::None;
-    }
-    alias_key(&path)
 }
 
 pub fn normalize_type(ty: &mut syn::Type, against: &Normalization) {
@@ -295,16 +200,6 @@ pub fn normalize_type(ty: &mut syn::Type, against: &Normalization) {
 pub fn normalize_item_types(item: &mut syn::Item, against: &Normalization) {
     use syn::visit_mut::VisitMut;
 
-    // An alias IS a reduction rule, so rewriting its own target with it would be
-    // circular: `pub type Duration = std::time::Duration` would become
-    // `pub type Duration = Duration`. Leave a collected alias's declaration alone;
-    // nothing downstream reads it as a boundary type.
-    if let syn::Item::Type(t) = item {
-        if against.declares(&t.ident) {
-            return;
-        }
-    }
-
     struct ItemNormalizer<'a> {
         against: &'a Normalization,
     }
@@ -324,21 +219,9 @@ fn reduce_flat_path(path: &mut syn::Path, against: &Normalization) {
         return;
     }
 
-    // A crate's alias names one COMPLETE type, arguments included, so a match
-    // replaces the whole thing: the alias name carries no arguments of its own.
-    // Tried first, and exactly — `zenoh::Wrap<u8>` is not `zenoh::Wrap<String>`.
-    if let Some(name) = against.alias_of(path) {
-        let ident = syn::Ident::new(
-            name,
-            path.segments.last().expect("len checked").ident.span(),
-        );
-        path.leading_colon = None;
-        path.segments = std::iter::once(syn::PathSegment::from(ident)).collect();
-        return;
-    }
-
-    // The language's own aliases name a CONSTRUCTOR, so arguments are ignored when
-    // matching and preserved when rewriting: `std::vec::Vec<Foo>` is `Vec<Foo>`.
+    // A prelude entry names a CONSTRUCTOR, so arguments are ignored when matching
+    // and preserved when rewriting: `std::vec::Vec<Foo>` is `Vec<Foo>`. A crate's
+    // own alias is NOT consulted — see rule 4.
     if let Some(name) = against.constructor_of(path) {
         let mut last = path.segments.last().expect("len checked").clone();
         last.ident = syn::Ident::new(name, last.ident.span());

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -3,8 +3,12 @@
 //! replaces the per-module copies that used to live in `core::unfold`,
 //! `core::expand`, and the jnigen adapter.
 
+use std::collections::HashMap;
+
 use proc_macro2::Span;
 use quote::ToTokens;
+
+use crate::SourceLocation;
 
 /// The single-segment path type for a bare item ident (`Foo` → `Foo`) —
 /// direct construction, no string round trip, cannot fail.
@@ -29,13 +33,18 @@ pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
 ///    `#[prebindgen]` source crates chained into the registry,
 ///    hyphens-as-underscores) reduces the same way (`myflat::Foo` ≡ `Foo`).
 ///    Pure callers pass `&[]`.
-/// 4. The std prelude whitelist reduces to its bare form — exactly
-///    `std|core|alloc :: vec::Vec | option::Option | result::Result |
-///    string::String | boxed::Box` (with or without a leading `::`).
-///    Nothing else: `std::ffi::CString` stays qualified, and unknown crate
-///    paths (`zenoh::KeyExpr`) are NEVER touched — the registry has no
-///    index of a foreign namespace, so `a::KeyExpr` and `b::KeyExpr` may be
-///    genuinely distinct types and their spelling is their identity.
+/// 4. A path that some **alias** names reduces to that alias's name. Two
+///    sources of aliases, treated identically because they say the same
+///    kind of thing: [`Normalization::PRELUDE`], which the language
+///    pre-declares, and every `#[prebindgen] pub type X = path;` the
+///    ingested crates wrote. So `std::vec::Vec` ≡ `Vec` and, given
+///    `pub type Session = zenoh::Session`, `zenoh::Session` ≡ `Session`.
+///
+///    Nothing else: `std::ffi::CString` stays qualified, and a foreign path
+///    nobody aliased (`zenoh::KeyExpr` with no such declaration) is NEVER
+///    touched — the registry has no index of a foreign namespace, so
+///    `a::KeyExpr` and `b::KeyExpr` may be genuinely distinct types and
+///    their spelling is their identity.
 /// 5. Lifetimes are NOT normalized (`&'a T` ≠ `&T`, `Foo<'static>` ≠ `Foo`)
 ///    — [`match_pattern`] treats lifetimes as fixed structure and
 ///    foreign-type declarations (`ptr_class!(ZKeyExpr<'static>)`) rely on
@@ -44,10 +53,126 @@ pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
 /// Idempotent; recurses through references, slices, tuples, pointers,
 /// generic arguments, and `impl Trait` bounds. Paths with a qualified self
 /// (`<T as Trait>::Assoc`) are left untouched.
-pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
+/// What a captured path may be reduced against: the ingested source crates' own
+/// modules, and every name an alias gives to a foreign path.
+///
+/// One value rather than a bare `&[String]`, because reduction has one rule and
+/// two sources of aliases feeding it — see [`normalize_type`]'s rule list.
+/// [`Self::default`] is the prelude alone, which is what a caller normalizing a
+/// lone type (rather than an ingested stream) wants.
+#[derive(Clone, Debug)]
+pub struct Normalization {
+    /// Module name per ingested source, first-seen order. The first doubles as the
+    /// default module for references with no recorded origin.
+    pub source_modules: Vec<String>,
+    /// Path → the name it is known by. `std::vec::Vec` → `Vec`,
+    /// `zenoh::Session` → `Session`.
+    aliases: HashMap<String, String>,
+}
+
+impl Normalization {
+    /// The names the language **pre-declares**, so no source crate has to write
+    /// them — exactly Rust's own idea of a prelude, a set of `use`s you need not
+    /// write. A crate need not write `use std::vec::Vec`, and need not write
+    /// `#[prebindgen] pub type Vec = std::vec::Vec` either, for the same reason.
+    ///
+    /// Not identical to Rust's prelude: it adds `MaybeUninit`, which the grammar
+    /// recognises for out-parameters. Its entries are exactly the bare names
+    /// [`lower_path`](crate::core::flat) classifies as builtins and that have a
+    /// std path at all — `str` has none, and neither do the scalars.
+    ///
+    /// Written with the `std` root; `core` and `alloc` are re-exports of the same
+    /// items, so a leading `core`/`alloc` is read as `std` before matching.
+    pub const PRELUDE: &'static [(&'static str, &'static str)] = &[
+        ("std::vec::Vec", "Vec"),
+        ("std::option::Option", "Option"),
+        ("std::result::Result", "Result"),
+        ("std::string::String", "String"),
+        ("std::boxed::Box", "Box"),
+        ("std::mem::MaybeUninit", "MaybeUninit"),
+    ];
+
+    /// The prelude alone: no ingested sources, no declared aliases.
+    pub fn prelude() -> Self {
+        Self {
+            source_modules: Vec::new(),
+            aliases: Self::PRELUDE
+                .iter()
+                .map(|(path, name)| ((*path).to_string(), (*name).to_string()))
+                .collect(),
+        }
+    }
+
+    /// Collect from a captured stream, before anything is normalized.
+    ///
+    /// Both entry points — `FlatBuilder::build` and `Registry::from_items` — build
+    /// this, so they cannot normalize differently. Gathering every module and alias
+    /// first is what makes reduction order-independent: a signature may name a type
+    /// whose alias is declared later, or in another source.
+    pub fn from_items(items: &[(syn::Item, SourceLocation)]) -> Self {
+        let mut out = Self::prelude();
+        for (_, loc) in items {
+            if let Some(crate_name) = &loc.crate_name {
+                let module = crate_name.replace('-', "_");
+                if !out.source_modules.contains(&module) {
+                    out.source_modules.push(module);
+                }
+            }
+        }
+        for (item, _) in items {
+            // A marked `type X = path;` declares `X` as the name for `path`. Only a
+            // path-shaped target can be a reduction key: `Box<dyn Error>` never
+            // appears *as a path* in a signature.
+            if let syn::Item::Type(t) = item {
+                if let syn::Type::Path(tp) = &*t.ty {
+                    if tp.qself.is_none() {
+                        out.aliases.insert(path_key(&tp.path), t.ident.to_string());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// The name this path is known by, if any.
+    fn alias_of(&self, path: &syn::Path) -> Option<&str> {
+        self.aliases.get(&path_key(path)).map(String::as_str)
+    }
+
+    /// True when `ident` is an alias this collected — so its own declaration is not
+    /// rewritten by the rule it defines.
+    fn declares(&self, ident: &syn::Ident) -> bool {
+        let name = ident.to_string();
+        self.aliases.values().any(|n| *n == name)
+    }
+}
+
+impl Default for Normalization {
+    fn default() -> Self {
+        Self::prelude()
+    }
+}
+
+/// A path as an alias-map key: segments joined, generic arguments dropped, and a
+/// leading `core`/`alloc` read as `std` since they re-export the same items.
+///
+/// Arguments are dropped so `zenoh::key_expr::KeyExpr<'static>` and a use site's
+/// `KeyExpr<'a>` share a key — a lifetime is spelling, as everywhere else in the
+/// model.
+fn path_key(path: &syn::Path) -> String {
+    let mut segs: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+    if let Some(first) = segs.first_mut() {
+        if first == "core" || first == "alloc" {
+            *first = "std".to_string();
+        }
+    }
+    segs.join("::")
+}
+
+pub fn normalize_type(ty: &mut syn::Type, against: &Normalization) {
     use syn::visit_mut::VisitMut;
     struct Normalizer<'a> {
-        modules: &'a [String],
+        against: &'a Normalization,
     }
     impl VisitMut for Normalizer<'_> {
         fn visit_type_mut(&mut self, ty: &mut syn::Type) {
@@ -61,16 +186,13 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
             }
             if let syn::Type::Path(tp) = ty {
                 if tp.qself.is_none() {
-                    reduce_flat_path(&mut tp.path, self.modules);
+                    reduce_flat_path(&mut tp.path, self.against);
                 }
             }
             syn::visit_mut::visit_type_mut(self, ty);
         }
     }
-    Normalizer {
-        modules: source_modules,
-    }
-    .visit_type_mut(ty);
+    Normalizer { against }.visit_type_mut(ty);
 }
 
 /// Apply [`normalize_type`] to every type position inside an item — fn
@@ -78,29 +200,53 @@ pub fn normalize_type(ty: &mut syn::Type, source_modules: &[String]) {
 /// pass ([`crate::api::core::registry::Registry::from_items`]) that makes
 /// captured spellings canonical before any key is formed, so every
 /// downstream `TypeKey::from_type` sees the flat spelling.
-pub fn normalize_item_types(item: &mut syn::Item, source_modules: &[String]) {
+pub fn normalize_item_types(item: &mut syn::Item, against: &Normalization) {
     use syn::visit_mut::VisitMut;
+
+    // An alias IS a reduction rule, so rewriting its own target with it would be
+    // circular: `pub type Duration = std::time::Duration` would become
+    // `pub type Duration = Duration`. Leave a collected alias's declaration alone;
+    // nothing downstream reads it as a boundary type.
+    if let syn::Item::Type(t) = item {
+        if against.declares(&t.ident) {
+            return;
+        }
+    }
+
     struct ItemNormalizer<'a> {
-        modules: &'a [String],
+        against: &'a Normalization,
     }
     impl VisitMut for ItemNormalizer<'_> {
         fn visit_type_mut(&mut self, ty: &mut syn::Type) {
             // Normalizes the whole subtree; no further descent needed.
-            normalize_type(ty, self.modules);
+            normalize_type(ty, self.against);
         }
     }
-    ItemNormalizer {
-        modules: source_modules,
-    }
-    .visit_item_mut(item);
+    ItemNormalizer { against }.visit_item_mut(item);
 }
 
 /// The path-reduction step of [`normalize_type`]: collapse a reducible
 /// multi-segment path to its final segment. See the rule list there.
-fn reduce_flat_path(path: &mut syn::Path, source_modules: &[String]) {
+fn reduce_flat_path(path: &mut syn::Path, against: &Normalization) {
     if path.segments.len() < 2 {
         return;
     }
+
+    // An alias names this path — the prelude's or a source crate's, treated alike.
+    // The use site's own arguments ride along, because a prelude alias names a
+    // generic: `std::vec::Vec<Foo>` is `Vec<Foo>`. The key is the WHOLE path, so a
+    // different path that merely ends in the same segment never matches —
+    // `foreign::Wrapper<u8>` is not an alias to `other::Wrapper`.
+    if let Some(name) = against.alias_of(path) {
+        let mut last = path.segments.last().expect("len checked").clone();
+        last.ident = syn::Ident::new(name, last.ident.span());
+        path.leading_colon = None;
+        path.segments = std::iter::once(last).collect();
+        return;
+    }
+
+    // Otherwise only a prefix into the flat namespace reduces, to the final
+    // segment: this crate's own path, or an ingested source's module.
     let head = path
         .segments
         .first()
@@ -109,26 +255,7 @@ fn reduce_flat_path(path: &mut syn::Path, source_modules: &[String]) {
         .to_string();
     let reduce = match head.as_str() {
         "crate" | "self" => true,
-        "std" | "core" | "alloc" => {
-            let tail: Vec<String> = path
-                .segments
-                .iter()
-                .skip(1)
-                .map(|s| s.ident.to_string())
-                .collect();
-            matches!(
-                tail.iter()
-                    .map(String::as_str)
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-                ["vec", "Vec"]
-                    | ["option", "Option"]
-                    | ["result", "Result"]
-                    | ["string", "String"]
-                    | ["boxed", "Box"]
-            )
-        }
-        other => source_modules.iter().any(|m| m == other),
+        other => against.source_modules.iter().any(|m| m == other),
     };
     if reduce {
         let last = path.segments.last().expect("len checked").clone();

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -34,11 +34,25 @@ pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
 ///    hyphens-as-underscores) reduces the same way (`myflat::Foo` ≡ `Foo`).
 ///    Pure callers pass `&[]`.
 /// 4. A path that some **alias** names reduces to that alias's name. Two
-///    sources of aliases, treated identically because they say the same
-///    kind of thing: [`Normalization::PRELUDE`], which the language
-///    pre-declares, and every `#[prebindgen] pub type X = path;` the
-///    ingested crates wrote. So `std::vec::Vec` ≡ `Vec` and, given
-///    `pub type Session = zenoh::Session`, `zenoh::Session` ≡ `Session`.
+///    sources of aliases, and they **partition** the targets rather than
+///    competing, because a target either has a grammar meaning or it does
+///    not:
+///
+///    * [`Normalization::PRELUDE`], which the language pre-declares, over
+///      targets the grammar **models**. Each names a *constructor*, so
+///      arguments are ignored when matching and preserved when rewriting:
+///      `std::vec::Vec<Foo>` ≡ `Vec<Foo>`.
+///    * every `#[prebindgen] pub type X = path;` an ingested crate wrote,
+///      over targets the grammar does **not** model. Each names one
+///      *complete type*, so the key includes its type arguments and a match
+///      replaces the whole type: given `pub type Session = zenoh::Session`,
+///      `zenoh::Session` ≡ `Session`.
+///
+///    An alias whose target the grammar already models is therefore NOT a
+///    reduction rule — the prelude owns that path. `type Bytes = Vec<u8>`
+///    is a perfectly good name for an [`Extern`](crate::core::flat::Extern),
+///    but it must not make `Vec<u8>` stop being a sequence, and it must not
+///    capture `Vec<String>`.
 ///
 ///    Nothing else: `std::ffi::CString` stays qualified, and a foreign path
 ///    nobody aliased (`zenoh::KeyExpr` with no such declaration) is NEVER
@@ -65,8 +79,12 @@ pub struct Normalization {
     /// Module name per ingested source, first-seen order. The first doubles as the
     /// default module for references with no recorded origin.
     pub source_modules: Vec<String>,
-    /// Path → the name it is known by. `std::vec::Vec` → `Vec`,
-    /// `zenoh::Session` → `Session`.
+    /// Constructor path → name, from [`Self::PRELUDE`] alone. Matched with the use
+    /// site's type arguments **ignored and preserved**, because a prelude entry
+    /// names a constructor: `std::vec::Vec` is every `Vec<T>`.
+    constructors: HashMap<String, String>,
+    /// Complete type → name, from the aliases the ingested crates declared. Matched
+    /// exactly, arguments included, because an alias names one whole type.
     aliases: HashMap<String, String>,
 }
 
@@ -96,10 +114,11 @@ impl Normalization {
     pub fn prelude() -> Self {
         Self {
             source_modules: Vec::new(),
-            aliases: Self::PRELUDE
+            constructors: Self::PRELUDE
                 .iter()
                 .map(|(path, name)| ((*path).to_string(), (*name).to_string()))
                 .collect(),
+            aliases: HashMap::new(),
         }
     }
 
@@ -122,21 +141,46 @@ impl Normalization {
         for (item, _) in items {
             // A marked `type X = path;` declares `X` as the name for `path`. Only a
             // path-shaped target can be a reduction key: `Box<dyn Error>` never
-            // appears *as a path* in a signature.
-            if let syn::Item::Type(t) = item {
-                if let syn::Type::Path(tp) = &*t.ty {
-                    if tp.qself.is_none() {
-                        out.aliases.insert(path_key(&tp.path), t.ident.to_string());
-                    }
-                }
+            // appears *as a path* in a signature — it is still an `Extern`, just not
+            // a spelling anyone writes.
+            let syn::Item::Type(t) = item else { continue };
+            let syn::Type::Path(tp) = &*t.ty else {
+                continue;
+            };
+            if tp.qself.is_some() {
+                continue;
             }
+            // The language's aliases and a crate's PARTITION the targets: a target
+            // either has a grammar meaning or it does not. So an alias to something
+            // the grammar already models is not a reduction rule — the prelude owns
+            // that path, and `Vec<u8>` must keep meaning a sequence rather than be
+            // retyped by an unrelated declaration. A single-segment target is a bare
+            // builtin or scalar, and dead as a key anyway, since `reduce_flat_path`
+            // bails below two segments.
+            if tp.path.segments.len() < 2
+                || out.constructors.contains_key(&constructor_key(&tp.path))
+            {
+                continue;
+            }
+            // First declaration wins, so two names for one target reduce
+            // deterministically rather than by stream order.
+            out.aliases
+                .entry(alias_key(&tp.path))
+                .or_insert_with(|| t.ident.to_string());
         }
         out
     }
 
-    /// The name this path is known by, if any.
+    /// The name a crate's alias gives this exact type, arguments included.
     fn alias_of(&self, path: &syn::Path) -> Option<&str> {
-        self.aliases.get(&path_key(path)).map(String::as_str)
+        self.aliases.get(&alias_key(path)).map(String::as_str)
+    }
+
+    /// The bare name the language knows this constructor by, arguments ignored.
+    fn constructor_of(&self, path: &syn::Path) -> Option<&str> {
+        self.constructors
+            .get(&constructor_key(path))
+            .map(String::as_str)
     }
 
     /// True when `ident` is an alias this collected — so its own declaration is not
@@ -153,20 +197,68 @@ impl Default for Normalization {
     }
 }
 
-/// A path as an alias-map key: segments joined, generic arguments dropped, and a
-/// leading `core`/`alloc` read as `std` since they re-export the same items.
+/// A path as an alias-map key: segments joined, **type** arguments kept, lifetimes
+/// dropped, and a leading `core`/`alloc` read as `std` since they re-export the
+/// same items.
 ///
-/// Arguments are dropped so `zenoh::key_expr::KeyExpr<'static>` and a use site's
-/// `KeyExpr<'a>` share a key — a lifetime is spelling, as everywhere else in the
-/// model.
-fn path_key(path: &syn::Path) -> String {
-    let mut segs: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
-    if let Some(first) = segs.first_mut() {
-        if first == "core" || first == "alloc" {
-            *first = "std".to_string();
+/// Type arguments are part of the key because they are part of the type:
+/// `Vec<u8>`, `Vec<String>` and the bare constructor `Vec` are three different
+/// things, and conflating them lets a concrete alias capture every other
+/// instantiation.
+///
+/// Lifetimes are dropped, so a target `zenoh::key_expr::KeyExpr<'static>` and a use
+/// site's `KeyExpr<'a>` share a key — a lifetime is spelling, as everywhere else in
+/// the model.
+fn alias_key(path: &syn::Path) -> String {
+    let mut out = String::new();
+    for (i, seg) in path.segments.iter().enumerate() {
+        if i > 0 {
+            out.push_str("::");
         }
+        let mut ident = seg.ident.to_string();
+        if i == 0 && (ident == "core" || ident == "alloc") {
+            ident = "std".to_string();
+        }
+        out.push_str(&ident);
     }
-    segs.join("::")
+    let args = type_args(path);
+    if !args.is_empty() {
+        out.push('<');
+        out.push_str(&args.join(","));
+        out.push('>');
+    }
+    out
+}
+
+/// The last segment's **type** arguments, rendered; lifetimes and anything else
+/// excluded. Empty for a path with no arguments, or with only lifetimes.
+fn type_args(path: &syn::Path) -> Vec<String> {
+    let Some(seg) = path.segments.last() else {
+        return Vec::new();
+    };
+    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
+        return Vec::new();
+    };
+    ab.args
+        .iter()
+        .filter_map(|a| match a {
+            syn::GenericArgument::Type(t) => Some(t.to_token_stream().to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The path a prelude entry is keyed under: the same, minus type arguments.
+///
+/// A prelude entry names a **constructor** — `std::vec::Vec` matches every `Vec<T>`
+/// — which is the one asymmetry between the language's aliases and a crate's. A
+/// crate's alias names a complete type, so its key keeps the arguments.
+fn constructor_key(path: &syn::Path) -> String {
+    let mut path = path.clone();
+    if let Some(last) = path.segments.last_mut() {
+        last.arguments = syn::PathArguments::None;
+    }
+    alias_key(&path)
 }
 
 pub fn normalize_type(ty: &mut syn::Type, against: &Normalization) {
@@ -232,12 +324,22 @@ fn reduce_flat_path(path: &mut syn::Path, against: &Normalization) {
         return;
     }
 
-    // An alias names this path — the prelude's or a source crate's, treated alike.
-    // The use site's own arguments ride along, because a prelude alias names a
-    // generic: `std::vec::Vec<Foo>` is `Vec<Foo>`. The key is the WHOLE path, so a
-    // different path that merely ends in the same segment never matches —
-    // `foreign::Wrapper<u8>` is not an alias to `other::Wrapper`.
+    // A crate's alias names one COMPLETE type, arguments included, so a match
+    // replaces the whole thing: the alias name carries no arguments of its own.
+    // Tried first, and exactly — `zenoh::Wrap<u8>` is not `zenoh::Wrap<String>`.
     if let Some(name) = against.alias_of(path) {
+        let ident = syn::Ident::new(
+            name,
+            path.segments.last().expect("len checked").ident.span(),
+        );
+        path.leading_colon = None;
+        path.segments = std::iter::once(syn::PathSegment::from(ident)).collect();
+        return;
+    }
+
+    // The language's own aliases name a CONSTRUCTOR, so arguments are ignored when
+    // matching and preserved when rewriting: `std::vec::Vec<Foo>` is `Vec<Foo>`.
+    if let Some(name) = against.constructor_of(path) {
         let mut last = path.segments.last().expect("len checked").clone();
         last.ident = syn::Ident::new(name, last.ident.span());
         path.leading_colon = None;


### PR DESCRIPTION
Three things one question kept surfacing: **what does the language know without being
told, and what must it be told?**

Prompted by `Duration` — not a primitive, not a flat-library type, and until now with
nowhere to belong.

## The std whitelist was a prelude all along

`reduce_flat_path` already reduced `crate`/`self` and any source-module prefix: a path
into the flat namespace collapses to its bare name. Bolted on was a five-entry
whitelist of std paths, the only thing in prebindgen that named the std library at
all.

Naming what that whitelist *is* removes the exception — those are **aliases the
language pre-declares**, a prelude in exactly Rust's sense. A crate need not write
`use std::vec::Vec`, and need not write `#[prebindgen] pub type Vec = std::vec::Vec`
either, for the same reason.

```rust
const PRELUDE: &[(&str, &str)] = &[
    ("std::vec::Vec", "Vec"),       ("std::option::Option", "Option"),
    ("std::result::Result", "Result"), ("std::string::String", "String"),
    ("std::boxed::Box", "Box"),     ("std::mem::MaybeUninit", "MaybeUninit"),
];
```

Each entry names a **constructor**, so arguments are ignored when matching and
preserved when rewriting: `std::vec::Vec<Foo>` is `Vec<Foo>`. `core`/`alloc` roots are
read as `std`, since they re-export the same items.

`Normalization` now holds what to reduce against, replacing the module-gathering loop
that `FlatBuilder::build` and `Registry::from_items` each wrote separately. They cannot
normalize differently now.

### A bug fix falls out

`mem::MaybeUninit` joins the prelude. It was a grammar builtin that was **not**
reducible, so it worked only because perftest-flat happens to `use` it — written
`&mut std::mem::MaybeUninit<Payload>` it became an unresolvable nominal type and
silently refused the item. `maybe_uninit_inner`'s comment claimed normalization had
already reduced it, which was false.

One test row per prelude entry now pins both spellings to the same kind, so that class
of drift fails a test instead of waiting to be discovered.

### An alias is a one-way road, not an equivalence

Reduction is *only* the prelude, `crate`/`self`, and source modules. A crate's
`#[prebindgen] pub type X = path;` is deliberately **not** a reduction rule: it brings
a foreign type into the flat API under a name, and that name is thereafter the only
way to spell it. `zenoh::Session` in a signature stays refused even when
`type Session = zenoh::Session` is declared — the diagnosis already said as much
("give the type a name here … and refer to that").

This PR tried the other way first, and review found two bugs that were one category
error: normalization decides which spellings denote **one type**, and an alias does not
create such a spelling. `Vec<u8>` ≡ `Bytes` turns a sequence into an extern, and once
one path can stand for two types, key shape decides which — type arguments, const
arguments, associated bindings, each a fresh way to collide. Removing the equivalence
makes the class unreachable rather than patched, and drops 133 lines.

So the prelude and a crate's aliases are not "two kinds of alias" needing a partition.
Different mechanisms, different jobs: one reduces spellings, the other declares a
name.

## `Opaque` becomes `Extern`, and carries what it points at

It was never only handles: `pub type Duration = std::time::Duration` crosses **by
value** through a `convert!`, erased to a Kotlin integer. What the frontend knows is
narrower and truer — *this name is in the flat API and its contents are not modelled* —
and the adapter decides the rest, as `Opaque`'s own doc already admitted.

`target` is now a modelled fact, so an adapter can recognise `std::time::Duration`
without taking syntax apart.

Deliberately **not** classified as std-vs-foreign: `pub type Error = zenoh::Error`
*is* `Box<dyn std::error::Error + Send + Sync>`, so std-ness is a property of the
spelling, not the type. A rule keyed on the path root would answer differently for one
type depending on who aliased it — which is why std types keep needing a declaration
rather than getting a category of their own.

## `args` is gone from `Named`

A reference is a name. Nothing could read retained arguments: a surviving reference
resolves to a declared type, and no declaration takes type parameters, so `Foo<u8>`
against a declared `Foo` would not compile in the source crate. They are still
*lowered*, so a bad type inside one is diagnosed — the dropped test row asserted a
shape real source cannot produce.

Shrinking `Named` made `Array` the largest variant and tripped
`clippy::large_enum_variant`, so its extent is boxed — the same trade-off
`Unsupported::error` already makes.

## Verification

522 tests and 18 doctests on `--all --all-features`; default features clean; clippy
clean in all three configurations CI runs, each with `-- -D warnings`.
`examples/regen-check.sh` is **byte-identical**, which is what proves rewriting
reduction changed no behaviour on any real source, and the JVM covertest passes all 48
sections — the path `convert!(Duration)` actually runs through.

The boundary ledger is unmoved at 205: nothing outside `core::flat` gained a
classification site.

## Noted, not fixed

- **`convert!` validates nothing** — keyed on a `TypeKey` string with no existence
  check, so a decl naming something absent is a silent no-op.
- **The `default_module` fallback is fragile**: a marked alias gets no `item_origins`
  stamp, so generated code qualifies it with the *first* source module. A
  `convert!`-only type from a second, renamed source would be qualified wrongly. Not
  reachable today; `Extern` now carries what a proper stamp would need.
- **`Cow<'_, [u8]>`** still cannot be declared — generic and lifetime-bearing — so
  `zbytes_to_bytes` remains refused when zenoh-flat migrates.

Refs #211. Umbrella: #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
