### PR TITLE
`const _` is a Guard, not a Constant

### DIFF
--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -15,8 +15,8 @@ use crate::SourceLocation;
 /// One member of the flat API.
 ///
 /// Three modelled kinds — a function, a type, a constant — plus
-/// [`Element::Guard`] for prebindgen's own injected checks and
-/// [`Element::Unsupported`] for anything the language cannot express. No *marked*
+/// [`Element::Guard`] for an anonymous const and [`Element::Unsupported`] for
+/// anything the language cannot express. No *marked*
 /// item passes through verbatim: a `#[prebindgen]` crate marks the items that
 /// cross the boundary, and the supporting code around them is the consumer
 /// crate's job — the proc-macro enforces that already, refusing to mark a `use`,
@@ -27,8 +27,8 @@ pub enum Element {
     /// A type declaration: a struct, either enum shape, or an opaque handle.
     Type(Type),
     Constant(Constant),
-    /// A compile-time check prebindgen injects into the generated file. Carries
-    /// no API surface: nothing can name it, declare it, or cross it.
+    /// An anonymous const — infrastructure re-emitted verbatim. Carries no API
+    /// surface: nothing can name it, declare it, or cross it.
     Guard(Guard),
     /// An item the language cannot express — a parameter type outside the
     /// grammar, a `self` receiver, a reference to a type the flat API never
@@ -350,17 +350,23 @@ pub struct Constant {
     pub origin: Origin<syn::ItemConst>,
 }
 
-/// A compile-time check prebindgen injects into the generated file.
+/// An **anonymous const**: `const _: T = ..`, whatever produced it.
 ///
-/// Today that is one `const _: () = { konst::assertc_eq!(..) }` per ingested
-/// source crate, synthesized by [`Source`](crate::Source) to assert that the
-/// crate's `FEATURES` match what the build script asked for. **Nothing marked it**
-/// — it is prebindgen's own item, riding the same stream — which is why it is not
-/// part of the flat API even though it arrives with it.
+/// The definition is the shape, not the origin. A const with no name has no
+/// address, so nothing can declare it, reference it, or emit it as an alias —
+/// which is what puts it outside the flat API rather than in it, and that holds
+/// however the item arrived: synthesized, hand-fed to [`FlatBuilder`](super::FlatBuilder), or written
+/// as `#[prebindgen] const _: () = ..` in a source crate.
 ///
-/// Recognised by shape rather than by provenance: a constant with no name has no
-/// address, so nothing can declare it, reference it, or emit it as an alias. That
-/// is the property that makes it infrastructure, and it holds whoever wrote it.
+/// **Today's producer** is [`Source`](crate::Source)'s cfg filter, which
+/// synthesizes `const _: () = { konst::assertc_eq!(..) }` to assert that a source
+/// crate's `FEATURES` match what the build script asked for. Nothing *marked*
+/// that one — it is prebindgen's own item riding the same stream — but it is not
+/// the only thing that can land here, and the model does not claim otherwise.
+///
+/// **Cardinality is zero or more.** `enable_feature_filtering(None)` produces
+/// none, and each item iterator taken from a `Source` emits its own, so composing
+/// two iterators from one crate yields two.
 ///
 /// It carries no type, unlike a [`Constant`]. The item is emitted verbatim, so
 /// what its types mean is the consumer crate's business; modelling them would let

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -15,8 +15,9 @@ use crate::SourceLocation;
 /// One member of the flat API.
 ///
 /// Three modelled kinds — a function, a type, a constant — plus
-/// [`Element::Unsupported`] for anything the language cannot express. There is no
-/// verbatim-passthrough variant: a `#[prebindgen]` crate marks the items that
+/// [`Element::Guard`] for prebindgen's own injected checks and
+/// [`Element::Unsupported`] for anything the language cannot express. No *marked*
+/// item passes through verbatim: a `#[prebindgen]` crate marks the items that
 /// cross the boundary, and the supporting code around them is the consumer
 /// crate's job — the proc-macro enforces that already, refusing to mark a `use`,
 /// `mod`, `impl` or `macro_rules!` at all.
@@ -26,6 +27,9 @@ pub enum Element {
     /// A type declaration: a struct, either enum shape, or an opaque handle.
     Type(Type),
     Constant(Constant),
+    /// A compile-time check prebindgen injects into the generated file. Carries
+    /// no API surface: nothing can name it, declare it, or cross it.
+    Guard(Guard),
     /// An item the language cannot express — a parameter type outside the
     /// grammar, a `self` receiver, a reference to a type the flat API never
     /// declares, or a whole item kind it does not model such as a `union`.
@@ -42,17 +46,16 @@ impl Element {
     /// The item's name, which is also its address: `#[prebindgen]` names live
     /// in one flat namespace across every ingested source crate.
     ///
-    /// `None` when the item has no address — an unnamed `const _` (each
-    /// source's injected feature guard, so several may coexist), or an item
-    /// kind with no identifier at all.
+    /// `None` when the item has no address — a [`Guard`], or an item kind with
+    /// no identifier at all.
     pub fn name(&self) -> Option<&syn::Ident> {
-        let named = match self {
+        match self {
             Element::Function(f) => Some(&f.name),
             Element::Type(t) => Some(t.name()),
             Element::Constant(c) => Some(&c.name),
+            Element::Guard(_) => None,
             Element::Unsupported(u) => u.name.as_ref(),
-        };
-        named.filter(|id| *id != "_")
+        }
     }
 
     /// Where the item was captured, including the crate that marked it.
@@ -64,6 +67,7 @@ impl Element {
             Element::Function(f) => &f.origin.location,
             Element::Type(t) => t.location(),
             Element::Constant(c) => &c.origin.location,
+            Element::Guard(g) => &g.origin.location,
             Element::Unsupported(u) => &u.origin.location,
         }
     }
@@ -74,6 +78,7 @@ impl Element {
             Element::Function(f) => syn::Item::Fn(f.origin.syntax.clone()),
             Element::Type(t) => t.syntax(),
             Element::Constant(c) => syn::Item::Const(c.origin.syntax.clone()),
+            Element::Guard(g) => syn::Item::Const(g.origin.syntax.clone()),
             Element::Unsupported(u) => u.origin.syntax.clone(),
         }
     }
@@ -334,16 +339,35 @@ pub struct Field {
 
 /// A `#[prebindgen]` constant.
 ///
-/// Also the home of the unnamed `const _` feature guard each source injects: it
-/// is a constant, so it is modelled as one, and [`Element::name`] returning
-/// `None` for `_` is what keeps several of them from colliding in the flat
-/// namespace.
+/// Always named: an unnamed `const _` is a [`Guard`], not a constant with no
+/// address.
 #[derive(Clone, Debug)]
 pub struct Constant {
     pub name: syn::Ident,
     pub ty: TypeRef,
     /// The whole item — the initializer expression included, which is where a
     /// consumer that re-emits the value reads it from.
+    pub origin: Origin<syn::ItemConst>,
+}
+
+/// A compile-time check prebindgen injects into the generated file.
+///
+/// Today that is one `const _: () = { konst::assertc_eq!(..) }` per ingested
+/// source crate, synthesized by [`Source`](crate::Source) to assert that the
+/// crate's `FEATURES` match what the build script asked for. **Nothing marked it**
+/// — it is prebindgen's own item, riding the same stream — which is why it is not
+/// part of the flat API even though it arrives with it.
+///
+/// Recognised by shape rather than by provenance: a constant with no name has no
+/// address, so nothing can declare it, reference it, or emit it as an alias. That
+/// is the property that makes it infrastructure, and it holds whoever wrote it.
+///
+/// It carries no type, unlike a [`Constant`]. The item is emitted verbatim, so
+/// what its types mean is the consumer crate's business; modelling them would let
+/// a guard that names something undeclared refuse the whole element.
+#[derive(Clone, Debug)]
+pub struct Guard {
+    /// Emitted verbatim, so the item is all there is.
     pub origin: Origin<syn::ItemConst>,
 }
 

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -121,11 +121,12 @@
 //! module does not model is a `union`, and it is diagnosed like anything else the
 //! language cannot express.
 //!
-//! The one item that *is* re-emitted verbatim was never marked: [`Guard`], the
-//! feature check [`Source`](crate::Source) injects into the stream on its own
-//! behalf. It is modelled rather than dropped because this module must be total
-//! over what it is handed — but it is a separate element, so nothing that
-//! consumes the API has to remember to skip it.
+//! The one item that *is* re-emitted verbatim is a [`Guard`] — an anonymous
+//! const, which has no address and so cannot be part of an API addressed by name.
+//! Today these are the feature checks [`Source`](crate::Source) injects on its own
+//! behalf. Modelled rather than dropped because this module must be total over
+//! what it is handed, and a separate element so nothing that consumes the API has
+//! to remember to skip it.
 //!
 //! # Declaring a handle
 //!
@@ -499,7 +500,7 @@ impl Flat {
             .flat_map(TypeRef::walk)
     }
 
-    /// Prebindgen's own injected compile-time checks, in stream order.
+    /// Every anonymous const, in stream order — **zero or more**.
     ///
     /// Not part of the flat API — see [`Guard`] — but ingested with it, and a
     /// consumer that re-emits the source must re-emit these too.

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -114,12 +114,18 @@
 //! adapter declaration is examined. A binding is built against a model the
 //! frontend could read in full, or it is not built.
 //!
-//! There is **no verbatim passthrough**, because a `#[prebindgen]` crate marks
-//! the items that cross the boundary and leaves the supporting code to the
+//! No **marked** item passes through verbatim, because a `#[prebindgen]` crate
+//! marks the items that cross the boundary and leaves the supporting code to the
 //! consumer. The proc-macro already enforces that — a `use`, `mod`, `impl` or
 //! `macro_rules!` cannot be marked at all — so the only item kind left that this
 //! module does not model is a `union`, and it is diagnosed like anything else the
 //! language cannot express.
+//!
+//! The one item that *is* re-emitted verbatim was never marked: [`Guard`], the
+//! feature check [`Source`](crate::Source) injects into the stream on its own
+//! behalf. It is modelled rather than dropped because this module must be total
+//! over what it is handed — but it is a separate element, so nothing that
+//! consumes the API has to remember to skip it.
 //!
 //! # Declaring a handle
 //!
@@ -168,8 +174,8 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{
-        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Param, Struct,
-        Type, Unsupported, Variant,
+        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Guard, Param,
+        Struct, Type, Unsupported, Variant,
     },
     origin::Origin,
     ty::{RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType, UnsupportedTypeReason},
@@ -327,9 +333,11 @@ impl FlatBuilder {
             crate::api::core::types_util::normalize_item_types(item, &normalization);
         }
 
-        // Pass 1: the consts an array length may name. Unnamed `const _` items
-        // are excluded for the same reason `Element::name` skips them — they
-        // are not addressable, so no length can name one.
+        // Pass 1: the consts an array length may name. Unnamed items are
+        // excluded because no length can name one — the same fact that makes
+        // them `Guard`s. This is the one place that tests the spelling rather
+        // than the classification, and it has to: it runs before Pass 2, so no
+        // classification exists yet.
         let consts = ConstIndex::new(items.iter().filter_map(|(item, loc)| match item {
             syn::Item::Const(c) if c.ident != "_" => Some((
                 c.ident.to_string(),
@@ -491,6 +499,17 @@ impl Flat {
             .flat_map(TypeRef::walk)
     }
 
+    /// Prebindgen's own injected compile-time checks, in stream order.
+    ///
+    /// Not part of the flat API — see [`Guard`] — but ingested with it, and a
+    /// consumer that re-emits the source must re-emit these too.
+    pub fn guards(&self) -> impl Iterator<Item = &Guard> {
+        self.elements.iter().filter_map(|e| match e {
+            Element::Guard(g) => Some(g),
+            _ => None,
+        })
+    }
+
     /// Every item the language could not express, with its diagnosis.
     ///
     /// Present in the model so a consumer can inspect what a source crate marked
@@ -594,6 +613,7 @@ fn resolve_references(elements: &mut [Element]) {
                     Element::Function(f) => &f.origin.location,
                     Element::Type(t) => t.location_rc(),
                     Element::Constant(c) => &c.origin.location,
+                    Element::Guard(g) => &g.origin.location,
                     Element::Unsupported(u) => &u.origin.location,
                 }),
             );
@@ -625,9 +645,12 @@ fn element_type_refs(element: &Element) -> Vec<&TypeRef> {
                 .iter()
                 .flat_map(|a| a.fields.iter().map(|f| &f.ty)),
         ),
-        // An enum names nothing, an extern hides what it names, and an
+        // An enum names nothing, an extern hides what it names, a guard is
+        // emitted verbatim so its types are the consumer's business, and an
         // unsupported item already has a diagnosis worth keeping.
-        Element::Type(Type::Enum(_) | Type::Extern(_)) | Element::Unsupported(_) => {}
+        Element::Type(Type::Enum(_) | Type::Extern(_))
+        | Element::Guard(_)
+        | Element::Unsupported(_) => {}
     }
     refs
 }
@@ -918,10 +941,12 @@ fn lower_item(item: syn::Item, loc: SourceLocation, consts: &ConstIndex) -> Elem
                 }))
             }
         },
