### PR TITLE
Flat owns the type index too

### DIFF
--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -388,11 +388,16 @@ impl FlatBuilder {
                 }
             }
         }
-        Ok(Flat {
+        let mut flat = Flat {
             elements,
             by_name,
             source_modules,
-        })
+            by_type: std::collections::HashMap::new(),
+        };
+        for i in 0..flat.elements.len() {
+            flat.index_types_of(i);
+        }
+        Ok(flat)
     }
 }
 
@@ -438,6 +443,18 @@ pub struct Flat {
     /// API. Positions rather than clones, so there is one copy of each element
     /// and source order stays available.
     by_name: std::collections::HashMap<String, usize>,
+    /// Normalized type spelling → this module's reading of it.
+    ///
+    /// The keyed form of [`Self::type_refs`]: a consumer holding a `syn::Type`
+    /// asks what the frontend made of it without lowering it a second time.
+    /// A type mentioned in several places keeps the **first mention in element
+    /// order**, a property of the model rather than of ingestion order.
+    ///
+    /// Unlike [`Self::source_modules`] this *is* extended by
+    /// [`Self::add_local_function`]: a binding-local fn's parameter types have
+    /// readings like any others, and a lookup that missed them would report
+    /// "no reading" for one that exists.
+    by_type: std::collections::HashMap<String, TypeRef>,
 }
 
 /// A name a lookup can be performed with.
@@ -634,6 +651,37 @@ impl Flat {
         })
     }
 
+    /// This module's reading of `ty`, if the flat API mentions that type.
+    ///
+    /// `None` means no captured item and no binding-local fn writes this type —
+    /// it is one the binding invented, and there is nothing for the frontend to
+    /// have decided about it.
+    ///
+    /// The argument is normalized the way [`TypeKey`](crate::core::TypeKey) does
+    /// before lookup, so an adapter-authored spelling finds the same entry a
+    /// captured one does.
+    pub fn type_ref(&self, ty: &syn::Type) -> Option<&TypeRef> {
+        self.by_type
+            .get(&crate::api::core::types_util::canonical_spelling(ty))
+    }
+
+    /// Index every type the element at `pos` writes. Idempotent per key: the
+    /// first mention in element order wins.
+    fn index_types_of(&mut self, pos: usize) {
+        let refs: Vec<TypeRef> = element_type_refs(&self.elements[pos])
+            .into_iter()
+            .flat_map(TypeRef::walk)
+            .cloned()
+            .collect();
+        for ty in refs {
+            self.by_type
+                .entry(crate::api::core::types_util::canonical_spelling(
+                    &ty.origin.syntax,
+                ))
+                .or_insert(ty);
+        }
+    }
+
     /// Every item the language could not express, with its diagnosis.
     ///
     /// Present in the model so a consumer can inspect what a source crate marked
@@ -693,6 +741,7 @@ impl Flat {
         });
         self.by_name.insert(f.name.to_string(), self.elements.len());
         self.elements.push(Element::Function(f));
+        self.index_types_of(self.elements.len() - 1);
     }
 
     /// The declaration a reference denotes.

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -445,8 +445,11 @@ pub struct Flat {
     by_name: std::collections::HashMap<String, usize>,
     /// Normalized type spelling → this module's reading of it.
     ///
-    /// The keyed form of [`Self::type_refs`]: a consumer holding a `syn::Type`
-    /// asks what the frontend made of it without lowering it a second time.
+    /// Every type the API **mentions** — a parameter, a return, a field, a
+    /// constant's type, and everything nested inside those — keyed so a consumer
+    /// holding a `syn::Type` can ask what the frontend made of it without
+    /// lowering it a second time.
+    ///
     /// A type mentioned in several places keeps the **first mention in element
     /// order**, a property of the model rather than of ingestion order.
     ///
@@ -586,24 +589,6 @@ impl Flat {
             Element::Constant(c) => Some(c),
             _ => None,
         })
