### PR TITLE
JniGen keeps declarations, not the builder that made them

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -67,7 +67,7 @@ impl DeclaredKind {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// The module path a generated call to `#[prebindgen]` fn `ident` must be
     /// qualified with: the fn's **origin crate** as recorded from its
     /// stream's `SourceLocation` stamp (multi-source bindings — helper
@@ -103,18 +103,8 @@ impl JniGenBuilder {
     }
 }
 
-impl JniGenBuilder {
-    /// Start a binding generator with default settings: empty base
-    /// package, no `JNINative` init block, identity
-    /// name-mangling, handle locks enabled. Adjust settings with the `set_*`
-    /// methods, add declarations with [`package`](Self::package),
-    /// [`expand`](Self::expand), [`convert`](Self::convert), etc., then run the
-    /// result through `JniGenBuilder::build` → `JniGen::write_rust` /
-    /// `write_kotlin`. Settings and
-    /// declarations may be interleaved in any order — the builder stores
-    /// only raw inputs, and every setting-derived name is computed at the
-    /// point of use.
-    pub fn new() -> Self {
+impl Default for Declarations {
+    fn default() -> Self {
         Self {
             package: String::new(),
             fun_name_mangle: None,
@@ -142,10 +132,27 @@ impl JniGenBuilder {
             local_fns: Vec::new(),
             iface_specs: Default::default(),
             fn_plans: Default::default(),
-            sources: Default::default(),
         }
     }
+}
 
+impl JniGenBuilder {
+    /// Start a binding generator with default settings: empty base
+    /// package, no `JNINative` init block, identity
+    /// name-mangling, handle locks enabled. Adjust settings with the `set_*`
+    /// methods, add declarations with [`package`](Self::package),
+    /// [`expand`](Self::expand), [`convert`](Self::convert), etc., then run the
+    /// result through [`build`](Self::build) → `JniGen::write_rust` /
+    /// `write_kotlin`. Settings and
+    /// declarations may be interleaved in any order — the builder stores
+    /// only raw inputs, and every setting-derived name is computed at the
+    /// point of use.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Declarations {
     /// Apply the package-level function-name mangle closure to `name`.
     pub(crate) fn mangle_fun(&self, package: &str, name: &str) -> String {
         match &self.fun_name_mangle {
@@ -237,14 +244,12 @@ impl JniGenBuilder {
     }
 }
 
-impl Default for JniGenBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 // ── Accepting a `PackageDecl` ────────────────────────────────────────────
 
+/// The describing surface: everything that *adds* to [`Declarations`].
+///
+/// Every method here takes `self` or `&mut self`; not one of them exists on
+/// `Declarations`, which is the whole point of the two types.
 impl JniGenBuilder {
     /// Register a package's worth of classes, functions and consts (a
     /// [`PackageDecl`], built with [`package!`](crate::package)). Call it once
@@ -295,7 +300,7 @@ impl JniGenBuilder {
             functions,
             constants,
         } = decl;
-        self.packages.entry(name.clone()).or_default();
+        self.decls.packages.entry(name.clone()).or_default();
         for class in classes {
             self.accept_class(&name, class);
         }
@@ -306,7 +311,7 @@ impl JniGenBuilder {
         // source was already lowered to an expression (`path()`) at decl
         // time, so only three storage kinds exist internally.
         for c in constants {
-            let pkg = self.packages.entry(name.clone()).or_default();
+            let pkg = self.decls.packages.entry(name.clone()).or_default();
             match c.source {
                 super::decl::ConstSource::Item => {
                     let mut entry = FunctionEntry::new(c.rust_ident);
@@ -340,16 +345,16 @@ impl JniGenBuilder {
     pub fn ignore(mut self, decl: impl Into<IgnoreDecl>) -> Self {
         match decl.into().0 {
             super::decl::IgnoreKind::Fun(ident) => {
-                self.ignored_fns.insert(ident);
+                self.decls.ignored_fns.insert(ident);
             }
             super::decl::IgnoreKind::Type(key) => {
-                self.ignored_class_types.insert(key);
+                self.decls.ignored_class_types.insert(key);
             }
             super::decl::IgnoreKind::Const(ident) => {
-                self.ignored_const_idents.insert(ident);
+                self.decls.ignored_const_idents.insert(ident);
             }
             super::decl::IgnoreKind::Matching(pred) => {
-                self.ignored_name_predicates.push(pred);
+                self.decls.ignored_name_predicates.push(pred);
             }
         }
         self
@@ -397,7 +402,7 @@ impl JniGenBuilder {
             );
         }
         let short = rust_short_name(key);
-        match self.types.entry(key.clone()) {
+        match self.decls.types.entry(key.clone()) {
             std::collections::hash_map::Entry::Occupied(e) => {
                 let cfg = e.into_mut();
                 cfg.kind.merge(kind, &short);
@@ -414,6 +419,7 @@ impl JniGenBuilder {
     /// idempotent).
     fn store_iface_opts(&mut self, key: &TypeKey, iface: IfaceOpts) {
         let cfg = self
+            .decls
             .types
             .get_mut(key)
             .expect("register_class created the entry");
@@ -527,7 +533,8 @@ impl JniGenBuilder {
             // A constructor member's return is a factory, never
             // output-flattened — derived from `class_members` in
             // `build_deconstructors` (`skip_output`), not stored separately.
-            self.class_members
+            self.decls
+                .class_members
                 .entry(key.clone())
                 .or_default()
                 .push(ClassMember {
@@ -541,7 +548,8 @@ impl JniGenBuilder {
     fn accept_function(&mut self, subpackage: &str, decl: FunctionDecl) {
         let mut entry = FunctionEntry::new(decl.rust_ident.clone());
         entry.kotlin_name_override = decl.kotlin_name_override.clone();
-        self.packages
+        self.decls
+            .packages
             .entry(subpackage.to_string())
             .or_default()
             .functions
@@ -578,17 +586,20 @@ impl JniGenBuilder {
                     p = quote::quote!(#path)
                 );
             };
-            self.local_fns.push((rust_ident.clone(), path, sig));
+            self.decls.local_fns.push((rust_ident.clone(), path, sig));
         }
         for (param, pdecl) in param_expands {
-            self.fn_param_expands
+            self.decls
+                .fn_param_expands
                 .push((rust_ident.clone(), param, pdecl));
         }
         if let Some(rdecl) = return_expand {
-            self.fn_return_expands.push((rust_ident.clone(), rdecl));
+            self.decls
+                .fn_return_expands
+                .push((rust_ident.clone(), rdecl));
         }
         for param in split_on_params {
-            self.fn_split_params.push((rust_ident.clone(), param));
+            self.decls.fn_split_params.push((rust_ident.clone(), param));
         }
     }
 }
@@ -619,7 +630,7 @@ impl JniGenBuilder {
                      .variant_self()",
                     decl.key.as_str()
                 );
-                self.param_expand_decls.push(decl);
+                self.decls.param_expand_decls.push(decl);
             }
             ExpandDecl::Return(decl) => {
                 assert!(
@@ -628,12 +639,14 @@ impl JniGenBuilder {
                      .field_self()",
                     decl.key.as_str()
                 );
-                self.return_expand_decls.push(decl);
+                self.decls.return_expand_decls.push(decl);
             }
         }
         self
     }
+}
 
+impl Declarations {
     /// The Kotlin name of `func` as a declared member (`.method`/`.constructor`)
     /// of the class keyed by `key`, if it is one — the name-inheritance
     /// source for [`ExpandReturnDecl::field`].
@@ -1389,11 +1402,13 @@ impl JniGenBuilder {
         // Binding-local fn sources (`fun!(crate::f).sig(…)`) join the same
         // synthesis list as fun/method/constructor sites — after the
         // pre-pass they lower exactly like `#[prebindgen]` fn sources.
-        self.local_fns.append(&mut decl.locals);
-        self.convert_decls.push(decl);
+        self.decls.local_fns.append(&mut decl.locals);
+        self.decls.convert_decls.push(decl);
         self
     }
+}
 
+impl Declarations {
     /// Derive the rank-0 **input** converter body for a `convert!`-declared
     /// type: `(continue_ty, exc, body)` where `continue_ty` is the conversion
     /// fn's parameter type (by value) — the composed-converter machinery
@@ -1699,7 +1714,7 @@ fn fn_return_type(item_fn: &syn::ItemFn) -> syn::Type {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Build a `KotlinMeta` carrying just the value-context Kotlin name.
     /// Used by every built-in converter (primitives, structs, `Option<_>`,
     /// `Vec<_>`, `impl Fn(...)` lambdas). Errors are routed uniformly to the

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -42,7 +42,7 @@ impl TypeConfig {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Classify `bare` against the declared-type table and the registry's
     /// captured structs. Callers strip `Option<_>` / `&_` layers first —
     /// wrapper folding is the resolver's business, not this table's.

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -77,12 +77,12 @@ impl JniGenBuilder {
         // directly by many emitters, so mangling at this single storage
         // point keeps every reader consistent; warn here (the raw input is
         // only available now) when a segment was changed.
-        self.package = mangle_package(&trimmed);
-        if self.package != trimmed {
+        self.decls.package = mangle_package(&trimmed);
+        if self.decls.package != trimmed {
             println!(
                 "cargo:warning=prebindgen: package prefix `{trimmed}` sanitized to `{}` \
                  (invalid Kotlin package identifier)",
-                self.package
+                self.decls.package
             );
         }
         self
@@ -99,7 +99,7 @@ impl JniGenBuilder {
     /// keeps the generator free of any concrete loading logic. Unset = no
     /// init block.
     pub fn set_jni_native_init(mut self, code: impl Into<String>) -> Self {
-        self.jni_native_init = Some(code.into());
+        self.decls.jni_native_init = Some(code.into());
         self
     }
 
@@ -112,7 +112,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str) -> String + Send + Sync + 'static,
     {
-        self.harness_name_mangle = Some(Arc::new(f));
+        self.decls.harness_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -124,7 +124,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
-        self.fun_name_mangle = Some(Arc::new(f));
+        self.decls.fun_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -140,7 +140,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
-        self.interface_name_mangle = Some(Arc::new(f));
+        self.decls.interface_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -151,7 +151,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
-        self.ptr_class_name_mangle = Some(Arc::new(f));
+        self.decls.ptr_class_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -163,7 +163,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
-        self.data_class_name_mangle = Some(Arc::new(f));
+        self.decls.data_class_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -174,7 +174,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str, &str) -> String + Send + Sync + 'static,
     {
-        self.enum_name_mangle = Some(Arc::new(f));
+        self.decls.enum_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -187,7 +187,7 @@ impl JniGenBuilder {
     where
         F: Fn(&str, &str, &str) -> String + Send + Sync + 'static,
     {
-        self.method_name_mangle = Some(Arc::new(f));
+        self.decls.method_name_mangle = Some(Arc::new(f));
         self
     }
 
@@ -204,12 +204,12 @@ impl JniGenBuilder {
     /// re-verified on your own workload — generate once with `false`,
     /// benchmark both, and keep the default — not as an optimization knob.
     pub fn set_emit_handle_locks(mut self, emit: bool) -> Self {
-        self.emit_handle_locks = emit;
+        self.decls.emit_handle_locks = emit;
         self
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Materialize a [`NameSpec`] into a concrete Kotlin FQN under the
     /// current settings. Precedence for a declared class: per-decl
     /// `name_override` (package-resolved, mangle-bypassed), then the mangle

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -1,20 +1,20 @@
 //! Declaration objects: one standalone, independently-constructible value
-//! type per kind of thing `JniGenBuilder` can be told about (a `ptr_class`, an
+//! type per kind of thing `Declarations` can be told about (a `ptr_class`, an
 //! `enum_class`, a function, a scalar wire mapping, …), plus the `PackageDecl`
 //! that aggregates the package-scoped ones. Each type is both its own
-//! "builder" and the final value `JniGenBuilder`/`PackageDecl` accepts — no separate
+//! "builder" and the final value `Declarations`/`PackageDecl` accepts — no separate
 //! `Builder`/`Decl` split, no terminal `.build()` call.
 //!
-//! `JniGenBuilder` itself only ever *accepts* fully-built values of these types
+//! `Declarations` itself only ever *accepts* fully-built values of these types
 //! (`JniGenBuilder::package`, `JniGenBuilder::expand`, `JniGenBuilder::convert`, in
 //! `builder.rs`); none of them reach back
-//! into any `JniGenBuilder` state while being built.
+//! into any `Declarations` state while being built.
 
 use super::*;
 
 // ──────────────────────────────────────────────────────────────────────
 // Shared local accumulators (replayed into `Expansions`/`Deconstructors`
-// by the accept logic in `builder.rs` once a decl is handed to `JniGenBuilder`)
+// by the accept logic in `builder.rs` once a decl is handed to `Declarations`)
 // ──────────────────────────────────────────────────────────────────────
 
 /// One arm of an `expand_param!` `.variant*` list (type-level or per-fn).
@@ -1884,7 +1884,7 @@ pub struct ConvertDecl {
     pub(crate) output: Option<ConvertSpec>,
     pub(crate) domain: Option<crate::core::RepresentationDomain>,
     /// Binding-local fn sources declared on this convert (`fun!(crate::f)
-    /// .sig(…)`): drained into [`JniGenBuilder::local_fns`] at acceptance so the
+    /// .sig(…)`): drained into [`Declarations::local_fns`] at acceptance so the
     /// synthesis pre-pass covers them.
     pub(crate) locals: Vec<(syn::Ident, syn::Path, syn::Signature)>,
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -20,7 +20,7 @@ use crate::api::core::registry::Conversions;
 /// Errors cannot reach a caller-side error sink (the declaring call already
 /// returned), so they are converted to `__JniErr` and logged via `tracing`.
 pub(crate) fn callback_input(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     args: &[syn::Type],
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -403,7 +403,7 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
 /// upstream type a bare `<ident>` resolves to in their include-site
 /// `use` statements. Pairs with output body below.
 pub(crate) fn enum_input_body(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     e: &syn::ItemEnum,
 ) -> (syn::Type, syn::Expr) {
@@ -443,7 +443,7 @@ pub(crate) fn enum_input_body(
 /// upstream of the cast. The body works without naming the enum type
 /// at all — `v` is already typed via the wrapper signature, so the
 /// `as` cast picks up the right type by inference.
-pub(crate) fn enum_output_body(_ext: &JniGenBuilder, e: &syn::ItemEnum) -> (syn::Type, syn::Expr) {
+pub(crate) fn enum_output_body(_ext: &Declarations, e: &syn::ItemEnum) -> (syn::Type, syn::Expr) {
     assert_only_unit_variants(e);
     let body: syn::Expr = syn::parse_quote!({ v as jni::sys::jint });
     (syn::parse_quote!(jni::sys::jint), body)

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -30,7 +30,7 @@ use crate::api::core::{
 /// [`UnfoldShape::Base`]: crate::api::core::unfold::UnfoldShape::Base
 /// [`UnfoldShape::Optional`]: crate::api::core::unfold::UnfoldShape::Optional
 pub(crate) fn emit_unfold_delivery(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::unfold::UnfoldPlan,
     iface: Option<&IfaceSpec>,
@@ -788,7 +788,7 @@ fn reach_leaf(
 /// arm of fallible externs (whose `fail` falls back to a binding-error
 /// `signal_error` with default ze values).
 pub(crate) fn encode_plan_leaves(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     plan: &crate::api::core::unfold::UnfoldPlan,
     obj_idents: &[syn::Ident],

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::api::core::registry::Conversions;
 
 pub(crate) fn struct_input_body(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     s: &syn::ItemStruct,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
@@ -280,7 +280,7 @@ pub(crate) fn struct_input_body(
 /// one field out of a `JObject` the caller already handed us costs nothing
 /// extra, so the asymmetry is real rather than an oversight.
 pub(crate) fn sum_input_body(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     e: &syn::ItemEnum,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
@@ -377,7 +377,7 @@ pub(crate) fn sum_input_body(
 /// [`struct_input_body`] performs, for the positions that are properties of a
 /// generated class rather than fields of a data class.
 fn read_kotlin_property(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     receiver: &TokenStream,
     prop: &str,
@@ -869,7 +869,7 @@ fn wire_kotlin_type(entry: &crate::api::core::registry::TypeEntry<KotlinMeta>) -
 /// text spliced into a wrapper whose import set this plan does not own.
 #[allow(clippy::too_many_arguments)]
 fn build_flat_sum_field(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     sum_ty: &syn::Type,
     field: syn::Ident,
@@ -1116,7 +1116,7 @@ fn push_handle_leaf(
 /// `.jobject_input()` opt-in); an unmarked data class either returns a complete
 /// plan or a validation error — never a silent object fallback.
 pub(crate) fn build_flat_input_plan(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg_ty: &syn::Type,
@@ -1202,7 +1202,7 @@ pub(crate) fn build_flat_input_plan(
 
 #[allow(clippy::too_many_arguments)]
 fn build_flat_struct_node(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     st: &syn::ItemStruct,
     optional: bool,
@@ -1797,7 +1797,7 @@ pub(crate) struct OptionScalarInputPlan {
 /// only the cases that *would* box are intercepted — niche cases (already
 /// unboxed / ABI-clean) and opaque/value projections are left untouched.
 pub(crate) fn build_option_scalar_input_plan(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg_ty: &syn::Type,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -5,8 +5,8 @@ use super::*;
 
 /// Last-segment ident of a `TypeKey` — e.g. `"Publisher<'static>"` →
 /// `"Publisher"`, `"AdvancedSubscriber<()>"` → `"AdvancedSubscriber"`. Used by
-/// the structured builders ([`JniGenBuilder::ptr_class`],
-/// [`JniGenBuilder::data_class`]) to derive a default Kotlin class name from
+/// the structured builders ([`Declarations::ptr_class`],
+/// [`Declarations::data_class`]) to derive a default Kotlin class name from
 /// the Rust type-key. Panics for non-path types (e.g. closures, references) —
 /// the per-kind `*_name_mangle` closures see only path-shaped
 /// shorts. For verbatim Kotlin expressions on non-path types, use a
@@ -23,7 +23,7 @@ pub(crate) fn rust_short_name(key: &TypeKey) -> String {
 
 /// Fallible variant of [`rust_short_name`] — returns `None` for
 /// non-path types instead of panicking. Used by
-/// [`JniGenBuilder::note_wrapper_registration`] which is called for rank-0
+/// [`Declarations::note_wrapper_registration`] which is called for rank-0
 /// wrapper patterns including non-path shapes like `()` where there
 /// is no Kotlin short name to derive.
 pub(crate) fn rust_short_name_opt(key: &TypeKey) -> Option<String> {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -10,7 +10,7 @@ use crate::api::core::registry::Conversions;
 /// in `Nullable`) are encodable as a single `L<FQN>;` ctor arg; a
 /// collection layer (`Iterable`, i.e. `Vec<Handle>`) would need array
 /// codegen and is a loud build-time error until implemented.
-pub(crate) fn handle_field_fqn(ext: &JniGenBuilder, h: &Projection) -> String {
+pub(crate) fn handle_field_fqn(ext: &Declarations, h: &Projection) -> String {
     fn assert_scalar(s: &FoldStrategy) {
         match s {
             FoldStrategy::Base => {}
@@ -81,7 +81,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 /// model (`registry.flat()`) — both populated before `resolve` — never the
 /// output converter table (not yet built at this stage).
 pub(crate) fn synth_value_struct_leaves(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     s: &syn::ItemStruct,
     path_prefix: &[crate::api::core::unfold::PathStep],
@@ -171,7 +171,7 @@ pub(crate) fn synth_value_struct_leaves(
 /// plan `flatten_struct_factory` walks for the Kotlin side, so the slot
 /// order and JVM descriptors agree by construction.
 pub(crate) fn flatten_struct_encode(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     s: &syn::ItemStruct,
     access: &TokenStream,
@@ -575,7 +575,7 @@ fn encode_field(
 }
 
 pub(crate) fn struct_output_body(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     s: &syn::ItemStruct,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
@@ -637,7 +637,7 @@ pub(crate) fn struct_output_body(
 }
 
 pub(crate) fn struct_module_path(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     s: &syn::ItemStruct,
 ) -> syn::Path {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -41,7 +41,7 @@ pub(crate) const SUM_TAG_LEAF: &str = "tag";
 /// `variant!(V).name(...)` rename carries through to the builder's parameter
 /// names too.
 pub(crate) fn synth_sum_leaves(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     sum_cfg: &SumConfig,
     item_enum: &syn::ItemEnum,
 ) -> Vec<crate::api::core::unfold::UnfoldLeaf> {
@@ -162,7 +162,7 @@ pub(crate) fn is_sum_leaves(leaves: &[crate::api::core::unfold::UnfoldLeaf]) -> 
 /// is that a leaf here is not an independent expression — its slot exists in
 /// every arm and only one arm computes it.
 pub(crate) fn encode_sum_group(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     leaves: &[crate::api::core::unfold::UnfoldLeaf],
     obj_idents: &[syn::Ident],

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -30,7 +30,7 @@ pub(crate) fn slice_or_vec_elem(arg_ty: &syn::Type) -> Option<(syn::Type, bool)>
 /// classifier, `render_extern_decl`, and the synthetic-extern emitter so all
 /// four sites agree on which params take the handle path.
 pub(crate) fn vec_build_elem(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     arg_ty: &syn::Type,
 ) -> Option<(syn::Type, bool)> {
@@ -60,7 +60,7 @@ pub(crate) fn vec_build_elem(
 /// Deduped by [`TypeKey`] and sorted for deterministic output (mirrors
 /// [`build_handle_destructor_items`]).
 pub(crate) fn collect_vec_build_elem_types(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Type> {
     let declared = ext.declared_functions();
@@ -99,7 +99,7 @@ pub(crate) struct VecBuildHelpers {
 /// from the element's **Kotlin** data-class short name (first char lowercased) so
 /// the generated methods read naturally (`Payload` → `payloadVec`).
 pub(crate) fn vec_build_helpers(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     elem: &syn::Type,
 ) -> Option<VecBuildHelpers> {
@@ -137,7 +137,7 @@ pub(crate) fn vec_build_helpers(
 /// through the method mangler like every other `JNINative` extern. The Rust JNI symbol
 /// (see [`vec_helper_symbol`]) and the Kotlin call site both use this, so they
 /// agree.
-pub(crate) fn vec_helper_method_name(ext: &JniGenBuilder, base: &str, suffix: &str) -> String {
+pub(crate) fn vec_helper_method_name(ext: &Declarations, base: &str, suffix: &str) -> String {
     ext.mangle_jni_method(&format!("{base}{suffix}"))
 }
 
@@ -145,7 +145,7 @@ pub(crate) fn vec_helper_method_name(ext: &JniGenBuilder, base: &str, suffix: &s
 /// `Java_<pkg>_<JNINative>_…` scheme function wrappers use via the plan's
 /// `native_symbol` (see `symbol`, #86); these helpers live on the
 /// `JNINative` object, so they share its class path.
-fn vec_helper_symbol(ext: &JniGenBuilder, base: &str, suffix: &str) -> String {
+fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
     ext.native_method_symbol(&vec_helper_method_name(ext, base, suffix))
 }
 
@@ -164,7 +164,7 @@ fn vec_helper_symbol(ext: &JniGenBuilder, base: &str, suffix: &str) -> String {
 /// shared across all callers of a given element type). This keeps the Kotlin
 /// push loop free of a per-element failure check.
 pub(crate) fn build_vec_build_helper_items(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::api::core::{registry::Conversions, types_util::result_ok_type};
 
 pub(crate) fn emit_jni_function_wrapper(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
 ) -> TokenStream {
@@ -14,7 +14,7 @@ pub(crate) fn emit_jni_function_wrapper(
 
 /// The synthetic nullary getter signature a declared const is emitted
 /// through: `pub fn const_get_<ident_lower>() -> <const ty>`. Both sides —
-/// the Rust extern ([`JniGenBuilder::on_const`] via
+/// the Rust extern ([`Declarations::on_const`] via
 /// [`emit_jni_function_wrapper_with_callee`]) and the Kotlin `val`
 /// initializer (`render_const_val`) — derive the extern symbol from this one
 /// ident, so they stay in sync by construction. The body is never used.
@@ -32,7 +32,7 @@ pub(crate) fn const_getter_fn(c: &syn::ItemConst) -> syn::ItemFn {
 /// shared closeable `val` is semantically wrong (whose `close()` is it?).
 /// Expose a factory function instead — the established idiom (e.g. zenoh's
 /// `encoding_const_*` companion factories).
-pub(crate) fn reject_handle_const(ext: &JniGenBuilder, c: &syn::ItemConst) {
+pub(crate) fn reject_handle_const(ext: &Declarations, c: &syn::ItemConst) {
     reject_handle_constant_type(ext, &c.ty, "const", &c.ident.to_string());
 }
 
@@ -41,7 +41,7 @@ pub(crate) fn reject_handle_const(ext: &JniGenBuilder, c: &syn::ItemConst) {
 /// declared opaque handle. `what`/`ident` shape the error message
 /// (`const MAX_LEN` / `constant fn encoding_const_x_str`).
 pub(crate) fn reject_handle_constant_type(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     ty: &syn::Type,
     what: &str,
     name: &str,
@@ -79,7 +79,7 @@ pub(crate) fn reject_handle_constant_type(
 /// the `val` initializer's throwing `JniErrorHandler` only fits the
 /// infallible wrapper shape), and its return type must not peel to a
 /// declared opaque handle (same rationale as [`reject_handle_const`]).
-pub(crate) fn validate_constant_fn(ext: &JniGenBuilder, f: &syn::ItemFn) {
+pub(crate) fn validate_constant_fn(ext: &Declarations, f: &syn::ItemFn) {
     assert!(
         f.sig.inputs.is_empty(),
         "constant fn `{}`: takes {} parameter(s) — a function-backed constant must be nullary \
@@ -115,7 +115,7 @@ pub(crate) fn const_expr_getter_fn(kotlin_name: &str, ty: &syn::Type) -> syn::It
 /// Validates an expression constant's declared value type (checked on both
 /// write paths): not a `Result` (a domain-fallible value is not a constant),
 /// not (peeled to) a declared opaque handle.
-pub(crate) fn validate_constant_expr(ext: &JniGenBuilder, kotlin_name: &str, ty: &syn::Type) {
+pub(crate) fn validate_constant_expr(ext: &Declarations, kotlin_name: &str, ty: &syn::Type) {
     assert!(
         result_ok_type(ty).is_none(),
         "constant expr `{kotlin_name}`: type is a `Result` — an expression constant must be \
@@ -127,11 +127,11 @@ pub(crate) fn validate_constant_expr(ext: &JniGenBuilder, kotlin_name: &str, ty:
 /// [`emit_jni_function_wrapper`] with the raw callee expression overridable:
 /// `None` = the ordinary `<origin module>::<fn ident>(args)` call; `Some(e)`
 /// splices `e` verbatim as the value the output phase converts. Used by the
-/// const getter emission (`JniGenBuilder::on_const`), whose synthetic nullary `f`
+/// const getter emission (`Declarations::on_const`), whose synthetic nullary `f`
 /// carries the signature while the value comes from
 /// `<origin module>::<CONST_IDENT>` — a path, not a call.
 pub(crate) fn emit_jni_function_wrapper_with_callee(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     callee: Option<syn::Expr>,
@@ -433,7 +433,7 @@ fn unfold_builder_param(iterable_fold: bool) -> TokenStream {
 /// site only renders each [`InputKind`]'s decode.
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     original_ident: &syn::Ident,
     param: &PlanParam,
@@ -702,7 +702,7 @@ fn emit_plain_decode(
 /// through the same error sink as any fallible input. The returned call
 /// argument is the built value (`&value` when the original parameter was `&T`).
 pub(crate) fn emit_expanded_param(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     plan: &crate::api::core::expand::FoldPlan,
     leaves: &[PlanLeaf],

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -31,7 +31,7 @@ pub(crate) struct JniFunctionPlan {
     /// The onError handler interfaces — the always-present binding
     /// `JniErrorHandler` plus, for a fallible function, its typed domain
     /// `<Err>Handler` (see [`ErrorIfaces`]). Shared from the
-    /// [`JniGenBuilder::iface_spec`] memo: one derivation per channel feeds the Rust
+    /// [`Declarations::iface_spec`] memo: one derivation per channel feeds the Rust
     /// `__SINK_*` statics, the Kotlin sink wiring, and the interface
     /// declarations, so the FQN/descriptor pairs of the cached `run` lookups
     /// cannot drift. `None` = the domain channel is underivable (the Rust
@@ -150,7 +150,7 @@ pub(crate) struct UnfoldOutputPlan {
     /// The builder/folder `fun interface` spec the delivery calls into —
     /// [`folder_iface_for_plan`] for an iterable fold (incl. the fixed
     /// whole-element form), the memoized [`SpecKey::Builder`] spec
-    /// otherwise. Shared from the [`JniGenBuilder::iface_spec`] memo: one
+    /// otherwise. Shared from the [`Declarations::iface_spec`] memo: one
     /// derivation feeds the Rust upcall statics, every Kotlin surface read,
     /// and the interface declaration, so the cached `run` FQN/descriptor
     /// pair cannot drift. `None` = underivable (the Rust emitter keeps its
@@ -242,7 +242,7 @@ impl PlanError {
             ),
             PlanError::UnresolvedOutput { ty } => format!(
                 "JniGen::on_function: return type `{}` of `{}` has no registered output \
-                 converter — register one via `JniGenBuilder::output_wrapper(pat, |…| Some((ty, exc, body)))` \
+                 converter — register one via `Declarations::output_wrapper(pat, |…| Some((ty, exc, body)))` \
                  (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
                   to bind a domain exception)",
                 ty, fn_ident,
@@ -267,7 +267,7 @@ impl PlanError {
 ///
 /// [`Prebindgen::validate_resolved`]: crate::api::core::prebindgen::Prebindgen::validate_resolved
 pub(crate) fn validate_bindings(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
 ) -> Result<(), String> {
     let mut errors: Vec<String> = Vec::new();
@@ -315,7 +315,7 @@ pub(crate) fn validate_bindings(
     }
 
     // Declared consts: their synthetic nullary getters run through the same
-    // plan machinery (`JniGenBuilder::on_const`).
+    // plan machinery (`Declarations::on_const`).
     if let Some(declared_consts) = ext.declared_consts() {
         let mut consts: Vec<&crate::api::core::flat::Constant> =
             registry.flat().constants().collect();
@@ -372,7 +372,7 @@ impl FnOutputPlan {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// The memoized lowered plan for one bound function — the "build the plan
     /// once and store it" stage [`JniFunctionPlan::build`] anticipated (issue
     /// #90). Keyed by the function's ident (bound functions live in one flat
@@ -382,7 +382,7 @@ impl JniGenBuilder {
     /// (an unresolved converter) is passed through — it only occurs at the
     /// validation phase, which reports it and fails `resolve` before any
     /// emitter runs. Same interior-mutable contract as
-    /// [`JniGenBuilder::iface_spec`]; drift is guarded externally by the byte-identity
+    /// [`Declarations::iface_spec`]; drift is guarded externally by the byte-identity
     /// regen check (a plan change alters generated code).
     pub(crate) fn fn_plan(
         &self,
@@ -402,10 +402,10 @@ impl JniGenBuilder {
 
 impl JniFunctionPlan {
     /// Lower `f`'s inputs. Deterministic over `(ext, registry, f)`. Emission
-    /// and validation go through the memo [`JniGenBuilder::fn_plan`], so the plan is
+    /// and validation go through the memo [`Declarations::fn_plan`], so the plan is
     /// built ONCE per function and shared; this is the underlying derivation.
     pub fn build(
-        ext: &JniGenBuilder,
+        ext: &Declarations,
         registry: &Registry<KotlinMeta>,
         f: &syn::ItemFn,
     ) -> Result<Self, PlanError> {
@@ -516,7 +516,7 @@ fn kotlin_jvm_slots(ty: &str) -> usize {
 /// collection helper; recursive data-class leaves are valid in constructor
 /// expansions and reuse the same Rust/Kotlin lowering as ordinary parameters.
 fn classify_leaf(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     ident: &syn::Ident,
     ty: &syn::Type,
@@ -610,7 +610,7 @@ fn classify_leaf(
 /// declared-surface facts from `classify_return`'s inputs
 /// (render_extern_decl's `ret_decl` reconstruction).
 fn build_output(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     f: &syn::ItemFn,
 ) -> Result<FnOutputPlan, PlanError> {
@@ -712,7 +712,7 @@ impl ReturnSurface {
     /// the single peel that subsumed both `classify_return`'s inline peel
     /// and the former `canonical_return_ty`.
     pub fn classify(
-        ext: &JniGenBuilder,
+        ext: &Declarations,
         registry: &impl Conversions<KotlinMeta>,
         output: &syn::ReturnType,
     ) -> (Self, syn::Type) {

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -55,7 +55,7 @@ pub(crate) fn handle_kt_type(strategy: &FoldStrategy, leaf: &kt::KtType) -> kt::
 /// Typed Kotlin leaf of a projection. Declared handle projections
 /// take their configured class FQN; the built-in `u64` projection is Kotlin's
 /// stable unsigned scalar type.
-pub(crate) fn projection_leaf_kt(ext: &JniGenBuilder, proj: &Projection) -> Option<kt::KtType> {
+pub(crate) fn projection_leaf_kt(ext: &Declarations, proj: &Projection) -> Option<kt::KtType> {
     match proj.kind {
         ProjectionKind::Handle => ext.kotlin_fqn(&proj.leaf_key).map(kt::KtType::cls),
         ProjectionKind::Unsigned64 => Some(kt::KtType::cls("ULong")),
@@ -169,7 +169,7 @@ pub(crate) fn is_kotlin_primitive_ty(t: &kt::KtType) -> bool {
 ///   optional) and a leaf reconstructs with its wrap.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn flatten_struct_factory(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     s: &syn::ItemStruct,
     prefix: &str,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -14,7 +14,7 @@
 //! `run` with raw typed `jvalue`s: no per-leaf boxing upcalls, no erased
 //! `FunctionN`.
 //!
-//! Each identity's spec is derived ONCE, through the [`JniGenBuilder::iface_spec`]
+//! Each identity's spec is derived ONCE, through the [`Declarations::iface_spec`]
 //! memo keyed by [`SpecKey`], and shared by all three sites — the
 //! FQN/descriptor pair cannot drift between the artifact tiers (issue #107).
 //! The constructors stay deterministic over `(ext, registry)`; in debug
@@ -668,7 +668,7 @@ fn subject_short(ty: &syn::Type) -> String {
 
 /// Package a subject type's interface lives in: the package of the type's
 /// registered Kotlin FQN, the root `ext.package` otherwise.
-fn subject_package(ext: &JniGenBuilder, subject: &syn::Type) -> String {
+fn subject_package(ext: &Declarations, subject: &syn::Type) -> String {
     let key = TypeKey::from_type(&crate::api::core::types_util::peel_ref_option_vec(subject));
     ext.kotlin_fqn(&key)
         .and_then(|fqn| fqn.rsplit_once('.').map(|(p, _)| p.to_string()))
@@ -678,7 +678,7 @@ fn subject_package(ext: &JniGenBuilder, subject: &syn::Type) -> String {
 /// The interface param list for a decomposition's leaves: names from
 /// [`plan_leaf_names`], typed + raw views per leaf.
 fn plan_leaf_params(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     leaves: &[crate::api::core::unfold::UnfoldLeaf],
 ) -> Option<Vec<IfaceParam>> {
@@ -698,7 +698,7 @@ fn plan_leaf_params(
 /// inert-group nullability rule below have to hold at every one of those sites,
 /// not just where the plan happens to be walked as a whole.
 fn plan_leaf_param(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     name: String,
     leaf: &crate::api::core::unfold::UnfoldLeaf,
@@ -743,7 +743,7 @@ fn plan_leaf_param(
 ///   the close-unless-taken contract needs the native side to `close()` the
 ///   wrapped object after the invoke.
 fn leaf_iface_param(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     name: String,
     out_ty: &syn::Type,
@@ -855,7 +855,7 @@ fn leaf_iface_param(
 /// `run` (close-unless-taken). Replaces the former Rust-side `new_object` +
 /// post-invoke `close()`. `None` if the arg's projection FQN can't be resolved.
 pub(crate) fn owned_handle_iface_param(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     name: String,
     out_ty: &syn::Type,
@@ -971,12 +971,12 @@ pub(crate) fn fixed_leaf_element_keys(
 }
 
 /// Derive the spec for one identity — the SINGLE construction point behind
-/// [`JniGenBuilder::iface_spec`]. Any `syn` context comes from the key's stored
+/// [`Declarations::iface_spec`]. Any `syn` context comes from the key's stored
 /// normalized type ([`TypeKey::to_type`] — a clone, not a reparse). A
 /// `Folder` derivation folds the fixed-builder typed-group view in per
 /// `DeconId` (see [`fixed_decon_ids`]).
 fn derive_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     key: &SpecKey,
 ) -> Option<IfaceSpec> {
@@ -999,7 +999,7 @@ fn derive_iface_spec(
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// The memoized spec for one interface identity: derived once per
     /// generator run and shared by every consumer — the resolve-time
     /// trampoline, the per-function plan, and the declaration emitter — so
@@ -1045,7 +1045,7 @@ impl JniGenBuilder {
 /// property types, not the wire — so it reassembles through the same inlined
 /// `when` over the tag that a sum-typed struct field gets.
 fn fixed_reassembly(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     source: &syn::Type,
     leaves: &[crate::api::core::unfold::UnfoldLeaf],
@@ -1070,7 +1070,7 @@ fn fixed_reassembly(
 /// returning `Unit`. Named `<ArgShorts>Callback` (`Fn()` → `VoidCallback`),
 /// placed in the first arg type's package (root for `Fn()`).
 pub(crate) fn callback_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     cb_args: &[syn::Type],
 ) -> Option<IfaceSpec> {
@@ -1302,7 +1302,7 @@ pub(crate) fn callback_iface_spec(
 /// function's own plan. Named `<decl-base>Builder`, placed in the source
 /// type's package.
 pub(crate) fn builder_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
@@ -1328,7 +1328,7 @@ pub(crate) fn builder_iface_spec(
 /// the element's deconstructor declaration. Named `<decl-base>Folder`,
 /// placed in the element type's package.
 pub(crate) fn folder_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
@@ -1354,7 +1354,7 @@ pub(crate) fn folder_iface_spec(
 /// without a deconstructor — no declaration involved):
 /// `run(acc: A, element): A`. One shape per element type by construction.
 pub(crate) fn whole_folder_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     element: &syn::Type,
 ) -> Option<IfaceSpec> {
@@ -1386,11 +1386,11 @@ pub(crate) fn whole_folder_iface_spec(
 
 /// The folder spec for an `Iterable` plan: declaration-keyed when the
 /// element decomposes, whole-element otherwise. Thin KEY dispatch into the
-/// [`JniGenBuilder::iface_spec`] memo — the fixed-builder typed-group view is
+/// [`Declarations::iface_spec`] memo — the fixed-builder typed-group view is
 /// applied there per `DeconId` (the declaration identity the JVM resolves
 /// against), not per this plan's own `fixed_builder` flag.
 pub(crate) fn folder_iface_for_plan(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     plan: &UnfoldPlan,
 ) -> Option<std::sync::Arc<IfaceSpec>> {
@@ -1415,7 +1415,7 @@ pub(crate) fn folder_iface_for_plan(
 /// emission (`write_iface_files`), keyed by the element's deconstructor so the
 /// two stay in lockstep.
 pub(crate) fn fixed_folder_typed_groups(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
@@ -1449,7 +1449,7 @@ pub(crate) fn fixed_folder_typed_groups(
 /// Keyed by the error type's deconstructor declaration. Named
 /// `<decl-base>Handler`, placed in the error type's package.
 pub(crate) fn error_handler_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
@@ -1481,7 +1481,7 @@ pub(crate) fn error_handler_iface_spec(
 /// The shared infallible handler `JniErrorHandler<out R> { run(je: String?): R }`
 /// — every function without an error plan takes one; placed in the root
 /// package.
-pub(crate) fn jni_error_handler_iface_spec(ext: &JniGenBuilder) -> IfaceSpec {
+pub(crate) fn jni_error_handler_iface_spec(ext: &Declarations) -> IfaceSpec {
     let params = vec![IfaceParam::same(
         "je".to_string(),
         kt::KtType::string().nullable(),
@@ -1521,11 +1521,11 @@ pub(crate) struct ErrorIfaces {
 /// The onError handler interfaces for a declared function — the always-present
 /// binding `JniErrorHandler` plus, for a fallible function, its
 /// declaration-keyed typed domain `<Src>Handler`. Thin KEY dispatch into the
-/// [`JniGenBuilder::iface_spec`] memo. `None` = the domain handler is underivable
+/// [`Declarations::iface_spec`] memo. `None` = the domain handler is underivable
 /// (the Rust emitter panics, the Kotlin renderer skips) — the binding channel
 /// alone always derives.
 pub(crate) fn onerror_iface_spec(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     fn_ident: &syn::Ident,
 ) -> Option<ErrorIfaces> {

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1,6 +1,6 @@
-//! `KotlinExt` impl for [`JniGenBuilder`].
+//! `KotlinExt` impl for [`Declarations`].
 //!
-//! [`JniGenBuilder::write_kotlin`] is the single entry point for every Kotlin
+//! [`Declarations::write_kotlin`] is the single entry point for every Kotlin
 //! file the JNI back-end emits. Each per-kind emitter builds in-memory
 //! [`kt::KtFile`] *model fragments* (declarations, not strings — the
 //! generator module `api::gen::kotlin` owns formatting and imports):
@@ -36,8 +36,8 @@ use crate::api::{
 
 /// Declaration of one auto-generated typed `NativeHandle` subclass.
 ///
-/// Consumed by [`JniGenBuilder::write_typed_handles`] (and forwarded to
-/// [`JniGenBuilder::write_jni_wrappers`] so the same promotion list can carve
+/// Consumed by [`Declarations::write_typed_handles`] (and forwarded to
+/// [`Declarations::write_jni_wrappers`] so the same promotion list can carve
 /// the matching skip-list). Each entry says "this Kotlin class is the
 /// home for the named `#[prebindgen]` functions"; everything else stays
 /// in the catch-all `JNIWrappers` object.
@@ -72,7 +72,7 @@ impl super::JniGen {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Kotlin emission body — the public entry point is
     /// `JniGen::write_kotlin`, which guarantees the registry
     /// was resolved first.
@@ -463,7 +463,7 @@ pub(crate) struct OwnedTypedHandle {
     pub key: TypeKey,
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Emit one Kotlin `enum class` file per `enum_class`-declared type.
     /// Variants render in declaration order using SCREAMING_SNAKE_CASE names; the
     /// constructor stores the Rust discriminant value (or the ordinal as
@@ -1135,7 +1135,7 @@ impl JniGenBuilder {
         uses.into_iter()
             .filter_map(|u| {
                 // Every spec comes from the SAME memo the wrappers and the
-                // resolve-time trampoline read ([`JniGenBuilder::iface_spec`]) —
+                // resolve-time trampoline read ([`Declarations::iface_spec`]) —
                 // this site only classifies the extras: `is_error` ⇒ also
                 // emit the zero-alloc capture holder used by the generated
                 // wrappers' error channel; `fixed` carries a
@@ -1695,7 +1695,7 @@ impl JniGenBuilder {
     }
 
     /// Emit the centralized Native-object Kotlin file under `output_dir`
-    /// (class name from [`JniGenBuilder::jni_native_class_name`]). Holds one
+    /// (class name from [`Declarations::jni_native_class_name`]). Holds one
     /// `external fun` per `#[prebindgen]` function — names mangled as methods
     /// via [`JniGenBuilder::set_method_name_mangle`], parameter and return types rendered at
     /// the JNI **wire** level so the declarations match the Rust extern
@@ -1703,7 +1703,7 @@ impl JniGenBuilder {
     /// `Java_<package>_<jni_native_class>_<name>` (see `symbol`, #86). Every generated native
     /// call routes through this object, so its static initializer is the
     /// single point at which native-library loading can be triggered: when
-    /// [`JniGenBuilder::jni_native_init`] is set, its Kotlin statement(s) are emitted
+    /// [`Declarations::jni_native_init`] is set, its Kotlin statement(s) are emitted
     /// inside an `init { … }` block here (e.g. a reference to the consumer's
     /// own loader object). Unset, the holder stays free of any loading logic
     /// and the wrapper layer is responsible for loading.
@@ -1844,7 +1844,7 @@ impl JniGenBuilder {
     /// same `handles` slice to both methods.
     ///
     /// Each handle's `kotlin_fqn` must be registered via
-    /// [`JniGenBuilder::kotlin_fqn`] so the generator can map it back to its
+    /// [`Declarations::kotlin_fqn`] so the generator can map it back to its
     /// Rust type-key (which identifies the first param to drop in each
     /// promoted method's signature).
     pub(crate) fn write_typed_handles(

--- a/prebindgen/src/api/lang/jnigen/jni/metadata.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/metadata.rs
@@ -64,7 +64,7 @@ pub enum ProjectionKind {
 #[derive(Clone, Debug)]
 pub struct Projection {
     /// Canonical key of the leaf type (e.g. `ZKeyExpr`, `ZenohId`); derive
-    /// the typed Kotlin FQN via `JniGenBuilder::kotlin_fqn` — a typed key, so the
+    /// the typed Kotlin FQN via `Declarations::kotlin_fqn` — a typed key, so the
     /// lookup cannot drift from the declaration table's constructor.
     pub leaf_key: crate::api::core::registry::TypeKey,
     /// `false` for `&T` borrows of a handle — still a projection (param

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -371,9 +371,13 @@ pub(crate) type MethodNameMangle = Arc<dyn Fn(&str, &str, &str) -> String + Send
 pub struct JniGen {
     /// What the binding declared. The emitters read it for names, classes and
     /// decompositions.
-    pub(crate) gen: JniGenBuilder,
+    ///
+    /// A [`Declarations`], not the [`JniGenBuilder`] it came from: the builder's
+    /// mutators would otherwise ride into the finished object, and "finished"
+    /// would be a comment rather than a type.
+    decls: Declarations,
     /// Every crossing this binding needs, each with its conversion.
-    pub(crate) registry: crate::core::Registry<KotlinMeta>,
+    registry: crate::core::Registry<KotlinMeta>,
 }
 
 // Opaque — exists so `Result<JniGen, _>::expect_err` works in tests.
@@ -402,7 +406,7 @@ impl JniGen {
     ) -> Result<std::path::PathBuf, crate::core::WriteRustError> {
         Ok(crate::api::core::write::write_rust(
             &self.registry,
-            &self.gen,
+            &self.decls,
             out_path,
         )?)
     }
@@ -413,13 +417,28 @@ impl JniGen {
     }
 
     /// What the binding declared.
-    pub fn declarations(&self) -> &JniGenBuilder {
-        &self.gen
+    pub fn declarations(&self) -> &Declarations {
+        &self.decls
     }
 }
 
+/// Everything a binding **declared**, once it is done declaring.
+///
+/// The read-only half of what used to be one `JniGenBuilder`. Splitting it is what
+/// keeps the phase separation now that a generator owns its own registry: before
+/// [#253](https://github.com/milyin/prebindgen/pull/253) a build script held a
+/// `RegistryBuilder` and then a `Registry`, and that type split *was* the
+/// enforcement. Once `JniGen::builder().source(..).build()` moved both inside the
+/// generator, the built object was left holding the builder — mutators and all.
+///
+/// So the mutators live on [`JniGenBuilder`] and nothing else, and this type — the
+/// one a [`JniGen`] keeps and every emitter reads — **has no `&mut self` method at
+/// all**. Not "the obvious ones were removed": none, which
+/// `a_built_jnigen_exposes_no_mutation` checks by reading the source, because a
+/// one-line grep once missed a multi-line signature and let `Registry::supply`
+/// survive two commits that claimed it was gone.
 #[derive(Clone)]
-pub struct JniGenBuilder {
+pub struct Declarations {
     /// Single source of truth for the JVM/Kotlin namespace this binding
     /// targets, dot-separated (e.g. `io.zenoh.jni`). Empty = no prefix.
     /// Every derived form — slash-separated for `FindClass`
@@ -577,6 +596,18 @@ pub struct JniGenBuilder {
     /// "derived state, keyed by `(self, registry)`" contract as
     /// [`Self::iface_specs`].
     pub(crate) fn_plans: std::cell::RefCell<HashMap<syn::Ident, std::rc::Rc<JniFunctionPlan>>>,
+}
+
+/// Describe a JNI binding: state the Kotlin surface, then [`build`](Self::build).
+///
+/// Holds the [`Declarations`] being filled and the sources to parse, and it is the
+/// only type with mutators. `build` consumes it, hands the declarations to the
+/// registry, and stores them in a [`JniGen`] — from where nothing can declare
+/// anything again, because this type is gone by then.
+#[derive(Clone, Default)]
+pub struct JniGenBuilder {
+    /// What has been declared so far. Moved out whole by [`Self::build`].
+    pub(crate) decls: Declarations,
 
     /// Where the `#[prebindgen]` items come from.
     ///
@@ -584,6 +615,10 @@ pub struct JniGenBuilder {
     /// three feeders it has — so a build script says where the source is in the
     /// vocabulary the model already uses, and never names a `Flat` or a
     /// `Registry` itself.
+    ///
+    /// Not a declaration, which is why it stays here rather than moving across:
+    /// it is *input to* building, and keeping it out is what makes
+    /// [`Declarations`] mean one thing.
     pub(crate) sources: crate::api::core::flat::FlatBuilder,
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -442,9 +442,9 @@ pub struct Declarations {
     /// Single source of truth for the JVM/Kotlin namespace this binding
     /// targets, dot-separated (e.g. `io.zenoh.jni`). Empty = no prefix.
     /// Every derived form — slash-separated for `FindClass`
-    /// (`JniGenBuilder::java_class_prefix()`), `_`-mangled for JNI extern idents
-    /// (`JniGenBuilder::jni_class_path()`), dot-separated for Kotlin `package`
-    /// declarations — is computed from this at the point of use.
+    /// ([`Declarations::java_class_prefix`]), `_`-mangled for JNI extern idents,
+    /// dot-separated for Kotlin `package` declarations — is computed from this at
+    /// the point of use.
     /// `pub(crate)`: consumers go through [`JniGenBuilder::set_package_prefix`],
     /// whose trimming a direct field write would bypass.
     pub(crate) package: String,

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -4,7 +4,7 @@
 //! (`expectedSel: Int, expected00: Long?, …`); the raw call site passes magic
 //! ints and null-padding. Two mechanisms turn that into idiomatic Kotlin:
 //!
-//! * **Proactive splittability check** ([`JniGenBuilder::validate_split_declarations`]):
+//! * **Proactive splittability check** ([`Declarations::validate_split_declarations`]):
 //!   every multi-variant `expand_param!` declaration (type-level or per-fn) is
 //!   verified up front to be *splittable* — its arms surface as pairwise-distinct
 //!   JVM signatures — so a function can safely request overloads. A collision is
@@ -35,7 +35,7 @@ use crate::api::core::{
     registry::Conversions,
 };
 
-impl JniGenBuilder {
+impl Declarations {
     /// Proactively verify every multi-variant `expand_param!` declaration is
     /// splittable (its arms have pairwise-distinct JVM-erased signatures), so
     /// [`FunctionDecl::split_on_param`](crate::fun) can emit unambiguous
@@ -108,7 +108,7 @@ impl JniGenBuilder {
 /// Uses the shared [`erase_kt_type`] model (issue #89 stage 2) so the split
 /// ambiguity check and the whole-artifact overload table agree on erasure.
 fn arm_erased_sig(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     target: &syn::Type,
     ctor: Option<&syn::Ident>,
@@ -141,7 +141,7 @@ fn arm_erased_sig(
 /// type with no resolved surface. References are peeled first (`&T` erases
 /// like `T`).
 fn rust_type_erased(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     ty: &syn::Type,
 ) -> ErasedJvmType {
@@ -405,7 +405,7 @@ fn resolve_split<'a>(
 /// Emits the cartesian product of the named params' arms; panics (a build
 /// error) if the product has two combinations with the same JVM signature.
 pub(crate) fn render_param_overloads(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     sel_fun: &kt::KtFun,

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -67,7 +67,7 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
 /// them), and the `fromParts` factory's raw-text class references carry their
 /// imports on the factory body `Code`.
 pub(crate) fn build_data_class(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     class_name: &str,
     item_struct: &syn::ItemStruct,
     registry: &Registry<KotlinMeta>,
@@ -254,7 +254,7 @@ pub(crate) fn build_data_class(
 /// to the matching `Java_<pkg>_<class>_<mangled-freePtr>`
 /// extern on the Rust side (the auto-generated destructor).
 pub(crate) fn build_typed_handle(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     class_name: &str,
     rust_doc_name: &str,
@@ -464,7 +464,7 @@ pub(crate) fn is_iterable_fold(shape: &crate::api::core::unfold::UnfoldShape) ->
 /// `kt_return` (Unit is no return type). `None` if a param's converter isn't
 /// resolved. Full-FQN types throughout — no derivation-time shortening.
 pub(crate) fn render_extern_decl(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
 ) -> Option<kt::KtFun> {
@@ -752,7 +752,7 @@ pub(crate) struct WrapperSurface {
 /// import set. Validation calls this directly and skips the body work
 /// (`build_native_call` / `render_body` / KDoc / opaque-lock collection).
 pub(crate) fn build_wrapper_surface(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     kotlin_name_override: Option<&str>,
@@ -831,7 +831,7 @@ pub(crate) fn build_wrapper_surface(
 }
 
 pub(crate) fn render_wrapper_fn(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
     kotlin_name_override: Option<&str>,
@@ -888,7 +888,7 @@ pub(crate) fn render_wrapper_fn(
 /// the ordinary output machinery — plus the public lazily-initialized `val`
 /// that calls it once, on first use (see [`render_val_over_helper`]).
 pub(crate) fn render_const_val(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     package: &str,
     c: &syn::ItemConst,
     registry: &Registry<KotlinMeta>,
@@ -919,7 +919,7 @@ pub(crate) fn render_const_val(
 /// computed once, on first use, through the ordinary generated wrapper
 /// (one JNI call, exactly like a const getter).
 pub(crate) fn render_constant_fn_val(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     package: &str,
     f: &syn::ItemFn,
     registry: &Registry<KotlinMeta>,
@@ -949,7 +949,7 @@ pub(crate) fn render_constant_fn_val(
 /// is the binding-defined expression, evaluated once, on first use, through
 /// the generated getter.
 pub(crate) fn render_const_expr_val(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     package: &str,
     decl: &crate::api::lang::jnigen::jni::decl::ConstExprDecl,
     registry: &Registry<KotlinMeta>,
@@ -982,7 +982,7 @@ pub(crate) fn render_const_expr_val(
 /// `error(...)` at first use). Lazy, not eager: a consts-heavy package must
 /// not fire one JNI call per `val` at class-load (issue #58).
 fn render_val_over_helper(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     mut helper: kt::KtFun,
     val_name: String,
@@ -1072,7 +1072,7 @@ struct DomainSink {
 /// instance-method receiver (the first param whose peeled type matches
 /// `receiver_key`), which is bound to `this` and dropped from the signature.
 fn classify_params(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -1262,7 +1262,7 @@ fn classify_params(
 /// with no such projection ⇒ the callback is passed directly (M1–M4
 /// unchanged).
 fn classify_output(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     f: &syn::ItemFn,
     fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
@@ -1434,7 +1434,7 @@ fn classify_output(
 /// deliberately deferred to [`build_success_return`], after the native error
 /// captures have been checked.
 fn build_native_call(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     jni_call: &str,
     params: &[Param],
     out: &OutputPlan,
@@ -1530,7 +1530,7 @@ fn build_native_call(
 /// This expression is emitted only after binding/domain captures have been
 /// checked, so a native failure placeholder can never reach an enum lookup,
 /// value projection, or erased-result cast.
-fn build_success_return(ext: &JniGenBuilder, out: &OutputPlan, raw: &str) -> String {
+fn build_success_return(ext: &Declarations, out: &OutputPlan, raw: &str) -> String {
     if let Some(p) = &out.projection {
         // Fold the wrap through the projection strategy. The wrap class is
         // the projection leaf's typed short name (a Handle's typed-handle
@@ -1807,7 +1807,7 @@ fn render_value_stmt(bind: &str, body_expr: &str, opaques: &[Opaque]) -> kt::Cod
 /// statements are needed) so the caller can bind it to `__ret`, rethrow a
 /// captured sink error, then return.
 fn render_core_stmt(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     opaques: &[Opaque],
     body_expr: &str,
     imports: &mut BTreeSet<String>,
@@ -1912,7 +1912,7 @@ enum BodyReturn {
 }
 
 fn render_body(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     params: &[Param],
     opaques: &[Opaque],
     sink: &ErrorSink,
@@ -2007,7 +2007,7 @@ fn render_body(
 /// value projection that can't be built Rust-side).
 /// Shared by the unfold builder/fold lambda and the callback lambda params.
 pub(crate) fn unfold_leaf_kt(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     out_ty: &syn::Type,
     nullable: bool,
@@ -2145,7 +2145,7 @@ pub(crate) fn kotlin_for_wire(wire: &syn::Type) -> Option<kt::KtType> {
 ///   and pick the JNI extern's wire return (`Long` for `Handle`). `None` for
 ///   plain non-projection returns.
 pub(crate) fn classify_return(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     output: &syn::ReturnType,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -248,7 +248,7 @@ impl super::JniGen {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Human-readable class-kind name of a declared type (report use).
     pub(crate) fn class_kind_name(&self, key: &TypeKey) -> &'static str {
         let Some(cfg) = self.types.get(key) else {

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -1,4 +1,4 @@
-//! Structural converter-selection policy for [`JniGenBuilder`].
+//! Structural converter-selection policy for [`Declarations`].
 
 use super::*;
 use crate::api::core::registry::Conversions;
@@ -33,7 +33,7 @@ fn ref_wildcard(r: &syn::TypeReference) -> syn::Type {
     syn::Type::Reference(pr)
 }
 
-impl JniGenBuilder {
+impl Declarations {
     /// Select the input converter for `ty`: terminals, user wrappers, then
     /// built-in structural wrappers.
     pub(crate) fn select_input_type(

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -183,7 +183,7 @@ pub(crate) struct SumPlanField {
 /// name) — consistently for BOTH sides, where the former parallel walks
 /// could silently diverge on such edge cases.
 pub(crate) fn build_struct_plan(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     s: &syn::ItemStruct,
     depth: usize,
@@ -215,7 +215,7 @@ pub(crate) fn build_struct_plan(
 /// `owner` is the dotted path used in diagnostics (`Config.mode`,
 /// `Reading::Exact.v0`).
 pub(crate) fn classify_field(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     ty: &syn::Type,
     owner: &str,
@@ -464,7 +464,7 @@ impl PlanFieldKind {
 /// whenever a payload's converter happened to resolve later than this plan
 /// was first attempted.
 fn sum_plan_kind(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     ty: &syn::Type,
     owner: &str,

--- a/prebindgen/src/api/lang/jnigen/jni/symbol.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbol.rs
@@ -69,7 +69,7 @@ pub(crate) fn native_symbol(package: &str, class: &str, method: &str) -> String 
 /// The long native symbol for **overloaded** natives: the short name plus
 /// `__` and the escaped argument signature (the descriptor between `(` and
 /// `)`, e.g. `ILjava/lang/String;` — `/`→`_`, `;`→`_2`, `[`→`_3`). Nothing
-/// JniGenBuilder emits today is overloaded at the extern level (every `JNINative`
+/// Declarations emits today is overloaded at the extern level (every `JNINative`
 /// method is uniquely named), so this is provided-but-unwired per #86's
 /// direction: if overloaded natives are ever emitted, they must come from
 /// this same abstraction.

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -34,10 +34,7 @@ use super::*;
 ///   names colliding in one package, including a collision the mangler
 ///   created.
 /// * **Warnings** — where the default mangler sanitized a Rust-derived name.
-pub(crate) fn validate_symbols(
-    ext: &JniGenBuilder,
-    registry: &Registry<KotlinMeta>,
-) -> Vec<String> {
+pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMeta>) -> Vec<String> {
     let mut errors: Vec<String> = Vec::new();
     // (package, name) → origin, for top-level-unique Kotlin declarations.
     let mut top_level: BTreeMap<(String, String), String> = BTreeMap::new();
@@ -113,7 +110,7 @@ pub(crate) fn validate_symbols(
         // name `Companion` is ours — an artifact of emitting a companion at
         // all, not a name Kotlin reserves — so when a variant wants it the
         // generator renames the companion instead of making the source crate
-        // rename a legitimate variant (`JniGenBuilder::sum_companion_name`).
+        // rename a legitimate variant (`Declarations::sum_companion_name`).
         //
         // The interface's own name is different: BOTH colliding names come
         // from the source crate (the enum's name and its variant's), so the
@@ -262,7 +259,7 @@ fn check_ident(name: &str, origin: &str, errors: &mut Vec<String>) {
 
 /// Emit a `cargo:warning` for each Rust struct field (data-class property) or
 /// enum variant whose Kotlin name the default mangler had to change.
-fn warn_derived_name_changes(ext: &JniGenBuilder, registry: &Registry<KotlinMeta>) {
+fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>) {
     let warn = |raw: &str, mangled: &str, what: &str, owner: &str| {
         if raw != mangled {
             println!(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/flatten.rs
@@ -655,10 +655,11 @@ fn ignore_matching_acknowledges_naming_family() {
         .ignore(crate::ty!(ZUnusedThing));
     // The predicate flows through the Prebindgen hook…
     {
-        let preds = jni.ignored_name_predicates();
+        let preds = jni.decls.ignored_name_predicates();
         assert_eq!(preds.len(), 1);
         assert!(preds[0]("detail_const_a") && !preds[0]("z_len"));
         assert!(jni
+            .decls
             .ignored_types()
             .contains(&TypeKey::parse("ZUnusedThing").expect("test type")));
     }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -31,6 +31,7 @@ mod consts;
 mod cross_artifact;
 mod flatten;
 mod niches;
+mod phases;
 mod sealed;
 mod snapshots;
 mod symbols;

--- a/prebindgen/src/api/lang/jnigen/jni/tests/phases.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/phases.rs
@@ -19,15 +19,22 @@
 /// styling: `Registry::supply` survived two commits claiming it was gone because
 /// the check for it was a single-line grep and its signature spanned lines.
 ///
-/// `builder.rs` and `config.rs` are skipped, exactly as the registry test skips
-/// `declare.rs` — `JniGenBuilder` is *meant* to be mutable, and that is the whole
-/// point of it being a different type.
+/// **No file is skipped**, and the exemption is per `impl` block rather than per
+/// file. `builder.rs` and `config.rs` are where the mutators live, but they also
+/// hold six `impl Declarations` blocks between them — most of the read API — so
+/// skipping those files wholesale, as the first version of this test did, left
+/// the larger half of what it claims to guard unguarded.
+///
+/// The self type is read off the `impl` header and matched by **suffix**, so a
+/// qualified path is not a way around it: `impl super::JniGen` occurs in
+/// `kotlin_emit.rs` and `report.rs`, and an unqualified-prefix match missed both.
 #[test]
 fn a_built_jnigen_exposes_no_mutation() {
     let mut offenders: Vec<String> = Vec::new();
 
     let root = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api/lang/jnigen/jni");
     let mut dirs = vec![std::path::PathBuf::from(root)];
+    let mut sealed_blocks = 0usize;
     while let Some(dir) = dirs.pop() {
         for entry in std::fs::read_dir(&dir).expect("jnigen module dir") {
             let path = entry.expect("dir entry").path();
@@ -47,27 +54,27 @@ fn a_built_jnigen_exposes_no_mutation() {
                 .expect("file name")
                 .to_string_lossy()
                 .to_string();
-            if name == "builder.rs" || name == "config.rs" {
-                continue;
-            }
             let src = std::fs::read_to_string(&path).expect("read source");
             let bare: String = src.chars().filter(|c| !c.is_whitespace()).collect();
 
-            // Walk the `impl` blocks, and only complain inside the two types a
-            // built binding keeps. An `impl JniGenBuilder` in one of these files
-            // is the describing half and is allowed to mutate.
             let mut rest = bare.as_str();
             while let Some(at) = rest.find("impl") {
                 rest = &rest[at + "impl".len()..];
-                let sealed = rest.starts_with("Declarations{")
-                    || rest.starts_with("JniGen{")
-                    || rest.starts_with("PrebindgenforDeclarations{");
-                // The block's own text, up to the next `impl` — good enough,
-                // because a nested `impl` would start its own scan anyway.
+                let Some(brace) = rest.find('{') else { break };
+                let header = &rest[..brace];
+                // A trait impl's self type is what follows `for`; an inherent
+                // impl's is the whole header.
+                let self_ty = header.rsplit("for").next().unwrap_or(header);
+                // Suffix, so `super::JniGen` and `crate::…::Declarations` count.
+                // `JniGenBuilder` does not end with either name, which is what
+                // exempts the describing half without naming a file.
+                let sealed = self_ty.ends_with("Declarations") || self_ty.ends_with("JniGen");
+
+                // The block's own text, up to the next `impl`.
                 let end = rest.find("impl").unwrap_or(rest.len());
                 if sealed {
-                    let block = &rest[..end];
-                    let mut scan = block;
+                    sealed_blocks += 1;
+                    let mut scan = &rest[..end];
                     while let Some(f) = scan.find("fn") {
                         scan = &scan[f + "fn".len()..];
                         let Some(open) = scan.find('(') else { break };
@@ -84,6 +91,14 @@ fn a_built_jnigen_exposes_no_mutation() {
     assert!(
         offenders.is_empty(),
         "a built `JniGen` and its `Declarations` must be read-only; found mutation: {offenders:#?}"
+    );
+    // A scanner that silently matches nothing passes forever. This is the count
+    // at the time of writing; it may drift upward freely, and a *drop* means the
+    // header matching stopped recognising blocks it used to.
+    assert!(
+        sealed_blocks >= 22,
+        "expected to scan at least 22 sealed impl blocks, saw {sealed_blocks} — \
+         the header matching is no longer finding them"
     );
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/phases.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/phases.rs
@@ -1,0 +1,139 @@
+//! The describe/built split is only worth having if something checks it.
+
+/// A built `JniGen` has no route back into being described.
+///
+/// The sibling of `a_built_registry_exposes_no_mutation`, and it exists for the
+/// same reason at one remove. That test guards `Registry`, which a build script
+/// used to build itself — the `RegistryBuilder` → `Registry` split *was* the
+/// enforcement, and it lived in the caller's hands. Once
+/// `JniGen::builder().source(..).build()` moved both phases inside the generator,
+/// the guarantee became this crate's to keep, and there was nothing keeping it:
+/// `JniGen` held its `JniGenBuilder` whole, mutators and all.
+///
+/// So [`Declarations`](crate::lang::Declarations) exists, and what this checks is
+/// that it stays what it is: the type a built binding keeps, with **no `&mut self`
+/// method at all** — not "the obvious ones were removed".
+///
+/// Reads the source with **all** whitespace stripped, which makes a multi-line
+/// signature indistinguishable from a one-line one. That is not defensive
+/// styling: `Registry::supply` survived two commits claiming it was gone because
+/// the check for it was a single-line grep and its signature spanned lines.
+///
+/// `builder.rs` and `config.rs` are skipped, exactly as the registry test skips
+/// `declare.rs` — `JniGenBuilder` is *meant* to be mutable, and that is the whole
+/// point of it being a different type.
+#[test]
+fn a_built_jnigen_exposes_no_mutation() {
+    let mut offenders: Vec<String> = Vec::new();
+
+    let root = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api/lang/jnigen/jni");
+    let mut dirs = vec![std::path::PathBuf::from(root)];
+    while let Some(dir) = dirs.pop() {
+        for entry in std::fs::read_dir(&dir).expect("jnigen module dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                // `tests/` is this file's own home, and a fixture may hold a
+                // builder mutably on purpose.
+                if path.file_name().is_some_and(|n| n != "tests") {
+                    dirs.push(path);
+                }
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .expect("file name")
+                .to_string_lossy()
+                .to_string();
+            if name == "builder.rs" || name == "config.rs" {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("read source");
+            let bare: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+
+            // Walk the `impl` blocks, and only complain inside the two types a
+            // built binding keeps. An `impl JniGenBuilder` in one of these files
+            // is the describing half and is allowed to mutate.
+            let mut rest = bare.as_str();
+            while let Some(at) = rest.find("impl") {
+                rest = &rest[at + "impl".len()..];
+                let sealed = rest.starts_with("Declarations{")
+                    || rest.starts_with("JniGen{")
+                    || rest.starts_with("PrebindgenforDeclarations{");
+                // The block's own text, up to the next `impl` — good enough,
+                // because a nested `impl` would start its own scan anyway.
+                let end = rest.find("impl").unwrap_or(rest.len());
+                if sealed {
+                    let block = &rest[..end];
+                    let mut scan = block;
+                    while let Some(f) = scan.find("fn") {
+                        scan = &scan[f + "fn".len()..];
+                        let Some(open) = scan.find('(') else { break };
+                        if scan[open..].starts_with("(&mutself") {
+                            offenders.push(format!("{name}: fn {}(&mut self …)", &scan[..open]));
+                        }
+                    }
+                }
+                rest = &rest[end..];
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "a built `JniGen` and its `Declarations` must be read-only; found mutation: {offenders:#?}"
+    );
+}
+
+/// The two `RefCell`s on `Declarations` are memos, and are named here so a third
+/// one has to be argued for rather than merely added.
+///
+/// Interior mutability is not a hole in the split: `iface_specs` and `fn_plans`
+/// cache work derived from `(declarations, registry)`, both of which are frozen by
+/// the time anything reads them. Caching a pure function of frozen inputs is not
+/// re-declaring anything. A `RefCell` holding *declaration state* would be, and
+/// that is what this catches.
+#[test]
+fn declarations_interior_mutability_is_only_the_two_memos() {
+    let src = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/api/lang/jnigen/jni/mod.rs"
+    ))
+    .expect("read mod.rs");
+
+    let decls = {
+        let start = src.find("pub struct Declarations {").expect("Declarations");
+        let rest = &src[start..];
+        let end = rest.find("\n}\n").expect("struct end");
+        &rest[..end]
+    };
+
+    // Whitespace-stripped, for the reason the sibling test gives: `iface_specs`
+    // wraps onto a second line, so a line-based scan sees a bare `RefCell<..>`
+    // with no field name attached — which is how this check first "passed" on a
+    // field it could not identify.
+    let bare: String = decls.chars().filter(|c| !c.is_whitespace()).collect();
+
+    let mut named: Vec<String> = Vec::new();
+    let mut rest = bare.as_str();
+    while let Some(at) = rest.find("RefCell") {
+        // The field name is the ident before the `:` that introduces this type.
+        let decl_start = rest[..at].rfind(',').map(|i| i + 1).unwrap_or(0);
+        let field = &rest[decl_start..at];
+        named.push(field.trim_end_matches(|c: char| c != ':').to_string());
+        rest = &rest[at + "RefCell".len()..];
+    }
+
+    assert_eq!(
+        named.len(),
+        2,
+        "expected exactly the two memo fields, found: {named:#?}"
+    );
+    assert!(
+        named.iter().any(|f| f.contains("iface_specs:"))
+            && named.iter().any(|f| f.contains("fn_plans:")),
+        "the two memos must be `iface_specs` and `fn_plans`, found: {named:#?}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -298,7 +298,8 @@ fn reopened_ptr_class_keeps_gc_managed() {
             .package(crate::package!().class(first).class(second));
         drop(registry);
         let key = TypeKey::from_type(&syn::parse_quote!(Session));
-        jni.types
+        jni.decls
+            .types
             .get(&key)
             .expect("declared")
             .opaque()
@@ -647,10 +648,14 @@ fn sum_is_its_own_type_kind() {
         .package(crate::package!().class(crate::sealed_class!(Reading)));
     let ty: syn::Type = syn::parse_quote!(Reading);
     assert!(matches!(
-        jni.type_kind(&registry, &ty),
+        jni.decls.type_kind(&registry, &ty),
         crate::api::lang::jnigen::jni::classify::TypeKind::Sum
     ));
-    let cfg = jni.types.get(&TypeKey::from_type(&ty)).expect("declared");
+    let cfg = jni
+        .decls
+        .types
+        .get(&TypeKey::from_type(&ty))
+        .expect("declared");
     assert!(cfg.special_decl());
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -36,7 +36,7 @@ fn generated_converter_attr() -> syn::Attribute {
 // and consuming-crate wrapper exts like ZenohJniExt).
 // ──────────────────────────────────────────────────────────────────────
 
-impl JniGenBuilder {
+impl Declarations {
     /// Build the standard JNI input-converter `fn`. Body assumes in-scope
     /// `env: &mut JNIEnv` and `v: &<wire>` (or `v: <wire>` for raw-pointer
     /// wires); produces a value of `rust`. Returned function has its name
@@ -548,7 +548,7 @@ pub(crate) fn build_signal_domain_error_item() -> syn::Item {
 /// whose declare/undeclare fns are `#[cfg]`'d out of the scan) from
 /// producing destructors that reference types not in scope.
 pub(crate) fn build_handle_destructor_items(
-    ext: &JniGenBuilder,
+    ext: &Declarations,
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
@@ -619,7 +619,7 @@ pub(crate) fn build_handle_destructor_items(
 /// the two `Option<_>` sub-cases (direct-handle-by-value vs general), which
 /// share a pattern and so live together in [`JniGenBuilder::input_option`] to keep
 /// their original fall-through.
-impl JniGenBuilder {
+impl Declarations {
     /// `& _` / `& mut _` borrow: share T's resolved converter — `&T`'s entry
     /// points at the same `ItemFn` (the fn returns owned `T`; the call site in
     /// `emit_jni_function_wrapper` adds `&decoded`). Exists so the
@@ -961,25 +961,31 @@ impl JniGenBuilder {
     ///
     /// The seam tests use to feed synthetic items without a source directory;
     /// `build` is this with the model read from [`Self::source`].
+    ///
+    /// **This is the phase change.** The declarations are taken out of the
+    /// builder here and never put back: everything below runs against
+    /// `&decls`, and what it produces is stored in a [`JniGen`], which has no
+    /// route to a `JniGenBuilder` at all.
     pub(crate) fn build_with(
         self,
         registry: crate::api::core::registry::RegistryBuilder<KotlinMeta>,
     ) -> Result<JniGen, crate::core::WriteRustError> {
-        let registry = self
+        let decls = self.decls;
+        let registry = decls
             .declare_into(registry)?
-            .validate_with(&self)?
-            .convert_with(|crossing, built| self.convert_crossing(crossing, built))?
+            .validate_with(&decls)?
+            .convert_with(|crossing, built| decls.convert_crossing(crossing, built))?
             .build()?;
         // Post-resolve invariants, run once here so the writers are pure reads
         // and a `JniGen` is valid by construction.
-        self.validate_resolved(&registry)
+        decls
+            .validate_resolved(&registry)
             .map_err(|message| crate::core::ScanError::AdapterInvariant { message })?;
-        Ok(JniGen {
-            gen: self,
-            registry,
-        })
+        Ok(JniGen { decls, registry })
     }
+}
 
+impl Declarations {
     /// Build the conversion for one crossing, against what is already built.
     ///
     /// `None` is *cannot*, never *not yet*: `crossings` hands them out
@@ -1081,7 +1087,7 @@ impl JniGenBuilder {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     pub(crate) fn build_value_struct_decons(
         &self,
         registry: &impl Conversions<KotlinMeta>,
@@ -1191,7 +1197,7 @@ impl JniGenBuilder {
     }
 }
 
-impl JniGenBuilder {
+impl Declarations {
     fn dispatch_fn_input(
         &self,
         args: &[syn::Type],
@@ -1215,7 +1221,7 @@ impl JniGenBuilder {
     }
 }
 
-impl Prebindgen for JniGenBuilder {
+impl Prebindgen for Declarations {
     /// Cross-language extras every JNI converter carries — currently
     /// the Kotlin value-context type name. Filled by the rank-N
     /// handlers at the same point they build the wire/body; the
@@ -1565,7 +1571,7 @@ impl Prebindgen for JniGenBuilder {
 /// Structural converter builders — the rank-0 terminal chains and the rank-1
 /// wrapper-shape handlers, now inherent helpers called by the structural
 /// [`Prebindgen::on_input_type`] / [`Prebindgen::on_output_type`].
-impl JniGenBuilder {
+impl Declarations {
     // ── Input converters ─────────────────────────────────────────────
 
     /// Whole-type **input** terminal categories (opaque handle, enum,
@@ -2182,7 +2188,7 @@ impl JniGenBuilder {
 /// These were trait methods the registry called back into the adapter from
 /// inside `resolve`. They are the adapter's own business now, gathered into the
 /// one value the registry is constructed from.
-impl JniGenBuilder {
+impl Declarations {
     /// Union of every `.fun(...)` list across all
     /// [`Self::package`] subpackage contexts. Each entry is a
     /// `#[prebindgen]` fn ident the user explicitly hooked into the

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -42,9 +42,9 @@ pub use jni::{
     box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong, box_jshort,
     decode_byte_array, decode_string, encode_byte_array, encode_string, matching, null_byte_array,
     null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl, ConvertSourceDecl,
-    DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl, FieldsDecl,
-    FunctionDecl, IgnoreDecl, JniBindingError, JniGen, JniGenBuilder, PackageDecl, PtrClassDecl,
-    SealedClassDecl, VariantDecl,
+    DataClassDecl, Declarations, EnumClassDecl, ExpandDecl, ExpandParamDecl, ExpandReturnDecl,
+    FieldsDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen, JniGenBuilder, PackageDecl,
+    PtrClassDecl, SealedClassDecl, VariantDecl,
 };
 
 // Kotlin emission types now live in the standalone generator module

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -348,7 +348,7 @@ pub mod lang {
         box_jboolean, box_jbyte, box_jchar, box_jdouble, box_jfloat, box_jint, box_jlong,
         box_jshort, decode_byte_array, decode_string, encode_byte_array, encode_string, matching,
         null_byte_array, null_string, CachedIfaceMethod, ClassDecl, ConstDecl, ConvertDecl,
-        ConvertSourceDecl, DataClassDecl, EnumClassDecl, ExpandDecl, ExpandParamDecl,
+        ConvertSourceDecl, DataClassDecl, Declarations, EnumClassDecl, ExpandDecl, ExpandParamDecl,
         ExpandReturnDecl, FieldsDecl, FunctionDecl, IgnoreDecl, JniBindingError, JniGen,
         JniGenBuilder, KotlinFile, PackageDecl, PtrClassDecl, SealedClassDecl, VariantDecl,
         WriteKotlinError,


### PR DESCRIPTION
Before #253 a build script held the phases apart itself: it built a `Flat`, made a `RegistryBuilder`, resolved it into a `Registry`, and handed that to the generator. **That type split was the enforcement**, and it lived in the caller's hands.

#253 moved it inside the generator — a better API, and the guarantee went with it. `build(self)` consumed the builder and then stored it back inside the built object:

```rust
pub struct JniGen {
    pub(crate) gen: JniGenBuilder,   // 54 mutators ride along
    pub(crate) registry: Registry<KotlinMeta>,
}
```

The type meaning *"still being described"* was retained by the type meaning *"finished"*.

**Nothing was wrong, and that is the point.** `.gen` / `.registry` were touched only in `mod.rs`, every other file already went through the `&`-accessors, and no `&mut JniGen` existed anywhere. Convention held it — and convention is what this replaces, for the reason #252 gave for `Registry`, whose `supply` survived two commits claiming it was gone.

## The split

| | |
|---|---|
| **`Declarations`** | what was declared. **No `&mut self` method at all.** What a `JniGen` keeps and every emitter reads. |
| **`JniGenBuilder { decls, sources }`** | the describing surface, and the only type with mutators. `build_with` takes `decls` out and never puts them back. |

It fell almost exactly on file boundaries, which is why it is mostly a rename: the **17 mutators** were already concentrated in `builder.rs` and `config.rs`, and the **~117 read methods** were already in files that only read.

`sources` stays on the builder — it is *input to* building, not a declaration, and keeping it out is what makes `Declarations` mean one thing.

`JniGen`'s fields are now module-private rather than `pub(crate)`. **`Flat` comes along for free**: `Registry::flat` is private and `Registry::flat()` returns `&Flat`, so a `Registry` that cannot be reached mutably seals the model too.

## Two guards, both proven to fail before being trusted

**`a_built_jnigen_exposes_no_mutation`** — reads the source with **all** whitespace stripped, so a multi-line signature is indistinguishable from a one-line one, and complains about any `fn(&mut self)` inside an `impl Declarations`, `impl JniGen`, or the `Prebindgen` impl. Sabotaged with a `&mut self` on `Declarations`: it fails and names the file. `builder.rs` and `config.rs` are skipped, exactly as the registry's own test skips `declare.rs` — the builder is *meant* to be mutable.

**`declarations_interior_mutability_is_only_the_two_memos`** — `iface_specs` and `fn_plans` stay `RefCell` deliberately: they cache a pure function of `(declarations, registry)`, both frozen by the time anything reads them, and caching that is not re-declaring anything. Naming them means a third has to be argued for rather than merely added.

Worth noting: its first version scanned line by line and could not see `iface_specs`, whose declaration wraps — the very hazard the sibling test exists for. It strips whitespace too now.

## Verification

- **Reported**: regen-check byte-identical on every committed artifact. The two untracked `example_flat_aarch64_unstable.{rs,h}` are the pre-existing #219 disagreement.
- **Explained**: a pure representation change — nothing about what is generated moves. **Ledger unchanged at 154**, which is the check that no classification site was rewritten while things were being moved.
- **Asserted**: the type a built binding keeps has no mutators.
- 527 lib tests (525 + the two guards), `--all-features` clean, clippy clean on both toolchains with `-D warnings`, and **no new rustdoc warnings** — 31 before, 31 after (the mutator doc-links moved to `JniGenBuilder`).

`Cbindgen` is untouched by decision, and follows by analogy — which is why the guard is written to be copied rather than generalised over both generators now.