### PR TITLE
Take the reading from the declaration; `reading` becomes a lookup

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -46,7 +46,6 @@
 
 2	api/core/registry/scan.rs
 10	api/core/types_util.rs
-1	api/core/unfold.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
@@ -72,4 +71,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 136
+# total: 135

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -673,10 +673,14 @@ impl Flat {
     /// `origin.syntax` is reasoning from the spelling, which is what `origin` is
     /// not for. This exists for the one case with no element behind it: a type a
     /// build script declared, or one expansion composed. `ensure_entry` is its
-    /// only caller, and `classify_has_exactly_one_caller` keeps it that way.
+    /// only caller — the single call in the whole crate — and
+    /// `classify_has_no_caller_outside_the_registry` keeps it that way.
     ///
     /// Whoever asks is expected to keep the answer. The registry does: a reading is
-    /// taken once when a type-table cell is born, and lives in that cell.
+    /// taken once when a type-table cell is born, and lives in that cell — and
+    /// [`Registry::reading`](crate::api::core::registry::Registry::reading) hands
+    /// back only what is in one, so a second source of readings cannot reappear
+    /// here (#266).
     ///
     /// `Err` means the spelling is outside the accepted grammar — a real diagnosis
     /// about a type the *binding* built, not a cache miss.

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -417,31 +417,31 @@ impl<M> Registry<M> {
             .entry = entry;
     }
 
-    /// The reading for `ty` — stored if the scan took one, lowered if it did not.
+    /// The reading the scan stored for `ty` — **a lookup, and only a lookup**.
     ///
     /// **The registry is the authority on what a type means**, because it is the
     /// thing that stores readings: `ensure_entry` asks the grammar once when a cell
     /// is born, and this hands that answer back. `Flat::classify` is its private
-    /// tool, and the two calls in this module are its only callers.
+    /// tool, and `ensure_entry` is its only caller.
     ///
-    /// The fallback is not the round trip this design forbids. That one is a
-    /// consumer holding an **element** — whose `ret` / `ty` is already a `TypeRef`
-    /// — reaching into `origin.syntax` and re-deriving what it was handed; the
-    /// signatures in `unfold` and `expand` now make it impossible. This is a type
-    /// the *binding* composed, with no element behind it and no cell yet: a value
-    /// form's field record naming a combination the scan never registered whole.
-    /// There is nothing to look up, so the grammar is asked — once, here, rather
-    /// than by each consumer.
+    /// This used to classify on a miss, which meant there were two sources of
+    /// readings and no way to tell them apart. The fallback fired constantly, and
+    /// on **scalars** — `i64`, `String`, `bool` — which are certainly registered by
+    /// the time a binding is built. That was the tell: the misses were not unknown
+    /// types but an inverted order, [`unfold`](crate::api::core::unfold) asking
+    /// about the leaves its caller registers one loop later. Because `classify`
+    /// answered correctly, nothing downstream was wrong and nothing showed it
+    /// (#266). The declarations now carry their own readings, so there is no such
+    /// caller left.
+    ///
+    /// `None` therefore means the type never entered the pipeline — a caller
+    /// asking out of order, not a cache miss to paper over.
     pub(crate) fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
         let key = TypeKey::from_type(ty);
-        if let Some(cell) = self
-            .input_types
+        self.input_types
             .get(&key)
             .or_else(|| self.output_types.get(&key))
-        {
-            return Some((*cell.subject).clone());
-        }
-        self.flat.classify(ty).ok()
+            .map(|cell| (*cell.subject).clone())
     }
 
     /// Register `ty` (and its nested positions) as a required **input** so

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -797,6 +797,45 @@ fn a_source_type_cell_carries_the_models_typeref() {
     assert!(matches!(inner.subject.kind, TypeKind::Scalar(_)));
 }
 