-    }
-
-    /// Every type the API **mentions**, at every nesting depth — as distinct from
-    /// [`Self::types`], which is every type it **declares**.
-    ///
-    /// A parameter, a return, a field, a constant's type, and everything reachable
-    /// inside those. The same type mentioned in several places yields one
-    /// [`TypeRef`] per mention, each with its own spelling and origin; a consumer
-    /// that wants one per type indexes them and picks, and element order makes
-    /// that pick deterministic.
-    ///
-    /// This is how a later stage gets the frontend's reading of a type it holds
-    /// only as syntax, without lowering it a second time.
-    pub fn type_refs(&self) -> impl Iterator<Item = &TypeRef> {
-        self.elements
-            .iter()
-            .flat_map(element_type_refs)
-            .flat_map(TypeRef::walk)
     }
 
     /// The `struct` declared under this name, or `None` for any other shape.

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -102,11 +102,9 @@ impl TypeKey {
     /// Build a key directly from a `syn::Type` (normalizing a clone; the
     /// input is not modified).
     pub fn from_type(ty: &syn::Type) -> Self {
-        let mut t = ty.clone();
-        crate::api::core::types_util::normalize_type(
-            &mut t,
-            &crate::api::core::types_util::Normalization::prelude(),
-        );
+        // Off the shared reduction, so this key and the model's type index
+        // cannot drift apart about what a type is called.
+        let t = crate::api::core::types_util::canonical_type(ty);
         Self {
             canon: t.to_token_stream().to_string().into(),
             ty: std::rc::Rc::new(t),
@@ -299,15 +297,6 @@ pub struct Registry<M = ()> {
     pub input_types: HashMap<TypeKey, TypeCell<M>>,
     pub output_types: HashMap<TypeKey, TypeCell<M>>,
 
-    /// The frontend's reading of every type the flat API mentions, keyed the way
-    /// the tables are, so a cell gets its [`TypeSubject::Source`] by lookup
-    /// instead of by lowering the type a second time.
-    ///
-    /// Built once from [`Self::flat`] before anything is scanned. A type
-    /// mentioned in several places keeps the first mention in **element order** —
-    /// a property of the model, not of the order items were fed in.
-    type_refs: HashMap<TypeKey, crate::api::core::flat::TypeRef>,
-
     /// Resolved constructor-expansion plans, keyed by `(function, parameter)`.
     /// Filled by [`crate::api::core::expand::apply`] before resolution; read
     /// by language adapters at the parameter-emission site. Empty unless the
@@ -359,7 +348,6 @@ impl<M> Registry<M> {
             flat: crate::api::core::flat::Flat::default(),
             input_types: Default::default(),
             output_types: Default::default(),
-            type_refs: HashMap::new(),
             expansion_plans: HashMap::new(),
             unfold_plans: HashMap::new(),
             error_plans: HashMap::new(),
@@ -836,17 +824,6 @@ impl<M> Registry<M> {
         }
 
         let mut registry = Registry::empty();
-        // Every type the model mentions, indexed the way the type tables are.
-        // Read up front, from the whole model: which mention of a repeated type
-        // wins is then decided by element order rather than by when a scan
-        // happened to reach it.
-        for ty in flat.type_refs() {
-            registry
-                .type_refs
-                .entry(TypeKey::from_type(&ty.origin.syntax))
-                .or_insert_with(|| ty.clone());
-        }
-
         registry.flat = flat;
         Ok(registry)
     }
@@ -1391,7 +1368,7 @@ impl<M> Registry<M> {
     /// adapter-authored type otherwise.
     fn ensure_entry(&mut self, dir: Direction, ty: &syn::Type, root: bool) {
         let key = TypeKey::from_type(ty);
-        let subject = match self.type_refs.get(&key) {
+        let subject = match self.flat.type_ref(ty) {
             Some(t) => TypeSubject::Source(t.clone()),
             None => TypeSubject::Adapter(key.to_type()),
         };

--- a/prebindgen/src/api/core/registry.rs
+++ b/prebindgen/src/api/core/registry.rs
@@ -155,7 +155,11 @@ impl TypeSubject {
     /// Where the source wrote this type, or `None` when no source did.
     pub fn location(&self) -> Option<&SourceLocation> {
         match self {
-            TypeSubject::Source(t) => Some(&t.origin.location),
+            // Having a reading and having a reportable position are different
+            // facts: a binding-local fn's types are lowered — so they have
+            // readings — against no file at all. Reporting `:0:0` would invent a
+            // position; `None` says what is true.
+            TypeSubject::Source(t) => Some(&*t.origin.location).filter(|l| l.has_position()),
             TypeSubject::Adapter(_) => None,
         }
     }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1367,3 +1367,71 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
     );
     assert!(matches!(cell.subject.kind(), Some(TypeKind::Optional(_))));
 }
+
+/// A type with no source position must not get an invented one.
+///
+/// Three facts have to stay apart: a type can have a **frontend reading**
+/// (`TypeSubject::Source`), a **reportable position**, or neither. A
+/// binding-local fn's parameter types have the first and not the second —
+/// `lower_signature` lowers them against `SourceLocation::default()`, since
+/// `Origin` needs a location and a `sig!(..)` has no file.
+///
+/// Indexing those types (this PR) flipped their cells from `Adapter` to
+/// `Source`, and `location()` returned the default unconditionally, so the
+/// diagnostic read `:0:0: error:` — a position that looks real. The same fault
+/// already showed for any hand-built stream, whose captured items also carry
+/// default locations; both are fixed by asking whether the location has a
+/// position at all.
+#[test]
+fn an_unresolved_type_without_a_position_reports_none() {
+    let reg: Registry<()> =
+        Registry::from_items(vec![fn_item("fn captured(x: u64) -> u64 { x }")]).unwrap();
+    let ext = StubExt {
+        local_fns: vec![(
+            syn::parse_str("fn helper(v: Option<u64>) -> u64 { 0 }").unwrap(),
+            "helpers".into(),
+        )],
+        functions: ["helper"]
+            .iter()
+            .map(|s| syn::parse_str(s).unwrap())
+            .collect(),
+        ..Default::default()
+    };
+    // `StubExt` supplies no converters, so every scanned type is unresolved:
+    // `Option<u64>` reached only through the local fn, `u64` through both.
+    let err = reg.resolve(ext).expect_err("StubExt resolves nothing");
+    let msg = err.to_string();
+
+    assert!(
+        !msg.contains(":0:0:"),
+        "no file and no line means no position to print:\n{msg}"
+    );
+    assert!(
+        msg.contains("error: unresolved prebindgen input type `Option < u64 >`"),
+        "the local-only type is still reported, just without a position:\n{msg}"
+    );
+
+    // A captured item that DOES have a position still reports it.
+    let located: Registry<()> = Registry::from_items(vec![(
+        syn::parse_quote!(
+            pub fn f(x: u64) -> u64 {
+                x
+            }
+        ),
+        SourceLocation {
+            file: "src/lib.rs".into(),
+            line: 12,
+            column: 3,
+            crate_name: Some("myflat".into()),
+        },
+    )])
+    .unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("f").unwrap());
+    let err = located.resolve(ext).expect_err("StubExt resolves nothing");
+    assert!(
+        err.to_string().contains("src/lib.rs:12:3: error:"),
+        "a real position must still be reported:\n{}",
+        err
+    );
+}

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1272,3 +1272,98 @@ fn an_alias_flows_through_both_type_diagnostics() {
             .expect("an alias is a captured item; neither site may fail");
     }
 }
+
+/// A type only a **binding-local** fn writes still has a frontend reading, and
+/// its cell must say so.
+///
+/// The ordering that made this wrong: the type index used to be built in
+/// `from_flat`, while local fns are inserted later by `resolve`. So their
+/// parameter types missed the index and their cells came out `Adapter` — "no
+/// reading" — even though `lower_signature` had produced `TypeRef`s for them.
+/// `Flat` owns the index now and `add_local_function` feeds it.
+#[test]
+fn a_type_only_a_local_fn_writes_still_has_a_reading() {
+    use crate::api::core::flat::TypeKind;
+
+    /// Resolves anything to itself, so declaring the local fn does not also
+    /// require an adapter that can convert its types.
+    struct AnyConverterExt(StubExt);
+    impl AnyConverterExt {
+        fn converter(ty: &syn::Type) -> Option<ConverterImpl<()>> {
+            Some(ConverterImpl {
+                destination: ty.clone(),
+                function: syn::parse_quote!(
+                    fn __id() {}
+                ),
+                pre_stages: vec![],
+                subs: vec![],
+                niches: Niches::empty(),
+                metadata: (),
+            })
+        }
+    }
+    impl Prebindgen for AnyConverterExt {
+        type Metadata = ();
+        fn declared_functions(&self) -> HashSet<syn::Ident> {
+            self.0.declared_functions()
+        }
+        fn local_functions(&self) -> Vec<(syn::ItemFn, String)> {
+            self.0.local_functions()
+        }
+        fn on_function(&self, f: &syn::ItemFn, r: &Registry<()>) -> TokenStream {
+            self.0.on_function(f, r)
+        }
+        fn on_struct(&self, st: &syn::ItemStruct, r: &Registry<()>) -> TokenStream {
+            self.0.on_struct(st, r)
+        }
+        fn on_enum(&self, e: &syn::ItemEnum, r: &Registry<()>) -> TokenStream {
+            self.0.on_enum(e, r)
+        }
+        fn on_input_type(&self, t: &syn::Type, _r: &Registry<()>) -> Option<ConverterImpl<()>> {
+            Self::converter(t)
+        }
+        fn on_output_type(&self, t: &syn::Type, _r: &Registry<()>) -> Option<ConverterImpl<()>> {
+            Self::converter(t)
+        }
+    }
+
+    // `Option<u64>` appears nowhere in the captured stream.
+    let reg: Registry<()> =
+        Registry::from_items(vec![fn_item("fn captured(x: u64) -> u64 { x }")]).unwrap();
+    assert!(
+        reg.flat()
+            .type_ref(&syn::parse_quote!(Option<u64>))
+            .is_none(),
+        "fixture precondition: the captured stream never writes this type"
+    );
+
+    let ext = AnyConverterExt(StubExt {
+        local_fns: vec![(
+            syn::parse_str("fn helper(v: Option<u64>) -> u64 { 0 }").unwrap(),
+            "helpers".into(),
+        )],
+        functions: ["helper"]
+            .iter()
+            .map(|s| syn::parse_str(s).unwrap())
+            .collect(),
+        ..Default::default()
+    });
+    let gen = reg.resolve(ext).expect("resolve");
+    let reg = gen.registry();
+
+    // The model now holds the reading …
+    let read = reg
+        .flat()
+        .type_ref(&syn::parse_quote!(Option<u64>))
+        .expect("a local fn's parameter type is in the model");
+    assert!(matches!(read.kind, TypeKind::Optional(_)));
+
+    // … and the cell scanned from that parameter carries it, rather than
+    // claiming the type is one the binding invented.
+    let cell = &reg.input_types[&TypeKey::parse("Option<u64>").expect("test type")];
+    assert!(
+        matches!(cell.subject, TypeSubject::Source(_)),
+        "the frontend read this type; the cell must not call it adapter-authored"
+    );
+    assert!(matches!(cell.subject.kind(), Some(TypeKind::Optional(_))));
+}

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -168,6 +168,29 @@ fn constructor_key(path: &syn::Path) -> String {
     out
 }
 
+/// A type reduced to the spelling everything keys on: prelude-normalized, so
+/// `std::option::Option<T>` and `Option<T>` are one entry.
+///
+/// The **single** definition of that reduction. Two things key on it — the
+/// model's type index ([`Flat::type_ref`](crate::core::flat::Flat::type_ref))
+/// and [`TypeKey`](crate::core::TypeKey) — and they have to agree, so neither
+/// spells it out itself.
+///
+/// Deliberately `prelude()` rather than a source-module-aware normalization: a
+/// key must mean the same thing before and after ingestion knows what the source
+/// modules are.
+pub fn canonical_type(ty: &syn::Type) -> syn::Type {
+    let mut t = ty.clone();
+    normalize_type(&mut t, &Normalization::prelude());
+    t
+}
+
+/// [`canonical_type`] as tokens — the string form both indexes use as their key.
+pub fn canonical_spelling(ty: &syn::Type) -> String {
+    use quote::ToTokens;
+    canonical_type(ty).to_token_stream().to_string()
+}
+
 pub fn normalize_type(ty: &mut syn::Type, against: &Normalization) {
     use syn::visit_mut::VisitMut;
     struct Normalizer<'a> {

--- a/prebindgen/src/api/record.rs
+++ b/prebindgen/src/api/record.rs
@@ -47,6 +47,20 @@ impl std::fmt::Display for SourceLocation {
 }
 
 impl SourceLocation {
+    /// Whether this names an actual place in an actual file.
+    ///
+    /// Not everything with a `SourceLocation` has one. A signature a build
+    /// script wrote (`sig!(..)`), or a hand-built item stream in a test, is
+    /// lowered against [`SourceLocation::default`] because [`Origin`] requires
+    /// *a* location — but there is no file and no line, and a diagnostic that
+    /// renders it anyway emits `:0:0:`, which reads as a real position and is
+    /// worse than saying nothing.
+    ///
+    /// [`Origin`]: crate::core::flat::Origin
+    pub fn has_position(&self) -> bool {
+        !self.file.is_empty()
+    }
+
     pub fn from_span(span: &proc_macro2::Span) -> Self {
         if_rust_version::if_rust_version! { >= 1.88 {
             // Convert proc_macro2::Span to proc_macro::Span to access file() method


### PR DESCRIPTION
`Registry::type_refs` was a private `HashMap<TypeKey, TypeRef>` built in
`from_flat` by walking `flat.type_refs()`, with exactly **one** consumer:
`ensure_entry`, deciding whether a new cell's subject is `Source(TypeRef)` — the
frontend's reading — or `Adapter(syn::Type)`, meaning no reading exists.

An index over `Flat`'s own content, held outside `Flat`. And `Flat::type_refs()`
had no other caller, so the public iterator existed solely to feed it. #243 made
`Flat` the only *item* index; this was the last one left.

## The shape

`Flat` gains `by_type` and:

```rust
/// This module's reading of `ty`, if the flat API mentions that type.
pub fn type_ref(&self, ty: &syn::Type) -> Option<&TypeRef>
```

so `from_flat` collapses to what it always should have been:

```rust
pub fn from_flat(flat: Flat) -> Result<Self, ScanError> {
    // …the expressibility check…
    let mut registry = Registry::empty();
    registry.flat = flat;
    Ok(registry)
}
```

After this, everything left in `Registry` is genuinely its own: the two type
tables (adapter answers plus roots) and the five adapter-declared plan maps.

## A binding-local fn's types are now indexed

The old ordering got this wrong. The index was built in `from_flat`; local fns are
inserted later by `resolve`. So their parameter types missed the index and their
cells came out `Adapter` — *"no frontend reading"* — even though `lower_signature`
had produced real `TypeRef`s for them. Simply false, and a straight relocation
would have carried it across.

`add_local_function` feeds the index. **Deliberately unlike `source_modules`**,
which stays frozen: that one decides `default_module`, so extending it would
change how *captured* items are qualified. This one only makes a cell tell the
truth about a reading that already exists.

## One definition of canonical spelling

Two things must agree on what a type is called: this index and `TypeKey`. Adding a
second copy of "prelude-normalize, then token string" would have made that worse,
so it moved to `types_util::{canonical_type, canonical_spelling}` — the module
both `flat` and `registry` already depend on — and `TypeKey::from_type` derives
from it. Net fewer definitions than before.

## Verification

* 592 + 520 tests. The new one covers the case the local-fn fix exists for, and
  fails when `add_local_function` stops feeding the index.
* covertest-kotlin 48 sections
* `cargo +1.85 clippy --all-targets --no-default-features --all-features -- --deny
  warnings`
* `regen-check.sh` byte-identical (after `git clean -fd examples/` and `cargo clean
  -p example-cbindgen -p example-flat`)

On that last point: reported because it is worth knowing, **not** because it was a
constraint. An architecture change whose generated output moves without changing
semantics or performance would have been equally acceptable; the check is
instrumentation for learning what moved, not a bar the design has to clear.