-        // Including the unnamed `const _` each source injects as its feature
-        // guard: it is a const, so it is one here. `Element::name` returns
-        // `None` for `_`, which is what keeps several sources' guards from
-        // colliding in the flat namespace.
+        // An unnamed const is a `Guard`, not a constant: nothing can name it, so
+        // it is not part of the API, and several sources' guards coexist because
+        // none of them has an address to collide on.
+        syn::Item::Const(c) if c.ident == "_" => Element::Guard(Guard {
+            origin: Origin::new(c, at),
+        }),
         syn::Item::Const(c) => match lower_type(&c.ty, consts, &at) {
             Ok(ty) => Element::Constant(Constant {
                 name: c.ident.clone(),

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -866,11 +866,12 @@ fn consts_carry_their_type_and_value() {
     assert_eq!(tokens(&c.origin.syntax.expr), "4");
 }
 
-/// An unnamed `const _` — each source's injected feature guard — is a const
-/// like any other, and simply has no address, so several sources may each carry
-/// one without colliding in the flat namespace.
+/// An unnamed const is a `Guard`, not a `Constant`: nothing can name it, so it
+/// is not part of the API. Several coexist because none has an address to
+/// collide on — which is what lets a binding ingest two source crates, each
+/// injecting its own feature check.
 #[test]
-fn an_unnamed_const_is_a_const_without_an_address() {
+fn an_unnamed_const_is_a_guard() {
     let elements = parse(vec![
         syn::parse_quote!(
             const _: () = ();
@@ -879,8 +880,11 @@ fn an_unnamed_const_is_a_const_without_an_address() {
             const _: () = ();
         ),
     ]);
-    assert!(elements.iter().all(|e| matches!(e, Element::Constant(_))));
+    assert!(elements.iter().all(|e| matches!(e, Element::Guard(_))));
     assert!(elements.iter().all(|e| e.name().is_none()));
+    // A guard writes no type slot, so a consumer walking the API never reaches
+    // one — the reason it carries no `TypeRef`.
+    assert!(!elements.iter().any(|e| matches!(e, Element::Constant(_))));
 }
 
 /// An item kind the language does not model is diagnosed, not carried: a

--- a/prebindgen/src/api/core/flat/tests/mod.rs
+++ b/prebindgen/src/api/core/flat/tests/mod.rs
@@ -157,6 +157,7 @@ fn describe(e: &Element) -> String {
         Element::Function(f) => format!("function `{}`", f.name),
         Element::Type(t) => describe_type(t),
         Element::Constant(c) => format!("constant `{}`", c.name),
+        Element::Guard(_) => "guard".to_string(),
         Element::Unsupported(u) => match &u.name {
             Some(name) => format!("unsupported `{name}` ({})", u.error),
             None => format!("unsupported ({})", u.error),

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -14,7 +14,7 @@
 //!    until no unresolved type advances, then propagates `ConverterImpl::subs`
 //!    from required roots.
 //! 5. [`registry::Registry::write_rust`] emits adapter prerequisites,
-//!    converters, per-item wrapper Rust, and passthrough items.
+//!    converters, per-item wrapper Rust, and verbatim anonymous consts.
 //!
 //! Secondary artifacts such as C headers or Kotlin sources are produced by the
 //! language adapter after the Rust registry is resolved.

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -504,14 +504,16 @@ pub trait Prebindgen {
     /// (see [`const_path_alias`]) when [`Self::source_module`] is available —
     /// initializer tokens are never copied, so a const whose initializer
     /// references source-crate internals stays valid in the generated file.
-    /// Unnamed `const _` items (self-contained infrastructure guards, e.g.
-    /// the injected `konst::assertc_eq!` feature check) and adapters without
-    /// a source module pass through verbatim.
+    /// An adapter without a source module passes the const through verbatim.
+    ///
+    /// A const reaching here is always named: prebindgen's own injected feature
+    /// checks are [`Guard`](crate::api::core::flat::Guard)s, not consts, so this
+    /// never has to recognise one.
     fn on_const(&self, c: &syn::ItemConst, _registry: &Registry<Self::Metadata>) -> TokenStream {
         use quote::ToTokens;
         match self.source_module() {
-            Some(m) if c.ident != "_" => const_path_alias(c, m),
-            _ => c.to_token_stream(),
+            Some(m) => const_path_alias(c, m),
+            None => c.to_token_stream(),
         }
     }
 

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -4,8 +4,8 @@
 //! * Item maps (`functions`, `structs`, `enums`, `consts`) indexed by ident.
 //!   Duplicate names across kinds OR within a kind are an error — prebindgen
 //!   items live in one flat namespace.
-//! * `guards` — prebindgen's own injected feature checks, emitted verbatim.
-//!   Not API: no source crate marked them.
+//! * `guards` — anonymous consts, emitted verbatim. Not API: having no name,
+//!   they cannot be declared, so they are neither gated nor addressable.
 //! * `input_types` / `output_types` — direction-specific type tables. Each
 //!   scanned type maps to either a resolved [`TypeEntry`] or an unresolved cell
 //!   that the fixed-point resolver can retry.
@@ -140,7 +140,7 @@ impl fmt::Display for TypeKey {
 /// What a type-table key names.
 ///
 /// Two populations, and saying which is which is what keeps one origin per cell:
-/// a type the flat API contains **is** a [`TypeRef`], reused whole, so its
+/// a type the flat API contains **is** a [`TypeRef`](crate::api::core::flat::TypeRef), reused whole, so its
 /// classification and its source location are already there.
 #[derive(Clone, Debug)]
 pub enum TypeSubject {
@@ -297,9 +297,10 @@ pub struct Registry<M = ()> {
     pub structs: HashMap<syn::Ident, (syn::ItemStruct, SourceLocation)>,
     pub enums: HashMap<syn::Ident, (syn::ItemEnum, SourceLocation)>,
     pub consts: HashMap<syn::Ident, (syn::ItemConst, SourceLocation)>,
-    /// Prebindgen's own injected compile-time checks — one feature guard per
-    /// ingested source crate — re-emitted verbatim. Not API: see
-    /// [`Guard`](crate::api::core::flat::Guard).
+    /// Anonymous consts, in stream order, re-emitted verbatim — **zero or
+    /// more**. Not API: having no name, they cannot be declared, so they are
+    /// neither gated nor addressable. See
+    /// [`Guard`](crate::api::core::flat::Guard) for what produces them.
     pub guards: Vec<crate::api::core::flat::Guard>,
 
     /// Origin crate name of each named item (fn/struct/enum/const),
@@ -827,8 +828,12 @@ impl<M> Registry<M> {
     /// `enums`, `consts`, `guards`). Signature/body scanning that
     /// drives type-resolution requirements happens later, in
     /// [`Self::scan_declared`], and is gated on what the language adapter
-    /// has explicitly declared. Items that are never declared remain in
-    /// the registry but never drive type resolution and never emit.
+    /// has explicitly declared. An **API** item that is never declared remains
+    /// in the registry but never drives type resolution and never emits.
+    ///
+    /// `guards` is the exception, and it is not one of the API maps: an
+    /// anonymous const has no name to declare, so it is outside the gate
+    /// entirely and always emits.
     pub fn from_items<I>(items: I) -> Result<Self, ScanError>
     where
         I: IntoIterator<Item = (syn::Item, SourceLocation)>,
@@ -839,7 +844,7 @@ impl<M> Registry<M> {
         Self::from_flat(flat)
     }
 
-    /// Index a parsed [`Flat`] model.
+    /// Index a parsed [`Flat`](crate::api::core::flat::Flat) model.
     ///
     /// The registry is a **projection** of the model, not a second reading of the
     /// source: `Flat` decided what every item means, and this arranges those
@@ -918,9 +923,8 @@ impl<M> Registry<M> {
                         (t.origin.syntax.clone(), element.location().clone()),
                     );
                 }
-                // Prebindgen's own feature guard, re-emitted verbatim. The only
-                // item here that no source crate marked, which is why it is not
-                // in any of the API maps.
+                // An anonymous const, re-emitted verbatim. No name means nothing
+                // can declare it, which is why it is in none of the API maps.
                 Element::Guard(g) => registry.guards.push(g.clone()),
                 Element::Constant(c) => {
                     registry.consts.insert(

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -4,8 +4,8 @@
 //! * Item maps (`functions`, `structs`, `enums`, `consts`) indexed by ident.
 //!   Duplicate names across kinds OR within a kind are an error — prebindgen
 //!   items live in one flat namespace.
-//! * `passthrough` — items that aren't function/struct/enum/const (use, mod,
-//!   type alias, macro_rules) emitted verbatim.
+//! * `guards` — prebindgen's own injected feature checks, emitted verbatim.
+//!   Not API: no source crate marked them.
 //! * `input_types` / `output_types` — direction-specific type tables. Each
 //!   scanned type maps to either a resolved [`TypeEntry`] or an unresolved cell
 //!   that the fixed-point resolver can retry.
@@ -297,8 +297,10 @@ pub struct Registry<M = ()> {
     pub structs: HashMap<syn::Ident, (syn::ItemStruct, SourceLocation)>,
     pub enums: HashMap<syn::Ident, (syn::ItemEnum, SourceLocation)>,
     pub consts: HashMap<syn::Ident, (syn::ItemConst, SourceLocation)>,
-    /// Anything else (use, mod, type alias, macro_rules) — passed through.
-    pub passthrough: Vec<(syn::Item, SourceLocation)>,
+    /// Prebindgen's own injected compile-time checks — one feature guard per
+    /// ingested source crate — re-emitted verbatim. Not API: see
+    /// [`Guard`](crate::api::core::flat::Guard).
+    pub guards: Vec<crate::api::core::flat::Guard>,
 
     /// Origin crate name of each named item (fn/struct/enum/const),
     /// recorded by [`Self::from_items`] from each item's
@@ -386,7 +388,7 @@ impl<M> Registry<M> {
             structs: HashMap::new(),
             enums: HashMap::new(),
             consts: HashMap::new(),
-            passthrough: Vec::new(),
+            guards: Vec::new(),
             item_origins: HashMap::new(),
             source_modules: Vec::new(),
             input_types: Default::default(),
@@ -822,7 +824,7 @@ impl<M> Registry<M> {
     /// override could only fix one module).
     ///
     /// This step only populates the item maps (`functions`, `structs`,
-    /// `enums`, `consts`, `passthrough`). Signature/body scanning that
+    /// `enums`, `consts`, `guards`). Signature/body scanning that
     /// drives type-resolution requirements happens later, in
     /// [`Self::scan_declared`], and is gated on what the language adapter
     /// has explicitly declared. Items that are never declared remain in
@@ -916,16 +918,10 @@ impl<M> Registry<M> {
                         (t.origin.syntax.clone(), element.location().clone()),
                     );
                 }
-                // An unnamed `const _` is each source's injected `konst` feature
-                // guard: not addressable, re-emitted verbatim. That is the whole
-                // of `passthrough` now — the proc-macro refuses to mark a `use`,
-                // `mod` or `macro_rules!`, so nothing else ever reached it.
-                Element::Constant(c) if named.is_none() => {
-                    registry.passthrough.push((
-                        syn::Item::Const(c.origin.syntax.clone()),
-                        element.location().clone(),
-                    ));
-                }
+                // Prebindgen's own feature guard, re-emitted verbatim. The only
+                // item here that no source crate marked, which is why it is not
+                // in any of the API maps.
+                Element::Guard(g) => registry.guards.push(g.clone()),
                 Element::Constant(c) => {
                     registry.consts.insert(
                         c.name.clone(),
@@ -1245,12 +1241,8 @@ impl<M> Registry<M> {
             let mut skipped_consts: Vec<String> = self
                 .consts
                 .keys()
-                // Unnamed consts (`const _`, e.g. the injected feature
-                // guard) are infrastructure: not declarable, always emitted
-                // verbatim — never a skip.
                 .filter(|k| {
-                    *k != "_"
-                        && !decl_consts.contains(*k)
+                    !decl_consts.contains(*k)
                         && !declared.ignored_consts.contains(*k)
                         && !pred_ignored(&k.to_string())
                 })

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -905,7 +905,11 @@ fn from_flat_projects_each_element_kind() {
     assert!(reg.enums.contains_key(&id("Sum")), "a sum is an enum here");
     assert!(reg.enums.contains_key(&id("Flags")));
     assert!(reg.consts.contains_key(&id("K")));
-    assert_eq!(reg.guards.len(), 2, "one guard per source");
+    assert_eq!(
+        reg.guards.len(),
+        2,
+        "both anonymous consts, in stream order"
+    );
     assert!(
         !reg.structs.contains_key(&id("Handle")) && !reg.enums.contains_key(&id("Handle")),
         "an Extern names a type; it declares no body to index"

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -750,7 +750,7 @@ fn builder_and_from_items_agree() {
         built.default_module().map(module),
         streamed.default_module().map(module)
     );
-    assert_eq!(built.passthrough.len(), streamed.passthrough.len());
+    assert_eq!(built.guards.len(), streamed.guards.len());
 }
 
 // ── What a table cell knows about its type ─────────────────────────────
@@ -905,7 +905,7 @@ fn from_flat_projects_each_element_kind() {
     assert!(reg.enums.contains_key(&id("Sum")), "a sum is an enum here");
     assert!(reg.enums.contains_key(&id("Flags")));
     assert!(reg.consts.contains_key(&id("K")));
-    assert_eq!(reg.passthrough.len(), 2, "one guard per source");
+    assert_eq!(reg.guards.len(), 2, "one guard per source");
     assert!(
         !reg.structs.contains_key(&id("Handle")) && !reg.enums.contains_key(&id("Handle")),
         "an Extern names a type; it declares no body to index"
@@ -1028,4 +1028,53 @@ fn a_well_formed_binding_local_fn_passes() {
     };
     reg.resolve(ext)
         .expect("a grammatical local fn passes, undeclared types and all");
+}
+
+/// A guard is not a const, structurally — so nothing that consumes the const
+/// surface has to remember it exists.
+///
+/// The three `c.ident == "_"` sentinel checks this replaced had gone **dead**
+/// without anyone noticing: once ingestion routed unnamed consts away from
+/// `consts`, they guarded a state the pipeline could no longer produce. This is
+/// the assertion that would have caught that, and that keeps a future
+/// reclassification honest.
+#[test]
+fn a_guard_never_reaches_the_const_surface() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                const _: () = ();
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub const REAL: u64 = 7;
+            ),
+            loc.clone(),
+        ),
+        // A second source's guard: several coexist, having no address to collide on.
+        (
+            syn::parse_quote!(
+                const _: () = ();
+            ),
+            loc.clone(),
+        ),
+    ];
+    let mut reg: Registry<()> = Registry::from_items(items).unwrap();
+
+    assert_eq!(reg.guards.len(), 2);
+    assert_eq!(reg.consts.len(), 1);
+    assert!(reg
+        .consts
+        .contains_key(&syn::parse_str::<syn::Ident>("REAL").unwrap()));
+
+    // An adapter WITH a const mechanism that declares nothing warns about `REAL`
+    // only: a guard is not undeclared API, it is not API.
+    let ext = StubExt {
+        consts: Some(HashSet::new()),
+        ..Default::default()
+    };
+    reg.scan_declared(&ext).expect("guards are not declarable");
 }

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -2,7 +2,7 @@
 //!
 //! `write_rust` collects every resolved input/output converter (each entry
 //! already carries its full `ItemFn`), every per-item `on_<kind>` output,
-//! and every passthrough item; concatenates them; and hands them to
+//! and every injected guard; concatenates them; and hands them to
 //! `Destination::write` (which does prettyplease formatting and
 //! resolves the path against `OUT_DIR`).
 
@@ -105,27 +105,25 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     // Consts: an adapter WITH a const declaration mechanism
     // (`declared_consts() == Some(set)`) emits declared consts only,
     // symmetric with functions; an adapter without one (`None`) gets every
-    // const passed through verbatim via the default `on_const`. Unnamed
-    // consts (`const _`, e.g. the injected `konst::assertc_eq!` feature
-    // guard) are infrastructure, not declarable API — they bypass the gate
-    // and always emit.
+    // const passed through verbatim via the default `on_const`. Prebindgen's
+    // own injected feature guards are not consts at all — see `guards` below.
     let declared_consts = ext.declared_consts();
     items.extend(parse_items_from_tokens(
         "on_const",
         sorted_items_by_ident(&registry.consts)
             .into_iter()
             .filter(|(ident, _)| {
-                *ident == "_"
-                    || declared_consts
-                        .as_ref()
-                        .is_none_or(|set| set.contains(*ident))
+                declared_consts
+                    .as_ref()
+                    .is_none_or(|set| set.contains(*ident))
             })
             .map(|(_, (item, _))| ext.on_const(item, registry)),
     )?);
 
-    // 3. Passthrough items verbatim.
-    for (item, _) in &registry.passthrough {
-        items.push(item.clone());
+    // 3. Prebindgen's own injected feature guards, verbatim. Last, and in
+    //    stream order, so a generated file ends with one guard per source crate.
+    for guard in &registry.guards {
+        items.push(syn::Item::Const(guard.origin.syntax.clone()));
     }
 
     // 4. Cross-cutting post-process pass. Adapters use this to qualify

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -2,7 +2,7 @@
 //!
 //! `write_rust` collects every resolved input/output converter (each entry
 //! already carries its full `ItemFn`), every per-item `on_<kind>` output,
-//! and every injected guard; concatenates them; and hands them to
+//! and every anonymous const; concatenates them; and hands them to
 //! `Destination::write` (which does prettyplease formatting and
 //! resolves the path against `OUT_DIR`).
 
@@ -120,8 +120,9 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
             .map(|(_, (item, _))| ext.on_const(item, registry)),
     )?);
 
-    // 3. Prebindgen's own injected feature guards, verbatim. Last, and in
-    //    stream order, so a generated file ends with one guard per source crate.
+    // 3. Anonymous consts, verbatim. Last, and in stream order. Ungated on
+    //    purpose: with no name there is nothing for an adapter to declare, so
+    //    the const gate above cannot apply to them.
     for guard in &registry.guards {
         items.push(syn::Item::Const(guard.origin.syntax.clone()));
     }

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -222,3 +222,100 @@ fn bad_generated_tokens_report_emission_phase() {
         err
     );
 }
+
+/// An adapter with a const mechanism gates **named** consts and cannot gate
+/// guards — pinned at the emission site, not just in the registry.
+///
+/// `a_guard_never_reaches_the_const_surface` proves the maps are separate, but it
+/// never calls `write_rust`. This is what would catch a change that keeps
+/// `Registry::guards` populated and then forgets to emit them, or re-gates them
+/// on the way out.
+#[test]
+fn guards_emit_ungated_and_in_stream_order() {
+    /// Declares a const mechanism (`Some`) and declares nothing through it.
+    struct ConstGatingExt;
+
+    impl Prebindgen for ConstGatingExt {
+        type Metadata = ();
+
+        fn declared_consts(&self) -> Option<HashSet<syn::Ident>> {
+            // The gate exists and is empty: `KEPT_OUT` must not emit.
+            Some(HashSet::new())
+        }
+        fn on_function(&self, f: &syn::ItemFn, _r: &Registry<()>) -> TokenStream {
+            f.to_token_stream()
+        }
+        fn on_struct(&self, s: &syn::ItemStruct, _r: &Registry<()>) -> TokenStream {
+            s.to_token_stream()
+        }
+        fn on_enum(&self, e: &syn::ItemEnum, _r: &Registry<()>) -> TokenStream {
+            e.to_token_stream()
+        }
+        fn on_input_type(
+            &self,
+            _ty: &syn::Type,
+            _r: &Registry<()>,
+        ) -> Option<crate::api::core::prebindgen::ConverterImpl<()>> {
+            None
+        }
+        fn on_output_type(
+            &self,
+            _ty: &syn::Type,
+            _r: &Registry<()>,
+        ) -> Option<crate::api::core::prebindgen::ConverterImpl<()>> {
+            None
+        }
+    }
+
+    let loc = SourceLocation::default();
+    // Two distinguishable guards, straddling the named const, so the assertion
+    // below pins order rather than merely presence.
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                const _: () = {
+                    first_check();
+                };
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub const KEPT_OUT: u64 = 7;
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                const _: () = {
+                    second_check();
+                };
+            ),
+            loc.clone(),
+        ),
+    ];
+    let registry: Registry<()> = Registry::from_items(items).expect("index");
+    assert_eq!(registry.guards.len(), 2);
+
+    let dir = crate::api::test_util::unique_test_dir("write_guards");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = registry
+        .resolve(ConstGatingExt)
+        .expect("resolve")
+        .write_rust(dir.join("gen.rs"))
+        .expect("write_rust");
+    let src = std::fs::read_to_string(&path).unwrap();
+
+    // The named const is gated out; both guards emit regardless.
+    assert!(
+        !src.contains("KEPT_OUT"),
+        "declared_consts is empty:\n{src}"
+    );
+    let first = src
+        .find("first_check")
+        .unwrap_or_else(|| panic!("guard 1 missing:\n{src}"));
+    let second = src
+        .find("second_check")
+        .unwrap_or_else(|| panic!("guard 2 missing:\n{src}"));
+    assert!(first < second, "guards must keep stream order:\n{src}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -315,7 +315,7 @@ pub(crate) fn validate_bindings(
         let mut const_idents: Vec<&syn::Ident> = registry.consts.keys().collect();
         const_idents.sort();
         for ident in const_idents {
-            if *ident == "_" || !declared_consts.contains(ident) {
+            if !declared_consts.contains(ident) {
                 continue;
             }
             let (item_const, _) = &registry.consts[ident];

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1587,12 +1587,6 @@ impl Prebindgen for JniGen {
     /// const's type flows through the ordinary output-converter machinery);
     /// only the callee expression differs — a path to the const, not a call.
     fn on_const(&self, c: &syn::ItemConst, registry: &Registry<KotlinMeta>) -> TokenStream {
-        // Unnamed infrastructure consts (`const _`, e.g. the injected
-        // `konst::assertc_eq!` feature guard) pass through verbatim — no
-        // getter, no Kotlin surface.
-        if c.ident == "_" {
-            return c.to_token_stream();
-        }
         reject_handle_const(self, c);
         let getter = const_getter_fn(c);
         let const_ident = &c.ident;


### PR DESCRIPTION
Stacked on #239. Small, and it removes a sentinel that had already gone stale.

The injected feature check is modelled as a `Constant` whose name happens to be
`_`, and every consumer that must not treat it as API re-checks that sentinel.
**Five sites do, across four files.**

## Why the sentinel is wrong, not just untidy

**The guard is not a captured item.** `Source`'s cfg filter *synthesizes* it
(`api/batching/cfg_filter.rs:143`) — one per ingested crate, asserting that
crate's `FEATURES` match what the build script asked for. Nothing in the source
crate marked it, so it was never part of the flat API, which is the set of things
a `#[prebindgen]` crate declares.

**Four of the five checks were already dead.** Once L1 routed unnamed consts away
from `consts`, `write.rs`'s const gate, the skipped-const warning, and *both*
`on_const` implementations (the default and JniGen's) guarded a state the pipeline
could no longer produce. `registry.consts` has exactly one writer, in the arm
after the `named.is_none()` check. That is precisely the failure mode a sentinel
invites, and it had already happened without anyone noticing.

## The change

```rust
Element::Guard(Guard { origin: Origin<syn::ItemConst> })
```

Named for what it **is** — a compile-time assertion protecting the generated file
— not for what a consumer does with it. `Element` classifies; `Passthrough` would
name an emission strategy, and that variant was deliberately deleted earlier in
this program.

Recognised by **shape**, not provenance: a constant with no name has no address,
so nothing can declare it, reference it, or emit it as an alias. That is the
property that makes it infrastructure, and it holds whoever wrote it — so no new
ingestion channel is needed and today's behaviour is preserved exactly.

It carries **no `TypeRef`**. The item is emitted verbatim, so what its types mean
is the consumer crate's business. Today the guard's `()` *is* lowered and *does*
participate in `first_unresolved`, so a guard naming an undeclared type would turn
the whole element `Unsupported` and — post-L1 — fail the build. `()` is `Unit`, so
that never bit; dropping the slot removes the coupling rather than fixing a live
bug.

Knock-ons:

* `Element::name` loses its `.filter(|id| *id != "_")`, which existed for this alone
* `Registry::passthrough` → `guards: Vec<Guard>` — the bucket's one occupant now
  names it. Emission unmoved: last in `write_rust`, in stream order.
* **One `"_"` comparison stays**, in `flat/mod.rs`'s Pass 1. The `ConstIndex` an
  array extent resolves against is built before Pass 2 classifies anything, so it
  has only raw items to filter. It is the one site that cannot read a
  classification, and the comment now says so.
* The module doc's "no verbatim passthrough" claim is **amended, not reversed**:
  no *marked* item passes through, and the one item that does was never marked.

## Verification

* `regen-check.sh` — the two `example_flat_aarch64` goldens drift **byte-for-byte
  identically to the base branch** (the known `--features unstable` mismatch);
  every other generated file is byte-identical. Diffed both branches to confirm
  rather than assuming.
* covertest-kotlin `./gradlew run` — 48 sections. The case that matters most here:
  it ingests **two** source crates, so it carries two guards.
* 524 + 452 tests, doctests, clippy in all three feature configs with `-D warnings`

Two tests, both checked against a reverted classification (`if c.ident == "_"` →
`if false`) and confirmed to fail:

* an unnamed const is a `Guard`, several coexist, and none is a `Constant`;
* a guard never reaches the const surface — the assertion that would have caught
  the four checks going dead, and that keeps a future reclassification honest.

Ledger unchanged: it counts `syn::Type`/`syn::Expr` variant mentions, and an ident
comparison is one of its listed blind spots either way.