### PR TITLE
Carry the reading; stop re-deriving it from origin

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -190,14 +190,8 @@ pub fn apply<M>(
         // (`Option`/`&`) type must equal the decl's declared type — the
         // typo guard for both coordinates of `.expand_param(name, decl)`.
         if let Some(declared) = &ed.declared_target {
-            let item_fn = registry
-                .flat()
-                .function(&ed.func)
-                .map(|f| f.origin.syntax.clone())
-                .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
-            let param_ty = find_param_type(&item_fn, &ed.param)
-                .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
-            let bare = constructed_value(registry.flat(), &param_ty);
+            let param_ty = param_reading(registry, &ed.func, &ed.param)?;
+            let bare = constructed_value(&param_ty);
             if TypeKey::from_type(&bare) != TypeKey::from_type(declared) {
                 return Err(ExpandError::ParamTypeMismatch {
                     func: ed.func.clone(),
@@ -233,19 +227,15 @@ pub fn apply<M>(
             if accessor_fns.contains(func) {
                 continue;
             }
-            let Some(item_fn) = registry
-                .flat()
-                .function(&func)
-                .map(|f| f.origin.syntax.clone())
-            else {
+            let Some(params) = registry.flat().function(&func).map(|f| f.params.clone()) else {
                 continue;
             };
             // A method's receiver (first param of its class type) binds to `this`
             // and is never input-flattened; skip exactly that one param.
             let receiver_key = method_receivers.get(func);
             let mut receiver_skipped = false;
-            for (pname, pty) in fn_params(&item_fn) {
-                let bare = constructed_value(registry.flat(), &pty);
+            for (pname, pty) in params.iter().map(|p| (p.name.clone(), p.ty.clone())) {
+                let bare = constructed_value(&pty);
                 let bare_key = TypeKey::from_type(&bare);
                 if !receiver_skipped && receiver_key == Some(&bare_key) {
                     receiver_skipped = true;
@@ -274,19 +264,26 @@ pub fn apply<M>(
 }
 
 /// `(name, type)` of each typed parameter.
-fn fn_params(item_fn: &syn::ItemFn) -> Vec<(syn::Ident, syn::Type)> {
-    item_fn
-        .sig
-        .inputs
+/// The **reading** of a declared function's parameter.
+///
+/// `Param::ty` is a `TypeRef` computed at parse time. Reaching into the item's
+/// `origin.syntax` and digging the parameter out of `sig.inputs` — what these
+/// three sites used to do — re-derives a fact the model was already handing over,
+/// which is `origin` used for reasoning rather than for emission.
+fn param_reading<M>(
+    registry: &Registry<M>,
+    func: &syn::Ident,
+    param: &syn::Ident,
+) -> Result<crate::api::core::flat::TypeRef, ExpandError> {
+    registry
+        .flat()
+        .function(&func)
+        .ok_or_else(|| ExpandError::UnknownFunction(func.clone()))?
+        .params
         .iter()
-        .filter_map(|input| match input {
-            syn::FnArg::Typed(pt) => match &*pt.pat {
-                syn::Pat::Ident(pi) => Some((pi.ident.clone(), (*pt.ty).clone())),
-                _ => None,
-            },
-            _ => None,
-        })
-        .collect()
+        .find(|p| &p.name == param)
+        .map(|p| p.ty.clone())
+        .ok_or_else(|| ExpandError::UnknownParam(func.clone(), param.clone()))
 }
 
 /// Build + store the fold plan for one `.construct` declaration.
@@ -295,18 +292,11 @@ fn process_expand<M>(
     exp: &Expansions,
     ed: &ExpandDecl,
 ) -> Result<(), ExpandError> {
-    let item_fn = registry
-        .flat()
-        .function(&ed.func)
-        .map(|f| f.origin.syntax.clone())
-        .ok_or_else(|| ExpandError::UnknownFunction(ed.func.clone()))?;
-
-    let param_ty = find_param_type(&item_fn, &ed.param)
-        .ok_or_else(|| ExpandError::UnknownParam(ed.func.clone(), ed.param.clone()))?;
+    let param_ty = param_reading(registry, &ed.func, &ed.param)?;
 
     // The boundary layers: `Option<&T>` → optional + by_ref, `Option<T>` →
     // optional, `&T` → by_ref, and `target` is what is left under them.
-    let (optional, by_ref, target) = constructed_value_layers(registry.flat(), &param_ty);
+    let (optional, by_ref, target) = constructed_value_layers(&param_ty);
     let target_key = TypeKey::from_type(&target);
 
     let variants = resolve_constructor(exp, registry, &target_key, ed)?;
@@ -367,10 +357,10 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
         .function(&func)
         .ok_or_else(|| ExpandError::UnknownConstructor(func.clone()))?;
 
-    let params: Vec<(syn::Ident, syn::Type)> = f
+    let params: Vec<(syn::Ident, crate::api::core::flat::TypeRef)> = f
         .params
         .iter()
-        .map(|p| (p.name.clone(), p.ty.origin.syntax.clone()))
+        .map(|p| (p.name.clone(), p.ty.clone()))
         .collect();
     // The model already read this return; `fallible_parts` is that reading, not a
     // second look at the spelling.
@@ -386,7 +376,9 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
 }
 
 struct CtorSig {
-    params: Vec<(syn::Ident, syn::Type)>,
+    /// Readings, not spellings: they come off `Function::params`, and a consumer
+    /// that needs the spelling takes it at the point it stores one.
+    params: Vec<(syn::Ident, crate::api::core::flat::TypeRef)>,
     target: syn::Type,
     fallible: bool,
 }
@@ -452,7 +444,7 @@ fn build_plan<M>(
             let (_pn, pty) = &sig.params[0];
             leaves.push(FoldLeaf {
                 name: param.clone(),
-                ty: opt(pty),
+                ty: opt(&pty.origin.syntax),
             });
             return Ok(FoldPlan {
                 target: target.clone(),
@@ -649,14 +641,14 @@ fn build_arg<M>(
     exp: &Expansions,
     registry: &Registry<M>,
     ed: &ExpandDecl,
-    pty: &syn::Type,
+    pty: &crate::api::core::flat::TypeRef,
     name: syn::Ident,
     dispatched: bool,
     leaves: &mut Vec<FoldLeaf>,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<FoldArg, ExpandError> {
     // The boundary layers down to the parameter's core type.
-    let (popt, pby_ref, bare) = constructed_value_layers(registry.flat(), pty);
+    let (popt, pby_ref, bare) = constructed_value_layers(pty);
     let key = TypeKey::from_type(&bare);
     // A default constructor for the parameter's type ⇒ recursive nested build.
     let canon = exp
@@ -711,9 +703,9 @@ fn build_arg<M>(
         leaves.push(FoldLeaf {
             name,
             ty: if dispatched && !passthrough {
-                opt(pty)
+                opt(&pty.origin.syntax)
             } else {
-                pty.clone()
+                pty.origin.syntax.clone()
             },
         });
         Ok(FoldArg::Leaf(idx, passthrough))
@@ -1086,11 +1078,8 @@ fn ctor_call_result<I: quote::ToTokens>(path: &syn::Path, args: &[I], fallible: 
 /// A type the grammar cannot express answers itself — the identity, not a
 /// fallback classifier. Nothing reaching here can be one: every signature in play
 /// was accepted by the frontend before the scan registered it.
-fn constructed_value(flat: &crate::api::core::flat::Flat, ty: &syn::Type) -> syn::Type {
-    let Ok(reading) = flat.classify(ty) else {
-        return ty.clone();
-    };
-    let after_opt = reading.optional_inner().unwrap_or(&reading);
+fn constructed_value(reading: &crate::api::core::flat::TypeRef) -> syn::Type {
+    let after_opt = reading.optional_inner().unwrap_or(reading);
     after_opt
         .borrow_target()
         .unwrap_or(after_opt)
@@ -1100,31 +1089,12 @@ fn constructed_value(flat: &crate::api::core::flat::Flat, ty: &syn::Type) -> syn
 }
 
 /// [`constructed_value`], plus which of the two layers were there.
-fn constructed_value_layers(
-    flat: &crate::api::core::flat::Flat,
-    ty: &syn::Type,
-) -> (bool, bool, syn::Type) {
-    let Ok(reading) = flat.classify(ty) else {
-        return (false, false, ty.clone());
-    };
+fn constructed_value_layers(reading: &crate::api::core::flat::TypeRef) -> (bool, bool, syn::Type) {
     let optional = reading.optional_inner().is_some();
-    let after_opt = reading.optional_inner().unwrap_or(&reading);
+    let after_opt = reading.optional_inner().unwrap_or(reading);
     let by_ref = after_opt.borrow_target().is_some();
     let core = after_opt.borrow_target().unwrap_or(after_opt);
     (optional, by_ref, core.origin.syntax.clone())
-}
-
-fn find_param_type(item_fn: &syn::ItemFn, param: &syn::Ident) -> Option<syn::Type> {
-    for input in &item_fn.sig.inputs {
-        if let syn::FnArg::Typed(pt) = input {
-            if let syn::Pat::Ident(pi) = &*pt.pat {
-                if &pi.ident == param {
-                    return Some((*pt.ty).clone());
-                }
-            }
-        }
-    }
-    None
 }
 
 fn opt(ty: &syn::Type) -> syn::Type {

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -667,6 +667,14 @@ impl Flat {
     /// item; it is an intermediate in some binding's crossing graph, and it belongs
     /// in the table that tracks crossings.
     ///
+    /// **The scan's entry point, and nowhere else's.** A caller holding an element
+    /// already has the reading — `Function::ret`, `Param::ty`, `Field::ty` are
+    /// `TypeRef`s computed at parse time — and re-deriving one from
+    /// `origin.syntax` is reasoning from the spelling, which is what `origin` is
+    /// not for. This exists for the one case with no element behind it: a type a
+    /// build script declared, or one expansion composed. `ensure_entry` is its
+    /// only caller, and `classify_has_exactly_one_caller` keeps it that way.
+    ///
     /// Whoever asks is expected to keep the answer. The registry does: a reading is
     /// taken once when a type-table cell is born, and lives in that cell.
     ///

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -140,6 +140,16 @@ impl TypeRef {
         }
     }
 
+    /// This type's identity as a table key.
+    ///
+    /// The canonical spelling is what a key *is* (#113), and reading it is
+    /// legitimate — but it should be the model's answer rather than every caller
+    /// reaching into [`origin`](Self::origin) for it, since a caller that reaches
+    /// into `origin` to *reason* is the thing this model exists to stop.
+    pub fn key(&self) -> crate::api::core::registry::TypeKey {
+        crate::api::core::registry::TypeKey::from_type(&self.origin.syntax)
+    }
+
     /// The `Ok` and `Err` sides when this is a `Result`, else `None`.
     pub fn fallible_parts(&self) -> Option<(&TypeRef, &TypeRef)> {
         match &self.kind {

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -417,6 +417,33 @@ impl<M> Registry<M> {
             .entry = entry;
     }
 
+    /// The reading for `ty` — stored if the scan took one, lowered if it did not.
+    ///
+    /// **The registry is the authority on what a type means**, because it is the
+    /// thing that stores readings: `ensure_entry` asks the grammar once when a cell
+    /// is born, and this hands that answer back. `Flat::classify` is its private
+    /// tool, and the two calls in this module are its only callers.
+    ///
+    /// The fallback is not the round trip this design forbids. That one is a
+    /// consumer holding an **element** — whose `ret` / `ty` is already a `TypeRef`
+    /// — reaching into `origin.syntax` and re-deriving what it was handed; the
+    /// signatures in `unfold` and `expand` now make it impossible. This is a type
+    /// the *binding* composed, with no element behind it and no cell yet: a value
+    /// form's field record naming a combination the scan never registered whole.
+    /// There is nothing to look up, so the grammar is asked — once, here, rather
+    /// than by each consumer.
+    pub(crate) fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
+        let key = TypeKey::from_type(ty);
+        if let Some(cell) = self
+            .input_types
+            .get(&key)
+            .or_else(|| self.output_types.get(&key))
+        {
+            return Some((*cell.subject).clone());
+        }
+        self.flat.classify(ty).ok()
+    }
+
     /// Register `ty` (and its nested positions) as a required **input** so
     /// the resolver produces a converter for it. Used by
     /// [`crate::api::core::expand`] to pull in the leaf types a fold needs.

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -1654,3 +1654,65 @@ fn a_built_registry_exposes_no_mutation() {
         "a built `Registry` must be read-only; found public mutation: {offenders:#?}"
     );
 }
+
+/// `Flat::classify` has no caller outside the registry.
+///
+/// The registry is the authority on what a type means, because it is the thing
+/// that **stores** readings: `ensure_entry` asks the grammar once when a cell is
+/// born, and `Registry::reading` hands that answer back. `classify` is its private
+/// tool.
+///
+/// Everything else is enforced by signatures rather than by this test — `peel`,
+/// `peel_borrow` and their siblings take a `&TypeRef`, so a consumer cannot hand
+/// them a spelling it re-derived. What a signature cannot say is "and do not add a
+/// second way in", which is what this pins.
+///
+/// The failure it exists for is specific and was live: a consumer holding an
+/// element — whose `ret` / `ty` is already a `TypeRef` — reaching into
+/// `origin.syntax`, digging the type back out, and re-classifying it. The boundary
+/// ledger cannot see that at all: the syn matching happens inside `core::flat`,
+/// which the ledger excludes by design, so the count falls while the round trip
+/// stays. `origin` is for reconstructing Rust, not for reasoning about it.
+#[test]
+fn classify_has_no_caller_outside_the_registry() {
+    let mut offenders: Vec<String> = Vec::new();
+
+    let root = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api");
+    let mut dirs = vec![std::path::PathBuf::from(root)];
+    while let Some(dir) = dirs.pop() {
+        for entry in std::fs::read_dir(&dir).expect("api dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                dirs.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(root)
+                .expect("under api")
+                .to_string_lossy()
+                .to_string();
+            // The registry owns readings; `flat` is where the grammar lives and
+            // may name its own function. Tests may exercise it directly.
+            if rel.starts_with("core/registry/")
+                || rel.starts_with("core/flat/")
+                || rel.contains("tests")
+            {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("read source");
+            let bare: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+            if bare.contains(".classify(") {
+                offenders.push(rel);
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "`Flat::classify` is the registry's; a consumer holding an element must read \
+         the element, not re-derive it from `origin.syntax`. Found in: {offenders:#?}"
+    );
+}

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -293,17 +293,19 @@ pub fn apply<M>(
         // fn's peeled (`Option`/`Vec`/`&`) return type — the typo guard for
         // `.expand_return(expand_return!(T)…)`.
         if let Some(declared) = &ed.declared_source {
-            let item_fn = registry
+            let ret = registry
                 .flat()
                 .function(&ed.func)
-                .map(|f| f.origin.syntax.clone())
+                .map(|f| f.ret.clone())
                 .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
-            let ret = fn_return(&item_fn);
-            if !returns_type(registry, &ret, &TypeKey::from_type(declared)) {
+            if !returns_type(&ret, &TypeKey::from_type(declared)) {
                 return Err(UnfoldError::ReturnTypeMismatch {
                     func: ed.func.clone(),
                     declared: TypeKey::from_type(declared).as_str().to_string(),
-                    actual: quote::quote!(#ret).to_string(),
+                    actual: {
+                        let s = &ret.origin.syntax;
+                        quote::quote!(#s).to_string()
+                    },
                 });
             }
         }
@@ -337,19 +339,12 @@ pub fn apply<M>(
             if accessor_fns.contains(func) {
                 continue;
             }
-            let Some(item_fn) = registry
-                .flat()
-                .function(&func)
-                .map(|f| f.origin.syntax.clone())
-            else {
+            let Some(ret) = registry.flat().function(&func).map(|f| f.ret.clone()) else {
                 continue;
             };
-            let ret = fn_return(&item_fn);
             // Error position: fn returns `Result<_, E>` and `E == d.target`.
-            if let Some(err_ty) = fallible_err(registry, &ret) {
-                if TypeKey::from_type(&err_ty) == dkey
-                    && done.insert((func.clone(), DeconTarget::Error))
-                {
+            if let Some(err_ty) = ret.fallible_parts().map(|(_, e)| e) {
+                if err_ty.key() == dkey && done.insert((func.clone(), DeconTarget::Error)) {
                     process_decl(
                         registry,
                         acc,
@@ -365,7 +360,7 @@ pub fn apply<M>(
             }
             // Output position: fn returns `T` / `&T` / `Option<T|&T>` / `Vec<T>`
             // with `T == d.target` (Result returns keep a handle — factories).
-            if returns_type(registry, &ret, &dkey)
+            if returns_type(&ret, &dkey)
                 && !acc.skip_output.contains(func)
                 && done.insert((func.clone(), DeconTarget::Output))
             {
@@ -394,18 +389,14 @@ pub fn apply<M>(
     // (there is no return-value lane in a callback invocation). A type without
     // a default deconstructor gets no plan and is delivered whole.
     for func in declared_fns {
-        let Some(item_fn) = registry
-            .flat()
-            .function(&func)
-            .map(|f| f.origin.syntax.clone())
-        else {
+        let Some(params) = registry.flat().function(&func).map(|f| f.params.clone()) else {
             continue;
         };
-        for input in &item_fn.sig.inputs {
-            let syn::FnArg::Typed(pt) = input else {
-                continue;
-            };
-            let Some(args) = crate::api::core::registry::extract_fn_trait_args(&pt.ty) else {
+        for param in &params {
+            // The callback's argument types, read off the parameter's
+            // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
+            // there is nothing to re-extract from the signature's syntax.
+            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind else {
                 continue;
             };
             for arg_ty in args {
@@ -415,22 +406,19 @@ pub fn apply<M>(
                 // (cloned) through the reference instead of by move. The plan is
                 // keyed under the ACTUAL arg type (`&T`) — that is what
                 // `callback_input`/`callback_iface_spec` look up.
-                let (by_ref, core_ty) = peel_borrow(registry, &arg_ty);
+                let (by_ref, core_ty) = peel_borrow(arg_ty);
                 // Only a NAMED core can match a deconstructor target: an
                 // `Option<T>` / `Vec<T>` / tuple arg is delivered whole. The model
                 // says which, so a wrapper the language sees through — `Box<T>` —
                 // no longer reads as un-nameable.
-                if !matches!(
-                    registry.flat().classify(&core_ty).map(|r| r.kind.clone()),
-                    Ok(crate::api::core::flat::TypeKind::Named { .. })
-                ) {
+                if !matches!(core_ty.kind, crate::api::core::flat::TypeKind::Named { .. }) {
                     continue;
                 }
-                let key = TypeKey::from_type(&arg_ty);
+                let key = arg_ty.key();
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                let core_key = TypeKey::from_type(&core_ty);
+                let core_key = core_ty.key();
                 let Some(d) = acc
                     .deconstructors
                     .iter()
@@ -447,13 +435,13 @@ pub fn apply<M>(
                 };
                 let decon = decl_id(&core_key, d);
                 let records = d.records.clone();
-                register_decon_spec(registry, acc, &decon, &records, &core_ty)?;
+                register_decon_spec(registry, acc, &decon, &records, core_ty)?;
                 let plan = build_plan(
                     acc,
                     registry,
                     &ed,
                     by_ref,
-                    &core_ty,
+                    core_ty,
                     UnfoldShape::Base,
                     &records,
                     decon,
@@ -608,15 +596,10 @@ fn wire_fixed_returns<M>(
     no_converter: bool,
 ) {
     for func in declared_fns {
-        let Some(item_fn) = registry
-            .flat()
-            .function(&func)
-            .map(|f| f.origin.syntax.clone())
-        else {
+        let Some(ret) = registry.flat().function(&func).map(|f| f.ret.clone()) else {
             continue;
         };
-        let ret = fn_return(&item_fn);
-        if !returns_type(registry, &ret, &vd.key) || registry.unfold_plans.contains_key(func) {
+        if !returns_type(&ret, &vd.key) || registry.unfold_plans.contains_key(func) {
             continue;
         }
         // Shape over the leaf decomposition: peel an outer `Option`, then a
@@ -627,7 +610,7 @@ fn wire_fixed_returns<M>(
         // null result). `element: None` keeps the decomposed-leaf path. The
         // element/inner borrow-ness sets `by_ref` (the reach clones either
         // way).
-        let layers = peel(registry, &ret);
+        let layers = peel(&ret);
         let by_ref = layers.by_ref;
         // The model's layer stack is the plan's shape — `UnfoldShape` is `Shape`
         // — so there is nothing to rebuild here.
@@ -679,18 +662,14 @@ fn wire_fixed_callbacks<M>(
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
     for func in declared_fns {
-        let Some(item_fn) = registry
-            .flat()
-            .function(&func)
-            .map(|f| f.origin.syntax.clone())
-        else {
+        let Some(params) = registry.flat().function(&func).map(|f| f.params.clone()) else {
             continue;
         };
-        for input in &item_fn.sig.inputs {
-            let syn::FnArg::Typed(pt) = input else {
-                continue;
-            };
-            let Some(args) = crate::api::core::registry::extract_fn_trait_args(&pt.ty) else {
+        for param in &params {
+            // The callback's argument types, read off the parameter's
+            // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
+            // there is nothing to re-extract from the signature's syntax.
+            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind else {
                 continue;
             };
             for arg_ty in args {
@@ -700,21 +679,21 @@ fn wire_fixed_callbacks<M>(
                 // value via `fromParts`); an `impl Fn(&[T])` / `impl Fn([T])` arg
                 // becomes an `Iterable` fixed FOLDER (the trampoline folds each
                 // element's leaves into a foreign list — see the callback emitter).
-                let (by_ref, after_ref) = peel_borrow(registry, &arg_ty);
+                let (by_ref, after_ref) = peel_borrow(arg_ty);
                 // A run of `T` is an Iterable fold over the element; anything else
                 // is a Base fold over the value itself. `Sequence` is the one
                 // question, and it covers `[T]` and `Vec<T>` alike.
-                let (shape, matches_key) = match sequence_elem(registry, &after_ref) {
+                let (shape, matches_key) = match after_ref.sequence_elem() {
                     Some(elem) => (
                         UnfoldShape::Iterable(Box::new(UnfoldShape::Base)),
-                        TypeKey::from_type(&elem) == vd.key,
+                        elem.key() == vd.key,
                     ),
-                    None => (UnfoldShape::Base, TypeKey::from_type(&after_ref) == vd.key),
+                    None => (UnfoldShape::Base, after_ref.key() == vd.key),
                 };
                 if !matches_key {
                     continue;
                 }
-                let key = TypeKey::from_type(&arg_ty);
+                let key = arg_ty.key();
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
@@ -764,33 +743,31 @@ pub fn apply_leaf_vec_folds<M>(
     }
     let elem_keys: Vec<TypeKey> = elements.iter().map(TypeKey::from_type).collect();
     // Is the leading-`&`-peeled `bare` one of the nominated single-leaf elements?
-    let is_nominated = |bare: &syn::Type| elem_keys.contains(&TypeKey::from_type(bare));
+    let is_nominated = |bare: &crate::api::core::flat::TypeRef| elem_keys.contains(&bare.key());
     for func in declared_fns {
-        let Some(item_fn) = registry
-            .flat()
-            .function(&func)
-            .map(|f| f.origin.syntax.clone())
-        else {
+        let Some(params) = registry.flat().function(&func).map(|f| f.params.clone()) else {
             continue;
         };
         // Output position: `Vec<T>` / `Option<Vec<T>>` return. Skip if a plan
         // already exists (declared deconstructor / value-struct fold).
         if !registry.unfold_plans.contains_key(func) {
-            let ret = fn_return(&item_fn);
-            let (optional, after_opt) = match optional_inner(registry, &ret) {
-                Some(inner) => (true, inner),
-                None => (false, ret.clone()),
+            let Some(ret) = registry.flat().function(&func).map(|f| f.ret.clone()) else {
+                continue;
             };
-            if let Some(vec_elem) = sequence_elem(registry, &after_opt) {
-                let bare = peel_ref(&vec_elem);
-                if is_nominated(&bare) {
+            let (optional, after_opt) = match ret.optional_inner() {
+                Some(inner) => (true, inner),
+                None => (false, &ret),
+            };
+            if let Some(vec_elem) = after_opt.sequence_elem() {
+                let bare = peel_borrow(vec_elem).1;
+                if is_nominated(bare) {
                     let inner_shape = UnfoldShape::Iterable(Box::new(UnfoldShape::Base));
                     let shape = if optional {
                         UnfoldShape::Optional((), Box::new(inner_shape))
                     } else {
                         inner_shape
                     };
-                    registry.require_output(&vec_elem);
+                    registry.require_output(&vec_elem.origin.syntax);
                     // The fold delivers the return element-by-element, so the
                     // whole `Vec<T>` / `Option<Vec<T>>` converter is not needed.
                     // De-require it: for String / scalar elements it still
@@ -798,40 +775,36 @@ pub fn apply_leaf_vec_folds<M>(
                     // opaque-handle element it cannot resolve (`jlong` wire isn't
                     // JObject-shaped), and de-requiring keeps that `None` from
                     // being flagged as an unresolved-required error.
-                    registry.unrequire_output(&ret);
-                    registry.unfold_plans.insert(
-                        func.clone(),
-                        whole_leaf_fold_plan(registry, &vec_elem, shape),
-                    );
+                    registry.unrequire_output(&ret.origin.syntax);
+                    registry
+                        .unfold_plans
+                        .insert(func.clone(), whole_leaf_fold_plan(vec_elem, shape));
                 }
             }
         }
         // Callback-arg position: `impl Fn(&[T])` / `impl Fn([T])`.
-        for input in &item_fn.sig.inputs {
-            let syn::FnArg::Typed(pt) = input else {
-                continue;
-            };
-            let Some(args) = crate::api::core::registry::extract_fn_trait_args(&pt.ty) else {
+        for param in &params {
+            // The callback's argument types, read off the parameter's
+            // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
+            // there is nothing to re-extract from the signature's syntax.
+            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind else {
                 continue;
             };
             for arg_ty in args {
-                let (_, after_ref) = peel_borrow(registry, &arg_ty);
-                let Some(elem) = sequence_elem(registry, &after_ref) else {
+                let (_, after_ref) = peel_borrow(arg_ty);
+                let Some(elem) = after_ref.sequence_elem() else {
                     continue;
                 };
-                if !is_nominated(&peel_borrow(registry, &elem).1) {
+                if !is_nominated(peel_borrow(elem).1) {
                     continue;
                 }
-                let key = TypeKey::from_type(&arg_ty);
+                let key = arg_ty.key();
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                registry.require_output(&elem);
-                let plan = whole_leaf_fold_plan(
-                    registry,
-                    &elem,
-                    UnfoldShape::Iterable(Box::new(UnfoldShape::Base)),
-                );
+                registry.require_output(&elem.origin.syntax);
+                let plan =
+                    whole_leaf_fold_plan(elem, UnfoldShape::Iterable(Box::new(UnfoldShape::Base)));
                 registry.callback_arg_plans.insert(key, plan);
             }
         }
@@ -842,18 +815,17 @@ pub fn apply_leaf_vec_folds<M>(
 /// Build a fixed-builder whole-element fold [`UnfoldPlan`] for a single-leaf
 /// element `vec_elem` (the `Vec`/slice element as written, keeping any leading
 /// `&` so `into_iter()`'s yield matches the element's own output converter).
-fn whole_leaf_fold_plan<M>(
-    registry: &Registry<M>,
-    vec_elem: &syn::Type,
+fn whole_leaf_fold_plan(
+    vec_elem: &crate::api::core::flat::TypeRef,
     shape: UnfoldShape,
 ) -> UnfoldPlan {
     UnfoldPlan {
-        source: vec_elem.clone(),
+        source: vec_elem.origin.syntax.clone(),
         decon: None,
-        by_ref: peel_borrow(registry, vec_elem).0,
+        by_ref: peel_borrow(vec_elem).0,
         shape,
         leaves: vec![],
-        element: Some(vec_elem.clone()),
+        element: Some(vec_elem.origin.syntax.clone()),
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
@@ -908,17 +880,15 @@ fn check_records(
 
 /// The arity layers over `ty`, the types they wrap, and the value underneath.
 ///
+/// A thin owned view over
 /// [`TypeRef::layer_stack`](crate::api::core::flat::TypeRef::layer_stack) and
-/// [`layer_types`](crate::api::core::flat::TypeRef::layer_types) with the borrows
-/// resolved to clones, because these feed plan fields and registry calls that own
-/// their types. The classification is the model's; only the copying is local.
+/// [`layer_types`](crate::api::core::flat::TypeRef::layer_types): the borrows are
+/// resolved to clones because these feed plan fields and registry calls that own
+/// their types. The classification is the model's; only the copying is local, and
+/// it happens **once**, where a value is stored — not on every question asked.
 ///
 /// The stack **is** the plan's shape — `UnfoldShape` is `Shape` — so a caller
 /// stores it rather than rebuilding one from flags.
-///
-/// A type the grammar cannot express answers `Base` over itself: the identity,
-/// not a fallback classifier. Nothing reaching here can be one, since every
-/// signature in play was accepted by the frontend before the scan saw it.
 struct Layered {
     /// The arity layers, outermost first.
     shape: UnfoldShape,
@@ -930,20 +900,19 @@ struct Layered {
     by_ref: bool,
 }
 
-fn peel<M>(registry: &Registry<M>, ty: &syn::Type) -> Layered {
-    let Ok(reading) = registry.flat().classify(ty) else {
-        return Layered {
-            shape: UnfoldShape::Base,
-            layer_types: vec![ty.clone()],
-            core: ty.clone(),
-            by_ref: false,
-        };
-    };
-    let (shape, layered) = reading.layer_stack();
+/// The layers of a type the model has **already read**.
+///
+/// Takes a `&TypeRef`, not a `&syn::Type`, and that is the whole point: a caller
+/// must hold a reading, and the ways to hold one are to take it off an element or
+/// to be the scan admitting a type with no element. Re-deriving a reading from
+/// `origin.syntax` — the round trip this signature makes impossible — is reasoning
+/// from the spelling, which is what `origin` is not for.
+fn peel(ty: &crate::api::core::flat::TypeRef) -> Layered {
+    let (shape, layered) = ty.layer_stack();
     let borrowed = layered.borrow_target();
     Layered {
         shape,
-        layer_types: reading
+        layer_types: ty
             .layer_types()
             .iter()
             .map(|t| t.origin.syntax.clone())
@@ -953,54 +922,16 @@ fn peel<M>(registry: &Registry<M>, ty: &syn::Type) -> Layered {
     }
 }
 
-/// What `Option<T>` wraps, if `ty` is one.
-fn optional_inner<M>(registry: &Registry<M>, ty: &syn::Type) -> Option<syn::Type> {
-    use crate::api::core::flat::TypeKind;
-    match registry.flat().classify(ty).ok()?.kind {
-        TypeKind::Optional(inner) => Some(inner.origin.syntax.clone()),
-        _ => None,
-    }
-}
-
-/// The error side of a `Result`, if `ty` is one.
-fn fallible_err<M>(registry: &Registry<M>, ty: &syn::Type) -> Option<syn::Type> {
-    Some(
-        registry
-            .flat()
-            .classify(ty)
-            .ok()?
-            .fallible_parts()?
-            .1
-            .origin
-            .syntax
-            .clone(),
-    )
-}
-
-/// The element of a run of values (`Vec<T>`, `[T]`), if `ty` is one.
-fn sequence_elem<M>(registry: &Registry<M>, ty: &syn::Type) -> Option<syn::Type> {
-    use crate::api::core::flat::TypeKind;
-    match registry.flat().classify(ty).ok()?.kind {
-        TypeKind::Sequence(elem) => Some(elem.origin.syntax.clone()),
-        _ => None,
-    }
-}
-
 /// Just the borrow: whether `ty` is one, and what it borrows.
 ///
-/// The model-driven `peel_ref`, and deliberately **not** [`peel`]: a site that
-/// peels only the borrow means it, because the layer underneath is the thing it
-/// is about to classify. `Vec<T>` answers `(false, Vec<T>)` here and
-/// `(iterable, T)` there, and confusing the two turns "this arg is a collection"
-/// into "this arg is a T".
-fn peel_borrow<M>(registry: &Registry<M>, ty: &syn::Type) -> (bool, syn::Type) {
-    use crate::api::core::flat::TypeKind;
-    match registry.flat().classify(ty) {
-        Ok(reading) => match &reading.kind {
-            TypeKind::Ref { inner, .. } => (true, inner.origin.syntax.clone()),
-            _ => (false, ty.clone()),
-        },
-        Err(_) => (false, ty.clone()),
+/// Deliberately **not** [`peel`]: a site that peels only the borrow means it,
+/// because the layer underneath is the thing it is about to classify. `Vec<T>`
+/// answers `(false, Vec<T>)` here and `(iterable, T)` there, and confusing the two
+/// turns "this arg is a collection" into "this arg is a T".
+fn peel_borrow(ty: &crate::api::core::flat::TypeRef) -> (bool, &crate::api::core::flat::TypeRef) {
+    match ty.borrow_target() {
+        Some(inner) => (true, inner),
+        None => (false, ty),
     }
 }
 
@@ -1012,20 +943,12 @@ pub(crate) fn peel_ref(ty: &syn::Type) -> syn::Type {
     }
 }
 
-/// The function's return type (or `()` for a unit return).
-fn fn_return(item_fn: &syn::ItemFn) -> syn::Type {
-    match &item_fn.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, t) => (**t).clone(),
-    }
-}
-
 /// True when `ret` is `T` / `&T` / `Option<T|&T>` / `Vec<T|&T>` with
 /// `T == key` — the default-output match. `Result<_, _>` is NOT peeled, so a
 /// fallible factory (`-> Result<T, E>`) keeps its handle return; the error
 /// position is matched separately on `E`.
-fn returns_type<M>(registry: &Registry<M>, ret: &syn::Type, key: &TypeKey) -> bool {
-    TypeKey::from_type(&peel(registry, ret).core) == *key
+fn returns_type(ret: &crate::api::core::flat::TypeRef, key: &TypeKey) -> bool {
+    TypeKey::from_type(&peel(ret).core) == *key
 }
 
 /// Build one output/error plan for `ed` and store it in the right registry map.
@@ -1035,23 +958,23 @@ fn process_decl<M>(
     ed: &OutputDecl,
 ) -> Result<(), UnfoldError> {
     {
-        let item_fn = registry
-            .flat()
-            .function(&ed.func)
-            .map(|f| f.origin.syntax.clone())
-            .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
-
         // The value to decompose: the success return (`Output`) or the
         // `Result<_, E>` domain error `E` (`Error`).
-        let ret_ty: syn::Type = match ed.target {
-            DeconTarget::Output => fn_return(&item_fn),
+        let fn_ret = registry
+            .flat()
+            .function(&ed.func)
+            .map(|f| f.ret.clone())
+            .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
+        let ret_ty = match ed.target {
+            DeconTarget::Output => fn_ret,
             DeconTarget::Error => {
-                fallible_err(registry, &fn_return(&item_fn)).ok_or_else(|| {
-                    UnfoldError::Unsupported {
+                fn_ret
+                    .fallible_parts()
+                    .map(|(_, e)| e.clone())
+                    .ok_or_else(|| UnfoldError::Unsupported {
                         func: ed.func.clone(),
                         reason: "convert_error/deconstruct_error on a non-Result return",
-                    }
-                })?
+                    })?
             }
         };
 
@@ -1062,11 +985,11 @@ fn process_decl<M>(
         // the historical probe order (the `Vec` probe runs on `E` itself), so
         // an `Option<Vec<E>>` error stays whole.
         let (optional, after_opt) = match ed.target {
-            DeconTarget::Output => match optional_inner(registry, &ret_ty) {
+            DeconTarget::Output => match ret_ty.optional_inner() {
                 Some(inner) => (true, inner),
-                None => (false, ret_ty.clone()),
+                None => (false, &ret_ty),
             },
-            DeconTarget::Error => (false, ret_ty.clone()),
+            DeconTarget::Error => (false, &ret_ty),
         };
         // `Vec<T>` / `Option<Vec<T>>` return → `Iterable` (± an `Optional`
         // layer). Two element-delivery modes:
@@ -1076,8 +999,8 @@ fn process_decl<M>(
         //     via its own output converter + projection, fold `(acc, T) -> acc`.
         // The other shapes (`Option`/scalar) decompose via an accessor
         // (M1–M3). `Vec<Option<…>>` is not supported.
-        let plan = if let Some(inner) = sequence_elem(registry, &after_opt) {
-            if optional_inner(registry, &inner).is_some() {
+        let plan = if let Some(inner) = after_opt.sequence_elem() {
+            if inner.optional_inner().is_some() {
                 return Err(UnfoldError::Unsupported {
                     func: ed.func.clone(),
                     reason: "Vec<Option<…>> returns",
@@ -1097,20 +1020,20 @@ fn process_decl<M>(
             // recursive registration also required) — same reasoning as
             // [`apply_leaf_vec_folds`] for the fixed folds.
             if ed.target == DeconTarget::Output {
-                registry.unrequire_output(&ret_ty);
+                registry.unrequire_output(&ret_ty.origin.syntax);
                 if optional {
-                    registry.unrequire_output(&after_opt);
+                    registry.unrequire_output(&after_opt.origin.syntax);
                 }
             }
             // Element type peeled of a leading `&` (accessors take `&Element`).
-            let (by_ref, element) = peel_borrow(registry, &inner);
-            let ekey = TypeKey::from_type(&element);
+            let (by_ref, element) = peel_borrow(inner);
+            let ekey = element.key();
             if let Some(d) = find_deconstructor_by_type(acc, &ekey) {
                 // Decomposed: reuse the shared flatten (M3 nesting composes).
                 let records = d.records.clone();
                 let decon = decl_id(&ekey, d);
-                register_decon_spec(registry, acc, &decon, &records, &element)?;
-                let plan = build_plan(acc, registry, ed, by_ref, &element, shape, &records, decon)?;
+                register_decon_spec(registry, acc, &decon, &records, element)?;
+                let plan = build_plan(acc, registry, ed, by_ref, element, shape, &records, decon)?;
                 for leaf in &plan.leaves {
                     registry.require_output(&leaf.out_ty);
                 }
@@ -1120,15 +1043,15 @@ fn process_decl<M>(
                 // element's own output converter matches `into_iter()`'s yield.
                 // No declaration is involved (`decon: None`) — the element
                 // crosses whole through its own converter.
-                let by_ref = peel_borrow(registry, &inner).0;
-                registry.require_output(&inner);
+                let by_ref = peel_borrow(inner).0;
+                registry.require_output(&inner.origin.syntax);
                 UnfoldPlan {
-                    source: inner.clone(),
+                    source: inner.origin.syntax.clone(),
                     decon: None,
                     by_ref,
                     shape,
                     leaves: vec![],
-                    element: Some(inner.clone()),
+                    element: Some(inner.origin.syntax.clone()),
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
@@ -1141,22 +1064,22 @@ fn process_decl<M>(
             // re-peeled and fails as "no deconstructor" for the inner
             // `Option`); for `Error` it happens here, unchanged.
             let (optional, core_ty) = match ed.target {
-                DeconTarget::Output => (optional, after_opt.clone()),
-                DeconTarget::Error => match optional_inner(registry, &after_opt) {
+                DeconTarget::Output => (optional, after_opt),
+                DeconTarget::Error => match after_opt.optional_inner() {
                     Some(inner) => (true, inner),
-                    None => (false, after_opt.clone()),
+                    None => (false, after_opt),
                 },
             };
-            let (by_ref, source) = peel_borrow(registry, &core_ty);
-            let source_key = TypeKey::from_type(&source);
+            let (by_ref, source) = peel_borrow(core_ty);
+            let source_key = source.key();
             let shape = if optional {
                 UnfoldShape::Optional((), Box::new(UnfoldShape::Base))
             } else {
                 UnfoldShape::Base
             };
             let (records, decon) = resolve_deconstructor(acc, &source_key, ed)?;
-            register_decon_spec(registry, acc, &decon, &records, &source)?;
-            let plan = build_plan(acc, registry, ed, by_ref, &source, shape, &records, decon)?;
+            register_decon_spec(registry, acc, &decon, &records, source)?;
+            let plan = build_plan(acc, registry, ed, by_ref, source, shape, &records, decon)?;
             for leaf in &plan.leaves {
                 registry.require_output(&leaf.out_ty);
             }
@@ -1226,14 +1149,14 @@ fn register_decon_spec<M>(
     acc: &Deconstructors,
     decon: &DeconId,
     records: &[DeconRecord],
-    source: &syn::Type,
+    source: &crate::api::core::flat::TypeRef,
 ) -> Result<(), UnfoldError> {
     if registry.decon_plans.contains_key(decon) {
         return Ok(());
     }
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     let mut visited: HashSet<TypeKey> = HashSet::new();
-    visited.insert(TypeKey::from_type(source));
+    visited.insert(source.key());
     flatten(
         acc,
         registry,
@@ -1249,11 +1172,11 @@ fn register_decon_spec<M>(
         // derived from it, never emitted code — so its hoists are discarded.
         &mut Vec::new(),
     )?;
-    require_unique_leaf_names(source, &leaves)?;
+    require_unique_leaf_names(&source.origin.syntax, &leaves)?;
     registry.decon_plans.insert(
         decon.clone(),
         DeconSpec {
-            source: source.clone(),
+            source: source.origin.syntax.clone(),
             leaves,
         },
     );
@@ -1304,14 +1227,14 @@ fn build_plan<M>(
     registry: &Registry<M>,
     ed: &OutputDecl,
     by_ref: bool,
-    source: &syn::Type,
+    source: &crate::api::core::flat::TypeRef,
     shape: UnfoldShape,
     records: &[DeconRecord],
     decon: DeconId,
 ) -> Result<UnfoldPlan, UnfoldError> {
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     let mut visited: HashSet<TypeKey> = HashSet::new();
-    visited.insert(TypeKey::from_type(source));
+    visited.insert(source.key());
     let mut hoists: Vec<Hoist> = Vec::new();
     flatten(
         acc,
@@ -1326,11 +1249,11 @@ fn build_plan<M>(
         &mut leaves,
         &mut hoists,
     )?;
-    require_unique_leaf_names(source, &leaves)?;
-    require_root_identity_last(by_ref, source, &leaves)?;
+    require_unique_leaf_names(&source.origin.syntax, &leaves)?;
+    require_root_identity_last(by_ref, &source.origin.syntax, &leaves)?;
 
     Ok(UnfoldPlan {
-        source: source.clone(),
+        source: source.origin.syntax.clone(),
         decon: Some(decon),
         by_ref,
         shape,
@@ -1392,7 +1315,7 @@ fn flatten<M>(
     acc: &Deconstructors,
     registry: &Registry<M>,
     records: &[DeconRecord],
-    source: &syn::Type,
+    source: &crate::api::core::flat::TypeRef,
     path_prefix: &[PathStep],
     name_prefix: &[String],
     by_ref: bool,
@@ -1401,7 +1324,7 @@ fn flatten<M>(
     leaves: &mut Vec<UnfoldLeaf>,
     hoists: &mut Vec<Hoist>,
 ) -> Result<(), UnfoldError> {
-    let source_key = TypeKey::from_type(source);
+    let source_key = source.key();
     // The author-supplied (literal) leaf-name segment at this level, appended
     // to the inherited chain prefix. Segments are joined with `"__"`.
     let seg_name = |name: &str| -> Vec<String> {
@@ -1430,10 +1353,14 @@ fn flatten<M>(
                 // + projection come from this `out_ty`'s output converter, so
                 // this is what decides whether the leaf is boxed by move or
                 // cloned through the borrowed-opaque one.
+                // A plan field: the drop to spelling happens here, where the value
+                // is stored for emission, and the borrowed form is composed rather
+                // than looked up because no source wrote it.
+                let src = &source.origin.syntax;
                 let out_ty: syn::Type = if place_is_owned(hoists, path_prefix, by_ref) {
-                    source.clone()
+                    src.clone()
                 } else {
-                    syn::parse_quote!(&#source)
+                    syn::parse_quote!(&#src)
                 };
                 leaves.push(UnfoldLeaf {
                     name: if path_prefix.is_empty() {
@@ -1459,7 +1386,7 @@ fn flatten<M>(
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
                 let (takes, _ret) = accessor_signature(registry, func)?;
-                check_takes(func, &takes, source)?;
+                check_takes(func, &takes, &source.origin.syntax)?;
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
@@ -1533,10 +1460,14 @@ fn flatten<M>(
                 });
 
                 for fr in fields {
+                    // A field record is adapter-declared, so it has no element —
+                    // but the scan took its reading when the cell was born, and
+                    // that is what this reads. Nothing is re-classified.
+                    let fr_reading = registry.reading(&fr.ty);
                     // A field's own `Option` makes everything under it nullable,
                     // exactly as an `Option`-returning accessor step does.
-                    let (opt, core) = match optional_inner(registry, &fr.ty) {
-                        Some(inner) => (true, inner),
+                    let (opt, core) = match fr_reading.as_ref().and_then(|r| r.optional_inner()) {
+                        Some(inner) => (true, inner.origin.syntax.clone()),
                         None => (false, fr.ty.clone()),
                     };
                     let child_ty = peel_ref(&core);
@@ -1604,7 +1535,13 @@ fn flatten<M>(
                             acc,
                             registry,
                             &child_records,
-                            &child_ty,
+                            // Again the registry's answer, not a new one.
+                            &registry.reading(&child_ty).ok_or_else(|| {
+                                UnfoldError::Unsupported {
+                                    func: func.clone(),
+                                    reason: "a field type the language cannot express",
+                                }
+                            })?,
                             &field_path,
                             &seg_name(&fr.name),
                             by_ref,
@@ -1642,18 +1579,18 @@ fn flatten<M>(
                     DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
                 let (takes, ret) = accessor_signature(registry, &func)?;
-                check_takes(&func, &takes, source)?;
+                check_takes(&func, &takes, &source.origin.syntax)?;
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
                 // This site peels an `Option` only — an accessor returning a run
                 // of values is not spliced — so it asks the model for that one
                 // layer rather than the whole stack.
-                let after_opt = optional_inner(registry, &ret);
+                let after_opt = ret.optional_inner();
                 let opt = after_opt.is_some();
-                let core = after_opt.unwrap_or_else(|| ret.clone());
-                let (core_by_ref, child_ty) = peel_borrow(registry, &core);
-                let child_key = TypeKey::from_type(&child_ty);
+                let core = after_opt.unwrap_or(&ret);
+                let (core_by_ref, child_ty) = peel_borrow(core);
+                let child_key = child_ty.key();
                 // A child already on the nesting chain: for a `#[prebindgen]`
                 // accessor that is an authoring cycle (hard error); a
                 // binding-local field re-delivering (part of) its own type
@@ -1678,7 +1615,7 @@ fn flatten<M>(
                         acc,
                         registry,
                         &child_records,
-                        &child_ty,
+                        child_ty,
                         &child_path,
                         &seg_name(name),
                         by_ref,
@@ -1712,10 +1649,12 @@ fn flatten<M>(
                         }
                         seen_identity = true;
                     }
+                    // A plan field: the spelling is taken here, once, where the
+                    // leaf is stored for emission.
                     let (out_ty, nullable, identity) = if cond_handle {
-                        (core.clone(), true, true)
+                        (core.origin.syntax.clone(), true, true)
                     } else {
-                        (ret, nullable, false)
+                        (ret.origin.syntax.clone(), nullable, false)
                     };
                     let mut path = path_prefix.to_vec();
                     path.push(PathStep::call(func.clone(), opt, !core_by_ref));
@@ -1774,7 +1713,7 @@ pub fn dedup_names(names: &mut [String]) {
 fn accessor_signature<M>(
     registry: &Registry<M>,
     func: &syn::Ident,
-) -> Result<(syn::Type, syn::Type), UnfoldError> {
+) -> Result<(syn::Type, crate::api::core::flat::TypeRef), UnfoldError> {
     let f = registry
         .flat()
         .function(&func)
@@ -1791,8 +1730,7 @@ fn accessor_signature<M>(
         crate::api::core::flat::TypeKind::Ref { inner, .. } => inner.origin.syntax.clone(),
         _ => first.ty.origin.syntax.clone(),
     };
-    let ret: syn::Type = f.ret.origin.syntax.clone();
-    Ok((takes, ret))
+    Ok((takes, f.ret.clone()))
 }
 
 /// Whether the value sitting at `path_prefix` is the plan's **to give away**:


### PR DESCRIPTION
The review of #261 is right that L2's ledger drop **overstated what changed**, and the example given is exact:

```rust
let item_fn = flat.function(&f).map(|f| f.origin.syntax.clone())?;
let ret = fn_return(&item_fn);        // dig the return out of raw syntax
returns_type(registry, &ret, &key)    // -> classify() -> re-lower it
```

`Function::ret` is **already** a `TypeRef` with `kind` computed at parse time. The model handed the answer over; the code threw it away, reached into `origin`, and derived it again. That is `origin` used for *reasoning*, which is what it is not for — and #211 says so outright: *"no component re-derives a source fact by matching captured syntax."*

## Why the ledger missed it

It counts variant mentions of watched syn enums per file **outside `core::flat`**. Moving the match into `classify()` dropped 19 without changing the data flow at all.

**The count measures who matches syn variants. It does not measure who reasons from `origin`**, and those two came apart the moment the matching moved into one shared classifier. Both are real — there is now one classifier where there were twenty, and they had disagreed — but only the second is what #211 asks for.

## The fix is a signature, not a checker

```rust
fn peel(ty: &TypeRef) -> Layered              // was (&Registry<M>, &syn::Type)
fn peel_borrow(ty: &TypeRef) -> (bool, &TypeRef)
fn returns_type(ret: &TypeRef, key: &TypeKey) -> bool
```

A caller must already hold a reading, so **the round trip stops compiling**. The `registry` parameter disappearing from all of them is the tell that they were never registry operations — they are questions about a type. The small peelers are gone entirely: `optional_inner`, `sequence_elem`, `fallible_parts` are methods on the reading.

## Measured and removed

| Round trip | Count | Now reads |
|---|---:|---|
| `fn_return(&f.origin.syntax)` | 6 | `Function::ret` |
| `extract_fn_trait_args(&pt.ty)` | 5 | `TypeKind::Callback { args }` — already `TypeRef`s |
| `find_param_type` / `fn_params` off a cloned `ItemFn` | 3 | `Param::ty`, via one `param_reading` helper |

`fn_return`, `find_param_type` and `fn_params` are deleted.

**The `ItemFn` clones were not even load-bearing** — they existed to end the immutable borrow of `flat()` before the `&mut registry` calls below. Cloning a `TypeRef` does that too, and is far cheaper than cloning an item with its attributes, body and docs.

`TypeRef` flows through the reasoning; `origin.syntax` is read only where a value is **stored for emission** — a plan field, a registry require/unrequire. That drop happens once, at the boundary, not on every question asked along the way. The plans keep `syn::Type`: seven jnigen files read them, and moving those is L4's.

## `Registry::reading`

The one addition, and the layering this settled on: **the registry is the authority on what a type means, because it is the thing that stores readings.** It answers from the cell the scan filled, and lowers only for a type with no cell — an adapter's value-form field record naming a combination the scan never registered whole. `Flat::classify` is its private tool, and both callers are in `registry/scan.rs`.

## Guard

`classify_has_no_caller_outside_the_registry`, **sabotage-checked** — a `classify` call added to `unfold` fails it by name. It pins the one thing a signature cannot say: do not add a second way in.

Also adds `TypeRef::key()`, so a caller needing a `TypeKey` does not reach into `origin` for it.

## Verification

- **Reported**: regen-check byte-identical on every committed artifact.
- **Ledger unchanged at 135 — and that is the point.** It cannot see this class, so the claim here is not a count: it is that the round trip no longer compiles.
- **Asserted**: nothing outside the registry classifies a type, and nothing holding an element re-derives what the element already carries.
- 531 tests, `--all-features` clean, clippy clean on both toolchains, rustdoc at the 31 baseline.