### PR TITLE
The type table carries Flat's reading of each type

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -299,7 +299,7 @@ fn process_expand<M>(
     exp: &Expansions,
     ed: &ExpandDecl,
 ) -> Result<(), ExpandError> {
-    let (item_fn, loc) = registry
+    let (item_fn, _) = registry
         .functions
         .get(&ed.func)
         .cloned()
@@ -334,7 +334,7 @@ fn process_expand<M>(
     )?;
 
     for leaf in &plan.leaves {
-        registry.require_input(&leaf.ty, &loc);
+        registry.require_input(&leaf.ty);
     }
     registry
         .expansion_plans

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -104,9 +104,7 @@ fn constructor_plan_and_fold() {
 
     // Leaf types registered as required inputs (so the resolver builds
     // their converters).
-    assert!(reg
-        .required_inputs_scan
-        .contains(&TypeKey::from_type(&plan.leaves[1].ty)));
+    assert!(reg.input_types[&TypeKey::from_type(&plan.leaves[1].ty)].root);
 
     let locals = vec![ident("sel"), ident("v0"), ident("vid")];
     let folded = emit_fold(plan, &locals, &src_qualify);

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -15,8 +15,8 @@ use crate::SourceLocation;
 /// One member of the flat API.
 ///
 /// Three modelled kinds — a function, a type, a constant — plus
-/// [`Element::Guard`] for prebindgen's own injected checks and
-/// [`Element::Unsupported`] for anything the language cannot express. No *marked*
+/// [`Element::Guard`] for an anonymous const and [`Element::Unsupported`] for
+/// anything the language cannot express. No *marked*
 /// item passes through verbatim: a `#[prebindgen]` crate marks the items that
 /// cross the boundary, and the supporting code around them is the consumer
 /// crate's job — the proc-macro enforces that already, refusing to mark a `use`,
@@ -27,8 +27,8 @@ pub enum Element {
     /// A type declaration: a struct, either enum shape, or an opaque handle.
     Type(Type),
     Constant(Constant),
-    /// A compile-time check prebindgen injects into the generated file. Carries
-    /// no API surface: nothing can name it, declare it, or cross it.
+    /// An anonymous const — infrastructure re-emitted verbatim. Carries no API
+    /// surface: nothing can name it, declare it, or cross it.
     Guard(Guard),
     /// An item the language cannot express — a parameter type outside the
     /// grammar, a `self` receiver, a reference to a type the flat API never
@@ -350,17 +350,23 @@ pub struct Constant {
     pub origin: Origin<syn::ItemConst>,
 }
 
-/// A compile-time check prebindgen injects into the generated file.
+/// An **anonymous const**: `const _: T = ..`, whatever produced it.
 ///
-/// Today that is one `const _: () = { konst::assertc_eq!(..) }` per ingested
-/// source crate, synthesized by [`Source`](crate::Source) to assert that the
-/// crate's `FEATURES` match what the build script asked for. **Nothing marked it**
-/// — it is prebindgen's own item, riding the same stream — which is why it is not
-/// part of the flat API even though it arrives with it.
+/// The definition is the shape, not the origin. A const with no name has no
+/// address, so nothing can declare it, reference it, or emit it as an alias —
+/// which is what puts it outside the flat API rather than in it, and that holds
+/// however the item arrived: synthesized, hand-fed to [`FlatBuilder`](super::FlatBuilder), or written
+/// as `#[prebindgen] const _: () = ..` in a source crate.
 ///
-/// Recognised by shape rather than by provenance: a constant with no name has no
-/// address, so nothing can declare it, reference it, or emit it as an alias. That
-/// is the property that makes it infrastructure, and it holds whoever wrote it.
+/// **Today's producer** is [`Source`](crate::Source)'s cfg filter, which
+/// synthesizes `const _: () = { konst::assertc_eq!(..) }` to assert that a source
+/// crate's `FEATURES` match what the build script asked for. Nothing *marked*
+/// that one — it is prebindgen's own item riding the same stream — but it is not
+/// the only thing that can land here, and the model does not claim otherwise.
+///
+/// **Cardinality is zero or more.** `enable_feature_filtering(None)` produces
+/// none, and each item iterator taken from a `Source` emits its own, so composing
+/// two iterators from one crate yields two.
 ///
 /// It carries no type, unlike a [`Constant`]. The item is emitted verbatim, so
 /// what its types mean is the consumer crate's business; modelling them would let

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -15,8 +15,9 @@ use crate::SourceLocation;
 /// One member of the flat API.
 ///
 /// Three modelled kinds — a function, a type, a constant — plus
-/// [`Element::Unsupported`] for anything the language cannot express. There is no
-/// verbatim-passthrough variant: a `#[prebindgen]` crate marks the items that
+/// [`Element::Guard`] for prebindgen's own injected checks and
+/// [`Element::Unsupported`] for anything the language cannot express. No *marked*
+/// item passes through verbatim: a `#[prebindgen]` crate marks the items that
 /// cross the boundary, and the supporting code around them is the consumer
 /// crate's job — the proc-macro enforces that already, refusing to mark a `use`,
 /// `mod`, `impl` or `macro_rules!` at all.
@@ -26,6 +27,9 @@ pub enum Element {
     /// A type declaration: a struct, either enum shape, or an opaque handle.
     Type(Type),
     Constant(Constant),
+    /// A compile-time check prebindgen injects into the generated file. Carries
+    /// no API surface: nothing can name it, declare it, or cross it.
+    Guard(Guard),
     /// An item the language cannot express — a parameter type outside the
     /// grammar, a `self` receiver, a reference to a type the flat API never
     /// declares, or a whole item kind it does not model such as a `union`.
@@ -42,17 +46,16 @@ impl Element {
     /// The item's name, which is also its address: `#[prebindgen]` names live
     /// in one flat namespace across every ingested source crate.
     ///
-    /// `None` when the item has no address — an unnamed `const _` (each
-    /// source's injected feature guard, so several may coexist), or an item
-    /// kind with no identifier at all.
+    /// `None` when the item has no address — a [`Guard`], or an item kind with
+    /// no identifier at all.
     pub fn name(&self) -> Option<&syn::Ident> {
-        let named = match self {
+        match self {
             Element::Function(f) => Some(&f.name),
             Element::Type(t) => Some(t.name()),
             Element::Constant(c) => Some(&c.name),
+            Element::Guard(_) => None,
             Element::Unsupported(u) => u.name.as_ref(),
-        };
-        named.filter(|id| *id != "_")
+        }
     }
 
     /// Where the item was captured, including the crate that marked it.
@@ -64,6 +67,7 @@ impl Element {
             Element::Function(f) => &f.origin.location,
             Element::Type(t) => t.location(),
             Element::Constant(c) => &c.origin.location,
+            Element::Guard(g) => &g.origin.location,
             Element::Unsupported(u) => &u.origin.location,
         }
     }
@@ -74,6 +78,7 @@ impl Element {
             Element::Function(f) => syn::Item::Fn(f.origin.syntax.clone()),
             Element::Type(t) => t.syntax(),
             Element::Constant(c) => syn::Item::Const(c.origin.syntax.clone()),
+            Element::Guard(g) => syn::Item::Const(g.origin.syntax.clone()),
             Element::Unsupported(u) => u.origin.syntax.clone(),
         }
     }
@@ -334,16 +339,35 @@ pub struct Field {
 
 /// A `#[prebindgen]` constant.
 ///
-/// Also the home of the unnamed `const _` feature guard each source injects: it
-/// is a constant, so it is modelled as one, and [`Element::name`] returning
-/// `None` for `_` is what keeps several of them from colliding in the flat
-/// namespace.
+/// Always named: an unnamed `const _` is a [`Guard`], not a constant with no
+/// address.
 #[derive(Clone, Debug)]
 pub struct Constant {
     pub name: syn::Ident,
     pub ty: TypeRef,
     /// The whole item — the initializer expression included, which is where a
     /// consumer that re-emits the value reads it from.
+    pub origin: Origin<syn::ItemConst>,
+}
+
+/// A compile-time check prebindgen injects into the generated file.
+///
+/// Today that is one `const _: () = { konst::assertc_eq!(..) }` per ingested
+/// source crate, synthesized by [`Source`](crate::Source) to assert that the
+/// crate's `FEATURES` match what the build script asked for. **Nothing marked it**
+/// — it is prebindgen's own item, riding the same stream — which is why it is not
+/// part of the flat API even though it arrives with it.
+///
+/// Recognised by shape rather than by provenance: a constant with no name has no
+/// address, so nothing can declare it, reference it, or emit it as an alias. That
+/// is the property that makes it infrastructure, and it holds whoever wrote it.
+///
+/// It carries no type, unlike a [`Constant`]. The item is emitted verbatim, so
+/// what its types mean is the consumer crate's business; modelling them would let
+/// a guard that names something undeclared refuse the whole element.
+#[derive(Clone, Debug)]
+pub struct Guard {
+    /// Emitted verbatim, so the item is all there is.
     pub origin: Origin<syn::ItemConst>,
 }
 

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -473,6 +473,24 @@ impl Flat {
         })
     }
 
+    /// Every type the API **mentions**, at every nesting depth — as distinct from
+    /// [`Self::types`], which is every type it **declares**.
+    ///
+    /// A parameter, a return, a field, a constant's type, and everything reachable
+    /// inside those. The same type mentioned in several places yields one
+    /// [`TypeRef`] per mention, each with its own spelling and origin; a consumer
+    /// that wants one per type indexes them and picks, and element order makes
+    /// that pick deterministic.
+    ///
+    /// This is how a later stage gets the frontend's reading of a type it holds
+    /// only as syntax, without lowering it a second time.
+    pub fn type_refs(&self) -> impl Iterator<Item = &TypeRef> {
+        self.elements
+            .iter()
+            .flat_map(element_type_refs)
+            .flat_map(TypeRef::walk)
+    }
+
     /// Every item the language could not express, with its diagnosis.
     ///
     /// Present in the model so a consumer can inspect what a source crate marked
@@ -588,11 +606,12 @@ fn resolve_references(elements: &mut [Element]) {
     }
 }
 
-/// The first type this element names that the flat API does not declare.
-fn first_unresolved(
-    element: &Element,
-    declared: &std::collections::HashSet<String>,
-) -> Option<String> {
+/// Every type slot this element writes, outermost only — a parameter, a return,
+/// a field, a constant's type.
+///
+/// The one place the slots are enumerated, so a new element shape is taught to
+/// every consumer at once instead of drifting between them.
+fn element_type_refs(element: &Element) -> Vec<&TypeRef> {
     let mut refs: Vec<&TypeRef> = Vec::new();
     match element {
         Element::Function(f) => {
@@ -606,11 +625,21 @@ fn first_unresolved(
                 .iter()
                 .flat_map(|a| a.fields.iter().map(|f| &f.ty)),
         ),
-        // An enum names nothing, an opaque hides what it names, and an
+        // An enum names nothing, an extern hides what it names, and an
         // unsupported item already has a diagnosis worth keeping.
         Element::Type(Type::Enum(_) | Type::Extern(_)) | Element::Unsupported(_) => {}
     }
-    refs.into_iter().find_map(|r| r.first_unresolved(declared))
+    refs
+}
+
+/// The first type this element names that the flat API does not declare.
+fn first_unresolved(
+    element: &Element,
+    declared: &std::collections::HashSet<String>,
+) -> Option<String> {
+    element_type_refs(element)
+        .into_iter()
+        .find_map(|r| r.first_unresolved(declared))
 }
 
 /// If `ty` is `impl Fn(T1, T2, ...) + Send + Sync + 'static`, return the `Fn`

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -121,11 +121,12 @@
 //! module does not model is a `union`, and it is diagnosed like anything else the
 //! language cannot express.
 //!
-//! The one item that *is* re-emitted verbatim was never marked: [`Guard`], the
-//! feature check [`Source`](crate::Source) injects into the stream on its own
-//! behalf. It is modelled rather than dropped because this module must be total
-//! over what it is handed — but it is a separate element, so nothing that
-//! consumes the API has to remember to skip it.
+//! The one item that *is* re-emitted verbatim is a [`Guard`] — an anonymous
+//! const, which has no address and so cannot be part of an API addressed by name.
+//! Today these are the feature checks [`Source`](crate::Source) injects on its own
+//! behalf. Modelled rather than dropped because this module must be total over
+//! what it is handed, and a separate element so nothing that consumes the API has
+//! to remember to skip it.
 //!
 //! # Declaring a handle
 //!
@@ -499,7 +500,7 @@ impl Flat {
             .flat_map(TypeRef::walk)
     }
 
-    /// Prebindgen's own injected compile-time checks, in stream order.
+    /// Every anonymous const, in stream order — **zero or more**.
     ///
     /// Not part of the flat API — see [`Guard`] — but ingested with it, and a
     /// consumer that re-emits the source must re-emit these too.

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -114,12 +114,18 @@
 //! adapter declaration is examined. A binding is built against a model the
 //! frontend could read in full, or it is not built.
 //!
-//! There is **no verbatim passthrough**, because a `#[prebindgen]` crate marks
-//! the items that cross the boundary and leaves the supporting code to the
+//! No **marked** item passes through verbatim, because a `#[prebindgen]` crate
+//! marks the items that cross the boundary and leaves the supporting code to the
 //! consumer. The proc-macro already enforces that — a `use`, `mod`, `impl` or
 //! `macro_rules!` cannot be marked at all — so the only item kind left that this
 //! module does not model is a `union`, and it is diagnosed like anything else the
 //! language cannot express.
+//!
+//! The one item that *is* re-emitted verbatim was never marked: [`Guard`], the
+//! feature check [`Source`](crate::Source) injects into the stream on its own
+//! behalf. It is modelled rather than dropped because this module must be total
+//! over what it is handed — but it is a separate element, so nothing that
+//! consumes the API has to remember to skip it.
 //!
 //! # Declaring a handle
 //!
@@ -168,8 +174,8 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{
-        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Param, Struct,
-        Type, Unsupported, Variant,
+        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Guard, Param,
+        Struct, Type, Unsupported, Variant,
     },
     origin::Origin,
     ty::{RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType, UnsupportedTypeReason},
@@ -327,9 +333,11 @@ impl FlatBuilder {
             crate::api::core::types_util::normalize_item_types(item, &normalization);
         }
 
-        // Pass 1: the consts an array length may name. Unnamed `const _` items
-        // are excluded for the same reason `Element::name` skips them — they
-        // are not addressable, so no length can name one.
+        // Pass 1: the consts an array length may name. Unnamed items are
+        // excluded because no length can name one — the same fact that makes
+        // them `Guard`s. This is the one place that tests the spelling rather
+        // than the classification, and it has to: it runs before Pass 2, so no
+        // classification exists yet.
         let consts = ConstIndex::new(items.iter().filter_map(|(item, loc)| match item {
             syn::Item::Const(c) if c.ident != "_" => Some((
                 c.ident.to_string(),
@@ -491,6 +499,17 @@ impl Flat {
             .flat_map(TypeRef::walk)
     }
 
+    /// Prebindgen's own injected compile-time checks, in stream order.
+    ///
+    /// Not part of the flat API — see [`Guard`] — but ingested with it, and a
+    /// consumer that re-emits the source must re-emit these too.
+    pub fn guards(&self) -> impl Iterator<Item = &Guard> {
+        self.elements.iter().filter_map(|e| match e {
+            Element::Guard(g) => Some(g),
+            _ => None,
+        })
+    }
+
     /// Every item the language could not express, with its diagnosis.
     ///
     /// Present in the model so a consumer can inspect what a source crate marked
@@ -594,6 +613,7 @@ fn resolve_references(elements: &mut [Element]) {
                     Element::Function(f) => &f.origin.location,
                     Element::Type(t) => t.location_rc(),
                     Element::Constant(c) => &c.origin.location,
+                    Element::Guard(g) => &g.origin.location,
                     Element::Unsupported(u) => &u.origin.location,
                 }),
             );
@@ -625,9 +645,12 @@ fn element_type_refs(element: &Element) -> Vec<&TypeRef> {
                 .iter()
                 .flat_map(|a| a.fields.iter().map(|f| &f.ty)),
         ),
-        // An enum names nothing, an extern hides what it names, and an
+        // An enum names nothing, an extern hides what it names, a guard is
+        // emitted verbatim so its types are the consumer's business, and an
         // unsupported item already has a diagnosis worth keeping.
-        Element::Type(Type::Enum(_) | Type::Extern(_)) | Element::Unsupported(_) => {}
+        Element::Type(Type::Enum(_) | Type::Extern(_))
+        | Element::Guard(_)
+        | Element::Unsupported(_) => {}
     }
     refs
 }
@@ -918,10 +941,12 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
                 }))
             }
         },
