### PR TITLE
Don't assume how Rust spells an optional

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -836,7 +836,8 @@ pub(crate) unsafe fn HoldPolicy_to_JObject_d2a5bcc4<'a>(
         let ___grace_present: jni::sys::jboolean;
         let ___grace__tag: jni::sys::jint;
         let ___grace_g0: jni::sys::jlong;
-        match &v.grace {
+        let __oc0: &::core::option::Option<_> = &v.grace;
+        match __oc0 {
             ::core::option::Option::Some(__o0) => {
                 ___grace_present = 1u8;
                 match __o0 {
@@ -7444,7 +7445,8 @@ pub(crate) unsafe fn Observation_to_JObject_435b0724<'a>(
         let ___fallback_g3: jni::objects::JObject;
         let ___fallback_g4: jni::sys::jint;
         let ___fallback_g5: jni::sys::jlong;
-        match &v.fallback {
+        let __oc0: &::core::option::Option<_> = &v.fallback;
+        match __oc0 {
             ::core::option::Option::Some(__o0) => {
                 ___fallback_present = 1u8;
                 match __o0 {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -418,8 +418,9 @@ pub(crate) unsafe fn Annotated_to_JObject_b543f0d9<'a>(
         let ___alternate_o2: jni::sys::jdouble;
         let ___alternate_o3: jni::sys::jboolean;
         let ___alternate_o4: jni::objects::JObject;
-        match &v.alternate {
-            Some(__c0) => {
+        let __on0: &::core::option::Option<_> = &v.alternate;
+        match __on0 {
+            ::core::option::Option::Some(__c0) => {
                 let ___alternate_id: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
                     env,
                     __c0.id.clone(),
@@ -448,7 +449,7 @@ pub(crate) unsafe fn Annotated_to_JObject_b543f0d9<'a>(
                 ___alternate_o3 = ___alternate_flag;
                 ___alternate_o4 = ___alternate_label;
             }
-            None => {
+            ::core::option::Option::None => {
                 ___alternate_present = 0u8;
                 ___alternate_o0 = 0i64;
                 ___alternate_o1 = 0i32;

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -958,38 +958,6 @@ impl Declarations {
                 format!("{name_prefix}__{name}")
             };
 
-            // An `Option` the READING sees but the SYNTAX still wraps — `Box<
-            // Option<T>>`. `Box<T>` *is* `T` in the model, deliberately, so the
-            // peel below reaches the `T` and records an optional access step.
-            // That step carries the field name and the optional flag and
-            // nothing else: the wrapper is dropped, and the emitter applies
-            // `Option`'s match to a value whose Rust type still spells `Box`,
-            // which does not compile (match ergonomics does not deref a `Box`).
-            //
-            // Rejected here, at the declaration, rather than emitted and
-            // discovered by rustc. This is a RESERVED shape, not a refused one
-            // — see #268, which owns teaching the path algebra to deref a
-            // transparent wrapper.
-            assert!(
-                field.ty.optional_inner().is_none()
-                    || option_inner_type(&field.ty.origin.syntax).is_some(),
-                "expand_return!({}).fields(fields!({})): field `{}.{dotted}` is `{}` — an \
-                 `Option` behind a transparent wrapper. The wrapper is invisible to the \
-                 model and load-bearing in the generated Rust, and the leaf access path \
-                 cannot yet say `deref, then match` (reserved — see \
-                 https://github.com/milyin/prebindgen/issues/268). Spell the field \
-                 `Option<{}>`, or override it with .field(\"{dotted}\", ...)",
-                key.as_str(),
-                decl.func,
-                st.name,
-                field.ty.origin.syntax.to_token_stream(),
-                field
-                    .ty
-                    .optional_inner()
-                    .map(|i| i.origin.syntax.to_token_stream().to_string())
-                    .unwrap_or_default(),
-            );
-
             // An explicit override replaces the field type's default
             // decomposition wholesale — including any nesting it would have had.
             if let Some((_, ovr)) = decl.overrides.iter().find(|(f, _)| *f == dotted) {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -722,6 +722,33 @@ pub(crate) fn bind_hoists(
     out
 }
 
+/// Bind `e` so it can be destructured as an `Option` **whatever Rust
+/// representation the source used for it**.
+///
+/// `kind` says a position is optional; it deliberately does not say whether
+/// Rust spells that `Option<T>`, `Box<Option<T>>`, or something else — the flat
+/// model states the destination-language invariant, and the side interpreting
+/// it is the side that must accept any representation. Matching the reached
+/// place directly assumed one, which is `classify off kind, spell off syntax`
+/// broken in the direction nothing was watching: the classification was right
+/// and the *spelling* came from it too. `Box<Option<T>>` then produced
+/// `match &place { Some(..) => .. }` and `E0308` (#268).
+///
+/// A type-ascribed `let` is a coercion site, and deref coercion is transitive
+/// **and** a no-op when the types already match — so this one shape serves
+/// every representation, and the plain `Option<T>` case is unchanged in
+/// behaviour. The payload stays `_`: what it is, is the source's business.
+///
+/// `e` is expected to be a **reference** already — [`compose_step`] composes a
+/// field read as `&(e).f` — so nothing is borrowed here. Borrowing only: an
+/// owned position cannot be made representation-agnostic this way, because
+/// deref coercion applies to references and moving out of a wrapper is
+/// something only some of them permit (`Box` does, `Rc` cannot). A site that
+/// must MOVE the payload keeps its direct match; see `owned_place` below.
+pub(crate) fn bind_as_option(e: &TokenStream, bind: &syn::Ident) -> TokenStream {
+    quote! { let #bind: &::core::option::Option<_> = #e; }
+}
+
 /// Reach a leaf's input by folding its `path` over `base`, then hand the
 /// reached expression to `body` (which renders the encode and yields
 /// `JObject`). Every optional nesting step becomes a `match`: its `None` arm
@@ -765,10 +792,33 @@ fn reach_leaf(
                 depth + 1,
                 body,
             );
-            quote! {
-                match #opt_e {
-                    ::core::option::Option::Some(#nested) => { #inner }
-                    ::core::option::Option::None => jni::objects::JObject::null(),
+            // A FIELD read composes to a borrow (`&(e).f`), so it goes through
+            // a coercion site and the destructuring stops caring which
+            // representation the source spelled the optional as.
+            //
+            // A CALL composes to the accessor's own returned value, which is
+            // owned and whose payload downstream may move. Borrowing it to
+            // coerce would change that ownership, so it keeps its direct match
+            // — and an owned position could not be made representation-agnostic
+            // this way regardless (see [`bind_as_option`]).
+            if path[k].is_field() {
+                let opt_bind = format_ident!("__o{}", depth);
+                let coerce = bind_as_option(&opt_e, &opt_bind);
+                quote! {
+                    {
+                        #coerce
+                        match #opt_bind {
+                            ::core::option::Option::Some(#nested) => { #inner }
+                            ::core::option::Option::None => jni::objects::JObject::null(),
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    match #opt_e {
+                        ::core::option::Option::Some(#nested) => { #inner }
+                        ::core::option::Option::None => jni::objects::JObject::null(),
+                    }
                 }
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
@@ -87,33 +87,54 @@ mod destructure_ledger {
     //! of them permit (`Box` can, `Rc` cannot), so a site that must MOVE keeps
     //! its direct match and is correct only for representations that allow it.
     //!
+    //! ## Coverage
+    //!
+    //! The table is checked against the **directory listing**, not kept by
+    //! hand. A hand-listed census had already let `convert.rs` sit outside the
+    //! guard entirely with two uncounted destructures, and would have let any
+    //! new emitter module do the same — "a new destructure cannot be added
+    //! silently" is only true if a new *file* cannot be either.
+    //!
     //! To change it deliberately: update the table below in the same commit,
     //! and say in review which category the new site is.
 
     use proc_macro2::{Delimiter, TokenStream, TokenTree};
 
-    /// `(file, destructuring-pattern count)`.
+    /// `(file, destructuring-pattern count)` — **every** `.rs` in this
+    /// directory, checked against the directory listing so a new emitter module
+    /// cannot sit outside the census.
     const LEDGER: &[(&str, usize)] = &[
+        ("callback.rs", 0),
+        // The `Option<T>` output converters' niche and boxed-primitive arms.
+        // They destructure `v`, the converter's own parameter — whose Rust type
+        // is the crossing's SPELLING. Correct today only because a wrapped
+        // spelling gets no converter at all (#270); if that is fixed and
+        // `Box<Option<T>>` becomes a crossing, these two need coercing.
+        ("convert.rs", 2),
         // 2 fn-return matches (owned), 2 leaf reaches (one coerced, one owned
         // accessor return), 1 owned identity move, 1 emitter-bound local.
         ("delivery.rs", 6),
+        ("flat_input.rs", 0),
+        // This file. The spellings in `the_census_is_spelling_independent` are
+        // string literals, which tokenize as one `Literal` and are never walked.
+        ("mod.rs", 0),
+        ("names.rs", 0),
         // Both coerced: the `Option<sum>` present-flag split, and the nested
         // plan's present-flag split.
         ("struct_out.rs", 2),
-        // Constructions only.
-        ("flat_input.rs", 0),
+        ("sum_out.rs", 0),
+        ("vec_build.rs", 0),
         ("wrapper.rs", 0),
     ];
 
-    /// Count `Some ( … ) =>` patterns inside `quote!` bodies.
+    /// Count `Some ( … ) =>` patterns inside `quote!` / `parse_quote!` bodies.
     ///
     /// `in_quote` is what keeps the emitter's own `if let Some(..)` out of the
-    /// count: only tokens below a `quote!` are emitted Rust.
+    /// count: only tokens below one of those macros are emitted Rust.
     fn count(ts: TokenStream, in_quote: bool, n: &mut usize) {
         let toks: Vec<TokenTree> = ts.into_iter().collect();
         let mut i = 0;
         while i < toks.len() {
-            // `quote! { … }` / `quote!( … )` — descend, now emitting.
             if let TokenTree::Ident(id) = &toks[i] {
                 let bang =
                     matches!(toks.get(i + 1), Some(TokenTree::Punct(p)) if p.as_char() == '!');
@@ -150,10 +171,36 @@ mod destructure_ledger {
 
     #[test]
     fn option_destructuring_sites_are_accounted_for() {
-        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api/lang/jnigen/jni/emit");
+        let dir = std::path::Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/api/lang/jnigen/jni/emit"
+        ));
+
+        // The census is over the DIRECTORY, not a hand-kept list: a new emitter
+        // module that hand-listing would have let slip past the guard entirely
+        // shows up here as an unlisted file.
+        let mut on_disk: Vec<String> = std::fs::read_dir(dir)
+            .expect("emit dir")
+            .map(|e| e.expect("dir entry").path())
+            .filter(|p| p.extension().is_some_and(|x| x == "rs"))
+            .map(|p| {
+                p.file_name()
+                    .expect("file name")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        on_disk.sort();
+        let mut listed: Vec<String> = LEDGER.iter().map(|(f, _)| (*f).to_string()).collect();
+        listed.sort();
+        assert_eq!(
+            listed, on_disk,
+            "the destructure census must cover every emitter file — add the new              module to LEDGER with its count (see this module's docs for what              counts)"
+        );
+
         let mut drift: Vec<String> = Vec::new();
         for (file, expected) in LEDGER {
-            let src = std::fs::read_to_string(std::path::Path::new(dir).join(file))
+            let src = std::fs::read_to_string(dir.join(file))
                 .unwrap_or_else(|e| panic!("read {file}: {e}"));
             let ts: TokenStream = src
                 .parse()

--- a/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
@@ -49,12 +49,27 @@ mod destructure_ledger {
     //! coercion site, deref coercion is transitive and a no-op when the types
     //! already match, so one shape serves every representation.
     //!
-    //! ## What this counts, and what it cannot
+    //! ## Why this walks tokens
     //!
-    //! Only **patterns** — `Option::Some(..) =>` — never constructions. Building
-    //! an `Option` the emitter itself owns says nothing about the source's
-    //! representation and is always safe, which is why `flat_input.rs` and
-    //! `wrapper.rs` sit at zero here despite emitting `Option::Some` freely.
+    //! The first version of this check matched the text `option::Option::Some(`
+    //! and was wrong in the way that matters: `struct_out.rs` emitted a second
+    //! destructure spelled bare `Some(#cbind) =>`, and the census could not see
+    //! it. That site was a real unfixed instance of the very bug — an
+    //! unqualified match on a source place — so the guard's blind spot was
+    //! exactly the bug's hiding place. A guard that can be evaded by choosing a
+    //! different spelling of the same pattern is not a guard.
+    //!
+    //! So the scan parses each file's tokens, descends only into `quote!`
+    //! bodies — which is what "emitted Rust" means, and keeps the emitter's own
+    //! `if let Some(x)` out of the count — and recognizes a `Some ( … ) =>`
+    //! pattern whatever path prefix it carries.
+    //!
+    //! ## What it counts, and what it cannot
+    //!
+    //! Only **patterns**, never constructions. Building an `Option` the emitter
+    //! itself owns says nothing about the source's representation and is always
+    //! safe, which is why `flat_input.rs` and `wrapper.rs` sit at zero despite
+    //! emitting `Option::Some` freely.
     //!
     //! It cannot tell a *coerced* destructure from a raw one, so a count that
     //! does not move is not proof of correctness. Its job is to make a NEW
@@ -75,17 +90,63 @@ mod destructure_ledger {
     //! To change it deliberately: update the table below in the same commit,
     //! and say in review which category the new site is.
 
+    use proc_macro2::{Delimiter, TokenStream, TokenTree};
+
     /// `(file, destructuring-pattern count)`.
     const LEDGER: &[(&str, usize)] = &[
         // 2 fn-return matches (owned), 2 leaf reaches (one coerced, one owned
         // accessor return), 1 owned identity move, 1 emitter-bound local.
         ("delivery.rs", 6),
-        // The `Option<sum>` present-flag split — coerced.
-        ("struct_out.rs", 1),
+        // Both coerced: the `Option<sum>` present-flag split, and the nested
+        // plan's present-flag split.
+        ("struct_out.rs", 2),
         // Constructions only.
         ("flat_input.rs", 0),
         ("wrapper.rs", 0),
     ];
+
+    /// Count `Some ( … ) =>` patterns inside `quote!` bodies.
+    ///
+    /// `in_quote` is what keeps the emitter's own `if let Some(..)` out of the
+    /// count: only tokens below a `quote!` are emitted Rust.
+    fn count(ts: TokenStream, in_quote: bool, n: &mut usize) {
+        let toks: Vec<TokenTree> = ts.into_iter().collect();
+        let mut i = 0;
+        while i < toks.len() {
+            // `quote! { … }` / `quote!( … )` — descend, now emitting.
+            if let TokenTree::Ident(id) = &toks[i] {
+                let bang =
+                    matches!(toks.get(i + 1), Some(TokenTree::Punct(p)) if p.as_char() == '!');
+                if (id == "quote" || id == "parse_quote") && bang {
+                    if let Some(TokenTree::Group(g)) = toks.get(i + 2) {
+                        count(g.stream(), true, n);
+                        i += 3;
+                        continue;
+                    }
+                }
+                // A `Some( … ) =>` arm. The path in front is not inspected, so
+                // `Some`, `Option::Some` and `::core::option::Option::Some` all
+                // land here — the spelling is what the first version of this
+                // check wrongly keyed on.
+                if in_quote && id == "Some" {
+                    let parens = matches!(
+                        toks.get(i + 1),
+                        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Parenthesis
+                    );
+                    // `=>` is two Puncts: '=' joint, then '>'.
+                    let fat_arrow = matches!(toks.get(i + 2), Some(TokenTree::Punct(p)) if p.as_char() == '=')
+                        && matches!(toks.get(i + 3), Some(TokenTree::Punct(p)) if p.as_char() == '>');
+                    if parens && fat_arrow {
+                        *n += 1;
+                    }
+                }
+            }
+            if let TokenTree::Group(g) = &toks[i] {
+                count(g.stream(), in_quote, n);
+            }
+            i += 1;
+        }
+    }
 
     #[test]
     fn option_destructuring_sites_are_accounted_for() {
@@ -94,18 +155,11 @@ mod destructure_ledger {
         for (file, expected) in LEDGER {
             let src = std::fs::read_to_string(std::path::Path::new(dir).join(file))
                 .unwrap_or_else(|e| panic!("read {file}: {e}"));
-            // A pattern arm is `Option::Some(<binding>) =>`; a construction has
-            // no `=>` after its closing paren. Whitespace is stripped so line
-            // wrapping cannot hide a site.
-            let bare: String = src.chars().filter(|c| !c.is_whitespace()).collect();
-            let found = bare
-                .match_indices("option::Option::Some(")
-                .filter(|(i, _)| {
-                    bare[*i..]
-                        .find(')')
-                        .is_some_and(|j| bare[*i + j..].starts_with(")=>"))
-                })
-                .count();
+            let ts: TokenStream = src
+                .parse()
+                .unwrap_or_else(|e| panic!("tokenize {file}: {e}"));
+            let mut found = 0usize;
+            count(ts, false, &mut found);
             if found != *expected {
                 drift.push(format!("  {file}: {expected} -> {found}"));
             }
@@ -120,5 +174,38 @@ mod destructure_ledger {
              table and say which in review.",
             drift.join("\n"),
         );
+    }
+
+    /// The guard catches a destructure **however it is spelled** — the failure
+    /// the first version had, and the reason this one walks tokens.
+    ///
+    /// A ledger that has never been seen to fail is not evidence of anything,
+    /// so this proves it on both spellings rather than asserting it in prose.
+    #[test]
+    fn the_census_is_spelling_independent() {
+        let one = |body: &str| {
+            let src = format!("fn f() {{ quote! {{ match x {{ {body} }} }}; }}");
+            let mut n = 0usize;
+            count(src.parse().expect("tokenize"), false, &mut n);
+            n
+        };
+        for spelling in [
+            "Some(v) => {}",
+            "Option::Some(v) => {}",
+            "::core::option::Option::Some(v) => {}",
+        ] {
+            assert_eq!(one(spelling), 1, "not counted: {spelling}");
+        }
+        // A construction is not a destructure, and the emitter's own control
+        // flow is not emitted Rust.
+        let mut n = 0usize;
+        count(
+            "fn f() { if let Some(x) = y { quote! { Some(#x) }; } }"
+                .parse()
+                .expect("tokenize"),
+            false,
+            &mut n,
+        );
+        assert_eq!(n, 0, "constructions and host-code matches must not count");
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
@@ -28,3 +28,97 @@ pub(crate) use struct_out::*;
 pub(crate) use sum_out::*;
 pub(crate) use vec_build::*;
 pub(crate) use wrapper::*;
+
+#[cfg(test)]
+mod destructure_ledger {
+    //! A committed census of every place this adapter **destructures an
+    //! `Option` in emitted Rust**.
+    //!
+    //! `kind` says a position is optional. It deliberately does not say whether
+    //! Rust spells that `Option<T>`, `Box<Option<T>>`, `Cow<'_, Option<T>>` or
+    //! anything else — the flat model states the destination-language
+    //! invariant, and the side reading it is the side that must accept any
+    //! representation. So an emitter may classify off `kind`, but it must not
+    //! *spell* off it, and matching a reached place against `Option`'s patterns
+    //! does exactly that.
+    //!
+    //! That is how #268 happened: `match &place { Some(..) => .. }` is `E0308`
+    //! the moment the source spells the field `Box<Option<T>>`, and no test
+    //! could see it because this suite asserts on generated text and never
+    //! compiles it. The fix is [`bind_as_option`] — a type-ascribed `let` is a
+    //! coercion site, deref coercion is transitive and a no-op when the types
+    //! already match, so one shape serves every representation.
+    //!
+    //! ## What this counts, and what it cannot
+    //!
+    //! Only **patterns** — `Option::Some(..) =>` — never constructions. Building
+    //! an `Option` the emitter itself owns says nothing about the source's
+    //! representation and is always safe, which is why `flat_input.rs` and
+    //! `wrapper.rs` sit at zero here despite emitting `Option::Some` freely.
+    //!
+    //! It cannot tell a *coerced* destructure from a raw one, so a count that
+    //! does not move is not proof of correctness. Its job is to make a NEW
+    //! destructure impossible to add silently: the number moves, and review has
+    //! to say which of the three it is —
+    //!
+    //!   * destructuring a coerced binding (fine — that is the fix),
+    //!   * destructuring a value the emitter itself bound (fine — the emitter
+    //!     owns its type),
+    //!   * destructuring a place read from the source (**the bug**; route it
+    //!     through [`bind_as_option`]).
+    //!
+    //! Owned positions are the standing exception: deref coercion applies to
+    //! references, and moving a payload out of a wrapper is something only some
+    //! of them permit (`Box` can, `Rc` cannot), so a site that must MOVE keeps
+    //! its direct match and is correct only for representations that allow it.
+    //!
+    //! To change it deliberately: update the table below in the same commit,
+    //! and say in review which category the new site is.
+
+    /// `(file, destructuring-pattern count)`.
+    const LEDGER: &[(&str, usize)] = &[
+        // 2 fn-return matches (owned), 2 leaf reaches (one coerced, one owned
+        // accessor return), 1 owned identity move, 1 emitter-bound local.
+        ("delivery.rs", 6),
+        // The `Option<sum>` present-flag split — coerced.
+        ("struct_out.rs", 1),
+        // Constructions only.
+        ("flat_input.rs", 0),
+        ("wrapper.rs", 0),
+    ];
+
+    #[test]
+    fn option_destructuring_sites_are_accounted_for() {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api/lang/jnigen/jni/emit");
+        let mut drift: Vec<String> = Vec::new();
+        for (file, expected) in LEDGER {
+            let src = std::fs::read_to_string(std::path::Path::new(dir).join(file))
+                .unwrap_or_else(|e| panic!("read {file}: {e}"));
+            // A pattern arm is `Option::Some(<binding>) =>`; a construction has
+            // no `=>` after its closing paren. Whitespace is stripped so line
+            // wrapping cannot hide a site.
+            let bare: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+            let found = bare
+                .match_indices("option::Option::Some(")
+                .filter(|(i, _)| {
+                    bare[*i..]
+                        .find(')')
+                        .is_some_and(|j| bare[*i + j..].starts_with(")=>"))
+                })
+                .count();
+            if found != *expected {
+                drift.push(format!("  {file}: {expected} -> {found}"));
+            }
+        }
+        assert!(
+            drift.is_empty(),
+            "OPTION-DESTRUCTURING LEDGER DRIFT:\n{}\n\n\
+             An emitter must not assume how Rust spells an optional — see this \
+             module's docs. If the new site destructures a place read from the \
+             source, route it through `bind_as_option`; if it is a coerced \
+             binding, an emitter-owned value, or an owned move, update the \
+             table and say which in review.",
+            drift.join("\n"),
+        );
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -485,10 +485,16 @@ fn encode_field(
                     let sbind = format_ident!("__o{}", depth);
                     let inner_arms: Vec<TokenStream> =
                         arm_code.iter().map(|a| quote! { #a }).collect();
+                    // Destructured through a coercion site: `kind` says this
+                    // field is optional, and how Rust spells that is the
+                    // source's business (#268).
+                    let obind = format_ident!("__oc{}", depth);
+                    let coerce = bind_as_option(&quote!(&#value), &obind);
                     preludes.extend(quote! {
                         let #flag_id: jni::sys::jboolean;
                         #decls
-                        match &#value {
+                        #coerce
+                        match #obind {
                             ::core::option::Option::Some(#sbind) => {
                                 #flag_id = 1u8;
                                 match #sbind { #(#inner_arms)* }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -334,16 +334,22 @@ fn encode_field(
                         child_slots.iter().map(|sl| sl.ident.clone()).collect();
                     let defaults: Vec<TokenStream> =
                         child_slots.iter().map(|sl| sl.default.clone()).collect();
+                    // Destructured through a coercion site: `kind` says this
+                    // field is optional, and how Rust spells that is the
+                    // source's business (#268).
+                    let obind = format_ident!("__on{}", depth);
+                    let coerce = bind_as_option(&quote!(&#value), &obind);
                     preludes.extend(quote! {
                         let #flag_id: jni::sys::jboolean;
                         #( let #outer_ids: #outer_tys; )*
-                        match &#value {
-                            Some(#cbind) => {
+                        #coerce
+                        match #obind {
+                            ::core::option::Option::Some(#cbind) => {
                                 #child_pre
                                 #flag_id = 1u8;
                                 #( #outer_ids = #inner_ids; )*
                             }
-                            None => {
+                            ::core::option::Option::None => {
                                 #flag_id = 0u8;
                                 #( #outer_ids = #defaults; )*
                             }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -531,25 +531,29 @@ fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
     }
 }
 
-/// An `Option` the reading sees through a transparent wrapper is **reserved**,
-/// and says so by name.
+/// A field's optional-ness is read off `kind`; **how Rust spells it is the
+/// source's business**, and the emitter must accept any of the spellings.
 ///
-/// `Box<T>` *is* `T` in the model, deliberately — so a field spelled
-/// `Box<Option<Child>>` peels to `Child` and records an optional access step
-/// that has no way to say "deref first". The emitter then matches `Option`'s
-/// patterns against a value still typed `Box<Option<Child>>`, which is `E0308`.
+/// `Box<T>` *is* `T` in the model, deliberately: the flat model states the
+/// destination-language invariant, and no target language can tell an
+/// `Option<T>` field from a `Box<Option<T>>` one. The emitter used to classify
+/// off `kind` correctly ("optional ⇒ needs a `Some`/`None` split") and then
+/// *spell* off `kind` too, matching `Option`'s patterns against a place still
+/// typed `Box<Option<Child>>` — `E0308` (#268).
 ///
-/// The shape used to be *accepted* and mis-emitted: nothing in this suite
-/// compiles the generated Rust, so `contains` assertions passed over it happily.
-/// Rejecting at the declaration is what makes it visible — see #268, which owns
-/// teaching the path algebra the wrapper.
+/// So the destructuring goes through a coercion site. Deref coercion is
+/// transitive and a no-op when the types already match, which is why one shape
+/// serves every representation and the plain spelling is unchanged.
 ///
-/// The plain `Option<Child>` case is asserted alongside, because a guard that
-/// also rejected the ordinary spelling would be worse than no guard.
+/// Both spellings are asserted to reach the SAME leaf surface: if the wrapper
+/// changed what crosses, the model would be leaking a Rust detail it exists to
+/// hide. (What this cannot yet assert is that the result compiles — nothing in
+/// this suite compiles generated Rust, which is exactly how the bug survived.
+/// #269 owns that, and names this test.)
 #[test]
-fn an_option_behind_a_transparent_wrapper_is_reserved_by_name() {
+fn an_optional_field_crosses_the_same_however_rust_spells_it() {
     let loc = myflat_loc();
-    let build = |field_ty: syn::Type| {
+    let build = |field_ty: syn::Type| -> String {
         let items = vec![
             (
                 syn::Item::Struct(syn::parse_quote!(
@@ -599,39 +603,41 @@ fn an_option_behind_a_transparent_wrapper_is_reserved_by_name() {
         let dir = unique_test_dir("jnigen_vf_boxed_opt");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        let _ = jni
-            .build_with(registry)
-            .map(|g| g.write_rust(dir.join("g.rs")));
+        let gen = jni.build_with(registry).expect("resolve");
+        std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+            .expect("read rust")
     };
 
-    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        build(syn::parse_quote!(Box<Option<ZKeyExpr>>))
-    }))
-    .expect_err("an Option behind a transparent wrapper must be rejected");
-    let msg = err
-        .downcast_ref::<String>()
-        .cloned()
-        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
-        .unwrap_or_default();
-    assert!(
-        msg.contains("transparent wrapper"),
-        "the message names the shape: {msg}"
-    );
-    assert!(
-        msg.contains("ZSampleStruct.kex"),
-        "the message names the offending field: {msg}"
-    );
-    // Reserved, not refused: the diagnosis says where the work is tracked.
-    assert!(
-        msg.contains("issues/268"),
-        "a reserved shape names its issue: {msg}"
-    );
+    let plain = build(syn::parse_quote!(Option<ZKeyExpr>));
+    let boxed = build(syn::parse_quote!(Box<Option<ZKeyExpr>>));
 
-    // The ordinary spelling is untouched.
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        build(syn::parse_quote!(Option<ZKeyExpr>))
-    }))
-    .expect("a plain `Option<T>` field is the supported shape");
+    for (label, rust) in [("Option<T>", &plain), ("Box<Option<T>>", &boxed)] {
+        let rc: String = rust.split_whitespace().collect();
+        // The destructuring is coerced, never applied to the raw place — the
+        // one thing that makes it representation-agnostic.
+        assert!(
+            rc.contains("let__o0:&::core::option::Option<_>=&"),
+            "{label}: the optional field is reached through a coercion site:\n{rust}"
+        );
+        assert!(
+            !rc.contains("match&(&__vf0).kex"),
+            "{label}: the raw place is never destructured directly:\n{rust}"
+        );
+        // …and the field still crosses as the child's own expansion.
+        assert!(
+            rc.contains("myflat::z_keyexpr_as_str(__n0)"),
+            "{label}: the child's boundary still applies:\n{rust}"
+        );
+    }
+
+    // The wrapper changes the Rust spelling and NOTHING that crosses. Compared
+    // after normalizing the one legitimate difference — the field's own type is
+    // spelled in the generated converter signatures.
+    assert_eq!(
+        plain.replace("Box<Option<ZKeyExpr>>", "Option<ZKeyExpr>"),
+        boxed.replace("Box<Option<ZKeyExpr>>", "Option<ZKeyExpr>"),
+        "a transparent wrapper must not change what crosses the boundary"
+    );
 }
 
 /// Naming a field the value form does not have is the very drift this


### PR DESCRIPTION
Closes #268.

## The bug

A value-form field spelled `Box<Option<Child>>` emitted a match against a place still typed `&Box<Option<Child>>` — `E0308`. Confirmed against `rustc` on a reduced case.

## The model is not at fault, and the obvious fix would have made it so

`kind` states the **destination-language invariant**. It does not care whether a reference is `&T` or `Cow<'_, T>`, a sequence `[T]` or `Vec<T>`, an optional `Option<T>` or `Box<Option<T>>`. `flat/ty.rs` says so for both wrappers already. Recording a "transparent-wrapper depth" on `TypeRef` — which is where I started — would push a Rust representation detail back into the one thing built to abstract it away.

The defect is on the **interpreting** side. This is `classify off kind, spell off syntax` broken in the direction nothing was watching: the emitter classified off `kind` correctly (*optional ⇒ needs a `Some`/`None` split*) and then **spelled** off `kind` too, assuming the place literally *is* an `Option`.

## The fix costs nothing

A type-ascribed `let` is a coercion site, and deref coercion is transitive **and** a no-op when the types already match:

```rust
let __o0: &::core::option::Option<_> = &(&__vf0).kex;
match __o0 { Some(__n0) => .., None => .. }
```

One shape serves `Option<T>`, `Box<Option<T>>`, `Rc<Option<T>>` and nested wrappers; the plain spelling behaves identically. The payload stays `_` — what it is, is the source's business.

## Borrowed vs owned, and why the tests earned their keep

Applied only where the destructured expression is a **borrow**. `fold_steps` composes a field read to a reference and an accessor call to an owned value, so the two are told apart by `PathStep::is_field`.

My first attempt coerced unconditionally, and two existing tests failed immediately — borrowing an accessor's returned `Option` to coerce it changes ownership for everything downstream that moves the payload. Owned positions therefore keep their direct match, and that is documented rather than silently left: deref coercion applies to references, and moving a payload out of a wrapper is something only some of them permit (`Box` can, `Rc` cannot).

## The audit

Swept the adapter for the same assumption. Only **two** sites destructured a place read from the source: `reach_leaf` (the reported bug) and the `Option<sum>` present-flag split in `struct_out.rs`. Everything else emitting `Option::Some` — 7 sites in `flat_input.rs`, 2 in `wrapper.rs` — is **construction**, a value whose type the emitter owns, which says nothing about the source's representation and is safe.

`reach_optional`'s `.map`/`.and_then` was left alone deliberately: a method call is not a coercion site, and its optional steps are `Call`s returning owned `Option`s (nested conditional hoists are rejected in `flatten`), so a wrapped field cannot reach it. Not restructured speculatively.

## The guard, and what it is not

`destructure_ledger` (`jni/emit/mod.rs`) is a committed census of destructuring sites. It counts **patterns**, not constructions — which is why `flat_input.rs` and `wrapper.rs` sit at zero.

Stated plainly in its own docs: it **cannot tell a coerced destructure from a raw one**, so a count that does not move is not proof of correctness. Its only job is to make a new site impossible to add silently, forcing review to say which of three categories it is. I verified it works by adding a destructure and watching it fail, then reverting.

It is an explicit half-measure standing in for a compile check — see below.

## Verification

- 534 lib tests; `cargo test` and `--all --all-features` (14/14 binaries); clippy `--deny warnings`; fmt with the CLI-only config.
- **Goldens move**, unlike #267 — this change gives up byte-identity by design. The diff is exactly **two coercion sites and nothing else**, verified by reading it. Forced rebuild first.
- covertest-kotlin **48/48** on the JVM. This carries more weight than usual here, since byte-identity is not available as a net.
- The `Box<Option<T>>` output checked against `rustc` by hand.

## Known gap

**Nothing here compiles the generated Rust** — the reason this bug survived years of green tests. #269 owns that and has been updated to name this PR's test as its first customer, with the ledger flagged for reconsideration once a real compile check exists.

Split out rather than smuggled in: **#270** — a *non*-decomposed `Box<Option<T>>` field still fails to resolve, because converter identity keys on the spelling. Same root cause, different layer (it reaches `TypeKey` and resolution), and it is what the two hardcoded `TypeKey == "Box < String >"` matches in `trait_impl.rs` are already working around by hand.
