### PR TITLE
Cow<'_, T> is transparent, like Box<T>

### DIFF
--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -131,6 +131,8 @@ fn the_prelude_reaches_every_builtin_by_either_spelling() {
         let bare: proc_macro2::TokenStream = match *name {
             "Result" => quote::quote!(Result<u8, Error>),
             "String" => quote::quote!(String),
+            // `Cow` needs a lifetime and an unsized target to be valid Rust.
+            "Cow" => quote::quote!(Cow<'_, [u8]>),
             _ => {
                 let n = quote::format_ident!("{name}");
                 quote::quote!(#n<u8>)
@@ -141,6 +143,7 @@ fn the_prelude_reaches_every_builtin_by_either_spelling() {
             match *name {
                 "Result" => quote::quote!(#p<u8, Error>),
                 "String" => quote::quote!(#p),
+                "Cow" => quote::quote!(#p<'_, [u8]>),
                 _ => quote::quote!(#p<u8>),
             }
         };
@@ -359,6 +362,83 @@ fn a_sequence_is_a_sequence_borrowed_or_owned() {
         panic!("a reference");
     };
     assert!(matches!(inner.kind, TypeKind::Sequence(_)));
+}
+
+/// `Cow<'_, T>` **is** `T`, the same treatment `Box<T>` gets: borrowed or owned, and
+/// no destination language can tell.
+///
+/// Both adapters already behave that way — cbindgen lowers `Cow<'_, [T]>` "just like
+/// `Vec<T>` outputs", and jnigen's converter is `byte_array_from_slice(&v)`, which
+/// works by deref and is identical to the `Vec<u8>` one — so this classification
+/// predicts their behaviour rather than leaving it a special case.
+#[test]
+fn a_cow_is_what_it_borrows() {
+    // The property the whole treatment rests on: indistinguishable from the owned
+    // spelling of the same thing.
+    assert_eq!(
+        format!("{:?}", kind(quote::quote!(Cow<'_, [u8]>))),
+        format!("{:?}", kind(quote::quote!(Vec<u8>))),
+        "a byte Cow classifies exactly as a byte Vec"
+    );
+    assert!(matches!(kind(quote::quote!(Cow<'_, str>)), TypeKind::Str));
+
+    // The `Cow` survives where codegen reads it: a generated signature must spell
+    // `Cow<'_, [u8]>`, which is not interchangeable with `Vec<u8>` in Rust.
+    let ty = lower(quote::quote!(Cow<'_, [u8]>)).expect("in the language");
+    assert_eq!(tokens(&ty.origin.syntax), "Cow < '_ , [u8] >");
+
+    // Transparent for any target, as `Box` is: whether it can actually cross is the
+    // adapter's call, and both already restrict which elements they accept.
+    let TypeKind::Sequence(elem) = kind(quote::quote!(Cow<'_, [Sample]>)) else {
+        panic!("a sequence");
+    };
+    assert!(matches!(elem.kind, TypeKind::Named { .. }));
+
+    // A lifetime argument is expected on `Cow` alone. On any other builtin it is
+    // still not a shape the language has, so the exception is exactly one name wide:
+    // `Vec<'a, u8>` is a nominal `Vec` nobody declared, and the item is refused.
+    let element = {
+        let mut items = fixture_types();
+        let n = items.len();
+        items.push(syn::parse_quote!(
+            pub struct S {
+                pub f: Vec<'a, u8>,
+            }
+        ));
+        parse(items).remove(n)
+    };
+    assert!(matches!(
+        as_unsupported(&element),
+        ItemError::UnresolvedType { name } if name == "Vec"
+    ));
+}
+
+/// The signature that motivated this: zenoh-flat's `zbytes_to_bytes`. It was refused
+/// under the closed API because a lifetime argument sent `Cow` to an undeclared
+/// nominal type.
+#[test]
+fn a_cow_returning_accessor_resolves() {
+    let flat = Flat::builder()
+        .items(
+            vec![
+                syn::parse_quote!(
+                    pub type ZBytes = zenoh::bytes::ZBytes;
+                ),
+                syn::parse_quote!(
+                    pub fn zbytes_to_bytes(z: &ZBytes) -> Cow<'_, [u8]> {}
+                ),
+            ]
+            .into_iter()
+            .map(|i: syn::Item| (i, loc())),
+        )
+        .build()
+        .expect("parses");
+
+    assert_eq!(flat.unsupported().count(), 0, "no longer refused");
+    let f = flat.function("zbytes_to_bytes").expect("survives");
+    assert!(matches!(f.ret.kind, TypeKind::Sequence(_)));
+    // And the return still spells its `Cow`, so an adapter can emit the signature.
+    assert_eq!(tokens(&f.ret.origin.syntax), "Cow < '_ , [u8] >");
 }
 
 /// A raw pointer is not in the language. A `#[prebindgen]` crate is idiomatic

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -534,9 +534,11 @@ fn lower_path(
                 return Ok(TypeKind::Str);
             }
         }
-        // A builtin generic takes types only; a lifetime argument on one is not
-        // a shape this language has.
-        if !has_lifetime_arg {
+        // A builtin generic takes TYPE arguments only — a lifetime on one is not a
+        // shape this language has — with one exception: `Cow`'s own signature HAS a
+        // lifetime, so it is the one builtin where a lifetime argument is expected
+        // rather than refused.
+        if !has_lifetime_arg || name == "Cow" {
             let mut args = args;
             let arity = |n: usize| {
                 if args.len() == n {
@@ -567,6 +569,22 @@ fn lower_path(
                 // Rust spells. (A shared-ownership handle would classify as a
                 // `Ref` for the same reason, when the language accepts one.)
                 "Box" => {
+                    arity(1)?;
+                    return Ok(args.remove(0).kind);
+                }
+                // `Cow<'_, T>` **is** `T`, for the same reason `Box<T>` is: borrowed
+                // or owned, and no destination language can tell. Both adapters
+                // already say exactly that — cbindgen lowers it "just like `Vec<T>`
+                // outputs", and jnigen's converter body is
+                // `byte_array_from_slice(&v)`, which works by deref and is identical
+                // to the `Vec<u8>` one. So this classification *predicts* their
+                // behaviour instead of leaving it a special case.
+                //
+                // The `Cow` survives in `TypeRef::origin`, which is where an adapter
+                // reads the param type its generated fn must spell — and it must,
+                // since `Cow<'_, [u8]>` is not interchangeable with `Vec<u8>` in a
+                // Rust signature.
+                "Cow" => {
                     arity(1)?;
                     return Ok(args.remove(0).kind);
                 }

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -87,7 +87,8 @@ impl Normalization {
     /// `#[prebindgen] pub type Vec = std::vec::Vec` either, for the same reason.
     ///
     /// Not identical to Rust's prelude: it adds `MaybeUninit`, which the grammar
-    /// recognises for out-parameters. Its entries are exactly the bare names
+    /// recognises for out-parameters, and `Cow`, which it treats as transparent.
+    /// Its entries are exactly the bare names
     /// [`lower_path`](crate::core::flat) classifies as builtins and that have a
     /// std path at all — `str` has none, and neither do the scalars.
     ///
@@ -100,6 +101,7 @@ impl Normalization {
         ("std::string::String", "String"),
         ("std::boxed::Box", "Box"),
         ("std::mem::MaybeUninit", "MaybeUninit"),
+        ("std::borrow::Cow", "Cow"),
     ];
 
     /// The prelude alone: no ingested sources, no declared aliases.


### PR DESCRIPTION
Closes the `Cow` item from #235's "noted, not fixed" list, now that #235 has merged.

## The problem

zenoh-flat's byte accessor was refused by the closed flat API:

```rust
#[prebindgen] pub fn zbytes_to_bytes(z: &ZBytes) -> Cow<'_, [u8]>
```

`lower_path`'s guard says *"a builtin generic takes types only; a lifetime argument on
one is not a shape this language has"* and skips the entire builtin match when any
lifetime argument is present. `Cow` is the counterexample that assumption did not
anticipate — a builtin generic whose **own signature** includes a lifetime — so
`Cow<'_, [u8]>` fell through to an undeclared nominal `Cow` and the item became
`Unsupported`. `zbytes_to_bytes` would have vanished when zenoh-flat migrates.

## A `Cow` carries nothing a destination language can see

Both adapters already say so, in code:

* **cbindgen** — *"`Cow<'_, [T]>` → `T_wire* + size_t`. The C side receives an owned
  malloc'd copy, **just like `Vec<T>` outputs**"* (`cbindgen/emit.rs:677`), and
  `type_contains_vec = is_vec(ty) || cow_slice_elem(ty).is_some()` (`mod.rs:605`)
  groups them outright.
* **jnigen** — `env.byte_array_from_slice(&v)` (`jni/trait_impl.rs:159`). `&Cow<[u8]>`
  auto-derefs to `&[u8]`, so there is **no Cow-specific conversion at all**, and the
  Kotlin type is `ByteArray` — exactly what `Vec<u8>` produces.

So `Cow<'_, T>` classifies as **`T`'s own kind**, the `Box<T>` treatment, and **no
`TypeKind` variant is added**: the semantic surface stays silent about a fact no
destination acts on.

What codegen genuinely needs is the *spelling*. jnigen rewrites its generated fn's
param type to `::std::borrow::Cow<'_, [u8]>` because "the param type must be resolvable
without imports", and `Cow<'_, [u8]>` is not interchangeable with `Vec<u8>` in a Rust
signature. Spelling already travels in `origin` — so this is exactly **classify off
`kind`, spell off `origin`**, and both adapters' existing behaviour becomes *predicted*
by the classification rather than special-cased.

Transparent for **any** target, as `Box` is. Whether a `Cow` can actually cross stays
the adapter's call, and both already restrict — cbindgen to scalar slices, jnigen to
`[u8]` — refusing the rest with their own diagnostics. That is #211's division of
labour: the frontend says what a type *is*.

## `std::borrow::Cow` joins the prelude

For the reason every entry is there: a name no source has to import. It also stops the
frontend being **stricter than the adapters** — both tail-match the last path segment,
so they accept `std::borrow::Cow`, and the cbindgen fixture
`cow_u8_returns_scalar_array` writes exactly that spelling. That fixture is the proof
the qualified form occurs in practice, and it still passes unchanged.

## Tests

Three rows, each **verified to fail against the old guard** before being kept:

- `a_cow_is_what_it_borrows` — the property the treatment rests on: `Cow<'_, [u8]>` and
  `Vec<u8>` classify *identically*; `Cow<'_, str>` is a `Str`; the `Cow` survives in
  `origin.syntax` so a signature can still be spelled; transparent for a non-scalar
  target too; and a lifetime argument on any **other** builtin is still refused
  (`Vec<'a, u8>` → an undeclared nominal `Vec`), so the exception is exactly one name
  wide.
- `a_cow_returning_accessor_resolves` — `zbytes_to_bytes`'s real signature, which now
  survives with a `Sequence` return still spelling its `Cow`.
- the prelude drift-guard gains its `Cow` row, spelled `Cow<'_, [u8]>` so it is valid
  Rust.

## Verification

524 tests and 18 doctests; clippy clean in all three configurations with
`-- -D warnings`; `examples/regen-check.sh` **byte-identical**; boundary ledger
**unmoved** (the new arm matches a name, not a `syn` variant); JVM covertest 48
sections.

zenoh-flat is a separate repo and not yet migrated, so `zbytes_to_bytes` is covered by
the acceptance row above rather than by a build.

## Noted, not fixed

- jnigen's `cow_bytes_output` and cbindgen's `cow_slice_elem` stay as adapter-side syntax
  matching, which L3/L4 will migrate to reading `origin.syntax`. They are the model for
  a framework-level std type.
- `Cow` as an **input** is unmodelled in practice — no source writes one — the same
  position `Box<String>` is in.
- If codegen ever needs a *classified* signal rather than reading the syntax, that is an
  `origin` extension; deliberately deferred.

Refs #211. Umbrella: #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
