### PR TITLE
An alias counts as a declaration of its name

### DIFF
--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -886,14 +886,21 @@ impl<M> Registry<M> {
         })
     }
 
-    /// Whether a name declares a type with a **body** — a struct or either enum
-    /// shape, never an alias.
+    /// Whether the source declares a type under this name — **including an
+    /// alias**.
     ///
-    /// The predicate form of [`Self::declared_type_idents`], shared so its two
-    /// callers cannot drift: both warn about a declared-or-ignored type the
-    /// source does not define, and both must answer the same way about an alias.
-    fn declares_type_body(&self, ident: &syn::Ident) -> bool {
-        self.flat.struct_type(ident).is_some() || self.flat.enum_item(ident).is_some()
+    /// The question both type-diagnostic sites ask, shared so they cannot drift.
+    /// An alias counts because `#[prebindgen] pub type Handle = ..` *is* a
+    /// declaration of that name: it can be declared bare by an adapter (landing
+    /// in the no-indexed-body branch above, which is what
+    /// `ptr_class(ZKeyExpr<'static>)` relies on), so a diagnostic that says
+    /// "no such captured item" would be false.
+    ///
+    /// Distinct from [`Self::declared_type_idents`], which excludes aliases
+    /// because it feeds a *"skipping undeclared struct/enum"* warning — a
+    /// different question, about what an adapter left unclaimed.
+    fn declares_type(&self, ident: &syn::Ident) -> bool {
+        self.flat.declared_type(ident).is_some()
     }
 
     /// The origin crate's **module path** for an item, read off the element's
@@ -999,7 +1006,7 @@ impl<M> Registry<M> {
             let last = tp.path.segments.last().expect("len checked");
             if self.flat.source_modules().contains(&head) {
                 qualified.push((key.to_string(), last.to_token_stream().to_string()));
-            } else if self.declares_type_body(&last.ident) {
+            } else if self.declares_type(&last.ident) {
                 println!(
                     "cargo:warning=prebindgen: declared type `{}` is path-qualified, but a \
                      captured #[prebindgen] item `{}` exists — if you meant the source item, \
@@ -1114,7 +1121,7 @@ impl<M> Registry<M> {
 
         for key in &declared.ignored_types {
             let ty = key.to_type();
-            let matched = bare_path_ident(&ty).is_some_and(|ident| self.declares_type_body(&ident));
+            let matched = bare_path_ident(&ty).is_some_and(|ident| self.declares_type(&ident));
             if !matched {
                 println!(
                     "cargo:warning=prebindgen: ignored type `{}` not found among #[prebindgen] items",

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -876,9 +876,14 @@ impl<M> Registry<M> {
         })
     }
 
-    /// Every **declared type** name — struct or either enum shape, never an
-    /// alias. The set the old `structs`/`enums` map keys formed together.
-    fn declared_type_idents(&self) -> impl Iterator<Item = &syn::Ident> {
+    /// Every **struct or enum** name — either enum shape, never an alias.
+    ///
+    /// Named for its population rather than as the iterator form of
+    /// [`Self::declares_type`], which it is **not**: that predicate counts every
+    /// declared type, aliases included. This one feeds *"skipping undeclared
+    /// `#[prebindgen]` struct/enum"*, which names a kind an alias is not — so the
+    /// two answer differently on purpose, and the names now say so.
+    fn struct_enum_idents(&self) -> impl Iterator<Item = &syn::Ident> {
         use crate::api::core::flat::Type;
         self.flat.types().filter_map(|t| match t {
             Type::Struct(_) | Type::Variant(_) | Type::Enum(_) => Some(t.name()),
@@ -896,7 +901,7 @@ impl<M> Registry<M> {
     /// `ptr_class(ZKeyExpr<'static>)` relies on), so a diagnostic that says
     /// "no such captured item" would be false.
     ///
-    /// Distinct from [`Self::declared_type_idents`], which excludes aliases
+    /// Distinct from [`Self::struct_enum_idents`], which excludes aliases
     /// because it feeds a *"skipping undeclared struct/enum"* warning — a
     /// different question, about what an adapter left unclaimed.
     fn declares_type(&self, ident: &syn::Ident) -> bool {
@@ -1165,7 +1170,7 @@ impl<M> Registry<M> {
                 || declared.ignored_types.contains(key)
                 || declared.boundary_only_types.contains(key)
         };
-        for ident in self.declared_type_idents() {
+        for ident in self.struct_enum_idents() {
             let name = ident.to_string();
             let key = TypeKey::from_ident(ident);
             if !type_acknowledged(&key) && !pred_ignored(&name) {

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1227,14 +1227,14 @@ fn every_declared_type_counts_including_an_alias() {
 
     // The sibling that must NOT change: it feeds a "skipping undeclared
     // struct/enum" warning, so an alias — which is neither — stays out.
-    let bodies: HashSet<String> = reg.declared_type_idents().map(|i| i.to_string()).collect();
+    let bodies: HashSet<String> = reg.struct_enum_idents().map(|i| i.to_string()).collect();
     assert_eq!(
         bodies,
         ["S", "Sum", "Flags"]
             .map(String::from)
             .into_iter()
             .collect(),
-        "declared_type_idents feeds a struct/enum message and must exclude aliases"
+        "struct_enum_idents feeds a struct/enum message and must exclude aliases"
     );
 }
 

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1191,3 +1191,84 @@ fn enum_item_answers_for_both_shapes() {
     assert!(reg.flat().struct_type("S").is_some());
     assert!(reg.flat().struct_type("Sum").is_none());
 }
+
+// ── An alias is a declaration of its name ──────────────────────────────
+
+/// The predicate both type diagnostics gate on counts **every** declared type,
+/// alias included.
+///
+/// An alias was excluded because the pre-`Flat` code asked the `structs`/`enums`
+/// maps, which never held one. That was an artefact of where the answer came
+/// from, not a decision: `#[prebindgen] pub type Handle = ..` declares the name
+/// `Handle`, an adapter may declare it bare, and a diagnostic that says "no such
+/// captured item" about it is simply false.
+#[test]
+fn every_declared_type_counts_including_an_alias() {
+    let reg: Registry<()> = crate::api::test_util::reg_with(&[
+        "pub struct S { pub a: u64 }",
+        "pub enum Sum { A(u64), B }",
+        "pub enum Flags { X = 1 }",
+        "pub type Handle = other::Inner;",
+        "pub fn f(x: u64) -> u64 { x }",
+        "pub const K: u64 = 7;",
+    ]);
+    let id = |n: &str| syn::parse_str::<syn::Ident>(n).unwrap();
+
+    for name in ["S", "Sum", "Flags", "Handle"] {
+        assert!(
+            reg.declares_type(&id(name)),
+            "`{name}` is a declared type and must count"
+        );
+    }
+    // Not types: a fn and a const share the flat namespace but declare no type.
+    for name in ["f", "K", "Absent"] {
+        assert!(!reg.declares_type(&id(name)), "`{name}` declares no type");
+    }
+
+    // The sibling that must NOT change: it feeds a "skipping undeclared
+    // struct/enum" warning, so an alias — which is neither — stays out.
+    let bodies: HashSet<String> = reg.declared_type_idents().map(|i| i.to_string()).collect();
+    assert_eq!(
+        bodies,
+        ["S", "Sum", "Flags"]
+            .map(String::from)
+            .into_iter()
+            .collect(),
+        "declared_type_idents feeds a struct/enum message and must exclude aliases"
+    );
+}
+
+/// Both diagnostic sites reach the predicate for an alias, and neither errors.
+///
+/// `scan_declared` is the entry point for both: a path-qualified declared type
+/// whose tail names an alias (the "did you mean the bare name?" heuristic) and
+/// an ignored type that names one (the "not found among #[prebindgen] items"
+/// check). The messages themselves are `cargo:warning=` on stdout and are not
+/// captured here — what this pins is that an alias flows through the same path a
+/// struct does, without the `QualifiedDeclaredTypes` hard error.
+#[test]
+fn an_alias_flows_through_both_type_diagnostics() {
+    let build = |declare_qualified: bool| {
+        let reg: Registry<()> = crate::api::test_util::reg_with(&[
+            "pub type Handle = other::Inner;",
+            "pub fn f(x: u64) -> u64 { x }",
+        ]);
+        let mut ext = StubExt::default();
+        if declare_qualified {
+            // Head is NOT a source module, so this is the warn-and-pass-through
+            // branch rather than the hard error.
+            ext.types
+                .insert(TypeKey::parse("foreign::Handle").expect("test type"));
+        } else {
+            ext.ignored_types
+                .insert(TypeKey::parse("Handle").expect("test type"));
+        }
+        (reg, ext)
+    };
+
+    for qualified in [true, false] {
+        let (mut reg, ext) = build(qualified);
+        reg.scan_declared(&ext)
+            .expect("an alias is a captured item; neither site may fail");
+    }
+}


### PR DESCRIPTION
The follow-up #243's review asked for. There, both type-diagnostic sites were
restored to `structs || enums` because that PR's claim was that it moved **no**
behaviour, and a `cargo:warning=` that starts firing would have put a hole in the
thing `regen-check` was proving. This is the change on its merits, with the
argument and the tests.

## What was wrong

Two sites ask *"does the source declare a type under this name?"*:

| site | diagnostic |
|---|---|
| path-qualified heuristic | `ptr_class!(foreign::Handle)` → "a captured item `Handle` exists — declare it by its bare name" |
| ignored-type check | `ignore_types(Handle)` → "not found among `#[prebindgen]` items" |

Both answered **no** for an alias, and both were wrong to. `#[prebindgen] pub type
Handle = ..` *is* a declaration of the name `Handle`, and an adapter may declare it
bare — that lands in the no-indexed-body branch, which is exactly what
`ptr_class(ZKeyExpr<'static>)` relies on.

So the first **suppressed a fix-it suggestion that would have worked**, and the
second **called a captured item missing**.

The exclusion was never a decision. It is an artefact of where the answer used to
come from: the pre-`Flat` code asked the `structs`/`enums` maps, which never held
an alias because the registry had no map for one. #243 moved the lookup to the
model and the artefact became visible.

`declares_type_body` → `declares_type`, and it is now
`flat.declared_type(..).is_some()`.

## The sibling that must *not* change

`declared_type_idents` looks like it should follow and does not. It feeds
*"skipping undeclared `#[prebindgen]` struct/enum"* — a different question, about
what an adapter left **unclaimed**, naming a kind an alias is not. Warning about
unclaimed aliases may well be worth doing; it needs its own message, and it is not
this.

Both halves are pinned by the test, and both were checked against their own
violation:

| sabotage | result |
|---|---|
| predicate reverted to bodies-only | **FAILED** |
| `declared_type_idents` starts including aliases | **FAILED** |
| unmodified | ok |

## Nothing in-tree exercises this

Measured, not assumed: the four example crates emit **251** of these warnings, and
the set is **byte-identical** before and after. So the examples cannot serve as
evidence here and the tests construct the case directly.

Stated plainly: the warning *text* is `cargo:warning=` on stdout and is **not**
captured. What the second test pins is that an alias reaches both sites through
`scan_declared` without tripping the `QualifiedDeclaredTypes` hard error — that is
what it claims, and not more.

## Verification

* 591 + 519 tests (2 new)
* `regen-check.sh` byte-identical after `cargo clean -p example-cbindgen -p
  example-flat`
* covertest-kotlin 48 sections
* `cargo +1.85 clippy --all-targets --no-default-features --all-features -- --deny
  warnings`