+/// `Registry::reading` is a **lookup**. A type with no cell answers `None`, even
+/// when the grammar would classify it happily.
+///
+/// It used to fall back to `Flat::classify`, and the failure that hid is the one
+/// this pins: `i64` is not an exotic spelling, it is a scalar every binding
+/// registers. A miss on one could only mean the caller asked *before*
+/// registration — which is exactly what the value-form walk was doing, for every
+/// leaf its caller registered one loop later (#266). Because `classify` returned
+/// the right answer, the ordering bug produced correct output and no signal at
+/// all.
+///
+/// This cannot be caught by `classify_has_no_caller_outside_the_registry`: that
+/// scan excludes `core/registry/` by design, since the registry is where
+/// `classify` legitimately lives. The second door was inside the room.
+#[test]
+fn reading_is_a_lookup_not_a_classification() {
+    let items = vec![fn_item("fn f(x: u64) -> u64 { x }")];
+    let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("f").unwrap());
+    let reg = ext
+        .declare_into_any(reg)
+        .expect("declare")
+        .scanned()
+        .unwrap();
+
+    // Registered by the declared fn — the lookup hits.
+    assert!(
+        reg.reading(&syn::parse_quote!(u64)).is_some(),
+        "a type the scan registered has its reading in a cell"
+    );
+    // Never registered, and perfectly expressible. The grammar's answer is not
+    // this method's to give.
+    assert!(
+        reg.reading(&syn::parse_quote!(i64)).is_none(),
+        "`reading` answers from the type table; it must not classify on a miss"
+    );
+}
+
 /// A type only the binding authored is **classified but placeless**: it has a
 /// reading, because it is a type in this language, and no location, because no
 /// source wrote it. Declaring a type the source never mentions is the ordinary

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -105,8 +105,17 @@ pub struct FieldRecord {
     pub members: Vec<syn::Ident>,
     /// The leaf name (already `__`-joined across inlined nesting).
     pub name: String,
-    /// The field's type as written, `Option` / `Vec` layers included.
-    pub ty: syn::Type,
+    /// The field's **reading**, `Option` / `Vec` layers included — and its
+    /// syntax with it, which is what a leaf's `out_ty` spells.
+    ///
+    /// The declaration carries this rather than naming a `syn::Type` for the
+    /// walk to look up, because there was nothing to look up: a field record is
+    /// built from an element whose every field already has a reading, and the
+    /// types it names are the ones the caller registers *after* the walk
+    /// returns. Asking the registry here was asking before registration
+    /// (#266) — a lookup that could only miss, answered by a second source of
+    /// readings that hid the ordering.
+    pub ty: crate::api::core::flat::TypeRef,
     /// How this field decomposes.
     pub decon: FieldDecon,
 }
@@ -935,14 +944,6 @@ fn peel_borrow(ty: &crate::api::core::flat::TypeRef) -> (bool, &crate::api::core
     }
 }
 
-/// Strip a single leading `&` (one level) from a type.
-pub(crate) fn peel_ref(ty: &syn::Type) -> syn::Type {
-    match ty {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other.clone(),
-    }
-}
-
 /// True when `ret` is `T` / `&T` / `Option<T|&T>` / `Vec<T|&T>` with
 /// `T == key` — the default-output match. `Result<_, _>` is NOT peeled, so a
 /// fallible factory (`-> Result<T, E>`) keeps its handle return; the error
