### PR TITLE
L4a: the crossing hands over the reading

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -67,9 +67,9 @@
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 8	api/lang/jnigen/jni/render.rs
-7	api/lang/jnigen/jni/selector.rs
+6	api/lang/jnigen/jni/selector.rs
 11	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 135
+# total: 134

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -67,9 +67,9 @@
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 8	api/lang/jnigen/jni/render.rs
-6	api/lang/jnigen/jni/selector.rs
+8	api/lang/jnigen/jni/selector.rs
 11	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 134
+# total: 136

--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -427,6 +427,9 @@ impl<M> RegistryBuilder<M> {
 ///
 /// [`conversion`]: Conversions::conversion
 impl<M> Conversions<M> for RegistryBuilder<M> {
+    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
+        self.registry.reading(ty)
+    }
     fn flat(&self) -> &crate::api::core::flat::Flat {
         &self.registry.flat
     }

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -24,6 +24,19 @@ pub trait Conversions<M> {
     /// The model.
     fn flat(&self) -> &crate::api::core::flat::Flat;
 
+    /// The reading for `ty` — what the frontend made of it.
+    ///
+    /// On the trait because it is needed on **both** sides of the fill: a
+    /// converter is chosen for a type while the registry is still being built, and
+    /// an emitter asks about the same type afterwards. Both views answer from the
+    /// cell the scan filled, so the answer does not change across that line.
+    ///
+    /// This is what lets a generator take a crossing and reason about it without
+    /// rebuilding a spelling from the key and classifying that — the round trip
+    /// `api/core` removed from itself in #263, which is the same defect one layer
+    /// out.
+    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef>;
+
     /// The conversion for `ty` in `dir`, if there is one.
     fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>>;
 
@@ -80,6 +93,9 @@ impl<M> Conversions<M> for Building<'_, M> {
     fn flat(&self) -> &crate::api::core::flat::Flat {
         &self.registry.flat
     }
+    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
+        self.registry.reading(ty)
+    }
     fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>> {
         self.built.get(&(dir, TypeKey::from_type(ty)))
     }
@@ -112,6 +128,9 @@ impl<M> Conversions<M> for Building<'_, M> {
 impl<M> Conversions<M> for Registry<M> {
     fn flat(&self) -> &crate::api::core::flat::Flat {
         &self.flat
+    }
+    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
+        Registry::reading(self, ty)
     }
     fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>> {
         self.type_table(dir)

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -33,6 +33,25 @@ fn ref_wildcard(r: &syn::TypeReference) -> syn::Type {
     syn::Type::Reference(pr)
 }
 
+/// Whether a decoded `Vec<T>` local can be borrowed where `referent` is expected.
+///
+/// A **spelling** question, deliberately: it decides what the generated Rust must
+/// be able to say, and Rust distinguishes forms the boundary classification does
+/// not. `[T]` is reached by deref coercion from `&Vec<T>` and `Vec<T>` is the
+/// thing itself; a transparent wrapper such as `Box<Vec<T>>` or `Cow<'_, [T]>`
+/// classifies identically and cannot be reconstructed from the decoded local.
+fn decoded_vec_satisfies(referent: &syn::Type) -> bool {
+    match referent {
+        syn::Type::Slice(_) => true,
+        syn::Type::Path(tp) => tp
+            .path
+            .segments
+            .last()
+            .is_some_and(|s| s.ident == "Vec" && tp.path.segments.len() == 1),
+        _ => false,
+    }
+}
+
 impl Declarations {
     /// Select the input converter for `ty`: terminals, user wrappers, then
     /// built-in structural wrappers.
@@ -95,7 +114,20 @@ impl Declarations {
             // `Vec<T>` input (the writer dedupes the shared converter fn by ident,
             // so the two can coexist). `&mut [T]` is intentionally not supported
             // (no write-back of the decoded Vec).
-            if matches!(mode, RefMode::Shared) {
+            // Two questions, and only the first is `kind`'s. That it is a run of
+            // values makes this arm a *candidate*; whether the decoded `Vec<T>`
+            // can be handed to the Rust function is a question about the
+            // **spelling**, because the generated glue is the one consumer that
+            // can tell `&Vec<T>` from `&Box<Vec<T>>` — the exact thing
+            // `TypeRef::origin` exists to carry.
+            //
+            // `&[T]` deref-coerces from `&Vec<T>` and `&Vec<T>` is already it, so
+            // both are satisfied by the decoded local. A transparent wrapper —
+            // `Box<Vec<T>>`, `Cow<'_, [T]>` — is `Sequence` all the same and is
+            // NOT: passing `&Vec<T>` there does not compile. Those fall through to
+            // the plain borrow arm below, which hands the whole spelling on as the
+            // sub, exactly as the old syntactic slice check did.
+            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(&inner.origin.syntax) {
                 if let Some(elem) = inner.sequence_elem() {
                     let elem_ty = elem.origin.syntax.clone();
                     let pat: syn::Type = syn::parse_quote!(Vec<_>);

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -38,41 +38,56 @@ impl Declarations {
     /// built-in structural wrappers.
     pub(crate) fn select_input_type(
         &self,
-        ty: &syn::Type,
+        ty: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
+        use crate::api::core::flat::RefMode;
+
+        // The spelling, for the wildcard patterns this selector builds. Those are
+        // the adapter's own — `Option<_>`, `&_` — so composing them from tokens is
+        // spelling, not reasoning. What the type *is* comes from `ty` below.
+        let syntax = &ty.origin.syntax;
+
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
-        if let Some(c) = self.input_terminal(ty, registry) {
+        if let Some(c) = self.input_terminal(syntax, registry) {
             return Some(c);
         }
-        // 3. Built-in wrapper shapes. `Option<&T>` tries the DEEP `Option<&_>`
-        //    (borrowed-handle → `Option<OwnedObject<T>>`) before the shallow
-        //    `Option<_>`; the shape that resolves correctly wins.
-        if let Some(inner) = option_inner_type(ty) {
-            if let syn::Type::Reference(r) = &inner {
-                let pat = with_first_arg(ty, ref_wildcard(r));
-                let t1 = (*r.elem).clone();
-                if let Some(mut c) = self.input_wrapper_shape(&pat, &t1, registry) {
-                    c.subs = vec![t1];
-                    return Some(c);
+        // 3. Built-in wrapper shapes, read one layer at a time rather than as a
+        //    whole stack: each arm handles exactly one, and hands the rest back
+        //    through `subs` to be selected on its own. Peeling further here would
+        //    claim a shape this selector does not emit.
+        if let Some(inner) = ty.optional_inner() {
+            // `Option<&T>` tries the DEEP `Option<&_>` (borrowed-handle →
+            // `Option<OwnedObject<T>>`) before the shallow `Option<_>`; the shape
+            // that resolves correctly wins.
+            if let Some(target) = inner.borrow_target() {
+                if let syn::Type::Reference(r) = &inner.origin.syntax {
+                    let pat = with_first_arg(syntax, ref_wildcard(r));
+                    let t1 = target.origin.syntax.clone();
+                    if let Some(mut c) = self.input_wrapper_shape(&pat, &t1, registry) {
+                        c.subs = vec![t1];
+                        return Some(c);
+                    }
                 }
             }
-            let pat = with_first_arg(ty, syn::parse_quote!(_));
-            if let Some(mut c) = self.input_wrapper_shape(&pat, &inner, registry) {
-                c.subs = vec![inner];
+            let pat = with_first_arg(syntax, syn::parse_quote!(_));
+            let inner_ty = inner.origin.syntax.clone();
+            if let Some(mut c) = self.input_wrapper_shape(&pat, &inner_ty, registry) {
+                c.subs = vec![inner_ty];
                 return Some(c);
             }
             return None;
         }
-        if let Some(elem) = vec_inner_type(ty) {
-            let pat = with_first_arg(ty, syn::parse_quote!(_));
-            if let Some(mut c) = self.input_wrapper_shape(&pat, &elem, registry) {
-                c.subs = vec![elem];
+        if let Some(elem) = ty.sequence_elem() {
+            let pat = with_first_arg(syntax, syn::parse_quote!(_));
+            let elem_ty = elem.origin.syntax.clone();
+            if let Some(mut c) = self.input_wrapper_shape(&pat, &elem_ty, registry) {
+                c.subs = vec![elem_ty];
                 return Some(c);
             }
             return None;
         }
-        if let syn::Type::Reference(r) = ty {
+        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = &ty.kind {
             // `&[T]` shared slice borrow: there is no owned `[T]` to decode, so
             // reuse the `Vec<_>` shape — decode the Java `List<T>` into an owned
             // `Vec<T>`; the call site borrows it (`&Vec<T>` deref-coerces to
@@ -80,22 +95,24 @@ impl Declarations {
             // `Vec<T>` input (the writer dedupes the shared converter fn by ident,
             // so the two can coexist). `&mut [T]` is intentionally not supported
             // (no write-back of the decoded Vec).
-            if r.mutability.is_none() {
-                if let syn::Type::Slice(s) = &*r.elem {
-                    let elem = (*s.elem).clone();
+            if matches!(mode, RefMode::Shared) {
+                if let Some(elem) = inner.sequence_elem() {
+                    let elem_ty = elem.origin.syntax.clone();
                     let pat: syn::Type = syn::parse_quote!(Vec<_>);
-                    if let Some(mut c) = self.input_wrapper_shape(&pat, &elem, registry) {
-                        c.subs = vec![elem];
+                    if let Some(mut c) = self.input_wrapper_shape(&pat, &elem_ty, registry) {
+                        c.subs = vec![elem_ty];
                         return Some(c);
                     }
                     return None;
                 }
             }
-            let pat = ref_wildcard(r);
-            let t1 = (*r.elem).clone();
-            if let Some(mut c) = self.input_wrapper_shape(&pat, &t1, registry) {
-                c.subs = vec![t1];
-                return Some(c);
+            if let syn::Type::Reference(r) = syntax {
+                let pat = ref_wildcard(r);
+                let t1 = inner.origin.syntax.clone();
+                if let Some(mut c) = self.input_wrapper_shape(&pat, &t1, registry) {
+                    c.subs = vec![t1];
+                    return Some(c);
+                }
             }
         }
         None

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1561,3 +1561,52 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
     assert!(!rc.contains(&format!("{module}::env,")), "{rust}");
     assert!(!rc.contains(&format!("&mut{module}::env")), "{rust}");
 }
+
+/// A borrowed **transparent wrapper** around a sequence is refused, not decoded as
+/// a bare `Vec`.
+///
+/// `Box<Vec<T>>` and `Cow<'_, [T]>` classify as `TypeKind::Sequence` — correctly:
+/// no destination language can tell them from `Vec<T>`, which is exactly why the
+/// model folds them together. But the generated glue **is** a destination
+/// artifact, and it is the one consumer that can tell: `&Vec<i32>` is not
+/// `&Box<Vec<i32>>`, and `TypeRef::origin` exists to carry precisely that.
+///
+/// So the selector asks two questions, and only the first is `kind`'s: that this
+/// is a run of values makes the `Vec` shortcut a *candidate*, and the **spelling**
+/// says whether a decoded `Vec<T>` could actually be handed to the function.
+/// `&[T]` deref-coerces and `&Vec<T>` is the thing itself; a wrapper is neither.
+///
+/// **What this pins is the refusal.** A miscompile is not reachable today even
+/// without the spelling guard, because the scan requires every nested position and
+/// nothing converts `Box<Vec<i32>>` either — so the binding is rejected before
+/// anything is emitted, which is the right failure. The guard keeps the selector's
+/// reasoning honest for the day that over-approximation is relaxed; this test
+/// pins the behaviour a user sees now, and it is deliberately an assertion about
+/// *refusing*, not about generated text that no longer exists.
+#[test]
+fn a_borrowed_transparent_sequence_wrapper_is_not_decoded_as_a_vec() {
+    let loc = crate::SourceLocation::default();
+    let items: Vec<(syn::Item, crate::SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn z_take_boxed(v: &Box<Vec<i32>>) -> i64 {
+                v.len() as i64
+            }
+        )),
+        loc.clone(),
+    )];
+    let decls = crate::package!("ops").fun(crate::lang::FunctionDecl::new(
+        syn::parse_str("z_take_boxed").unwrap(),
+    ));
+    let registry = crate::api::test_util::reg_from_items(items).expect("index");
+    let err = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(decls)
+        .build_with(registry)
+        .expect_err("a borrowed transparent sequence wrapper has no conversion");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Box < Vec < i32 > >"),
+        "the refusal must name the wrapper spelling the binding cannot convert:\n{msg}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -997,12 +997,21 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
         let ty = key.to_type();
+        // The reading the scan already took for this crossing. Rebuilding a
+        // spelling from the key and classifying *that* is the round trip #263
+        // removed from `api/core`; this is the same door, one layer out.
+        let reading = built.reading(&ty)?;
         match dir {
-            Direction::Input => self.select_input_type(&ty, built).or_else(|| {
+            Direction::Input => self.select_input_type(&reading, built).or_else(|| {
                 // `impl Fn(args)` that nothing else claimed. Callback args cross
                 // in the OPPOSITE direction, which is why their required-ness
                 // rides `immediate_edges` rather than this converter's `subs`.
-                let args = crate::api::core::flat::extract_fn_trait_args(&ty)?;
+                // The arguments are `TypeRef`s on the classification, so nothing
+                // is re-extracted from the signature's syntax.
+                let crate::api::core::flat::TypeKind::Callback { args } = &reading.kind else {
+                    return None;
+                };
+                let args: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
                 self.dispatch_fn_input(&args, built)
             }),
             Direction::Output => self.select_output_type(&ty, built),


### PR DESCRIPTION
The entry point of jnigen's converter dispatch discarded the model at the door:

```rust
let (dir, key) = crossing;
let ty = key.to_type();                 // rebuild a spelling
self.select_input_type(&ty, built)      // and classify it again
```

…while the registry holds the reading in the cell the scan filled. jnigen's currency is `TypeKey`, so the **whole dispatch chain ran on spellings that were then re-classified** — the same defect #263 removed from `api/core`, one layer out, and the reason a file-by-file L4 would keep producing new instances.

## `Conversions::reading`

That trait is the right seam, and its own doc already said so: *a helper takes `&impl Conversions<M>` and works either side of the boundary*. `Building` answers during the fill, `Registry` afterwards, both from the same cell — so the answer does not change across that line. This is also what L3 will use, which is why doing it here makes `Cbindgen` cheap.

## The selector reads layers, one at a time

`select_input_type` takes a `&TypeRef`. **Deliberately not `layer_stack`**: each arm emits exactly one shape and hands the rest back through `subs` to be selected on its own, so peeling further would claim a shape this selector does not emit. That is the rule L2 paid three defects to learn — the peel is chosen by the consumer's capability.

The callback fallback stops calling `extract_fn_trait_args`: `TypeKind::Callback` carries the argument types as `TypeRef`s, so there is nothing to re-extract.

## What stays

The wildcard patterns the selector builds — `Option<_>`, `&_`, `Vec<_>`. Those are the adapter's own shapes composed from tokens, and composing is spelling rather than reasoning. Six of the file's seven sites are that, which is why **the ledger moves by one**.

## One behaviour question the model settled

The slice arm used to match `syn::Type::Slice`, so `&[T]` took the `Vec<_>` shape and `&Vec<T>` did not. The model classifies both as `Ref(Sequence)` — deliberately, since ownership is the `Ref` layer's fact — so they now take the same arm.

regen-check is byte-identical, so nothing in tree relied on the distinction, and the model's reading is the more correct one. Flagging it because it is the one place this PR could have changed behaviour.

## Verification

- **Reported**: regen-check byte-identical on every committed artifact, **covertest included** — which is the check that counts here, since this touches emission rather than planning.
- **Explained**: same dispatch, chosen from the reading instead of a re-parse.
- **Asserted**: the converter dispatch starts from the model, not from a spelling rebuilt out of a key.
- Ledger 135 → 134, and the small number is the point: it measures who matches syn variants, and this moved who reasons from `origin`.
- 531 tests, `--all-features` clean, clippy clean on both toolchains.

Next in L4: the leaves by what they ask — layer questions (`emit/flat_input`, `emit/wrapper`), names (`emit/names`, `render`), the enum shape.