### PR TITLE
A lookup takes the name the caller already holds

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -192,7 +192,7 @@ pub fn apply<M>(
         if let Some(declared) = &ed.declared_target {
             let item_fn = registry
                 .flat()
-                .function(&ed.func.to_string())
+                .function(&ed.func)
                 .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
             let param_ty = find_param_type(&item_fn, &ed.param)
@@ -239,7 +239,7 @@ pub fn apply<M>(
             }
             let Some(item_fn) = registry
                 .flat()
-                .function(&func.to_string())
+                .function(&func)
                 .map(|f| f.origin.syntax.clone())
             else {
                 continue;
@@ -305,7 +305,7 @@ fn process_expand<M>(
 ) -> Result<(), ExpandError> {
     let item_fn = registry
         .flat()
-        .function(&ed.func.to_string())
+        .function(&ed.func)
         .map(|f| f.origin.syntax.clone())
         .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
 
@@ -379,7 +379,7 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
     // elided return and a written `-> ()` are one thing.
     let f = registry
         .flat()
-        .function(&func.to_string())
+        .function(&func)
         .ok_or_else(|| ExpandError::UnknownConstructor(func.clone()))?;
 
     let params: Vec<(syn::Ident, syn::Type)> = f

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -440,6 +440,71 @@ pub struct Flat {
     by_name: std::collections::HashMap<String, usize>,
 }
 
+/// A name a lookup can be performed with.
+///
+/// Exists because callers hold different spellings of the same fact: an adapter
+/// walking captured items has a `syn::Ident`, a resolved reference has the
+/// `String` inside a [`TypeId`], and a test has a literal. One accessor takes all
+/// three rather than each call site converting.
+///
+/// **The conversion is moved, not removed.** `proc_macro2::Ident` hashes by
+/// `to_string()` and offers no borrow as `str`, so an `Ident` lookup allocates
+/// wherever it happens; doing it here keeps `&str` and `&String` callers — among
+/// them the per-edge and per-reference lookups in the scan and the resolver —
+/// allocation-free.
+///
+/// Sealed: what may name an element is the language's business, not a caller's.
+///
+/// ```
+/// # prebindgen::Source::init_doctest_simulate();
+/// use prebindgen::core::flat::Flat;
+///
+/// let flat = Flat::builder().source("source_ffi").build()?;
+/// let ident = quote::format_ident!("test_function");
+///
+/// // The same element, whichever spelling the caller happens to hold.
+/// assert!(flat.function("test_function").is_some());
+/// assert!(flat.function(&ident).is_some());
+/// # Ok::<_, prebindgen::core::flat::ParseError>(())
+/// ```
+pub trait Name: sealed::Sealed {
+    /// The name as a string, borrowed when the caller already holds one.
+    fn as_name(&self) -> std::borrow::Cow<'_, str>;
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for str {}
+    impl Sealed for String {}
+    impl Sealed for syn::Ident {}
+    impl<T: ?Sized + Sealed> Sealed for &T {}
+}
+
+impl Name for str {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed(self)
+    }
+}
+
+impl Name for String {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed(self)
+    }
+}
+
+impl Name for syn::Ident {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Owned(self.to_string())
+    }
+}
+
+/// So a caller already holding a reference does not have to reborrow.
+impl<T: ?Sized + Name> Name for &T {
+    fn as_name(&self) -> std::borrow::Cow<'_, str> {
+        T::as_name(self)
+    }
+}
+
 impl Flat {
     /// Start collecting what to parse.
     pub fn builder() -> FlatBuilder {
@@ -454,11 +519,12 @@ impl Flat {
     /// The element with this name, whatever kind it is — including an
     /// [`Element::Unsupported`], which still holds its name against the
     /// namespace.
-    pub fn element(&self, name: &str) -> Option<&Element> {
-        self.elements.get(*self.by_name.get(name)?)
+    pub fn element<N: Name + ?Sized>(&self, name: &N) -> Option<&Element> {
+        self.elements
+            .get(*self.by_name.get(name.as_name().as_ref())?)
     }
 
-    pub fn function(&self, name: &str) -> Option<&Function> {
+    pub fn function<N: Name + ?Sized>(&self, name: &N) -> Option<&Function> {
         match self.element(name)? {
             Element::Function(f) => Some(f),
             _ => None,
@@ -470,14 +536,14 @@ impl Flat {
     /// Named `declared_type` because `type` is a keyword; it is the accessor a
     /// resolved [`TypeKind::Named`] reference leads to, and [`Self::resolve`] is
     /// the same lookup taking a [`TypeId`].
-    pub fn declared_type(&self, name: &str) -> Option<&Type> {
+    pub fn declared_type<N: Name + ?Sized>(&self, name: &N) -> Option<&Type> {
         match self.element(name)? {
             Element::Type(t) => Some(t),
             _ => None,
         }
     }
 
-    pub fn constant(&self, name: &str) -> Option<&Constant> {
+    pub fn constant<N: Name + ?Sized>(&self, name: &N) -> Option<&Constant> {
         match self.element(name)? {
             Element::Constant(c) => Some(c),
             _ => None,
@@ -527,7 +593,7 @@ impl Flat {
     ///
     /// A tuple struct is an [`Extern`] rather than a `Struct`, so this answers
     /// only for a product of fields that cross the boundary.
-    pub fn struct_type(&self, name: &str) -> Option<&Struct> {
+    pub fn struct_type<N: Name + ?Sized>(&self, name: &N) -> Option<&Struct> {
         match self.declared_type(name)? {
             Type::Struct(s) => Some(s),
             _ => None,
@@ -541,7 +607,7 @@ impl Flat {
     /// Rust and both keep that item. A consumer re-emitting the source wants the
     /// item without caring which shape it is; one that acts on the distinction
     /// reaches for [`Self::declared_type`].
-    pub fn enum_item(&self, name: &str) -> Option<&syn::ItemEnum> {
+    pub fn enum_item<N: Name + ?Sized>(&self, name: &N) -> Option<&syn::ItemEnum> {
         match self.declared_type(name)? {
             Type::Variant(v) => Some(&v.origin.syntax),
             Type::Enum(e) => Some(&e.origin.syntax),

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -896,12 +896,7 @@ impl<M> Registry<M> {
         // Off the element's own location, which covers both populations: a
         // captured item stamped at capture time, and a binding-local fn stamped
         // by `add_local_function`.
-        let crate_name = self
-            .flat
-            .element(&ident.to_string())?
-            .location()
-            .crate_name
-            .as_ref()?;
+        let crate_name = self.flat.element(&ident)?.location().crate_name.as_ref()?;
         let module = crate_name.replace('-', "_");
         syn::parse_str(&module).ok()
     }
@@ -997,7 +992,7 @@ impl<M> Registry<M> {
             let last = tp.path.segments.last().expect("len checked");
             if self.flat.source_modules().contains(&head) {
                 qualified.push((key.to_string(), last.to_token_stream().to_string()));
-            } else if self.flat.declared_type(&last.ident.to_string()).is_some() {
+            } else if self.flat.declared_type(&last.ident).is_some() {
                 println!(
                     "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
                      captured #[prebindgen] item `{}` exists — if you meant the source item, \
@@ -1019,11 +1014,7 @@ impl<M> Registry<M> {
 
         // Scan declared functions.
         for ident in &declared.functions {
-            if let Some(item_fn) = self
-                .flat
-                .function(&ident.to_string())
-                .map(|f| f.origin.syntax.clone())
-            {
+            if let Some(item_fn) = self.flat.function(&ident).map(|f| f.origin.syntax.clone()) {
                 self.scan_fn_signature(&item_fn)?;
             } else {
                 missing.push(("function", ident.to_string()));
@@ -1031,7 +1022,7 @@ impl<M> Registry<M> {
         }
 
         for ident in &declared.ignored_functions {
-            if self.flat.function(&ident.to_string()).is_none() {
+            if self.flat.function(&ident).is_none() {
                 println!(
                     "cargo:warning=prebindgen: ignored function `{}` not found among #[prebindgen] items",
                     ident
@@ -1044,7 +1035,7 @@ impl<M> Registry<M> {
         // `extra_required_types`) — but they are referenced by name from
         // adapter declarations, so a missing one is a hard error.
         for ident in &declared.helper_functions {
-            if self.flat.function(&ident.to_string()).is_none() {
+            if self.flat.function(&ident).is_none() {
                 missing.push(("helper function", ident.to_string()));
             }
         }
@@ -1054,10 +1045,8 @@ impl<M> Registry<M> {
         // so the type is required in the output direction only.
         if let Some(decl_consts) = &declared.consts {
             for ident in decl_consts {
-                if let Some(item_const) = self
-                    .flat
-                    .constant(&ident.to_string())
-                    .map(|c| c.origin.syntax.clone())
+                if let Some(item_const) =
+                    self.flat.constant(&ident).map(|c| c.origin.syntax.clone())
                 {
                     self.ensure_entry(Direction::Output, &item_const.ty, true);
                 } else {
@@ -1065,7 +1054,7 @@ impl<M> Registry<M> {
                 }
             }
             for ident in &declared.ignored_consts {
-                if self.flat.constant(&ident.to_string()).is_none() {
+                if self.flat.constant(&ident).is_none() {
                     println!(
                         "cargo:warning=prebindgen: ignored const `{}` not found among #[prebindgen] items",
                         ident
@@ -1092,14 +1081,14 @@ impl<M> Registry<M> {
             if let Some(ident) = bare_path_ident(&ty) {
                 if let Some(s) = self
                     .flat
-                    .struct_type(&ident.to_string())
+                    .struct_type(&ident)
                     .map(|s| s.origin.syntax.clone())
                 {
                     self.scan_struct(&s)?;
                     self.ensure_entry(Direction::Input, &ty, true);
                     self.ensure_entry(Direction::Output, &ty, true);
                     matched = true;
-                } else if let Some(e) = self.flat.enum_item(&ident.to_string()).cloned() {
+                } else if let Some(e) = self.flat.enum_item(&ident).cloned() {
                     self.scan_enum(&e)?;
                     self.ensure_entry(Direction::Input, &ty, true);
                     self.ensure_entry(Direction::Output, &ty, true);
@@ -1119,8 +1108,7 @@ impl<M> Registry<M> {
         for key in &declared.ignored_types {
             let ty = key.to_type();
             let matched = bare_path_ident(&ty).is_some_and(|ident| {
-                self.flat.struct_type(&ident.to_string()).is_some()
-                    || self.flat.enum_item(&ident.to_string()).is_some()
+                self.flat.struct_type(&ident).is_some() || self.flat.enum_item(&ident).is_some()
             });
             if !matched {
                 println!(
@@ -1430,7 +1418,7 @@ impl<M> Registry<M> {
         // contribute nothing here.
         if let Some(name) = bare_path_ident(ty) {
             use crate::api::core::flat::{Field, Type};
-            let fields: Vec<&Field> = match self.flat.declared_type(&name.to_string()) {
+            let fields: Vec<&Field> = match self.flat.declared_type(&name) {
                 Some(Type::Struct(s)) => s.fields.iter().collect(),
                 Some(Type::Variant(v)) => v
                     .alternatives
@@ -1485,7 +1473,7 @@ impl<M> Registry<M> {
                     .into())
                 }
             };
-            if self.flat.element(&ident.to_string()).is_some() {
+            if self.flat.element(&ident).is_some() {
                 return Err(ScanError::AdapterInvariant {
                     message: format!(
                         "binding-local fn `{ident}` collides with a `#[prebindgen]` item — \

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -298,7 +298,7 @@ pub fn apply<M>(
         if let Some(declared) = &ed.declared_source {
             let item_fn = registry
                 .flat()
-                .function(&ed.func.to_string())
+                .function(&ed.func)
                 .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
             let ret = fn_return(&item_fn);
@@ -342,7 +342,7 @@ pub fn apply<M>(
             }
             let Some(item_fn) = registry
                 .flat()
-                .function(&func.to_string())
+                .function(&func)
                 .map(|f| f.origin.syntax.clone())
             else {
                 continue;
@@ -399,7 +399,7 @@ pub fn apply<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -611,7 +611,7 @@ fn wire_fixed_returns<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -696,7 +696,7 @@ fn wire_fixed_callbacks<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -783,7 +783,7 @@ pub fn apply_leaf_vec_folds<M>(
     for func in declared_fns {
         let Some(item_fn) = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|f| f.origin.syntax.clone())
         else {
             continue;
@@ -960,7 +960,7 @@ fn process_decl<M>(
     {
         let item_fn = registry
             .flat()
-            .function(&ed.func.to_string())
+            .function(&ed.func)
             .map(|f| f.origin.syntax.clone())
             .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
 
@@ -1713,7 +1713,7 @@ fn accessor_signature<M>(
 ) -> Result<(syn::Type, syn::Type), UnfoldError> {
     let f = registry
         .flat()
-        .function(&func.to_string())
+        .function(&func)
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
 
     // First parameter is the receiver `&T`; peel the borrow to get `T`. The
@@ -1760,7 +1760,7 @@ fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> b
 fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
     registry
         .flat()
-        .function(&func.to_string())
+        .function(&func)
         .and_then(|f| f.params.first())
         .is_some_and(|p| !matches!(p.ty.kind, crate::api::core::flat::TypeKind::Ref { .. }))
 }

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -194,7 +194,7 @@ impl Cbindgen {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
                     .flat()
-                    .function(&f.to_string())
+                    .function(&f)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (repr, by_ref) = one_param(item);
@@ -238,7 +238,7 @@ impl Cbindgen {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
                     .flat()
-                    .function(&f.to_string())
+                    .function(&f)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (param, by_ref) = one_param(item);

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -55,7 +55,7 @@ impl Cbindgen {
         ty: &syn::Type,
     ) -> Option<Vec<syn::Variant>> {
         let ident = type_path_tail(ty)?;
-        let item = registry.flat().enum_item(&ident.to_string())?;
+        let item = registry.flat().enum_item(&ident)?;
         Some(item.variants.iter().cloned().collect())
     }
 
@@ -285,7 +285,7 @@ impl Cbindgen {
         self.functions.keys().any(|orig| {
             registry
                 .flat()
-                .function(&orig.to_string())
+                .function(&orig)
                 // The model already decided that an elided return and `-> ()`
                 // are one thing, so there is no second arm to write here.
                 .map(|f| type_contains_vec(&f.ret.origin.syntax))
@@ -304,7 +304,7 @@ impl Cbindgen {
         let ident = type_path_tail(ty)?;
         let item = registry
             .flat()
-            .struct_type(&ident.to_string())
+            .struct_type(&ident)
             .map(|__s| &__s.origin.syntax)?;
         if let syn::Fields::Named(named) = &item.fields {
             Some(

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -393,7 +393,7 @@ fn type_short(ty: &syn::Type) -> String {
 /// The indexed `syn::ItemEnum` for a declared enum type, by tail ident.
 fn enum_item<'r>(registry: &'r Registry<()>, ty: &syn::Type) -> Option<&'r syn::ItemEnum> {
     let ident = type_path_tail(ty)?;
-    registry.flat().enum_item(&ident.to_string())
+    registry.flat().enum_item(&ident)
 }
 
 /// Hard error when a `.tagged_union()`-declared enum is unit-only. The

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -812,7 +812,7 @@ impl JniGen {
         let func = &decl.func;
         let item_fn = registry
             .flat()
-            .function(&func.to_string())
+            .function(&func)
             .map(|__f| &__f.origin.syntax)
             .unwrap_or_else(|| {
                 panic!(
@@ -1035,7 +1035,7 @@ impl JniGen {
                     let ident = bare_path_ident(&probe).expect("a sum type is a path type");
                     let item_enum = registry
                         .flat()
-                        .enum_item(&ident.to_string())
+                        .enum_item(&ident)
                         .expect("TypeKind::Sum implies an indexed enum");
                     let sum_cfg = self.types[&TypeKey::from_type(&probe)]
                         .sum()
@@ -1398,7 +1398,7 @@ impl JniGen {
             ConvertSpec::PrebindgenFn(f) => {
                 let item_fn = registry
                     .flat()
-                    .function(&f.to_string())
+                    .function(&f)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| {
                         panic!(
@@ -1474,7 +1474,7 @@ impl JniGen {
             ConvertSpec::PrebindgenFn(g) => {
                 let item_fn = registry
                     .flat()
-                    .function(&g.to_string())
+                    .function(&g)
                     .map(|__f| &__f.origin.syntax)
                     .unwrap_or_else(|| {
                         panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -65,7 +65,7 @@ impl JniGen {
         if let Some(name) = bare_path_ident(bare) {
             if let Some(st) = registry
                 .flat()
-                .struct_type(&name.to_string())
+                .struct_type(&name)
                 .map(|__s| &__s.origin.syntax)
             {
                 return TypeKind::DataStruct { st, cfg };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -882,7 +882,7 @@ fn build_flat_sum_field(
     use crate::api::core::types_util::SumSpec;
 
     let ident = bare_path_ident(sum_ty)?;
-    let item_enum = registry.flat().enum_item(&ident.to_string())?;
+    let item_enum = registry.flat().enum_item(&ident)?;
     let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
     let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
@@ -1135,7 +1135,7 @@ pub(crate) fn build_flat_input_plan(
     };
     let Some(st) = registry
         .flat()
-        .struct_type(&name.to_string())
+        .struct_type(&name)
         .map(|__s| &__s.origin.syntax)
     else {
         return Ok(None);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -222,12 +222,9 @@ pub(crate) fn encode_sum_group(
     let tag_id = &obj_idents[tag_idx];
     // A unit variant contributes no leaf, so the arm list is driven by the
     // enum's own variants, not by the grouped leaves.
-    let item_enum = registry
-        .flat()
-        .enum_item(&ident.to_string())
-        .unwrap_or_else(|| {
-            panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
-        });
+    let item_enum = registry.flat().enum_item(&ident).unwrap_or_else(|| {
+        panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
+    });
     let spec = crate::api::core::types_util::SumSpec::from_item_enum(item_enum);
 
     let arms: Vec<TokenStream> = spec

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -305,7 +305,7 @@ pub(crate) fn validate_bindings(
         }
         let item_fn = &registry
             .flat()
-            .function(&ident.to_string())
+            .function(&ident)
             .expect("iterating the model's own function names")
             .origin
             .syntax;
@@ -327,7 +327,7 @@ pub(crate) fn validate_bindings(
             }
             let item_const = &registry
                 .flat()
-                .constant(&ident.to_string())
+                .constant(&ident)
                 .expect("iterating the model's own const names")
                 .origin
                 .syntax;

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -492,7 +492,7 @@ impl JniGen {
             }) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident) else {
                 continue;
             };
             let (package, class_name) = match kotlin_fqn.rsplit_once('.') {
@@ -548,7 +548,7 @@ impl JniGen {
             let Some(ident) = bare_path_ident(&ty) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident) else {
                 continue;
             };
             assert!(
@@ -895,7 +895,7 @@ impl JniGen {
             };
             let Some(item_struct) = registry
                 .flat()
-                .struct_type(&ident.to_string())
+                .struct_type(&ident)
                 .map(|__s| &__s.origin.syntax)
             else {
                 continue;
@@ -927,7 +927,7 @@ impl JniGen {
             for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
                 if let Some(item_fn) = registry
                     .flat()
-                    .function(&m.rust_ident.to_string())
+                    .function(&m.rust_ident)
                     .map(|__f| &__f.origin.syntax)
                 {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
@@ -961,7 +961,7 @@ impl JniGen {
                 for m in ctors {
                     if let Some(item_fn) = registry
                         .flat()
-                        .function(&m.rust_ident.to_string())
+                        .function(&m.rust_ident)
                         .map(|__f| &__f.origin.syntax)
                     {
                         if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
@@ -1081,7 +1081,7 @@ impl JniGen {
             {
                 let Some(item_fn) = registry
                     .flat()
-                    .function(&ident.to_string())
+                    .function(&ident)
                     .map(|__f| &__f.origin.syntax)
                 else {
                     continue;
@@ -1451,7 +1451,7 @@ impl JniGen {
             .unwrap_or_else(|| panic!("sum builder: `{key}` is not a path type"));
         let item_enum = registry
             .flat()
-            .enum_item(&ident.to_string())
+            .enum_item(&ident)
             .unwrap_or_else(|| panic!("sum builder: no indexed enum `{ident}`"));
         let sum_cfg = self.types[&key]
             .sum()
@@ -1595,7 +1595,7 @@ impl JniGen {
         for entry in &pkg_cfg.functions {
             let item_fn = &registry
                 .flat()
-                .function(&entry.rust_ident.to_string())
+                .function(&entry.rust_ident)
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: function `{}` registered via .function(...) is \
@@ -1620,7 +1620,7 @@ impl JniGen {
         for entry in &pkg_cfg.constants {
             let item_const = registry
                 .flat()
-                .constant(&entry.rust_ident.to_string())
+                .constant(&entry.rust_ident)
                 .map(|__c| &__c.origin.syntax)
                 .unwrap_or_else(|| {
                     panic!(
@@ -1649,7 +1649,7 @@ impl JniGen {
         for entry in &pkg_cfg.constant_functions {
             let item_fn = &registry
                 .flat()
-                .function(&entry.rust_ident.to_string())
+                .function(&entry.rust_ident)
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: constant fn `{}` registered via .constant_fun(...) \
@@ -1720,7 +1720,7 @@ impl JniGen {
             }
             let item_fn = &registry
                 .flat()
-                .function(&ident.to_string())
+                .function(&ident)
                 .expect("iterating the model's own function names")
                 .origin
                 .syntax;
@@ -1742,7 +1742,7 @@ impl JniGen {
         for ident in const_idents {
             let Some(item_const) = registry
                 .flat()
-                .constant(&ident.to_string())
+                .constant(&ident)
                 .map(|__c| &__c.origin.syntax)
             else {
                 continue; // missing decl already warned by the scan

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -111,11 +111,7 @@ fn arm_erased_sig(
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
     match ctor {
-        Some(cf) => match registry
-            .flat()
-            .function(&cf.to_string())
-            .map(|__f| &__f.origin.syntax)
-        {
+        Some(cf) => match registry.flat().function(&cf).map(|__f| &__f.origin.syntax) {
             Some(item_fn) => item_fn
                 .sig
                 .inputs
@@ -257,7 +253,7 @@ fn variant_typed_params(
         Some(cf) => {
             let item_fn = registry
                 .flat()
-                .function(&cf.to_string())
+                .function(&cf)
                 .map(|__f| &__f.origin.syntax)?;
             let optional = item_fn
                 .sig

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -311,7 +311,7 @@ pub(crate) fn build_typed_handle(
     for m in members.iter().filter(|m| m.kind == MemberKind::Constructor) {
         if let Some(item_fn) = registry
             .flat()
-            .function(&m.rust_ident.to_string())
+            .function(&m.rust_ident)
             .map(|__f| &__f.origin.syntax)
         {
             if let Some(f) = render_wrapper_fn(
@@ -424,7 +424,7 @@ pub(crate) fn build_typed_handle(
     for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
         if let Some(item_fn) = registry
             .flat()
-            .function(&m.rust_ident.to_string())
+            .function(&m.rust_ident)
             .map(|__f| &__f.origin.syntax)
         {
             if let Some(f) = render_wrapper_fn(

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -190,7 +190,7 @@ impl crate::api::core::Generation<JniGen> {
         let registry = self.registry();
         let Some(item_fn) = registry
             .flat()
-            .function(&rust_ident.to_string())
+            .function(&rust_ident)
             .map(|__f| &__f.origin.syntax)
         else {
             return;

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -488,12 +488,9 @@ fn sum_plan_kind(
     let ident = bare_path_ident(ty).unwrap_or_else(|| {
         panic!("fromParts bridge: sealed-class field `{owner}` is not a path type")
     });
-    let item_enum = registry
-        .flat()
-        .enum_item(&ident.to_string())
-        .unwrap_or_else(|| {
-            panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
-        });
+    let item_enum = registry.flat().enum_item(&ident).unwrap_or_else(|| {
+        panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
+    });
     let key = TypeKey::from_ident(&ident);
     let cfg = ext
         .types

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -127,8 +127,8 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
                 short.to_string(),
                 format!("sealed class `{key}` itself (its variants' supertype)"),
             )]);
-            if let Some(item_enum) = bare_path_ident(&key.to_type())
-                .and_then(|i| registry.flat().enum_item(&i.to_string()))
+            if let Some(item_enum) =
+                bare_path_ident(&key.to_type()).and_then(|i| registry.flat().enum_item(&i))
             {
                 for v in &item_enum.variants {
                     let name = ext.sum_variant_class_name(sum_cfg, &v.ident);
@@ -174,7 +174,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             // prototype, so the validator doesn't pay for body codegen.
             if let Some(item_fn) = registry
                 .flat()
-                .function(&entry.rust_ident.to_string())
+                .function(&entry.rust_ident)
                 .map(|__f| &__f.origin.syntax)
             {
                 if let Some(s) = build_wrapper_surface(ext, item_fn, registry, Some(&name), None) {
@@ -219,7 +219,7 @@ pub(crate) fn validate_symbols(ext: &JniGen, registry: &Registry<KotlinMeta>) ->
             check_ident(&name, &format!("method `{}`", m.rust_ident), &mut errors);
             let Some(item_fn) = registry
                 .flat()
-                .function(&m.rust_ident.to_string())
+                .function(&m.rust_ident)
                 .map(|__f| &__f.origin.syntax)
             else {
                 continue;
@@ -282,7 +282,7 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
         };
         if let Some(s) = registry
             .flat()
-            .struct_type(&ident.to_string())
+            .struct_type(&ident)
             .map(|__s| &__s.origin.syntax)
         {
             for f in &s.fields {
@@ -297,7 +297,7 @@ fn warn_derived_name_changes(ext: &JniGen, registry: &Registry<KotlinMeta>) {
                 }
             }
         }
-        if let Some(e) = registry.flat().enum_item(&ident.to_string()) {
+        if let Some(e) = registry.flat().enum_item(&ident) {
             for v in &e.variants {
                 let screaming =
                     crate::api::lang::jnigen::util::camel_to_screaming_snake(&v.ident.to_string());

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1047,7 +1047,7 @@ impl Prebindgen for JniGen {
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident.to_string()) else {
+            let Some(item_enum) = registry.flat().enum_item(&ident) else {
                 continue;
             };
             out.push(crate::api::core::unfold::SumDecon {
@@ -1218,7 +1218,7 @@ impl Prebindgen for JniGen {
                 // A registry-absent fn already hard-errored in the scan.
                 let Some(item_fn) = registry
                     .flat()
-                    .function(&m.rust_ident.to_string())
+                    .function(&m.rust_ident)
                     .map(|__f| &__f.origin.syntax)
                 else {
                     continue;
@@ -1289,7 +1289,7 @@ impl Prebindgen for JniGen {
         for ident in self.declared_functions() {
             let Some(item_fn) = registry
                 .flat()
-                .function(&ident.to_string())
+                .function(&ident)
                 .map(|__f| &__f.origin.syntax)
             else {
                 continue;
@@ -1684,7 +1684,7 @@ impl JniGen {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
-                    if let Some(e) = registry.flat().enum_item(&name.to_string()) {
+                    if let Some(e) = registry.flat().enum_item(&name) {
                         let (wire, body) = enum_input_body(self, registry, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
@@ -1786,7 +1786,7 @@ impl JniGen {
             // OUTPUT direction has no counterpart: a sum crosses Rust →
             // Kotlin flattened, always.)
             if self.types.get(&key).is_some_and(|c| c.sum().is_some()) {
-                if let Some(e) = registry.flat().enum_item(&name.to_string()) {
+                if let Some(e) = registry.flat().enum_item(&name) {
                     let (wire, body) = sum_input_body(self, e, registry)?;
                     // The wire's own null niche, exactly as a data class gets
                     // — that is what lets `Option<sum>` fold with JVM null as
@@ -1809,7 +1809,7 @@ impl JniGen {
             }
             if let Some(s) = registry
                 .flat()
-                .struct_type(&name.to_string())
+                .struct_type(&name)
                 .map(|__s| &__s.origin.syntax)
             {
                 let (wire, body) = struct_input_body(self, s, registry)?;
@@ -1902,7 +1902,7 @@ impl JniGen {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
-                    if let Some(e) = registry.flat().enum_item(&name.to_string()) {
+                    if let Some(e) = registry.flat().enum_item(&name) {
                         let (wire, body) = enum_output_body(self, e);
                         let niches = default_niches_for_wire(&wire);
                         let kotlin_name = cfg
@@ -2000,7 +2000,7 @@ impl JniGen {
         if let Some(name) = bare_path_ident(ty) {
             if let Some(s) = registry
                 .flat()
-                .struct_type(&name.to_string())
+                .struct_type(&name)
                 .map(|__s| &__s.origin.syntax)
             {
                 let (wire, body) = struct_output_body(self, s, registry)?;


### PR DESCRIPTION
Follow-up to #243, which made `Flat` the only index and left every lookup spelling
its argument `&x.to_string()` — **73 call sites** — because the accessors take
`&str` while callers hold a `syn::Ident`.

## The fact that shapes the fix

The obvious move is to re-key `by_name` as `HashMap<syn::Ident, _>`. That is
**strictly worse**, and checking `proc_macro2` rather than assuming is what showed
it:

* `impl Hash for Ident` hashes via `self.to_string()` (`proc-macro2/src/lib.rs:1030`)
  — so an `Ident`-keyed map allocates on every lookup *and* every insert, and the
  `&str` callers would start paying too.
* `Ident` has no `Borrow<str>` and no `as_str()`, so there is no borrow-based path
  from an `Ident` to a `&str` key either.

**The allocation cannot be removed, only moved.** This is call-site noise, not cost,
so the fix belongs in the API.

## The shape

```rust
pub trait Name: sealed::Sealed { fn as_name(&self) -> Cow<'_, str>; }

impl Name for str          // Borrowed — free
impl Name for String       // Borrowed — free
impl Name for syn::Ident   // Owned    — the allocation, moved inside
impl<T: ?Sized + Name> Name for &T
```

The six accessors — `element`, `function`, `declared_type`, `constant`,
`struct_type`, `enum_item` — take `&N: Name + ?Sized`.

```rust
flat.function(&ident)         // was flat.function(&ident.to_string())
flat.function("foo")          // unchanged
flat.declared_type(&id.name)  // still Borrowed, still free
```

`Cow` rather than a simpler `impl Display` + `format!` because **two callers must
stay allocation-free**: `immediate_edges` runs per type-graph edge across both the
scan and the resolver's BFS, and `Flat::resolve` runs per reference. Both hold a
`String` or `&str`.

The blanket `&T` impl is what let the migration be one mechanical rule
(`&X.to_string()` → `&X`) — without it, the sites where `X` is already a reference
would have produced `&&Ident`.

**Sealed**, so the one new public name cannot grow a second meaning from outside.
That is the trade against the alternative that avoids a trait: a `*_by_name` twin
for each accessor — twelve names instead of seven, and two spellings per concept to
keep in agreement.

## Verification

Signature change only — no generated byte and no test assertion moves. Call sites
lose **22 net lines**; `flat/mod.rs` is the only file that gains any.

* `regen-check.sh` byte-identical, after `cargo clean -p example-cbindgen -p
  example-flat` so the build scripts genuinely re-run
* `cargo +1.85 clippy --all-targets --no-default-features --all-features -- --deny
  warnings` — CI's exact invocation on the MSRV, which is what caught the lint on #243
* 589 + 517 tests, doctests, covertest-kotlin 48 sections

No new test: the existing 589 exercise every accessor through the new signature. A
doc-test on `Name` pins that both spellings reach the same element.