@@ -1460,18 +1461,17 @@ fn flatten<M>(
                 });
 
                 for fr in fields {
-                    // A field record is adapter-declared, so it has no element —
-                    // but the scan took its reading when the cell was born, and
-                    // that is what this reads. Nothing is re-classified.
-                    let fr_reading = registry.reading(&fr.ty);
+                    // The declaration carries the field's reading, so nothing is
+                    // looked up and nothing is re-classified.
+                    //
                     // A field's own `Option` makes everything under it nullable,
                     // exactly as an `Option`-returning accessor step does.
-                    let (opt, core) = match fr_reading.as_ref().and_then(|r| r.optional_inner()) {
-                        Some(inner) => (true, inner.origin.syntax.clone()),
-                        None => (false, fr.ty.clone()),
+                    let (opt, core) = match fr.ty.optional_inner() {
+                        Some(inner) => (true, inner),
+                        None => (false, &fr.ty),
                     };
-                    let child_ty = peel_ref(&core);
-                    let child_key = TypeKey::from_type(&child_ty);
+                    let child_ty = core.borrow_target().unwrap_or(core);
+                    let child_key = child_ty.key();
 
                     // Same three-way choice a `.field()` record makes: declared
                     // override, else the field type's own deconstructor, else
@@ -1535,13 +1535,8 @@ fn flatten<M>(
                             acc,
                             registry,
                             &child_records,
-                            // Again the registry's answer, not a new one.
-                            &registry.reading(&child_ty).ok_or_else(|| {
-                                UnfoldError::Unsupported {
-                                    func: func.clone(),
-                                    reason: "a field type the language cannot express",
-                                }
-                            })?,
+                            // The declaration's reading, peeled — not a new one.
+                            child_ty,
                             &field_path,
                             &seg_name(&fr.name),
                             by_ref,
@@ -1559,7 +1554,7 @@ fn flatten<M>(
                         leaves.push(UnfoldLeaf {
                             name: seg_name(&fr.name).join("__"),
                             path: field_path,
-                            out_ty: fr.ty.clone(),
+                            out_ty: fr.ty.origin.syntax.clone(),
                             identity: false,
                             nullable,
                             source: LeafSource::Field,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -958,6 +958,38 @@ impl Declarations {
                 format!("{name_prefix}__{name}")
             };
 
+            // An `Option` the READING sees but the SYNTAX still wraps — `Box<
+            // Option<T>>`. `Box<T>` *is* `T` in the model, deliberately, so the
+            // peel below reaches the `T` and records an optional access step.
+            // That step carries the field name and the optional flag and
+            // nothing else: the wrapper is dropped, and the emitter applies
+            // `Option`'s match to a value whose Rust type still spells `Box`,
+            // which does not compile (match ergonomics does not deref a `Box`).
+            //
+            // Rejected here, at the declaration, rather than emitted and
+            // discovered by rustc. This is a RESERVED shape, not a refused one
+            // — see #268, which owns teaching the path algebra to deref a
+            // transparent wrapper.
+            assert!(
+                field.ty.optional_inner().is_none()
+                    || option_inner_type(&field.ty.origin.syntax).is_some(),
+                "expand_return!({}).fields(fields!({})): field `{}.{dotted}` is `{}` — an \
+                 `Option` behind a transparent wrapper. The wrapper is invisible to the \
+                 model and load-bearing in the generated Rust, and the leaf access path \
+                 cannot yet say `deref, then match` (reserved — see \
+                 https://github.com/milyin/prebindgen/issues/268). Spell the field \
+                 `Option<{}>`, or override it with .field(\"{dotted}\", ...)",
+                key.as_str(),
+                decl.func,
+                st.name,
+                field.ty.origin.syntax.to_token_stream(),
+                field
+                    .ty
+                    .optional_inner()
+                    .map(|i| i.origin.syntax.to_token_stream().to_string())
+                    .unwrap_or_default(),
+            );
+
             // An explicit override replaces the field type's default
             // decomposition wholesale — including any nesting it would have had.
             if let Some((_, ovr)) = decl.overrides.iter().find(|(f, _)| *f == dotted) {

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -838,33 +838,31 @@ impl Declarations {
         decl: &FieldsDecl,
     ) -> Vec<crate::api::core::unfold::FieldRecord> {
         let func = &decl.func;
-        let item_fn = registry
-            .flat()
-            .function(&func)
-            .map(|func| &func.origin.syntax)
-            .unwrap_or_else(|| {
-                panic!(
-                    "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
+        let accessor = registry.flat().function(&func).unwrap_or_else(|| {
+            panic!(
+                "expand_return!({}).fields(fields!({func})): no `#[prebindgen]` function \
                  `{func}` — a value form is an accessor `fn {func}(v: &{}) -> {}Struct`",
-                    key.as_str(),
-                    key.as_str(),
-                    key.as_str(),
-                )
-            });
-        let ret: syn::Type = match &item_fn.sig.output {
-            syn::ReturnType::Type(_, t) => crate::api::core::unfold::peel_ref(t),
-            syn::ReturnType::Default => panic!(
-                "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
-                 value form returns the struct holding this type's fields",
-                key.as_str()
-            ),
-        };
-        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, &ret) else {
+                key.as_str(),
+                key.as_str(),
+                key.as_str(),
+            )
+        });
+        // The accessor's return as the model read it, peeled of a leading `&`.
+        // An elided return and a written `-> ()` are one thing here, because the
+        // model already normalized them.
+        let ret = accessor.ret.borrow_target().unwrap_or(&accessor.ret);
+        assert!(
+            !matches!(ret.kind, crate::api::core::flat::TypeKind::Unit),
+            "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
+             value form returns the struct holding this type's fields",
+            key.as_str(),
+        );
+        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, &ret.origin.syntax) else {
             panic!(
                 "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
                  not a struct — a value form returns a struct whose fields become the leaves",
                 key.as_str(),
-                ret.to_token_stream(),
+                ret.origin.syntax.to_token_stream(),
             )
         };
         let st = st.clone();
@@ -890,7 +888,7 @@ impl Declarations {
                 named.contains(field),
                 "fields!({func}).field(\"{field}\", ...): `{}` has no field `{field}` \
                  (fields: {})",
-                st.ident,
+                st.name,
                 named.iter().cloned().collect::<Vec<_>>().join(", "),
             );
         }
@@ -899,7 +897,7 @@ impl Declarations {
                 named.contains(field),
                 "fields!({func}).name(\"{field}\", ...): `{}` has no field `{field}` \
                  (fields: {})",
-                st.ident,
+                st.name,
                 named.iter().cloned().collect::<Vec<_>>().join(", "),
             );
         }
@@ -916,22 +914,13 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
         key: &TypeKey,
         decl: &FieldsDecl,
-        st: &syn::ItemStruct,
+        st: &crate::api::core::flat::Struct,
         members: &[syn::Ident],
         name_prefix: &str,
         depth: usize,
         out: &mut Vec<crate::api::core::unfold::FieldRecord>,
     ) {
         use crate::api::core::unfold::{FieldDecon, FieldRecord};
-        let syn::Fields::Named(named) = &st.fields else {
-            panic!(
-                "expand_return!({}).fields(fields!({})): `{}` has no named fields — a value \
-                 form is a plain struct whose fields become the leaves",
-                key.as_str(),
-                decl.func,
-                st.ident,
-            )
-        };
         // A value form holding itself would expand forever; the cycle rule for
         // everything reachable BELOW a field is core's `visited` check.
         assert!(
@@ -940,10 +929,13 @@ impl Declarations {
              deep — is a value form holding itself?",
             key.as_str(),
             decl.func,
-            st.ident,
+            st.name,
         );
-        for field in &named.named {
-            let Some(fname) = field.ident.as_ref() else {
+        // A tuple struct is an `Extern` rather than a `Struct`, so it never
+        // reaches here — `lower_value_form`'s "not a struct" diagnosis catches
+        // it at the return type, which is where the author wrote it.
+        for field in &st.fields {
+            let Some(fname) = field.name.as_ref() else {
                 continue;
             };
             let mut member_path = members.to_vec();
@@ -980,17 +972,16 @@ impl Declarations {
                 // Mirror that exact normalization here; peeling `Vec` would
                 // accept `expand_return!(T)` and only fail later when core
                 // applies its records to `Vec<T>`.
-                let peeled = option_inner_type(&field.ty)
-                    .map(|t| crate::api::core::unfold::peel_ref(&t))
-                    .unwrap_or_else(|| crate::api::core::unfold::peel_ref(&field.ty));
-                let actual = TypeKey::from_type(&peeled);
+                let under_opt = field.ty.optional_inner().unwrap_or(&field.ty);
+                let peeled = under_opt.borrow_target().unwrap_or(under_opt);
+                let actual = peeled.key();
                 assert!(
                     actual == ovr.key,
                     "fields!({}).field(\"{dotted}\", expand_return!({})): `{}.{dotted}` is \
                      `{}`, not `{}` — a per-field override names the field's own type",
                     decl.func,
                     ovr.key.as_str(),
-                    st.ident,
+                    st.name,
                     actual.as_str(),
                     ovr.key.as_str(),
                 );
@@ -1008,12 +999,12 @@ impl Declarations {
             // object (the rule `synth_value_struct_leaves` already follows).
             // A `sealed_class!` field has no whole-value converter at all, so it
             // must decompose into its selector and groups wherever it appears.
-            let bare = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
-            let probe = vec_inner_type(&bare).unwrap_or_else(|| bare.clone());
-            match self.type_kind(registry, &probe) {
+            let bare = field.ty.optional_inner().unwrap_or(&field.ty);
+            let probe = bare.sequence_elem().unwrap_or(bare);
+            match self.type_kind(registry, &probe.origin.syntax) {
                 TypeKind::DataStruct { st, cfg: Some(_) }
-                    if option_inner_type(&field.ty).is_none()
-                        && vec_inner_type(&field.ty).is_none() =>
+                    if field.ty.optional_inner().is_none()
+                        && field.ty.sequence_elem().is_none() =>
                 {
                     let child = st.clone();
                     self.walk_value_form(
@@ -1036,18 +1027,18 @@ impl Declarations {
                     // (the `fromParts` bridge's `PlanFieldKind::Sum` does — a
                     // data-class field can be `Option<sum>`).
                     assert!(
-                        vec_inner_type(&bare).is_none(),
+                        bare.sequence_elem().is_none(),
                         "expand_return!({}).fields(fields!({})): field `{}.{}` is a \
                          `Vec<{}>` — a sequence of tag-gated groups has variable arity and \
                          cannot be laid out in a fixed leaf list",
                         key.as_str(),
                         decl.func,
-                        st.ident,
+                        st.name,
                         dotted,
-                        probe.to_token_stream(),
+                        probe.origin.syntax.to_token_stream(),
                     );
                     assert!(
-                        option_inner_type(&field.ty).is_none(),
+                        field.ty.optional_inner().is_none(),
                         "expand_return!({}).fields(fields!({})): field `{}.{}` is an \
                          `Option<{}>` — an optional sum would need a present flag beside its \
                          tag, which an output leaf list cannot carry. Give the field a \
@@ -1055,17 +1046,21 @@ impl Declarations {
                          or override it with .field(\"{}\", ...)",
                         key.as_str(),
                         decl.func,
-                        st.ident,
+                        st.name,
                         dotted,
-                        probe.to_token_stream(),
+                        probe.origin.syntax.to_token_stream(),
                         dotted,
                     );
-                    let ident = bare_path_ident(&probe).expect("a sum type is a path type");
+                    // The name is the reading's, not a path taken apart to
+                    // re-derive one.
+                    let crate::api::core::flat::TypeKind::Named { id } = &probe.kind else {
+                        panic!("a sum type is a named type")
+                    };
                     let item_enum = registry
                         .flat()
-                        .enum_item(&ident)
+                        .enum_item(&id.name)
                         .expect("TypeKind::Sum implies an indexed enum");
-                    let sum_cfg = self.types[&TypeKey::from_type(&probe)]
+                    let sum_cfg = self.types[&probe.key()]
                         .sum()
                         .expect("TypeKind::Sum implies a sealed-class config");
                     out.push(FieldRecord {

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -25,8 +25,13 @@ pub(crate) enum TypeKind<'r, 'c> {
     Sum,
     /// A `#[prebindgen]` struct from the source crate that is none of the
     /// special kinds; flattens field-by-field when emitters support it.
+    ///
+    /// The **element**, not its `syn::ItemStruct`. A flattening emitter wants
+    /// each field's reading, and the model already decided one per field; going
+    /// through the syntax means asking some other authority for it again. An
+    /// emitter that only re-emits the struct reads `st.origin.syntax`.
     DataStruct {
-        st: &'r syn::ItemStruct,
+        st: &'r crate::api::core::flat::Struct,
         cfg: Option<&'c TypeConfig>,
     },
     /// Scalars, `String`, undeclared / non-path types.
@@ -59,16 +64,12 @@ impl Declarations {
                 DeclaredKind::Sealed(_) => return TypeKind::Sum,
                 // A data class is exactly a declared source struct — fall
                 // through to the registry probe below, which supplies the
-                // `syn::ItemStruct` its emitters flatten.
+                // element its emitters flatten.
                 DeclaredKind::Data => {}
             }
         }
         if let Some(name) = bare_path_ident(bare) {
-            if let Some(st) = registry
-                .flat()
-                .struct_type(&name)
-                .map(|st| &st.origin.syntax)
-            {
+            if let Some(st) = registry.flat().struct_type(&name) {
                 return TypeKind::DataStruct { st, cfg };
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -1287,7 +1287,7 @@ fn build_flat_struct_node(
                 let node = build_flat_struct_node(
                     ext,
                     registry,
-                    child,
+                    &child.origin.syntax,
                     child_optional,
                     &child_native,
                     &field_ref,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -127,7 +127,7 @@ pub(crate) fn synth_value_struct_leaves(
             // converter for it, failing the resolve with the sum named rather
             // than the unsupported position.
             TypeKind::Handle | TypeKind::Enum | TypeKind::Sum => return None,
-            TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
+            TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.origin.syntax.clone()),
             _ => None,
         };
         if let Some(child) = nested {

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -300,7 +300,7 @@ pub(crate) fn classify_field(
             let child_fqn = cfg
                 .and_then(|c| c.name_spec.as_ref())
                 .map(|s| ext.fqn_of(s));
-            let plan = build_struct_plan(ext, registry, &st.clone(), depth + 1)?;
+            let plan = build_struct_plan(ext, registry, &st.origin.syntax, depth + 1)?;
             return Some(PlanFieldKind::Nested {
                 optional: option_inner_type(&effective_ty).is_some(),
                 child_fqn,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -531,6 +531,109 @@ fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
     }
 }
 
+/// An `Option` the reading sees through a transparent wrapper is **reserved**,
+/// and says so by name.
+///
+/// `Box<T>` *is* `T` in the model, deliberately — so a field spelled
+/// `Box<Option<Child>>` peels to `Child` and records an optional access step
+/// that has no way to say "deref first". The emitter then matches `Option`'s
+/// patterns against a value still typed `Box<Option<Child>>`, which is `E0308`.
+///
+/// The shape used to be *accepted* and mis-emitted: nothing in this suite
+/// compiles the generated Rust, so `contains` assertions passed over it happily.
+/// Rejecting at the declaration is what makes it visible — see #268, which owns
+/// teaching the path algebra the wrapper.
+///
+/// The plain `Option<Child>` case is asserted alongside, because a guard that
+/// also rejected the ordinary spelling would be worse than no guard.
+#[test]
+fn an_option_behind_a_transparent_wrapper_is_reserved_by_name() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| {
+        let items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZSampleStruct {
+                        pub kex: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::ptr_class!(ZKeyExpr))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZKeyExpr).field(crate::fun!(z_keyexpr_as_str)))
+            .expand(crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)));
+        let dir = unique_test_dir("jnigen_vf_boxed_opt");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = jni
+            .build_with(registry)
+            .map(|g| g.write_rust(dir.join("g.rs")));
+    };
+
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build(syn::parse_quote!(Box<Option<ZKeyExpr>>))
+    }))
+    .expect_err("an Option behind a transparent wrapper must be rejected");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("transparent wrapper"),
+        "the message names the shape: {msg}"
+    );
+    assert!(
+        msg.contains("ZSampleStruct.kex"),
+        "the message names the offending field: {msg}"
+    );
+    // Reserved, not refused: the diagnosis says where the work is tracked.
+    assert!(
+        msg.contains("issues/268"),
+        "a reserved shape names its issue: {msg}"
+    );
+
+    // The ordinary spelling is untouched.
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build(syn::parse_quote!(Option<ZKeyExpr>))
+    }))
+    .expect("a plain `Option<T>` field is the supported shape");
+}
+
 /// Naming a field the value form does not have is the very drift this
 /// declarator exists to catch, so it is an error rather than a silent no-op.
 #[test]


### PR DESCRIPTION
Closes #266.

## What was wrong

`Registry::reading` fell back to `Flat::classify` on a table miss. Instrumenting it showed the fallback firing constantly — `i64` ×48, `String` ×25, `bool` ×16, `Option<ZStamp>` ×16 across the test suite.

Scalars reaching a lookup miss is the tell. `i64` is certainly registered by the time a binding is built, so these were never unknown types — they were an **inverted order**. `flatten` asked `registry.reading(&fr.ty)` for exactly the leaf types its caller registers one loop later:

```rust
let plan = build_plan(..)?;              // <- the walk asks here
for leaf in &plan.leaves {
    registry.require_output(&leaf.out_ty);   // <- registration happens HERE
}
```

Because `classify` returned the *right* answer, the output was correct and nothing showed it. That is the actual defect: an ordering bug papered over by a second source of readings, with the registry no longer the single authority on what a type means.

## What this does instead

Not "register earlier". A `FieldRecord` is adapter-declared, and it is built from an element whose every field **already has a reading** — there was never anything to look up. `FieldRecord::ty` becomes a `TypeRef`, the walk reads it, and the reason the fallback existed goes with it.

That means the value-form walk needs per-field readings, so `TypeKind::DataStruct` carries `&flat::Struct` rather than its `syn::ItemStruct` — the one leak #229's L4 list names by hand:

> `classify.rs` — … Its one leak is `DataStruct { st: &syn::ItemStruct }`, where `flat::Struct` exists

The probes follow: `optional_inner` / `sequence_elem` / `borrow_target` off `kind` instead of re-matching syntax. That retires `unfold::peel_ref` and takes `api/core/unfold.rs` off the boundary ledger entirely (136 → 135). Four sites that only ever wanted the syntax now say `st.origin.syntax`.

`api/core/unfold.rs` now calls `reading` **zero** times. The sole consumer left is `convert_crossing`, whose key comes from `Registry::crossings()` and so always hits a cell.

## Acceptance

- [x] The fallback is deleted; `reading` is a lookup.
- [x] `Flat::classify` keeps exactly one caller, `ensure_entry`.
- [x] Regen byte-identical.

## Verification

- 605 lib tests; `cargo test` and `cargo test --all --all-features` both green (14/14 binaries).
- `examples/regen-check.sh` byte-identical **after a forced rebuild** (`cargo clean -p` the four example crates first — a cached build passes this vacuously).
- `covertest-kotlin ./gradlew run` — 48/48 sections on the JVM.
- The issue's own probe is silent: a clean `cargo build --workspace` prints **0** `PROBE_READING_MISS`, and the test suite prints exactly 1 — the new test deliberately asking for an unregistered `i64`.
- clippy `--all-targets --no-default-features --all-features -- --deny warnings`, and fmt with the CLI-only config.

## Notes for review

- **The new test earns its place.** `classify_has_no_caller_outside_the_registry` cannot catch this: it excludes `core/registry/` by design, because that is where `classify` legitimately lives. The second door was inside the room, so `reading_is_a_lookup_not_a_classification` pins the behaviour directly.
- **Doc comments were the other half.** `Registry::reading`, `Flat::classify` and `flatten` all carried prose *arguing for* the fallback; leaving that would have been worse than leaving the code. `Flat::classify` also named a stale test (`classify_has_exactly_one_caller`), now corrected.
- **Two deliberate widenings**, both toward the model and both regen-neutral: `optional_inner()` sees through `Box<Option<T>>` where the syn matcher did not, and a value form written `-> ()` now gets the clearer "returns nothing" diagnosis instead of "not a struct".
- **The ledger delta is not the measure here** (136 → 135). Most of this change lives in the ledger's own declared blind spot — helper delegation through `classify.rs`, which has zero watched sites. #229 makes exactly this point about #264.
- **`zenoh-flat-jni` could not be regen-checked**: that checkout's `build.rs` predates the current API (`JniGen::new`, `Registry::builder()` arity) and fails to compile identically on unmodified `language-integration`. Pre-existing drift, unrelated to this change.