-        // Including the unnamed `const _` each source injects as its feature
-        // guard: it is a const, so it is one here. `Element::name` returns
-        // `None` for `_`, which is what keeps several sources' guards from
-        // colliding in the flat namespace.
+        // An unnamed const is a `Guard`, not a constant: nothing can name it, so
+        // it is not part of the API, and several sources' guards coexist because
+        // none of them has an address to collide on.
+        syn::Item::Const(c) if c.ident == "_" => Element::Guard(Guard {
+            origin: Origin::new(c, at),
+        }),
         syn::Item::Const(c) => match lower_type(&c.ty, consts, &at) {
             Ok(ty) => Element::Constant(Constant {
                 name: c.ident.clone(),

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -866,11 +866,12 @@ fn consts_carry_their_type_and_value() {
     assert_eq!(tokens(&c.origin.syntax.expr), "4");
 }
 
-/// An unnamed `const _` — each source's injected feature guard — is a const
-/// like any other, and simply has no address, so several sources may each carry
-/// one without colliding in the flat namespace.
+/// An unnamed const is a `Guard`, not a `Constant`: nothing can name it, so it
+/// is not part of the API. Several coexist because none has an address to
+/// collide on — which is what lets a binding ingest two source crates, each
+/// injecting its own feature check.
 #[test]
-fn an_unnamed_const_is_a_const_without_an_address() {
+fn an_unnamed_const_is_a_guard() {
     let elements = parse(vec![
         syn::parse_quote!(
             const _: () = ();
@@ -879,8 +880,11 @@ fn an_unnamed_const_is_a_const_without_an_address() {
             const _: () = ();
         ),
     ]);
-    assert!(elements.iter().all(|e| matches!(e, Element::Constant(_))));
+    assert!(elements.iter().all(|e| matches!(e, Element::Guard(_))));
     assert!(elements.iter().all(|e| e.name().is_none()));
+    // A guard writes no type slot, so a consumer walking the API never reaches
+    // one — the reason it carries no `TypeRef`.
+    assert!(!elements.iter().any(|e| matches!(e, Element::Constant(_))));
 }
 
 /// An item kind the language does not model is diagnosed, not carried: a

--- a/prebindgen/src/api/core/flat/tests/mod.rs
+++ b/prebindgen/src/api/core/flat/tests/mod.rs
@@ -157,6 +157,7 @@ fn describe(e: &Element) -> String {
         Element::Function(f) => format!("function `{}`", f.name),
         Element::Type(t) => describe_type(t),
         Element::Constant(c) => format!("constant `{}`", c.name),
+        Element::Guard(_) => "guard".to_string(),
         Element::Unsupported(u) => match &u.name {
             Some(name) => format!("unsupported `{name}` ({})", u.error),
             None => format!("unsupported ({})", u.error),

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -84,6 +84,37 @@ impl TypeRef {
         }
     }
 
+    /// This type and every type reachable inside it, outermost first.
+    ///
+    /// The nested positions are real [`TypeRef`]s carrying their own spelling and
+    /// origin, so a consumer that indexes types finds `Foo` from `Vec<Foo>` with
+    /// the classification already made rather than a sub-path to re-read.
+    ///
+    /// A [`Named`](TypeKind::Named)'s generic arguments are **not** among them:
+    /// [`TypeId`] keeps a name and nothing else, so `MyBox<Foo>` reaches no `Foo`
+    /// here. The full spelling is in [`Self::origin`] for whoever needs it.
+    pub fn walk(&self) -> Vec<&TypeRef> {
+        let mut out = Vec::new();
+        self.collect_refs(&mut out);
+        out
+    }
+
+    fn collect_refs<'a>(&'a self, out: &mut Vec<&'a TypeRef>) {
+        out.push(self);
+        match &self.kind {
+            TypeKind::Optional(t) | TypeKind::Sequence(t) | TypeKind::Ref { inner: t, .. } => {
+                t.collect_refs(out)
+            }
+            TypeKind::Array { elem, .. } => elem.collect_refs(out),
+            TypeKind::Fallible { ok, err } => {
+                ok.collect_refs(out);
+                err.collect_refs(out);
+            }
+            TypeKind::Callback { args } => args.iter().for_each(|t| t.collect_refs(out)),
+            TypeKind::Named { .. } | TypeKind::Scalar(_) | TypeKind::Str | TypeKind::Unit => {}
+        }
+    }
+
     fn collect_extents<'a>(&'a self, out: &mut Vec<&'a ArrayExtent>) {
         match &self.kind {
             TypeKind::Array { elem, extent } => {

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -39,7 +39,7 @@ pub use self::{
     niches::{NicheSlot, Niches},
     prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},
     registry::{
-        Direction, Generation, Registry, RegistryBuilder, ScanError, TypeEntry, TypeKey,
-        WriteRustError,
+        Direction, Generation, Registry, RegistryBuilder, ScanError, TypeCell, TypeEntry, TypeKey,
+        TypeSubject, WriteRustError,
     },
 };

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -14,7 +14,7 @@
 //!    until no unresolved type advances, then propagates `ConverterImpl::subs`
 //!    from required roots.
 //! 5. [`registry::Registry::write_rust`] emits adapter prerequisites,
-//!    converters, per-item wrapper Rust, and passthrough items.
+//!    converters, per-item wrapper Rust, and verbatim anonymous consts.
 //!
 //! Secondary artifacts such as C headers or Kotlin sources are produced by the
 //! language adapter after the Rust registry is resolved.

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -504,14 +504,16 @@ pub trait Prebindgen {
     /// (see [`const_path_alias`]) when [`Self::source_module`] is available —
     /// initializer tokens are never copied, so a const whose initializer
     /// references source-crate internals stays valid in the generated file.
-    /// Unnamed `const _` items (self-contained infrastructure guards, e.g.
-    /// the injected `konst::assertc_eq!` feature check) and adapters without
-    /// a source module pass through verbatim.
+    /// An adapter without a source module passes the const through verbatim.
+    ///
+    /// A const reaching here is always named: prebindgen's own injected feature
+    /// checks are [`Guard`](crate::api::core::flat::Guard)s, not consts, so this
+    /// never has to recognise one.
     fn on_const(&self, c: &syn::ItemConst, _registry: &Registry<Self::Metadata>) -> TokenStream {
         use quote::ToTokens;
         match self.source_module() {
-            Some(m) if c.ident != "_" => const_path_alias(c, m),
-            _ => c.to_token_stream(),
+            Some(m) => const_path_alias(c, m),
+            None => c.to_token_stream(),
         }
     }
 

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -4,8 +4,8 @@
 //! * Item maps (`functions`, `structs`, `enums`, `consts`) indexed by ident.
 //!   Duplicate names across kinds OR within a kind are an error — prebindgen
 //!   items live in one flat namespace.
-//! * `guards` — prebindgen's own injected feature checks, emitted verbatim.
-//!   Not API: no source crate marked them.
+//! * `guards` — anonymous consts, emitted verbatim. Not API: having no name,
+//!   they cannot be declared, so they are neither gated nor addressable.
 //! * `input_types` / `output_types` — direction-specific type tables. Each
 //!   scanned type maps to either a resolved [`TypeEntry`] or an unresolved cell
 //!   that the fixed-point resolver can retry.
@@ -140,7 +140,7 @@ impl fmt::Display for TypeKey {
 /// What a type-table key names.
 ///
 /// Two populations, and saying which is which is what keeps one origin per cell:
-/// a type the flat API contains **is** a [`TypeRef`], reused whole, so its
+/// a type the flat API contains **is** a [`TypeRef`](crate::api::core::flat::TypeRef), reused whole, so its
 /// classification and its source location are already there.
 #[derive(Clone, Debug)]
 pub enum TypeSubject {
@@ -297,9 +297,10 @@ pub struct Registry<M = ()> {
     pub structs: HashMap<syn::Ident, (syn::ItemStruct, SourceLocation)>,
     pub enums: HashMap<syn::Ident, (syn::ItemEnum, SourceLocation)>,
     pub consts: HashMap<syn::Ident, (syn::ItemConst, SourceLocation)>,
-    /// Prebindgen's own injected compile-time checks — one feature guard per
-    /// ingested source crate — re-emitted verbatim. Not API: see
-    /// [`Guard`](crate::api::core::flat::Guard).
+    /// Anonymous consts, in stream order, re-emitted verbatim — **zero or
+    /// more**. Not API: having no name, they cannot be declared, so they are
+    /// neither gated nor addressable. See
+    /// [`Guard`](crate::api::core::flat::Guard) for what produces them.
     pub guards: Vec<crate::api::core::flat::Guard>,
 
     /// Origin crate name of each named item (fn/struct/enum/const),
@@ -827,8 +828,12 @@ impl<M> Registry<M> {
     /// `enums`, `consts`, `guards`). Signature/body scanning that
     /// drives type-resolution requirements happens later, in
     /// [`Self::scan_declared`], and is gated on what the language adapter
-    /// has explicitly declared. Items that are never declared remain in
-    /// the registry but never drive type resolution and never emit.
+    /// has explicitly declared. An **API** item that is never declared remains
+    /// in the registry but never drives type resolution and never emits.
+    ///
+    /// `guards` is the exception, and it is not one of the API maps: an
+    /// anonymous const has no name to declare, so it is outside the gate
+    /// entirely and always emits.
     pub fn from_items<I>(items: I) -> Result<Self, ScanError>
     where
         I: IntoIterator<Item = (syn::Item, SourceLocation)>,
@@ -839,7 +844,7 @@ impl<M> Registry<M> {
         Self::from_flat(flat)
     }
 
-    /// Index a parsed [`Flat`] model.
+    /// Index a parsed [`Flat`](crate::api::core::flat::Flat) model.
     ///
     /// The registry is a **projection** of the model, not a second reading of the
     /// source: `Flat` decided what every item means, and this arranges those
@@ -918,9 +923,8 @@ impl<M> Registry<M> {
                         (t.origin.syntax.clone(), element.location().clone()),
                     );
                 }
-                // Prebindgen's own feature guard, re-emitted verbatim. The only
-                // item here that no source crate marked, which is why it is not
-                // in any of the API maps.
+                // An anonymous const, re-emitted verbatim. No name means nothing
+                // can declare it, which is why it is in none of the API maps.
                 Element::Guard(g) => registry.guards.push(g.clone()),
                 Element::Constant(c) => {
                     registry.consts.insert(

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -137,6 +137,66 @@ impl fmt::Display for TypeKey {
     }
 }
 
+/// What a type-table key names.
+///
+/// Two populations, and saying which is which is what keeps one origin per cell:
+/// a type the flat API contains **is** a [`TypeRef`], reused whole, so its
+/// classification and its source location are already there.
+#[derive(Clone, Debug)]
+pub enum TypeSubject {
+    /// A type the flat API contains — the frontend's own reading, unmodified.
+    Source(crate::api::core::flat::TypeRef),
+    /// A type only the binding authored: a declared wire type with no
+    /// `#[prebindgen]` item behind it, an [`unfold`](crate::api::core::unfold)
+    /// leaf. It has no reading and no source location — a fact about it, rather
+    /// than information that went missing.
+    Adapter(syn::Type),
+}
+
+impl TypeSubject {
+    /// Where the source wrote this type, or `None` when no source did.
+    pub fn location(&self) -> Option<&SourceLocation> {
+        match self {
+            TypeSubject::Source(t) => Some(&t.origin.location),
+            TypeSubject::Adapter(_) => None,
+        }
+    }
+
+    /// The frontend's classification, or `None` for an adapter-authored type.
+    pub fn kind(&self) -> Option<&crate::api::core::flat::TypeKind> {
+        match self {
+            TypeSubject::Source(t) => Some(&t.kind),
+            TypeSubject::Adapter(_) => None,
+        }
+    }
+
+    /// The type as Rust must spell it, either way.
+    pub fn syntax(&self) -> &syn::Type {
+        match self {
+            TypeSubject::Source(t) => &t.origin.syntax,
+            TypeSubject::Adapter(ty) => ty,
+        }
+    }
+}
+
+/// One type-table cell: what the key names, and the adapter's answer for it.
+pub struct TypeCell<M = ()> {
+    /// The type itself, as the frontend reads it when it can.
+    pub subject: TypeSubject,
+    /// The binding asks for this cell **directly** — a declared fn's signature, a
+    /// declared type, an `unfold` leaf — as opposed to reaching it through some
+    /// converter's [`TypeEntry::subs`].
+    ///
+    /// A scan fact. Whether a converter is *needed* here is reachability from
+    /// these roots, which [`crate::api::core::resolve`] derives rather than
+    /// stores: the scan deliberately over-approximates the table (every nested
+    /// position, every struct in both directions), so the roots are what say
+    /// which of it has to work.
+    pub root: bool,
+    /// The adapter's converter, once resolved.
+    pub entry: Option<TypeEntry<M>>,
+}
+
 /// Per-cell registry entry.
 #[derive(Clone)]
 pub struct TypeEntry<M = ()> {
@@ -159,10 +219,6 @@ pub struct TypeEntry<M = ()> {
     /// terminal converters; populated by wrapper converters. Used by the
     /// post-resolution propagation pass.
     pub subs: Vec<TypeKey>,
-    /// Initially true for types that appear directly in a `#[prebindgen]` fn
-    /// signature; false for sub-positions. Promoted true by the propagation
-    /// pass for any type reachable via `subs` from another required type.
-    pub required: bool,
     /// Wire bit-patterns this converter never produces / always rejects.
     /// Wrappers (`Option<_>`, sum-typed enums) carve from this set for
     /// their own discriminants. See [`Niches`] for the cascade model.
@@ -262,21 +318,20 @@ pub struct Registry<M = ()> {
     /// back to `crate`.
     pub(crate) source_modules: Vec<String>,
 
-    /// Type tables, one per direction. Each scanned type maps to its resolved
-    /// [`TypeEntry`] (`Some`) or stays unresolved (`None`) until the structural
-    /// resolver fills it.
-    pub input_types: HashMap<TypeKey, Option<TypeEntry<M>>>,
-    pub output_types: HashMap<TypeKey, Option<TypeEntry<M>>>,
+    /// Type tables, one per direction. Each scanned type gets a [`TypeCell`]
+    /// holding what the key names, whether the binding asks for it directly, and
+    /// the resolved [`TypeEntry`] once the structural resolver fills it.
+    pub input_types: HashMap<TypeKey, TypeCell<M>>,
+    pub output_types: HashMap<TypeKey, TypeCell<M>>,
 
-    /// First-seen source location for each type key. Used in error messages
-    /// to point the user at where a required-but-unresolved type came from.
-    pub type_locations: HashMap<TypeKey, SourceLocation>,
-
-    /// Sidecar tracking which keys were registered as top-level fn-signature
-    /// types, separate from per-entry `required` (which the resolver flips
-    /// into `TypeEntry::required` once an entry is filled).
-    pub required_inputs_scan: HashSet<TypeKey>,
-    pub required_outputs_scan: HashSet<TypeKey>,
+    /// The frontend's reading of every type the flat API mentions, keyed the way
+    /// the tables are, so a cell gets its [`TypeSubject::Source`] by lookup
+    /// instead of by lowering the type a second time.
+    ///
+    /// Built once from [`Self::flat`] before anything is scanned. A type
+    /// mentioned in several places keeps the first mention in **element order** —
+    /// a property of the model, not of the order items were fed in.
+    type_refs: HashMap<TypeKey, crate::api::core::flat::TypeRef>,
 
     /// Resolved constructor-expansion plans, keyed by `(function, parameter)`.
     /// Filled by [`crate::api::core::expand::apply`] before resolution; read
@@ -336,9 +391,7 @@ impl<M> Registry<M> {
             source_modules: Vec::new(),
             input_types: Default::default(),
             output_types: Default::default(),
-            type_locations: HashMap::new(),
-            required_inputs_scan: HashSet::new(),
-            required_outputs_scan: HashSet::new(),
+            type_refs: HashMap::new(),
             expansion_plans: HashMap::new(),
             unfold_plans: HashMap::new(),
             error_plans: HashMap::new(),
@@ -813,6 +866,17 @@ impl<M> Registry<M> {
         }
 
         let mut registry = Registry::empty();
+        // Every type the model mentions, indexed the way the type tables are.
+        // Read up front, from the whole model: which mention of a repeated type
+        // wins is then decided by element order rather than by when a scan
+        // happened to reach it.
+        for ty in flat.type_refs() {
+            registry
+                .type_refs
+                .entry(TypeKey::from_type(&ty.origin.syntax))
+                .or_insert_with(|| ty.clone());
+        }
+
         // First-seen order, which is what makes the first entry the default
         // module. Derived from the elements rather than stored twice.
         for element in flat.elements() {
@@ -1030,8 +1094,8 @@ impl<M> Registry<M> {
 
         // Scan declared functions.
         for ident in &declared.functions {
-            if let Some((item_fn, loc)) = self.functions.get(ident).cloned() {
-                self.scan_fn_signature(&item_fn, &loc)?;
+            if let Some((item_fn, _)) = self.functions.get(ident).cloned() {
+                self.scan_fn_signature(&item_fn)?;
             } else {
                 missing.push(("function", ident.to_string()));
             }
@@ -1061,8 +1125,8 @@ impl<M> Registry<M> {
         // so the type is required in the output direction only.
         if let Some(decl_consts) = &declared.consts {
             for ident in decl_consts {
-                if let Some((item_const, loc)) = self.consts.get(ident).cloned() {
-                    self.ensure_entry(Direction::Output, &item_const.ty, true, &loc);
+                if let Some((item_const, _)) = self.consts.get(ident).cloned() {
+                    self.ensure_entry(Direction::Output, &item_const.ty, true);
                 } else {
                     missing.push(("constant", ident.to_string()));
                 }
@@ -1085,7 +1149,7 @@ impl<M> Registry<M> {
         // Adapter-required extra output types — synthesized values with no
         // `#[prebindgen]` item behind them (e.g. expression constants).
         for ty in &declared.required_output_types {
-            self.ensure_entry(Direction::Output, ty, true, &SourceLocation::default());
+            self.ensure_entry(Direction::Output, ty, true);
         }
 
         // Scan declared types.
@@ -1093,15 +1157,15 @@ impl<M> Registry<M> {
             let ty = key.to_type();
             let mut matched = false;
             if let Some(ident) = bare_path_ident(&ty) {
-                if let Some((s, loc)) = self.structs.get(&ident).cloned() {
-                    self.scan_struct(&s, &loc)?;
-                    self.ensure_entry(Direction::Input, &ty, true, &loc);
-                    self.ensure_entry(Direction::Output, &ty, true, &loc);
+                if let Some((s, _)) = self.structs.get(&ident).cloned() {
+                    self.scan_struct(&s)?;
+                    self.ensure_entry(Direction::Input, &ty, true);
+                    self.ensure_entry(Direction::Output, &ty, true);
                     matched = true;
-                } else if let Some((e, loc)) = self.enums.get(&ident).cloned() {
-                    self.scan_enum(&e, &loc)?;
-                    self.ensure_entry(Direction::Input, &ty, true, &loc);
-                    self.ensure_entry(Direction::Output, &ty, true, &loc);
+                } else if let Some((e, _)) = self.enums.get(&ident).cloned() {
+                    self.scan_enum(&e)?;
+                    self.ensure_entry(Direction::Input, &ty, true);
+                    self.ensure_entry(Direction::Output, &ty, true);
                     matched = true;
                 }
             }
@@ -1110,9 +1174,8 @@ impl<M> Registry<M> {
                 // `ptr_class(ZKeyExpr<'static>)` on a re-exported
                 // foreign type). Still mark required so the resolver
                 // tries to produce a converter for it.
-                let loc = self.type_locations.get(key).cloned().unwrap_or_default();
-                self.ensure_entry(Direction::Input, &ty, true, &loc);
-                self.ensure_entry(Direction::Output, &ty, true, &loc);
+                self.ensure_entry(Direction::Input, &ty, true);
+                self.ensure_entry(Direction::Output, &ty, true);
             }
         }
 
@@ -1205,16 +1268,8 @@ impl<M> Registry<M> {
         Ok(())
     }
 
-    /// True iff the key was scanned as a top-level fn-signature input type.
-    pub fn is_required_input_at_scan(&self, key: &TypeKey) -> bool {
-        self.required_inputs_scan.contains(key)
-    }
-    pub fn is_required_output_at_scan(&self, key: &TypeKey) -> bool {
-        self.required_outputs_scan.contains(key)
-    }
-
     /// Direction-indexed read access to the type-resolution tables.
-    pub(crate) fn type_table(&self, dir: Direction) -> &HashMap<TypeKey, Option<TypeEntry<M>>> {
+    pub(crate) fn type_table(&self, dir: Direction) -> &HashMap<TypeKey, TypeCell<M>> {
         match dir {
             Direction::Input => &self.input_types,
             Direction::Output => &self.output_types,
@@ -1222,10 +1277,7 @@ impl<M> Registry<M> {
     }
 
     /// Direction-indexed mutable access to the type-resolution tables.
-    pub(crate) fn type_table_mut(
-        &mut self,
-        dir: Direction,
-    ) -> &mut HashMap<TypeKey, Option<TypeEntry<M>>> {
+    pub(crate) fn type_table_mut(&mut self, dir: Direction) -> &mut HashMap<TypeKey, TypeCell<M>> {
         match dir {
             Direction::Input => &mut self.input_types,
             Direction::Output => &mut self.output_types,
@@ -1238,30 +1290,30 @@ impl<M> Registry<M> {
     /// its wire form.
     pub fn input_entry(&self, ty: &syn::Type) -> Option<&TypeEntry<M>> {
         let key = TypeKey::from_type(ty);
-        self.type_table(Direction::Input).get(&key)?.as_ref()
+        self.type_table(Direction::Input).get(&key)?.entry.as_ref()
     }
 
     /// Look up the resolved output entry for `ty`. See [`Self::input_entry`].
     pub fn output_entry(&self, ty: &syn::Type) -> Option<&TypeEntry<M>> {
         let key = TypeKey::from_type(ty);
-        self.type_table(Direction::Output).get(&key)?.as_ref()
+        self.type_table(Direction::Output).get(&key)?.entry.as_ref()
     }
 
     /// Register `ty` (and its nested positions) as a required **input** so
     /// the resolver produces a converter for it. Used by
     /// [`crate::api::core::expand`] to pull in the leaf types a fold needs.
-    pub(crate) fn require_input(&mut self, ty: &syn::Type, loc: &SourceLocation) {
+    pub(crate) fn require_input(&mut self, ty: &syn::Type) {
         // Leaf/expansion types are concrete (no disallowed `impl Trait`), so
         // the recursive registration cannot fail here.
-        let _ = self.register_type_recursive(Direction::Input, ty, true, loc);
+        let _ = self.register_type_recursive(Direction::Input, ty, true);
     }
 
     /// Register `ty` (and its nested positions) as a required **output** so the
     /// resolver produces a converter for it. The output-side peer of
     /// [`Self::require_input`]; used by [`crate::api::core::unfold`] to pull in
     /// the leaf types a decomposition delivers.
-    pub(crate) fn require_output(&mut self, ty: &syn::Type, loc: &SourceLocation) {
-        let _ = self.register_type_recursive(Direction::Output, ty, true, loc);
+    pub(crate) fn require_output(&mut self, ty: &syn::Type) {
+        let _ = self.register_type_recursive(Direction::Output, ty, true);
     }
 
     /// Drop `ty` from the required-output scan set. The type's table entry is
@@ -1274,7 +1326,7 @@ impl<M> Registry<M> {
     /// `Vec<opaque-handle>` it cannot resolve at all (a `jlong` wire is not
     /// JObject-shaped), so requiring it would wrongly fail resolution.
     pub(crate) fn unrequire_output(&mut self, ty: &syn::Type) {
-        self.required_outputs_scan.remove(&TypeKey::from_type(ty));
+        self.clear_root(Direction::Output, ty);
     }
 
     /// Drop `ty` from the required-input scan set — the input-side peer of
@@ -1284,14 +1336,19 @@ impl<M> Registry<M> {
     /// converter is genuinely not needed (and for an undeclared type cannot
     /// resolve at all).
     pub(crate) fn unrequire_input(&mut self, ty: &syn::Type) {
-        self.required_inputs_scan.remove(&TypeKey::from_type(ty));
+        self.clear_root(Direction::Input, ty);
     }
 
-    fn scan_fn_signature(
-        &mut self,
-        f: &syn::ItemFn,
-        loc: &SourceLocation,
-    ) -> Result<(), ScanError> {
+    /// Stop treating `ty` as a root. The cell stays, so the resolver still fills
+    /// it if it can — only the demand that it *must* resolve is dropped.
+    fn clear_root(&mut self, dir: Direction, ty: &syn::Type) {
+        let key = TypeKey::from_type(ty);
+        if let Some(cell) = self.type_table_mut(dir).get_mut(&key) {
+            cell.root = false;
+        }
+    }
+
+    fn scan_fn_signature(&mut self, f: &syn::ItemFn) -> Result<(), ScanError> {
         // Mechanical: register every fn-signature type as the user wrote it.
         // No semantic transformations (no &T→T strip, no ZResult<T>→T strip,
         // no skip for () / ZResult<()>). The adapter handles structural
@@ -1306,7 +1363,7 @@ impl<M> Registry<M> {
             match input {
                 syn::FnArg::Receiver(_) => continue,
                 syn::FnArg::Typed(pt) => {
-                    self.register_type_recursive(Direction::Input, &pt.ty, true, loc)?;
+                    self.register_type_recursive(Direction::Input, &pt.ty, true)?;
                 }
             }
         }
@@ -1314,51 +1371,50 @@ impl<M> Registry<M> {
             syn::ReturnType::Default => syn::parse_quote!(()),
             syn::ReturnType::Type(_, ty) => (**ty).clone(),
         };
-        self.register_type_recursive(Direction::Output, &ret_ty, true, loc)?;
+        self.register_type_recursive(Direction::Output, &ret_ty, true)?;
         Ok(())
     }
 
-    fn scan_struct(&mut self, s: &syn::ItemStruct, loc: &SourceLocation) -> Result<(), ScanError> {
+    fn scan_struct(&mut self, s: &syn::ItemStruct) -> Result<(), ScanError> {
         // The struct itself can appear in either direction.
         let ty: syn::Type = crate::api::core::types_util::type_from_ident(&s.ident);
-        self.ensure_entry(Direction::Input, &ty, false, loc);
-        self.ensure_entry(Direction::Output, &ty, false, loc);
+        self.ensure_entry(Direction::Input, &ty, false);
+        self.ensure_entry(Direction::Output, &ty, false);
 
         if let syn::Fields::Named(named) = &s.fields {
             for field in &named.named {
-                self.register_type_recursive(Direction::Input, &field.ty, false, loc)?;
-                self.register_type_recursive(Direction::Output, &field.ty, false, loc)?;
+                self.register_type_recursive(Direction::Input, &field.ty, false)?;
+                self.register_type_recursive(Direction::Output, &field.ty, false)?;
             }
         }
         Ok(())
     }
 
-    fn scan_enum(&mut self, e: &syn::ItemEnum, loc: &SourceLocation) -> Result<(), ScanError> {
+    fn scan_enum(&mut self, e: &syn::ItemEnum) -> Result<(), ScanError> {
         let ty: syn::Type = crate::api::core::types_util::type_from_ident(&e.ident);
-        self.ensure_entry(Direction::Input, &ty, false, loc);
-        self.ensure_entry(Direction::Output, &ty, false, loc);
+        self.ensure_entry(Direction::Input, &ty, false);
+        self.ensure_entry(Direction::Output, &ty, false);
 
         for variant in &e.variants {
             for field in &variant.fields {
-                self.register_type_recursive(Direction::Input, &field.ty, false, loc)?;
-                self.register_type_recursive(Direction::Output, &field.ty, false, loc)?;
+                self.register_type_recursive(Direction::Input, &field.ty, false)?;
+                self.register_type_recursive(Direction::Output, &field.ty, false)?;
             }
         }
         Ok(())
     }
 
-    /// Register `ty` as an entry in the given direction, then recurse into
-    /// every nested position. `top_required` applies only to `ty` itself;
-    /// nested positions are always recorded as not-required.
+    /// Register `ty` as a cell in the given direction, then recurse into every
+    /// nested position. `root` applies only to `ty` itself — a nested position is
+    /// never something the binding asked for directly.
     fn register_type_recursive(
         &mut self,
         dir: Direction,
         ty: &syn::Type,
-        top_required: bool,
-        loc: &SourceLocation,
+        root: bool,
     ) -> Result<(), ScanError> {
         let mut visited: HashSet<TypeKey> = HashSet::new();
-        self.register_type_inner(dir, ty, top_required, loc, &mut visited)
+        self.register_type_inner(dir, ty, root, &mut visited)
     }
 
     fn register_type_inner(
@@ -1366,7 +1422,6 @@ impl<M> Registry<M> {
         dir: Direction,
         ty: &syn::Type,
         is_top: bool,
-        loc: &SourceLocation,
         visited: &mut HashSet<TypeKey>,
     ) -> Result<(), ScanError> {
         // A disallowed `impl Trait` cannot reach here: every fn whose signature
@@ -1379,33 +1434,35 @@ impl<M> Registry<M> {
             return Ok(()); // cycle guard
         }
 
-        self.ensure_entry(dir, ty, is_top, loc);
+        self.ensure_entry(dir, ty, is_top);
 
         for (child_dir, sub) in self.immediate_edges(dir, ty) {
-            self.register_type_inner(child_dir, &sub, false, loc, visited)?;
+            self.register_type_inner(child_dir, &sub, false, visited)?;
         }
         Ok(())
     }
 
-    fn ensure_entry(
-        &mut self,
-        dir: Direction,
-        ty: &syn::Type,
-        required: bool,
-        loc: &SourceLocation,
-    ) {
+    /// Create the cell for `ty` in `dir` if it has none, and mark it a root when
+    /// the binding asked for it directly.
+    ///
+    /// The one place a cell is born, which is what lets the subject be decided
+    /// once: the model's reading if the flat API mentions this type, an
+    /// adapter-authored type otherwise.
+    fn ensure_entry(&mut self, dir: Direction, ty: &syn::Type, root: bool) {
         let key = TypeKey::from_type(ty);
-        let table = self.type_table_mut(dir);
-        table.entry(key.clone()).or_insert(None);
-        if required {
-            match dir {
-                Direction::Input => self.required_inputs_scan.insert(key.clone()),
-                Direction::Output => self.required_outputs_scan.insert(key.clone()),
-            };
-        }
-        self.type_locations
+        let subject = match self.type_refs.get(&key) {
+            Some(t) => TypeSubject::Source(t.clone()),
+            None => TypeSubject::Adapter(key.to_type()),
+        };
+        let cell = self
+            .type_table_mut(dir)
             .entry(key)
-            .or_insert_with(|| loc.clone());
+            .or_insert_with(|| TypeCell {
+                subject,
+                root: false,
+                entry: None,
+            });
+        cell.root |= root;
     }
 
     /// Enumerate the immediate type-graph edges out of `(dir, ty)`:
@@ -1430,20 +1487,24 @@ impl<M> Registry<M> {
         for sub in positions {
             out.push((child_dir, sub));
         }
+        // A declared type's own fields, read off the element rather than off its
+        // `syn::Fields`: a positional field is an ordinary `Field` there, so the
+        // named-only asymmetry the syntax walk had does not arise. An `Enum` has
+        // no fields and an `Extern` declares none, which is what makes both
+        // contribute nothing here.
         if let Some(name) = bare_path_ident(ty) {
-            if let Some((s, _)) = self.structs.get(&name) {
-                if let syn::Fields::Named(named) = &s.fields {
-                    for field in &named.named {
-                        out.push((dir, field.ty.clone()));
-                    }
-                }
-            }
-            if let Some((e, _)) = self.enums.get(&name) {
-                for variant in &e.variants {
-                    for field in &variant.fields {
-                        out.push((dir, field.ty.clone()));
-                    }
-                }
+            use crate::api::core::flat::{Field, Type};
+            let fields: Vec<&Field> = match self.flat.declared_type(&name.to_string()) {
+                Some(Type::Struct(s)) => s.fields.iter().collect(),
+                Some(Type::Variant(v)) => v
+                    .alternatives
+                    .iter()
+                    .flat_map(|a| a.fields.iter())
+                    .collect(),
+                Some(Type::Enum(_) | Type::Extern(_)) | None => Vec::new(),
+            };
+            for field in fields {
+                out.push((dir, field.ty.origin.syntax.clone()));
             }
         }
         out
@@ -1573,10 +1634,9 @@ impl<M> Registry<M> {
         // Adapter-derived extra requirements (registry-aware — e.g. the
         // other-side types of `convert!` conversion fns, per direction).
         for (dir, ty) in ext.extra_required_types(self) {
-            let loc = SourceLocation::default();
             match dir {
-                Direction::Input => self.require_input(&ty, &loc),
-                Direction::Output => self.require_output(&ty, &loc),
+                Direction::Input => self.require_input(&ty),
+                Direction::Output => self.require_output(&ty),
             }
         }
         // Boundary-only types: every crossing is now covered by a plan (fold

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -4,8 +4,8 @@
 //! * Item maps (`functions`, `structs`, `enums`, `consts`) indexed by ident.
 //!   Duplicate names across kinds OR within a kind are an error — prebindgen
 //!   items live in one flat namespace.
-//! * `passthrough` — items that aren't function/struct/enum/const (use, mod,
-//!   type alias, macro_rules) emitted verbatim.
+//! * `guards` — prebindgen's own injected feature checks, emitted verbatim.
+//!   Not API: no source crate marked them.
 //! * `input_types` / `output_types` — direction-specific type tables. Each
 //!   scanned type maps to either a resolved [`TypeEntry`] or an unresolved cell
 //!   that the fixed-point resolver can retry.
@@ -297,8 +297,10 @@ pub struct Registry<M = ()> {
     pub structs: HashMap<syn::Ident, (syn::ItemStruct, SourceLocation)>,
     pub enums: HashMap<syn::Ident, (syn::ItemEnum, SourceLocation)>,
     pub consts: HashMap<syn::Ident, (syn::ItemConst, SourceLocation)>,
-    /// Anything else (use, mod, type alias, macro_rules) — passed through.
-    pub passthrough: Vec<(syn::Item, SourceLocation)>,
+    /// Prebindgen's own injected compile-time checks — one feature guard per
+    /// ingested source crate — re-emitted verbatim. Not API: see
+    /// [`Guard`](crate::api::core::flat::Guard).
+    pub guards: Vec<crate::api::core::flat::Guard>,
 
     /// Origin crate name of each named item (fn/struct/enum/const),
     /// recorded by [`Self::from_items`] from each item's
@@ -386,7 +388,7 @@ impl<M> Registry<M> {
             structs: HashMap::new(),
             enums: HashMap::new(),
             consts: HashMap::new(),
-            passthrough: Vec::new(),
+            guards: Vec::new(),
             item_origins: HashMap::new(),
             source_modules: Vec::new(),
             input_types: Default::default(),
@@ -822,7 +824,7 @@ impl<M> Registry<M> {
     /// override could only fix one module).
     ///
     /// This step only populates the item maps (`functions`, `structs`,
-    /// `enums`, `consts`, `passthrough`). Signature/body scanning that
+    /// `enums`, `consts`, `guards`). Signature/body scanning that
     /// drives type-resolution requirements happens later, in
     /// [`Self::scan_declared`], and is gated on what the language adapter
     /// has explicitly declared. Items that are never declared remain in
@@ -916,16 +918,10 @@ impl<M> Registry<M> {
                         (t.origin.syntax.clone(), element.location().clone()),
                     );
                 }
-                // An unnamed `const _` is each source's injected `konst` feature
-                // guard: not addressable, re-emitted verbatim. That is the whole
-                // of `passthrough` now — the proc-macro refuses to mark a `use`,
-                // `mod` or `macro_rules!`, so nothing else ever reached it.
-                Element::Constant(c) if named.is_none() => {
-                    registry.passthrough.push((
-                        syn::Item::Const(c.origin.syntax.clone()),
-                        element.location().clone(),
-                    ));
-                }
+                // Prebindgen's own feature guard, re-emitted verbatim. The only
+                // item here that no source crate marked, which is why it is not
+                // in any of the API maps.
+                Element::Guard(g) => registry.guards.push(g.clone()),
                 Element::Constant(c) => {
                     registry.consts.insert(
                         c.name.clone(),
@@ -1245,12 +1241,8 @@ impl<M> Registry<M> {
             let mut skipped_consts: Vec<String> = self
                 .consts
                 .keys()
-                // Unnamed consts (`const _`, e.g. the injected feature
-                // guard) are infrastructure: not declarable, always emitted
-                // verbatim — never a skip.
                 .filter(|k| {
-                    *k != "_"
-                        && !decl_consts.contains(*k)
+                    !decl_consts.contains(*k)
                         && !declared.ignored_consts.contains(*k)
                         && !pred_ignored(&k.to_string())
                 })

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -905,7 +905,11 @@ fn from_flat_projects_each_element_kind() {
     assert!(reg.enums.contains_key(&id("Sum")), "a sum is an enum here");
     assert!(reg.enums.contains_key(&id("Flags")));
     assert!(reg.consts.contains_key(&id("K")));
-    assert_eq!(reg.guards.len(), 2, "one guard per source");
+    assert_eq!(
+        reg.guards.len(),
+        2,
+        "both anonymous consts, in stream order"
+    );
     assert!(
         !reg.structs.contains_key(&id("Handle")) && !reg.enums.contains_key(&id("Handle")),
         "an Extern names a type; it declares no body to index"

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -93,8 +93,8 @@ fn scan_declared_empty_ext_marks_nothing_required() {
     let mut reg: Registry<()> = Registry::from_items(items).unwrap();
     let ext = StubExt::default();
     reg.scan_declared(&ext).expect("empty ext = no scan");
-    assert!(reg.required_inputs_scan.is_empty());
-    assert!(reg.required_outputs_scan.is_empty());
+    assert!(!reg.input_types.values().any(|c| c.root));
+    assert!(!reg.output_types.values().any(|c| c.root));
 }
 
 #[test]
@@ -107,18 +107,14 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("a").unwrap());
     reg.scan_declared(&ext).unwrap();
-    assert!(reg
-        .required_inputs_scan
-        .contains(&TypeKey::parse("u64").expect("test type")));
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::parse("u64").expect("test type")));
-    assert!(!reg
-        .required_inputs_scan
-        .contains(&TypeKey::parse("u32").expect("test type")));
-    assert!(!reg
-        .required_outputs_scan
-        .contains(&TypeKey::parse("u32").expect("test type")));
+    let is_root = |t: &HashMap<TypeKey, TypeCell<()>>, k: &str| {
+        t.get(&TypeKey::parse(k).expect("test type"))
+            .is_some_and(|c| c.root)
+    };
+    assert!(is_root(&reg.input_types, "u64"));
+    assert!(is_root(&reg.output_types, "u64"));
+    assert!(!is_root(&reg.input_types, "u32"));
+    assert!(!is_root(&reg.output_types, "u32"));
 }
 
 #[test]
@@ -239,8 +235,8 @@ fn scan_declared_accepts_ignore_predicates() {
     ext.ignored_name_predicates
         .push(std::sync::Arc::new(|n: &str| n.starts_with("nothing_")));
     reg.scan_declared(&ext).expect("predicates must scan clean");
-    // Nothing was declared, so nothing became required.
-    assert!(reg.required_inputs_scan.is_empty());
+    // Nothing was declared, so nothing became a root.
+    assert!(!reg.input_types.values().any(|c| c.root));
 }
 
 #[test]
@@ -274,7 +270,6 @@ fn type_entry_helpers_expose_converter_chain_contract() {
             TypeKey::parse("Rust").expect("test type"),
             TypeKey::parse("Mid").expect("test type"),
         ],
-        required: true,
         niches: Niches::empty(),
         metadata: (),
     };
@@ -527,16 +522,13 @@ fn qualified_signature_matches_bare_declaration() {
     ext.types
         .insert(TypeKey::parse("Thing").expect("test type"));
     reg.scan_declared(&ext).unwrap();
-    assert!(reg
-        .required_inputs_scan
-        .contains(&TypeKey::parse("&Thing").expect("test type")));
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::parse("Vec<Thing>").expect("test type")));
+    assert!(reg.input_types[&TypeKey::parse("&Thing").expect("test type")].root);
+    assert!(reg.output_types[&TypeKey::parse("Vec<Thing>").expect("test type")].root);
     // No spelling-variant duplicate cells survive anywhere.
-    let no_paths = |set: &HashSet<TypeKey>| !set.iter().any(|k| k.as_str().contains("::"));
-    assert!(no_paths(&reg.required_inputs_scan));
-    assert!(no_paths(&reg.required_outputs_scan));
+    let no_paths =
+        |t: &HashMap<TypeKey, TypeCell<()>>| !t.keys().any(|k| k.as_str().contains("::"));
+    assert!(no_paths(&reg.input_types));
+    assert!(no_paths(&reg.output_types));
 }
 
 #[test]
@@ -562,12 +554,8 @@ fn multi_source_rename_cross_reference_normalizes() {
     ext.types
         .insert(TypeKey::parse("TypeB").expect("test type"));
     reg.scan_declared(&ext).unwrap();
-    assert!(reg
-        .required_inputs_scan
-        .contains(&TypeKey::parse("&TypeA").expect("test type")));
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::parse("TypeB").expect("test type")));
+    assert!(reg.input_types[&TypeKey::parse("&TypeA").expect("test type")].root);
+    assert!(reg.output_types[&TypeKey::parse("TypeB").expect("test type")].root);
 }
 
 #[test]
@@ -605,8 +593,8 @@ fn foreign_qualified_declared_type_stays_supported() {
     ext.types.insert(foreign.clone());
     reg.scan_declared(&ext)
         .expect("foreign qualified declaration is supported");
-    assert!(reg.required_inputs_scan.contains(&foreign));
-    assert!(reg.required_outputs_scan.contains(&foreign));
+    assert!(reg.input_types[&foreign].root);
+    assert!(reg.output_types[&foreign].root);
 }
 
 // ── The directory-reading builder ──────────────────────────────────────
@@ -763,6 +751,64 @@ fn builder_and_from_items_agree() {
         streamed.default_module().map(module)
     );
     assert_eq!(built.passthrough.len(), streamed.passthrough.len());
+}
+
+// ── What a table cell knows about its type ─────────────────────────────
+
+/// A cell for a type the source wrote carries the **frontend's own** reading:
+/// the same classification the element holds, and the item's location. Not a
+/// re-derivation — the registry looks the model up rather than lowering twice.
+#[test]
+fn a_source_type_cell_carries_the_models_typeref() {
+    use crate::api::core::flat::TypeKind;
+
+    let loc = SourceLocation {
+        file: "src/lib.rs".into(),
+        line: 42,
+        column: 7,
+        crate_name: Some("myflat".into()),
+    };
+    let item: syn::Item = syn::parse_str("pub fn f(v: Option<u64>) -> u64 { v.unwrap() }").unwrap();
+    let mut reg: Registry<()> = Registry::from_items([(item, loc.clone())]).unwrap();
+
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("f").unwrap());
+    reg.scan_declared(&ext).unwrap();
+
+    let key = TypeKey::parse("Option<u64>").expect("test type");
+    let cell = &reg.input_types[&key];
+    assert!(cell.root, "a top-level parameter is a root");
+    assert!(
+        matches!(cell.subject.kind(), Some(TypeKind::Optional(_))),
+        "the frontend classified it, so the cell has that classification"
+    );
+    // One location per cell, and it is the model's — not a copy the scan made.
+    assert_eq!(cell.subject.location(), Some(&loc));
+
+    // The nested position is in the model too, and is not a root.
+    let inner = &reg.input_types[&TypeKey::parse("u64").expect("test type")];
+    assert!(!inner.root);
+    assert!(matches!(inner.subject.kind(), Some(TypeKind::Scalar(_))));
+}
+
+/// A type only the binding authored has **no** reading and no location — a fact
+/// about it, not information that went missing. Declaring a type the source
+/// never mentions is the ordinary way to reach this state.
+#[test]
+fn an_adapter_authored_type_cell_has_no_source_reading() {
+    let items = vec![fn_item("fn f(x: u64) -> u64 { x }")];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+
+    let mut ext = StubExt::default();
+    ext.types
+        .insert(TypeKey::parse("Foreign").expect("test type"));
+    reg.scan_declared(&ext).unwrap();
+
+    let cell = &reg.input_types[&TypeKey::parse("Foreign").expect("test type")];
+    assert!(cell.root, "the binding asked for it directly");
+    assert!(matches!(cell.subject, TypeSubject::Adapter(_)));
+    assert!(cell.subject.kind().is_none());
+    assert_eq!(cell.subject.location(), None);
 }
 
 // ── The projection itself ──────────────────────────────────────────────

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -750,7 +750,7 @@ fn builder_and_from_items_agree() {
         built.default_module().map(module),
         streamed.default_module().map(module)
     );
-    assert_eq!(built.passthrough.len(), streamed.passthrough.len());
+    assert_eq!(built.guards.len(), streamed.guards.len());
 }
 
 // ── What a table cell knows about its type ─────────────────────────────
@@ -905,7 +905,7 @@ fn from_flat_projects_each_element_kind() {
     assert!(reg.enums.contains_key(&id("Sum")), "a sum is an enum here");
     assert!(reg.enums.contains_key(&id("Flags")));
     assert!(reg.consts.contains_key(&id("K")));
-    assert_eq!(reg.passthrough.len(), 2, "one guard per source");
+    assert_eq!(reg.guards.len(), 2, "one guard per source");
     assert!(
         !reg.structs.contains_key(&id("Handle")) && !reg.enums.contains_key(&id("Handle")),
         "an Extern names a type; it declares no body to index"
@@ -1028,4 +1028,53 @@ fn a_well_formed_binding_local_fn_passes() {
     };
     reg.resolve(ext)
         .expect("a grammatical local fn passes, undeclared types and all");
+}
+
+/// A guard is not a const, structurally — so nothing that consumes the const
+/// surface has to remember it exists.
+///
+/// The three `c.ident == "_"` sentinel checks this replaced had gone **dead**
+/// without anyone noticing: once ingestion routed unnamed consts away from
+/// `consts`, they guarded a state the pipeline could no longer produce. This is
+/// the assertion that would have caught that, and that keeps a future
+/// reclassification honest.
+#[test]
+fn a_guard_never_reaches_the_const_surface() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                const _: () = ();
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub const REAL: u64 = 7;
+            ),
+            loc.clone(),
+        ),
+        // A second source's guard: several coexist, having no address to collide on.
+        (
+            syn::parse_quote!(
+                const _: () = ();
+            ),
+            loc.clone(),
+        ),
+    ];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+
+    assert_eq!(reg.guards.len(), 2);
+    assert_eq!(reg.consts.len(), 1);
+    assert!(reg
+        .consts
+        .contains_key(&syn::parse_str::<syn::Ident>("REAL").unwrap()));
+
+    // An adapter WITH a const mechanism that declares nothing warns about `REAL`
+    // only: a guard is not undeclared API, it is not API.
+    let ext = StubExt {
+        consts: Some(HashSet::new()),
+        ..Default::default()
+    };
+    reg.scan_declared(&ext).expect("guards are not declarable");
 }

--- a/prebindgen/src/api/core/resolve.rs
+++ b/prebindgen/src/api/core/resolve.rs
@@ -15,11 +15,14 @@
 //! args resolve in the opposite direction). New slots only go `None → Some`, so
 //! the loop terminates.
 //!
-//! After the loop, [`propagate_required`] performs a BFS from the scan-time
-//! required entries through `subs` edges; the final invariant is that every
-//! `required: true && None` is reported as an error.
+//! After the loop, [`required_set`] performs a BFS from the **root** cells — the
+//! ones the binding asked for directly — through `subs` edges. It returns the
+//! reachable set rather than storing it: needing a converter is a property of the
+//! graph, so it is derived once at the end instead of written back into every
+//! cell it was computed from. The final invariant is that every reachable-but-
+//! unresolved cell is reported as an error.
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 use crate::{
     api::core::{
@@ -105,7 +108,6 @@ pub fn resolve<E: Prebindgen>(
         apply_deltas(registry, Direction::Input, deltas_in);
         apply_deltas(registry, Direction::Output, deltas_out);
     }
-    propagate_required(registry);
     final_invariant_check(registry)
 }
 
@@ -119,15 +121,11 @@ fn collect_deltas<E: Prebindgen>(
     let mut deltas: Vec<(TypeKey, TypeEntry<E::Metadata>)> = Vec::new();
     let table = registry.type_table(dir);
     for (key, slot) in table {
-        if slot.is_some() {
+        if slot.entry.is_some() {
             continue;
         }
         let key_ty = key.to_type();
-        let scan_required = match dir {
-            Direction::Input => registry.is_required_input_at_scan(key),
-            Direction::Output => registry.is_required_output_at_scan(key),
-        };
-        if let Some(entry) = resolve_one(ext, &key_ty, dir, scan_required, registry) {
+        if let Some(entry) = resolve_one(ext, &key_ty, dir, registry) {
             deltas.push((key.clone(), entry));
         }
     }
@@ -144,9 +142,9 @@ fn apply_deltas<M>(
 ) {
     let table = registry.type_table_mut(dir);
     for (key, entry) in deltas {
-        if let Some(slot) = table.get_mut(&key) {
-            if slot.is_none() {
-                *slot = Some(entry);
+        if let Some(cell) = table.get_mut(&key) {
+            if cell.entry.is_none() {
+                cell.entry = Some(entry);
             }
         }
     }
@@ -160,7 +158,6 @@ fn resolve_one<E: Prebindgen>(
     ext: &E,
     key_ty: &syn::Type,
     dir: Direction,
-    scan_required: bool,
     registry: &Registry<E::Metadata>,
 ) -> Option<TypeEntry<E::Metadata>> {
     let conv: Option<ConverterImpl<E::Metadata>> = match dir {
@@ -183,7 +180,6 @@ fn resolve_one<E: Prebindgen>(
         function: c.function,
         pre_stages: c.pre_stages,
         subs: c.subs.iter().map(TypeKey::from_type).collect(),
-        required: scan_required,
         niches: c.niches,
         metadata: c.metadata,
     })
@@ -193,77 +189,47 @@ fn resolve_one<E: Prebindgen>(
 // Required-flag propagation (BFS from required entries through `subs`)
 // ──────────────────────────────────────────────────────────────────────
 
-fn propagate_required<M>(registry: &mut Registry<M>) {
-    // Seed the queue from scan-time required keys plus any `required: true`
-    // already on resolved entries.
+/// The cells a converter must exist for: every root, plus everything reachable
+/// from one through a resolved converter's `subs`.
+///
+/// Derived, never stored. Needing a converter is a property of the graph, and the
+/// graph is not complete until resolution has run — so computing it once here
+/// beats maintaining a flag that every edge discovery has to write back.
+fn required_set<M>(registry: &Registry<M>) -> HashSet<(Direction, TypeKey)> {
+    let mut required: HashSet<(Direction, TypeKey)> = HashSet::new();
     let mut queue: VecDeque<(Direction, TypeKey)> = VecDeque::new();
-    for k in &registry.required_inputs_scan {
-        queue.push_back((Direction::Input, k.clone()));
-    }
-    for k in &registry.required_outputs_scan {
-        queue.push_back((Direction::Output, k.clone()));
-    }
-
-    while let Some((dir, key)) = queue.pop_front() {
-        // Mark this entry's `required: true` if it's resolved.
-        let subs = mark_and_get_subs(registry, dir, &key);
-        // Subs travel in the same direction as the parent — they're the
-        // inner converters this body delegates to.
-        for sub_key in subs {
-            if !is_required_resolved(registry, dir, &sub_key) {
-                set_required(registry, dir, &sub_key);
-                queue.push_back((dir, sub_key));
+    for dir in [Direction::Input, Direction::Output] {
+        for (key, cell) in registry.type_table(dir) {
+            if cell.root && required.insert((dir, key.clone())) {
+                queue.push_back((dir, key.clone()));
             }
         }
     }
-}
 
-fn mark_and_get_subs<M>(registry: &mut Registry<M>, dir: Direction, key: &TypeKey) -> Vec<TypeKey> {
-    let table = registry.type_table_mut(dir);
-    match table.get_mut(key) {
-        Some(Some(entry)) => {
-            entry.required = true;
-            entry.subs.clone()
-        }
-        _ => vec![],
-    }
-}
-
-fn is_required_resolved<M>(registry: &Registry<M>, dir: Direction, key: &TypeKey) -> bool {
-    let table = registry.type_table(dir);
-    table
-        .get(key)
-        .and_then(|slot| slot.as_ref())
-        .is_some_and(|e| e.required)
-}
-
-fn set_required<M>(registry: &mut Registry<M>, dir: Direction, key: &TypeKey) {
-    match dir {
-        Direction::Input => {
-            registry.required_inputs_scan.insert(key.clone());
-        }
-        Direction::Output => {
-            registry.required_outputs_scan.insert(key.clone());
+    while let Some((dir, key)) = queue.pop_front() {
+        // Subs travel in the same direction as the parent — they are the inner
+        // converters this body delegates to. An unresolved cell has none to give,
+        // which is why this cannot run before the fixed-point loop.
+        let Some(entry) = registry
+            .type_table(dir)
+            .get(&key)
+            .and_then(|c| c.entry.as_ref())
+        else {
+            continue;
+        };
+        for sub_key in &entry.subs {
+            if required.insert((dir, sub_key.clone())) {
+                queue.push_back((dir, sub_key.clone()));
+            }
         }
     }
-    let table = registry.type_table_mut(dir);
-    if let Some(Some(entry)) = table.get_mut(key) {
-        entry.required = true;
-    }
-}
-
-fn lookup_slot<'a, M>(
-    registry: &'a Registry<M>,
-    dir: Direction,
-    key: &TypeKey,
-) -> Option<&'a Option<TypeEntry<M>>> {
-    registry.type_table(dir).get(key)
+    required
 }
 
 /// BFS from unresolved required-roots through the type graph, surfacing
 /// further unresolved entries reachable through struct fields, enum variants,
 /// generic args, and `impl Fn(...)` args. Stops at resolved nodes — their
-/// `subs` were already walked by `propagate_required`, so traversing through
+/// `subs` were already walked by `required_set`, so traversing through
 /// them risks reporting dependents the resolved converter doesn't actually
 /// need.
 fn collect_unresolved_descendants<M>(
@@ -292,13 +258,13 @@ fn collect_unresolved_descendants<M>(
     }
 
     while let Some((dir, key)) = queue.pop_front() {
-        match lookup_slot(registry, dir, &key) {
-            Some(None) => {
+        match registry.type_table(dir).get(&key) {
+            Some(cell) if cell.entry.is_none() => {
                 // Registered but unresolved — report it and keep walking.
                 out.push(UnresolvedEntry {
                     key: key.clone(),
                     direction: dir,
-                    location: registry.type_locations.get(&key).cloned(),
+                    location: cell.subject.location().cloned(),
                 });
                 enqueue_edges_from(dir, &key, &mut queue, seen);
             }
@@ -308,50 +274,36 @@ fn collect_unresolved_descendants<M>(
                 // include registered-but-unresolved types worth flagging.
                 enqueue_edges_from(dir, &key, &mut queue, seen);
             }
-            Some(Some(_)) => {
-                // Resolved — `propagate_required` already walked its `subs`.
-                // Stop here to avoid spurious reports for descendants the
-                // resolved converter doesn't need.
+            Some(_) => {
+                // Resolved — `required_set` already walked its `subs`. Stop here
+                // to avoid spurious reports for descendants the resolved
+                // converter doesn't need.
             }
         }
     }
 }
 
 fn final_invariant_check<M>(registry: &Registry<M>) -> Result<(), ResolveError> {
+    let required = required_set(registry);
     let mut entries: Vec<UnresolvedEntry> = Vec::new();
-    let scan_required_input = &registry.required_inputs_scan;
-    let scan_required_output = &registry.required_outputs_scan;
     let mut unresolved_required_roots: Vec<(Direction, TypeKey)> = Vec::new();
-    let mut seen_unresolved: std::collections::HashSet<(Direction, TypeKey)> =
-        std::collections::HashSet::new();
+    let mut seen_unresolved: HashSet<(Direction, TypeKey)> = HashSet::new();
 
-    for (key, slot) in &registry.input_types {
-        let needs = match slot {
-            Some(e) => e.required,
-            None => scan_required_input.contains(key),
-        };
-        if needs && slot.is_none() {
-            unresolved_required_roots.push((Direction::Input, key.clone()));
-            seen_unresolved.insert((Direction::Input, key.clone()));
+    for dir in [Direction::Input, Direction::Output] {
+        // Sorted, so a build that fails reports the same list every time.
+        let mut keys: Vec<&TypeKey> = registry.type_table(dir).keys().collect();
+        keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        for key in keys {
+            let cell = &registry.type_table(dir)[key];
+            if cell.entry.is_some() || !required.contains(&(dir, key.clone())) {
+                continue;
+            }
+            unresolved_required_roots.push((dir, key.clone()));
+            seen_unresolved.insert((dir, key.clone()));
             entries.push(UnresolvedEntry {
                 key: key.clone(),
-                direction: Direction::Input,
-                location: registry.type_locations.get(key).cloned(),
-            });
-        }
-    }
-    for (key, slot) in &registry.output_types {
-        let needs = match slot {
-            Some(e) => e.required,
-            None => scan_required_output.contains(key),
-        };
-        if needs && slot.is_none() {
-            unresolved_required_roots.push((Direction::Output, key.clone()));
-            seen_unresolved.insert((Direction::Output, key.clone()));
-            entries.push(UnresolvedEntry {
-                key: key.clone(),
-                direction: Direction::Output,
-                location: registry.type_locations.get(key).cloned(),
+                direction: dir,
+                location: cell.subject.location().cloned(),
             });
         }
     }

--- a/prebindgen/src/api/core/resolve/tests.rs
+++ b/prebindgen/src/api/core/resolve/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api::test_util::cell;
 
 /// Regression: when a required type is itself unresolved AND has fields
 /// that are also unresolved, the diagnostic must list both. Previously
@@ -9,29 +10,17 @@ use super::*;
 fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
     use crate::api::core::registry::{Registry, TypeKey};
 
-    let mut reg: Registry<()> = Registry::empty();
+    // A struct whose field type the build.rs forgot to declare. Registering
+    // `Outer` as a root walks into the field through the model, so `ZKeyExpr`
+    // gets a cell that is NOT a root — exactly the case the BFS is here to
+    // catch. Driven through the real scan rather than simulated, so the state
+    // under test is one the pipeline can actually produce.
+    let mut reg: Registry<()> =
+        crate::api::test_util::reg_with(&["pub struct Outer { pub inner: ZKeyExpr }"]);
+    reg.require_input(&syn::parse_quote!(Outer));
 
-    // Index a struct `Outer { inner: ZKeyExpr }` so the BFS can walk
-    // into its field. `ZKeyExpr` itself stays *unindexed* (the user's
-    // build.rs forgot to declare it), but it does appear in the type
-    // tables because scan-recursion would have registered it as a field
-    // of `Outer`. Simulate the post-scan registry state directly.
-    let outer_struct: syn::ItemStruct = syn::parse_str("struct Outer { inner: ZKeyExpr }").unwrap();
-    reg.structs.insert(
-        outer_struct.ident.clone(),
-        (outer_struct, SourceLocation::default()),
-    );
-
-    // `Outer` is a required INPUT, unresolved (slot stays `None`).
-    let outer_key = TypeKey::parse("Outer").expect("test type");
-    reg.input_types.insert(outer_key.clone(), None);
-    reg.required_inputs_scan.insert(outer_key.clone());
-
-    // `ZKeyExpr` is also in the type table (scan recursed into the
-    // field) but unresolved and NOT marked required at scan time —
-    // exactly the case the BFS is here to catch.
     let zke_key = TypeKey::parse("ZKeyExpr").expect("test type");
-    reg.input_types.insert(zke_key.clone(), None);
+    assert!(!reg.input_types[&zke_key].root, "the field is not a root");
 
     let err = final_invariant_check(&reg).expect_err("must surface unresolved");
     let ResolveError::Unresolved { entries } = err;
@@ -76,25 +65,29 @@ fn final_invariant_stops_at_resolved_nodes() {
     let inner_key = TypeKey::parse("Inner").expect("test type");
     let unrelated_key = TypeKey::parse("Unrelated").expect("test type");
 
-    reg.input_types.insert(outer_key.clone(), None);
-    reg.required_inputs_scan.insert(outer_key.clone());
+    reg.input_types
+        .insert(outer_key.clone(), cell(&outer_key, true, None));
 
     reg.input_types.insert(
         inner_key.clone(),
-        Some(TypeEntry {
-            destination: syn::parse_quote!(i64),
-            function: syn::parse_quote!(
-                fn __dummy() {}
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            required: false,
-            niches: crate::api::core::niches::Niches::empty(),
-            metadata: (),
-        }),
+        cell(
+            &inner_key,
+            false,
+            Some(TypeEntry {
+                destination: syn::parse_quote!(i64),
+                function: syn::parse_quote!(
+                    fn __dummy() {}
+                ),
+                pre_stages: vec![],
+                subs: vec![],
+                niches: crate::api::core::niches::Niches::empty(),
+                metadata: (),
+            }),
+        ),
     );
 
-    reg.input_types.insert(unrelated_key.clone(), None);
+    reg.input_types
+        .insert(unrelated_key.clone(), cell(&unrelated_key, false, None));
 
     let err = final_invariant_check(&reg).expect_err("must surface Outer");
     let ResolveError::Unresolved { entries } = err;
@@ -110,4 +103,50 @@ fn final_invariant_stops_at_resolved_nodes() {
         reported
     );
     let _ = Direction::Input; // keep import used
+}
+
+/// A type nothing declares directly, reached only through a resolved converter's
+/// `subs`, must still fail the build when it has no converter of its own.
+///
+/// This is the half of the old `required` flag that is derived rather than
+/// stored: `Mid` is not a root, and only `required_set`'s walk through `Outer`'s
+/// `subs` makes it something a converter must exist for.
+#[test]
+fn a_type_reachable_only_through_subs_must_still_resolve() {
+    use crate::api::{
+        core::registry::{Registry, TypeKey},
+        test_util::cell,
+    };
+
+    let mut reg: Registry<()> = Registry::empty();
+    let outer = TypeKey::parse("Outer").expect("test type");
+    let mid = TypeKey::parse("Mid").expect("test type");
+
+    // `Outer` is a root AND resolved — so it is not itself reportable — but its
+    // converter delegates to `Mid`.
+    reg.input_types.insert(
+        outer.clone(),
+        cell(
+            &outer,
+            true,
+            Some(TypeEntry {
+                destination: syn::parse_quote!(i64),
+                function: syn::parse_quote!(
+                    fn __outer() {}
+                ),
+                pre_stages: vec![],
+                subs: vec![mid.clone()],
+                niches: crate::api::core::niches::Niches::empty(),
+                metadata: (),
+            }),
+        ),
+    );
+    // `Mid` is present, unresolved, and NOT a root.
+    reg.input_types.insert(mid.clone(), cell(&mid, false, None));
+
+    let err = final_invariant_check(&reg).expect_err("Mid must be reported");
+    let ResolveError::Unresolved { entries } = err;
+    let reported: std::collections::HashSet<String> =
+        entries.iter().map(|e| e.key.to_string()).collect();
+    assert_eq!(reported, ["Mid".to_string()].into_iter().collect());
 }

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -393,7 +393,7 @@ pub fn apply<M>(
     // (there is no return-value lane in a callback invocation). A type without
     // a default deconstructor gets no plan and is delivered whole.
     for func in declared_fns {
-        let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
+        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
             continue;
         };
         for input in &item_fn.sig.inputs {
@@ -455,7 +455,7 @@ pub fn apply<M>(
                     continue;
                 }
                 for leaf in &plan.leaves {
-                    registry.require_output(&leaf.out_ty, &loc);
+                    registry.require_output(&leaf.out_ty);
                 }
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -601,7 +601,7 @@ fn wire_fixed_returns<M>(
     no_converter: bool,
 ) {
     for func in declared_fns {
-        let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
+        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
             continue;
         };
         let ret = fn_return(&item_fn);
@@ -651,7 +651,7 @@ fn wire_fixed_returns<M>(
             registry.unrequire_output(&core);
         }
         for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-            registry.require_output(&leaf.out_ty, &loc);
+            registry.require_output(&leaf.out_ty);
         }
         let plan = UnfoldPlan {
             source: vd.source.clone(),
@@ -682,7 +682,7 @@ fn wire_fixed_callbacks<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
     for func in declared_fns {
-        let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
+        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
             continue;
         };
         for input in &item_fn.sig.inputs {
@@ -718,7 +718,7 @@ fn wire_fixed_callbacks<M>(
                     continue;
                 }
                 for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-                    registry.require_output(&leaf.out_ty, &loc);
+                    registry.require_output(&leaf.out_ty);
                 }
                 let plan = UnfoldPlan {
                     source: vd.source.clone(),
@@ -765,7 +765,7 @@ pub fn apply_leaf_vec_folds<M>(
     // Is the leading-`&`-peeled `bare` one of the nominated single-leaf elements?
     let is_nominated = |bare: &syn::Type| elem_keys.contains(&TypeKey::from_type(bare));
     for func in declared_fns {
-        let Some((item_fn, loc)) = registry.functions.get(func).cloned() else {
+        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
             continue;
         };
         // Output position: `Vec<T>` / `Option<Vec<T>>` return. Skip if a plan
@@ -785,7 +785,7 @@ pub fn apply_leaf_vec_folds<M>(
                     } else {
                         inner_shape
                     };
-                    registry.require_output(&vec_elem, &loc);
+                    registry.require_output(&vec_elem);
                     // The fold delivers the return element-by-element, so the
                     // whole `Vec<T>` / `Option<Vec<T>>` converter is not needed.
                     // De-require it: for String / scalar elements it still
@@ -821,7 +821,7 @@ pub fn apply_leaf_vec_folds<M>(
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                registry.require_output(&elem, &loc);
+                registry.require_output(&elem);
                 let plan =
                     whole_leaf_fold_plan(&elem, UnfoldShape::Iterable(Box::new(UnfoldShape::Base)));
                 registry.callback_arg_plans.insert(key, plan);
@@ -938,7 +938,7 @@ fn process_decl<M>(
     ed: &OutputDecl,
 ) -> Result<(), UnfoldError> {
     {
-        let (item_fn, loc) = registry
+        let (item_fn, _) = registry
             .functions
             .get(&ed.func)
             .cloned()
@@ -1016,7 +1016,7 @@ fn process_decl<M>(
                 register_decon_spec(registry, acc, &decon, &records, &element)?;
                 let plan = build_plan(acc, registry, ed, by_ref, &element, shape, &records, decon)?;
                 for leaf in &plan.leaves {
-                    registry.require_output(&leaf.out_ty, &loc);
+                    registry.require_output(&leaf.out_ty);
                 }
                 plan
             } else {
@@ -1025,7 +1025,7 @@ fn process_decl<M>(
                 // No declaration is involved (`decon: None`) — the element
                 // crosses whole through its own converter.
                 let by_ref = matches!(&inner, syn::Type::Reference(_));
-                registry.require_output(&inner, &loc);
+                registry.require_output(&inner);
                 UnfoldPlan {
                     source: inner.clone(),
                     decon: None,
@@ -1065,7 +1065,7 @@ fn process_decl<M>(
             register_decon_spec(registry, acc, &decon, &records, &source)?;
             let plan = build_plan(acc, registry, ed, by_ref, &source, shape, &records, decon)?;
             for leaf in &plan.leaves {
-                registry.require_output(&leaf.out_ty, &loc);
+                registry.require_output(&leaf.out_ty);
             }
             plan
         };
@@ -1099,7 +1099,7 @@ fn process_decl<M>(
             } else {
                 leaf_ty
             };
-            registry.require_output(&cv_ty, &loc);
+            registry.require_output(&cv_ty);
             UnfoldPlan {
                 delivery: Delivery::Return,
                 convert_out_ty: Some(cv_ty),

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -93,9 +93,10 @@ fn accessor_optional_primitive() {
         "z_timestamp_ntp64"
     );
     assert_eq!(plan.leaves[0].out_ty.to_token_stream().to_string(), "i64");
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::from_type(&syn::parse_quote!(i64))));
+    assert!(
+        reg.output_types[&TypeKey::from_type(&syn::parse_quote!(i64))].root,
+        "the leaf type must be a root"
+    );
 }
 
 #[test]
@@ -161,9 +162,7 @@ fn accessor_plan_byref() {
 
     // Leaf out_tys registered as required outputs so the resolver builds
     // their converters.
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::from_type(&syn::parse_quote!(&str))));
+    assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(&str))].root);
 }
 
 #[test]
@@ -756,9 +755,7 @@ fn iterable_whole_element_plan() {
             .map(|t| t.to_token_stream().to_string()),
         Some("ZZenohId".to_string())
     );
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::from_type(&syn::parse_quote!(ZZenohId))));
+    assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(ZZenohId))].root);
 }
 
 #[test]
@@ -863,9 +860,7 @@ fn convert_output_single_value() {
         Some("Option < i64 >".to_string())
     );
     // The shaped convert type is registered as a required output.
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::from_type(&syn::parse_quote!(Option<i64>))));
+    assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(Option<i64>))].root);
 }
 
 #[test]
@@ -1354,12 +1349,8 @@ fn callback_arg_plan_derived() {
         "SampleKind"
     );
     // Leaf out_tys registered so the resolver builds their converters.
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::from_type(&syn::parse_quote!(&str))));
-    assert!(reg
-        .required_outputs_scan
-        .contains(&TypeKey::from_type(&syn::parse_quote!(SampleKind))));
+    assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(&str))].root);
+    assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(SampleKind))].root);
     // No return-position plan was created for the declaring fn.
     assert!(reg.unfold_plans.is_empty());
 }
@@ -1740,8 +1731,9 @@ fn sum_return_is_a_fixed_builder_plan() {
     assert!(!plan.leaves[0].has_converter());
     assert!(plan.leaves[1].has_converter());
     assert!(
-        !reg.required_outputs_scan
-            .contains(&TypeKey::from_type(&syn::parse_quote!(Reading))),
+        !reg.output_types
+            .get(&TypeKey::from_type(&syn::parse_quote!(Reading)))
+            .is_some_and(|c| c.root),
         "a sum has no whole-value converter, so its return must not require one"
     );
 }
@@ -1771,7 +1763,9 @@ fn sum_return_layers_ride_the_shape_fold() {
     for ty in ["Option<Reading>", "Vec<Reading>", "Reading"] {
         let ty: syn::Type = syn::parse_str(ty).unwrap();
         assert!(
-            !reg.required_outputs_scan.contains(&TypeKey::from_type(&ty)),
+            !reg.output_types
+                .get(&TypeKey::from_type(&ty))
+                .is_some_and(|c| c.root),
             "no layer of a sum return may require a whole-value converter: {}",
             ty.to_token_stream()
         );
@@ -1793,10 +1787,9 @@ fn sum_return_layers_ride_the_shape_fold() {
 fn a_vec_only_sum_return_drops_the_bare_requirement() {
     let mut reg = reg_with(&["fn read_all(n: i32) -> Vec<Reading> { todo!() }"]);
     let bare: syn::Type = syn::parse_quote!(Reading);
-    reg.require_output(&bare, &crate::SourceLocation::default());
+    reg.require_output(&bare);
     assert!(
-        reg.required_outputs_scan
-            .contains(&TypeKey::from_type(&bare)),
+        reg.output_types[&TypeKey::from_type(&bare)].root,
         "fixture precondition: the bare element starts out required"
     );
 
@@ -1807,7 +1800,9 @@ fn a_vec_only_sum_return_drops_the_bare_requirement() {
     for ty in ["Vec<Reading>", "Reading"] {
         let ty: syn::Type = syn::parse_str(ty).unwrap();
         assert!(
-            !reg.required_outputs_scan.contains(&TypeKey::from_type(&ty)),
+            !reg.output_types
+                .get(&TypeKey::from_type(&ty))
+                .is_some_and(|c| c.root),
             "no layer of a sum return may require a whole-value converter: {}",
             ty.to_token_stream()
         );

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -2,7 +2,7 @@
 //!
 //! `write_rust` collects every resolved input/output converter (each entry
 //! already carries its full `ItemFn`), every per-item `on_<kind>` output,
-//! and every passthrough item; concatenates them; and hands them to
+//! and every injected guard; concatenates them; and hands them to
 //! `Destination::write` (which does prettyplease formatting and
 //! resolves the path against `OUT_DIR`).
 
@@ -105,27 +105,25 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     // Consts: an adapter WITH a const declaration mechanism
     // (`declared_consts() == Some(set)`) emits declared consts only,
     // symmetric with functions; an adapter without one (`None`) gets every
-    // const passed through verbatim via the default `on_const`. Unnamed
-    // consts (`const _`, e.g. the injected `konst::assertc_eq!` feature
-    // guard) are infrastructure, not declarable API — they bypass the gate
-    // and always emit.
+    // const passed through verbatim via the default `on_const`. Prebindgen's
+    // own injected feature guards are not consts at all — see `guards` below.
     let declared_consts = ext.declared_consts();
     items.extend(parse_items_from_tokens(
         "on_const",
         sorted_items_by_ident(&registry.consts)
             .into_iter()
             .filter(|(ident, _)| {
-                *ident == "_"
-                    || declared_consts
-                        .as_ref()
-                        .is_none_or(|set| set.contains(*ident))
+                declared_consts
+                    .as_ref()
+                    .is_none_or(|set| set.contains(*ident))
             })
             .map(|(_, (item, _))| ext.on_const(item, registry)),
     )?);
 
-    // 3. Passthrough items verbatim.
-    for (item, _) in &registry.passthrough {
-        items.push(item.clone());
+    // 3. Prebindgen's own injected feature guards, verbatim. Last, and in
+    //    stream order, so a generated file ends with one guard per source crate.
+    for guard in &registry.guards {
+        items.push(syn::Item::Const(guard.origin.syntax.clone()));
     }
 
     // 4. Cross-cutting post-process pass. Adapters use this to qualify

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -2,7 +2,7 @@
 //!
 //! `write_rust` collects every resolved input/output converter (each entry
 //! already carries its full `ItemFn`), every per-item `on_<kind>` output,
-//! and every injected guard; concatenates them; and hands them to
+//! and every anonymous const; concatenates them; and hands them to
 //! `Destination::write` (which does prettyplease formatting and
 //! resolves the path against `OUT_DIR`).
 
@@ -120,8 +120,9 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
             .map(|(_, (item, _))| ext.on_const(item, registry)),
     )?);
 
-    // 3. Prebindgen's own injected feature guards, verbatim. Last, and in
-    //    stream order, so a generated file ends with one guard per source crate.
+    // 3. Anonymous consts, verbatim. Last, and in stream order. Ungated on
+    //    purpose: with no name there is nothing for an adapter to declare, so
+    //    the const gate above cannot apply to them.
     for guard in &registry.guards {
         items.push(syn::Item::Const(guard.origin.syntax.clone()));
     }

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -162,13 +162,13 @@ pub fn collect_converter_items<M>(registry: &Registry<M>) -> Vec<(syn::Ident, sy
 }
 
 fn walk_resolved<M, F: FnMut(&TypeKey, &TypeEntry<M>)>(
-    table: &std::collections::HashMap<TypeKey, Option<TypeEntry<M>>>,
+    table: &std::collections::HashMap<TypeKey, crate::api::core::registry::TypeCell<M>>,
     mut f: F,
 ) {
     let mut keys: Vec<&TypeKey> = table.keys().collect();
     keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
     for key in keys {
-        if let Some(Some(entry)) = table.get(key) {
+        if let Some(entry) = table.get(key).and_then(|c| c.entry.as_ref()) {
             f(key, entry);
         }
     }

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 
 use super::*;
-use crate::SourceLocation;
+use crate::{api::test_util::cell, SourceLocation};
 
 struct IdentityExt;
 
@@ -66,35 +66,41 @@ fn dedup_and_sort() {
 
     reg.input_types.insert(
         key_a.clone(),
-        Some(TypeEntry {
-            destination: wire.clone(),
-            function: syn::parse_quote!(
-                fn handle_to_u64_aaaa(v: i64) -> u64 {
-                    v as u64
-                }
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            required: true,
-            niches: crate::api::core::niches::Niches::empty(),
-            metadata: (),
-        }),
+        cell(
+            &key_a,
+            true,
+            Some(TypeEntry {
+                destination: wire.clone(),
+                function: syn::parse_quote!(
+                    fn handle_to_u64_aaaa(v: i64) -> u64 {
+                        v as u64
+                    }
+                ),
+                pre_stages: vec![],
+                subs: vec![],
+                niches: crate::api::core::niches::Niches::empty(),
+                metadata: (),
+            }),
+        ),
     );
     reg.input_types.insert(
         key_b.clone(),
-        Some(TypeEntry {
-            destination: wire2.clone(),
-            function: syn::parse_quote!(
-                fn Ptr_to_Sample_bbbb(v: *const u8) -> Sample {
-                    decode_sample(v)
-                }
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            required: true,
-            niches: crate::api::core::niches::Niches::empty(),
-            metadata: (),
-        }),
+        cell(
+            &key_b,
+            true,
+            Some(TypeEntry {
+                destination: wire2.clone(),
+                function: syn::parse_quote!(
+                    fn Ptr_to_Sample_bbbb(v: *const u8) -> Sample {
+                        decode_sample(v)
+                    }
+                ),
+                pre_stages: vec![],
+                subs: vec![],
+                niches: crate::api::core::niches::Niches::empty(),
+                metadata: (),
+            }),
+        ),
     );
 
     let items = collect_converter_items(&reg);

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -222,3 +222,100 @@ fn bad_generated_tokens_report_emission_phase() {
         err
     );
 }
+
+/// An adapter with a const mechanism gates **named** consts and cannot gate
+/// guards — pinned at the emission site, not just in the registry.
+///
+/// `a_guard_never_reaches_the_const_surface` proves the maps are separate, but it
+/// never calls `write_rust`. This is what would catch a change that keeps
+/// `Registry::guards` populated and then forgets to emit them, or re-gates them
+/// on the way out.
+#[test]
+fn guards_emit_ungated_and_in_stream_order() {
+    /// Declares a const mechanism (`Some`) and declares nothing through it.
+    struct ConstGatingExt;
+
+    impl Prebindgen for ConstGatingExt {
+        type Metadata = ();
+
+        fn declared_consts(&self) -> Option<HashSet<syn::Ident>> {
+            // The gate exists and is empty: `KEPT_OUT` must not emit.
+            Some(HashSet::new())
+        }
+        fn on_function(&self, f: &syn::ItemFn, _r: &Registry<()>) -> TokenStream {
+            f.to_token_stream()
+        }
+        fn on_struct(&self, s: &syn::ItemStruct, _r: &Registry<()>) -> TokenStream {
+            s.to_token_stream()
+        }
+        fn on_enum(&self, e: &syn::ItemEnum, _r: &Registry<()>) -> TokenStream {
+            e.to_token_stream()
+        }
+        fn on_input_type(
+            &self,
+            _ty: &syn::Type,
+            _r: &Registry<()>,
+        ) -> Option<crate::api::core::prebindgen::ConverterImpl<()>> {
+            None
+        }
+        fn on_output_type(
+            &self,
+            _ty: &syn::Type,
+            _r: &Registry<()>,
+        ) -> Option<crate::api::core::prebindgen::ConverterImpl<()>> {
+            None
+        }
+    }
+
+    let loc = SourceLocation::default();
+    // Two distinguishable guards, straddling the named const, so the assertion
+    // below pins order rather than merely presence.
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                const _: () = {
+                    first_check();
+                };
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub const KEPT_OUT: u64 = 7;
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                const _: () = {
+                    second_check();
+                };
+            ),
+            loc.clone(),
+        ),
+    ];
+    let registry: Registry<()> = Registry::from_items(items).expect("index");
+    assert_eq!(registry.guards.len(), 2);
+
+    let dir = crate::api::test_util::unique_test_dir("write_guards");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = registry
+        .resolve(ConstGatingExt)
+        .expect("resolve")
+        .write_rust(dir.join("gen.rs"))
+        .expect("write_rust");
+    let src = std::fs::read_to_string(&path).unwrap();
+
+    // The named const is gated out; both guards emit regardless.
+    assert!(
+        !src.contains("KEPT_OUT"),
+        "declared_consts is empty:\n{src}"
+    );
+    let first = src
+        .find("first_check")
+        .unwrap_or_else(|| panic!("guard 1 missing:\n{src}"));
+    let second = src
+        .find("second_check")
+        .unwrap_or_else(|| panic!("guard 2 missing:\n{src}"));
+    assert!(first < second, "guards must keep stream order:\n{src}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -315,7 +315,7 @@ pub(crate) fn validate_bindings(
         let mut const_idents: Vec<&syn::Ident> = registry.consts.keys().collect();
         const_idents.sort();
         for ident in const_idents {
-            if *ident == "_" || !declared_consts.contains(ident) {
+            if !declared_consts.contains(ident) {
                 continue;
             }
             let (item_const, _) = &registry.consts[ident];

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -8,7 +8,7 @@ use crate::{
             niches::{NicheSlot, Niches},
             registry::{Registry, TypeEntry, TypeKey},
         },
-        test_util::unique_test_dir,
+        test_util::{cell, unique_test_dir},
     },
     SourceLocation,
 };
@@ -55,7 +55,6 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
         function: func,
         pre_stages: vec![],
         subs: vec![],
-        required: false,
         niches,
         metadata: KotlinMeta::default(),
     }
@@ -67,8 +66,9 @@ fn install_input(
     _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
+    let key = TypeKey::parse(ty_str).expect("test type");
     reg.input_types
-        .insert(TypeKey::parse(ty_str).expect("test type"), Some(e));
+        .insert(key.clone(), cell(&key, true, Some(e)));
 }
 
 fn install_output(
@@ -77,6 +77,7 @@ fn install_output(
     _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
+    let key = TypeKey::parse(ty_str).expect("test type");
     reg.output_types
-        .insert(TypeKey::parse(ty_str).expect("test type"), Some(e));
+        .insert(key.clone(), cell(&key, true, Some(e)));
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1587,12 +1587,6 @@ impl Prebindgen for JniGen {
     /// const's type flows through the ordinary output-converter machinery);
     /// only the callee expression differs — a path to the const, not a call.
     fn on_const(&self, c: &syn::ItemConst, registry: &Registry<KotlinMeta>) -> TokenStream {
-        // Unnamed infrastructure consts (`const _`, e.g. the injected
-        // `konst::assertc_eq!` feature guard) pass through verbatim — no
-        // getter, no Kotlin surface.
-        if c.ident == "_" {
-            return c.to_token_stream();
-        }
         reject_handle_const(self, c);
         let getter = const_getter_fn(c);
         let const_ident = &c.ident;

--- a/prebindgen/src/api/test_util.rs
+++ b/prebindgen/src/api/test_util.rs
@@ -6,7 +6,20 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use crate::api::core::registry::Registry;
+use crate::api::core::registry::{Registry, TypeCell, TypeEntry, TypeKey, TypeSubject};
+
+/// A type-table cell for a fixture.
+///
+/// The subject is always [`TypeSubject::Adapter`]: a hand-built table has no
+/// `Flat` behind it, so no key in one has a source reading. A test that cares
+/// about the `Source` side builds its registry from items instead.
+pub(crate) fn cell<M>(key: &TypeKey, root: bool, entry: Option<TypeEntry<M>>) -> TypeCell<M> {
+    TypeCell {
+        subject: TypeSubject::Adapter(key.to_type()),
+        root,
+        entry,
+    }
+}
 
 /// Index a `Registry` from a list of Rust item sources.
 ///

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -296,7 +296,7 @@ pub mod core {
     pub use crate::api::core::{
         ConverterImpl, Direction, DomainScalar, Element, Flat, Generation, Gravestone, NicheSlot,
         Niches, Prebindgen, Registry, RegistryBuilder, RepresentationDomain, ScalarValue,
-        ScanError, Stage, Transmute, TypeEntry, TypeKey, WriteRustError,
+        ScanError, Stage, Transmute, TypeCell, TypeEntry, TypeKey, TypeSubject, WriteRustError,
     };
 }
 


### PR DESCRIPTION
Stacked on #238 (L1). Enabling step for L2.

L1 made `Registry` a projection of `Flat` for the **item** maps. The **type
table** — what generation actually runs on — still threw the frontend's work away,
keying cells by a normalized `syn::Type` with the classification deleted. That
deletion is why `types_util` exports `is_option_type` / `option_inner_type` /
`result_parts` / `bare_path_ident`: **144 uses outside that one file**, all
recomputing what `Flat` already decided.

## `TypeEntry` had nothing to reuse — the cell did

`destination`, `function`, `pre_stages`, `niches`, `metadata` are the adapter's
answer, not the source's meaning. Flat models what the source means; `TypeEntry` is
what the target does about it, and neither contains the other. The reuse is one
level up:

```rust
input_types: HashMap<TypeKey, TypeCell<M>>

TypeCell  { subject: TypeSubject, root: bool, entry: Option<TypeEntry<M>> }
TypeSubject::Source(TypeRef) | TypeSubject::Adapter(syn::Type)
```

An enum rather than an `Option<TypeRef>` beside a location, because a type the
flat API contains **is** a `TypeRef` — classification and origin together — and a
type only the binding authored has no reading *and* no source location. That is a
fact about it, not information that went missing.

So `type_locations` is deleted: `TypeRef.origin.location` **is** it. The old map
was worse than duplicated, it was circular — the declared-type path read a key's
location back out of the map it was about to write, falling back to
`SourceLocation::default()`. With one origin per cell the whole `loc` parameter
threads out of `ensure_entry`, the three `scan_*` methods, `register_type_*`,
`require_input` and `require_output`.

## The readings come from the model, not from lowering twice

`Flat::type_refs` walks every type the API *mentions* — distinct from `types()`,
which is every type it *declares* — and `from_flat` indexes it before anything is
scanned. `ensure_entry` looks a key up.

Keying by type rather than threading positionally is what makes it right for
generics: `TypeId` carries no arguments, so `MyBox<Foo>` has no `Foo` child in its
`kind`, yet the registry's walk still emits a `Foo` sub-key — which then finds its
reading from wherever else in the model `Foo` appears.

`first_unresolved`'s per-element slot enumeration became `element_type_refs`, so
the slots are listed once and `type_refs` cannot drift from the resolver.

## `required` stops being stored

It was one name over three storages, and two facts: *is a root* (a scan fact) and
*is reachable from a root through the adapter's `subs`* (a derivation). The old
code wrote the derived answer back into `TypeEntry::required` **and**
`required_*_scan`, which already held the root fact.

Now the cell keeps `root` and `resolve::required_set` returns the reachable set for
`final_invariant_check`. Gone: `required_inputs_scan`, `required_outputs_scan`,
`TypeEntry::required`, `propagate_required`, `set_required`, `is_required_resolved`,
`mark_and_get_subs`, `is_required_*_at_scan`, `lookup_slot`.

`root` stays a field rather than folding into `TypeSubject`, because the axes are
independent — all four combinations occur:

| | `root: true` | `root: false` |
|---|---|---|
| **`Source`** | a declared fn's top-level param or return | `Foo` inside `Vec<Foo>`; a field type |
| **`Adapter`** | `required_output_types`, a declared type with no indexed body, an `unfold` leaf | a nested position the model never mentions |

## `immediate_edges` reads elements

A declared type's fields come from `flat.declared_type` rather than
`syn::Fields::Named`, which silently skipped positional fields. Same edge set today
— a tuple struct is an `Extern` and declares none — without the asymmetry.

Its fallout was one fixture that hand-inserted into `reg.structs` while leaving
`flat` empty. It now drives the real scan, which is a state the pipeline can
actually produce.

## Measured

**3 `Adapter` cells out of 342** across the four examples: `Option<Summary>` and
`Result<Summary, String>` (shapes the adapter composes, which the source never
writes), and `MaybeUninit<Payload>`.

That last one is the evidence for a deferral. Flat absorbs `MaybeUninit` into
`RefMode::Out`, so the bare node exists *only* in the registry's syntactic walk —
which is exactly why `immediate_subtype_positions` is **not** yet replaced by a
`TypeKind`-children walk, and why the `Option` earns its keep rather than being
collapsed away.

**The ledger does not move.** This makes the classification available; taking
callers off raw syntax is L2's own work.

## Verification

* `regen-check.sh` — **byte-identical**
* covertest-kotlin `./gradlew run` — 48 sections
* 523 (all-features) + 451 (default) tests, doctests, clippy in all three feature
  configs with `-D warnings`

Three tests added. The third — a type reachable only through a converter's `subs`
must still fail the build — was checked against a deliberately broken `subs` walk
and fails as it should.