### PR TITLE
Flat is the only index; Registry stops keeping a second one

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -192,7 +192,7 @@ pub fn apply<M>(
         if let Some(declared) = &ed.declared_target {
             let item_fn = registry
                 .flat()
-                .function(&ed.func.to_string())
+                .function(&ed.func)
                 .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
             let param_ty = find_param_type(&item_fn, &ed.param)
@@ -239,7 +239,7 @@ pub fn apply<M>(
             }
             let Some(item_fn) = registry
                 .flat()
-                .function(&func.to_string())
+                .function(&func)
                 .map(|f| f.origin.syntax.clone())
             else {
                 continue;
@@ -305,7 +305,7 @@ fn process_expand<M>(
 ) -> Result<(), ExpandError> {
     let item_fn = registry
         .flat()
-        .function(&ed.func.to_string())
+        .function(&ed.func)
         .map(|f| f.origin.syntax.clone())
         .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
 
@@ -379,7 +379,7 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
     // elided return and a written `-> ()` are one thing.
     let f = registry
         .flat()
-        .function(&func.to_string())
+        .function(&func)
         .ok_or_else(|| ExpandError::UnknownConstructor(func.clone()))?;
 
     let params: Vec<(syn::Ident, syn::Type)> = f

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashSet;
 
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::api::core::{
@@ -190,10 +190,10 @@ pub fn apply<M>(
         // (`Option`/`&`) type must equal the decl's declared type — the
         // typo guard for both coordinates of `.expand_param(name, decl)`.
         if let Some(declared) = &ed.declared_target {
-            let (item_fn, _) = registry
-                .functions
-                .get(&ed.func)
-                .cloned()
+            let item_fn = registry
+                .flat()
+                .function(&ed.func.to_string())
+                .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
             let param_ty = find_param_type(&item_fn, &ed.param)
                 .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
@@ -237,7 +237,11 @@ pub fn apply<M>(
             if accessor_fns.contains(func) {
                 continue;
             }
-            let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
+            let Some(item_fn) = registry
+                .flat()
+                .function(&func.to_string())
+                .map(|f| f.origin.syntax.clone())
+            else {
                 continue;
             };
             // A method's receiver (first param of its class type) binds to `this`
@@ -299,10 +303,10 @@ fn process_expand<M>(
     exp: &Expansions,
     ed: &ExpandDecl,
 ) -> Result<(), ExpandError> {
-    let (item_fn, _) = registry
-        .functions
-        .get(&ed.func)
-        .cloned()
+    let item_fn = registry
+        .flat()
+        .function(&ed.func.to_string())
+        .map(|f| f.origin.syntax.clone())
         .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
 
     let param_ty = find_param_type(&item_fn, &ed.param)
@@ -370,25 +374,20 @@ fn resolve_constructor<M>(
 /// Constructor signature: parameter `(name, type)` pairs, the produced
 /// (`Ok`) target type, and whether it is fallible (`-> Result<_, _>`).
 fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSig, ExpandError> {
-    let (item_fn, _) = registry
-        .functions
-        .get(func)
+    // Read off the element rather than re-walked from the signature: `params`
+    // and `ret` are the same facts, already decided once — including that an
+    // elided return and a written `-> ()` are one thing.
+    let f = registry
+        .flat()
+        .function(&func.to_string())
         .ok_or_else(|| ExpandError::UnknownConstructor(func.clone()))?;
 
-    let mut params: Vec<(syn::Ident, syn::Type)> = Vec::new();
-    for input in &item_fn.sig.inputs {
-        if let syn::FnArg::Typed(pt) = input {
-            let name = match &*pt.pat {
-                syn::Pat::Ident(pi) => pi.ident.clone(),
-                _ => syn::Ident::new("arg", Span::call_site()),
-            };
-            params.push((name, (*pt.ty).clone()));
-        }
-    }
-    let ret: syn::Type = match &item_fn.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, t) => (**t).clone(),
-    };
+    let params: Vec<(syn::Ident, syn::Type)> = f
+        .params
+        .iter()
+        .map(|p| (p.name.clone(), p.ty.origin.syntax.clone()))
+        .collect();
+    let ret: syn::Type = f.ret.origin.syntax.clone();
     let (target, fallible) = match result_ok_type(&ret) {
         Some(ok) => (ok, true),
         None => (ret, false),

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -44,7 +44,7 @@
 4	api/core/expand.rs
 11	api/core/registry.rs
 40	api/core/types_util.rs
-18	api/core/unfold.rs
+16	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
@@ -70,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 204
+# total: 202

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -647,7 +647,7 @@ impl Flat {
         })
     }
 
-    /// Check a function signature against the source language's grammar.
+    /// Lower a function signature written outside the captured stream.
     ///
     /// For the **one input that does not come through this module**: a binding's
     /// `local_functions`, whose signatures are written by hand in a build script
@@ -655,10 +655,12 @@ impl Flat {
     /// lowered here, so this exists to keep the grammar decided in one place
     /// rather than re-checked at the far end.
     ///
-    /// Grammar only. Whether the types it names are *declared* is a whole-model
-    /// question ([`resolve_references`]), and a binding-local fn may legitimately
-    /// name types the source crate never did.
-    pub fn check_signature(&self, f: &syn::ItemFn) -> Result<Function, ItemError> {
+    /// Grammar only, and it **validates by lowering**: an `Err` is a shape the
+    /// language cannot express, an `Ok` is the element to admit. Whether the types
+    /// it names are *declared* is a whole-model question ([`resolve_references`]),
+    /// and a binding-local fn may legitimately name types the source crate never
+    /// did.
+    pub fn lower_signature(&self, f: &syn::ItemFn) -> Result<Function, ItemError> {
         // Rebuilt from the model rather than kept: this runs once per local fn,
         // and a stored index would be a second copy of what `constants()` says.
         let consts = ConstIndex::new(self.constants().map(|c| {

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -378,7 +378,21 @@ impl FlatBuilder {
             .enumerate()
             .filter_map(|(i, e)| e.name().map(|n| (n.to_string(), i)))
             .collect();
-        Ok(Flat { elements, by_name })
+        // Frozen here, from the captured stream alone. See the field's docs.
+        let mut source_modules: Vec<String> = Vec::new();
+        for element in &elements {
+            if let Some(crate_name) = element.location().crate_name.as_ref() {
+                let module = crate_name.replace('-', "_");
+                if !source_modules.contains(&module) {
+                    source_modules.push(module);
+                }
+            }
+        }
+        Ok(Flat {
+            elements,
+            by_name,
+            source_modules,
+        })
     }
 }
 
@@ -407,6 +421,15 @@ impl FlatBuilder {
 pub struct Flat {
     /// Source order, so iteration reports items as the sources were fed.
     elements: Vec<Element>,
+    /// Module name of every **captured** source, in first-seen order (crate
+    /// names, dashes normalized to underscores). The first doubles as the
+    /// default module for a reference with no recorded origin.
+    ///
+    /// Computed once in [`FlatBuilder::build`] and frozen: it is a property of
+    /// the ingested stream, so a binding-local function added later must not
+    /// extend it — that would change which module an unqualified reference
+    /// resolves against.
+    source_modules: Vec<String>,
     /// Name → position in [`Self::elements`].
     ///
     /// A map rather than a scan because every typed accessor and every
@@ -500,6 +523,40 @@ impl Flat {
             .flat_map(TypeRef::walk)
     }
 
+    /// The `struct` declared under this name, or `None` for any other shape.
+    ///
+    /// A tuple struct is an [`Extern`] rather than a `Struct`, so this answers
+    /// only for a product of fields that cross the boundary.
+    pub fn struct_type(&self, name: &str) -> Option<&Struct> {
+        match self.declared_type(name)? {
+            Type::Struct(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// The `syn::ItemEnum` behind **either** enum shape.
+    ///
+    /// A sum and a C-style enum are different elements — numbered differently
+    /// and consumed as different constructs — but both were spelled `enum` in
+    /// Rust and both keep that item. A consumer re-emitting the source wants the
+    /// item without caring which shape it is; one that acts on the distinction
+    /// reaches for [`Self::declared_type`].
+    pub fn enum_item(&self, name: &str) -> Option<&syn::ItemEnum> {
+        match self.declared_type(name)? {
+            Type::Variant(v) => Some(&v.origin.syntax),
+            Type::Enum(e) => Some(&e.origin.syntax),
+            _ => None,
+        }
+    }
+
+    /// Module name of every captured source, in first-seen order.
+    ///
+    /// The first entry is the default module for a reference with no recorded
+    /// origin. Empty for a hand-built stream that carried no crate stamps.
+    pub fn source_modules(&self) -> &[String] {
+        &self.source_modules
+    }
+
     /// Every anonymous const, in stream order — **zero or more**.
     ///
     /// Not part of the flat API — see [`Guard`] — but ingested with it, and a
@@ -535,7 +592,7 @@ impl Flat {
     /// Grammar only. Whether the types it names are *declared* is a whole-model
     /// question ([`resolve_references`]), and a binding-local fn may legitimately
     /// name types the source crate never did.
-    pub fn check_signature(&self, f: &syn::ItemFn) -> Result<(), ItemError> {
+    pub fn check_signature(&self, f: &syn::ItemFn) -> Result<Function, ItemError> {
         // Rebuilt from the model rather than kept: this runs once per local fn,
         // and a stored index would be a second copy of what `constants()` says.
         let consts = ConstIndex::new(self.constants().map(|c| {
@@ -545,9 +602,29 @@ impl Flat {
                 c.origin.crate_name().map(str::to_owned),
             )
         }));
-        // A synthesized fn has no captured location; the caller names it.
+        // A synthesized fn has no captured location, but it does have an origin
+        // crate — the caller supplies it, and `add_local_function` records it.
         let at = Rc::new(SourceLocation::default());
-        lower_fn(f, &at, &consts).map(|_| ())
+        lower_fn(f, &at, &consts)
+    }
+
+    /// Admit a binding-local function: one a build script wrote via `sig!(..)`
+    /// rather than one a source crate marked.
+    ///
+    /// The model is the pipeline's only index, so a function nothing captured
+    /// still has to live here or nothing downstream can find it. `crate_name` is
+    /// the module its generated call qualifies against, stamped onto the
+    /// element's location where [`Element::location`] already looks for it.
+    ///
+    /// Deliberately does **not** extend [`Self::source_modules`]: see that
+    /// field's docs.
+    pub(crate) fn add_local_function(&mut self, mut f: Function, crate_name: String) {
+        f.origin.location = Rc::new(SourceLocation {
+            crate_name: Some(crate_name),
+            ..SourceLocation::default()
+        });
+        self.by_name.insert(f.name.to_string(), self.elements.len());
+        self.elements.push(Element::Function(f));
     }
 
     /// The declaration a reference denotes.

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -440,6 +440,71 @@ pub struct Flat {
     by_name: std::collections::HashMap<String, usize>,
 }
 
+/// A name a lookup can be performed with.
+///
+/// Exists because callers hold different spellings of the same fact: an adapter
+/// walking captured items has a `syn::Ident`, a resolved reference has the
+/// `String` inside a [`TypeId`], and a test has a literal. One accessor takes all
+/// three rather than each call site converting.
+///
+/// **The conversion is moved, not removed.** `proc_macro2::Ident` hashes by
+/// `to_string()` and offers no borrow as `str`, so an `Ident` lookup allocates
+/// wherever it happens; doing it here keeps `&str` and `&String` callers — among
+/// them the per-edge and per-reference lookups in the scan and the resolver —
+/// allocation-free.
+///
+/// Sealed: what may name an element is the language's business, not a caller's.
+///
+/// ```
+/// # prebindgen::Source::init_doctest_simulate();
+/// use prebindgen::core::flat::Flat;
+///
+/// let flat = Flat::builder().source("source_ffi").build()?;
+/// let ident = quote::format_ident!("test_function");
+///
+/// // The same element, whichever spelling the caller happens to hold.
+/// assert!(flat.function("test_function").is_some());
+/// assert!(flat.function(&ident).is_some());
+/// # Ok::<_, prebindgen::core::flat::ParseError>(())
+/// ```
+pub trait Name: sealed::Sealed {
+    /// The name as a string, borrowed when the caller already holds one.
+    fn as_name(&self) -> std::borrow::Cow<'_, str>;
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for str {}
+    impl Sealed for String {}
+    impl Sealed for syn::Ident {}
+    impl<T: ?Sized + Sealed> Sealed for &T {}
+}
+
+impl Name for str {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed(self)
+    }
+}
+
+impl Name for String {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed(self)
+    }
+}
+
+impl Name for syn::Ident {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Owned(self.to_string())
+    }
+}
+
+/// So a caller already holding a reference does not have to reborrow.
+impl<T: ?Sized + Name> Name for &T {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        T::as_name(self)
+    }
+}
+
 impl Flat {
     /// Start collecting what to parse.
     pub fn builder() -> FlatBuilder {
@@ -454,11 +519,12 @@ impl Flat {
     /// The element with this name, whatever kind it is — including an
     /// [`Element::Unsupported`], which still holds its name against the
     /// namespace.
-    pub fn element(&self, name: &str) -> Option<&Element> {
-        self.elements.get(*self.by_name.get(name)?)
+    pub fn element<N: Name + ?Sized>(&self, name: &N) -> Option<&Element> {
+        self.elements
+            .get(*self.by_name.get(name.as_name().as_ref())?)
     }
 
-    pub fn function(&self, name: &str) -> Option<&Function> {
+    pub fn function<N: Name + ?Sized>(&self, name: &N) -> Option<&Function> {
         match self.element(name)? {
             Element::Function(f) => Some(f),
             _ => None,
@@ -470,14 +536,14 @@ impl Flat {
     /// Named `declared_type` because `type` is a keyword; it is the accessor a
     /// resolved [`TypeKind::Named`] reference leads to, and [`Self::resolve`] is
     /// the same lookup taking a [`TypeId`].
-    pub fn declared_type(&self, name: &str) -> Option<&Type> {
+    pub fn declared_type<N: Name + ?Sized>(&self, name: &N) -> Option<&Type> {
         match self.element(name)? {
             Element::Type(t) => Some(t),
             _ => None,
         }
     }
 
-    pub fn constant(&self, name: &str) -> Option<&Constant> {
+    pub fn constant<N: Name + ?Sized>(&self, name: &N) -> Option<&Constant> {
         match self.element(name)? {
             Element::Constant(c) => Some(c),
             _ => None,
@@ -527,7 +593,7 @@ impl Flat {
     ///
     /// A tuple struct is an [`Extern`] rather than a `Struct`, so this answers
     /// only for a product of fields that cross the boundary.
-    pub fn struct_type(&self, name: &str) -> Option<&Struct> {
+    pub fn struct_type<N: Name + ?Sized>(&self, name: &N) -> Option<&Struct> {
         match self.declared_type(name)? {
             Type::Struct(s) => Some(s),
             _ => None,
@@ -541,7 +607,7 @@ impl Flat {
     /// Rust and both keep that item. A consumer re-emitting the source wants the
     /// item without caring which shape it is; one that acts on the distinction
     /// reaches for [`Self::declared_type`].
-    pub fn enum_item(&self, name: &str) -> Option<&syn::ItemEnum> {
+    pub fn enum_item<N: Name + ?Sized>(&self, name: &N) -> Option<&syn::ItemEnum> {
         match self.declared_type(name)? {
             Type::Variant(v) => Some(&v.origin.syntax),
             Type::Enum(e) => Some(&e.origin.syntax),

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -293,34 +293,6 @@ pub struct Registry<M = ()> {
     /// later stage can ask it what a name means through the registry it already
     /// has — see [`Self::flat`].
     flat: crate::api::core::flat::Flat,
-    pub functions: HashMap<syn::Ident, (syn::ItemFn, SourceLocation)>,
-    pub structs: HashMap<syn::Ident, (syn::ItemStruct, SourceLocation)>,
-    pub enums: HashMap<syn::Ident, (syn::ItemEnum, SourceLocation)>,
-    pub consts: HashMap<syn::Ident, (syn::ItemConst, SourceLocation)>,
-    /// Anonymous consts, in stream order, re-emitted verbatim — **zero or
-    /// more**. Not API: having no name, they cannot be declared, so they are
-    /// neither gated nor addressable. See
-    /// [`Guard`](crate::api::core::flat::Guard) for what produces them.
-    pub guards: Vec<crate::api::core::flat::Guard>,
-
-    /// Origin crate name of each named item (fn/struct/enum/const),
-    /// recorded by [`Self::from_items`] from each item's
-    /// [`SourceLocation::crate_name`] stamp (absent for hand-built,
-    /// origin-less item streams). Adapters
-    /// consult [`Self::origin_module`] so generated references qualify each
-    /// item with the module of the crate that actually defines it — the
-    /// multi-source model, where a binding layers helper `#[prebindgen]`
-    /// crates on top of the flat crate.
-    pub(crate) item_origins: HashMap<syn::Ident, String>,
-
-    /// Module name of every ingested source, in first-seen stream order
-    /// (crate names, dashes normalized to underscores). The FIRST entry
-    /// doubles as the **default module** for references with no recorded
-    /// origin (e.g. a declared type with no `#[prebindgen]` item);
-    /// origin-less hand-built streams leave it empty and adapters fall
-    /// back to `crate`.
-    pub(crate) source_modules: Vec<String>,
-
     /// Type tables, one per direction. Each scanned type gets a [`TypeCell`]
     /// holding what the key names, whether the binding asks for it directly, and
     /// the resolved [`TypeEntry`] once the structural resolver fills it.
@@ -385,13 +357,6 @@ impl<M> Registry<M> {
     pub(crate) fn empty() -> Self {
         Self {
             flat: crate::api::core::flat::Flat::default(),
-            functions: HashMap::new(),
-            structs: HashMap::new(),
-            enums: HashMap::new(),
-            consts: HashMap::new(),
-            guards: Vec::new(),
-            item_origins: HashMap::new(),
-            source_modules: Vec::new(),
             input_types: Default::default(),
             output_types: Default::default(),
             type_refs: HashMap::new(),
@@ -780,7 +745,7 @@ impl<M> Registry<M> {
     /// // Annotated only because nothing here resolves: in a build script `M` is
     /// // fixed by the adapter passed to `resolve`, so no call site names it.
     /// let registry: Registry<()> = Registry::builder().source("source_ffi").build()?;
-    /// assert!(registry.functions.contains_key(&quote::format_ident!("test_function")));
+    /// assert!(registry.flat().function("test_function").is_some());
     /// # Ok::<_, prebindgen::core::ScanError>(())
     /// ```
     ///
@@ -858,8 +823,6 @@ impl<M> Registry<M> {
     /// a source crate that needs migrating sees one list instead of one rebuild
     /// per item.
     pub fn from_flat(flat: crate::api::core::flat::Flat) -> Result<Self, ScanError> {
-        use crate::api::core::flat::{Element, Type};
-
         let entries: Vec<NotExpressibleEntry> = flat
             .unsupported()
             .map(|u| NotExpressibleEntry {
@@ -882,67 +845,6 @@ impl<M> Registry<M> {
                 .type_refs
                 .entry(TypeKey::from_type(&ty.origin.syntax))
                 .or_insert_with(|| ty.clone());
-        }
-
-        // First-seen order, which is what makes the first entry the default
-        // module. Derived from the elements rather than stored twice.
-        for element in flat.elements() {
-            if let Some(crate_name) = element.location().crate_name.as_ref() {
-                let module = crate_name.replace('-', "_");
-                if !registry.source_modules.contains(&module) {
-                    registry.source_modules.push(module);
-                }
-            }
-        }
-
-        for element in flat.elements() {
-            let crate_name = element.location().crate_name.clone();
-            let named = element.name().cloned();
-            match element {
-                Element::Function(f) => {
-                    registry.functions.insert(
-                        f.name.clone(),
-                        (f.origin.syntax.clone(), element.location().clone()),
-                    );
-                }
-                Element::Type(Type::Struct(t)) => {
-                    registry.structs.insert(
-                        t.name.clone(),
-                        (t.origin.syntax.clone(), element.location().clone()),
-                    );
-                }
-                Element::Type(Type::Variant(t)) => {
-                    registry.enums.insert(
-                        t.name.clone(),
-                        (t.origin.syntax.clone(), element.location().clone()),
-                    );
-                }
-                Element::Type(Type::Enum(t)) => {
-                    registry.enums.insert(
-                        t.name.clone(),
-                        (t.origin.syntax.clone(), element.location().clone()),
-                    );
-                }
-                // An anonymous const, re-emitted verbatim. No name means nothing
-                // can declare it, which is why it is in none of the API maps.
-                Element::Guard(g) => registry.guards.push(g.clone()),
-                Element::Constant(c) => {
-                    registry.consts.insert(
-                        c.name.clone(),
-                        (c.origin.syntax.clone(), element.location().clone()),
-                    );
-                }
-                // An `Extern` states that a name exists and its contents do not
-                // cross. There is no map for that, and adapters have never seen
-                // one — a type alias was already a no-op here. Reachable through
-                // [`Self::flat`] for the stages that will want it.
-                Element::Type(Type::Extern(_)) => {}
-                // Refused above.
-                Element::Unsupported(_) => unreachable!("checked before indexing"),
-            }
-            if let (Some(ident), Some(crate_name)) = (named, crate_name) {
-                registry.item_origins.insert(ident, crate_name);
-            }
         }
 
         registry.flat = flat;
@@ -968,16 +870,38 @@ impl<M> Registry<M> {
     /// [`SourceLocation::crate_name`] was set — an origin-less hand-built
     /// stream indexes items that map never sees, and callers are expected to
     /// pair this with `origin_module(..).unwrap_or_else(default_module)`.
+    /// Every **declared type** name — struct or either enum shape, never an
+    /// alias. The set the old `structs`/`enums` maps' keys formed together.
+    fn declared_type_idents(&self) -> impl Iterator<Item = &syn::Ident> {
+        use crate::api::core::flat::Type;
+        self.flat.types().filter_map(|t| match t {
+            Type::Struct(_) | Type::Variant(_) | Type::Enum(_) => Some(t.name()),
+            Type::Extern(_) => None,
+        })
+    }
+
     pub fn named_item_idents(&self) -> impl Iterator<Item = &syn::Ident> {
-        self.functions
-            .keys()
-            .chain(self.structs.keys())
-            .chain(self.enums.keys())
-            .chain(self.consts.keys())
+        use crate::api::core::flat::{Element, Type};
+        self.flat.elements().filter_map(|e| match e {
+            // An `Extern` names a type without declaring a body, and is
+            // deliberately absent: its caller decides which names to qualify in
+            // generated Rust, and qualifying an alias would move that output.
+            Element::Type(Type::Extern(_)) => None,
+            Element::Function(_) | Element::Type(_) | Element::Constant(_) => e.name(),
+            Element::Guard(_) | Element::Unsupported(_) => None,
+        })
     }
 
     pub fn origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
-        let crate_name = self.item_origins.get(ident)?;
+        // Off the element's own location, which covers both populations: a
+        // captured item stamped at capture time, and a binding-local fn stamped
+        // by `add_local_function`.
+        let crate_name = self
+            .flat
+            .element(&ident.to_string())?
+            .location()
+            .crate_name
+            .as_ref()?;
         let module = crate_name.replace('-', "_");
         syn::parse_str(&module).ok()
     }
@@ -990,7 +914,8 @@ impl<M> Registry<M> {
     /// registry-level override could only fix ONE module, which is
     /// incomplete with chained multi-source streams.
     pub fn default_module(&self) -> Option<syn::Path> {
-        self.source_modules
+        self.flat
+            .source_modules()
             .first()
             .and_then(|m| syn::parse_str(m).ok())
     }
@@ -998,7 +923,8 @@ impl<M> Registry<M> {
     /// Module paths of every ingested source, ingestion order — e.g. for a
     /// glob import that must see all sources' items.
     pub fn all_source_modules(&self) -> Vec<syn::Path> {
-        self.source_modules
+        self.flat
+            .source_modules()
             .iter()
             .filter_map(|m| syn::parse_str(m).ok())
             .collect()
@@ -1069,10 +995,9 @@ impl<M> Registry<M> {
                 .ident
                 .to_string();
             let last = tp.path.segments.last().expect("len checked");
-            if self.source_modules.contains(&head) {
+            if self.flat.source_modules().contains(&head) {
                 qualified.push((key.to_string(), last.to_token_stream().to_string()));
-            } else if self.structs.contains_key(&last.ident) || self.enums.contains_key(&last.ident)
-            {
+            } else if self.flat.declared_type(&last.ident.to_string()).is_some() {
                 println!(
                     "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
                      captured #[prebindgen] item `{}` exists — if you meant the source item, \
@@ -1094,7 +1019,11 @@ impl<M> Registry<M> {
 
         // Scan declared functions.
         for ident in &declared.functions {
-            if let Some((item_fn, _)) = self.functions.get(ident).cloned() {
+            if let Some(item_fn) = self
+                .flat
+                .function(&ident.to_string())
+                .map(|f| f.origin.syntax.clone())
+            {
                 self.scan_fn_signature(&item_fn)?;
             } else {
                 missing.push(("function", ident.to_string()));
@@ -1102,7 +1031,7 @@ impl<M> Registry<M> {
         }
 
         for ident in &declared.ignored_functions {
-            if !self.functions.contains_key(ident) {
+            if self.flat.function(&ident.to_string()).is_none() {
                 println!(
                     "cargo:warning=prebindgen: ignored function `{}` not found among #[prebindgen] items",
                     ident
@@ -1115,7 +1044,7 @@ impl<M> Registry<M> {
         // `extra_required_types`) — but they are referenced by name from
         // adapter declarations, so a missing one is a hard error.
         for ident in &declared.helper_functions {
-            if !self.functions.contains_key(ident) {
+            if self.flat.function(&ident.to_string()).is_none() {
                 missing.push(("helper function", ident.to_string()));
             }
         }
@@ -1125,14 +1054,18 @@ impl<M> Registry<M> {
         // so the type is required in the output direction only.
         if let Some(decl_consts) = &declared.consts {
             for ident in decl_consts {
-                if let Some((item_const, _)) = self.consts.get(ident).cloned() {
+                if let Some(item_const) = self
+                    .flat
+                    .constant(&ident.to_string())
+                    .map(|c| c.origin.syntax.clone())
+                {
                     self.ensure_entry(Direction::Output, &item_const.ty, true);
                 } else {
                     missing.push(("constant", ident.to_string()));
                 }
             }
             for ident in &declared.ignored_consts {
-                if !self.consts.contains_key(ident) {
+                if self.flat.constant(&ident.to_string()).is_none() {
                     println!(
                         "cargo:warning=prebindgen: ignored const `{}` not found among #[prebindgen] items",
                         ident
@@ -1157,12 +1090,16 @@ impl<M> Registry<M> {
             let ty = key.to_type();
             let mut matched = false;
             if let Some(ident) = bare_path_ident(&ty) {
-                if let Some((s, _)) = self.structs.get(&ident).cloned() {
+                if let Some(s) = self
+                    .flat
+                    .struct_type(&ident.to_string())
+                    .map(|s| s.origin.syntax.clone())
+                {
                     self.scan_struct(&s)?;
                     self.ensure_entry(Direction::Input, &ty, true);
                     self.ensure_entry(Direction::Output, &ty, true);
                     matched = true;
-                } else if let Some((e, _)) = self.enums.get(&ident).cloned() {
+                } else if let Some(e) = self.flat.enum_item(&ident.to_string()).cloned() {
                     self.scan_enum(&e)?;
                     self.ensure_entry(Direction::Input, &ty, true);
                     self.ensure_entry(Direction::Output, &ty, true);
@@ -1182,7 +1119,8 @@ impl<M> Registry<M> {
         for key in &declared.ignored_types {
             let ty = key.to_type();
             let matched = bare_path_ident(&ty).is_some_and(|ident| {
-                self.structs.contains_key(&ident) || self.enums.contains_key(&ident)
+                self.flat.struct_type(&ident.to_string()).is_some()
+                    || self.flat.enum_item(&ident.to_string()).is_some()
             });
             if !matched {
                 println!(
@@ -1202,8 +1140,9 @@ impl<M> Registry<M> {
                 && declared.ignored_name_predicates.iter().any(|p| p(name))
         };
         let mut skipped_fns: Vec<String> = self
-            .functions
-            .keys()
+            .flat
+            .functions()
+            .map(|f| &f.name)
             .filter(|k| {
                 !declared.functions.contains(*k)
                     && !declared.ignored_functions.contains(*k)
@@ -1226,7 +1165,7 @@ impl<M> Registry<M> {
                 || declared.ignored_types.contains(key)
                 || declared.boundary_only_types.contains(key)
         };
-        for ident in self.structs.keys().chain(self.enums.keys()) {
+        for ident in self.declared_type_idents() {
             let name = ident.to_string();
             let key = TypeKey::from_ident(ident);
             if !type_acknowledged(&key) && !pred_ignored(&name) {
@@ -1243,8 +1182,9 @@ impl<M> Registry<M> {
 
         if let Some(decl_consts) = &declared.consts {
             let mut skipped_consts: Vec<String> = self
-                .consts
-                .keys()
+                .flat
+                .constants()
+                .map(|c| &c.name)
                 .filter(|k| {
                     !decl_consts.contains(*k)
                         && !declared.ignored_consts.contains(*k)
@@ -1531,18 +1471,21 @@ impl<M> Registry<M> {
         for (item_fn, origin) in adapter.local_functions() {
             let ident = item_fn.sig.ident.clone();
             // The one input that does not come through `Flat`: a `sig!(..)` is
-            // written by hand in a build script and inserted straight into the
-            // maps, so the grammar has to be checked here or nowhere. Silently
-            // dropping a `self` receiver or a pattern parameter would surface as
-            // an arity mismatch out of rustc on generated code, which is the
-            // wrong end of the pipeline to learn about a build.rs typo.
-            if let Err(error) = self.flat.check_signature(&item_fn) {
-                return Err(ScanError::AdapterInvariant {
-                    message: format!("binding-local fn `{ident}`: {error}"),
+            // written by hand in a build script, so the grammar has to be checked
+            // here or nowhere. Silently dropping a `self` receiver or a pattern
+            // parameter would surface as an arity mismatch out of rustc on
+            // generated code, which is the wrong end of the pipeline to learn
+            // about a build.rs typo.
+            let lowered = match self.flat.check_signature(&item_fn) {
+                Ok(f) => f,
+                Err(error) => {
+                    return Err(ScanError::AdapterInvariant {
+                        message: format!("binding-local fn `{ident}`: {error}"),
+                    }
+                    .into())
                 }
-                .into());
-            }
-            if self.functions.contains_key(&ident) {
+            };
+            if self.flat.element(&ident.to_string()).is_some() {
                 return Err(ScanError::AdapterInvariant {
                     message: format!(
                         "binding-local fn `{ident}` collides with a `#[prebindgen]` item — \
@@ -1552,9 +1495,9 @@ impl<M> Registry<M> {
                 }
                 .into());
             }
-            self.functions
-                .insert(ident.clone(), (item_fn, crate::SourceLocation::default()));
-            self.item_origins.insert(ident, origin);
+            // Into the model, so every downstream stage finds it exactly where it
+            // finds a captured fn — there is one index, and this is it.
+            self.flat.add_local_function(lowered, origin);
         }
         let declared = DeclaredItems::from_adapter(&adapter)?;
         self.scan_declared_items(&declared)?;

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -886,14 +886,21 @@ impl<M> Registry<M> {
         })
     }
 
-    /// Whether a name declares a type with a **body** — a struct or either enum
-    /// shape, never an alias.
+    /// Whether the source declares a type under this name — **including an
+    /// alias**.
     ///
-    /// The predicate form of [`Self::declared_type_idents`], shared so its two
-    /// callers cannot drift: both warn about a declared-or-ignored type the
-    /// source does not define, and both must answer the same way about an alias.
-    fn declares_type_body(&self, ident: &syn::Ident) -> bool {
-        self.flat.struct_type(ident).is_some() || self.flat.enum_item(ident).is_some()
+    /// The question both type-diagnostic sites ask, shared so they cannot drift.
+    /// An alias counts because `#[prebindgen] pub type Handle = ..` *is* a
+    /// declaration of that name: it can be declared bare by an adapter (landing
+    /// in the no-indexed-body branch above, which is what
+    /// `ptr_class(ZKeyExpr<'static>)` relies on), so a diagnostic that says
+    /// "no such captured item" would be false.
+    ///
+    /// Distinct from [`Self::declared_type_idents`], which excludes aliases
+    /// because it feeds a *"skipping undeclared struct/enum"* warning — a
+    /// different question, about what an adapter left unclaimed.
+    fn declares_type(&self, ident: &syn::Ident) -> bool {
+        self.flat.declared_type(ident).is_some()
     }
 
     /// The origin crate's **module path** for an item, read off the element's
@@ -999,7 +1006,7 @@ impl<M> Registry<M> {
             let last = tp.path.segments.last().expect("len checked");
             if self.flat.source_modules().contains(&head) {
                 qualified.push((key.to_string(), last.to_token_stream().to_string()));
-            } else if self.declares_type_body(&last.ident) {
+            } else if self.declares_type(&last.ident) {
                 println!(
                     "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
                      captured #[prebindgen] item `{}` exists — if you meant the source item, \
@@ -1114,7 +1121,7 @@ impl<M> Registry<M> {
 
         for key in &declared.ignored_types {
             let ty = key.to_type();
-            let matched = bare_path_ident(&ty).is_some_and(|ident| self.declares_type_body(&ident));
+            let matched = bare_path_ident(&ty).is_some_and(|ident| self.declares_type(&ident));
             if !matched {
                 println!(
                     "cargo:warning=prebindgen: ignored type `{}` not found among #[prebindgen] items",

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -896,12 +896,7 @@ impl<M> Registry<M> {
         // Off the element's own location, which covers both populations: a
         // captured item stamped at capture time, and a binding-local fn stamped
         // by `add_local_function`.
-        let crate_name = self
-            .flat
-            .element(&ident.to_string())?
-            .location()
-            .crate_name
-            .as_ref()?;
+        let crate_name = self.flat.element(&ident)?.location().crate_name.as_ref()?;
         let module = crate_name.replace('-', "_");
         syn::parse_str(&module).ok()
     }
@@ -997,7 +992,7 @@ impl<M> Registry<M> {
             let last = tp.path.segments.last().expect("len checked");
             if self.flat.source_modules().contains(&head) {
                 qualified.push((key.to_string(), last.to_token_stream().to_string()));
-            } else if self.flat.declared_type(&last.ident.to_string()).is_some() {
+            } else if self.flat.declared_type(&last.ident).is_some() {
                 println!(
                     "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
                      captured #[prebindgen] item `{}` exists — if you meant the source item, \
@@ -1019,11 +1014,7 @@ impl<M> Registry<M> {
 
         // Scan declared functions.
         for ident in &declared.functions {
-            if let Some(item_fn) = self
-                .flat
-                .function(&ident.to_string())
-                .map(|f| f.origin.syntax.clone())
-            {
+            if let Some(item_fn) = self.flat.function(&ident).map(|f| f.origin.syntax.clone()) {
                 self.scan_fn_signature(&item_fn)?;
             } else {
                 missing.push(("function", ident.to_string()));
@@ -1031,7 +1022,7 @@ impl<M> Registry<M> {
         }
 
         for ident in &declared.ignored_functions {
-            if self.flat.function(&ident.to_string()).is_none() {
+            if self.flat.function(&ident).is_none() {
                 println!(
                     "cargo:warning=prebindgen: ignored function `{}` not found among #[prebindgen] items",
                     ident
@@ -1044,7 +1035,7 @@ impl<M> Registry<M> {
         // `extra_required_types`) — but they are referenced by name from
         // adapter declarations, so a missing one is a hard error.
         for ident in &declared.helper_functions {
-            if self.flat.function(&ident.to_string()).is_none() {
+            if self.flat.function(&ident).is_none() {
                 missing.push(("helper function", ident.to_string()));
             }
         }
@@ -1054,10 +1045,8 @@ impl<M> Registry<M> {
         // so the type is required in the output direction only.
         if let Some(decl_consts) = &declared.consts {
             for ident in decl_consts {
-                if let Some(item_const) = self
-                    .flat
-                    .constant(&ident.to_string())
-                    .map(|c| c.origin.syntax.clone())
+                if let Some(item_const) =
+                    self.flat.constant(&ident).map(|c| c.origin.syntax.clone())
                 {
                     self.ensure_entry(Direction::Output, &item_const.ty, true);
                 } else {
@@ -1065,7 +1054,7 @@ impl<M> Registry<M> {
                 }
             }
             for ident in &declared.ignored_consts {
-                if self.flat.constant(&ident.to_string()).is_none() {
+                if self.flat.constant(&ident).is_none() {
                     println!(
                         "cargo:warning=prebindgen: ignored const `{}` not found among #[prebindgen] items",
                         ident
@@ -1092,14 +1081,14 @@ impl<M> Registry<M> {
             if let Some(ident) = bare_path_ident(&ty) {
                 if let Some(s) = self
                     .flat
-                    .struct_type(&ident.to_string())
+                    .struct_type(&ident)
                     .map(|s| s.origin.syntax.clone())
                 {
                     self.scan_struct(&s)?;
                     self.ensure_entry(Direction::Input, &ty, true);
                     self.ensure_entry(Direction::Output, &ty, true);
                     matched = true;
-                } else if let Some(e) = self.flat.enum_item(&ident.to_string()).cloned() {
+                } else if let Some(e) = self.flat.enum_item(&ident).cloned() {
                     self.scan_enum(&e)?;
                     self.ensure_entry(Direction::Input, &ty, true);
                     self.ensure_entry(Direction::Output, &ty, true);
@@ -1119,8 +1108,7 @@ impl<M> Registry<M> {
         for key in &declared.ignored_types {
             let ty = key.to_type();
             let matched = bare_path_ident(&ty).is_some_and(|ident| {
-                self.flat.struct_type(&ident.to_string()).is_some()
-                    || self.flat.enum_item(&ident.to_string()).is_some()
+                self.flat.struct_type(&ident).is_some() || self.flat.enum_item(&ident).is_some()
             });
             if !matched {
                 println!(
@@ -1430,7 +1418,7 @@ impl<M> Registry<M> {
         // contribute nothing here.
         if let Some(name) = bare_path_ident(ty) {
             use crate::api::core::flat::{Field, Type};
-            let fields: Vec<&Field> = match self.flat.declared_type(&name.to_string()) {
+            let fields: Vec<&Field> = match self.flat.declared_type(&name) {
                 Some(Type::Struct(s)) => s.fields.iter().collect(),
                 Some(Type::Variant(v)) => v
                     .alternatives
@@ -1485,7 +1473,7 @@ impl<M> Registry<M> {
                     .into())
                 }
             };
-            if self.flat.element(&ident.to_string()).is_some() {
+            if self.flat.element(&ident).is_some() {
                 return Err(ScanError::AdapterInvariant {
                     message: format!(
                         "binding-local fn `{ident}` collides with a `#[prebindgen]` item — \

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -856,30 +856,14 @@ impl<M> Registry<M> {
         &self.flat
     }
 
-    /// The origin crate's **module path** for an item ingested via
-    /// the item's [`SourceLocation`] stamp, or `None` when unknown —
-    /// callers then fall
-    /// back to [`Self::default_module`].
-    /// Every **named** item the registry indexes — functions, structs, enums,
-    /// consts — regardless of whether the stream carried an origin stamp.
+    /// Every **named** item the model holds — functions, structs, either enum
+    /// shape, consts — regardless of whether the stream carried an origin stamp.
     ///
-    /// Lives here, beside the maps, so an adapter that needs "anything the
-    /// source crate defines" does not enumerate item kinds itself: a new kind
-    /// is added once, here, instead of drifting in each adapter. Deliberately
-    /// NOT keyed off [`Self::item_origins`], which holds only the items whose
-    /// [`SourceLocation::crate_name`] was set — an origin-less hand-built
-    /// stream indexes items that map never sees, and callers are expected to
-    /// pair this with `origin_module(..).unwrap_or_else(default_module)`.
-    /// Every **declared type** name — struct or either enum shape, never an
-    /// alias. The set the old `structs`/`enums` maps' keys formed together.
-    fn declared_type_idents(&self) -> impl Iterator<Item = &syn::Ident> {
-        use crate::api::core::flat::Type;
-        self.flat.types().filter_map(|t| match t {
-            Type::Struct(_) | Type::Variant(_) | Type::Enum(_) => Some(t.name()),
-            Type::Extern(_) => None,
-        })
-    }
-
+    /// Lives here so an adapter that needs "anything the source crate defines"
+    /// does not enumerate element kinds itself: a new kind is taught here once
+    /// instead of drifting in each adapter. An **alias is deliberately absent**
+    /// — see the arm below — and callers are expected to pair this with
+    /// `origin_module(..).unwrap_or_else(default_module)`.
     pub fn named_item_idents(&self) -> impl Iterator<Item = &syn::Ident> {
         use crate::api::core::flat::{Element, Type};
         self.flat.elements().filter_map(|e| match e {
@@ -892,6 +876,29 @@ impl<M> Registry<M> {
         })
     }
 
+    /// Every **declared type** name — struct or either enum shape, never an
+    /// alias. The set the old `structs`/`enums` map keys formed together.
+    fn declared_type_idents(&self) -> impl Iterator<Item = &syn::Ident> {
+        use crate::api::core::flat::Type;
+        self.flat.types().filter_map(|t| match t {
+            Type::Struct(_) | Type::Variant(_) | Type::Enum(_) => Some(t.name()),
+            Type::Extern(_) => None,
+        })
+    }
+
+    /// Whether a name declares a type with a **body** — a struct or either enum
+    /// shape, never an alias.
+    ///
+    /// The predicate form of [`Self::declared_type_idents`], shared so its two
+    /// callers cannot drift: both warn about a declared-or-ignored type the
+    /// source does not define, and both must answer the same way about an alias.
+    fn declares_type_body(&self, ident: &syn::Ident) -> bool {
+        self.flat.struct_type(ident).is_some() || self.flat.enum_item(ident).is_some()
+    }
+
+    /// The origin crate's **module path** for an item, read off the element's
+    /// own [`SourceLocation`] stamp, or `None` when unknown — callers then fall
+    /// back to [`Self::default_module`].
     pub fn origin_module(&self, ident: &syn::Ident) -> Option<syn::Path> {
         // Off the element's own location, which covers both populations: a
         // captured item stamped at capture time, and a binding-local fn stamped
@@ -992,7 +999,7 @@ impl<M> Registry<M> {
             let last = tp.path.segments.last().expect("len checked");
             if self.flat.source_modules().contains(&head) {
                 qualified.push((key.to_string(), last.to_token_stream().to_string()));
-            } else if self.flat.declared_type(&last.ident).is_some() {
+            } else if self.declares_type_body(&last.ident) {
                 println!(
                     "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
                      captured #[prebindgen] item `{}` exists — if you meant the source item, \
@@ -1107,9 +1114,7 @@ impl<M> Registry<M> {
 
         for key in &declared.ignored_types {
             let ty = key.to_type();
-            let matched = bare_path_ident(&ty).is_some_and(|ident| {
-                self.flat.struct_type(&ident).is_some() || self.flat.enum_item(&ident).is_some()
-            });
+            let matched = bare_path_ident(&ty).is_some_and(|ident| self.declares_type_body(&ident));
             if !matched {
                 println!(
                     "cargo:warning=prebindgen: ignored type `{}` not found among #[prebindgen] items",
@@ -1282,7 +1287,7 @@ impl<M> Registry<M> {
         // No receiver or non-ident pattern can reach here: a captured item was
         // refused by the frontend and `from_flat` failed before indexing it, and
         // a binding-local fn was checked against the same grammar
-        // (`Flat::check_signature`) when `resolve` synthesized it.
+        // (`Flat::lower_signature`) when `resolve` synthesized it.
         for input in &f.sig.inputs {
             match input {
                 syn::FnArg::Receiver(_) => continue,
@@ -1464,7 +1469,7 @@ impl<M> Registry<M> {
             // parameter would surface as an arity mismatch out of rustc on
             // generated code, which is the wrong end of the pipeline to learn
             // about a build.rs typo.
-            let lowered = match self.flat.check_signature(&item_fn) {
+            let lowered = match self.flat.lower_signature(&item_fn) {
                 Ok(f) => f,
                 Err(error) => {
                     return Err(ScanError::AdapterInvariant {

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -876,9 +876,14 @@ impl<M> Registry<M> {
         })
     }
 
-    /// Every **declared type** name — struct or either enum shape, never an
-    /// alias. The set the old `structs`/`enums` map keys formed together.
-    fn declared_type_idents(&self) -> impl Iterator<Item = &syn::Ident> {
+    /// Every **struct or enum** name — either enum shape, never an alias.
+    ///
+    /// Named for its population rather than as the iterator form of
+    /// [`Self::declares_type`], which it is **not**: that predicate counts every
+    /// declared type, aliases included. This one feeds *"skipping undeclared
+    /// `#[prebindgen]` struct/enum"*, which names a kind an alias is not — so the
+    /// two answer differently on purpose, and the names now say so.
+    fn struct_enum_idents(&self) -> impl Iterator<Item = &syn::Ident> {
         use crate::api::core::flat::Type;
         self.flat.types().filter_map(|t| match t {
             Type::Struct(_) | Type::Variant(_) | Type::Enum(_) => Some(t.name()),
@@ -896,7 +901,7 @@ impl<M> Registry<M> {
     /// `ptr_class(ZKeyExpr<'static>)` relies on), so a diagnostic that says
     /// "no such captured item" would be false.
     ///
-    /// Distinct from [`Self::declared_type_idents`], which excludes aliases
+    /// Distinct from [`Self::struct_enum_idents`], which excludes aliases
     /// because it feeds a *"skipping undeclared struct/enum"* warning — a
     /// different question, about what an adapter left unclaimed.
     fn declares_type(&self, ident: &syn::Ident) -> bool {
@@ -1165,7 +1170,7 @@ impl<M> Registry<M> {
                 || declared.ignored_types.contains(key)
                 || declared.boundary_only_types.contains(key)
         };
-        for ident in self.declared_type_idents() {
+        for ident in self.struct_enum_idents() {
             let name = ident.to_string();
             let key = TypeKey::from_ident(ident);
             if !type_acknowledged(&key) && !pred_ignored(&name) {

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -645,7 +645,10 @@ fn builder_reads_a_source_directory() {
     let dir = write_source_dir("plain", "flat-crate", "marked_fn");
     let registry: Registry<()> = Registry::builder().source(&dir).build().expect("indexes");
 
-    assert!(registry.functions.contains_key(&fn_ident("marked_fn")));
+    assert!(registry
+        .flat()
+        .function(&fn_ident("marked_fn").to_string())
+        .is_some());
     // Dashes normalize to underscores, as they must to be a Rust module path.
     assert_eq!(
         registry.default_module().map(module),
@@ -708,7 +711,13 @@ fn builder_composes_directories_and_streams() {
         .expect("indexes");
 
     for name in ["flat_fn", "helper_fn", "synthetic"] {
-        assert!(registry.functions.contains_key(&fn_ident(name)), "{name}");
+        assert!(
+            registry
+                .flat()
+                .function(&fn_ident(name).to_string())
+                .is_some(),
+            "{name}"
+        );
     }
     // Each directory keeps its own origin; the stream item has none to keep.
     assert_eq!(
@@ -745,12 +754,18 @@ fn builder_and_from_items_agree() {
     let streamed: Registry<()> =
         Registry::from_items(crate::Source::new(&dir).items_all()).expect("indexes");
 
-    assert_eq!(built.functions.len(), streamed.functions.len());
+    assert_eq!(
+        built.flat().functions().count(),
+        streamed.flat().functions().count()
+    );
     assert_eq!(
         built.default_module().map(module),
         streamed.default_module().map(module)
     );
-    assert_eq!(built.guards.len(), streamed.guards.len());
+    assert_eq!(
+        built.flat().guards().count(),
+        streamed.flat().guards().count()
+    );
 }
 
 // ── What a table cell knows about its type ─────────────────────────────
@@ -900,18 +915,22 @@ fn from_flat_projects_each_element_kind() {
     let reg: Registry<()> = Registry::from_flat(flat).expect("project");
 
     let id = |n: &str| syn::parse_str::<syn::Ident>(n).unwrap();
-    assert!(reg.functions.contains_key(&id("f")));
-    assert!(reg.structs.contains_key(&id("S")));
-    assert!(reg.enums.contains_key(&id("Sum")), "a sum is an enum here");
-    assert!(reg.enums.contains_key(&id("Flags")));
-    assert!(reg.consts.contains_key(&id("K")));
+    assert!(reg.flat().function(&id("f").to_string()).is_some());
+    assert!(reg.flat().struct_type(&id("S").to_string()).is_some());
+    assert!(
+        reg.flat().enum_item(&id("Sum").to_string()).is_some(),
+        "a sum is an enum here"
+    );
+    assert!(reg.flat().enum_item(&id("Flags").to_string()).is_some());
+    assert!(reg.flat().constant(&id("K").to_string()).is_some());
     assert_eq!(
-        reg.guards.len(),
+        reg.flat().guards().count(),
         2,
         "both anonymous consts, in stream order"
     );
     assert!(
-        !reg.structs.contains_key(&id("Handle")) && !reg.enums.contains_key(&id("Handle")),
+        !reg.flat().struct_type(&id("Handle").to_string()).is_some()
+            && !reg.flat().enum_item(&id("Handle").to_string()).is_some(),
         "an Extern names a type; it declares no body to index"
     );
 
@@ -1068,11 +1087,9 @@ fn a_guard_never_reaches_the_const_surface() {
     ];
     let mut reg: Registry<()> = Registry::from_items(items).unwrap();
 
-    assert_eq!(reg.guards.len(), 2);
-    assert_eq!(reg.consts.len(), 1);
-    assert!(reg
-        .consts
-        .contains_key(&syn::parse_str::<syn::Ident>("REAL").unwrap()));
+    assert_eq!(reg.flat().guards().count(), 2);
+    assert_eq!(reg.flat().constants().count(), 1);
+    assert!(reg.flat().constant("REAL").is_some());
 
     // An adapter WITH a const mechanism that declares nothing warns about `REAL`
     // only: a guard is not undeclared API, it is not API.
@@ -1081,4 +1098,96 @@ fn a_guard_never_reaches_the_const_surface() {
         ..Default::default()
     };
     reg.scan_declared(&ext).expect("guards are not declarable");
+}
+
+// ── One index: what the deleted maps used to guarantee ─────────────────
+
+/// `named_item_idents` must **not** name an alias.
+///
+/// It used to derive from the four maps, and an `Extern` was in none of them.
+/// Derived from the model it would include alias names unless filtered — and its
+/// caller uses it to decide which names generated Rust qualifies, so including
+/// one would move generated output. This is the assertion that keeps the filter.
+#[test]
+fn named_item_idents_omits_aliases() {
+    let reg: Registry<()> = crate::api::test_util::reg_with(&[
+        "pub fn f(x: u64) -> u64 { x }",
+        "pub struct S { pub a: u64 }",
+        "pub enum E { A }",
+        "pub const K: u64 = 7;",
+        "pub type Handle = other::Inner;",
+    ]);
+    let names: HashSet<String> = reg.named_item_idents().map(|i| i.to_string()).collect();
+    assert_eq!(
+        names,
+        ["f", "S", "E", "K"].map(String::from).into_iter().collect(),
+        "an alias names a type but declares no body; it must not be qualified"
+    );
+}
+
+/// A binding-local fn joins the one index, carries its adapter-supplied origin
+/// crate — and does **not** join the source-module list.
+///
+/// The last part is the subtle one: `source_modules` decides `default_module`,
+/// which is what an unqualified reference resolves against. If a fn a build
+/// script invented could extend it, adding one would silently change how
+/// captured items are qualified.
+#[test]
+fn a_binding_local_fn_joins_the_index_but_not_the_source_modules() {
+    let at = SourceLocation {
+        crate_name: Some("myflat".into()),
+        ..SourceLocation::default()
+    };
+    let reg: Registry<()> = Registry::from_items(vec![(
+        syn::parse_quote!(
+            pub fn captured(x: u64) -> u64 {
+                x
+            }
+        ),
+        at,
+    )])
+    .unwrap();
+    let before_default = reg.default_module();
+    let before_all = reg.all_source_modules();
+
+    let ext = StubExt {
+        local_fns: vec![(
+            syn::parse_str("fn helper(v: u64) -> u64 { v }").unwrap(),
+            "my-helpers".into(),
+        )],
+        ..Default::default()
+    };
+    let gen = reg.resolve(ext).expect("resolve");
+    let reg = gen.registry();
+
+    // In the one index, reachable exactly like a captured fn.
+    assert!(reg.flat().function("helper").is_some());
+    // With its own origin crate, which is what qualifies its generated call.
+    assert_eq!(
+        reg.origin_module(&syn::parse_str::<syn::Ident>("helper").unwrap()),
+        Some(syn::parse_quote!(my_helpers))
+    );
+    // But the module list is untouched.
+    assert_eq!(reg.default_module(), before_default);
+    assert_eq!(reg.all_source_modules(), before_all);
+    assert!(!reg
+        .flat()
+        .source_modules()
+        .contains(&"my_helpers".to_string()));
+}
+
+/// Both enum shapes answer to `enum_item` — the merge the old `enums` map made,
+/// which 30 adapter reads depend on.
+#[test]
+fn enum_item_answers_for_both_shapes() {
+    let reg: Registry<()> = crate::api::test_util::reg_with(&[
+        "pub enum Sum { A(u64), B }",
+        "pub enum Flags { X = 1, Y = 2 }",
+        "pub struct S { pub a: u64 }",
+    ]);
+    assert!(reg.flat().enum_item("Sum").is_some(), "a sum");
+    assert!(reg.flat().enum_item("Flags").is_some(), "a C-style enum");
+    assert!(reg.flat().enum_item("S").is_none(), "not a struct");
+    assert!(reg.flat().struct_type("S").is_some());
+    assert!(reg.flat().struct_type("Sum").is_none());
 }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1227,14 +1227,14 @@ fn every_declared_type_counts_including_an_alias() {
 
     // The sibling that must NOT change: it feeds a "skipping undeclared
     // struct/enum" warning, so an alias — which is neither — stays out.
-    let bodies: HashSet<String> = reg.declared_type_idents().map(|i| i.to_string()).collect();
+    let bodies: HashSet<String> = reg.struct_enum_idents().map(|i| i.to_string()).collect();
     assert_eq!(
         bodies,
         ["S", "Sum", "Flags"]
             .map(String::from)
             .into_iter()
             .collect(),
-        "declared_type_idents feeds a struct/enum message and must exclude aliases"
+        "struct_enum_idents feeds a struct/enum message and must exclude aliases"
     );
 }
 

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1191,3 +1191,84 @@ fn enum_item_answers_for_both_shapes() {
     assert!(reg.flat().struct_type("S").is_some());
     assert!(reg.flat().struct_type("Sum").is_none());
 }
+
+// ── An alias is a declaration of its name ──────────────────────────────
+
+/// The predicate both type diagnostics gate on counts **every** declared type,
+/// alias included.
+///
+/// An alias was excluded because the pre-`Flat` code asked the `structs`/`enums`
+/// maps, which never held one. That was an artefact of where the answer came
+/// from, not a decision: `#[prebindgen] pub type Handle = ..` declares the name
+/// `Handle`, an adapter may declare it bare, and a diagnostic that says "no such
+/// captured item" about it is simply false.
+#[test]
+fn every_declared_type_counts_including_an_alias() {
+    let reg: Registry<()> = crate::api::test_util::reg_with(&[
+        "pub struct S { pub a: u64 }",
+        "pub enum Sum { A(u64), B }",
+        "pub enum Flags { X = 1 }",
+        "pub type Handle = other::Inner;",
+        "pub fn f(x: u64) -> u64 { x }",
+        "pub const K: u64 = 7;",
+    ]);
+    let id = |n: &str| syn::parse_str::<syn::Ident>(n).unwrap();
+
+    for name in ["S", "Sum", "Flags", "Handle"] {
+        assert!(
+            reg.declares_type(&id(name)),
+            "`{name}` is a declared type and must count"
+        );
+    }
+    // Not types: a fn and a const share the flat namespace but declare no type.
+    for name in ["f", "K", "Absent"] {
+        assert!(!reg.declares_type(&id(name)), "`{name}` declares no type");
+    }
+
+    // The sibling that must NOT change: it feeds a "skipping undeclared
+    // struct/enum" warning, so an alias — which is neither — stays out.
+    let bodies: HashSet<String> = reg.declared_type_idents().map(|i| i.to_string()).collect();
+    assert_eq!(
+        bodies,
+        ["S", "Sum", "Flags"]
+            .map(String::from)
+            .into_iter()
+            .collect(),
+        "declared_type_idents feeds a struct/enum message and must exclude aliases"
+    );
+}
+
+/// Both diagnostic sites reach the predicate for an alias, and neither errors.
+///
+/// `scan_declared` is the entry point for both: a path-qualified declared type
+/// whose tail names an alias (the "did you mean the bare name?" heuristic) and
+/// an ignored type that names one (the "not found among #[prebindgen] items"
+/// check). The messages themselves are `cargo:warning=` on stdout and are not
+/// captured here — what this pins is that an alias flows through the same path a
+/// struct does, without the `QualifiedDeclaredTypes` hard error.
+#[test]
+fn an_alias_flows_through_both_type_diagnostics() {
+    let build = |declare_qualified: bool| {
+        let reg: Registry<()> = crate::api::test_util::reg_with(&[
+            "pub type Handle = other::Inner;",
+            "pub fn f(x: u64) -> u64 { x }",
+        ]);
+        let mut ext = StubExt::default();
+        if declare_qualified {
+            // Head is NOT a source module, so this is the warn-and-pass-through
+            // branch rather than the hard error.
+            ext.types
+                .insert(TypeKey::parse("foreign::Handle").expect("test type"));
+        } else {
+            ext.ignored_types
+                .insert(TypeKey::parse("Handle").expect("test type"));
+        }
+        (reg, ext)
+    };
+
+    for qualified in [true, false] {
+        let (mut reg, ext) = build(qualified);
+        reg.scan_declared(&ext)
+            .expect("an alias is a captured item; neither site may fail");
+    }
+}

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -929,8 +929,8 @@ fn from_flat_projects_each_element_kind() {
         "both anonymous consts, in stream order"
     );
     assert!(
-        !reg.flat().struct_type(&id("Handle").to_string()).is_some()
-            && !reg.flat().enum_item(&id("Handle").to_string()).is_some(),
+        reg.flat().struct_type(&id("Handle").to_string()).is_none()
+            && reg.flat().enum_item(&id("Handle").to_string()).is_none(),
         "an Extern names a type; it declares no body to index"
     );
 

--- a/prebindgen/src/api/core/resolve/tests.rs
+++ b/prebindgen/src/api/core/resolve/tests.rs
@@ -44,20 +44,14 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
 /// that the resolved converter doesn't actually depend on.
 #[test]
 fn final_invariant_stops_at_resolved_nodes() {
-    use crate::{
-        api::core::registry::{Direction, Registry, TypeEntry, TypeKey},
-        SourceLocation as Loc,
-    };
+    use crate::api::core::registry::{Direction, Registry, TypeEntry, TypeKey};
 
-    let mut reg: Registry<()> = Registry::empty();
-
-    let outer_struct: syn::ItemStruct = syn::parse_str("struct Outer { inner: Inner }").unwrap();
-    let inner_struct: syn::ItemStruct =
-        syn::parse_str("struct Inner { unused: Unrelated }").unwrap();
-    reg.structs
-        .insert(outer_struct.ident.clone(), (outer_struct, Loc::default()));
-    reg.structs
-        .insert(inner_struct.ident.clone(), (inner_struct, Loc::default()));
+    // Through the real scan, so the state under test is one the pipeline can
+    // actually produce: `Unrelated` is a field type nothing declares.
+    let mut reg: Registry<()> = crate::api::test_util::reg_with(&[
+        "pub struct Outer { pub inner: Inner }",
+        "pub struct Inner { pub unused: Unrelated }",
+    ]);
 
     // `Outer` required & unresolved; `Inner` RESOLVED (with a dummy
     // entry); `Unrelated` unresolved but only reachable through Inner.

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -298,7 +298,7 @@ pub fn apply<M>(
         if let Some(declared) = &ed.declared_source {
             let item_fn = registry
                 .flat()
-                .function(&ed.func.to_string())
+                .function(&ed.func)
                 .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
             let ret = fn_return(&item_fn);
@@ -342,7 +342,7 @@ pub fn apply<M>(
             }
             let Some(item_fn) = registry
                 .flat()
-                .function(&func.to_string())
+                .function(&func)
                 .map(|f| f.origin.syntax.clone())
             else {
                 continue;
@@ -399,7 +399,7 @@ pub fn apply<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -611,7 +611,7 @@ fn wire_fixed_returns<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -696,7 +696,7 @@ fn wire_fixed_callbacks<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -783,7 +783,7 @@ pub fn apply_leaf_vec_folds<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -960,7 +960,7 @@ fn process_decl<M>(
     {
         let item_fn = registry
             .flat()
-            .function(&ed.func.to_string())
+            .function(&ed.func)
             .map(|f| f.origin.syntax.clone())
             .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
 
@@ -1713,7 +1713,7 @@ fn accessor_signature<M>(
 ) -> Result<(syn::Type, syn::Type), UnfoldError> {
     let f = registry
         .flat()
-        .function(&func.to_string())
+        .function(&func)
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
 
     // First parameter is the receiver `&T`; peel the borrow to get `T`. The
@@ -1760,7 +1760,7 @@ fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> b
 fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
     registry
         .flat()
-        .function(&func.to_string())
+        .function(&func)
         .and_then(|f| f.params.first())
         .is_some_and(|p| !matches!(p.ty.kind, crate::api::core::flat::TypeKind::Ref { .. }))
 }

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -296,10 +296,10 @@ pub fn apply<M>(
         // fn's peeled (`Option`/`Vec`/`&`) return type — the typo guard for
         // `.expand_return(expand_return!(T)…)`.
         if let Some(declared) = &ed.declared_source {
-            let (item_fn, _) = registry
-                .functions
-                .get(&ed.func)
-                .cloned()
+            let item_fn = registry
+                .flat()
+                .function(&ed.func.to_string())
+                .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
             let ret = fn_return(&item_fn);
             if !returns_type(&ret, &TypeKey::from_type(declared)) {
@@ -340,7 +340,11 @@ pub fn apply<M>(
             if accessor_fns.contains(func) {
                 continue;
             }
-            let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
+            let Some(item_fn) = registry
+                .flat()
+                .function(&func.to_string())
+                .map(|f| f.origin.syntax.clone())
+            else {
                 continue;
             };
             let ret = fn_return(&item_fn);
@@ -393,7 +397,11 @@ pub fn apply<M>(
     // (there is no return-value lane in a callback invocation). A type without
     // a default deconstructor gets no plan and is delivered whole.
     for func in declared_fns {
-        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
+        let Some(item_fn) = registry
+            .flat()
+            .function(&func.to_string())
+            .map(|f| f.origin.syntax.clone())
+        else {
             continue;
         };
         for input in &item_fn.sig.inputs {
@@ -601,7 +609,11 @@ fn wire_fixed_returns<M>(
     no_converter: bool,
 ) {
     for func in declared_fns {
-        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
+        let Some(item_fn) = registry
+            .flat()
+            .function(&func.to_string())
+            .map(|f| f.origin.syntax.clone())
+        else {
             continue;
         };
         let ret = fn_return(&item_fn);
@@ -682,7 +694,11 @@ fn wire_fixed_callbacks<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
     for func in declared_fns {
-        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
+        let Some(item_fn) = registry
+            .flat()
+            .function(&func.to_string())
+            .map(|f| f.origin.syntax.clone())
+        else {
             continue;
         };
         for input in &item_fn.sig.inputs {
@@ -765,7 +781,11 @@ pub fn apply_leaf_vec_folds<M>(
     // Is the leading-`&`-peeled `bare` one of the nominated single-leaf elements?
     let is_nominated = |bare: &syn::Type| elem_keys.contains(&TypeKey::from_type(bare));
     for func in declared_fns {
-        let Some((item_fn, _)) = registry.functions.get(func).cloned() else {
+        let Some(item_fn) = registry
+            .flat()
+            .function(&func.to_string())
+            .map(|f| f.origin.syntax.clone())
+        else {
             continue;
         };
         // Output position: `Vec<T>` / `Option<Vec<T>>` return. Skip if a plan
@@ -938,10 +958,10 @@ fn process_decl<M>(
     ed: &OutputDecl,
 ) -> Result<(), UnfoldError> {
     {
-        let (item_fn, _) = registry
-            .functions
-            .get(&ed.func)
-            .cloned()
+        let item_fn = registry
+            .flat()
+            .function(&ed.func.to_string())
+            .map(|f| f.origin.syntax.clone())
             .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
 
         // The value to decompose: the success return (`Output`) or the
@@ -1691,29 +1711,23 @@ fn accessor_signature<M>(
     registry: &Registry<M>,
     func: &syn::Ident,
 ) -> Result<(syn::Type, syn::Type), UnfoldError> {
-    let (item_fn, _) = registry
-        .functions
-        .get(func)
+    let f = registry
+        .flat()
+        .function(&func.to_string())
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
 
-    // First parameter is the receiver `&T`; peel the borrow to get `T`.
-    let takes = item_fn
-        .sig
-        .inputs
-        .iter()
-        .find_map(|input| match input {
-            syn::FnArg::Typed(pt) => Some((*pt.ty).clone()),
-            _ => None,
-        })
+    // First parameter is the receiver `&T`; peel the borrow to get `T`. The
+    // borrow is `TypeKind::Ref`, so the peel reads the classification instead of
+    // re-deciding it from `syn::Type::Reference`.
+    let first = f
+        .params
+        .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
-    let takes = match takes {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other,
+    let takes = match &first.ty.kind {
+        crate::api::core::flat::TypeKind::Ref { inner, .. } => inner.origin.syntax.clone(),
+        _ => first.ty.origin.syntax.clone(),
     };
-    let ret: syn::Type = match &item_fn.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, t) => (**t).clone(),
-    };
+    let ret: syn::Type = f.ret.origin.syntax.clone();
     Ok((takes, ret))
 }
 
@@ -1744,16 +1758,11 @@ fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> b
 /// compare target types, so `f(v: T)` and `f(v: &T)` are indistinguishable
 /// there by design.
 fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
-    registry.functions.get(func).is_some_and(|(f, _)| {
-        f.sig
-            .inputs
-            .iter()
-            .find_map(|input| match input {
-                syn::FnArg::Typed(pt) => Some(!matches!(*pt.ty, syn::Type::Reference(_))),
-                _ => None,
-            })
-            .unwrap_or(false)
-    })
+    registry
+        .flat()
+        .function(&func.to_string())
+        .and_then(|f| f.params.first())
+        .is_some_and(|p| !matches!(p.ty.kind, crate::api::core::flat::TypeKind::Ref { .. }))
 }
 
 fn check_takes(

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -7,7 +7,7 @@
 //! resolves the path against `OUT_DIR`).
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
@@ -81,49 +81,60 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     //    via `cargo:warning=` in `Registry::scan_declared`.
     let declared_fns = ext.declared_functions();
     let declared_types = ext.declared_types();
+    let flat = registry.flat();
     items.extend(parse_items_from_tokens(
         "on_function",
-        sorted_items_by_ident(&registry.functions)
+        sorted_by_name(flat.functions().map(|f| (&f.name, &f.origin.syntax)))
             .into_iter()
             .filter(|(ident, _)| declared_fns.contains(*ident))
-            .map(|(_, (item, _))| ext.on_function(item, registry)),
+            .map(|(_, item)| ext.on_function(item, registry)),
     )?);
     items.extend(parse_items_from_tokens(
         "on_struct",
-        sorted_items_by_ident(&registry.structs)
-            .into_iter()
-            .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
-            .map(|(_, (item, _))| ext.on_struct(item, registry)),
+        sorted_by_name(flat.types().filter_map(|t| match t {
+            crate::api::core::flat::Type::Struct(s) => Some((&s.name, &s.origin.syntax)),
+            _ => None,
+        }))
+        .into_iter()
+        .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
+        .map(|(_, item)| ext.on_struct(item, registry)),
     )?);
+    // Both enum shapes emit through `on_enum` and sort together: they were one
+    // map here before they were two elements, and an adapter re-emitting the
+    // item does not branch on the distinction.
     items.extend(parse_items_from_tokens(
         "on_enum",
-        sorted_items_by_ident(&registry.enums)
-            .into_iter()
-            .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
-            .map(|(_, (item, _))| ext.on_enum(item, registry)),
+        sorted_by_name(flat.types().filter_map(|t| match t {
+            crate::api::core::flat::Type::Variant(v) => Some((&v.name, &v.origin.syntax)),
+            crate::api::core::flat::Type::Enum(e) => Some((&e.name, &e.origin.syntax)),
+            _ => None,
+        }))
+        .into_iter()
+        .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
+        .map(|(_, item)| ext.on_enum(item, registry)),
     )?);
     // Consts: an adapter WITH a const declaration mechanism
     // (`declared_consts() == Some(set)`) emits declared consts only,
     // symmetric with functions; an adapter without one (`None`) gets every
     // const passed through verbatim via the default `on_const`. Prebindgen's
-    // own injected feature guards are not consts at all — see `guards` below.
+    // own injected feature guards are not consts at all — see the guards loop.
     let declared_consts = ext.declared_consts();
     items.extend(parse_items_from_tokens(
         "on_const",
-        sorted_items_by_ident(&registry.consts)
+        sorted_by_name(flat.constants().map(|c| (&c.name, &c.origin.syntax)))
             .into_iter()
             .filter(|(ident, _)| {
                 declared_consts
                     .as_ref()
                     .is_none_or(|set| set.contains(*ident))
             })
-            .map(|(_, (item, _))| ext.on_const(item, registry)),
+            .map(|(_, item)| ext.on_const(item, registry)),
     )?);
 
     // 3. Anonymous consts, verbatim. Last, and in stream order. Ungated on
     //    purpose: with no name there is nothing for an adapter to declare, so
     //    the const gate above cannot apply to them.
-    for guard in &registry.guards {
+    for guard in flat.guards() {
         items.push(syn::Item::Const(guard.origin.syntax.clone()));
     }
 
@@ -173,8 +184,16 @@ fn walk_resolved<M, F: FnMut(&TypeKey, &TypeEntry<M>)>(
     }
 }
 
-fn sorted_items_by_ident<T>(map: &HashMap<syn::Ident, T>) -> Vec<(&syn::Ident, &T)> {
-    let mut items: Vec<(&syn::Ident, &T)> = map.iter().collect();
+/// Name-sorted, because emission order is part of the generated file and the
+/// model is in source order. Was `sorted_items_by_ident` over the registry's
+/// maps; same ordering, read from the one index.
+fn sorted_by_name<'a, T>(
+    items: impl Iterator<Item = (&'a syn::Ident, &'a T)>,
+) -> Vec<(&'a syn::Ident, &'a T)>
+where
+    T: 'a,
+{
+    let mut items: Vec<(&syn::Ident, &T)> = items.collect();
     items.sort_by_key(|(left, _)| left.to_string());
     items
 }

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -113,47 +113,34 @@ fn dedup_and_sort() {
 
 #[test]
 fn write_rust_sorts_declared_items_by_ident() {
-    let mut reg: Registry<()> = Registry::empty();
+    // Fed in a deliberately un-sorted order: the assertion below is that
+    // emission sorts by name, and the model preserves stream order.
     let loc = SourceLocation::default();
-
-    reg.functions.insert(
-        syn::parse_quote!(b_fn),
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::parse_quote!(
                 fn b_fn() {}
             ),
             loc.clone(),
         ),
-    );
-    reg.functions.insert(
-        syn::parse_quote!(a_fn),
         (
             syn::parse_quote!(
                 fn a_fn() {}
             ),
             loc.clone(),
         ),
-    );
-    reg.structs.insert(
-        syn::parse_quote!(BStruct),
         (
             syn::parse_quote!(
                 pub struct BStruct;
             ),
             loc.clone(),
         ),
-    );
-    reg.structs.insert(
-        syn::parse_quote!(AStruct),
         (
             syn::parse_quote!(
                 pub struct AStruct;
             ),
             loc.clone(),
         ),
-    );
-    reg.enums.insert(
-        syn::parse_quote!(BEnum),
         (
             syn::parse_quote!(
                 pub enum BEnum {
@@ -162,9 +149,6 @@ fn write_rust_sorts_declared_items_by_ident() {
             ),
             loc.clone(),
         ),
-    );
-    reg.enums.insert(
-        syn::parse_quote!(AEnum),
         (
             syn::parse_quote!(
                 pub enum AEnum {
@@ -173,25 +157,20 @@ fn write_rust_sorts_declared_items_by_ident() {
             ),
             loc.clone(),
         ),
-    );
-    reg.consts.insert(
-        syn::parse_quote!(B_CONST),
         (
             syn::parse_quote!(
                 pub const B_CONST: u32 = 2;
             ),
             loc.clone(),
         ),
-    );
-    reg.consts.insert(
-        syn::parse_quote!(A_CONST),
         (
             syn::parse_quote!(
                 pub const A_CONST: u32 = 1;
             ),
             loc,
         ),
-    );
+    ];
+    let reg: Registry<()> = Registry::from_items(items).expect("index");
 
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -295,7 +274,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         ),
     ];
     let registry: Registry<()> = Registry::from_items(items).expect("index");
-    assert_eq!(registry.guards.len(), 2);
+    assert_eq!(registry.flat().guards().count(), 2);
 
     let dir = crate::api::test_util::unique_test_dir("write_guards");
     std::fs::create_dir_all(&dir).unwrap();

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -193,10 +193,10 @@ impl Cbindgen {
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
-                    .functions
-                    .get(f)
-                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f))
-                    .0;
+                    .flat()
+                    .function(&f.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (repr, by_ref) = one_param(item);
                 let ret = fn_ret(item);
                 let (ok, fallible) = match result_parts(&ret) {
@@ -237,10 +237,10 @@ impl Cbindgen {
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
-                    .functions
-                    .get(f)
-                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f))
-                    .0;
+                    .flat()
+                    .function(&f.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (param, by_ref) = one_param(item);
                 assert_eq!(TypeKey::from_type(&param), decl.key);
                 let ret = fn_ret(item);

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -195,7 +195,7 @@ impl Cbindgen {
                 let item = &registry
                     .flat()
                     .function(&f)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (repr, by_ref) = one_param(item);
                 let ret = fn_ret(item);
@@ -239,7 +239,7 @@ impl Cbindgen {
                 let item = &registry
                     .flat()
                     .function(&f)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (param, by_ref) = one_param(item);
                 assert_eq!(TypeKey::from_type(&param), decl.key);

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -194,7 +194,7 @@ impl Cbindgen {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
                     .flat()
-                    .function(&f.to_string())
+                    .function(&f)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (repr, by_ref) = one_param(item);
@@ -238,7 +238,7 @@ impl Cbindgen {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
                     .flat()
-                    .function(&f.to_string())
+                    .function(&f)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (param, by_ref) = one_param(item);

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -55,7 +55,7 @@ impl Cbindgen {
         ty: &syn::Type,
     ) -> Option<Vec<syn::Variant>> {
         let ident = type_path_tail(ty)?;
-        let (item, _) = registry.enums.get(&ident)?;
+        let item = registry.flat().enum_item(&ident.to_string())?;
         Some(item.variants.iter().cloned().collect())
     }
 
@@ -284,12 +284,11 @@ impl Cbindgen {
     pub(super) fn produces_array(&self, registry: &Registry<()>) -> bool {
         self.functions.keys().any(|orig| {
             registry
-                .functions
-                .get(orig)
-                .map(|(f, _)| match &f.sig.output {
-                    syn::ReturnType::Type(_, ty) => type_contains_vec(ty),
-                    syn::ReturnType::Default => false,
-                })
+                .flat()
+                .function(&orig.to_string())
+                // The model already decided that an elided return and `-> ()`
+                // are one thing, so there is no second arm to write here.
+                .map(|f| type_contains_vec(&f.ret.origin.syntax))
                 .unwrap_or(false)
         })
     }
@@ -303,7 +302,10 @@ impl Cbindgen {
         ty: &syn::Type,
     ) -> Option<Vec<(syn::Ident, syn::Type)>> {
         let ident = type_path_tail(ty)?;
-        let (item, _) = registry.structs.get(&ident)?;
+        let item = registry
+            .flat()
+            .struct_type(&ident.to_string())
+            .map(|__s| &__s.origin.syntax)?;
         if let syn::Fields::Named(named) = &item.fields {
             Some(
                 named

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -55,7 +55,7 @@ impl Cbindgen {
         ty: &syn::Type,
     ) -> Option<Vec<syn::Variant>> {
         let ident = type_path_tail(ty)?;
-        let item = registry.flat().enum_item(&ident.to_string())?;
+        let item = registry.flat().enum_item(&ident)?;
         Some(item.variants.iter().cloned().collect())
     }
 
@@ -285,7 +285,7 @@ impl Cbindgen {
         self.functions.keys().any(|orig| {
             registry
                 .flat()
-                .function(&orig.to_string())
+                .function(&orig)
                 // The model already decided that an elided return and `-> ()`
                 // are one thing, so there is no second arm to write here.
                 .map(|f| type_contains_vec(&f.ret.origin.syntax))
@@ -304,7 +304,7 @@ impl Cbindgen {
         let ident = type_path_tail(ty)?;
         let item = registry
             .flat()
-            .struct_type(&ident.to_string())
+            .struct_type(&ident)
             .map(|__s| &__s.origin.syntax)?;
         if let syn::Fields::Named(named) = &item.fields {
             Some(

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -305,7 +305,7 @@ impl Cbindgen {
         let item = registry
             .flat()
             .struct_type(&ident)
-            .map(|__s| &__s.origin.syntax)?;
+            .map(|st| &st.origin.syntax)?;
         if let syn::Fields::Named(named) = &item.fields {
             Some(
                 named

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -393,7 +393,7 @@ fn type_short(ty: &syn::Type) -> String {
 /// The indexed `syn::ItemEnum` for a declared enum type, by tail ident.
 fn enum_item<'r>(registry: &'r Registry<()>, ty: &syn::Type) -> Option<&'r syn::ItemEnum> {
     let ident = type_path_tail(ty)?;
-    registry.enums.get(&ident).map(|(e, _)| e)
+    registry.flat().enum_item(&ident.to_string())
 }
 
 /// Hard error when a `.tagged_union()`-declared enum is unit-only. The

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -393,7 +393,7 @@ fn type_short(ty: &syn::Type) -> String {
 /// The indexed `syn::ItemEnum` for a declared enum type, by tail ident.
 fn enum_item<'r>(registry: &'r Registry<()>, ty: &syn::Type) -> Option<&'r syn::ItemEnum> {
     let ident = type_path_tail(ty)?;
-    registry.flat().enum_item(&ident.to_string())
+    registry.flat().enum_item(&ident)
 }
 
 /// Hard error when a `.tagged_union()`-declared enum is unit-only. The

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -812,7 +812,7 @@ impl JniGen {
         let func = &decl.func;
         let item_fn = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|__f| &__f.origin.syntax)
             .unwrap_or_else(|| {
                 panic!(
@@ -1035,7 +1035,7 @@ impl JniGen {
                     let ident = bare_path_ident(&probe).expect("a sum type is a path type");
                     let item_enum = registry
                         .flat()
-                        .enum_item(&ident.to_string())
+                        .enum_item(&ident)
                         .expect("TypeKind::Sum implies an indexed enum");
                     let sum_cfg = self.types[&TypeKey::from_type(&probe)]
                         .sum()
@@ -1398,7 +1398,7 @@ impl JniGen {
             ConvertSpec::PrebindgenFn(f) => {
                 let item_fn = registry
                     .flat()
-                    .function(&f.to_string())
+                    .function(&f)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| {
                         panic!(
@@ -1474,7 +1474,7 @@ impl JniGen {
             ConvertSpec::PrebindgenFn(g) => {
                 let item_fn = registry
                     .flat()
-                    .function(&g.to_string())
+                    .function(&g)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| {
                         panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -813,7 +813,7 @@ impl JniGen {
         let item_fn = registry
             .flat()
             .function(&func)
-            .map(|__f| &__f.origin.syntax)
+            .map(|func| &func.origin.syntax)
             .unwrap_or_else(|| {
                 panic!(
                     "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
@@ -1399,7 +1399,7 @@ impl JniGen {
                 let item_fn = registry
                     .flat()
                     .function(&f)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                     .unwrap_or_else(|| {
                         panic!(
                             "convert!({}).input({f}): function not found among #[prebindgen] items",
@@ -1475,7 +1475,7 @@ impl JniGen {
                 let item_fn = registry
                     .flat()
                     .function(&g)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                     .unwrap_or_else(|| {
                         panic!(
                         "convert!({}).output({g}): function not found among #[prebindgen] items",

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -810,15 +810,19 @@ impl JniGen {
         decl: &FieldsDecl,
     ) -> Vec<crate::api::core::unfold::FieldRecord> {
         let func = &decl.func;
-        let (item_fn, _) = registry.functions.get(func).unwrap_or_else(|| {
-            panic!(
-                "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
+        let item_fn = registry
+            .flat()
+            .function(&func.to_string())
+            .map(|__f| &__f.origin.syntax)
+            .unwrap_or_else(|| {
+                panic!(
+                    "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
                  `{func}` — a value form is an accessor `fn {func}(v: &{}) -> {}Struct`",
-                key.as_str(),
-                key.as_str(),
-                key.as_str(),
-            )
-        });
+                    key.as_str(),
+                    key.as_str(),
+                    key.as_str(),
+                )
+            });
         let ret: syn::Type = match &item_fn.sig.output {
             syn::ReturnType::Type(_, t) => crate::api::core::unfold::peel_ref(t),
             syn::ReturnType::Default => panic!(
@@ -1029,9 +1033,9 @@ impl JniGen {
                         dotted,
                     );
                     let ident = bare_path_ident(&probe).expect("a sum type is a path type");
-                    let (item_enum, _) = registry
-                        .enums
-                        .get(&ident)
+                    let item_enum = registry
+                        .flat()
+                        .enum_item(&ident.to_string())
                         .expect("TypeKind::Sum implies an indexed enum");
                     let sum_cfg = self.types[&TypeKey::from_type(&probe)]
                         .sum()
@@ -1392,12 +1396,16 @@ impl JniGen {
         let target = key.to_type();
         let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
-                let (item_fn, _) = registry.functions.get(f).unwrap_or_else(|| {
-                    panic!(
-                        "convert!({}).input({f}): function not found among #[prebindgen] items",
-                        key.as_str()
-                    )
-                });
+                let item_fn = registry
+                    .flat()
+                    .function(&f.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "convert!({}).input({f}): function not found among #[prebindgen] items",
+                            key.as_str()
+                        )
+                    });
                 let (param_ty, by_ref) = convert_single_param(key, f, item_fn, "input");
                 // Return: `T` (infallible) or `Result<T, E>` (fallible — E
                 // routes to the caller's error handler via the exc slot).
@@ -1464,12 +1472,16 @@ impl JniGen {
         let target = key.to_type();
         let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
-                let (item_fn, _) = registry.functions.get(g).unwrap_or_else(|| {
-                    panic!(
+                let item_fn = registry
+                    .flat()
+                    .function(&g.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                    .unwrap_or_else(|| {
+                        panic!(
                         "convert!({}).output({g}): function not found among #[prebindgen] items",
                         key.as_str()
                     )
-                });
+                    });
                 let (param_ty, by_ref) = convert_single_param_any(g, item_fn);
                 assert!(
                     TypeKey::from_type(&param_ty) == *key,

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -63,7 +63,11 @@ impl JniGen {
             }
         }
         if let Some(name) = bare_path_ident(bare) {
-            if let Some((st, _)) = registry.structs.get(&name) {
+            if let Some(st) = registry
+                .flat()
+                .struct_type(&name.to_string())
+                .map(|__s| &__s.origin.syntax)
+            {
                 return TypeKind::DataStruct { st, cfg };
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -65,7 +65,7 @@ impl JniGen {
         if let Some(name) = bare_path_ident(bare) {
             if let Some(st) = registry
                 .flat()
-                .struct_type(&name.to_string())
+                .struct_type(&name)
                 .map(|__s| &__s.origin.syntax)
             {
                 return TypeKind::DataStruct { st, cfg };

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -66,7 +66,7 @@ impl JniGen {
             if let Some(st) = registry
                 .flat()
                 .struct_type(&name)
-                .map(|__s| &__s.origin.syntax)
+                .map(|st| &st.origin.syntax)
             {
                 return TypeKind::DataStruct { st, cfg };
             }

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -1,6 +1,6 @@
 //! One-stop classification of how a bare Rust type is declared to this
 //! adapter — the single precedence every emitter agrees on instead of each
-//! re-deriving it from `TypeConfig` flags and `registry.structs` probes.
+//! re-deriving it from `TypeConfig` flags and `registry.flat()` type probes.
 
 use super::*;
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -882,7 +882,7 @@ fn build_flat_sum_field(
     use crate::api::core::types_util::SumSpec;
 
     let ident = bare_path_ident(sum_ty)?;
-    let item_enum = registry.flat().enum_item(&ident.to_string())?;
+    let item_enum = registry.flat().enum_item(&ident)?;
     let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
     let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
@@ -1135,7 +1135,7 @@ pub(crate) fn build_flat_input_plan(
     };
     let Some(st) = registry
         .flat()
-        .struct_type(&name.to_string())
+        .struct_type(&name)
         .map(|__s| &__s.origin.syntax)
     else {
         return Ok(None);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -1136,7 +1136,7 @@ pub(crate) fn build_flat_input_plan(
     let Some(st) = registry
         .flat()
         .struct_type(&name)
-        .map(|__s| &__s.origin.syntax)
+        .map(|st| &st.origin.syntax)
     else {
         return Ok(None);
     };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -882,7 +882,7 @@ fn build_flat_sum_field(
     use crate::api::core::types_util::SumSpec;
 
     let ident = bare_path_ident(sum_ty)?;
-    let (item_enum, _) = registry.enums.get(&ident)?;
+    let item_enum = registry.flat().enum_item(&ident.to_string())?;
     let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
     let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
@@ -1133,7 +1133,11 @@ pub(crate) fn build_flat_input_plan(
     let Some(name) = bare_path_ident(&struct_ty) else {
         return Ok(None);
     };
-    let Some((st, _)) = registry.structs.get(&name) else {
+    let Some(st) = registry
+        .flat()
+        .struct_type(&name.to_string())
+        .map(|__s| &__s.origin.syntax)
+    else {
         return Ok(None);
     };
     let key = TypeKey::from_type(&struct_ty);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -76,9 +76,9 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 /// data-class behind `Option` / `Vec`. (Those are handled by the slower
 /// [`struct_output_body`] until the synthesizer is widened to wrap them.)
 ///
-/// Classification reads only `ext.types` (`opaque`/`enum_cfg`) and
-/// `registry.structs` — both populated before `resolve` — never the output
-/// converter table (not yet built at this stage).
+/// Classification reads only `ext.types` (`opaque`/`enum_cfg`) and the parsed
+/// model (`registry.flat()`) — both populated before `resolve` — never the
+/// output converter table (not yet built at this stage).
 pub(crate) fn synth_value_struct_leaves(
     ext: &JniGen,
     registry: &Registry<KotlinMeta>,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -222,9 +222,12 @@ pub(crate) fn encode_sum_group(
     let tag_id = &obj_idents[tag_idx];
     // A unit variant contributes no leaf, so the arm list is driven by the
     // enum's own variants, not by the grouped leaves.
-    let (item_enum, _) = registry.enums.get(&ident).unwrap_or_else(|| {
-        panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
-    });
+    let item_enum = registry
+        .flat()
+        .enum_item(&ident.to_string())
+        .unwrap_or_else(|| {
+            panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
+        });
     let spec = crate::api::core::types_util::SumSpec::from_item_enum(item_enum);
 
     let arms: Vec<TokenStream> = spec

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -222,12 +222,9 @@ pub(crate) fn encode_sum_group(
     let tag_id = &obj_idents[tag_idx];
     // A unit variant contributes no leaf, so the arm list is driven by the
     // enum's own variants, not by the grouped leaves.
-    let item_enum = registry
-        .flat()
-        .enum_item(&ident.to_string())
-        .unwrap_or_else(|| {
-            panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
-        });
+    let item_enum = registry.flat().enum_item(&ident).unwrap_or_else(|| {
+        panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
+    });
     let spec = crate::api::core::types_util::SumSpec::from_item_enum(item_enum);
 
     let arms: Vec<TokenStream> = spec

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -65,7 +65,11 @@ pub(crate) fn collect_vec_build_elem_types(
 ) -> Vec<syn::Type> {
     let declared = ext.declared_functions();
     let mut seen: std::collections::BTreeMap<String, syn::Type> = std::collections::BTreeMap::new();
-    for (ident, (item_fn, _)) in &registry.functions {
+    for (ident, item_fn) in registry
+        .flat()
+        .functions()
+        .map(|f| (&f.name, &f.origin.syntax))
+    {
         if !declared.contains(ident) {
             continue;
         }

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -296,19 +296,17 @@ pub(crate) fn validate_bindings(
     // Declared functions (incl. binding-local synthetics and fn-backed
     // constants), in deterministic ident order.
     let declared = ext.declared_functions();
-    let mut fn_idents: Vec<&syn::Ident> =
-        registry.flat().functions().map(|__f| &__f.name).collect();
-    fn_idents.sort();
-    for ident in fn_idents {
+    // The elements themselves, not their names: looking a name back up would be
+    // a second hash and an infallible-lookup-that-is-not. `Ident: Ord` is the
+    // string order, so the sort is unchanged.
+    let mut fns: Vec<&crate::api::core::flat::Function> = registry.flat().functions().collect();
+    fns.sort_by(|a, b| a.name.cmp(&b.name));
+    for f in fns {
+        let ident = &f.name;
         if !declared.contains(ident) {
             continue;
         }
-        let item_fn = &registry
-            .flat()
-            .function(&ident)
-            .expect("iterating the model's own function names")
-            .origin
-            .syntax;
+        let item_fn = &f.origin.syntax;
         match ext.fn_plan(registry, item_fn) {
             Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
             Err(e) => errors.push(e.message(ident)),
@@ -318,20 +316,15 @@ pub(crate) fn validate_bindings(
     // Declared consts: their synthetic nullary getters run through the same
     // plan machinery (`JniGen::on_const`).
     if let Some(declared_consts) = ext.declared_consts() {
-        let mut const_idents: Vec<&syn::Ident> =
-            registry.flat().constants().map(|__c| &__c.name).collect();
-        const_idents.sort();
-        for ident in const_idents {
+        let mut consts: Vec<&crate::api::core::flat::Constant> =
+            registry.flat().constants().collect();
+        consts.sort_by(|a, b| a.name.cmp(&b.name));
+        for c in consts {
+            let ident = &c.name;
             if !declared_consts.contains(ident) {
                 continue;
             }
-            let item_const = &registry
-                .flat()
-                .constant(&ident)
-                .expect("iterating the model's own const names")
-                .origin
-                .syntax;
-            let getter = const_getter_fn(item_const);
+            let getter = const_getter_fn(&c.origin.syntax);
             match ext.fn_plan(registry, &getter) {
                 Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
                 Err(e) => errors.push(e.message(&getter.sig.ident)),

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -305,7 +305,7 @@ pub(crate) fn validate_bindings(
         }
         let item_fn = &registry
             .flat()
-            .function(&ident.to_string())
+            .function(&ident)
             .expect("iterating the model's own function names")
             .origin
             .syntax;
@@ -327,7 +327,7 @@ pub(crate) fn validate_bindings(
             }
             let item_const = &registry
                 .flat()
-                .constant(&ident.to_string())
+                .constant(&ident)
                 .expect("iterating the model's own const names")
                 .origin
                 .syntax;

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -296,13 +296,19 @@ pub(crate) fn validate_bindings(
     // Declared functions (incl. binding-local synthetics and fn-backed
     // constants), in deterministic ident order.
     let declared = ext.declared_functions();
-    let mut fn_idents: Vec<&syn::Ident> = registry.functions.keys().collect();
+    let mut fn_idents: Vec<&syn::Ident> =
+        registry.flat().functions().map(|__f| &__f.name).collect();
     fn_idents.sort();
     for ident in fn_idents {
         if !declared.contains(ident) {
             continue;
         }
-        let (item_fn, _) = &registry.functions[ident];
+        let item_fn = &registry
+            .flat()
+            .function(&ident.to_string())
+            .expect("iterating the model's own function names")
+            .origin
+            .syntax;
         match ext.fn_plan(registry, item_fn) {
             Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
             Err(e) => errors.push(e.message(ident)),
@@ -312,13 +318,19 @@ pub(crate) fn validate_bindings(
     // Declared consts: their synthetic nullary getters run through the same
     // plan machinery (`JniGen::on_const`).
     if let Some(declared_consts) = ext.declared_consts() {
-        let mut const_idents: Vec<&syn::Ident> = registry.consts.keys().collect();
+        let mut const_idents: Vec<&syn::Ident> =
+            registry.flat().constants().map(|__c| &__c.name).collect();
         const_idents.sort();
         for ident in const_idents {
             if !declared_consts.contains(ident) {
                 continue;
             }
-            let (item_const, _) = &registry.consts[ident];
+            let item_const = &registry
+                .flat()
+                .constant(&ident.to_string())
+                .expect("iterating the model's own const names")
+                .origin
+                .syntax;
             let getter = const_getter_fn(item_const);
             match ext.fn_plan(registry, &getter) {
                 Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -492,7 +492,7 @@ impl JniGen {
             }) else {
                 continue;
             };
-            let Some((item_enum, _)) = registry.enums.get(&ident) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
                 continue;
             };
             let (package, class_name) = match kotlin_fqn.rsplit_once('.') {
@@ -548,7 +548,7 @@ impl JniGen {
             let Some(ident) = bare_path_ident(&ty) else {
                 continue;
             };
-            let Some((item_enum, _)) = registry.enums.get(&ident) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
                 continue;
             };
             assert!(
@@ -893,7 +893,11 @@ impl JniGen {
             }) else {
                 continue;
             };
-            let Some((item_struct, _)) = registry.structs.get(&ident) else {
+            let Some(item_struct) = registry
+                .flat()
+                .struct_type(&ident.to_string())
+                .map(|__s| &__s.origin.syntax)
+            else {
                 continue;
             };
 
@@ -921,7 +925,11 @@ impl JniGen {
                 imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
             }
             for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
-                if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
+                if let Some(item_fn) = registry
+                    .flat()
+                    .function(&m.rust_ident.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                         self,
                         item_fn,
@@ -951,7 +959,11 @@ impl JniGen {
                     .map(|c| *c)
                     .unwrap_or_else(|| KtClass::companion_object().vis(Vis::Public));
                 for m in ctors {
-                    if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
+                    if let Some(item_fn) = registry
+                        .flat()
+                        .function(&m.rust_ident.to_string())
+                        .map(|__f| &__f.origin.syntax)
+                    {
                         if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                             self,
                             item_fn,
@@ -1067,7 +1079,11 @@ impl JniGen {
             .collect();
         for ident in &declared_idents {
             {
-                let Some((item_fn, _loc)) = registry.functions.get(ident) else {
+                let Some(item_fn) = registry
+                    .flat()
+                    .function(&ident.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                else {
                     continue;
                 };
                 for input in &item_fn.sig.inputs {
@@ -1433,9 +1449,9 @@ impl JniGen {
         let iface_short = register_fqn(&iface_fqn, imports);
         let ident = bare_path_ident(source)
             .unwrap_or_else(|| panic!("sum builder: `{key}` is not a path type"));
-        let (item_enum, _) = registry
-            .enums
-            .get(&ident)
+        let item_enum = registry
+            .flat()
+            .enum_item(&ident.to_string())
             .unwrap_or_else(|| panic!("sum builder: no indexed enum `{ident}`"));
         let sum_cfg = self.types[&key]
             .sum()
@@ -1577,9 +1593,9 @@ impl JniGen {
         let mut file = kt::KtFile::new(&package);
         let mut imports: BTreeSet<String> = BTreeSet::new();
         for entry in &pkg_cfg.functions {
-            let (item_fn, _loc) = registry
-                .functions
-                .get(&entry.rust_ident)
+            let item_fn = &registry
+                .flat()
+                .function(&entry.rust_ident.to_string())
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: function `{}` registered via .function(...) is \
@@ -1588,6 +1604,7 @@ impl JniGen {
                         entry.rust_ident,
                     )
                 });
+            let item_fn = &item_fn.origin.syntax;
             let kotlin_name = self.effective_function_name(subpackage, entry);
             if let Some(f) = render_wrapper_fn(self, item_fn, registry, Some(&kotlin_name), None) {
                 // #52: idiomatic typed overloads for `.split_on_param`
@@ -1601,14 +1618,18 @@ impl JniGen {
         // Declared consts: a private nullary helper + the public
         // lazily-initialized `val` (see `render_const_val`).
         for entry in &pkg_cfg.constants {
-            let (item_const, _loc) = registry.consts.get(&entry.rust_ident).unwrap_or_else(|| {
-                panic!(
-                    "write_jni_package: const `{}` registered via .constant(...) is \
+            let item_const = registry
+                .flat()
+                .constant(&entry.rust_ident.to_string())
+                .map(|__c| &__c.origin.syntax)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "write_jni_package: const `{}` registered via .constant(...) is \
                      not in the prebindgen registry — check the spelling against the \
                      matching `#[prebindgen]` Rust const name.",
-                    entry.rust_ident,
-                )
-            });
+                        entry.rust_ident,
+                    )
+                });
             reject_handle_const(self, item_const);
             if let Some((helper, prop)) = render_const_val(
                 self,
@@ -1626,9 +1647,9 @@ impl JniGen {
         // `val` (see `render_constant_fn_val`). The JNINative extern and the
         // Rust wrapper are the plain declared-function ones.
         for entry in &pkg_cfg.constant_functions {
-            let (item_fn, _loc) = registry
-                .functions
-                .get(&entry.rust_ident)
+            let item_fn = &registry
+                .flat()
+                .function(&entry.rust_ident.to_string())
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: constant fn `{}` registered via .constant_fun(...) \
@@ -1637,6 +1658,7 @@ impl JniGen {
                         entry.rust_ident,
                     )
                 });
+            let item_fn = &item_fn.origin.syntax;
             validate_constant_fn(self, item_fn);
             if let Some((helper, prop)) = render_constant_fn_val(
                 self,
@@ -1689,13 +1711,19 @@ impl JniGen {
         // shortens types, collects imports, and wraps long signatures (no
         // derivation-time import set).
         let mut externs: Vec<kt::KtFun> = Vec::new();
-        let mut idents: Vec<&syn::Ident> = registry.functions.keys().collect();
+        let mut idents: Vec<&syn::Ident> =
+            registry.flat().functions().map(|__f| &__f.name).collect();
         idents.sort();
         for ident in idents {
             if !declared.contains(ident) {
                 continue;
             }
-            let (item_fn, _loc) = &registry.functions[ident];
+            let item_fn = &registry
+                .flat()
+                .function(&ident.to_string())
+                .expect("iterating the model's own function names")
+                .origin
+                .syntax;
             if let Some(fun) = render_extern_decl(self, item_fn, registry) {
                 externs.push(fun);
             }
@@ -1712,7 +1740,11 @@ impl JniGen {
             .collect();
         const_idents.sort_by_key(|i| i.to_string());
         for ident in const_idents {
-            let Some((item_const, _loc)) = registry.consts.get(ident) else {
+            let Some(item_const) = registry
+                .flat()
+                .constant(&ident.to_string())
+                .map(|__c| &__c.origin.syntax)
+            else {
                 continue; // missing decl already warned by the scan
             };
             let getter = crate::api::lang::jnigen::jni::const_getter_fn(item_const);

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -896,7 +896,7 @@ impl JniGen {
             let Some(item_struct) = registry
                 .flat()
                 .struct_type(&ident)
-                .map(|__s| &__s.origin.syntax)
+                .map(|st| &st.origin.syntax)
             else {
                 continue;
             };
@@ -928,7 +928,7 @@ impl JniGen {
                 if let Some(item_fn) = registry
                     .flat()
                     .function(&m.rust_ident)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                 {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                         self,
@@ -962,7 +962,7 @@ impl JniGen {
                     if let Some(item_fn) = registry
                         .flat()
                         .function(&m.rust_ident)
-                        .map(|__f| &__f.origin.syntax)
+                        .map(|func| &func.origin.syntax)
                     {
                         if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                             self,
@@ -1082,7 +1082,7 @@ impl JniGen {
                 let Some(item_fn) = registry
                     .flat()
                     .function(&ident)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                 else {
                     continue;
                 };
@@ -1621,7 +1621,7 @@ impl JniGen {
             let item_const = registry
                 .flat()
                 .constant(&entry.rust_ident)
-                .map(|__c| &__c.origin.syntax)
+                .map(|konst| &konst.origin.syntax)
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: const `{}` registered via .constant(...) is \
@@ -1711,20 +1711,13 @@ impl JniGen {
         // shortens types, collects imports, and wraps long signatures (no
         // derivation-time import set).
         let mut externs: Vec<kt::KtFun> = Vec::new();
-        let mut idents: Vec<&syn::Ident> =
-            registry.flat().functions().map(|__f| &__f.name).collect();
-        idents.sort();
-        for ident in idents {
-            if !declared.contains(ident) {
+        let mut fns: Vec<&crate::api::core::flat::Function> = registry.flat().functions().collect();
+        fns.sort_by(|a, b| a.name.cmp(&b.name));
+        for f in fns {
+            if !declared.contains(&f.name) {
                 continue;
             }
-            let item_fn = &registry
-                .flat()
-                .function(&ident)
-                .expect("iterating the model's own function names")
-                .origin
-                .syntax;
-            if let Some(fun) = render_extern_decl(self, item_fn, registry) {
+            if let Some(fun) = render_extern_decl(self, &f.origin.syntax, registry) {
                 externs.push(fun);
             }
         }
@@ -1743,7 +1736,7 @@ impl JniGen {
             let Some(item_const) = registry
                 .flat()
                 .constant(&ident)
-                .map(|__c| &__c.origin.syntax)
+                .map(|konst| &konst.origin.syntax)
             else {
                 continue; // missing decl already warned by the scan
             };

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -492,7 +492,7 @@ impl JniGen {
             }) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident) else {
                 continue;
             };
             let (package, class_name) = match kotlin_fqn.rsplit_once('.') {
@@ -548,7 +548,7 @@ impl JniGen {
             let Some(ident) = bare_path_ident(&ty) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident) else {
                 continue;
             };
             assert!(
@@ -895,7 +895,7 @@ impl JniGen {
             };
             let Some(item_struct) = registry
                 .flat()
-                .struct_type(&ident.to_string())
+                .struct_type(&ident)
                 .map(|__s| &__s.origin.syntax)
             else {
                 continue;
@@ -927,7 +927,7 @@ impl JniGen {
             for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
                 if let Some(item_fn) = registry
                     .flat()
-                    .function(&m.rust_ident.to_string())
+                    .function(&m.rust_ident)
                     .map(|__f| &__f.origin.syntax)
                 {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
@@ -961,7 +961,7 @@ impl JniGen {
                 for m in ctors {
                     if let Some(item_fn) = registry
                         .flat()
-                        .function(&m.rust_ident.to_string())
+                        .function(&m.rust_ident)
                         .map(|__f| &__f.origin.syntax)
                     {
                         if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
@@ -1081,7 +1081,7 @@ impl JniGen {
             {
                 let Some(item_fn) = registry
                     .flat()
-                    .function(&ident.to_string())
+                    .function(&ident)
                     .map(|__f| &__f.origin.syntax)
                 else {
                     continue;
@@ -1451,7 +1451,7 @@ impl JniGen {
             .unwrap_or_else(|| panic!("sum builder: `{key}` is not a path type"));
         let item_enum = registry
             .flat()
-            .enum_item(&ident.to_string())
+            .enum_item(&ident)
             .unwrap_or_else(|| panic!("sum builder: no indexed enum `{ident}`"));
         let sum_cfg = self.types[&key]
             .sum()
@@ -1595,7 +1595,7 @@ impl JniGen {
         for entry in &pkg_cfg.functions {
             let item_fn = &registry
                 .flat()
-                .function(&entry.rust_ident.to_string())
+                .function(&entry.rust_ident)
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: function `{}` registered via .function(...) is \
@@ -1620,7 +1620,7 @@ impl JniGen {
         for entry in &pkg_cfg.constants {
             let item_const = registry
                 .flat()
-                .constant(&entry.rust_ident.to_string())
+                .constant(&entry.rust_ident)
                 .map(|__c| &__c.origin.syntax)
                 .unwrap_or_else(|| {
                     panic!(
@@ -1649,7 +1649,7 @@ impl JniGen {
         for entry in &pkg_cfg.constant_functions {
             let item_fn = &registry
                 .flat()
-                .function(&entry.rust_ident.to_string())
+                .function(&entry.rust_ident)
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: constant fn `{}` registered via .constant_fun(...) \
@@ -1720,7 +1720,7 @@ impl JniGen {
             }
             let item_fn = &registry
                 .flat()
-                .function(&ident.to_string())
+                .function(&ident)
                 .expect("iterating the model's own function names")
                 .origin
                 .syntax;
@@ -1742,7 +1742,7 @@ impl JniGen {
         for ident in const_idents {
             let Some(item_const) = registry
                 .flat()
-                .constant(&ident.to_string())
+                .constant(&ident)
                 .map(|__c| &__c.origin.syntax)
             else {
                 continue; // missing decl already warned by the scan

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -126,7 +126,7 @@ pub(crate) struct SumConfig {
 pub struct FunctionEntry {
     /// Rust function ident — must match a `#[prebindgen]`-marked free
     /// function in the registered source module. Looked up by
-    /// `registry.functions[ident]`.
+    /// `registry.flat().function(ident)`.
     pub rust_ident: syn::Ident,
     /// Kotlin-side name override, set by chaining `.name("...")` after
     /// the entry's registration. `None` = derive from `rust_ident` via
@@ -306,7 +306,7 @@ pub(crate) enum MemberKind {
 /// JSONL).
 #[derive(Clone, Debug)]
 pub(crate) struct ClassMember {
-    /// Rust function ident (`registry.functions[ident]`).
+    /// Rust function ident (`registry.flat().function(ident)`).
     pub rust_ident: syn::Ident,
     /// Per-member `.name()` override, stored RAW — the effective Kotlin
     /// name is derived at point of use by [`JniGen::class_method_kotlin_name`]

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -111,8 +111,12 @@ fn arm_erased_sig(
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
     match ctor {
-        Some(cf) => match registry.functions.get(cf) {
-            Some((item_fn, _)) => item_fn
+        Some(cf) => match registry
+            .flat()
+            .function(&cf.to_string())
+            .map(|__f| &__f.origin.syntax)
+        {
+            Some(item_fn) => item_fn
                 .sig
                 .inputs
                 .iter()
@@ -251,7 +255,10 @@ fn variant_typed_params(
     let origin_kt = kt_param_name(&origin.to_string());
     let (names, optional): (Vec<String>, Vec<bool>) = match &variant.ctor {
         Some(cf) => {
-            let (item_fn, _) = registry.functions.get(cf)?;
+            let item_fn = registry
+                .flat()
+                .function(&cf.to_string())
+                .map(|__f| &__f.origin.syntax)?;
             let optional = item_fn
                 .sig
                 .inputs

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -111,11 +111,7 @@ fn arm_erased_sig(
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
     match ctor {
-        Some(cf) => match registry
-            .flat()
-            .function(&cf.to_string())
-            .map(|__f| &__f.origin.syntax)
-        {
+        Some(cf) => match registry.flat().function(&cf).map(|__f| &__f.origin.syntax) {
             Some(item_fn) => item_fn
                 .sig
                 .inputs
@@ -257,7 +253,7 @@ fn variant_typed_params(
         Some(cf) => {
             let item_fn = registry
                 .flat()
-                .function(&cf.to_string())
+                .function(&cf)
                 .map(|__f| &__f.origin.syntax)?;
             let optional = item_fn
                 .sig

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -111,7 +111,11 @@ fn arm_erased_sig(
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
     match ctor {
-        Some(cf) => match registry.flat().function(&cf).map(|__f| &__f.origin.syntax) {
+        Some(cf) => match registry
+            .flat()
+            .function(&cf)
+            .map(|func| &func.origin.syntax)
+        {
             Some(item_fn) => item_fn
                 .sig
                 .inputs
@@ -254,7 +258,7 @@ fn variant_typed_params(
             let item_fn = registry
                 .flat()
                 .function(&cf)
-                .map(|__f| &__f.origin.syntax)?;
+                .map(|func| &func.origin.syntax)?;
             let optional = item_fn
                 .sig
                 .inputs

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -312,7 +312,7 @@ pub(crate) fn build_typed_handle(
         if let Some(item_fn) = registry
             .flat()
             .function(&m.rust_ident)
-            .map(|__f| &__f.origin.syntax)
+            .map(|func| &func.origin.syntax)
         {
             if let Some(f) = render_wrapper_fn(
                 ext,
@@ -425,7 +425,7 @@ pub(crate) fn build_typed_handle(
         if let Some(item_fn) = registry
             .flat()
             .function(&m.rust_ident)
-            .map(|__f| &__f.origin.syntax)
+            .map(|func| &func.origin.syntax)
         {
             if let Some(f) = render_wrapper_fn(
                 ext,

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -309,7 +309,11 @@ pub(crate) fn build_typed_handle(
             .param(kt::KtParam::new("ptr", kt::KtType::long())),
     );
     for m in members.iter().filter(|m| m.kind == MemberKind::Constructor) {
-        if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
+        if let Some(item_fn) = registry
+            .flat()
+            .function(&m.rust_ident.to_string())
+            .map(|__f| &__f.origin.syntax)
+        {
             if let Some(f) = render_wrapper_fn(
                 ext,
                 item_fn,
@@ -418,7 +422,11 @@ pub(crate) fn build_typed_handle(
     // (receiver bound to `this`), delegating to the same centralized
     // `JNINative` extern as a free wrapper would.
     for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
-        if let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) {
+        if let Some(item_fn) = registry
+            .flat()
+            .function(&m.rust_ident.to_string())
+            .map(|__f| &__f.origin.syntax)
+        {
             if let Some(f) = render_wrapper_fn(
                 ext,
                 item_fn,
@@ -2324,10 +2332,11 @@ fn shape_notes(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<Strin
 /// key, when the item is indexed (a re-exported foreign type has none).
 pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Option<String> {
     let ident = bare_path_ident(&key.to_type())?;
+    let name = ident.to_string();
     let attrs = registry
-        .structs
-        .get(&ident)
-        .map(|(s, _)| s.attrs.as_slice())
-        .or_else(|| registry.enums.get(&ident).map(|(e, _)| e.attrs.as_slice()))?;
+        .flat()
+        .struct_type(&name)
+        .map(|s| s.origin.syntax.attrs.as_slice())
+        .or_else(|| registry.flat().enum_item(&name).map(|e| e.attrs.as_slice()))?;
     crate::api::lang::jnigen::util::doc_string(attrs)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -311,7 +311,7 @@ pub(crate) fn build_typed_handle(
     for m in members.iter().filter(|m| m.kind == MemberKind::Constructor) {
         if let Some(item_fn) = registry
             .flat()
-            .function(&m.rust_ident.to_string())
+            .function(&m.rust_ident)
             .map(|__f| &__f.origin.syntax)
         {
             if let Some(f) = render_wrapper_fn(
@@ -424,7 +424,7 @@ pub(crate) fn build_typed_handle(
     for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
         if let Some(item_fn) = registry
             .flat()
-            .function(&m.rust_ident.to_string())
+            .function(&m.rust_ident)
             .map(|__f| &__f.origin.syntax)
         {
             if let Some(f) = render_wrapper_fn(

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -190,7 +190,7 @@ impl crate::api::core::Generation<JniGen> {
         let registry = self.registry();
         let Some(item_fn) = registry
             .flat()
-            .function(&rust_ident.to_string())
+            .function(&rust_ident)
             .map(|__f| &__f.origin.syntax)
         else {
             return;

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -188,7 +188,11 @@ impl crate::api::core::Generation<JniGen> {
     ) {
         let ext = self.adapter();
         let registry = self.registry();
-        let Some((item_fn, _)) = registry.functions.get(rust_ident) else {
+        let Some(item_fn) = registry
+            .flat()
+            .function(&rust_ident.to_string())
+            .map(|__f| &__f.origin.syntax)
+        else {
             return;
         };
         let Some(f) = render_wrapper_fn(ext, item_fn, registry, kotlin_name, receiver_key) else {

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -191,7 +191,7 @@ impl crate::api::core::Generation<JniGen> {
         let Some(item_fn) = registry
             .flat()
             .function(&rust_ident)
-            .map(|__f| &__f.origin.syntax)
+            .map(|func| &func.origin.syntax)
         else {
             return;
         };

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -488,12 +488,9 @@ fn sum_plan_kind(
     let ident = bare_path_ident(ty).unwrap_or_else(|| {
         panic!("fromParts bridge: sealed-class field `{owner}` is not a path type")
     });
-    let item_enum = registry
-        .flat()
-        .enum_item(&ident.to_string())
-        .unwrap_or_else(|| {
-            panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
-        });
+    let item_enum = registry.flat().enum_item(&ident).unwrap_or_else(|| {
+        panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
+    });
     let key = TypeKey::from_ident(&ident);
     let cfg = ext
         .types

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -488,9 +488,12 @@ fn sum_plan_kind(
     let ident = bare_path_ident(ty).unwrap_or_else(|| {
         panic!("fromParts bridge: sealed-class field `{owner}` is not a path type")
     });
-    let (item_enum, _) = registry.enums.get(&ident).unwrap_or_else(|| {
-        panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
-    });
+    let item_enum = registry
+        .flat()
+        .enum_item(&ident.to_string())
+        .unwrap_or_else(|| {
+            panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
+        });
     let key = TypeKey::from_ident(&ident);
     let cfg = ext
         .types

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -127,8 +127,8 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
                 short.to_string(),
                 format!("sealed class `{key}` itself (its variants' supertype)"),
             )]);
-            if let Some(item_enum) = bare_path_ident(&key.to_type())
-                .and_then(|i| registry.flat().enum_item(&i.to_string()))
+            if let Some(item_enum) =
+                bare_path_ident(&key.to_type()).and_then(|i| registry.flat().enum_item(&i))
             {
                 for v in &item_enum.variants {
                     let name = ext.sum_variant_class_name(sum_cfg, &v.ident);
@@ -174,7 +174,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             // prototype, so the validator doesn't pay for body codegen.
             if let Some(item_fn) = registry
                 .flat()
-                .function(&entry.rust_ident.to_string())
+                .function(&entry.rust_ident)
                 .map(|__f| &__f.origin.syntax)
             {
                 if let Some(s) = build_wrapper_surface(ext, item_fn, registry, Some(&name), None) {
@@ -219,7 +219,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             check_ident(&name, &format!("method `{}`", m.rust_ident), &mut errors);
             let Some(item_fn) = registry
                 .flat()
-                .function(&m.rust_ident.to_string())
+                .function(&m.rust_ident)
                 .map(|__f| &__f.origin.syntax)
             else {
                 continue;
@@ -282,7 +282,7 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
         };
         if let Some(s) = registry
             .flat()
-            .struct_type(&ident.to_string())
+            .struct_type(&ident)
             .map(|__s| &__s.origin.syntax)
         {
             for f in &s.fields {
@@ -297,7 +297,7 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
                 }
             }
         }
-        if let Some(e) = registry.flat().enum_item(&ident.to_string()) {
+        if let Some(e) = registry.flat().enum_item(&ident) {
             for v in &e.variants {
                 let screaming =
                     crate::api::lang::jnigen::util::camel_to_screaming_snake(&v.ident.to_string());

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -175,7 +175,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             if let Some(item_fn) = registry
                 .flat()
                 .function(&entry.rust_ident)
-                .map(|__f| &__f.origin.syntax)
+                .map(|func| &func.origin.syntax)
             {
                 if let Some(s) = build_wrapper_surface(ext, item_fn, registry, Some(&name), None) {
                     for ov in render_param_overloads(ext, item_fn, registry, &s.fun) {
@@ -220,7 +220,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             let Some(item_fn) = registry
                 .flat()
                 .function(&m.rust_ident)
-                .map(|__f| &__f.origin.syntax)
+                .map(|func| &func.origin.syntax)
             else {
                 continue;
             };
@@ -283,7 +283,7 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
         if let Some(s) = registry
             .flat()
             .struct_type(&ident)
-            .map(|__s| &__s.origin.syntax)
+            .map(|st| &st.origin.syntax)
         {
             for f in &s.fields {
                 if let Some(fname) = &f.ident {

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -127,8 +127,8 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
                 short.to_string(),
                 format!("sealed class `{key}` itself (its variants' supertype)"),
             )]);
-            if let Some((item_enum, _)) =
-                bare_path_ident(&key.to_type()).and_then(|i| registry.enums.get(&i))
+            if let Some(item_enum) = bare_path_ident(&key.to_type())
+                .and_then(|i| registry.flat().enum_item(&i.to_string()))
             {
                 for v in &item_enum.variants {
                     let name = ext.sum_variant_class_name(sum_cfg, &v.ident);
@@ -172,7 +172,11 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             // surface signature (base + `.split_on_param` shells) comes from
             // the SAME `build_wrapper_surface` emission uses — a body-less
             // prototype, so the validator doesn't pay for body codegen.
-            if let Some((item_fn, _)) = registry.functions.get(&entry.rust_ident) {
+            if let Some(item_fn) = registry
+                .flat()
+                .function(&entry.rust_ident.to_string())
+                .map(|__f| &__f.origin.syntax)
+            {
                 if let Some(s) = build_wrapper_surface(ext, item_fn, registry, Some(&name), None) {
                     for ov in render_param_overloads(ext, item_fn, registry, &s.fun) {
                         add_overload(&fn_scope, &ov, &origin, &mut errors);
@@ -213,7 +217,11 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
         for m in &ext.class_members[key] {
             let name = ext.effective_method_name(key, m);
             check_ident(&name, &format!("method `{}`", m.rust_ident), &mut errors);
-            let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) else {
+            let Some(item_fn) = registry
+                .flat()
+                .function(&m.rust_ident.to_string())
+                .map(|__f| &__f.origin.syntax)
+            else {
                 continue;
             };
             let (scope, receiver) = match m.kind {
@@ -272,7 +280,11 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
             Some(i) => i,
             None => continue,
         };
-        if let Some((s, _)) = registry.structs.get(&ident) {
+        if let Some(s) = registry
+            .flat()
+            .struct_type(&ident.to_string())
+            .map(|__s| &__s.origin.syntax)
+        {
             for f in &s.fields {
                 if let Some(fname) = &f.ident {
                     let camel = kt_snake_to_camel(&fname.to_string());
@@ -285,7 +297,7 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
                 }
             }
         }
-        if let Some((e, _)) = registry.enums.get(&ident) {
+        if let Some(e) = registry.flat().enum_item(&ident.to_string()) {
             for v in &e.variants {
                 let screaming =
                     crate::api::lang::jnigen::util::camel_to_screaming_snake(&v.ident.to_string());

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -565,10 +565,11 @@ fn fn_plan_memo_shares_one_derivation() {
     let gen = registry.resolve(jni).expect("resolve");
     let (ext, registry) = (gen.adapter(), gen.registry());
     let f = &registry
-        .functions
-        .get(&syn::parse_str::<syn::Ident>("z_do_thing").unwrap())
+        .flat()
+        .function("z_do_thing")
         .expect("indexed")
-        .0;
+        .origin
+        .syntax;
 
     // The plan is already in the memo (populated at resolve by validation) —
     // repeated lookups return the SAME allocation, and it equals what a fresh

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -387,9 +387,9 @@ impl JniGen {
         // (`named_item_idents`) where a new kind is added once.
         //
         // The NAME SET is independent of origin stamps and the VALUE falls back
-        // to the default module: an origin-less hand-built stream indexes items
-        // that `item_origins` never sees, and those still need qualifying (core
-        // documents `crate` as their module).
+        // to the default module: an origin-less hand-built stream holds elements
+        // whose location carries no crate name, and those still need qualifying
+        // (core documents `crate` as their module).
         let length_names: std::collections::HashMap<String, syn::Path> = registry
             .named_item_idents()
             .map(|ident| {

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -988,7 +988,10 @@ impl Prebindgen for JniGen {
         registry: &Registry<KotlinMeta>,
     ) -> Vec<crate::api::core::unfold::ValueDecon> {
         let mut out = Vec::new();
-        for (ident, (item_struct, _loc)) in &registry.structs {
+        for (ident, item_struct) in registry.flat().types().filter_map(|t| match t {
+            crate::api::core::flat::Type::Struct(s) => Some((&s.name, &s.origin.syntax)),
+            _ => None,
+        }) {
             let source: syn::Type = syn::parse_quote!(#ident);
             let key = TypeKey::from_type(&source);
             // A `data_class` is a registered type that is neither an opaque
@@ -1044,7 +1047,7 @@ impl Prebindgen for JniGen {
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
-            let Some((item_enum, _)) = registry.enums.get(&ident) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
                 continue;
             };
             out.push(crate::api::core::unfold::SumDecon {
@@ -1073,11 +1076,14 @@ impl Prebindgen for JniGen {
                 out.push(bare);
             }
         };
-        for (item_fn, _loc) in registry.functions.values() {
-            // `Vec<T>` / `Option<Vec<T>>` return.
-            if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
+        for f in registry.flat().functions() {
+            let item_fn = &f.origin.syntax;
+            // `Vec<T>` / `Option<Vec<T>>` return. The model's `ret` already
+            // normalizes an elided return to `()`, so there is no arm for it.
+            {
+                let ret = &f.ret.origin.syntax;
                 let after_opt =
-                    crate::api::core::types_util::option_inner_type(ret).unwrap_or((**ret).clone());
+                    crate::api::core::types_util::option_inner_type(ret).unwrap_or(ret.clone());
                 if let Some(elem) = crate::api::core::types_util::vec_inner_type(&after_opt) {
                     consider(peel_leading_ref(&elem));
                 }
@@ -1210,7 +1216,11 @@ impl Prebindgen for JniGen {
         for (key, members) in &self.class_members {
             for m in members {
                 // A registry-absent fn already hard-errored in the scan.
-                let Some((item_fn, _)) = registry.functions.get(&m.rust_ident) else {
+                let Some(item_fn) = registry
+                    .flat()
+                    .function(&m.rust_ident.to_string())
+                    .map(|__f| &__f.origin.syntax)
+                else {
                     continue;
                 };
                 match m.kind {
@@ -1277,7 +1287,11 @@ impl Prebindgen for JniGen {
         // something that must not exist. Reject them here, where the message
         // can say what is actually unsupported and what to write instead.
         for ident in self.declared_functions() {
-            let Some((item_fn, _)) = registry.functions.get(&ident) else {
+            let Some(item_fn) = registry
+                .flat()
+                .function(&ident.to_string())
+                .map(|__f| &__f.origin.syntax)
+            else {
                 continue;
             };
             // (1) A sum in the `Ok` position of a fallible return. A sum is
@@ -1670,7 +1684,7 @@ impl JniGen {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
-                    if let Some((e, _)) = registry.enums.get(&name) {
+                    if let Some(e) = registry.flat().enum_item(&name.to_string()) {
                         let (wire, body) = enum_input_body(self, registry, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
@@ -1772,7 +1786,7 @@ impl JniGen {
             // OUTPUT direction has no counterpart: a sum crosses Rust →
             // Kotlin flattened, always.)
             if self.types.get(&key).is_some_and(|c| c.sum().is_some()) {
-                if let Some((e, _)) = registry.enums.get(&name) {
+                if let Some(e) = registry.flat().enum_item(&name.to_string()) {
                     let (wire, body) = sum_input_body(self, e, registry)?;
                     // The wire's own null niche, exactly as a data class gets
                     // — that is what lets `Option<sum>` fold with JVM null as
@@ -1793,7 +1807,11 @@ impl JniGen {
                     });
                 }
             }
-            if let Some((s, _)) = registry.structs.get(&name) {
+            if let Some(s) = registry
+                .flat()
+                .struct_type(&name.to_string())
+                .map(|__s| &__s.origin.syntax)
+            {
                 let (wire, body) = struct_input_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);
                 // Auto-generated struct: the value-context Kotlin name is
@@ -1884,7 +1902,7 @@ impl JniGen {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
-                    if let Some((e, _)) = registry.enums.get(&name) {
+                    if let Some(e) = registry.flat().enum_item(&name.to_string()) {
                         let (wire, body) = enum_output_body(self, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
@@ -1980,7 +1998,11 @@ impl JniGen {
             });
         }
         if let Some(name) = bare_path_ident(ty) {
-            if let Some((s, _)) = registry.structs.get(&name) {
+            if let Some(s) = registry
+                .flat()
+                .struct_type(&name.to_string())
+                .map(|__s| &__s.origin.syntax)
+            {
                 let (wire, body) = struct_output_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);
                 let kotlin_name = self

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1047,7 +1047,7 @@ impl Prebindgen for JniGen {
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident) else {
                 continue;
             };
             out.push(crate::api::core::unfold::SumDecon {
@@ -1218,7 +1218,7 @@ impl Prebindgen for JniGen {
                 // A registry-absent fn already hard-errored in the scan.
                 let Some(item_fn) = registry
                     .flat()
-                    .function(&m.rust_ident.to_string())
+                    .function(&m.rust_ident)
                     .map(|__f| &__f.origin.syntax)
                 else {
                     continue;
@@ -1289,7 +1289,7 @@ impl Prebindgen for JniGen {
         for ident in self.declared_functions() {
             let Some(item_fn) = registry
                 .flat()
-                .function(&ident.to_string())
+                .function(&ident)
                 .map(|__f| &__f.origin.syntax)
             else {
                 continue;
@@ -1684,7 +1684,7 @@ impl JniGen {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
-                    if let Some(e) = registry.flat().enum_item(&name.to_string()) {
+                    if let Some(e) = registry.flat().enum_item(&name) {
                         let (wire, body) = enum_input_body(self, registry, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
@@ -1786,7 +1786,7 @@ impl JniGen {
             // OUTPUT direction has no counterpart: a sum crosses Rust →
             // Kotlin flattened, always.)
             if self.types.get(&key).is_some_and(|c| c.sum().is_some()) {
-                if let Some(e) = registry.flat().enum_item(&name.to_string()) {
+                if let Some(e) = registry.flat().enum_item(&name) {
                     let (wire, body) = sum_input_body(self, e, registry)?;
                     // The wire's own null niche, exactly as a data class gets
                     // — that is what lets `Option<sum>` fold with JVM null as
@@ -1809,7 +1809,7 @@ impl JniGen {
             }
             if let Some(s) = registry
                 .flat()
-                .struct_type(&name.to_string())
+                .struct_type(&name)
                 .map(|__s| &__s.origin.syntax)
             {
                 let (wire, body) = struct_input_body(self, s, registry)?;
@@ -1902,7 +1902,7 @@ impl JniGen {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
-                    if let Some(e) = registry.flat().enum_item(&name.to_string()) {
+                    if let Some(e) = registry.flat().enum_item(&name) {
                         let (wire, body) = enum_output_body(self, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
@@ -2000,7 +2000,7 @@ impl JniGen {
         if let Some(name) = bare_path_ident(ty) {
             if let Some(s) = registry
                 .flat()
-                .struct_type(&name.to_string())
+                .struct_type(&name)
                 .map(|__s| &__s.origin.syntax)
             {
                 let (wire, body) = struct_output_body(self, s, registry)?;

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1219,7 +1219,7 @@ impl Prebindgen for JniGen {
                 let Some(item_fn) = registry
                     .flat()
                     .function(&m.rust_ident)
-                    .map(|__f| &__f.origin.syntax)
+                    .map(|func| &func.origin.syntax)
                 else {
                     continue;
                 };
@@ -1290,7 +1290,7 @@ impl Prebindgen for JniGen {
             let Some(item_fn) = registry
                 .flat()
                 .function(&ident)
-                .map(|__f| &__f.origin.syntax)
+                .map(|func| &func.origin.syntax)
             else {
                 continue;
             };
@@ -1810,7 +1810,7 @@ impl JniGen {
             if let Some(s) = registry
                 .flat()
                 .struct_type(&name)
-                .map(|__s| &__s.origin.syntax)
+                .map(|st| &st.origin.syntax)
             {
                 let (wire, body) = struct_input_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);
@@ -2001,7 +2001,7 @@ impl JniGen {
             if let Some(s) = registry
                 .flat()
                 .struct_type(&name)
-                .map(|__s| &__s.origin.syntax)
+                .map(|st| &st.origin.syntax)
             {
                 let (wire, body) = struct_output_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);


### PR DESCRIPTION
`Registry` held five maps — `functions`, `structs`, `enums`, `consts`, `guards` —
plus `item_origins` and `source_modules`. Every one was built in `from_flat` by
walking `flat.elements()`, and every one duplicated something `Flat` already had,
indexed the same way.

L1 made the registry a *projection* of the model. This finishes the thought: a
projection that **copies** is still two stores that can disagree. All seven fields
are deleted, and `from_flat` collapses to the expressibility check, the type-ref
index, and storing the model.

## Two things measuring the call sites turned up first

* **The `SourceLocation` half of every entry was dead.** All 44 `.get()` sites
  destructured `(item, _)`; every `values()` and index site bound `_loc`. Nothing
  had read it since L1 moved locations onto elements.
* **`guards` had exactly one reader** and was already `Vec<flat::Guard>` — the flat
  type, copied out of the model verbatim.

## The shape

`Flat` grows what the maps were providing, beside its existing typed accessors:

| new | why |
|---|---|
| `struct_type(name)` | a `Struct`, never a tuple struct (that is an `Extern`) |
| `enum_item(name)` | the `syn::ItemEnum` behind **either** enum shape — the merge the old `enums` map made, which 30 adapter reads depend on |
| `source_modules()` | frozen at `build()`; see invariant 2 |

`Registry` keeps `origin_module`, `default_module`, `all_source_modules` and
`named_item_idents` — they are *questions*, not storage — now answered off `flat`.

**No mirrored accessors on `Registry`.** One door, so there are not two interfaces
that have to agree.

### Binding-local fns move into the model

They were the one population `Flat` did not have: a `sig!(..)` is written by hand in
a build script and was inserted straight into `registry.functions`. Deleting that map
would have left `flat.function()` incomplete and "one index" a lie.

`check_signature` already lowered one through `lower_fn` and threw it away; it
returns the `Function` now, and a `pub(crate) add_local_function` admits it with the
adapter's origin crate stamped where `origin_module` already looks. Public surface
unchanged.

## Three invariants that would have moved generated output silently

Each is tested, and **each test was checked against its own violation**:

1. **`named_item_idents` must keep excluding `Extern`.** It derived from the four
   maps, and an alias was in none of them. Its one caller uses it to decide which
   names generated Rust qualifies — including an alias would move output.
2. **`source_modules` must not see binding-local fns.** It decides `default_module`,
   which is what an unqualified reference resolves against, so a fn a build script
   invented could otherwise change how *captured* items are qualified. Fixed by
   construction: `Flat` freezes it in `build()` from the captured stream.
3. **`item_origins` must keep seeing them** — the mirror of (2), and what qualifies
   a local fn's own generated call.

## Ledger 204 → 202

The first movement in this program, and it fell out rather than being the goal:
`accessor_signature` and `accessor_consumes` peel a borrow by reading
`TypeKind::Ref` instead of matching `syn::Type::Reference`. `ctor_signature` and two
return-type walks likewise read `params`/`ret` off the element instead of
re-deriving them — which also deletes three hand-rolled copies of "an elided return
is `()`", a fact the model states once.

That is the payoff beyond de-duplication: ~150 call sites now hold the
classification, not just syntax, which is what L3/L4 need.

## A latent nondeterminism this removes

Not in the original description, and worth stating: `trait_impl.rs`'s `value_decons`
and its single-leaf `consider` loop used to iterate `&registry.structs` and
`registry.functions.values()` — `HashMap` with `RandomState`, so a different order
every process. They are stream order now.

That the goldens come out byte-identical means nothing downstream depended on that
order, which is the good outcome — but it was luck rather than design, and it is
worth recording as removed rather than discovered later.

## Verification

* `regen-check.sh` byte-identical — run after **`cargo clean -p example-cbindgen -p
  example-flat`**. The script only regenerates what cargo decides to rebuild, so a
  cached run passes without checking anything; that is how a stray golden survived
  on #239.
* covertest-kotlin `./gradlew run` — 48 sections
* 589 (all-features) + 517 (default) tests, doctests, clippy clean in all three
  feature configs with `-D warnings`
