### PR TITLE
L2b: one layer read, and api/core stops classifying types

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -31,7 +31,7 @@ use quote::quote;
 
 use crate::api::core::{
     registry::{Registry, TypeKey},
-    types_util::{ident, option_inner_type, result_ok_type},
+    types_util::ident,
 };
 
 mod error;
@@ -197,11 +197,7 @@ pub fn apply<M>(
                 .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
             let param_ty = find_param_type(&item_fn, &ed.param)
                 .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
-            let inner = option_inner_type(&param_ty).unwrap_or(param_ty);
-            let bare = match &inner {
-                syn::Type::Reference(r) => (*r.elem).clone(),
-                other => other.clone(),
-            };
+            let bare = crossing_core(registry.flat(), &param_ty);
             if TypeKey::from_type(&bare) != TypeKey::from_type(declared) {
                 return Err(ExpandError::ParamTypeMismatch {
                     func: ed.func.clone(),
@@ -249,11 +245,7 @@ pub fn apply<M>(
             let receiver_key = method_receivers.get(func);
             let mut receiver_skipped = false;
             for (pname, pty) in fn_params(&item_fn) {
-                let core = option_inner_type(&pty).unwrap_or(pty);
-                let bare = match &core {
-                    syn::Type::Reference(r) => (*r.elem).clone(),
-                    other => other.clone(),
-                };
+                let bare = crossing_core(registry.flat(), &pty);
                 let bare_key = TypeKey::from_type(&bare);
                 if !receiver_skipped && receiver_key == Some(&bare_key) {
                     receiver_skipped = true;
@@ -312,16 +304,16 @@ fn process_expand<M>(
     let param_ty = find_param_type(&item_fn, &ed.param)
         .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
 
-    // Peel `Option<…>` (whole param optional) then a leading `&` (borrow):
-    // `Option<&T>` → optional + by_ref, `Option<T>` → optional, `&T` → by_ref.
-    let (optional, inner) = match option_inner_type(&param_ty) {
-        Some(i) => (true, i),
-        None => (false, param_ty.clone()),
-    };
-    let (by_ref, target) = match &inner {
-        syn::Type::Reference(r) => (true, (*r.elem).clone()),
-        other => (false, other.clone()),
-    };
+    // The boundary layers: `Option<&T>` → optional + by_ref, `Option<T>` →
+    // optional, `&T` → by_ref, and `target` is what is left under them.
+    let reading = registry.flat().classify(&param_ty).ok();
+    let layers = reading.as_ref().map(|r| r.layers());
+    let optional = layers.as_ref().is_some_and(|l| l.optional);
+    let by_ref = layers.as_ref().is_some_and(|l| l.by_ref);
+    let target = layers
+        .as_ref()
+        .map(|l| l.core.origin.syntax.clone())
+        .unwrap_or_else(|| param_ty.clone());
     let target_key = TypeKey::from_type(&target);
 
     let variants = resolve_constructor(exp, registry, &target_key, ed)?;
@@ -387,10 +379,11 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
         .iter()
         .map(|p| (p.name.clone(), p.ty.origin.syntax.clone()))
         .collect();
-    let ret: syn::Type = f.ret.origin.syntax.clone();
-    let (target, fallible) = match result_ok_type(&ret) {
-        Some(ok) => (ok, true),
-        None => (ret, false),
+    // The model already read this return; `fallible_parts` is that reading, not a
+    // second look at the spelling.
+    let (target, fallible) = match f.ret.fallible_parts() {
+        Some((ok, _)) => (ok.origin.syntax.clone(), true),
+        None => (f.ret.origin.syntax.clone(), false),
     };
     Ok(CtorSig {
         params,
@@ -669,15 +662,15 @@ fn build_arg<M>(
     leaves: &mut Vec<FoldLeaf>,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<FoldArg, ExpandError> {
-    // Peel `Option<…>` then a leading `&` to reach the parameter's core type.
-    let (popt, core) = match option_inner_type(pty) {
-        Some(i) => (true, i),
-        None => (false, pty.clone()),
-    };
-    let (pby_ref, bare) = match &core {
-        syn::Type::Reference(r) => (true, (*r.elem).clone()),
-        other => (false, other.clone()),
-    };
+    // The boundary layers down to the parameter's core type.
+    let preading = registry.flat().classify(pty).ok();
+    let players = preading.as_ref().map(|r| r.layers());
+    let popt = players.as_ref().is_some_and(|l| l.optional);
+    let pby_ref = players.as_ref().is_some_and(|l| l.by_ref);
+    let bare = players
+        .as_ref()
+        .map(|l| l.core.origin.syntax.clone())
+        .unwrap_or_else(|| pty.clone());
     let key = TypeKey::from_type(&bare);
     // A default constructor for the parameter's type ⇒ recursive nested build.
     let canon = exp
@@ -1087,6 +1080,24 @@ fn ctor_call_result<I: quote::ToTokens>(path: &syn::Path, args: &[I], fallible: 
 // ──────────────────────────────────────────────────────────────────────
 // Small helpers
 // ──────────────────────────────────────────────────────────────────────
+
+/// The type a value finally crosses as: the boundary layers off, read off the
+/// model's classification instead of by taking the spelling apart.
+///
+/// `Option<&T>` and `&T` and `T` all answer `T`, which is what every caller here
+/// wants — they are matching a declared target, and a declaration names the type,
+/// not the way a particular parameter happens to wrap it.
+///
+/// A type the grammar cannot express answers itself. That is the identity, not a
+/// fallback classifier: a type with no reading has no layers to peel, and nothing
+/// that reaches here can have one — every signature in play was accepted by the
+/// frontend before the scan registered it.
+fn crossing_core(flat: &crate::api::core::flat::Flat, ty: &syn::Type) -> syn::Type {
+    match flat.classify(ty) {
+        Ok(reading) => reading.layers().core.origin.syntax.clone(),
+        Err(_) => ty.clone(),
+    }
+}
 
 fn find_param_type(item_fn: &syn::ItemFn, param: &syn::Ident) -> Option<syn::Type> {
     for input in &item_fn.sig.inputs {

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -197,7 +197,7 @@ pub fn apply<M>(
                 .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
             let param_ty = find_param_type(&item_fn, &ed.param)
                 .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
-            let bare = crossing_core(registry.flat(), &param_ty);
+            let bare = constructed_value(registry.flat(), &param_ty);
             if TypeKey::from_type(&bare) != TypeKey::from_type(declared) {
                 return Err(ExpandError::ParamTypeMismatch {
                     func: ed.func.clone(),
@@ -245,7 +245,7 @@ pub fn apply<M>(
             let receiver_key = method_receivers.get(func);
             let mut receiver_skipped = false;
             for (pname, pty) in fn_params(&item_fn) {
-                let bare = crossing_core(registry.flat(), &pty);
+                let bare = constructed_value(registry.flat(), &pty);
                 let bare_key = TypeKey::from_type(&bare);
                 if !receiver_skipped && receiver_key == Some(&bare_key) {
                     receiver_skipped = true;
@@ -306,14 +306,7 @@ fn process_expand<M>(
 
     // The boundary layers: `Option<&T>` → optional + by_ref, `Option<T>` →
     // optional, `&T` → by_ref, and `target` is what is left under them.
-    let reading = registry.flat().classify(&param_ty).ok();
-    let layers = reading.as_ref().map(|r| r.layers());
-    let optional = layers.as_ref().is_some_and(|l| l.optional);
-    let by_ref = layers.as_ref().is_some_and(|l| l.by_ref);
-    let target = layers
-        .as_ref()
-        .map(|l| l.core.origin.syntax.clone())
-        .unwrap_or_else(|| param_ty.clone());
+    let (optional, by_ref, target) = constructed_value_layers(registry.flat(), &param_ty);
     let target_key = TypeKey::from_type(&target);
 
     let variants = resolve_constructor(exp, registry, &target_key, ed)?;
@@ -663,14 +656,7 @@ fn build_arg<M>(
     visited: &mut HashSet<TypeKey>,
 ) -> Result<FoldArg, ExpandError> {
     // The boundary layers down to the parameter's core type.
-    let preading = registry.flat().classify(pty).ok();
-    let players = preading.as_ref().map(|r| r.layers());
-    let popt = players.as_ref().is_some_and(|l| l.optional);
-    let pby_ref = players.as_ref().is_some_and(|l| l.by_ref);
-    let bare = players
-        .as_ref()
-        .map(|l| l.core.origin.syntax.clone())
-        .unwrap_or_else(|| pty.clone());
+    let (popt, pby_ref, bare) = constructed_value_layers(registry.flat(), pty);
     let key = TypeKey::from_type(&bare);
     // A default constructor for the parameter's type ⇒ recursive nested build.
     let canon = exp
@@ -1081,22 +1067,51 @@ fn ctor_call_result<I: quote::ToTokens>(path: &syn::Path, args: &[I], fallible: 
 // Small helpers
 // ──────────────────────────────────────────────────────────────────────
 
-/// The type a value finally crosses as: the boundary layers off, read off the
-/// model's classification instead of by taking the spelling apart.
+/// The value a constructor builds: `Option` off, then the borrow, and **nothing
+/// else** — read off the model's classification rather than by taking the
+/// spelling apart.
 ///
-/// `Option<&T>` and `&T` and `T` all answer `T`, which is what every caller here
-/// wants — they are matching a declared target, and a declaration names the type,
+/// `Option<&T>`, `&T` and `T` all answer `T`, which is what every caller here
+/// wants: they are matching a declared target, and a declaration names the type,
 /// not the way a particular parameter happens to wrap it.
 ///
-/// A type the grammar cannot express answers itself. That is the identity, not a
-/// fallback classifier: a type with no reading has no layers to peel, and nothing
-/// that reaches here can have one — every signature in play was accepted by the
-/// frontend before the scan registered it.
-fn crossing_core(flat: &crate::api::core::flat::Flat, ty: &syn::Type) -> syn::Type {
-    match flat.classify(ty) {
-        Ok(reading) => reading.layers().core.origin.syntax.clone(),
-        Err(_) => ty.clone(),
-    }
+/// **`Vec<T>` answers `Vec<T>`, deliberately.** Expansion builds one value —
+/// `FoldPlan`'s shape is `Base` or `Optional(Base)`, with no iterable arm — so
+/// peeling a `Sequence` here would let a `Vec<T>` parameter match a `T`
+/// constructor and emit a wrapper that reconstructs a single `T` and hands it to
+/// a parameter expecting the collection. Leaving the `Sequence` on the core is
+/// what makes that a non-match instead of a miscompile, and it is the reason this
+/// is not [`TypeRef::layers`], which peels all three.
+///
+/// A type the grammar cannot express answers itself — the identity, not a
+/// fallback classifier. Nothing reaching here can be one: every signature in play
+/// was accepted by the frontend before the scan registered it.
+fn constructed_value(flat: &crate::api::core::flat::Flat, ty: &syn::Type) -> syn::Type {
+    let Ok(reading) = flat.classify(ty) else {
+        return ty.clone();
+    };
+    let after_opt = reading.optional_inner().unwrap_or(&reading);
+    after_opt
+        .borrow_target()
+        .unwrap_or(after_opt)
+        .origin
+        .syntax
+        .clone()
+}
+
+/// [`constructed_value`], plus which of the two layers were there.
+fn constructed_value_layers(
+    flat: &crate::api::core::flat::Flat,
+    ty: &syn::Type,
+) -> (bool, bool, syn::Type) {
+    let Ok(reading) = flat.classify(ty) else {
+        return (false, false, ty.clone());
+    };
+    let optional = reading.optional_inner().is_some();
+    let after_opt = reading.optional_inner().unwrap_or(&reading);
+    let by_ref = after_opt.borrow_target().is_some();
+    let core = after_opt.borrow_target().unwrap_or(after_opt);
+    (optional, by_ref, core.origin.syntax.clone())
 }
 
 fn find_param_type(item_fn: &syn::ItemFn, param: &syn::Ident) -> Option<syn::Type> {

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -756,3 +756,48 @@ fn invalid_declarations_collected() {
         "{text}"
     );
 }
+
+/// A `Vec<T>` parameter is **not** a `T` parameter, even when `T` has a
+/// constructor.
+///
+/// Expansion builds one value: `FoldPlan`'s shape is `Base` or `Optional(Base)`,
+/// with no iterable arm. So the layer peel here stops at the borrow — if it also
+/// peeled the `Sequence`, a `Vec<T>` parameter would match a `T` constructor and
+/// the wrapper would reconstruct a single `T` and hand it to a parameter
+/// expecting the collection. Not a rejected plan: a wrong one, in generated code.
+///
+/// Missed once, and by everything: the whole suite passed either way, and
+/// regen-check was byte-identical, because no example declares a `Vec<T>`
+/// parameter whose element is constructible. That is what this fixture is.
+#[test]
+fn a_vec_param_does_not_match_its_elements_constructor() {
+    let mut reg: Registry<()> = reg_with(&[
+        "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
+        "fn z_keyexpr_join_all(parts: Vec<ZKeyExpr>) -> bool { todo!() }",
+    ]);
+    let mut exp = Expansions::default();
+    // The type-level default: every `ZKeyExpr` parameter may be built from a
+    // `String`. `parts` is a `Vec<ZKeyExpr>`, so it is not one of them.
+    exp.constructors.push(ConstructorDecl {
+        target: syn::parse_quote!(ZKeyExpr),
+        variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
+        default: true,
+    });
+
+    apply(
+        &mut reg,
+        &exp,
+        &[ident("z_keyexpr_join_all")].into_iter().collect(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .expect("apply");
+
+    assert!(
+        !reg.expansion_plans
+            .contains_key(&(ident("z_keyexpr_join_all"), ident("parts"))),
+        "a Vec<ZKeyExpr> parameter must not be expanded as one ZKeyExpr; \
+         plans: {:?}",
+        reg.expansion_plans.keys().collect::<Vec<_>>()
+    );
+}

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -44,10 +44,9 @@
 # A check that silently under-reports is worse than no check, which is why the
 # gaps are listed here rather than implied away.
 
-4	api/core/expand.rs
 2	api/core/registry/scan.rs
 10	api/core/types_util.rs
-16	api/core/unfold.rs
+1	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
@@ -73,4 +72,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 154
+# total: 135

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -181,7 +181,10 @@ pub use self::{
     },
     origin::Origin,
     spelling::{canonical_spelling, canonical_type, type_from_ident},
-    ty::{RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType, UnsupportedTypeReason},
+    ty::{
+        Layers, RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType,
+        UnsupportedTypeReason,
+    },
 };
 use crate::SourceLocation;
 

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -181,10 +181,7 @@ pub use self::{
     },
     origin::Origin,
     spelling::{canonical_spelling, canonical_type, type_from_ident},
-    ty::{
-        Layers, RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType,
-        UnsupportedTypeReason,
-    },
+    ty::{RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType, UnsupportedTypeReason},
 };
 use crate::SourceLocation;
 

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -1697,3 +1697,76 @@ fn an_unsupported_item_still_holds_its_name() {
     ])
     .is_err());
 }
+
+/// The layer stack accepts one shape — `Option<Vec<T>>` — and stops at the first
+/// layer that is out of that order or repeats.
+///
+/// A recursion would happily return `Iterable(Optional(Base))` for
+/// `Vec<Option<T>>`, and that is wrong in a way the shape alone does not show:
+/// the optional there belongs to the **element**, not to the boundary. The
+/// difference is behavioural — `returns_type` compares the core, so an unbounded
+/// peel makes a `Vec<Option<T>>` return match a decomposition target `T` and
+/// installs a nested optional fold, while the explicit path next to it still
+/// refuses `Vec<Option<…>>` as unsupported. One of the two has to be wrong, and
+/// it is not the refusal.
+///
+/// `layer_types` has to stop at the same place, or the registration view
+/// un-requires types the shape says are part of the element.
+#[test]
+fn the_layer_stack_stops_at_an_out_of_order_layer() {
+    use crate::api::core::shape::Shape;
+
+    let shape_of = |ty: proc_macro2::TokenStream| {
+        let reading = lower(ty).expect("lowers");
+        let (shape, core) = reading.layer_stack();
+        let rendered = match &shape {
+            Shape::Base => "Base".to_string(),
+            Shape::Optional(_, i) => match &**i {
+                Shape::Base => "Optional(Base)".to_string(),
+                Shape::Iterable(_) => "Optional(Iterable(Base))".to_string(),
+                Shape::Optional(..) => "Optional(Optional(..))".to_string(),
+            },
+            Shape::Iterable(i) => match &**i {
+                Shape::Base => "Iterable(Base)".to_string(),
+                other => format!("Iterable({other:?})"),
+            },
+        };
+        (
+            rendered,
+            quote::ToTokens::to_token_stream(&core.origin.syntax).to_string(),
+            reading.layer_types().len(),
+        )
+    };
+
+    // In order: both layers are the boundary's.
+    assert_eq!(
+        shape_of(quote::quote!(Option<Vec<Sample>>)),
+        ("Optional(Iterable(Base))".into(), "Sample".into(), 3)
+    );
+    assert_eq!(
+        shape_of(quote::quote!(Option<Sample>)),
+        ("Optional(Base)".into(), "Sample".into(), 2)
+    );
+    assert_eq!(
+        shape_of(quote::quote!(Vec<Sample>)),
+        ("Iterable(Base)".into(), "Sample".into(), 2)
+    );
+
+    // Out of order: the optional is the element's, so the stack stops.
+    assert_eq!(
+        shape_of(quote::quote!(Vec<Option<Sample>>)),
+        ("Iterable(Base)".into(), "Option < Sample >".into(), 2)
+    );
+
+    // Repeated: the boundary has one way to say absent.
+    assert_eq!(
+        shape_of(quote::quote!(Option<Option<Sample>>)),
+        ("Optional(Base)".into(), "Option < Sample >".into(), 2)
+    );
+
+    // A borrow is not a layer at all — it is ownership, and stays on the core.
+    assert_eq!(
+        shape_of(quote::quote!(Option<Vec<&Sample>>)),
+        ("Optional(Iterable(Base))".into(), "& Sample".into(), 3)
+    );
+}

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -64,17 +64,31 @@ impl TypeRef {
     /// matches those and falls through on anything else, instead of silently
     /// consuming a layer it cannot honour.
     pub fn layer_stack(&self) -> (crate::api::core::shape::Shape, &TypeRef) {
-        match &self.kind {
-            TypeKind::Optional(inner) => {
-                let (rest, core) = inner.layer_stack();
-                (crate::api::core::shape::Shape::optional((), rest), core)
-            }
-            TypeKind::Sequence(inner) => {
-                let (rest, core) = inner.layer_stack();
-                (crate::api::core::shape::Shape::iterable(rest), core)
-            }
-            _ => (crate::api::core::shape::Shape::Base, self),
+        use crate::api::core::shape::Shape;
+        // Bounded on purpose, and not a recursion: the accepted crossing is
+        // `Option<Vec<T>>` — at most one optional, then at most one run, in that
+        // order. Recursing would accept `Vec<Option<T>>` as `Iterable(Optional)`,
+        // which reads the inner optional as a boundary layer when it is part of
+        // the element, and `Option<Option<T>>` as two nullable layers when the
+        // boundary has one way to say absent.
+        let mut core = self;
+        let optional = matches!(core.kind, TypeKind::Optional(_));
+        if let TypeKind::Optional(inner) = &core.kind {
+            core = inner;
         }
+        let iterable = matches!(core.kind, TypeKind::Sequence(_));
+        if let TypeKind::Sequence(inner) = &core.kind {
+            core = inner;
+        }
+
+        let mut shape = Shape::Base;
+        if iterable {
+            shape = Shape::iterable(shape);
+        }
+        if optional {
+            shape = Shape::optional((), shape);
+        }
+        (shape, core)
     }
 
     /// Every type on the way down through the arity layers, outermost first and
@@ -84,11 +98,16 @@ impl TypeRef {
     /// crosses: a value delivered layer-by-layer needs each of these un-required,
     /// and none of them has a converter of its own.
     pub fn layer_types(&self) -> Vec<&TypeRef> {
+        // Stops exactly where `layer_stack` stops, or the registration view would
+        // un-require types the shape says are part of the element.
         let mut out = vec![self];
         let mut cur = self;
-        while let TypeKind::Optional(inner) | TypeKind::Sequence(inner) = &cur.kind {
+        if let TypeKind::Optional(inner) = &cur.kind {
             out.push(inner);
             cur = inner;
+        }
+        if let TypeKind::Sequence(inner) = &cur.kind {
+            out.push(inner);
         }
         out
     }

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -41,7 +41,88 @@ pub struct TypeRef {
     pub origin: Origin<syn::Type>,
 }
 
+/// The boundary layers a type wraps its payload in, and what is underneath.
+///
+/// See [`TypeRef::layers`].
+#[derive(Clone, Copy, Debug)]
+pub struct Layers<'a> {
+    /// An [`Optional`](TypeKind::Optional) was outermost.
+    pub optional: bool,
+    /// A [`Sequence`](TypeKind::Sequence) came next — a run of the core type.
+    pub iterable: bool,
+    /// The core is reached through a borrow.
+    pub by_ref: bool,
+    /// This type, then what is left after the optional peel, then after the
+    /// sequence peel. A layer that is absent repeats the one before it, so the
+    /// three are always present and always in that order.
+    ///
+    /// These are the spellings a boundary fold **registers** — the whole type,
+    /// the collection, the element — which is a different question from what
+    /// finally crosses. A layer delivered leaf-by-leaf needs each of them
+    /// un-required, and there is no converter for any of them.
+    pub wrappers: [&'a TypeRef; 3],
+    /// Past the borrow as well: the type that actually crosses.
+    pub core: &'a TypeRef,
+}
+
 impl TypeRef {
+    /// Peel the boundary layers: an optional, of a run of, borrowed `T`.
+    ///
+    /// The shape nearly every crossing is some subset of, and the question a
+    /// dozen sites used to ask by taking the spelling apart — `option_inner_type`,
+    /// then `vec_inner_type`, then a `syn::Type::Reference` match, each rebuilding
+    /// the peeled type as it went.
+    ///
+    /// **The order is fixed and each layer is peeled at most once**: `Optional`,
+    /// then `Sequence`, then `Ref`. That is not a convention, it is the shape of a
+    /// boundary — *an optional list of borrowed things* — and reading layers in
+    /// whatever order they appear would call `Vec<Option<T>>` an optional list,
+    /// which is a different type. A layer out of that position stays on the core,
+    /// where a caller that cares matches [`kind`](Self::kind) directly: `&[T]`
+    /// reports `by_ref` with a `Sequence` core, because the borrow is outside the
+    /// run.
+    ///
+    /// Every answer is a fact about the **classification**, so a spelling the
+    /// language does not distinguish cannot change it: `Box<Vec<T>>` reads the
+    /// same as `Vec<T>`, and `Cow<'_, [T]>` the same as either.
+    pub fn layers(&self) -> Layers<'_> {
+        let whole = self;
+        let mut core = self;
+
+        let optional = matches!(core.kind, TypeKind::Optional(_));
+        if let TypeKind::Optional(inner) = &core.kind {
+            core = inner;
+        }
+        let after_opt = core;
+
+        let iterable = matches!(core.kind, TypeKind::Sequence(_));
+        if let TypeKind::Sequence(inner) = &core.kind {
+            core = inner;
+        }
+        let after_seq = core;
+
+        let by_ref = matches!(core.kind, TypeKind::Ref { .. });
+        if let TypeKind::Ref { inner, .. } = &core.kind {
+            core = inner;
+        }
+
+        Layers {
+            optional,
+            iterable,
+            by_ref,
+            wrappers: [whole, after_opt, after_seq],
+            core,
+        }
+    }
+
+    /// The `Ok` and `Err` sides when this is a `Result`, else `None`.
+    pub fn fallible_parts(&self) -> Option<(&TypeRef, &TypeRef)> {
+        match &self.kind {
+            TypeKind::Fallible { ok, err } => Some((ok, err)),
+            _ => None,
+        }
+    }
+
     /// The extent of this type when it is an array, else `None`.
     pub fn array_extent(&self) -> Option<&ArrayExtent> {
         match &self.kind {

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -115,6 +115,35 @@ impl TypeRef {
         }
     }
 
+    /// What an `Option<T>` wraps, else `None`.
+    ///
+    /// One layer, named. [`layers`](Self::layers) peels the whole boundary shape;
+    /// these three peel exactly what a caller asks for, which matters when the
+    /// caller cannot *represent* the layers it does not peel — see
+    /// [`layers`](Self::layers) on why an unpeeled layer stays on the core.
+    pub fn optional_inner(&self) -> Option<&TypeRef> {
+        match &self.kind {
+            TypeKind::Optional(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    /// The element of a run of values (`Vec<T>`, `[T]`), else `None`.
+    pub fn sequence_elem(&self) -> Option<&TypeRef> {
+        match &self.kind {
+            TypeKind::Sequence(elem) => Some(elem),
+            _ => None,
+        }
+    }
+
+    /// What a borrow points at, else `None`.
+    pub fn borrow_target(&self) -> Option<&TypeRef> {
+        match &self.kind {
+            TypeKind::Ref { inner, .. } => Some(inner),
+            _ => None,
+        }
+    }
+
     /// The `Ok` and `Err` sides when this is a `Result`, else `None`.
     pub fn fallible_parts(&self) -> Option<(&TypeRef, &TypeRef)> {
         match &self.kind {

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -41,86 +41,63 @@ pub struct TypeRef {
     pub origin: Origin<syn::Type>,
 }
 
-/// The boundary layers a type wraps its payload in, and what is underneath.
-///
-/// See [`TypeRef::layers`].
-#[derive(Clone, Copy, Debug)]
-pub struct Layers<'a> {
-    /// An [`Optional`](TypeKind::Optional) was outermost.
-    pub optional: bool,
-    /// A [`Sequence`](TypeKind::Sequence) came next — a run of the core type.
-    pub iterable: bool,
-    /// The core is reached through a borrow.
-    pub by_ref: bool,
-    /// This type, then what is left after the optional peel, then after the
-    /// sequence peel. A layer that is absent repeats the one before it, so the
-    /// three are always present and always in that order.
-    ///
-    /// These are the spellings a boundary fold **registers** — the whole type,
-    /// the collection, the element — which is a different question from what
-    /// finally crosses. A layer delivered leaf-by-leaf needs each of them
-    /// un-required, and there is no converter for any of them.
-    pub wrappers: [&'a TypeRef; 3],
-    /// Past the borrow as well: the type that actually crosses.
-    pub core: &'a TypeRef,
-}
-
 impl TypeRef {
-    /// Peel the boundary layers: an optional, of a run of, borrowed `T`.
+    /// The **arity layers** over this type, and what they wrap.
     ///
-    /// The shape nearly every crossing is some subset of, and the question a
-    /// dozen sites used to ask by taking the spelling apart — `option_inner_type`,
-    /// then `vec_inner_type`, then a `syn::Type::Reference` match, each rebuilding
-    /// the peeled type as it went.
+    /// `Option<Vec<T>>` is `Optional(Iterable(Base))` over `T`. The stack is the
+    /// same [`Shape`](crate::core::shape::Shape) the expansion and decomposition plans are built from — so a
+    /// consumer that needs a plan shape has it, rather than rebuilding one from
+    /// flags that were derived from this type moments earlier.
     ///
-    /// **The order is fixed and each layer is peeled at most once**: `Optional`,
-    /// then `Sequence`, then `Ref`. That is not a convention, it is the shape of a
-    /// boundary — *an optional list of borrowed things* — and reading layers in
-    /// whatever order they appear would call `Vec<Option<T>>` an optional list,
-    /// which is a different type. A layer out of that position stays on the core,
-    /// where a caller that cares matches [`kind`](Self::kind) directly: `&[T]`
-    /// reports `by_ref` with a `Sequence` core, because the borrow is outside the
-    /// run.
+    /// **A borrow is not a layer.** `Optional` and `Iterable` change arity — none
+    /// or one, none or many — while `&T` is the same single value held
+    /// differently. That is ownership, and it stays on the returned core, where
+    /// [`borrow_target`](Self::borrow_target) reads it.
     ///
-    /// Every answer is a fact about the **classification**, so a spelling the
-    /// language does not distinguish cannot change it: `Box<Vec<T>>` reads the
-    /// same as `Vec<T>`, and `Cow<'_, [T]>` the same as either.
-    pub fn layers(&self) -> Layers<'_> {
-        let whole = self;
-        let mut core = self;
-
-        let optional = matches!(core.kind, TypeKind::Optional(_));
-        if let TypeKind::Optional(inner) = &core.kind {
-            core = inner;
+    /// A layer out of position is not a layer: `Vec<Option<T>>` is
+    /// `Iterable(Base)` over `Option<T>`, because the optional is inside the run.
+    /// The stack is what wraps the payload, in order, and nothing is reordered to
+    /// make it fit a shape a caller hoped for.
+    ///
+    /// Returning the stack rather than a set of flags is what lets a caller
+    /// **decline**: a consumer that can only build `Base` and `Optional(Base)`
+    /// matches those and falls through on anything else, instead of silently
+    /// consuming a layer it cannot honour.
+    pub fn layer_stack(&self) -> (crate::api::core::shape::Shape, &TypeRef) {
+        match &self.kind {
+            TypeKind::Optional(inner) => {
+                let (rest, core) = inner.layer_stack();
+                (crate::api::core::shape::Shape::optional((), rest), core)
+            }
+            TypeKind::Sequence(inner) => {
+                let (rest, core) = inner.layer_stack();
+                (crate::api::core::shape::Shape::iterable(rest), core)
+            }
+            _ => (crate::api::core::shape::Shape::Base, self),
         }
-        let after_opt = core;
+    }
 
-        let iterable = matches!(core.kind, TypeKind::Sequence(_));
-        if let TypeKind::Sequence(inner) = &core.kind {
-            core = inner;
+    /// Every type on the way down through the arity layers, outermost first and
+    /// ending at the core [`layer_stack`](Self::layer_stack) returns.
+    ///
+    /// What a **registration** walks, which is a different question from what
+    /// crosses: a value delivered layer-by-layer needs each of these un-required,
+    /// and none of them has a converter of its own.
+    pub fn layer_types(&self) -> Vec<&TypeRef> {
+        let mut out = vec![self];
+        let mut cur = self;
+        while let TypeKind::Optional(inner) | TypeKind::Sequence(inner) = &cur.kind {
+            out.push(inner);
+            cur = inner;
         }
-        let after_seq = core;
-
-        let by_ref = matches!(core.kind, TypeKind::Ref { .. });
-        if let TypeKind::Ref { inner, .. } = &core.kind {
-            core = inner;
-        }
-
-        Layers {
-            optional,
-            iterable,
-            by_ref,
-            wrappers: [whole, after_opt, after_seq],
-            core,
-        }
+        out
     }
 
     /// What an `Option<T>` wraps, else `None`.
     ///
-    /// One layer, named. [`layers`](Self::layers) peels the whole boundary shape;
-    /// these three peel exactly what a caller asks for, which matters when the
-    /// caller cannot *represent* the layers it does not peel — see
-    /// [`layers`](Self::layers) on why an unpeeled layer stays on the core.
+    /// One layer, named. [`layer_stack`](Self::layer_stack) reads the whole
+    /// arity stack; these three read exactly the layer a caller asks for, which
+    /// is what a consumer wants when it can only *represent* some of them.
     pub fn optional_inner(&self) -> Option<&TypeRef> {
         match &self.kind {
             TypeKind::Optional(inner) => Some(inner),

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -628,30 +628,23 @@ fn wire_fixed_returns<M>(
         // element/inner borrow-ness sets `by_ref` (the reach clones either
         // way).
         let layers = peel(registry, &ret);
-        let (optional, iterable, by_ref) = (layers.optional, layers.iterable, layers.by_ref);
-        let inner_shape = if iterable {
-            UnfoldShape::Iterable(Box::new(UnfoldShape::Base))
-        } else {
-            UnfoldShape::Base
-        };
-        let shape = if optional {
-            UnfoldShape::Optional((), Box::new(inner_shape))
-        } else {
-            inner_shape
-        };
+        let by_ref = layers.by_ref;
+        // The model's layer stack is the plan's shape — `UnfoldShape` is `Shape`
+        // — so there is nothing to rebuild here.
+        let shape = layers.shape.clone();
         if no_converter {
             // The plan delivers the return leaf-by-leaf, so no converter is
             // needed for the declared return — and for a sum none can exist.
             // Drop the scan-time registrations of every layer (the boundary-only
             // pass only reaches the bare type), so the missing converters are not
             // flagged as unresolved-required.
-            // All THREE peeled layers, the `Vec` element included. The shape
-            // fold peels here, so the matching unrequire belongs here; leaving
-            // the element out made the invariant depend on the adapter's
-            // `boundary_only_types` covering it — true for JniGenBuilder today, and
-            // the only reason a `Vec<sum>`-only declaration resolves.
-            for wrapper in &layers.wrappers {
-                registry.unrequire_output(wrapper);
+            // EVERY layer, the `Vec` element included. The shape fold peels here,
+            // so the matching unrequire belongs here; leaving the element out made
+            // the invariant depend on the adapter's `boundary_only_types` covering
+            // it — true for JniGenBuilder today, and the only reason a
+            // `Vec<sum>`-only declaration resolves.
+            for layer in &layers.layer_types {
+                registry.unrequire_output(layer);
             }
         }
         for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
@@ -913,49 +906,50 @@ fn check_records(
     Ok(())
 }
 
-/// The boundary layers of `ty`, as owned spellings.
+/// The arity layers over `ty`, the types they wrap, and the value underneath.
 ///
-/// [`TypeRef::layers`](crate::api::core::flat::TypeRef::layers) with the borrows
+/// [`TypeRef::layer_stack`](crate::api::core::flat::TypeRef::layer_stack) and
+/// [`layer_types`](crate::api::core::flat::TypeRef::layer_types) with the borrows
 /// resolved to clones, because these feed plan fields and registry calls that own
 /// their types. The classification is the model's; only the copying is local.
 ///
-/// A type the grammar cannot express answers "no layers, core is itself" — the
-/// identity, not a fallback classifier. Nothing reaching here can be one: every
+/// The stack **is** the plan's shape — `UnfoldShape` is `Shape` — so a caller
+/// stores it rather than rebuilding one from flags.
+///
+/// A type the grammar cannot express answers `Base` over itself: the identity,
+/// not a fallback classifier. Nothing reaching here can be one, since every
 /// signature in play was accepted by the frontend before the scan saw it.
-struct Peeled {
-    optional: bool,
-    iterable: bool,
-    by_ref: bool,
-    /// The whole type, after the optional peel, after the sequence peel — the
-    /// three spellings a fold registers.
-    wrappers: [syn::Type; 3],
-    /// Past the borrow as well: what actually crosses.
+struct Layered {
+    /// The arity layers, outermost first.
+    shape: UnfoldShape,
+    /// Every type on the way down, outermost first — what a registration walks.
+    layer_types: Vec<syn::Type>,
+    /// Past the borrow too: what actually crosses.
     core: syn::Type,
+    /// Whether the core is reached through a borrow.
+    by_ref: bool,
 }
 
-fn peel<M>(registry: &Registry<M>, ty: &syn::Type) -> Peeled {
-    match registry.flat().classify(ty) {
-        Ok(reading) => {
-            let l = reading.layers();
-            Peeled {
-                optional: l.optional,
-                iterable: l.iterable,
-                by_ref: l.by_ref,
-                wrappers: [
-                    l.wrappers[0].origin.syntax.clone(),
-                    l.wrappers[1].origin.syntax.clone(),
-                    l.wrappers[2].origin.syntax.clone(),
-                ],
-                core: l.core.origin.syntax.clone(),
-            }
-        }
-        Err(_) => Peeled {
-            optional: false,
-            iterable: false,
-            by_ref: false,
-            wrappers: [ty.clone(), ty.clone(), ty.clone()],
+fn peel<M>(registry: &Registry<M>, ty: &syn::Type) -> Layered {
+    let Ok(reading) = registry.flat().classify(ty) else {
+        return Layered {
+            shape: UnfoldShape::Base,
+            layer_types: vec![ty.clone()],
             core: ty.clone(),
-        },
+            by_ref: false,
+        };
+    };
+    let (shape, layered) = reading.layer_stack();
+    let borrowed = layered.borrow_target();
+    Layered {
+        shape,
+        layer_types: reading
+            .layer_types()
+            .iter()
+            .map(|t| t.origin.syntax.clone())
+            .collect(),
+        core: borrowed.unwrap_or(layered).origin.syntax.clone(),
+        by_ref: borrowed.is_some(),
     }
 }
 
@@ -1652,14 +1646,13 @@ fn flatten<M>(
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
-                let ret_layers = peel(registry, &ret);
-                let opt = ret_layers.optional;
-                // `wrappers[1]` is what is left after the optional peel: the
-                // borrowed form when there is one, which is what the `by_value`
-                // flags below ask about.
-                let core = ret_layers.wrappers[1].clone();
-                let core_by_ref = peel_borrow(registry, &core).0;
-                let child_ty = ret_layers.core.clone();
+                // This site peels an `Option` only — an accessor returning a run
+                // of values is not spliced — so it asks the model for that one
+                // layer rather than the whole stack.
+                let after_opt = optional_inner(registry, &ret);
+                let opt = after_opt.is_some();
+                let core = after_opt.unwrap_or_else(|| ret.clone());
+                let (core_by_ref, child_ty) = peel_borrow(registry, &core);
                 let child_key = TypeKey::from_type(&child_ty);
                 // A child already on the nesting chain: for a `#[prebindgen]`
                 // accessor that is an authoring cycle (hard error); a

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -27,10 +27,7 @@
 
 use std::collections::HashSet;
 
-use crate::api::core::{
-    registry::{Registry, TypeKey},
-    types_util::{option_inner_type, result_err_type, vec_inner_type},
-};
+use crate::api::core::registry::{Registry, TypeKey};
 
 mod error;
 mod plan;
@@ -302,7 +299,7 @@ pub fn apply<M>(
                 .map(|f| f.origin.syntax.clone())
                 .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
             let ret = fn_return(&item_fn);
-            if !returns_type(&ret, &TypeKey::from_type(declared)) {
+            if !returns_type(registry, &ret, &TypeKey::from_type(declared)) {
                 return Err(UnfoldError::ReturnTypeMismatch {
                     func: ed.func.clone(),
                     declared: TypeKey::from_type(declared).as_str().to_string(),
@@ -349,7 +346,7 @@ pub fn apply<M>(
             };
             let ret = fn_return(&item_fn);
             // Error position: fn returns `Result<_, E>` and `E == d.target`.
-            if let Some(err_ty) = result_err_type(&ret) {
+            if let Some(err_ty) = fallible_err(registry, &ret) {
                 if TypeKey::from_type(&err_ty) == dkey
                     && done.insert((func.clone(), DeconTarget::Error))
                 {
@@ -368,7 +365,7 @@ pub fn apply<M>(
             }
             // Output position: fn returns `T` / `&T` / `Option<T|&T>` / `Vec<T>`
             // with `T == d.target` (Result returns keep a handle — factories).
-            if returns_type(&ret, &dkey)
+            if returns_type(registry, &ret, &dkey)
                 && !acc.skip_output.contains(func)
                 && done.insert((func.clone(), DeconTarget::Output))
             {
@@ -418,13 +415,15 @@ pub fn apply<M>(
                 // (cloned) through the reference instead of by move. The plan is
                 // keyed under the ACTUAL arg type (`&T`) — that is what
                 // `callback_input`/`callback_iface_spec` look up.
-                let (by_ref, core_ty) = match &arg_ty {
-                    syn::Type::Reference(r) => (true, (*r.elem).clone()),
-                    other => (false, other.clone()),
-                };
-                // Only a bare path core type can match a deconstructor target
-                // (`Option<T>` / `Vec<T>` / tuple args are delivered whole).
-                if !matches!(&core_ty, syn::Type::Path(_)) {
+                let (by_ref, core_ty) = peel_borrow(registry, &arg_ty);
+                // Only a NAMED core can match a deconstructor target: an
+                // `Option<T>` / `Vec<T>` / tuple arg is delivered whole. The model
+                // says which, so a wrapper the language sees through — `Box<T>` —
+                // no longer reads as un-nameable.
+                if !matches!(
+                    registry.flat().classify(&core_ty).map(|r| r.kind.clone()),
+                    Ok(crate::api::core::flat::TypeKind::Named { .. })
+                ) {
                     continue;
                 }
                 let key = TypeKey::from_type(&arg_ty);
@@ -617,7 +616,7 @@ fn wire_fixed_returns<M>(
             continue;
         };
         let ret = fn_return(&item_fn);
-        if !returns_type(&ret, &vd.key) || registry.unfold_plans.contains_key(func) {
+        if !returns_type(registry, &ret, &vd.key) || registry.unfold_plans.contains_key(func) {
             continue;
         }
         // Shape over the leaf decomposition: peel an outer `Option`, then a
@@ -628,15 +627,8 @@ fn wire_fixed_returns<M>(
         // null result). `element: None` keeps the decomposed-leaf path. The
         // element/inner borrow-ness sets `by_ref` (the reach clones either
         // way).
-        let (optional, after_opt) = match option_inner_type(&ret) {
-            Some(inner) => (true, inner),
-            None => (false, ret.clone()),
-        };
-        let (iterable, core) = match vec_inner_type(&after_opt) {
-            Some(inner) => (true, inner),
-            None => (false, after_opt.clone()),
-        };
-        let by_ref = matches!(&core, syn::Type::Reference(_));
+        let layers = peel(registry, &ret);
+        let (optional, iterable, by_ref) = (layers.optional, layers.iterable, layers.by_ref);
         let inner_shape = if iterable {
             UnfoldShape::Iterable(Box::new(UnfoldShape::Base))
         } else {
@@ -658,9 +650,9 @@ fn wire_fixed_returns<M>(
             // the element out made the invariant depend on the adapter's
             // `boundary_only_types` covering it — true for JniGenBuilder today, and
             // the only reason a `Vec<sum>`-only declaration resolves.
-            registry.unrequire_output(&ret);
-            registry.unrequire_output(&after_opt);
-            registry.unrequire_output(&core);
+            for wrapper in &layers.wrappers {
+                registry.unrequire_output(wrapper);
+            }
         }
         for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
             registry.require_output(&leaf.out_ty);
@@ -715,16 +707,16 @@ fn wire_fixed_callbacks<M>(
                 // value via `fromParts`); an `impl Fn(&[T])` / `impl Fn([T])` arg
                 // becomes an `Iterable` fixed FOLDER (the trampoline folds each
                 // element's leaves into a foreign list — see the callback emitter).
-                let (by_ref, after_ref) = match &arg_ty {
-                    syn::Type::Reference(r) => (true, (*r.elem).clone()),
-                    other => (false, other.clone()),
-                };
-                let (shape, matches_key) = match &after_ref {
-                    syn::Type::Slice(s) => (
+                let (by_ref, after_ref) = peel_borrow(registry, &arg_ty);
+                // A run of `T` is an Iterable fold over the element; anything else
+                // is a Base fold over the value itself. `Sequence` is the one
+                // question, and it covers `[T]` and `Vec<T>` alike.
+                let (shape, matches_key) = match sequence_elem(registry, &after_ref) {
+                    Some(elem) => (
                         UnfoldShape::Iterable(Box::new(UnfoldShape::Base)),
-                        TypeKey::from_type(&s.elem) == vd.key,
+                        TypeKey::from_type(&elem) == vd.key,
                     ),
-                    other => (UnfoldShape::Base, TypeKey::from_type(other) == vd.key),
+                    None => (UnfoldShape::Base, TypeKey::from_type(&after_ref) == vd.key),
                 };
                 if !matches_key {
                     continue;
@@ -792,11 +784,11 @@ pub fn apply_leaf_vec_folds<M>(
         // already exists (declared deconstructor / value-struct fold).
         if !registry.unfold_plans.contains_key(func) {
             let ret = fn_return(&item_fn);
-            let (optional, after_opt) = match option_inner_type(&ret) {
+            let (optional, after_opt) = match optional_inner(registry, &ret) {
                 Some(inner) => (true, inner),
                 None => (false, ret.clone()),
             };
-            if let Some(vec_elem) = vec_inner_type(&after_opt) {
+            if let Some(vec_elem) = sequence_elem(registry, &after_opt) {
                 let bare = peel_ref(&vec_elem);
                 if is_nominated(&bare) {
                     let inner_shape = UnfoldShape::Iterable(Box::new(UnfoldShape::Base));
@@ -814,9 +806,10 @@ pub fn apply_leaf_vec_folds<M>(
                     // JObject-shaped), and de-requiring keeps that `None` from
                     // being flagged as an unresolved-required error.
                     registry.unrequire_output(&ret);
-                    registry
-                        .unfold_plans
-                        .insert(func.clone(), whole_leaf_fold_plan(&vec_elem, shape));
+                    registry.unfold_plans.insert(
+                        func.clone(),
+                        whole_leaf_fold_plan(registry, &vec_elem, shape),
+                    );
                 }
             }
         }
@@ -829,12 +822,11 @@ pub fn apply_leaf_vec_folds<M>(
                 continue;
             };
             for arg_ty in args {
-                let after_ref = peel_ref(&arg_ty);
-                let syn::Type::Slice(s) = &after_ref else {
+                let (_, after_ref) = peel_borrow(registry, &arg_ty);
+                let Some(elem) = sequence_elem(registry, &after_ref) else {
                     continue;
                 };
-                let elem = (*s.elem).clone();
-                if !is_nominated(&peel_ref(&elem)) {
+                if !is_nominated(&peel_borrow(registry, &elem).1) {
                     continue;
                 }
                 let key = TypeKey::from_type(&arg_ty);
@@ -842,8 +834,11 @@ pub fn apply_leaf_vec_folds<M>(
                     continue;
                 }
                 registry.require_output(&elem);
-                let plan =
-                    whole_leaf_fold_plan(&elem, UnfoldShape::Iterable(Box::new(UnfoldShape::Base)));
+                let plan = whole_leaf_fold_plan(
+                    registry,
+                    &elem,
+                    UnfoldShape::Iterable(Box::new(UnfoldShape::Base)),
+                );
                 registry.callback_arg_plans.insert(key, plan);
             }
         }
@@ -854,11 +849,15 @@ pub fn apply_leaf_vec_folds<M>(
 /// Build a fixed-builder whole-element fold [`UnfoldPlan`] for a single-leaf
 /// element `vec_elem` (the `Vec`/slice element as written, keeping any leading
 /// `&` so `into_iter()`'s yield matches the element's own output converter).
-fn whole_leaf_fold_plan(vec_elem: &syn::Type, shape: UnfoldShape) -> UnfoldPlan {
+fn whole_leaf_fold_plan<M>(
+    registry: &Registry<M>,
+    vec_elem: &syn::Type,
+    shape: UnfoldShape,
+) -> UnfoldPlan {
     UnfoldPlan {
         source: vec_elem.clone(),
         decon: None,
-        by_ref: matches!(vec_elem, syn::Type::Reference(_)),
+        by_ref: peel_borrow(registry, vec_elem).0,
         shape,
         leaves: vec![],
         element: Some(vec_elem.clone()),
@@ -914,6 +913,103 @@ fn check_records(
     Ok(())
 }
 
+/// The boundary layers of `ty`, as owned spellings.
+///
+/// [`TypeRef::layers`](crate::api::core::flat::TypeRef::layers) with the borrows
+/// resolved to clones, because these feed plan fields and registry calls that own
+/// their types. The classification is the model's; only the copying is local.
+///
+/// A type the grammar cannot express answers "no layers, core is itself" — the
+/// identity, not a fallback classifier. Nothing reaching here can be one: every
+/// signature in play was accepted by the frontend before the scan saw it.
+struct Peeled {
+    optional: bool,
+    iterable: bool,
+    by_ref: bool,
+    /// The whole type, after the optional peel, after the sequence peel — the
+    /// three spellings a fold registers.
+    wrappers: [syn::Type; 3],
+    /// Past the borrow as well: what actually crosses.
+    core: syn::Type,
+}
+
+fn peel<M>(registry: &Registry<M>, ty: &syn::Type) -> Peeled {
+    match registry.flat().classify(ty) {
+        Ok(reading) => {
+            let l = reading.layers();
+            Peeled {
+                optional: l.optional,
+                iterable: l.iterable,
+                by_ref: l.by_ref,
+                wrappers: [
+                    l.wrappers[0].origin.syntax.clone(),
+                    l.wrappers[1].origin.syntax.clone(),
+                    l.wrappers[2].origin.syntax.clone(),
+                ],
+                core: l.core.origin.syntax.clone(),
+            }
+        }
+        Err(_) => Peeled {
+            optional: false,
+            iterable: false,
+            by_ref: false,
+            wrappers: [ty.clone(), ty.clone(), ty.clone()],
+            core: ty.clone(),
+        },
+    }
+}
+
+/// What `Option<T>` wraps, if `ty` is one.
+fn optional_inner<M>(registry: &Registry<M>, ty: &syn::Type) -> Option<syn::Type> {
+    use crate::api::core::flat::TypeKind;
+    match registry.flat().classify(ty).ok()?.kind {
+        TypeKind::Optional(inner) => Some(inner.origin.syntax.clone()),
+        _ => None,
+    }
+}
+
+/// The error side of a `Result`, if `ty` is one.
+fn fallible_err<M>(registry: &Registry<M>, ty: &syn::Type) -> Option<syn::Type> {
+    Some(
+        registry
+            .flat()
+            .classify(ty)
+            .ok()?
+            .fallible_parts()?
+            .1
+            .origin
+            .syntax
+            .clone(),
+    )
+}
+
+/// The element of a run of values (`Vec<T>`, `[T]`), if `ty` is one.
+fn sequence_elem<M>(registry: &Registry<M>, ty: &syn::Type) -> Option<syn::Type> {
+    use crate::api::core::flat::TypeKind;
+    match registry.flat().classify(ty).ok()?.kind {
+        TypeKind::Sequence(elem) => Some(elem.origin.syntax.clone()),
+        _ => None,
+    }
+}
+
+/// Just the borrow: whether `ty` is one, and what it borrows.
+///
+/// The model-driven `peel_ref`, and deliberately **not** [`peel`]: a site that
+/// peels only the borrow means it, because the layer underneath is the thing it
+/// is about to classify. `Vec<T>` answers `(false, Vec<T>)` here and
+/// `(iterable, T)` there, and confusing the two turns "this arg is a collection"
+/// into "this arg is a T".
+fn peel_borrow<M>(registry: &Registry<M>, ty: &syn::Type) -> (bool, syn::Type) {
+    use crate::api::core::flat::TypeKind;
+    match registry.flat().classify(ty) {
+        Ok(reading) => match &reading.kind {
+            TypeKind::Ref { inner, .. } => (true, inner.origin.syntax.clone()),
+            _ => (false, ty.clone()),
+        },
+        Err(_) => (false, ty.clone()),
+    }
+}
+
 /// Strip a single leading `&` (one level) from a type.
 pub(crate) fn peel_ref(ty: &syn::Type) -> syn::Type {
     match ty {
@@ -934,21 +1030,8 @@ fn fn_return(item_fn: &syn::ItemFn) -> syn::Type {
 /// `T == key` — the default-output match. `Result<_, _>` is NOT peeled, so a
 /// fallible factory (`-> Result<T, E>`) keeps its handle return; the error
 /// position is matched separately on `E`.
-fn returns_type(ret: &syn::Type, key: &TypeKey) -> bool {
-    // Peel an outer `Option`, then a `Vec` (so `Option<Vec<T>>` matches too),
-    // then a leading `&`.
-    let mut core = ret.clone();
-    if let Some(inner) = option_inner_type(&core) {
-        core = inner;
-    }
-    if let Some(inner) = vec_inner_type(&core) {
-        core = inner;
-    }
-    let bare = match &core {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other.clone(),
-    };
-    TypeKey::from_type(&bare) == *key
+fn returns_type<M>(registry: &Registry<M>, ret: &syn::Type, key: &TypeKey) -> bool {
+    TypeKey::from_type(&peel(registry, ret).core) == *key
 }
 
 /// Build one output/error plan for `ed` and store it in the right registry map.
@@ -969,9 +1052,11 @@ fn process_decl<M>(
         let ret_ty: syn::Type = match ed.target {
             DeconTarget::Output => fn_return(&item_fn),
             DeconTarget::Error => {
-                result_err_type(&fn_return(&item_fn)).ok_or_else(|| UnfoldError::Unsupported {
-                    func: ed.func.clone(),
-                    reason: "convert_error/deconstruct_error on a non-Result return",
+                fallible_err(registry, &fn_return(&item_fn)).ok_or_else(|| {
+                    UnfoldError::Unsupported {
+                        func: ed.func.clone(),
+                        reason: "convert_error/deconstruct_error on a non-Result return",
+                    }
                 })?
             }
         };
@@ -983,7 +1068,7 @@ fn process_decl<M>(
         // the historical probe order (the `Vec` probe runs on `E` itself), so
         // an `Option<Vec<E>>` error stays whole.
         let (optional, after_opt) = match ed.target {
-            DeconTarget::Output => match option_inner_type(&ret_ty) {
+            DeconTarget::Output => match optional_inner(registry, &ret_ty) {
                 Some(inner) => (true, inner),
                 None => (false, ret_ty.clone()),
             },
@@ -997,8 +1082,8 @@ fn process_decl<M>(
         //     via its own output converter + projection, fold `(acc, T) -> acc`.
         // The other shapes (`Option`/scalar) decompose via an accessor
         // (M1–M3). `Vec<Option<…>>` is not supported.
-        let plan = if let Some(inner) = vec_inner_type(&after_opt) {
-            if option_inner_type(&inner).is_some() {
+        let plan = if let Some(inner) = sequence_elem(registry, &after_opt) {
+            if optional_inner(registry, &inner).is_some() {
                 return Err(UnfoldError::Unsupported {
                     func: ed.func.clone(),
                     reason: "Vec<Option<…>> returns",
@@ -1024,10 +1109,7 @@ fn process_decl<M>(
                 }
             }
             // Element type peeled of a leading `&` (accessors take `&Element`).
-            let (by_ref, element) = match &inner {
-                syn::Type::Reference(r) => (true, (*r.elem).clone()),
-                other => (false, other.clone()),
-            };
+            let (by_ref, element) = peel_borrow(registry, &inner);
             let ekey = TypeKey::from_type(&element);
             if let Some(d) = find_deconstructor_by_type(acc, &ekey) {
                 // Decomposed: reuse the shared flatten (M3 nesting composes).
@@ -1044,7 +1126,7 @@ fn process_decl<M>(
                 // element's own output converter matches `into_iter()`'s yield.
                 // No declaration is involved (`decon: None`) — the element
                 // crosses whole through its own converter.
-                let by_ref = matches!(&inner, syn::Type::Reference(_));
+                let by_ref = peel_borrow(registry, &inner).0;
                 registry.require_output(&inner);
                 UnfoldPlan {
                     source: inner.clone(),
@@ -1066,15 +1148,12 @@ fn process_decl<M>(
             // `Option`); for `Error` it happens here, unchanged.
             let (optional, core_ty) = match ed.target {
                 DeconTarget::Output => (optional, after_opt.clone()),
-                DeconTarget::Error => match option_inner_type(&after_opt) {
+                DeconTarget::Error => match optional_inner(registry, &after_opt) {
                     Some(inner) => (true, inner),
                     None => (false, after_opt.clone()),
                 },
             };
-            let (by_ref, source) = match &core_ty {
-                syn::Type::Reference(r) => (true, (*r.elem).clone()),
-                other => (false, other.clone()),
-            };
+            let (by_ref, source) = peel_borrow(registry, &core_ty);
             let source_key = TypeKey::from_type(&source);
             let shape = if optional {
                 UnfoldShape::Optional((), Box::new(UnfoldShape::Base))
@@ -1462,7 +1541,7 @@ fn flatten<M>(
                 for fr in fields {
                     // A field's own `Option` makes everything under it nullable,
                     // exactly as an `Option`-returning accessor step does.
-                    let (opt, core) = match option_inner_type(&fr.ty) {
+                    let (opt, core) = match optional_inner(registry, &fr.ty) {
                         Some(inner) => (true, inner),
                         None => (false, fr.ty.clone()),
                     };
@@ -1573,14 +1652,14 @@ fn flatten<M>(
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
-                let (opt, core) = match option_inner_type(&ret) {
-                    Some(inner) => (true, inner),
-                    None => (false, ret.clone()),
-                };
-                let child_ty = match &core {
-                    syn::Type::Reference(r) => (*r.elem).clone(),
-                    other => other.clone(),
-                };
+                let ret_layers = peel(registry, &ret);
+                let opt = ret_layers.optional;
+                // `wrappers[1]` is what is left after the optional peel: the
+                // borrowed form when there is one, which is what the `by_value`
+                // flags below ask about.
+                let core = ret_layers.wrappers[1].clone();
+                let core_by_ref = peel_borrow(registry, &core).0;
+                let child_ty = ret_layers.core.clone();
                 let child_key = TypeKey::from_type(&child_ty);
                 // A child already on the nesting chain: for a `#[prebindgen]`
                 // accessor that is an authoring cycle (hard error); a
@@ -1601,11 +1680,7 @@ fn flatten<M>(
                     visited.insert(child_key.clone());
                     let child_records = child_decl.records.clone();
                     let mut child_path = path_prefix.to_vec();
-                    child_path.push(PathStep::call(
-                        func.clone(),
-                        opt,
-                        !matches!(core, syn::Type::Reference(_)),
-                    ));
+                    child_path.push(PathStep::call(func.clone(), opt, !core_by_ref));
                     flatten(
                         acc,
                         registry,
@@ -1635,7 +1710,7 @@ fn flatten<M>(
                     // one-identity-per-deconstructor budget with
                     // `.field_self()` — two handle deliveries of one value
                     // make no sense.
-                    let cond_handle = local && opt && matches!(core, syn::Type::Reference(_));
+                    let cond_handle = local && opt && core_by_ref;
                     if cond_handle {
                         if seen_identity {
                             return Err(UnfoldError::MultipleIdentity {
@@ -1650,11 +1725,7 @@ fn flatten<M>(
                         (ret, nullable, false)
                     };
                     let mut path = path_prefix.to_vec();
-                    path.push(PathStep::call(
-                        func.clone(),
-                        opt,
-                        !matches!(core, syn::Type::Reference(_)),
-                    ));
+                    path.push(PathStep::call(func.clone(), opt, !core_by_ref));
                     leaves.push(UnfoldLeaf {
                         name: seg_name(name).join("__"),
                         path,

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1834,3 +1834,46 @@ fn sum_callback_arg_is_a_fixed_builder_plan() {
     assert!(matches!(plan.shape, UnfoldShape::Base));
     assert_eq!(plan.leaves[0].source, LeafSource::SumTag);
 }
+
+/// A `Vec<Option<T>>` return does not match a `T` decomposition.
+///
+/// The boundary accepts `Option<Vec<T>>` — an optional list — and the layer stack
+/// stops at any layer out of that order. So the optional inside a `Vec` belongs
+/// to the **element**, the return's core is `Option<Payload>` rather than
+/// `Payload`, and no fixed fold is installed.
+///
+/// This is the pairing that matters: the explicit decomposition path a few
+/// hundred lines up refuses `Vec<Option<…>>` outright as unsupported, so a
+/// silently-installed nested fold here would mean the two paths disagree about
+/// the same return type. An unbounded layer peel makes exactly that happen —
+/// verified by sabotage, not assumed.
+#[test]
+fn a_vec_of_optionals_installs_no_fixed_fold() {
+    let mut reg: Registry<()> =
+        reg_with(&["fn storage_get_vec(s: &Storage) -> Vec<Option<Payload>> { todo!() }"]);
+    let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
+        name: name.to_string(),
+        path: vec![PathStep::field(ident(name), false)],
+        out_ty: ty,
+        identity: false,
+        nullable: false,
+        source: LeafSource::Field,
+        group: None,
+    };
+    let vd = ValueDecon {
+        key: TypeKey::from_type(&syn::parse_quote!(Payload)),
+        source: syn::parse_quote!(Payload),
+        leaves: vec![
+            leaf("id", syn::parse_quote!(i64)),
+            leaf("seq", syn::parse_quote!(i32)),
+        ],
+    };
+    let declared: std::collections::HashSet<syn::Ident> =
+        ["storage_get_vec"].iter().map(|s| ident(s)).collect();
+    apply_value_structs(&mut reg, vec![vd], &declared).expect("apply_value_structs");
+
+    assert!(
+        !reg.unfold_plans.contains_key(&ident("storage_get_vec")),
+        "a Vec<Option<Payload>> return must not fold as a Payload decomposition"
+    );
+}

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -309,6 +309,11 @@ pub mod core {
     /// [`flat::Element`]s that make up one flat namespace, and the model itself.
     /// Not to be confused with [`crate::lang`], the *destination* adapters.
     pub use crate::api::core::flat;
+    /// The layer algebra a boundary value is shaped by — a leaf under an ordered
+    /// stack of `Optional` / `Iterable` layers. Public because the model now
+    /// *produces* it ([`flat::TypeRef::layer_stack`]) and the plan engines and
+    /// adapters consume it, so it is part of what a generator has to speak.
+    pub use crate::api::core::shape;
     /// [`Flat`] and [`Element`] sit here too, next to [`Registry`]: they are what
     /// a build script names, and the rest of the model stays in [`mod@flat`]
     /// where an adapter reaches for it.


### PR DESCRIPTION
**Ledger 154 → 135.** `expand.rs` 4 → 0, `unfold.rs` 16 → 1.

Every one of those sites asked the same question by taking a spelling apart: `option_inner_type`, then `vec_inner_type`, then a `syn::Type::Reference` match, each rebuilding the peeled type as it went. That is `Optional(Sequence(Ref))` — which the model already names.

## `TypeRef::layers()`

Answers it once. **The order is fixed and each layer peels at most once** — `Optional`, then `Sequence`, then `Ref` — because that is the shape of a boundary: *an optional list of borrowed things*. Reading layers in whatever order they appear would call `Vec<Option<T>>` an optional list, which is a different type. A layer out of position stays on the core, where a caller that cares matches `kind` directly: `&[T]` reports `by_ref` with a `Sequence` core, because the borrow is outside the run.

`wrappers` carries the three spellings a fold **registers** — the whole type, the collection, the element — which is a different question from what finally crosses, and the one site that un-requires a leaf-delivered layer needs all three. `TypeRef::fallible_parts()` covers the `Result` sites.

## Not every site wanted the full peel, and a test proved it

`peel_borrow` is the model-driven `peel_ref`, kept separate **deliberately**: a site that peels only the borrow means it, because the layer underneath is what it is about to classify. `Vec<T>` answers `(false, Vec<T>)` there and `(iterable, T)` in `layers()`.

Using `layers()` at the callback-arg site turned *"this arg is a collection"* into *"this arg is a T"* — caught by `callback_arg_nonbare_skipped`, which is exactly the fixture for it. Worth flagging as the one real semantic hazard in this change.

## The blind spot the ledger cannot see

Also migrated the ident-name classifiers — the `seg.ident == "Option"` family. Nine call sites of `option_inner_type` / `vec_inner_type` / `result_err_type` in `unfold`, plus `result_ok_type` in `expand`, which had the model's reading in hand already (`f.ret` is a `TypeRef`).

Those are a **listed blind spot** of the boundary check, so leaving them would have let `api/core` keep classifying while the count claimed otherwise.

## What stays, and why

`peel_ref` stays, and so does its one ledger site: `jnigen` calls it three times, so it cannot be deleted until L4. **The plan said it had no adapter callers; that was wrong**, and the honest count for this stage is 1 rather than 0.

`api/core` is now **13**: `types_util` 10, `registry/scan` 2, `unfold` 1.

- The ten in `types_util` have between 13 and 40 adapter callers each and take no model, so only L3/L4 can free them.
- The two in `scan` inspect a key a build-script author wrote, to diagnose that spelling, and stay for good.

## Verification

- **Reported**: regen-check byte-identical on every committed artifact.
- **Explained**: nothing about what is generated moves — the classification is the same, taken from the model instead of re-derived.
- **Asserted**: no site in `unfold` or `expand` decides what a source type means.
- 527 tests, `--all-features` clean, clippy clean on both toolchains with `-D warnings`, rustdoc still at the 31 baseline.