### PR TITLE
L1: Registry consumes Flat

### DIFF
--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -176,7 +176,7 @@ The seam that makes the direction real. Adapters were not touched.
 **Correctness is checked by default**, superseding L0's "inert until declared":
 ingestion fails on anything the language cannot express, listing every offender at
 once so a source crate needing migration sees one list. An opt-out for
-deliberately-unsupported elements is a separate issue.
+deliberately-unsupported elements is #237.
 
 The cost landed in test fixtures: 167 of 524 tests held an item naming a type they
 never declared. `test_util::declare_referenced` supplies a marked alias for those

--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -96,7 +96,7 @@ moves it.
 |---|---|---|
 | L0 | `Language` + `Element` + the ledger | **done** — [#227](https://github.com/milyin/prebindgen/pull/227) |
 | L0.5 | `Flat`: the model, indexed and resolved | **done** — this branch |
-| L1 | `Registry` consumes elements | not started |
+| L1 | `Registry` consumes elements | **done** — this branch |
 | L2 | `api/core` stops classifying source syntax | not started |
 | L3 | `Cbindgen` consumes elements | not started |
 | L4 | `JniGen` consumes elements *(the long pole — 105 sites)* | not started |
@@ -155,22 +155,37 @@ same treatment before they parse. `Cow<'_, [u8]>` has no alias spelling — gene
 and lifetime-bearing — so `zbytes_to_bytes` needs either the `MaybeUninit`
 treatment or a signature change.
 
-### L1 — `Registry` consumes elements
+### L1 — `Registry` consumes elements — **done**
 
-The seam that makes the direction real. Adapters must not need touching.
+The seam that makes the direction real. Adapters were not touched.
 
-- [ ] `Registry::from_flat(&Flat)`; `from_items` becomes `Flat::builder` +
-      `from_flat`, so both entry points share one parser
-- [ ] The `functions` / `structs` / `enums` / `consts` / `passthrough` maps are
-      rebuilt from each element's retained `syntax` — a projection, not a second
-      source of truth
-- [ ] `scan_fn_signature`'s receiver / parameter-pattern / `impl Trait` guards
-      are deleted: the diagnosis is already on `Element::Unsupported`, and
-      declaring such an item is what raises it
-- [ ] `ScanError`'s per-item variants map onto `ItemError`, so one authority
+- [x] `Registry::from_flat(Flat)`; `from_items` is `Flat::builder` + `from_flat`,
+      so both entry points share one parser
+- [x] The registry **holds** the model (`registry.flat()`), which is how L2–L4
+      reach it: an adapter already has the registry
+- [x] The maps are a projection of the elements — plus synthesis, since `resolve`
+      injects adapter-declared binding-local fns into `functions`
+- [x] `scan_fn_signature`'s receiver / parameter-pattern / `impl Trait` guards
+      deleted with their `ScanError` variants, along with `index_item`,
+      `check_no_duplicate` and `first_seen_loc`: `Flat` owns indexing and
+      duplicate detection
+- [x] `ParseError::DuplicateName` carries both crate names, so one authority
       produces the message
-- [ ] **Must not move**: every generated artifact byte-identical
-      (`examples/regen-check.sh`)
+- [x] **Did not move**: every generated artifact byte-identical
+
+**Correctness is checked by default**, superseding L0's "inert until declared":
+ingestion fails on anything the language cannot express, listing every offender at
+once so a source crate needing migration sees one list. An opt-out for
+deliberately-unsupported elements is a separate issue.
+
+The cost landed in test fixtures: 167 of 524 tests held an item naming a type they
+never declared. `test_util::declare_referenced` supplies a marked alias for those
+where the handle is incidental; the rest were real corrections — a path-qualified
+`std::time::Duration` that no declaration can name, and two array-length tests
+asserting shapes the subgrammar dropped in #212.
+
+**Still open**: `zenoh-flat`'s 26 unmarked aliases. Until they are marked,
+`zenoh-flat-c` and `zenoh-flat-jni` do not generate.
 
 ### L2 — `api/core` stops classifying source syntax
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -118,36 +118,6 @@ fn strip_flat_class_prefix(class: &str, name: &str) -> String {
 }
 
 fn main() {
-    // The flat API must be CLOSED: every type a marked signature names has to be
-    // declared here too, as a struct/enum or as `#[prebindgen] pub type X = ..`
-    // for a handle. `Flat` proves that across BOTH sources at once, which is the
-    // only way the helper crate's references to `perftest-flat`'s types can
-    // resolve — it cannot mark them itself.
-    //
-    // Asserted rather than merely computed: without this, an unmarked type would
-    // go unnoticed until the adapters consume elements (L1+), and then surface as
-    // a late unresolved-converter error instead of naming the missing marker.
-    //
-    // `source_named` for the helpers, for the reason spelled out at the registry
-    // below: the dep is renamed in Cargo.toml.
-    let flat = prebindgen::core::Flat::builder()
-        .source(perftest_flat::PREBINDGEN_OUT_DIR)
-        .source_named(cov_helpers::PREBINDGEN_OUT_DIR, "cov_helpers")
-        .build()
-        .expect("the flat API parses");
-    let unresolved: Vec<String> = flat
-        .unsupported()
-        .map(|u| match &u.name {
-            Some(name) => format!("  {name}: {}", u.error),
-            None => format!("  {}", u.error),
-        })
-        .collect();
-    assert!(
-        unresolved.is_empty(),
-        "the flat API is not closed:\n{}",
-        unresolved.join("\n")
-    );
-
     let jni = JniGen::new()
         .set_package_prefix("io.prebindgen.covertest")
         .set_jni_native_init("io.prebindgen.covertest.NativeLibrary.ensureLoaded()")

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -42,7 +42,7 @@
 # gaps are listed here rather than implied away.
 
 4	api/core/expand.rs
-12	api/core/registry.rs
+11	api/core/registry.rs
 40	api/core/types_util.rs
 18	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
@@ -70,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 205
+# total: 204

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -30,9 +30,11 @@ pub enum Element {
     /// grammar, a `self` receiver, a reference to a type the flat API never
     /// declares, or a whole item kind it does not model such as a `union`.
     ///
-    /// Inert: it is indexed under its name so nothing else can claim it, and
-    /// the diagnosis rides along, to be raised by whatever declares it. See the
-    /// [module docs](super) on where acceptance is enforced.
+    /// Indexed under its name so nothing else can claim it, with the diagnosis
+    /// riding along. Parsing carries it; building a
+    /// [`Registry`](crate::core::Registry) from a model holding one fails, reporting
+    /// every offender at once. See the [module docs](super) on where acceptance
+    /// is enforced.
     Unsupported(Unsupported),
 }
 

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -340,6 +340,8 @@ impl FlatBuilder {
                         name: first_name.clone(),
                         first: first.clone(),
                         second: element.location().clone(),
+                        first_crate: first.crate_name.clone(),
+                        second_crate: element.location().crate_name.clone(),
                     })));
                 }
                 seen.push((name.clone(), element.location().clone()));
@@ -382,7 +384,7 @@ impl FlatBuilder {
 /// Resolving here rather than in the adapters is the point of #211: a dangling
 /// name used to surface much later as an unresolved-converter error, from
 /// whichever adapter happened to look first.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Flat {
     /// Source order, so iteration reports items as the sources were fed.
     elements: Vec<Element>,
@@ -642,17 +644,30 @@ pub struct DuplicateName {
     pub name: syn::Ident,
     pub first: SourceLocation,
     pub second: SourceLocation,
+    /// The crate each was marked in. A captured file path is crate-relative
+    /// (both are `src/lib.rs`), so these are the only unambiguous coordinates
+    /// when two sources collide.
+    pub first_crate: Option<String>,
+    pub second_crate: Option<String>,
 }
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParseError::DuplicateName(d) => write!(
-                f,
-                "duplicate `#[prebindgen]` name `{}`: first at {}, again at {} — marked items \
-                 share one flat namespace across all source crates",
-                d.name, d.first, d.second
-            ),
+            ParseError::DuplicateName(d) => {
+                let at = |loc: &SourceLocation, krate: &Option<String>| match krate {
+                    Some(k) => format!("{loc} (crate `{k}`)"),
+                    None => loc.to_string(),
+                };
+                write!(
+                    f,
+                    "duplicate `#[prebindgen]` name `{}`: first at {}, again at {} — marked items \
+                     share one flat namespace across all source crates",
+                    d.name,
+                    at(&d.first, &d.first_crate),
+                    at(&d.second, &d.second_crate)
+                )
+            }
         }
     }
 }

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -96,14 +96,23 @@
 //! [`TypeKind`] is a form the language does not accept, so there is no second
 //! acceptance list to drift from it.
 //!
-//! But an item the language cannot express is not automatically a build failure.
-//! A source crate may mark items no binding uses, and those have never been
-//! required to be expressible — the pipeline scans a signature only once an
-//! adapter *declares* it. So parsing diagnoses per item and defers the raising:
-//! such an item becomes [`Element::Unsupported`], carrying the diagnosis, inert
-//! until something declares it. Only whole-stream rules — a duplicate name in
-//! the flat namespace — are [`ParseError`]s, because no declaration can make
-//! two items with one name unambiguous.
+//! **Parsing diagnoses; ingestion raises.** Those are two different points, and
+//! the split is what lets one model serve both.
+//!
+//! Parsing never fails on a single item: an item the language cannot express
+//! becomes [`Element::Unsupported`] carrying its diagnosis, and
+//! [`FlatBuilder::build`] returns the model with it in place. Only whole-stream
+//! rules — a duplicate name in the flat namespace — are [`ParseError`]s, because
+//! no declaration can make two items with one name unambiguous. So a consumer
+//! that wants to *inspect* what a source crate marked, refusals included, gets
+//! exactly that from [`Flat::unsupported`].
+//!
+//! [`Registry`](crate::core::Registry) ingestion is where the diagnoses are raised.
+//! Building a registry from this model **fails if any element is
+//! `Unsupported`** — all of them at once, so a source crate that needs migrating
+//! sees one list rather than one rebuild per item — and it fails before any
+//! adapter declaration is examined. A binding is built against a model the
+//! frontend could read in full, or it is not built.
 //!
 //! There is **no verbatim passthrough**, because a `#[prebindgen]` crate marks
 //! the items that cross the boundary and leaves the supporting code to the
@@ -133,7 +142,8 @@
 //! | `fn f(a: u8, ...)` | a function without the tail | the variadic arguments vanish |
 //! | `struct S<T>`, `fn f<T>()`, `struct S<const N: usize>` | `T` as a nominal reference | a parameter is indistinguishable from an item named `T` |
 //!
-//! All three are [`ItemError`]s, inert until declared, like any other refusal. A
+//! All three are [`ItemError`]s, carried like any other refusal and raised at
+//! registry ingestion. A
 //! **lifetime** binder is not among them: lifetimes are spelling, and the
 //! spelling already travels. Nor is `impl Trait` in argument position — Rust
 //! calls it an anonymous type parameter, but it is not a binder in the syntax,
@@ -378,8 +388,8 @@ impl FlatBuilder {
 /// Every [`TypeKind::Named`] in a surviving element denotes a [`Type`] this model
 /// holds, and [`Self::resolve`] hands it over. An item that named something the
 /// flat API does not declare is [`Element::Unsupported`] with
-/// [`ItemError::UnresolvedType`] — inert until an adapter declares it, exactly
-/// like every other refusal, so an item no binding uses stays harmless.
+/// [`ItemError::UnresolvedType`], exactly like every other refusal — carried
+/// here, raised by [`Registry`](crate::core::Registry) ingestion.
 ///
 /// Resolving here rather than in the adapters is the point of #211: a dangling
 /// name used to surface much later as an unresolved-converter error, from
@@ -465,13 +475,41 @@ impl Flat {
 
     /// Every item the language could not express, with its diagnosis.
     ///
-    /// An adapter raises one of these when it declares the item; until then they
-    /// are inert. See the [module docs](self) on where acceptance is enforced.
+    /// Present in the model so a consumer can inspect what a source crate marked
+    /// — building a [`Registry`](crate::core::Registry) from a model holding any of
+    /// these fails, and reports all of them. See the [module docs](self) on where
+    /// acceptance is enforced.
     pub fn unsupported(&self) -> impl Iterator<Item = &Unsupported> {
         self.elements.iter().filter_map(|e| match e {
             Element::Unsupported(u) => Some(u),
             _ => None,
         })
+    }
+
+    /// Check a function signature against the source language's grammar.
+    ///
+    /// For the **one input that does not come through this module**: a binding's
+    /// `local_functions`, whose signatures are written by hand in a build script
+    /// and inserted straight into the registry. Everything else was already
+    /// lowered here, so this exists to keep the grammar decided in one place
+    /// rather than re-checked at the far end.
+    ///
+    /// Grammar only. Whether the types it names are *declared* is a whole-model
+    /// question ([`resolve_references`]), and a binding-local fn may legitimately
+    /// name types the source crate never did.
+    pub fn check_signature(&self, f: &syn::ItemFn) -> Result<(), ItemError> {
+        // Rebuilt from the model rather than kept: this runs once per local fn,
+        // and a stored index would be a second copy of what `constants()` says.
+        let consts = ConstIndex::new(self.constants().map(|c| {
+            (
+                c.name.to_string(),
+                (*c.origin.syntax.expr).clone(),
+                c.origin.crate_name().map(str::to_owned),
+            )
+        }));
+        // A synthesized fn has no captured location; the caller names it.
+        let at = Rc::new(SourceLocation::default());
+        lower_fn(f, &at, &consts).map(|_| ())
     }
 
     /// The declaration a reference denotes.

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -571,6 +571,37 @@ fn extents_outside_the_subgrammar() {
         extent_reason(quote::quote!([u8; UNMARKED])),
         ArrayLenReason::NotAMarkedConst
     );
+    // Expression forms that BIND a local, which is the dangerous family: a length
+    // is qualified against its source module, so a local shadowing a marked item
+    // would be rewritten into it. Scope tracking is the general answer; none of
+    // these has a place in a boundary type, so the whole family is refused.
+    // (Moved here from the jnigen suite: the subgrammar is the frontend's.)
+    assert_eq!(
+        extent_reason(quote::quote!(
+            [u8; const {
+                let n = 3;
+                n
+            }]
+        )),
+        ArrayLenReason::NotLiteralOrName
+    );
+    assert_eq!(
+        extent_reason(quote::quote!(
+            [u8; match 3 {
+                n => n,
+            }]
+        )),
+        ArrayLenReason::NotLiteralOrName
+    );
+    assert_eq!(
+        extent_reason(quote::quote!([u8; if let n = 3 { n } else { 0 }])),
+        ArrayLenReason::NotLiteralOrName
+    );
+    // A CALL is not a name either, however const the callee.
+    assert_eq!(
+        extent_reason(quote::quote!([u8; array_len()])),
+        ArrayLenReason::NotLiteralOrName
+    );
     assert_eq!(
         extent_reason(quote::quote!([u8; 'c'])),
         ArrayLenReason::NotAnIntegerLiteral

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -663,6 +663,34 @@ impl<M> RegistryBuilder<M> {
     }
 }
 
+/// TEMPORARY scaffold — see the call site in [`Registry::from_items`].
+///
+/// Panics naming every item the flat language cannot express, so a fixture that
+/// references a type it never declares fails loudly and immediately.
+#[cfg(test)]
+fn assert_self_sufficient(items: &[(syn::Item, SourceLocation)]) {
+    // A stream that does not parse at all (a duplicate name) is a fixture testing
+    // exactly that; `from_items` reports it itself.
+    let Ok(flat) = crate::api::core::flat::Flat::builder()
+        .items(items.iter().cloned())
+        .build()
+    else {
+        return;
+    };
+    let bad: Vec<String> = flat
+        .unsupported()
+        .map(|u| match &u.name {
+            Some(name) => format!("  {name}: {}", u.error),
+            None => format!("  {}", u.error),
+        })
+        .collect();
+    assert!(
+        bad.is_empty(),
+        "fixture is not self-sufficient:\n{}",
+        bad.join("\n")
+    );
+}
+
 impl<M> Registry<M> {
     /// Start collecting what to index.
     ///
@@ -737,6 +765,11 @@ impl<M> Registry<M> {
         // alias-named paths, whose declaration may arrive later or in another
         // source.
         let items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
+        // TEMPORARY (deleted in the commit that flips the seam): prove every test
+        // fixture is self-sufficient *before* `from_items` routes through `Flat`,
+        // which is the only way to migrate them against a green build.
+        #[cfg(test)]
+        assert_self_sufficient(&items);
         let normalization = crate::api::core::types_util::Normalization::from_items(&items);
         registry
             .source_modules

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -316,8 +316,15 @@ pub struct Registry<M = ()> {
         HashMap<crate::api::core::unfold::DeconId, crate::api::core::unfold::DeconSpec>,
 }
 
-impl<M> Default for Registry<M> {
-    fn default() -> Self {
+impl<M> Registry<M> {
+    /// An empty registry: no model, no items, no types.
+    ///
+    /// **Not public.** A `Registry` is a projection of a [`Flat`], and one built
+    /// this way projects nothing — [`Self::flat`] would hand a later stage an
+    /// empty model that claims to be this registry's source. Outside this crate
+    /// the entry points are [`Self::from_items`], [`Self::from_flat`] and
+    /// [`Self::builder`], each of which has a model behind it.
+    pub(crate) fn empty() -> Self {
         Self {
             flat: crate::api::core::flat::Flat::default(),
             functions: HashMap::new(),
@@ -455,15 +462,25 @@ impl fmt::Display for ScanError {
                 write!(f, "type `{}` cannot be both declared and ignored", key)
             }
             ScanError::NotExpressible { entries } => {
-                writeln!(
+                write!(
                     f,
                     "{} `#[prebindgen]` item(s) the flat language cannot express:",
                     entries.len()
                 )?;
                 for e in entries {
+                    // The crate, because a captured path is crate-relative: with
+                    // several sources, two offenders both read `src/lib.rs:..`
+                    // and the location alone says nothing about which one to fix.
+                    // Same reason the duplicate-name diagnostic carries it.
+                    let in_crate = match &e.location.crate_name {
+                        Some(c) => format!(" in crate `{c}`"),
+                        None => String::new(),
+                    };
                     match &e.name {
-                        Some(name) => writeln!(f, "  {}: {name} {}", e.location, e.reason)?,
-                        None => writeln!(f, "  {}: {}", e.location, e.reason)?,
+                        Some(name) => {
+                            write!(f, "\n  {}{in_crate}: {name} {}", e.location, e.reason)?
+                        }
+                        None => write!(f, "\n  {}{in_crate}: {}", e.location, e.reason)?,
                     }
                 }
                 Ok(())
@@ -795,7 +812,7 @@ impl<M> Registry<M> {
             return Err(ScanError::NotExpressible { entries });
         }
 
-        let mut registry = Registry::default();
+        let mut registry = Registry::empty();
         // First-seen order, which is what makes the first entry the default
         // module. Derived from the elements rather than stored twice.
         for element in flat.elements() {
@@ -1281,8 +1298,10 @@ impl<M> Registry<M> {
         // wrappers; propagation through `subs` then marks transitive deps
         // (e.g. &Foo's `&_` converter returns subs=[Foo], so Foo becomes
         // required).
-        // No receiver or non-ident pattern can reach here: the frontend refuses
-        // such an item, and `from_flat` fails before indexing it.
+        // No receiver or non-ident pattern can reach here: a captured item was
+        // refused by the frontend and `from_flat` failed before indexing it, and
+        // a binding-local fn was checked against the same grammar
+        // (`Flat::check_signature`) when `resolve` synthesized it.
         for input in &f.sig.inputs {
             match input {
                 syn::FnArg::Receiver(_) => continue,
@@ -1350,9 +1369,10 @@ impl<M> Registry<M> {
         loc: &SourceLocation,
         visited: &mut HashSet<TypeKey>,
     ) -> Result<(), ScanError> {
-        // A disallowed `impl Trait` cannot reach here: the frontend refuses the
-        // item, naming the parameter it sits on, and `from_flat` fails before
-        // indexing it.
+        // A disallowed `impl Trait` cannot reach here: every fn whose signature
+        // reaches this point passed the frontend's grammar — captured items at
+        // ingestion, binding-local ones at synthesis — and it names the
+        // parameter the bad type sits on.
 
         let key = TypeKey::from_type(ty);
         if !visited.insert(key.clone()) {
@@ -1453,6 +1473,18 @@ impl<M> Registry<M> {
         // stage treats them exactly like `#[prebindgen]` fns.
         for (item_fn, origin) in adapter.local_functions() {
             let ident = item_fn.sig.ident.clone();
+            // The one input that does not come through `Flat`: a `sig!(..)` is
+            // written by hand in a build script and inserted straight into the
+            // maps, so the grammar has to be checked here or nowhere. Silently
+            // dropping a `self` receiver or a pattern parameter would surface as
+            // an arity mismatch out of rustc on generated code, which is the
+            // wrong end of the pipeline to learn about a build.rs typo.
+            if let Err(error) = self.flat.check_signature(&item_fn) {
+                return Err(ScanError::AdapterInvariant {
+                    message: format!("binding-local fn `{ident}`: {error}"),
+                }
+                .into());
+            }
             if self.functions.contains_key(&ident) {
                 return Err(ScanError::AdapterInvariant {
                     message: format!(

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -233,6 +233,10 @@ impl Direction {
 /// [`crate::api::core::prebindgen::ConverterImpl`] that produced it.
 /// Adapters that don't carry extras leave `M = ()`.
 pub struct Registry<M = ()> {
+    /// The parsed model these maps project. Held rather than discarded, so a
+    /// later stage can ask it what a name means through the registry it already
+    /// has — see [`Self::flat`].
+    flat: crate::api::core::flat::Flat,
     pub functions: HashMap<syn::Ident, (syn::ItemFn, SourceLocation)>,
     pub structs: HashMap<syn::Ident, (syn::ItemStruct, SourceLocation)>,
     pub enums: HashMap<syn::Ident, (syn::ItemEnum, SourceLocation)>,
@@ -315,6 +319,7 @@ pub struct Registry<M = ()> {
 impl<M> Default for Registry<M> {
     fn default() -> Self {
         Self {
+            flat: crate::api::core::flat::Flat::default(),
             functions: HashMap::new(),
             structs: HashMap::new(),
             enums: HashMap::new(),
@@ -334,6 +339,33 @@ impl<M> Default for Registry<M> {
             decon_plans: HashMap::new(),
         }
     }
+}
+
+impl From<crate::api::core::flat::ParseError> for ScanError {
+    fn from(e: crate::api::core::flat::ParseError) -> Self {
+        match e {
+            crate::api::core::flat::ParseError::DuplicateName(d) => {
+                ScanError::DuplicateName(Box::new(DuplicateNameError {
+                    name: d.name,
+                    first: d.first,
+                    second: d.second,
+                    first_crate: d.first_crate,
+                    second_crate: d.second_crate,
+                }))
+            }
+        }
+    }
+}
+
+/// One item of a [`ScanError::NotExpressible`] report.
+#[derive(Debug)]
+pub struct NotExpressibleEntry {
+    /// The item's name, or `None` for an item kind that has none.
+    pub name: Option<syn::Ident>,
+    /// Rendered [`ItemError`](crate::core::flat::ItemError) — the frontend's own
+    /// message, so one authority produces it.
+    pub reason: String,
+    pub location: SourceLocation,
 }
 
 /// Payload of [`ScanError::DuplicateName`], boxed to keep the error enum
@@ -361,15 +393,15 @@ pub enum ScanError {
     ConflictingTypeIntent {
         key: TypeKey,
     },
-    DisallowedImplTrait {
-        ty: String,
-        loc: SourceLocation,
-    },
-    UnsupportedReceiver {
-        loc: SourceLocation,
-    },
-    UnsupportedParamPattern {
-        loc: SourceLocation,
+    /// Items the flat language cannot express, all of them at once.
+    ///
+    /// The message for each comes from
+    /// [`ItemError`](crate::core::flat::ItemError), so one authority produces it.
+    /// This replaces the per-item guards the registry used to duplicate — a `self`
+    /// receiver, a non-ident parameter pattern, a disallowed `impl Trait` — which
+    /// the frontend now catches with a richer diagnosis (it names the parameter).
+    NotExpressible {
+        entries: Vec<NotExpressibleEntry>,
     },
     /// An adapter-invariant check failed — see [`Prebindgen::validate`].
     /// The message is adapter-authored and printed verbatim.
@@ -416,26 +448,25 @@ impl fmt::Display for ScanError {
                     e.second
                 )
             }
-            ScanError::ConflictingFunctionIntent { name } => write!(
-                f,
-                "function `{}` cannot be both declared and ignored",
-                name
-            ),
-            ScanError::ConflictingTypeIntent { key } => write!(
-                f,
-                "type `{}` cannot be both declared and ignored",
-                key
-            ),
-            ScanError::DisallowedImplTrait { ty, loc } => write!(
-                f,
-                "`impl Trait` is not allowed at {}: `{}` (only `impl Fn(...) + Send + Sync + 'static` is supported)",
-                loc, ty
-            ),
-            ScanError::UnsupportedReceiver { loc } => {
-                write!(f, "method receiver (`self`) parameters are not supported at {}", loc)
+            ScanError::ConflictingFunctionIntent { name } => {
+                write!(f, "function `{}` cannot be both declared and ignored", name)
             }
-            ScanError::UnsupportedParamPattern { loc } => {
-                write!(f, "non-ident parameter pattern is not supported at {}", loc)
+            ScanError::ConflictingTypeIntent { key } => {
+                write!(f, "type `{}` cannot be both declared and ignored", key)
+            }
+            ScanError::NotExpressible { entries } => {
+                writeln!(
+                    f,
+                    "{} `#[prebindgen]` item(s) the flat language cannot express:",
+                    entries.len()
+                )?;
+                for e in entries {
+                    match &e.name {
+                        Some(name) => writeln!(f, "  {}: {name} {}", e.location, e.reason)?,
+                        None => writeln!(f, "  {}: {}", e.location, e.reason)?,
+                    }
+                }
+                Ok(())
             }
             ScanError::AdapterInvariant { message } => write!(f, "{}", message),
             ScanError::DeclaredNotFound { entries } => {
@@ -663,34 +694,6 @@ impl<M> RegistryBuilder<M> {
     }
 }
 
-/// TEMPORARY scaffold — see the call site in [`Registry::from_items`].
-///
-/// Panics naming every item the flat language cannot express, so a fixture that
-/// references a type it never declares fails loudly and immediately.
-#[cfg(test)]
-fn assert_self_sufficient(items: &[(syn::Item, SourceLocation)]) {
-    // A stream that does not parse at all (a duplicate name) is a fixture testing
-    // exactly that; `from_items` reports it itself.
-    let Ok(flat) = crate::api::core::flat::Flat::builder()
-        .items(items.iter().cloned())
-        .build()
-    else {
-        return;
-    };
-    let bad: Vec<String> = flat
-        .unsupported()
-        .map(|u| match &u.name {
-            Some(name) => format!("  {name}: {}", u.error),
-            None => format!("  {}", u.error),
-        })
-        .collect();
-    assert!(
-        bad.is_empty(),
-        "fixture is not self-sufficient:\n{}",
-        bad.join("\n")
-    );
-}
-
 impl<M> Registry<M> {
     /// Start collecting what to index.
     ///
@@ -758,55 +761,116 @@ impl<M> Registry<M> {
     where
         I: IntoIterator<Item = (syn::Item, SourceLocation)>,
     {
+        let flat = crate::api::core::flat::Flat::builder()
+            .items(items)
+            .build()?;
+        Self::from_flat(flat)
+    }
+
+    /// Index a parsed [`Flat`] model.
+    ///
+    /// The registry is a **projection** of the model, not a second reading of the
+    /// source: `Flat` decided what every item means, and this arranges those
+    /// decisions into the maps adapters read. The model itself is kept
+    /// ([`Self::flat`]) so later stages can ask it questions rather than
+    /// re-deriving them.
+    ///
+    /// **Fails on anything the language cannot express** — a `self` receiver, an
+    /// `async fn`, a generic binder, a type form outside the grammar, or a
+    /// reference to a type the flat API does not declare. All of them at once, so
+    /// a source crate that needs migrating sees one list instead of one rebuild
+    /// per item.
+    pub fn from_flat(flat: crate::api::core::flat::Flat) -> Result<Self, ScanError> {
+        use crate::api::core::flat::{Element, Type};
+
+        let entries: Vec<NotExpressibleEntry> = flat
+            .unsupported()
+            .map(|u| NotExpressibleEntry {
+                name: u.name.clone(),
+                reason: u.error.to_string(),
+                location: (*u.origin.location).clone(),
+            })
+            .collect();
+        if !entries.is_empty() {
+            return Err(ScanError::NotExpressible { entries });
+        }
+
         let mut registry = Registry::default();
-        // Pass 1: collect and gather EVERY source module name first, so
-        // cross-source type references (`source_a::TypeA` in a later-chained
-        // source's signature) normalize order-independently in pass 2 — and so do
-        // alias-named paths, whose declaration may arrive later or in another
-        // source.
-        let items: Vec<(syn::Item, SourceLocation)> = items.into_iter().collect();
-        // TEMPORARY (deleted in the commit that flips the seam): prove every test
-        // fixture is self-sufficient *before* `from_items` routes through `Flat`,
-        // which is the only way to migrate them against a green build.
-        #[cfg(test)]
-        assert_self_sufficient(&items);
-        let normalization = crate::api::core::types_util::Normalization::from_items(&items);
-        registry
-            .source_modules
-            .clone_from(&normalization.source_modules);
-        // Pass 2: normalize each item's types to the canonical flat spelling
-        // (`crate::`/source-module paths reduce to the bare indexed name, and an
-        // aliased path to the name its alias gives it — see `normalize_type`'s
-        // rule list), then index. Every downstream `TypeKey::from_type` over a
-        // signature type therefore sees the normalized form, so bare adapter
-        // declarations match qualified captured spellings (issue #95).
-        for (mut item, loc) in items {
-            crate::api::core::types_util::normalize_item_types(&mut item, &normalization);
-            let crate_name = loc.crate_name.clone();
-            let named: Option<syn::Ident> = match &item {
-                syn::Item::Fn(f) => Some(f.sig.ident.clone()),
-                syn::Item::Struct(s) => Some(s.ident.clone()),
-                syn::Item::Enum(e) => Some(e.ident.clone()),
-                syn::Item::Const(c) if c.ident != "_" => Some(c.ident.clone()),
-                _ => None,
-            };
-            match registry.index_item(item, loc) {
-                Ok(()) => {
-                    // Only after successful indexing — a collision must keep
-                    // the FIRST item's origin for the error below.
-                    if let (Some(ident), Some(crate_name)) = (named, crate_name) {
-                        registry.item_origins.insert(ident, crate_name);
-                    }
+        // First-seen order, which is what makes the first entry the default
+        // module. Derived from the elements rather than stored twice.
+        for element in flat.elements() {
+            if let Some(crate_name) = element.location().crate_name.as_ref() {
+                let module = crate_name.replace('-', "_");
+                if !registry.source_modules.contains(&module) {
+                    registry.source_modules.push(module);
                 }
-                Err(ScanError::DuplicateName(mut e)) => {
-                    e.first_crate = registry.item_origins.get(&e.name).cloned();
-                    e.second_crate = crate_name;
-                    return Err(ScanError::DuplicateName(e));
-                }
-                Err(e) => return Err(e),
             }
         }
+
+        for element in flat.elements() {
+            let crate_name = element.location().crate_name.clone();
+            let named = element.name().cloned();
+            match element {
+                Element::Function(f) => {
+                    registry.functions.insert(
+                        f.name.clone(),
+                        (f.origin.syntax.clone(), element.location().clone()),
+                    );
+                }
+                Element::Type(Type::Struct(t)) => {
+                    registry.structs.insert(
+                        t.name.clone(),
+                        (t.origin.syntax.clone(), element.location().clone()),
+                    );
+                }
+                Element::Type(Type::Variant(t)) => {
+                    registry.enums.insert(
+                        t.name.clone(),
+                        (t.origin.syntax.clone(), element.location().clone()),
+                    );
+                }
+                Element::Type(Type::Enum(t)) => {
+                    registry.enums.insert(
+                        t.name.clone(),
+                        (t.origin.syntax.clone(), element.location().clone()),
+                    );
+                }
+                // An unnamed `const _` is each source's injected `konst` feature
+                // guard: not addressable, re-emitted verbatim. That is the whole
+                // of `passthrough` now — the proc-macro refuses to mark a `use`,
+                // `mod` or `macro_rules!`, so nothing else ever reached it.
+                Element::Constant(c) if named.is_none() => {
+                    registry.passthrough.push((
+                        syn::Item::Const(c.origin.syntax.clone()),
+                        element.location().clone(),
+                    ));
+                }
+                Element::Constant(c) => {
+                    registry.consts.insert(
+                        c.name.clone(),
+                        (c.origin.syntax.clone(), element.location().clone()),
+                    );
+                }
+                // An `Extern` states that a name exists and its contents do not
+                // cross. There is no map for that, and adapters have never seen
+                // one — a type alias was already a no-op here. Reachable through
+                // [`Self::flat`] for the stages that will want it.
+                Element::Type(Type::Extern(_)) => {}
+                // Refused above.
+                Element::Unsupported(_) => unreachable!("checked before indexing"),
+            }
+            if let (Some(ident), Some(crate_name)) = (named, crate_name) {
+                registry.item_origins.insert(ident, crate_name);
+            }
+        }
+
+        registry.flat = flat;
         Ok(registry)
+    }
+
+    /// The parsed model this registry projects.
+    pub fn flat(&self) -> &crate::api::core::flat::Flat {
+        &self.flat
     }
 
     /// The origin crate's **module path** for an item ingested via
@@ -1206,78 +1270,6 @@ impl<M> Registry<M> {
         self.required_inputs_scan.remove(&TypeKey::from_type(ty));
     }
 
-    fn index_item(&mut self, item: syn::Item, loc: SourceLocation) -> Result<(), ScanError> {
-        match item {
-            syn::Item::Fn(f) => {
-                self.check_no_duplicate(&f.sig.ident, &loc)?;
-                self.functions.insert(f.sig.ident.clone(), (f, loc));
-                Ok(())
-            }
-            syn::Item::Struct(s) => {
-                self.check_no_duplicate(&s.ident, &loc)?;
-                self.structs.insert(s.ident.clone(), (s, loc));
-                Ok(())
-            }
-            syn::Item::Enum(e) => {
-                self.check_no_duplicate(&e.ident, &loc)?;
-                self.enums.insert(e.ident.clone(), (e, loc));
-                Ok(())
-            }
-            syn::Item::Const(c) => {
-                // Unnamed `const _` items (each source's injected `konst`
-                // feature guard) live outside the flat namespace: several
-                // sources may each carry one, all passed through verbatim.
-                if c.ident == "_" {
-                    self.passthrough.push((syn::Item::Const(c), loc));
-                    return Ok(());
-                }
-                self.check_no_duplicate(&c.ident, &loc)?;
-                self.consts.insert(c.ident.clone(), (c, loc));
-                Ok(())
-            }
-            // `#[prebindgen] pub type X = ..` DECLARES an opaque type: it states
-            // something about the flat API's surface, and is not code to copy
-            // into the binding. Its target is routinely crate-private, so
-            // re-emitting it would not even compile.
-            syn::Item::Type(_) => Ok(()),
-            other => {
-                self.passthrough.push((other, loc));
-                Ok(())
-            }
-        }
-    }
-
-    fn check_no_duplicate(&self, name: &syn::Ident, loc: &SourceLocation) -> Result<(), ScanError> {
-        if let Some(first) = self.first_seen_loc(name) {
-            // Origin crates are unknown at this level; `from_items` enriches
-            // the error with them (the locations alone are crate-relative).
-            return Err(ScanError::DuplicateName(Box::new(DuplicateNameError {
-                name: name.clone(),
-                first,
-                second: loc.clone(),
-                first_crate: None,
-                second_crate: None,
-            })));
-        }
-        Ok(())
-    }
-
-    fn first_seen_loc(&self, name: &syn::Ident) -> Option<SourceLocation> {
-        if let Some((_, loc)) = self.functions.get(name) {
-            return Some(loc.clone());
-        }
-        if let Some((_, loc)) = self.structs.get(name) {
-            return Some(loc.clone());
-        }
-        if let Some((_, loc)) = self.enums.get(name) {
-            return Some(loc.clone());
-        }
-        if let Some((_, loc)) = self.consts.get(name) {
-            return Some(loc.clone());
-        }
-        None
-    }
-
     fn scan_fn_signature(
         &mut self,
         f: &syn::ItemFn,
@@ -1289,15 +1281,12 @@ impl<M> Registry<M> {
         // wrappers; propagation through `subs` then marks transitive deps
         // (e.g. &Foo's `&_` converter returns subs=[Foo], so Foo becomes
         // required).
+        // No receiver or non-ident pattern can reach here: the frontend refuses
+        // such an item, and `from_flat` fails before indexing it.
         for input in &f.sig.inputs {
             match input {
-                syn::FnArg::Receiver(_) => {
-                    return Err(ScanError::UnsupportedReceiver { loc: loc.clone() });
-                }
+                syn::FnArg::Receiver(_) => continue,
                 syn::FnArg::Typed(pt) => {
-                    if !matches!(&*pt.pat, syn::Pat::Ident(_)) {
-                        return Err(ScanError::UnsupportedParamPattern { loc: loc.clone() });
-                    }
                     self.register_type_recursive(Direction::Input, &pt.ty, true, loc)?;
                 }
             }
@@ -1361,15 +1350,9 @@ impl<M> Registry<M> {
         loc: &SourceLocation,
         visited: &mut HashSet<TypeKey>,
     ) -> Result<(), ScanError> {
-        // Reject `impl Trait` except `impl Fn(...) + Send + Sync + 'static`.
-        if let syn::Type::ImplTrait(it) = ty {
-            if extract_fn_trait_args(ty).is_none() {
-                return Err(ScanError::DisallowedImplTrait {
-                    ty: it.to_token_stream().to_string(),
-                    loc: loc.clone(),
-                });
-            }
-        }
+        // A disallowed `impl Trait` cannot reach here: the frontend refuses the
+        // item, naming the parameter it sits on, and `from_flat` fails before
+        // indexing it.
 
         let key = TypeKey::from_type(ty);
         if !visited.insert(key.clone()) {

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -84,22 +84,6 @@ fn fn_item(src: &str) -> (syn::Item, SourceLocation) {
 }
 
 #[test]
-fn from_items_does_not_scan_signatures() {
-    // A `#[prebindgen]`-marked fn whose return is a bare `impl Foo`
-    // would have failed `from_items` under the old code path
-    // (ScanError::DisallowedImplTrait). Now `from_items` is index-
-    // only and accepts it without complaint.
-    let items = vec![fn_item("fn bogus(x: u64) -> impl std::fmt::Debug { 0u64 }")];
-    let reg: Registry<()> = Registry::from_items(items).expect("from_items must succeed");
-    assert!(reg.required_inputs_scan.is_empty());
-    assert!(reg.required_outputs_scan.is_empty());
-    // The fn is indexed but no types are pre-required.
-    assert!(reg
-        .functions
-        .contains_key(&syn::parse_str("bogus").unwrap()));
-}
-
-#[test]
 fn scan_declared_empty_ext_marks_nothing_required() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
     let mut reg: Registry<()> = Registry::from_items(items).unwrap();
@@ -131,24 +115,6 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
     assert!(!reg
         .required_outputs_scan
         .contains(&TypeKey::parse("u32").expect("test type")));
-}
-
-#[test]
-fn scan_declared_fails_disallowed_impl_trait_only_when_fn_declared() {
-    let items = vec![fn_item("fn bogus(x: u64) -> impl std::fmt::Debug { 0u64 }")];
-    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
-
-    // Empty ext: the bogus fn is not scanned, so no error.
-    let empty = StubExt::default();
-    assert!(reg.scan_declared(&empty).is_ok());
-
-    // Declare the fn: scan now fires the disallowed-impl-Trait error.
-    let mut ext = StubExt::default();
-    ext.functions.insert(syn::parse_str("bogus").unwrap());
-    match reg.scan_declared(&ext) {
-        Err(ScanError::DisallowedImplTrait { .. }) => (),
-        other => panic!("expected DisallowedImplTrait, got {:?}", other),
-    }
 }
 
 #[test]

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -20,6 +20,7 @@ struct StubExt {
     consts: Option<HashSet<syn::Ident>>,
     types: HashSet<TypeKey>,
     ignored_types: HashSet<TypeKey>,
+    local_fns: Vec<(syn::ItemFn, String)>,
 }
 
 impl Prebindgen for StubExt {
@@ -45,6 +46,9 @@ impl Prebindgen for StubExt {
     }
     fn ignored_types(&self) -> HashSet<TypeKey> {
         self.ignored_types.clone()
+    }
+    fn local_functions(&self) -> Vec<(syn::ItemFn, String)> {
+        self.local_fns.clone()
     }
 
     fn on_function(&self, _f: &syn::ItemFn, _registry: &Registry<()>) -> TokenStream {
@@ -759,4 +763,223 @@ fn builder_and_from_items_agree() {
         streamed.default_module().map(module)
     );
     assert_eq!(built.passthrough.len(), streamed.passthrough.len());
+}
+
+// ── The projection itself ──────────────────────────────────────────────
+
+/// Every element kind lands where the projection says, the model is **kept**,
+/// and a name's origin crate survives the trip.
+///
+/// The seam's only direct test: everything else reaches `from_flat` through
+/// `from_items`, which cannot distinguish "the projection is right" from "the
+/// parser and the projection are wrong in matching ways".
+#[test]
+fn from_flat_projects_each_element_kind() {
+    let at = |krate: &str| SourceLocation {
+        file: "src/lib.rs".into(),
+        crate_name: Some(krate.to_string()),
+        ..SourceLocation::default()
+    };
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                pub fn f(v: u64) -> u64 {
+                    v
+                }
+            ),
+            at("myflat"),
+        ),
+        (
+            syn::parse_quote!(
+                pub struct S {
+                    pub a: u64,
+                }
+            ),
+            at("myflat"),
+        ),
+        // A sum and a C-style enum are different elements, one map.
+        (
+            syn::parse_quote!(
+                pub enum Sum {
+                    A(u64),
+                    B,
+                }
+            ),
+            at("myflat"),
+        ),
+        (
+            syn::parse_quote!(
+                pub enum Flags {
+                    X = 1,
+                    Y = 2,
+                }
+            ),
+            at("myflat"),
+        ),
+        (
+            syn::parse_quote!(
+                pub const K: u64 = 7;
+            ),
+            at("myflat"),
+        ),
+        // Each source's injected feature guard: no address, so several coexist.
+        (
+            syn::parse_quote!(
+                const _: () = ();
+            ),
+            at("myflat"),
+        ),
+        (
+            syn::parse_quote!(
+                const _: () = ();
+            ),
+            at("helpers"),
+        ),
+        // An alias declared by a SECONDARY source. It lands in no map — an
+        // `Extern` states a name exists, which the registry has never had a
+        // place for — but it DOES record an origin, so a reference to it
+        // qualifies against the crate that declared it rather than falling back
+        // to the default module.
+        (
+            syn::parse_quote!(
+                pub type Handle = helpers::Inner;
+            ),
+            at("helpers"),
+        ),
+    ];
+    let flat = crate::api::core::flat::Flat::builder()
+        .items(items)
+        .build()
+        .expect("parse");
+    let reg: Registry<()> = Registry::from_flat(flat).expect("project");
+
+    let id = |n: &str| syn::parse_str::<syn::Ident>(n).unwrap();
+    assert!(reg.functions.contains_key(&id("f")));
+    assert!(reg.structs.contains_key(&id("S")));
+    assert!(reg.enums.contains_key(&id("Sum")), "a sum is an enum here");
+    assert!(reg.enums.contains_key(&id("Flags")));
+    assert!(reg.consts.contains_key(&id("K")));
+    assert_eq!(reg.passthrough.len(), 2, "one guard per source");
+    assert!(
+        !reg.structs.contains_key(&id("Handle")) && !reg.enums.contains_key(&id("Handle")),
+        "an Extern names a type; it declares no body to index"
+    );
+
+    // The model is held, not discarded — this is what makes the registry a
+    // projection rather than a second reading.
+    assert!(reg.flat().element("f").is_some());
+    assert!(
+        reg.flat().declared_type("Handle").is_some(),
+        "the alias is reachable through the model even though no map holds it"
+    );
+
+    // Origins, including the alias's — a behaviour change from the old
+    // `syn::Item::Type` no-op, which recorded none.
+    assert_eq!(reg.origin_module(&id("f")), Some(syn::parse_quote!(myflat)));
+    assert_eq!(
+        reg.origin_module(&id("Handle")),
+        Some(syn::parse_quote!(helpers)),
+        "an alias declared by a helper crate qualifies against that crate"
+    );
+    // First-seen source order, which is what makes the first entry the default.
+    assert_eq!(reg.default_module(), Some(syn::parse_quote!(myflat)));
+}
+
+/// The inexpressible report names the **crate**, not just the location.
+///
+/// A captured path is crate-relative, so two offenders from different sources
+/// both read `src/lib.rs:0:0` and the location alone cannot say which crate to
+/// fix. Same reason the duplicate-name diagnostic carries it.
+#[test]
+fn not_expressible_report_names_the_crate_of_each_offender() {
+    let at = |krate: &str| SourceLocation {
+        file: "src/lib.rs".into(),
+        crate_name: Some(krate.to_string()),
+        ..SourceLocation::default()
+    };
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                pub async fn a() {}
+            ),
+            at("myflat"),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn b<T>(v: T) -> T {
+                    v
+                }
+            ),
+            at("helpers"),
+        ),
+    ];
+    let Err(err) = Registry::<()>::from_items(items) else {
+        panic!("both items are inexpressible")
+    };
+    let msg = err.to_string();
+
+    assert!(msg.contains("2 `#[prebindgen]` item(s)"), "{msg}");
+    assert!(msg.contains("in crate `myflat`"), "{msg}");
+    assert!(msg.contains("in crate `helpers`"), "{msg}");
+    // Both share a file path, so the crate is the only thing telling them apart.
+    assert_eq!(msg.matches("src/lib.rs").count(), 2, "{msg}");
+    // No trailing newline: the message is embedded in `expect`/`panic` output.
+    assert!(!msg.ends_with('\n'), "{msg:?}");
+}
+
+/// A binding-local fn is checked against the **same grammar** as a captured one.
+///
+/// `sig!(..)` is written by hand in a build script and inserted straight into the
+/// registry, so it is the one input that never passes through `Flat`. Without a
+/// check here a `self` receiver or a pattern parameter is silently dropped and
+/// the user meets it as an arity mismatch out of rustc on generated code — the
+/// wrong end of the pipeline to learn about a build.rs typo.
+#[test]
+fn a_binding_local_fn_is_checked_against_the_grammar() {
+    for (src, expected) in [
+        ("fn takes_self(&self, x: u32) -> u32 { x }", "receiver"),
+        (
+            "fn takes_pattern((a, b): (u32, u32)) -> u32 { a }",
+            "pattern",
+        ),
+        ("fn takes_impl(x: impl std::fmt::Debug) {}", "impl Trait"),
+        ("async fn is_async() {}", "async"),
+    ] {
+        let reg: Registry<()> =
+            Registry::from_items(vec![fn_item("fn good(x: u64) -> u64 { x }")]).unwrap();
+        let ext = StubExt {
+            local_fns: vec![(syn::parse_str(src).expect("parse local fn"), "b".into())],
+            ..Default::default()
+        };
+        let err = reg
+            .resolve(ext)
+            .expect_err(&format!("`{src}` must be refused"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("binding-local fn"),
+            "must say which input is at fault: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains(&expected.to_lowercase()),
+            "`{src}` should be diagnosed as {expected}, got: {msg}"
+        );
+    }
+}
+
+/// The same check accepts what the grammar allows, so it is a grammar check and
+/// not a blanket refusal — and it does **not** demand that a local fn's types be
+/// declared, which a binding-local fn legitimately may not be.
+#[test]
+fn a_well_formed_binding_local_fn_passes() {
+    let reg: Registry<()> =
+        Registry::from_items(vec![fn_item("fn good(x: u64) -> u64 { x }")]).unwrap();
+    let ext = StubExt {
+        local_fns: vec![(
+            syn::parse_str("fn helper(s: &Undeclared) -> u64 { 0 }").expect("parse"),
+            "b".into(),
+        )],
+        ..Default::default()
+    };
+    reg.resolve(ext)
+        .expect("a grammatical local fn passes, undeclared types and all");
 }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -309,6 +309,33 @@ fn type_entry_helpers_expose_converter_chain_contract() {
 /// `SourceLocation` file paths are crate-relative (both may read
 /// `src/lib.rs`), so the crates (stamped into each stream item's location
 /// by `Source`) are the only unambiguous coordinates.
+/// Ingestion checks that the flat API is expressible, and reports **every**
+/// offender at once — a source crate that needs migrating should see one list,
+/// not one rebuild per item.
+///
+/// This replaces two tests that asserted the opposite (that `from_items` was
+/// index-only and diagnosed at declaration time). The frontend owns that
+/// judgement now, and its diagnosis is richer: it names the parameter.
+#[test]
+fn from_items_rejects_what_the_language_cannot_express() {
+    let err = match Registry::<()>::from_items(vec![
+        fn_item("fn bogus(x: u64) -> impl std::fmt::Debug { 0u64 }"),
+        fn_item("fn worse(self) -> u64 { 0 }"),
+    ]) {
+        Ok(_) => panic!("neither item is expressible"),
+        Err(e) => e,
+    };
+
+    let ScanError::NotExpressible { entries } = &err else {
+        panic!("expected a NotExpressible report, got {err}");
+    };
+    assert_eq!(entries.len(), 2, "all offenders at once");
+
+    let msg = err.to_string();
+    assert!(msg.contains("bogus") && msg.contains("impl Trait"), "{msg}");
+    assert!(msg.contains("worse") && msg.contains("self"), "{msg}");
+}
+
 #[test]
 fn duplicate_name_across_sources_names_both_crates() {
     use crate::{

--- a/prebindgen/src/api/core/resolve/tests.rs
+++ b/prebindgen/src/api/core/resolve/tests.rs
@@ -9,7 +9,7 @@ use super::*;
 fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
     use crate::api::core::registry::{Registry, TypeKey};
 
-    let mut reg: Registry<()> = Registry::default();
+    let mut reg: Registry<()> = Registry::empty();
 
     // Index a struct `Outer { inner: ZKeyExpr }` so the BFS can walk
     // into its field. `ZKeyExpr` itself stays *unindexed* (the user's
@@ -60,7 +60,7 @@ fn final_invariant_stops_at_resolved_nodes() {
         SourceLocation as Loc,
     };
 
-    let mut reg: Registry<()> = Registry::default();
+    let mut reg: Registry<()> = Registry::empty();
 
     let outer_struct: syn::ItemStruct = syn::parse_str("struct Outer { inner: Inner }").unwrap();
     let inner_struct: syn::ItemStruct =

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -58,7 +58,7 @@ impl Prebindgen for IdentityExt {
 
 #[test]
 fn dedup_and_sort() {
-    let mut reg: Registry<()> = Registry::default();
+    let mut reg: Registry<()> = Registry::empty();
     let key_a = TypeKey::parse("u64").expect("test type");
     let key_b = TypeKey::parse("Sample").expect("test type");
     let wire: syn::Type = syn::parse_quote!(i64);
@@ -107,7 +107,7 @@ fn dedup_and_sort() {
 
 #[test]
 fn write_rust_sorts_declared_items_by_ident() {
-    let mut reg: Registry<()> = Registry::default();
+    let mut reg: Registry<()> = Registry::empty();
     let loc = SourceLocation::default();
 
     reg.functions.insert(

--- a/prebindgen/src/api/lang/cbindgen/tests/aliasing.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/aliasing.rs
@@ -38,7 +38,7 @@ fn build(fns: &[&str]) -> String {
         idents.push(f.sig.ident.clone());
         items.push((syn::Item::Fn(f), loc.clone()));
     }
-    let registry = Registry::<()>::from_items(items).expect("index items");
+    let registry = Registry::<()>::from_items(declare_referenced(items)).expect("index items");
 
     let mut cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(myflat))

--- a/prebindgen/src/api/lang/cbindgen/tests/boundary_invariants.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/boundary_invariants.rs
@@ -141,8 +141,10 @@ fn every_input_category() -> String {
         ),
     ];
 
-    let registry = Registry::<()>::from_items(items.into_iter().map(|i| (i, loc.clone())))
-        .expect("index items");
+    let registry = Registry::<()>::from_items(declare_referenced(
+        items.into_iter().map(|i| (i, loc.clone())),
+    ))
+    .expect("index items");
 
     let mut cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(example_flat))

--- a/prebindgen/src/api/lang/cbindgen/tests/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/builder.rs
@@ -10,8 +10,8 @@ fn function_name_renames_symbol() {
             unimplemented!()
         }
     );
-    let reg =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+    let reg = Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+        .expect("index items");
     let cb = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(rust_init))
@@ -81,10 +81,10 @@ fn free_memory_function_required() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     // String output (and an Error with a String field) but no free fn declared.
@@ -122,10 +122,10 @@ fn manglers_generate_all_names() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -211,8 +211,8 @@ fn qualified_signature_spelling_matches_bare_opaque_ptr() {
             unimplemented!()
         }
     );
-    let reg =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+    let reg = Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+        .expect("index items");
     let cb = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .opaque_ptr(syn::parse_quote!(ZKeyExpr))
@@ -244,10 +244,10 @@ fn enum_mirror_preserves_the_source_discriminant_domain() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(e), loc.clone()),
         (syn::Item::Fn(f), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()

--- a/prebindgen/src/api/lang/cbindgen/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/callbacks.rs
@@ -17,10 +17,10 @@ fn takeable_callback_param() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(func), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -77,10 +77,10 @@ fn callback_subscriber_emits_closure_structs() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -173,10 +173,10 @@ fn callback_scalar_arg_not_module_qualified() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -218,10 +218,10 @@ fn callback_struct_name_defaults_generically() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()

--- a/prebindgen/src/api/lang/cbindgen/tests/errors.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/errors.rs
@@ -10,10 +10,10 @@ fn result_error_not_declared_is_build_error() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     // Error declared as data_struct but NOT marked `.error()`.
@@ -49,8 +49,11 @@ fn fallible_input_without_result_needs_panic() {
     );
 
     // No `.panic()` → build error.
-    let reg1 = Registry::<()>::from_items([(syn::Item::Fn(func.clone()), loc.clone())])
-        .expect("index items");
+    let reg1 = Registry::<()>::from_items(declare_referenced([(
+        syn::Item::Fn(func.clone()),
+        loc.clone(),
+    )]))
+    .expect("index items");
     let cb1 = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(z_log));
@@ -62,8 +65,8 @@ fn fallible_input_without_result_needs_panic() {
     assert!(err.is_err(), "expected a build error without .panic()");
 
     // With `.panic()` → wrapper aborts on decode failure.
-    let reg2 =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+    let reg2 = Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+        .expect("index items");
     let cb2 = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
         .function(syn::parse_quote!(z_log))
@@ -95,11 +98,11 @@ fn error_out_param_is_null_guarded() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(ptr_fn), loc.clone()),
         (syn::Item::Fn(unit_fn), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()

--- a/prebindgen/src/api/lang/cbindgen/tests/inputs.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/inputs.rs
@@ -11,7 +11,8 @@ fn slice_u8_input_two_params() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -46,10 +47,10 @@ fn option_opaque_input_reuses_pointer() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -91,7 +92,8 @@ fn option_scalar_input_boxed_pointer() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -122,7 +124,8 @@ fn str_borrow_input_lowering() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -161,10 +164,10 @@ fn relation_to_lowering() {
         }
     );
 
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Enum(enum_item), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -221,11 +224,11 @@ fn enum_input_validates_the_discriminant() {
         }
     );
 
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Enum(enum_item), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -290,10 +293,10 @@ fn enum_input_without_error_channel_requires_panic() {
     );
     let build = |allow_panic: bool| {
         let loc = SourceLocation::default();
-        let registry = Registry::<()>::from_items([
+        let registry = Registry::<()>::from_items(declare_referenced([
             (syn::Item::Fn(func.clone()), loc.clone()),
             (syn::Item::Enum(enum_item.clone()), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let cbindgen = Cbindgen::new()
             .source_module(syn::parse_quote!(zenoh_flat))
@@ -331,10 +334,10 @@ fn mutable_opaque_borrow_input_lowering() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()

--- a/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
@@ -4,22 +4,24 @@ use super::*;
 fn bounded_duration_option_is_one_scalar_with_named_niche() {
     let loc = SourceLocation::default();
     let items: Vec<(syn::Item, SourceLocation)> = [
-        "pub fn duration_from_millis(v: u64) -> std::time::Duration { unimplemented!() }",
-        "pub fn duration_to_millis(v: &std::time::Duration) -> u64 { unimplemented!() }",
-        "pub fn duration_echo(v: Option<std::time::Duration>) -> Option<std::time::Duration> { unimplemented!() }",
-        "pub fn duration_nested_echo(v: Option<Option<std::time::Duration>>) -> Option<Option<std::time::Duration>> { unimplemented!() }",
+        "#[prebindgen] pub type Duration = std::time::Duration;",
+        "pub fn duration_from_millis(v: u64) -> Duration { unimplemented!() }",
+        "pub fn duration_to_millis(v: &Duration) -> u64 { unimplemented!() }",
+        "pub fn duration_echo(v: Option<Duration>) -> Option<Duration> { unimplemented!() }",
+        "pub fn duration_nested_echo(v: Option<Option<Duration>>) -> Option<Option<Duration>> { unimplemented!() }",
     ]
     .into_iter()
     .map(|source| {
-        let function: syn::ItemFn = syn::parse_str(source).unwrap();
-        (syn::Item::Fn(function), loc.clone())
+        // `syn::Item`, not `ItemFn`: a fixture declares the types it names.
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
     })
     .collect();
-    let registry = Registry::<()>::from_items(items).unwrap();
+    let registry = Registry::<()>::from_items(declare_referenced(items)).unwrap();
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(myflat))
         .convert(
-            crate::convert!(std::time::Duration)
+            crate::convert!(Duration)
                 .input(crate::fun!(duration_from_millis))
                 .output(crate::fun!(duration_to_millis))
                 .valid_range(0u64..=1_000_000u64),
@@ -68,11 +70,12 @@ fn bounded_float_option_uses_a_finite_bit_exact_niche() {
     ]
     .into_iter()
     .map(|source| {
-        let function: syn::ItemFn = syn::parse_str(source).unwrap();
-        (syn::Item::Fn(function), loc.clone())
+        // `syn::Item`, not `ItemFn`: a fixture declares the types it names.
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
     })
     .collect();
-    let registry = Registry::<()>::from_items(items).unwrap();
+    let registry = Registry::<()>::from_items(declare_referenced(items)).unwrap();
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(myflat))
         .convert(
@@ -113,11 +116,12 @@ fn custom_conversion_without_domain_stays_infallible() {
     ]
     .into_iter()
     .map(|source| {
-        let function: syn::ItemFn = syn::parse_str(source).unwrap();
-        (syn::Item::Fn(function), loc.clone())
+        // `syn::Item`, not `ItemFn`: a fixture declares the types it names.
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
     })
     .collect();
-    let registry = Registry::<()>::from_items(items).unwrap();
+    let registry = Registry::<()>::from_items(declare_referenced(items)).unwrap();
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(myflat))
         .convert(
@@ -165,10 +169,10 @@ fn keyexpr_try_from_lowering() {
         }
     );
 
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -238,7 +242,8 @@ fn opaque_error_lowering() {
     );
 
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))

--- a/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/lowering.rs
@@ -152,7 +152,7 @@ fn custom_conversion_without_domain_stays_infallible() {
 #[test]
 fn empty_adapter_writes_empty_file() {
     let cbindgen = Cbindgen::new();
-    let registry: Registry<()> = Registry::default();
+    let registry: Registry<()> = Registry::empty();
     let src = write(cbindgen, registry, "empty");
     assert!(src.trim().is_empty(), "expected empty output, got:\n{src}");
 }

--- a/prebindgen/src/api/lang/cbindgen/tests/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+pub(crate) use crate::api::test_util::declare_referenced;
 use crate::{api::test_util::unique_test_dir, SourceLocation};
 
 mod aliasing;

--- a/prebindgen/src/api/lang/cbindgen/tests/returns.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/returns.rs
@@ -10,10 +10,10 @@ fn result_unit_omits_out_param() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -47,10 +47,10 @@ fn result_string_uses_owned_string_wire() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -94,7 +94,8 @@ fn option_string_returns_pointer_null_for_none() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -136,10 +137,10 @@ fn result_option_uses_out_param() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -184,7 +185,8 @@ fn vec_string_returns_ptr_and_len() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -232,7 +234,8 @@ fn vec_u8_returns_scalar_array() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -260,7 +263,8 @@ fn cow_u8_returns_scalar_array() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -292,10 +296,10 @@ fn result_vec_uses_out_params() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -334,7 +338,8 @@ fn option_vec_uses_present_and_out() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -371,10 +376,10 @@ fn result_option_vec_full() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -412,10 +417,10 @@ fn result_pointer_returns_null_on_error() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Fn(func), loc.clone()),
         (syn::Item::Struct(error_struct()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -451,7 +456,8 @@ fn borrowed_ref_output_is_const_non_owning() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))
@@ -489,7 +495,8 @@ fn borrowed_option_ref_output_nullable() {
         }
     );
     let registry =
-        Registry::<()>::from_items([(syn::Item::Fn(func), loc.clone())]).expect("index items");
+        Registry::<()>::from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(zenoh_flat))

--- a/prebindgen/src/api/lang/cbindgen/tests/structs.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/structs.rs
@@ -22,11 +22,11 @@ fn opaque_owned_transmute_by_value() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(out_fn), loc.clone()),
         (syn::Item::Fn(in_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -117,11 +117,11 @@ fn opaque_data_no_gravestone_writeback() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(out_fn), loc.clone()),
         (syn::Item::Fn(in_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -196,13 +196,13 @@ fn repr_c_struct_visible_mirror_and_zero_copy_borrow() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(make_fn), loc.clone()),
         (syn::Item::Fn(put_fn), loc.clone()),
         (syn::Item::Fn(cb_fn), loc.clone()),
         (syn::Item::Fn(string_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -284,11 +284,11 @@ fn repr_c_struct_owned_inferred_field_nulls_without_default() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(put_fn), loc.clone()),
         (syn::Item::Fn(string_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -337,10 +337,10 @@ fn repr_c_struct_plain_data_has_no_writeback() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(take_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -385,11 +385,11 @@ fn repr_c_struct_bare_box_field_keeps_full_gravestone() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(put_fn), loc.clone()),
         (syn::Item::Fn(string_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -450,12 +450,12 @@ fn repr_c_struct_mut_ref_and_maybe_uninit_out_param() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(upd_fn), loc.clone()),
         (syn::Item::Fn(into_fn), loc.clone()),
         (syn::Item::Fn(string_fn), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -517,7 +517,7 @@ fn repr_c_struct_restricted_validity_field_is_rejected() {
                     unimplemented!()
                 }
             );
-            let registry = Registry::<()>::from_items([
+            let registry = Registry::<()>::from_items(declare_referenced([
                 (syn::Item::Struct(st), loc.clone()),
                 (
                     syn::Item::Enum(syn::parse_quote!(
@@ -529,7 +529,7 @@ fn repr_c_struct_restricted_validity_field_is_rejected() {
                     loc.clone(),
                 ),
                 (syn::Item::Fn(take), loc.clone()),
-            ])
+            ]))
             .expect("index items");
 
             let cbindgen = Cbindgen::new()
@@ -569,10 +569,10 @@ fn repr_c_struct_restricted_validity_field_accepted_when_acknowledged() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(take), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -612,10 +612,10 @@ fn repr_c_struct_restricted_validity_field_audited_even_when_output_only() {
         }
     );
     let registry = || {
-        Registry::<()>::from_items([
+        Registry::<()>::from_items(declare_referenced([
             (syn::Item::Struct(st.clone()), loc.clone()),
             (syn::Item::Fn(make.clone()), loc.clone()),
-        ])
+        ]))
         .expect("index items")
     };
 

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -39,12 +39,12 @@ fn tagged_union_mirror_and_converters() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(shape_enum()), loc.clone()),
         (syn::Item::Enum(operation_enum()), loc.clone()),
         (syn::Item::Fn(make), loc.clone()),
         (syn::Item::Fn(take), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -133,11 +133,11 @@ fn owning_payload_gets_typed_drop() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(shape_enum()), loc.clone()),
         (syn::Item::Enum(operation_enum()), loc.clone()),
         (syn::Item::Fn(make), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -189,10 +189,10 @@ fn plain_data_union_has_no_drop() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(e), loc.clone()),
         (syn::Item::Fn(make), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -223,12 +223,12 @@ fn tagged_union_as_data_struct_field() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(shape_enum()), loc.clone()),
         (syn::Item::Enum(operation_enum()), loc.clone()),
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(f), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -292,14 +292,14 @@ fn a_union_nested_in_a_struct_payload_is_freed() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(shape_enum()), loc.clone()),
         (syn::Item::Enum(operation_enum()), loc.clone()),
         (syn::Item::Struct(drawing), loc.clone()),
         (syn::Item::Enum(note), loc.clone()),
         (syn::Item::Fn(make), loc.clone()),
         (syn::Item::Fn(shape_new), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -345,10 +345,10 @@ fn plain_data_struct_decode_stays_infallible() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(f), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -381,11 +381,11 @@ fn declarators_do_not_accept_each_others_shape() {
 
     // Payload enum handed to `.enum_type()`.
     let payload_as_enum = || {
-        let registry = Registry::<()>::from_items([
+        let registry = Registry::<()>::from_items(declare_referenced([
             (syn::Item::Enum(shape_enum()), loc.clone()),
             (syn::Item::Enum(operation_enum()), loc.clone()),
             (syn::Item::Fn(make.clone()), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let cbindgen = Cbindgen::new()
             .source_module(syn::parse_quote!(example_flat))
@@ -404,10 +404,10 @@ fn declarators_do_not_accept_each_others_shape() {
         }
     );
     let unit_as_union = || {
-        let registry = Registry::<()>::from_items([
+        let registry = Registry::<()>::from_items(declare_referenced([
             (syn::Item::Enum(operation_enum()), loc.clone()),
             (syn::Item::Fn(unit_fn.clone()), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let cbindgen = Cbindgen::new()
             .source_module(syn::parse_quote!(example_flat))
@@ -442,10 +442,10 @@ fn each_payload_rejection_names_its_own_reason() {
                 Many(Vec<u8>),
             }
         );
-        let registry = Registry::<()>::from_items([
+        let registry = Registry::<()>::from_items(declare_referenced([
             (syn::Item::Enum(e), loc.clone()),
             (syn::Item::Fn(make.clone()), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let cbindgen = Cbindgen::new()
             .source_module(syn::parse_quote!(example_flat))
@@ -492,10 +492,10 @@ fn unsupported_payload_is_a_generation_error() {
         }
     );
     let boom = || {
-        let registry = Registry::<()>::from_items([
+        let registry = Registry::<()>::from_items(declare_referenced([
             (syn::Item::Enum(e.clone()), loc.clone()),
             (syn::Item::Fn(make.clone()), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let cbindgen = Cbindgen::new()
             .source_module(syn::parse_quote!(example_flat))
@@ -533,11 +533,11 @@ fn null_opaque_payload_is_reported_not_materialised() {
             unimplemented!()
         }
     );
-    let registry = Registry::<()>::from_items([
+    let registry = Registry::<()>::from_items(declare_referenced([
         (syn::Item::Enum(e), loc.clone()),
         (syn::Item::Fn(make), loc.clone()),
         (syn::Item::Fn(take), loc.clone()),
-    ])
+    ]))
     .expect("index items");
 
     let cbindgen = Cbindgen::new()
@@ -633,7 +633,7 @@ fn payload_wires_come_from_the_converter_destination() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<()>::from_items(items).expect("index items");
+    let registry = Registry::<()>::from_items(declare_referenced(items)).expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(example_flat))
@@ -726,7 +726,7 @@ fn bool_payload_is_normalised_not_materialised() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<()>::from_items(items).expect("index items");
+    let registry = Registry::<()>::from_items(declare_referenced(items)).expect("index items");
 
     let cbindgen = Cbindgen::new()
         .source_module(syn::parse_quote!(example_flat))

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -599,11 +599,12 @@ mod tests {
                 unimplemented!()
             }
         };
-        let registry = Registry::<KotlinMeta>::from_items(vec![(
-            syn::Item::Fn(ctor),
-            SourceLocation::default(),
-        )])
-        .expect("index constructor");
+        let registry =
+            Registry::<KotlinMeta>::from_items(crate::api::test_util::declare_referenced(vec![(
+                syn::Item::Fn(ctor),
+                SourceLocation::default(),
+            )]))
+            .expect("index constructor");
         let variant = crate::api::core::expand::FoldVariant {
             ctor: Some(syn::parse_quote!(z_summary_optional)),
             fallible: false,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/aliasing.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/aliasing.rs
@@ -41,7 +41,7 @@ fn build(fns: &[&str], tag: &str) -> String {
         decls = decls.fun(crate::lang::FunctionDecl::new(id));
         items.push((syn::Item::Fn(f), loc.clone()));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(decls);

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -32,7 +32,8 @@ fn callback_snapshot_pipeline() -> (String, std::collections::BTreeMap<String, S
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -217,7 +218,8 @@ fn callback_root_identity_moved_after_nested_borrow() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -312,7 +314,8 @@ fn callback_double_option_unwrap_pipeline() {
         )),
         loc.clone(),
     ));
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -480,7 +483,8 @@ fn iface_spec_memo_shares_one_derivation() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -552,7 +556,8 @@ fn fn_plan_memo_shares_one_derivation() {
         )),
         loc.clone(),
     )];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("thing").fun(crate::fun!(z_do_thing)));

--- a/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/config.rs
@@ -24,7 +24,7 @@ fn ptr_class_implements_adds_interface_supertypes() {
         .iter()
         .map(|src| (syn::Item::Fn(syn::parse_str(src).unwrap()), loc.clone()))
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(
@@ -74,7 +74,7 @@ fn ptr_class_interface_emits_generated_api() {
         .iter()
         .map(|src| (syn::Item::Fn(syn::parse_str(src).unwrap()), loc.clone()))
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(
@@ -133,7 +133,8 @@ fn interface_name_mangle_identity_rejected() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_thing_new() -> ZThing { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .set_interface_name_mangle(|package, n| {
@@ -179,7 +180,7 @@ fn interface_name_override_and_hook() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .set_interface_name_mangle(|package, n| {
@@ -241,7 +242,7 @@ fn data_class_interface_emits_generated_api() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t").class(
             crate::data_class!(ZStamp)
@@ -311,7 +312,8 @@ fn per_class_name_and_base_package_fun() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -387,7 +389,8 @@ fn setters_after_declarations_apply() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     // Declarations first, settings last.
     let jni = JniGen::new()
@@ -436,7 +439,8 @@ fn generation_writes_are_order_free() {
         let f: syn::ItemFn =
             syn::parse_str("pub fn z_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
         let registry =
-            Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+            Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+                .expect("index");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(crate::package!("thing").fun(crate::fun!(z_ping)));
@@ -492,7 +496,8 @@ fn method_hook_can_strip_flat_class_prefix() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .set_method_name_mangle(|package, class, name| {
@@ -570,7 +575,8 @@ fn method_name_mangle_hook_applies_order_independently() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -620,7 +626,8 @@ fn harness_hook_receives_derived_default() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .set_harness_name_mangle(|n| {
@@ -656,7 +663,8 @@ fn function_and_native_method_hooks_receive_placement() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_session_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .set_fun_name_mangle(|package, name| {
@@ -700,7 +708,8 @@ fn write_kotlin_owns_and_resets_the_root() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_ping(v: i64) -> i64 { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("thing").fun(crate::fun!(z_ping)));
@@ -748,7 +757,8 @@ fn report_explains_the_resolved_surface() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -864,7 +874,8 @@ fn docs_become_kdoc_with_shape_notes() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/consts.rs
@@ -29,7 +29,8 @@ fn const_items() -> Vec<(syn::Item, crate::SourceLocation)> {
 /// private helpers, and `JNINative` declares the matching `external fun`s.
 #[test]
 fn declared_consts_emit_getter_and_val() {
-    let registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(const_items())).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg")
@@ -108,12 +109,12 @@ fn declared_consts_emit_getter_and_val() {
 /// return: public `ULong`, private/native `Long`, with a bit-preserving wrap.
 #[test]
 fn unsigned_const_uses_ulong_surface() {
-    let registry = Registry::<KotlinMeta>::from_items(vec![(
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
         syn::Item::Const(syn::parse_quote!(
             pub const MAX_UNSIGNED: u64 = u64::MAX;
         )),
         myflat_loc(),
-    )])
+    )]))
     .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -143,7 +144,8 @@ fn unsigned_const_uses_ulong_surface() {
 /// acknowledges it without emitting.
 #[test]
 fn undeclared_const_not_emitted() {
-    let registry = Registry::<KotlinMeta>::from_items(const_items()).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(const_items())).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -184,7 +186,8 @@ fn constant_fun_source_emits_val_over_ordinary_wrapper() {
         )),
         loc.clone(),
     )];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -236,7 +239,8 @@ fn constant_fun_source_non_nullary_rejected() {
         )),
         loc.clone(),
     )];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg").constant(crate::constant!(SCALED).fun(crate::fun!(scaled))),
     );
@@ -272,7 +276,8 @@ fn constant_fun_source_handle_return_rejected() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
@@ -303,7 +308,8 @@ fn constant_expr_emits_getter_and_val() {
         )),
         loc.clone(),
     )];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg").fun(crate::fun!(tag_of)).constant(
@@ -374,7 +380,8 @@ fn constant_expr_handle_type_rejected() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
             .class(crate::ptr_class!(ZThing))
@@ -421,7 +428,8 @@ fn handle_const_rejected() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("things")
@@ -453,7 +461,8 @@ fn constant_with_source_calls_path_verbatim() {
         )),
         loc.clone(),
     )];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("cfg").fun(crate::fun!(unrelated)).constant(
             crate::constant!(COVER_VERSION)

--- a/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/cross_artifact.rs
@@ -261,7 +261,8 @@ fn run_pipeline(
     items: Vec<(syn::Item, crate::SourceLocation)>,
     jni: JniGen,
 ) -> (String, BTreeMap<String, String>) {
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let dir = unique_test_dir(tag);
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -19,7 +19,8 @@ fn inline_output_gets_own_builder() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -116,7 +117,8 @@ fn error_unwrap_universal_records() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -247,7 +249,8 @@ fn method_constructor_and_inline_field_self() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -317,7 +320,8 @@ fn rust_side_only_error_type() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -385,7 +389,8 @@ fn rust_side_only_input_type() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -429,7 +434,8 @@ fn rust_side_only_variant_self_rejected() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_run(opts: ZOpts) -> i64 { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .package(crate::package!("ops").fun(crate::fun!(z_run)))
         .expand(crate::expand_param!(ZOpts).variant_self());
@@ -449,7 +455,8 @@ fn rust_side_only_field_self_rejected() {
     let loc = myflat_loc();
     let f: syn::ItemFn = syn::parse_str("pub fn z_make() -> ZThing { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .package(crate::package!("ops").fun(crate::fun!(z_make)))
         .expand(crate::expand_return!(ZThing).field_self());
@@ -478,7 +485,8 @@ fn fn_expand_param_type_mismatch_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
@@ -513,7 +521,8 @@ fn fn_expand_return_type_mismatch_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))
@@ -545,7 +554,8 @@ fn fn_expand_param_unknown_param_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().package(
         crate::package!("ops")
             .class(crate::ptr_class!(ZThing).constructor(crate::fun!(z_thing_make)))
@@ -582,7 +592,8 @@ fn typo_in_expand_decl_is_hard_error() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn z_fallible() -> Result<i64, ZErr> { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
@@ -625,7 +636,8 @@ fn ignore_matching_acknowledges_naming_family() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_len)))
@@ -722,7 +734,8 @@ fn method_without_receiver_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t").class(
             crate::ptr_class!(ZThing)
@@ -753,7 +766,8 @@ fn constructor_with_wrong_return_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t").class(
             crate::ptr_class!(ZThing)
@@ -796,7 +810,8 @@ fn binding_local_field_conditional_handle() {
             loc.clone(),
         ));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -880,7 +895,8 @@ fn binding_local_field_name_collision_rejected() {
             loc.clone(),
         ));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -941,7 +957,8 @@ fn binding_local_field_splices_through_parent() {
             loc.clone(),
         ));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1015,7 +1032,8 @@ fn binding_local_functions_all_positions() {
             loc.clone(),
         ));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1110,7 +1128,8 @@ fn binding_local_fn_names_flow_through_manglers() {
     ] {
         items.push((syn::Item::Fn(syn::parse_str(src).unwrap()), loc.clone()));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         // Custom hooks: prefix every derived name — proof the hook RAN and
@@ -1199,7 +1218,8 @@ fn binding_local_fun_name_collision_rejected() {
         ),
         loc.clone(),
     ));
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t").class(crate::ptr_class!(ZThing)).fun(
             // shadows the #[prebindgen] fn of the same name
@@ -1252,7 +1272,8 @@ fn gc_managed_handle_lifecycle() {
             loc.clone(),
         ));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("t")
             .class(
@@ -1337,7 +1358,7 @@ fn split_fixture(extra: &[&str]) -> Registry<KotlinMeta> {
             loc.clone(),
         ));
     }
-    Registry::<KotlinMeta>::from_items(items).expect("index items")
+    Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items")
 }
 
 pub(super) fn write_all(gen: crate::api::core::Generation<JniGen>, tag: &str) -> String {
@@ -1523,7 +1544,7 @@ fn split_on_param_product_ambiguous_rejected() {
     for s in srcs {
         items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1566,7 +1587,7 @@ fn split_declaration_colliding_variants_rejected() {
     for s in srcs {
         items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1604,7 +1625,7 @@ fn split_declaration_collision_fails_resolve() {
     for s in srcs {
         items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1647,7 +1668,7 @@ fn split_no_split_suppresses_check() {
     for s in srcs {
         items.push((syn::Item::Fn(syn::parse_str(s).unwrap()), loc.clone()));
     }
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1832,7 +1853,8 @@ fn optional_selector_dispatch_end_to_end() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1891,7 +1913,8 @@ fn constructor_member_skips_default_output_expand() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1957,7 +1980,8 @@ fn qualified_signature_spelling_matches_bare_ptr_class() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(crate::ptr_class!(ZThing).method(crate::fun!(z_thing_name).name("name")))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -1,6 +1,7 @@
 use quote::ToTokens;
 
 use super::*;
+pub(crate) use crate::api::test_util::declare_referenced;
 use crate::{
     api::{
         core::{

--- a/prebindgen/src/api/lang/jnigen/jni/tests/niches.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/niches.rs
@@ -4,7 +4,7 @@ use super::*;
 /// remainder is empty. No widening to JObject.
 #[test]
 fn option_carves_single_niche() {
-    let mut reg = Registry::default();
+    let mut reg = Registry::empty();
     install_input(
         &mut reg,
         "TestType",
@@ -31,7 +31,7 @@ fn option_carves_single_niche() {
 /// wire. The third layer hits empty niches and falls back to box.
 #[test]
 fn option_cascades_through_multi_niche() {
-    let mut reg = Registry::default();
+    let mut reg = Registry::empty();
 
     // TestType: jint with two niches (MIN, MAX).
     install_input(
@@ -107,7 +107,7 @@ fn option_cascades_through_multi_niche() {
 /// `None` arm of the match, and the remainder is re-exported.
 #[test]
 fn option_output_cascades_through_multi_niche() {
-    let mut reg = Registry::default();
+    let mut reg = Registry::empty();
     install_output(
         &mut reg,
         "TestType",
@@ -165,7 +165,7 @@ fn option_output_cascades_through_multi_niche() {
 /// decoder stays on `JObject` (no boxing).
 #[test]
 fn option_over_jobject_uses_default_null_niche() {
-    let mut reg = Registry::default();
+    let mut reg = Registry::empty();
     install_input(
         &mut reg,
         "MyStruct",
@@ -191,7 +191,7 @@ fn option_over_jobject_uses_default_null_niche() {
 /// JNI primitives.
 #[test]
 fn option_fails_when_no_niche_and_non_primitive_wire() {
-    let mut reg = Registry::default();
+    let mut reg = Registry::empty();
     install_input(
         &mut reg,
         "MyStruct",
@@ -211,7 +211,7 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
 /// to widen.
 #[test]
 fn option_box_fallback_exposes_no_niches() {
-    let mut reg = Registry::default();
+    let mut reg = Registry::empty();
     install_input(
         &mut reg,
         "i64",

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -31,7 +31,8 @@ fn sealed_kotlin(rename_labeled: Option<&str>) -> String {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let mut sealed = crate::sealed_class!(Reading);
     if let Some(n) = rename_labeled {
@@ -155,7 +156,8 @@ fn declarators_do_not_accept_each_others_shape() {
 
     let emit = |item: syn::Item, decl: crate::lang::ClassDecl, tag: &str| {
         let registry =
-            Registry::<KotlinMeta>::from_items(vec![(item, loc.clone())]).expect("index items");
+            Registry::<KotlinMeta>::from_items(declare_referenced(vec![(item, loc.clone())]))
+                .expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(crate::package!().class(decl));
@@ -187,7 +189,7 @@ fn declarators_do_not_accept_each_others_shape() {
 fn unknown_variant_is_an_error() {
     let loc = myflat_loc();
     let boom = || {
-        let registry = Registry::<KotlinMeta>::from_items(vec![(
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
             syn::Item::Enum(syn::parse_quote!(
                 pub enum Reading {
                     Missing,
@@ -195,7 +197,7 @@ fn unknown_variant_is_an_error() {
                 }
             )),
             loc.clone(),
-        )])
+        )]))
         .expect("index items");
         let jni = JniGen::new().set_package_prefix("io.test.jni").package(
             crate::package!()
@@ -216,7 +218,7 @@ fn unknown_variant_is_an_error() {
 #[test]
 fn reopened_sealed_class_merges_variant_names() {
     let loc = myflat_loc();
-    let registry = Registry::<KotlinMeta>::from_items(vec![(
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
         syn::Item::Enum(syn::parse_quote!(
             pub enum Reading {
                 Missing,
@@ -225,7 +227,7 @@ fn reopened_sealed_class_merges_variant_names() {
             }
         )),
         loc.clone(),
-    )])
+    )]))
     .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -283,7 +285,8 @@ fn reopened_ptr_class_keeps_gc_managed() {
         )]
     };
     let gc_managed_of = |first: crate::lang::PtrClassDecl, second: crate::lang::PtrClassDecl| {
-        let registry = Registry::<KotlinMeta>::from_items(items()).expect("index items");
+        let registry =
+            Registry::<KotlinMeta>::from_items(declare_referenced(items())).expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(crate::package!().class(first).class(second));
@@ -339,7 +342,8 @@ fn a_type_gets_one_class_declarator() {
         ]
     };
     let declare = |first: crate::lang::ClassDecl, second: crate::lang::ClassDecl| {
-        let registry = Registry::<KotlinMeta>::from_items(items()).expect("index items");
+        let registry =
+            Registry::<KotlinMeta>::from_items(declare_referenced(items())).expect("index items");
         let _ = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(crate::package!().class(first).class(second));
@@ -440,9 +444,11 @@ fn variant_cannot_take_a_name_the_interface_body_already_uses() {
     // Resolve is where `validate_symbols` runs, so the error surfaces before
     // any artifact writer touches disk.
     let resolve_err = |decl: crate::lang::SealedClassDecl, item: syn::ItemEnum| -> String {
-        let registry =
-            Registry::<KotlinMeta>::from_items(vec![(syn::Item::Enum(item), loc.clone())])
-                .expect("index items");
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
+            syn::Item::Enum(item),
+            loc.clone(),
+        )]))
+        .expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(crate::package!().class(decl));
@@ -507,9 +513,11 @@ fn variant_cannot_take_a_name_the_interface_body_already_uses() {
 fn variant_named_companion_moves_the_companion_not_the_variant() {
     let loc = myflat_loc();
     let emit = |decl: crate::lang::SealedClassDecl, item: syn::ItemEnum, tag: &str| -> String {
-        let registry =
-            Registry::<KotlinMeta>::from_items(vec![(syn::Item::Enum(item), loc.clone())])
-                .expect("index items");
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
+            syn::Item::Enum(item),
+            loc.clone(),
+        )]))
+        .expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(crate::package!().class(decl));
@@ -579,7 +587,7 @@ fn variant_named_companion_moves_the_companion_not_the_variant() {
 fn payload_without_output_converter_is_an_error() {
     let loc = myflat_loc();
     let boom = || {
-        let registry = Registry::<KotlinMeta>::from_items(vec![(
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
             syn::Item::Enum(syn::parse_quote!(
                 pub enum Reading {
                     Missing,
@@ -589,7 +597,7 @@ fn payload_without_output_converter_is_an_error() {
                 }
             )),
             loc.clone(),
-        )])
+        )]))
         .expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
@@ -617,7 +625,7 @@ fn payload_without_output_converter_is_an_error() {
 #[test]
 fn sum_is_its_own_type_kind() {
     let loc = myflat_loc();
-    let registry = Registry::<KotlinMeta>::from_items(vec![(
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![(
         syn::Item::Enum(syn::parse_quote!(
             pub enum Reading {
                 Missing,
@@ -625,7 +633,7 @@ fn sum_is_its_own_type_kind() {
             }
         )),
         loc.clone(),
-    )])
+    )]))
     .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -658,7 +666,7 @@ fn vec_of_sum_is_rejected_as_a_struct_field() {
                 unimplemented!()
             }
         );
-        let registry = Registry::<KotlinMeta>::from_items(vec![
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![
             (
                 syn::Item::Enum(syn::parse_quote!(
                     pub enum Reading {
@@ -670,7 +678,7 @@ fn vec_of_sum_is_rejected_as_a_struct_field() {
             ),
             (syn::Item::Struct(st), loc.clone()),
             (syn::Item::Fn(f), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let jni = JniGen::new().set_package_prefix("io.test.jni").package(
             crate::package!()
@@ -726,11 +734,11 @@ fn recursive_sum_shapes_fail_deterministically() {
                 unimplemented!()
             }
         );
-        let registry = Registry::<KotlinMeta>::from_items(vec![
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(vec![
             (syn::Item::Enum(e), loc.clone()),
             (syn::Item::Struct(st), loc.clone()),
             (syn::Item::Fn(f), loc.clone()),
-        ])
+        ]))
         .expect("index items");
         let jni = JniGen::new().set_package_prefix("io.test.jni").package(
             crate::package!()
@@ -871,7 +879,8 @@ fn sum_returns(tag: &str) -> (String, String) {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::enum_class!(Priority))
@@ -1187,7 +1196,8 @@ fn a_data_class_field_may_be_a_sum_carrying_a_handle() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::ptr_class!(Probe))
@@ -1279,7 +1289,8 @@ fn two_sum_callback_args_keep_their_own_selectors() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::sealed_class!(Reading))
@@ -1358,7 +1369,8 @@ fn sum_in_result_ok_position_is_rejected_with_its_reason() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::sealed_class!(Reading))
@@ -1408,7 +1420,8 @@ fn undeclared_sum_in_result_error_position_is_rejected() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::sealed_class!(Reading))
@@ -1460,7 +1473,8 @@ fn the_diagnostic_names_the_whole_error_type_where_it_must() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::sealed_class!(Reading))
@@ -1516,7 +1530,8 @@ fn declared_sum_in_result_error_position_resolves() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .expand(crate::expand_return!(Reading).field(crate::fun!(reading_code)))
@@ -1560,7 +1575,8 @@ fn slice_of_sum_callback_arg_is_rejected_with_its_reason() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::sealed_class!(Reading))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/snapshots.rs
@@ -43,7 +43,8 @@ fn snapshot_pipeline() -> (String, std::collections::BTreeMap<String, String>) {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -242,7 +243,8 @@ fn handler_interfaces_carry_split_contract_kdoc() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("ops").fun(crate::fun!(z_fallible)))
@@ -302,7 +304,8 @@ fn box_string_field_maps_to_nullable_kotlin_string() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("payload")
@@ -379,7 +382,8 @@ fn slice_input_builds_vec_handle() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("foo")
@@ -500,7 +504,8 @@ fn native_symbols_are_jni_escaped() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.example.my_pkg")
@@ -568,7 +573,8 @@ fn jni_native_init_emits_init_block() {
         )),
         loc.clone(),
     )];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")

--- a/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/symbols.rs
@@ -25,7 +25,8 @@ fn resolve_result(tag: &str, registry: Registry<KotlinMeta>, jni: JniGen) -> Res
 
 fn one_fn(src: &str) -> Registry<KotlinMeta> {
     let f: syn::ItemFn = syn::parse_str(src).unwrap();
-    Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), myflat_loc())]).expect("index")
+    Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), myflat_loc())]))
+        .expect("index")
 }
 
 /// A `.name()` override that isn't a legal Kotlin identifier is a hard error
@@ -82,7 +83,7 @@ fn duplicate_native_symbol_is_error() {
             myflat_loc(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     // The JNINative extern method name (which the `Java_…` symbol derives
     // from) goes through the method hook; collapsing it onto one name for
     // every function forces two distinct fns to share a native symbol.
@@ -119,7 +120,7 @@ fn keyword_struct_field_is_sanitized_not_error() {
             myflat_loc(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
             .class(crate::data_class!(Payload))
@@ -186,7 +187,7 @@ fn same_name_same_signature_functions_collide() {
             myflat_loc(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     // Both forced to Kotlin name `combine`; both take one `Long` → same sig.
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -212,7 +213,7 @@ fn same_name_distinct_signature_functions_allowed() {
             myflat_loc(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     // Same name `combine`, but one takes Long and the other Boolean.
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -236,7 +237,7 @@ fn method_and_factory_same_name_do_not_collide() {
             myflat_loc(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing").class(
             crate::ptr_class!(Thing)

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -74,7 +74,8 @@ fn value_form_items() -> Vec<(syn::Item, crate::SourceLocation)> {
 /// Build the fixture through `JniGen`, letting the caller adjust the
 /// `ZSample` boundary decl. Returns the generated Rust + the joined Kotlin.
 fn value_form_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> (String, String) {
-    let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(value_form_items()))
+        .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -217,7 +218,8 @@ fn deriving_matches_the_equivalent_hand_written_list() {
      -> Vec<(String, String)> {
         let mut all = items.clone();
         all.extend(extra);
-        let registry = Registry::<KotlinMeta>::from_items(all).expect("index items");
+        let registry =
+            Registry::<KotlinMeta>::from_items(declare_referenced(all)).expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(
@@ -393,7 +395,8 @@ fn sum_field_gen(tag: &str) -> (String, String) {
         )),
         loc,
     ));
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -490,7 +493,8 @@ fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
                 loc.clone(),
             ),
         ];
-        let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+        let registry =
+            Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(
@@ -532,7 +536,8 @@ fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
 #[test]
 fn an_adjustment_naming_an_unknown_field_is_an_error() {
     let build = |decl: crate::lang::FieldsDecl| {
-        let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index");
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(value_form_items()))
+            .expect("index");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(
@@ -639,7 +644,8 @@ fn a_single_leaf_value_form_delivers_an_owned_field() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -698,7 +704,8 @@ fn a_single_leaf_consuming_value_form_moves_its_field() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -763,7 +770,8 @@ fn a_handle_field_of_a_consuming_value_form_moves() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -833,7 +841,8 @@ fn a_sole_handle_field_of_a_consuming_value_form_moves() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -904,7 +913,8 @@ fn an_optional_handle_field_of_a_consuming_value_form_moves() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -974,7 +984,8 @@ fn a_sole_optional_handle_field_takes_callback_delivery() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1040,7 +1051,8 @@ fn an_owned_root_identity_moves_without_any_value_form() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1072,7 +1084,8 @@ fn an_owned_root_identity_moves_without_any_value_form() {
 #[test]
 fn a_per_field_override_must_name_the_field_s_own_type() {
     let build = || {
-        let registry = Registry::<KotlinMeta>::from_items(value_form_items()).expect("index");
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(value_form_items()))
+            .expect("index");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(
@@ -1167,7 +1180,8 @@ fn a_nested_value_form_is_hoisted_too() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1283,7 +1297,8 @@ fn a_nested_consuming_value_form_moves_the_parent_s_field() {
         ),
     ] {
         let registry =
-            Registry::<KotlinMeta>::from_items(items(outer_by_value)).expect("index items");
+            Registry::<KotlinMeta>::from_items(declare_referenced(items(outer_by_value)))
+                .expect("index items");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(
@@ -1392,7 +1407,8 @@ fn nested_review_jni(outer: crate::lang::ExpandReturnDecl) -> JniGen {
 /// `Option` it cannot unwrap.
 #[test]
 fn an_optional_nested_value_form_is_rejected_before_emission() {
-    let registry = Registry::<KotlinMeta>::from_items(nested_review_items()).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(nested_review_items()))
+        .expect("index items");
     let jni = nested_review_jni(
         crate::expand_return!(ZReviewOuter).fields(crate::fields!(z_review_outer_to_struct)),
     );
@@ -1435,7 +1451,8 @@ fn a_value_form_under_an_optional_accessor_is_hoisted_conditionally() {
             loc,
         ),
     ]);
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1511,7 +1528,8 @@ fn conditional_owned_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> Stri
             loc,
         ),
     ]);
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1565,7 +1583,8 @@ fn an_owned_optional_payload_is_borrowed_for_the_steps_after_it() {
             loc,
         ),
     ]);
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1636,7 +1655,8 @@ fn a_rebased_hoist_projects_its_leading_fields_past_a_sibling_move() {
             loc,
         ),
     ]);
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1698,7 +1718,8 @@ fn a_consuming_value_form_keeps_its_by_value_boundary_behind_accessors() {
             loc,
         ),
     ]);
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1765,7 +1786,8 @@ fn an_owned_intermediate_result_is_borrowed_for_the_next_step() {
             loc,
         ),
     ]);
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1878,7 +1900,8 @@ fn a_sum_field_of_a_conditional_value_form_stays_inside_the_arm() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -1931,7 +1954,8 @@ fn a_sum_field_of_a_conditional_value_form_stays_inside_the_arm() {
 fn a_vec_field_override_must_name_the_whole_vec_type() {
     let build = || {
         let registry =
-            Registry::<KotlinMeta>::from_items(nested_review_items()).expect("index items");
+            Registry::<KotlinMeta>::from_items(declare_referenced(nested_review_items()))
+                .expect("index items");
         let jni = nested_review_jni(
             crate::expand_return!(ZReviewOuter).fields(
                 crate::fields!(z_review_outer_to_struct)
@@ -2000,7 +2024,8 @@ fn consuming_items() -> Vec<(syn::Item, crate::SourceLocation)> {
 }
 
 fn consuming_gen(tag: &str, decl: crate::lang::ExpandReturnDecl) -> String {
-    let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index items");
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(consuming_items()))
+        .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -2076,7 +2101,8 @@ fn a_borrowed_plan_clones_before_consuming() {
         )),
         loc,
     ));
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(
@@ -2141,7 +2167,8 @@ fn a_consuming_value_form_rejects_a_plain_field_sibling() {
 #[test]
 fn the_declarator_and_the_accessor_s_receiver_must_agree() {
     let build = |decl: crate::lang::ExpandReturnDecl| -> String {
-        let registry = Registry::<KotlinMeta>::from_items(consuming_items()).expect("index");
+        let registry = Registry::<KotlinMeta>::from_items(declare_referenced(consuming_items()))
+            .expect("index");
         let jni = JniGen::new()
             .set_package_prefix("io.test.jni")
             .package(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -4,21 +4,23 @@ use super::*;
 fn bounded_duration_option_uses_u64_niche_without_boxing() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [
-        "pub fn duration_from_millis(v: u64) -> std::time::Duration { unimplemented!() }",
-        "pub fn duration_to_millis(v: &std::time::Duration) -> u64 { unimplemented!() }",
-        "pub fn duration_echo(v: Option<std::time::Duration>) -> Option<std::time::Duration> { unimplemented!() }",
+        "#[prebindgen] pub type Duration = std::time::Duration;",
+        "pub fn duration_from_millis(v: u64) -> Duration { unimplemented!() }",
+        "pub fn duration_to_millis(v: &Duration) -> u64 { unimplemented!() }",
+        "pub fn duration_echo(v: Option<Duration>) -> Option<Duration> { unimplemented!() }",
     ]
     .into_iter()
     .map(|source| {
-        let function: syn::ItemFn = syn::parse_str(source).unwrap();
-        (syn::Item::Fn(function), loc.clone())
+        // `syn::Item`, not `ItemFn`: a fixture declares the types it names.
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
     })
     .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).unwrap();
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
-            crate::convert!(std::time::Duration)
+            crate::convert!(Duration)
                 .input(crate::fun!(duration_from_millis))
                 .output(crate::fun!(duration_to_millis))
                 .valid_range(0u64..=1_000_000u64),
@@ -68,14 +70,14 @@ fn flattened_field_composes_bounded_conversion_stages() {
         (
             syn::Item::Struct(syn::parse_quote!(
                 pub struct Timed {
-                    pub delay: Option<std::time::Duration>,
+                    pub delay: Option<Duration>,
                 }
             )),
             loc.clone(),
         ),
         (
             syn::Item::Fn(syn::parse_quote!(
-                pub fn duration_from_millis(v: u64) -> std::time::Duration {
+                pub fn duration_from_millis(v: u64) -> Duration {
                     unimplemented!()
                 }
             )),
@@ -83,7 +85,7 @@ fn flattened_field_composes_bounded_conversion_stages() {
         ),
         (
             syn::Item::Fn(syn::parse_quote!(
-                pub fn duration_to_millis(v: &std::time::Duration) -> u64 {
+                pub fn duration_to_millis(v: &Duration) -> u64 {
                     unimplemented!()
                 }
             )),
@@ -106,11 +108,12 @@ fn flattened_field_composes_bounded_conversion_stages() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
-            crate::convert!(std::time::Duration)
+            crate::convert!(Duration)
                 .input(crate::fun!(duration_from_millis))
                 .output(crate::fun!(duration_to_millis))
                 .valid_range(0u64..=1_000_000u64),
@@ -153,11 +156,11 @@ fn flattened_field_composes_bounded_conversion_stages() {
     assert!(rc.contains("jlong_to_u64"), "{rust}");
     assert!(rc.contains("u64_to_Duration"), "{rust}");
     assert!(
-        rc.contains("jlong_to_Option_std_time_Duration") && rc.contains("env,&__delay_raw)?"),
+        rc.contains("jlong_to_Option_Duration") && rc.contains("env,&__delay_raw)?"),
         "whole-JObject input must invoke the complete optional Duration converter:\n{rust}"
     );
     assert!(
-        rc.contains("let___delay:jni::sys::jlong=Option_std_time_Duration_to_jlong")
+        rc.contains("let___delay:jni::sys::jlong=Option_Duration_to_jlong")
             && rc.contains("\"(J)Lio/test/jni/Timed;\""),
         "whole-struct output must pass the niche as primitive jlong:\n{rust}"
     );
@@ -170,12 +173,16 @@ fn flattened_field_composes_bounded_conversion_stages() {
 
 #[test]
 fn duration_requires_an_explicit_conversion() {
-    let function: syn::ItemFn = syn::parse_str(
-        "pub fn duration_echo(v: std::time::Duration) -> std::time::Duration { unimplemented!() }",
-    )
-    .unwrap();
-    let registry = Registry::<KotlinMeta>::from_items([(syn::Item::Fn(function), myflat_loc())])
-        .expect("index items");
+    let alias: syn::Item =
+        syn::parse_str("#[prebindgen] pub type Duration = std::time::Duration;").unwrap();
+    let function: syn::ItemFn =
+        syn::parse_str("pub fn duration_echo(v: Duration) -> Duration { unimplemented!() }")
+            .unwrap();
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced([
+        (alias, myflat_loc()),
+        (syn::Item::Fn(function), myflat_loc()),
+    ]))
+    .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("time").fun(crate::fun!(duration_echo)));
@@ -192,19 +199,20 @@ fn duration_requires_an_explicit_conversion() {
 fn conversion_domain_must_match_the_representation() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [
-        "pub fn duration_from_millis(v: u64) -> std::time::Duration { unimplemented!() }",
-        "pub fn duration_use(v: std::time::Duration) { unimplemented!() }",
+        "pub fn duration_from_millis(v: u64) -> Duration { unimplemented!() }",
+        "pub fn duration_use(v: Duration) { unimplemented!() }",
     ]
     .into_iter()
     .map(|source| {
-        let function: syn::ItemFn = syn::parse_str(source).unwrap();
-        (syn::Item::Fn(function), loc.clone())
+        // `syn::Item`, not `ItemFn`: a fixture declares the types it names.
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
     })
     .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).unwrap();
     let jni = JniGen::new()
         .convert(
-            crate::convert!(std::time::Duration)
+            crate::convert!(Duration)
                 .input(crate::fun!(duration_from_millis))
                 .valid_range(0i64..=1_000i64),
         )
@@ -242,7 +250,8 @@ fn option_scalar_param_crosses_as_present_value_pair() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -339,7 +348,8 @@ fn vec_of_handle_output_folds_kotlin_side() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("thing")
@@ -422,7 +432,8 @@ fn option_scalar_struct_field_flattens() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
@@ -537,7 +548,8 @@ fn recursive_data_class_input_flattens_nested_and_optional_fields() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
 
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
@@ -653,7 +665,8 @@ fn jobject_input_is_an_explicit_hybrid_leaf_escape_hatch() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::data_class!(FlatChild))
@@ -726,7 +739,8 @@ fn recursive_flattened_owned_handles_join_lock_and_consume_scaffold() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::ptr_class!(Token))
@@ -782,10 +796,10 @@ fn recursive_flattening_rejects_jvm_parameter_slot_overflow() {
         }
     );
     let loc = myflat_loc();
-    let registry = Registry::<KotlinMeta>::from_items([
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced([
         (syn::Item::Struct(wide.clone()), loc.clone()),
         (syn::Item::Fn(use_wide.clone()), loc.clone()),
-    ])
+    ]))
     .expect("index items");
     let jni = JniGen::new().package(
         crate::package!()
@@ -802,10 +816,10 @@ fn recursive_flattening_rejects_jvm_parameter_slot_overflow() {
     // The explicit object boundary keeps the same public Kotlin data class,
     // but the native method receives it in one slot and performs the legacy
     // whole-object field decode instead of producing an illegal signature.
-    let registry = Registry::<KotlinMeta>::from_items([
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced([
         (syn::Item::Struct(wide), loc.clone()),
         (syn::Item::Fn(use_wide), loc),
-    ])
+    ]))
     .expect("index marked items");
     let jni = JniGen::new().package(
         crate::package!()
@@ -837,7 +851,8 @@ fn output_only_convert_resolves_without_input_twin() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output(crate::fun!(len_value)))
@@ -882,7 +897,8 @@ fn convert_fn_qualifies_with_origin_crate() {
         "my-helpers",
     )];
     let registry =
-        Registry::<KotlinMeta>::from_items(flat.into_iter().chain(helpers)).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(flat.into_iter().chain(helpers)))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Len).output(crate::fun!(len_value)))
@@ -917,7 +933,8 @@ fn convert_input_target_mismatch_rejected() {
             (syn::Item::Fn(f), loc.clone())
         })
         .collect();
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new()
         .convert(crate::convert!(Len).input(crate::fun!(from_long)))
         .package(crate::package!("len").fun(crate::fun!(use_len)));
@@ -938,7 +955,8 @@ fn convert_via_trait_impls() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn temp_double(c: Celsius) -> Celsius { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
@@ -973,7 +991,8 @@ fn convert_via_try_from_is_fallible() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn pct_use(p: Percent) -> i32 { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(crate::convert!(Percent).input(crate::try_from!(i32)))
@@ -1007,7 +1026,8 @@ fn option_composition_normalizes_fallible_stage_errors() {
     )
     .unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
@@ -1044,7 +1064,8 @@ fn convert_via_local_fns() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
@@ -1112,7 +1133,8 @@ fn convert_via_local_try_fn_is_fallible() {
     let f: syn::ItemFn =
         syn::parse_str("pub fn label_id(l: Label) -> Label { unimplemented!() }").unwrap();
     let registry =
-        Registry::<KotlinMeta>::from_items(vec![(syn::Item::Fn(f), loc)]).expect("index items");
+        Registry::<KotlinMeta>::from_items(declare_referenced(vec![(syn::Item::Fn(f), loc)]))
+            .expect("index items");
     let jni = JniGen::new()
         .set_package_prefix("io.test.jni")
         .convert(
@@ -1169,7 +1191,8 @@ fn data_class_members_reenter_as_field_leaves() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!().class(
             crate::data_class!(Point)
@@ -1268,7 +1291,8 @@ fn unsigned_scalars_use_lossless_kotlin_surface_and_raw_jni_wires() {
             loc,
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::data_class!(Unsigned))
@@ -1396,7 +1420,8 @@ fn data_class_properties_match_their_from_parts_params() {
             loc.clone(),
         ),
     ];
-    let registry = Registry::<KotlinMeta>::from_items(items).expect("index items");
+    let registry =
+        Registry::<KotlinMeta>::from_items(declare_referenced(items)).expect("index items");
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!()
             .class(crate::ptr_class!(Handle))
@@ -1476,35 +1501,10 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
         )),
         loc.clone(),
     ));
-    // A type owning an ASSOCIATED const, used as the other length below. It is
-    // deliberately NEVER declared to JniGen: it is only the Rust namespace for
-    // a compile-time length, not a boundary type, so qualification must not
-    // require a Kotlin class to exist for it.
-    items.push((
-        syn::Item::Struct(syn::parse_quote!(
-            pub struct Holder {
-                pub marker: u8,
-            }
-        )),
-        loc.clone(),
-    ));
-    // A `const fn` whose CALL is a length. Also never declared: its result
-    // determines an array size, which is no reason to put it in the Kotlin
-    // surface.
-    items.push((
-        syn::Item::Fn(syn::parse_quote!(
-            pub const fn array_len() -> usize {
-                4
-            }
-        )),
-        loc.clone(),
-    ));
     items.push((
         syn::Item::Struct(syn::parse_quote!(
             pub struct Blob {
                 pub bytes: [u8; env],
-                pub assoc: [u8; Holder::N],
-                pub called: [u8; array_len()],
             }
         )),
         loc.clone(),
@@ -1517,7 +1517,7 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
         )),
         loc.clone(),
     ));
-    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
+    let registry = Registry::<KotlinMeta>::from_items(declare_referenced(items)).unwrap();
     let jni = JniGen::new().set_package_prefix("io.test.jni").package(
         crate::package!("blob")
             .class(crate::data_class!(Blob))
@@ -1544,126 +1544,4 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
     );
     assert!(!rc.contains(&format!("{module}::env,")), "{rust}");
     assert!(!rc.contains(&format!("&mut{module}::env")), "{rust}");
-
-    // An ASSOCIATED const qualifies its leading TYPE segment and leaves the
-    // rest of the path relative to it — `myflat::Holder::N`, never
-    // `myflat::Holder::myflat::N`. `Holder` is UNDECLARED, so this also pins
-    // that qualification reads the registry rather than the declared surface.
-    // Asserted at the two CODE positions (return type and param type); the bare
-    // spelling legitimately survives inside the decode's diagnostic string,
-    // which names the type as the source wrote it.
-    assert!(
-        rc.contains(&format!("Result<[u8;{module}::Holder::N]")),
-        "{rust}"
-    );
-    assert!(
-        rc.contains(&format!("v:[u8;{module}::Holder::N]")),
-        "{rust}"
-    );
-    assert!(!rc.contains("Result<[u8;Holder::N]"), "{rust}");
-    assert!(!rc.contains("v:[u8;Holder::N]"), "{rust}");
-    // The leading segment is rewritten ONCE — the associated item stays
-    // relative to the type it belongs to.
-    assert!(
-        !rc.contains(&format!("{module}::Holder::{module}")),
-        "{rust}"
-    );
-
-    // A `const fn` CALL is a third shape a length can take, and its callee is
-    // an indexed item like the other two. Also undeclared.
-    assert!(
-        rc.contains(&format!("Result<[u8;{module}::array_len()]")),
-        "{rust}"
-    );
-    assert!(
-        rc.contains(&format!("v:[u8;{module}::array_len()]")),
-        "{rust}"
-    );
-    assert!(!rc.contains("Result<[u8;array_len()]"), "{rust}");
-    assert!(!rc.contains("v:[u8;array_len()]"), "{rust}");
-}
-
-/// An array length whose expression form is not on the supported whitelist is
-/// REJECTED, not qualified.
-///
-/// An inline `const { … }` block may bind locals, and this generator qualifies
-/// a length's bare paths against their source module — so a local shadowing a
-/// source item would be rewritten into it (`array_len` the local becoming
-/// `myflat::array_len` the fn). Scope tracking is the general answer; the shape
-/// has no place in an FFI boundary type, so the whole family is refused with a
-/// message naming the type and the fix. Silently mis-qualifying is the
-/// alternative this exists to prevent.
-#[test]
-#[should_panic(expected = "an unsupported expression form")]
-fn array_length_inline_const_block_is_rejected() {
-    // A local bound by an inline const block, shadowing the indexed fn.
-    check_array_length_rejected(syn::parse_quote!(
-        [u8; const {
-            let array_len = 3;
-            array_len
-        }]
-    ));
-}
-
-/// `match` arms bind their patterns directly, with no `Expr::Block` node in
-/// between — which is how this form slipped past the first, blacklist-shaped
-/// attempt. The whitelist refuses it because `match` is simply not on the list.
-#[test]
-#[should_panic(expected = "an unsupported expression form")]
-fn array_length_match_arm_binding_is_rejected() {
-    check_array_length_rejected(syn::parse_quote!(
-        [u8; match 3 {
-            array_len => array_len,
-        }]
-    ));
-}
-
-/// `if let` likewise binds without an intervening block node.
-#[test]
-#[should_panic(expected = "an unsupported expression form")]
-fn array_length_if_let_binding_is_rejected() {
-    check_array_length_rejected(syn::parse_quote!(
-        [u8; if let array_len = 3 { array_len } else { 0 }]
-    ));
-}
-
-fn check_array_length_rejected(field_ty: syn::Type) {
-    let loc = myflat_loc();
-    let mut items: Vec<(syn::Item, SourceLocation)> = Vec::new();
-    items.push((
-        syn::Item::Fn(syn::parse_quote!(
-            pub const fn array_len() -> usize {
-                4
-            }
-        )),
-        loc.clone(),
-    ));
-    // The offending length; in each case its binding shadows `array_len`.
-    items.push((
-        syn::Item::Struct(syn::parse_quote!(
-            pub struct Blob {
-                pub local: #field_ty,
-            }
-        )),
-        loc.clone(),
-    ));
-    items.push((
-        syn::Item::Fn(syn::parse_quote!(
-            pub fn blob_echo(b: Blob) -> Blob {
-                unimplemented!()
-            }
-        )),
-        loc.clone(),
-    ));
-    let registry = Registry::<KotlinMeta>::from_items(items).unwrap();
-    let jni = JniGen::new().set_package_prefix("io.test.jni").package(
-        crate::package!("blob")
-            .class(crate::data_class!(Blob))
-            .fun(crate::fun!(blob_echo)),
-    );
-    let dir = unique_test_dir("jnigen_array_len_scope");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let generation = registry.resolve(jni).unwrap();
-    generation.write_rust(dir.join("gen.rs")).unwrap();
 }

--- a/prebindgen/src/api/test_util.rs
+++ b/prebindgen/src/api/test_util.rs
@@ -8,16 +8,76 @@ use std::{
 
 use crate::api::core::registry::Registry;
 
-/// Index a `Registry` from a list of Rust function sources.
-pub(crate) fn reg_with(fns: &[&str]) -> Registry<()> {
-    let items = fns
+/// Index a `Registry` from a list of Rust item sources.
+///
+/// Accepts any item, not just a fn, so a fixture can declare the types it names.
+/// Whatever it does *not* declare is supplied by [`declare_referenced`], because
+/// these fixtures exist to exercise plan shapes and a handle declaration is noise
+/// in them.
+pub(crate) fn reg_with(sources: &[&str]) -> Registry<()> {
+    let items = sources
         .iter()
         .map(|src| {
-            let f: syn::ItemFn = syn::parse_str(src).expect("parse fn");
-            (syn::Item::Fn(f), crate::SourceLocation::default())
+            let item: syn::Item = syn::parse_str(src).expect("parse item");
+            (item, crate::SourceLocation::default())
         })
         .collect::<Vec<_>>();
-    Registry::from_items(items).expect("index")
+    Registry::from_items(declare_referenced(items)).expect("index")
+}
+
+/// Append a marked type alias for every nominal type the stream names but never
+/// declares, so a fixture satisfies the flat API's self-sufficiency rule.
+///
+/// A fixture that is *about* a handle's treatment already declares it; this covers
+/// the ones where the handle is incidental — `reg_with(&["fn get(s: &Storage) -> Payload"])`
+/// is testing an unfold plan, not what `Storage` is. Declaring them as
+/// [`Extern`](crate::core::flat::Extern)s is exactly what a real source crate does
+/// for a foreign handle, and it is inert for the registry either way: a type alias
+/// lands in no registry map.
+///
+/// Runs to a fixed point, since a declaration can only ever resolve more references.
+/// It cannot help a **path-qualified** name (`std::time::Duration`), which no
+/// declaration can name — such a fixture has to spell the type bare and declare it.
+pub(crate) fn declare_referenced<I>(items: I) -> Vec<(syn::Item, crate::SourceLocation)>
+where
+    I: IntoIterator<Item = (syn::Item, crate::SourceLocation)>,
+{
+    use crate::api::core::flat::{Flat, ItemError};
+
+    let mut items: Vec<(syn::Item, crate::SourceLocation)> = items.into_iter().collect();
+
+    loop {
+        let flat = Flat::builder()
+            .items(items.iter().cloned())
+            .build()
+            .expect("fixture parses");
+        // A set: the same name is reported once per referencing item.
+        let missing: std::collections::BTreeSet<String> = flat
+            .unsupported()
+            .filter_map(|u| match &*u.error {
+                // Skip a name the stream already holds. Refusal is transitive, so a
+                // declared struct whose own field is undeclared reports as
+                // unresolved too — declaring an alias for it would collide. Adding
+                // the root name resolves it on the next round.
+                ItemError::UnresolvedType { name }
+                    if !name.contains("::") && flat.element(name).is_none() =>
+                {
+                    Some(name.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        if missing.is_empty() {
+            return items;
+        }
+        for name in missing {
+            let ident = quote::format_ident!("{name}");
+            let alias: syn::Item = syn::parse_quote!(
+                pub type #ident = __fixture::#ident;
+            );
+            items.push((alias, crate::SourceLocation::default()));
+        }
+    }
 }
 
 /// A process-unique temp directory for a test that writes files. Keyed by


### PR DESCRIPTION
Stage L1 of #229.

`Flat` parsed captured items, resolved type references and answered by name — and
nothing consumed it. `Registry::from_items` indexed the raw item stream itself, so
the registry and the frontend were two readings of one source that could disagree.

The registry is now a **projection** of the model. `from_items` is
`Flat::builder().items(..).build()` + `from_flat`, so both entry points share one
parser, and the `Flat` is **held** rather than discarded — `registry.flat()`. That
is what makes the projection framing real rather than a slogan, and it is how
L2–L4 will reach the model: an adapter already has the registry.

The maps stay owned rather than becoming live queries, because they are a
projection *plus* synthesis: `resolve()` injects adapter-declared binding-local
fns straight into `functions`.

Two projection rules are asymmetries worth naming:

* an unnamed `const _` — each source's injected `konst` guard — is the whole of
  `passthrough` **on the proc-macro path**. See the behaviour-change note below
  for what this means for a hand-built stream.
* an `Extern` lands in **no** map. A type alias was already a no-op in the
  registry, and keeping it that way is what holds generation byte-identical. It
  stays reachable through `flat()`.

## Correctness is checked by default

A `self` receiver, an `async fn`, a generic binder, a type form outside the
grammar, or a reference to a type the flat API does not declare now fails the
build — reporting **all** offenders at once, so a source crate that needs
migrating sees one list rather than one rebuild per item.

Three registry guards become unreachable for *captured* items and are deleted with
their `ScanError` variants: `UnsupportedReceiver`, `UnsupportedParamPattern`,
`DisallowedImplTrait`. The frontend's diagnosis is strictly richer — it names the
parameter the bad type sits on. `index_item`, `check_no_duplicate` and
`first_seen_loc` go with them: `Flat` owns both indexing and duplicate detection.

**A binding's `local_functions` are the one input that never passes through
`Flat`** — a `sig!(..)` is written by hand in a build script and inserted straight
into the maps. `Flat::check_signature` runs the frontend's own `lower_fn` over each
one at synthesis, so the grammar stays decided in one place instead of being
re-checked at the far end. Grammar only: whether a local fn's types are *declared*
is a whole-model question, and a binding-local fn may legitimately name types the
source crate never did.

## ⚠️ Behaviour changes for anyone tracking the crate

Three, none of which the proc-macro path can produce, and all of which the public
`from_items` API can:

1. **A marked item the language cannot express now fails the build**, with no
   opt-out. #237 tracks the opt-out and lands after this. Out of tree,
   `zenoh-flat-c` and `zenoh-flat-jni` do not generate until `zenoh-flat`'s 26
   unmarked aliases are marked — the migration those repos already owed.
   prebindgen CI does not build them.
2. **`passthrough` narrows.** Any item kind other than an unnamed `const _` used
   to be re-emitted verbatim; it is now a hard `NotExpressible`. The proc-macro
   refuses to mark a `use`/`mod`/`macro_rules!`, so no captured stream can hit
   this — but a hand-built `from_items` stream can.
3. **`Registry: Default` is gone.** A registry built that way projects nothing, so
   `flat()` would hand a later stage an empty model claiming to be its source. The
   entry points are `from_items`, `from_flat` and `builder`.

## Diagnostics

`ParseError::DuplicateName` gains the two crate names so the one authority
produces the message, and `NotExpressible` renders the crate of each offender for
the same reason: a captured path is crate-relative, so two offenders from
different sources both read `src/lib.rs:…` and the location alone cannot say which
one to fix.

covertest-kotlin's hand-rolled closure assertion is removed — it was a stopgap for
exactly this stage.

## The cost, and where it landed

Entirely in test fixtures: **167 of 524 tests** held an item naming a type it never
declared, which the old registry accepted because it never looked. The first commit
fixes that alone, verified by a temporary in-`from_items` check, so the seam flip
lands against fixtures already known-good.

`test_util::declare_referenced` supplies a marked alias where the handle is
incidental to the test. The rest were real corrections: a path-qualified
`std::time::Duration` that no declaration can name, and two array-length tests
asserting shapes the subgrammar dropped in #212. One consequence worth knowing: no
fixture will notice an undeclared reference by accident any more —
`from_items_rejects_what_the_language_cannot_express` is what holds that line.

## Verification

* `regen-check.sh` — **byte-identical**, the invariant that matters most here. If
  the projection were wrong (most likely `named_item_idents` picking up `Extern`
  names), generated output would move.
* covertest-kotlin `./gradlew run` — 48 sections, every JniGen feature
* 524 + 452 tests, doctests, clippy in all three feature configs with `-D warnings`
* boundary ledger 205 → 204 (the deleted `impl Trait` classifier)