### PR TITLE
The selector reads the model instead of guessing types by name

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -515,6 +515,13 @@ fn main() {
                 // crossing covers the borrowed payload, the owned one, and the
                 // sum each report carries.
                 .fun(fun!(ledger_each))
+                // A transparent wrapper (`Box<Option<String>>`) in and out. The
+                // model erases the `Box`, so this must cross exactly as a
+                // `String?` — and because this crate compiles its generated
+                // binding, a converter that named the wrong type or bridged it
+                // with the wrong number of dereferences fails the build (#270).
+                .fun(fun!(boxed_note_echo))
+                .fun(fun!(plain_note_echo))
                 .fun(fun!(ledger_new))
                 .fun(fun!(archive_set_reading))
                 .fun(fun!(archive_reading))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -63,6 +63,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
 - `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue>): BlobValue`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
+- `boxed_note_echo` — `fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): String?`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
@@ -90,6 +91,7 @@ Base package: `io.prebindgen.covertest`
 - `percent_invalid_output` — `fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int?`
 - `percent_optional` — `fun percentOptional(p: Int?, onError: JniErrorHandler<Int?>): Int?`
 - `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int`
+- `plain_note_echo` — `fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): String?`
 - `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority>): Priority`
 - `priority_weight` — `fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int`
 - `reading_each` — `fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>)`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -894,6 +894,8 @@ internal object CovNative {
         errorSink: Any,
     ): Any?
 
+    external fun boxedNoteEcho(note: String?, errorSink: Any): String?
+
     external fun cacheConfigWeight(
         cachePresent: Boolean,
         cacheRepliesPriority: Int,
@@ -994,6 +996,8 @@ internal object CovNative {
     external fun percentOptional(p: Int?, errorSink: Any): Int?
 
     external fun percentScale(p: Int, factor: Int, errorSink: Any): Int
+
+    external fun plainNoteEcho(note: String?, errorSink: Any): String?
 
     external fun priorityOr(pPresent: Boolean, pValue: Int, fallback: Int, errorSink: Any): Int
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1577,6 +1577,45 @@ public fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Un
 }
 
 /**
+ * A **transparent wrapper**, and its unwrapped control.
+ *
+ * The model erases `Box`, so `Box<Box<Option<String>>>` classifies `Optional`
+ * exactly as a bare `Option<String>` does — one thing to every destination
+ * language, two spellings to Rust. That gap is the whole of #270: the adapter
+ * used to decide what a type *was* by rebuilding a pattern from its spelling,
+ * so a wrapped `Option` reconstructed as `Box<_>`, matched nothing, and got no
+ * converter at all.
+ *
+ * Declared here rather than only in a unit test because this crate's generated
+ * binding is `include!`d and **compiled**: a converter that named
+ * `Option<String>` for a `Box<Box<Option<String>>>` value, or bridged it with
+ * the wrong number of dereferences, fails to build. Nested deliberately — one
+ * dereference leaves a `Box<Option<String>>`, which still compiles as a
+ * *type* and would only fail here.
+ *
+ * A `Cow` payload is the other half and cannot appear in a compiled fixture:
+ * it must be REFUSED, which only
+ * `a_transparent_wrapper_is_bridged_only_where_it_can_be` can assert.
+ */
+public fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): String? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.boxedNoteEcho(note, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * The same crossing with nothing wrapped — the control the wrapped form must
+ * match, since the model says the two returns are the same type.
+ */
+public fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): String? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.plainNoteEcho(note, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * Build a [`Ledger`]; `n` selects which of the two slots are filled (bit 0 =
  * `filed`, bit 1 = `archived`), so a caller can drive every arm of the
  * conditional decomposition, both-present through both-absent.

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -657,6 +657,33 @@ pub(crate) unsafe fn BlobValue_to_JObject_89b5dab7<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Box_Box_Option_String_to_JString_299999e0<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<Box<Option<String>>>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        let v: Option<String> = (*(*v));
+        {
+            match v {
+                Some(value) => String_to_JString_c7f3ca43(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Box<String>,
@@ -2328,7 +2355,7 @@ pub(crate) unsafe fn JObject_to_Option_CacheConfig_a6be794d<'env, 'v>(
                 Some(JObject_to_CacheConfig_db89a97c(env, v)?)
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2352,7 +2379,7 @@ pub(crate) unsafe fn JObject_to_Option_Hold_230d7f9b<'env, 'v>(
         let __v: ::core::option::Option<perftest_flat::Hold> = {
             if v.is_null() { None } else { Some(JObject_to_Hold_5f85caaf(env, v)?) }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2376,7 +2403,7 @@ pub(crate) unsafe fn JObject_to_Option_Payload_97036642<'env, 'v>(
         let __v: ::core::option::Option<perftest_flat::Payload> = {
             if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2418,7 +2445,7 @@ pub(crate) unsafe fn JObject_to_Option_Percent_544dd364<'env, 'v>(
                 None
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2453,7 +2480,7 @@ pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
                 None
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2477,7 +2504,7 @@ pub(crate) unsafe fn JObject_to_Option_Reading_80df84a9<'env, 'v>(
         let __v: ::core::option::Option<perftest_flat::Reading> = {
             if v.is_null() { None } else { Some(JObject_to_Reading_2261050f(env, v)?) }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2512,7 +2539,7 @@ pub(crate) unsafe fn JObject_to_Option_f64_b3f3e9a9<'env, 'v>(
                 None
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2547,7 +2574,7 @@ pub(crate) unsafe fn JObject_to_Option_i64_2ba9a5ed<'env, 'v>(
                 None
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -2582,7 +2609,7 @@ pub(crate) unsafe fn JObject_to_Option_u64_32be16a2<'env, 'v>(
                 None
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -3045,7 +3072,7 @@ pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'v>(
             };
             __out.push(__elem);
         }
-        __out.into()
+        __out
     })
 }
 #[allow(
@@ -3089,7 +3116,7 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
             )?;
             __out.push(__elem);
         }
-        __out.into()
+        __out
     })
 }
 #[allow(
@@ -3130,7 +3157,7 @@ pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
             let __elem: Vec<u8> = JByteArray_to_Vec_u8_7936d5de(env, &__elem_wire)?;
             __out.push(__elem);
         }
-        __out.into()
+        __out
     })
 }
 #[allow(
@@ -5246,7 +5273,31 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
                 Some(JString_to_Box_String_027f6250(env, v)?)
             }
         };
-        __v.into()
+        __v
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JString_to_Option_String_56d5e304<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JString<'v>,
+) -> ::core::result::Result<Option<String>, __JniErr> {
+    Ok({
+        let __v: ::core::option::Option<String> = {
+            if v.is_null() { None } else { Some(JString_to_String_c7f3ca43(env, v)?) }
+        };
+        __v
     })
 }
 #[allow(
@@ -7996,6 +8047,33 @@ pub(crate) unsafe fn Option_Stamp_to_JObject_6375b503<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_String_to_JString_56d5e304<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<String>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        let v: Option<String> = v;
+        {
+            match v {
+                Some(value) => String_to_JString_c7f3ca43(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<&perftest_flat::Summary>,
@@ -9463,7 +9541,7 @@ pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
                 })
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -9495,7 +9573,7 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
         } else {
             Some(*std::boxed::Box::from_raw(*v as *mut perftest_flat::Summary))
         };
-        __v.into()
+        __v
     })
 }
 #[allow(
@@ -12606,6 +12684,48 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedNoteEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    note: jni::objects::JString<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let note = match JString_to_Option_String_56d5e304(&mut env, &note) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::boxed_note_echo(note);
+    match Box_Box_Option_String_to_JString_299999e0(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeight<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -15539,6 +15659,48 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_percentScale<'a>
                 &__e.to_string(),
             );
             0 as jni::sys::jint
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_plainNoteEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    note: jni::objects::JString<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let note = match JString_to_Option_String_56d5e304(&mut env, &note) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::plain_note_echo(note);
+    match Option_String_to_JString_56d5e304(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -380,7 +380,9 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBan
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -499,7 +501,9 @@ pub(crate) unsafe fn Annotated_to_JObject_b543f0d9<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -516,7 +520,9 @@ pub(crate) unsafe fn Archive_to_jlong_cd73502c<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -589,7 +595,9 @@ pub(crate) unsafe fn Arrays_to_JObject_71120c08<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -641,7 +649,35 @@ pub(crate) unsafe fn BlobValue_to_JObject_89b5dab7<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<String>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(v.as_str())
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -684,7 +720,9 @@ pub(crate) unsafe fn CacheConfig_to_JObject_db89a97c<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -701,7 +739,9 @@ pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -745,7 +785,9 @@ pub(crate) unsafe fn DurationBoundary_to_JObject_9c5bf9bc<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -787,7 +829,9 @@ pub(crate) unsafe fn Duration_to_u64_e3980876<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -804,7 +848,9 @@ pub(crate) unsafe fn EscapeProbe_to_jlong_416aab42<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -893,7 +939,9 @@ pub(crate) unsafe fn HoldPolicy_to_JObject_d2a5bcc4<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -940,7 +988,9 @@ pub(crate) unsafe fn JBooleanArray_to_bool_3_3f960c58<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -964,7 +1014,9 @@ pub(crate) unsafe fn JByteArray_to_Vec_u8_7936d5de<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1001,7 +1053,9 @@ pub(crate) unsafe fn JByteArray_to_u8_2_9ca14e44<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1038,7 +1092,9 @@ pub(crate) unsafe fn JByteArray_to_u8_4_39abedfa<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1085,7 +1141,9 @@ pub(crate) unsafe fn JDoubleArray_to_f64_2_dc30d1f9<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1132,7 +1190,9 @@ pub(crate) unsafe fn JIntArray_to_i32_3_60e5e35a<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1179,7 +1239,9 @@ pub(crate) unsafe fn JLongArray_to_i64_2_73596912<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1226,7 +1288,9 @@ pub(crate) unsafe fn JLongArray_to_u64_2_60bcc6a5<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1290,7 +1354,9 @@ pub(crate) unsafe fn JObject_to_Annotated_b543f0d9<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1373,7 +1439,9 @@ pub(crate) unsafe fn JObject_to_Arrays_71120c08<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1418,7 +1486,9 @@ pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1454,7 +1524,9 @@ pub(crate) unsafe fn JObject_to_CacheConfig_db89a97c<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1507,7 +1579,9 @@ pub(crate) unsafe fn JObject_to_DurationBoundary_9c5bf9bc<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1543,7 +1617,9 @@ pub(crate) unsafe fn JObject_to_HoldPolicy_d2a5bcc4<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1616,7 +1692,9 @@ pub(crate) unsafe fn JObject_to_Hold_5f85caaf<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1727,7 +1805,9 @@ pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1807,7 +1887,9 @@ pub(crate) unsafe fn JObject_to_Marker_3dc81334<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1843,7 +1925,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary16_e9d41606<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1879,7 +1963,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary2_a8f288cc<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1915,7 +2001,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary32_ed80fac3<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1951,7 +2039,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary4_ea3fd497<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2019,7 +2109,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary63_29aa82ff<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2055,7 +2147,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary64_b2751ca5<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2091,7 +2185,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary8_55b82b02<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2119,7 +2215,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundaryLeaf_93531764<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2155,7 +2253,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary_dc5ac22b<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2208,7 +2308,9 @@ pub(crate) unsafe fn JObject_to_Observation_435b0724<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2219,7 +2321,14 @@ pub(crate) unsafe fn JObject_to_Option_CacheConfig_a6be794d<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::CacheConfig>, __JniErr> {
     Ok({
-        if v.is_null() { None } else { Some(JObject_to_CacheConfig_db89a97c(env, v)?) }
+        let __v: ::core::option::Option<perftest_flat::CacheConfig> = {
+            if v.is_null() {
+                None
+            } else {
+                Some(JObject_to_CacheConfig_db89a97c(env, v)?)
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -2227,7 +2336,9 @@ pub(crate) unsafe fn JObject_to_Option_CacheConfig_a6be794d<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2237,14 +2348,21 @@ pub(crate) unsafe fn JObject_to_Option_Hold_230d7f9b<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Hold>, __JniErr> {
-    Ok({ if v.is_null() { None } else { Some(JObject_to_Hold_5f85caaf(env, v)?) } })
+    Ok({
+        let __v: ::core::option::Option<perftest_flat::Hold> = {
+            if v.is_null() { None } else { Some(JObject_to_Hold_5f85caaf(env, v)?) }
+        };
+        __v.into()
+    })
 }
 #[allow(
     non_snake_case,
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2254,14 +2372,21 @@ pub(crate) unsafe fn JObject_to_Option_Payload_97036642<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Payload>, __JniErr> {
-    Ok({ if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) } })
+    Ok({
+        let __v: ::core::option::Option<perftest_flat::Payload> = {
+            if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) }
+        };
+        __v.into()
+    })
 }
 #[allow(
     non_snake_case,
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2272,25 +2397,28 @@ pub(crate) unsafe fn JObject_to_Option_Percent_544dd364<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Percent>, __JniErr> {
     Ok({
-        if !v.is_null() {
-            let __unboxed: jni::sys::jint = env
-                .call_method(&v, "intValue", "()I", &[])
-                .and_then(|val| val.i())
-                .map(|__x| __x as jni::sys::jint)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Option unbox: {}", e)))?;
-            Some({
-                let __inner_s0 = jint_to_i32_a3e3b6ef(env, &__unboxed)?;
-                let __inner_s1 = i32_to_Percent_db3641cc(env, __inner_s0)
-                    .map_err(|__e| <__JniErr as ::core::convert::From<
+        let __v: ::core::option::Option<perftest_flat::Percent> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jint = env
+                    .call_method(&v, "intValue", "()I", &[])
+                    .and_then(|val| val.i())
+                    .map(|__x| __x as jni::sys::jint)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
-                    >>::from(__e.to_string()))?;
-                __inner_s1
-            })
-        } else {
-            None
-        }
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some({
+                    let __inner_s0 = jint_to_i32_a3e3b6ef(env, &__unboxed)?;
+                    let __inner_s1 = i32_to_Percent_db3641cc(env, __inner_s0)
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    __inner_s1
+                })
+            } else {
+                None
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -2298,7 +2426,9 @@ pub(crate) unsafe fn JObject_to_Option_Percent_544dd364<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2309,18 +2439,21 @@ pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Priority>, __JniErr> {
     Ok({
-        if !v.is_null() {
-            let __unboxed: jni::sys::jint = env
-                .call_method(&v, "intValue", "()I", &[])
-                .and_then(|val| val.i())
-                .map(|__x| __x as jni::sys::jint)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Option unbox: {}", e)))?;
-            Some(jint_to_Priority_447102d2(env, &__unboxed)?)
-        } else {
-            None
-        }
+        let __v: ::core::option::Option<perftest_flat::Priority> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jint = env
+                    .call_method(&v, "intValue", "()I", &[])
+                    .and_then(|val| val.i())
+                    .map(|__x| __x as jni::sys::jint)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some(jint_to_Priority_447102d2(env, &__unboxed)?)
+            } else {
+                None
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -2328,7 +2461,9 @@ pub(crate) unsafe fn JObject_to_Option_Priority_ad5cbb32<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2338,14 +2473,21 @@ pub(crate) unsafe fn JObject_to_Option_Reading_80df84a9<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Reading>, __JniErr> {
-    Ok({ if v.is_null() { None } else { Some(JObject_to_Reading_2261050f(env, v)?) } })
+    Ok({
+        let __v: ::core::option::Option<perftest_flat::Reading> = {
+            if v.is_null() { None } else { Some(JObject_to_Reading_2261050f(env, v)?) }
+        };
+        __v.into()
+    })
 }
 #[allow(
     non_snake_case,
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2356,18 +2498,21 @@ pub(crate) unsafe fn JObject_to_Option_f64_b3f3e9a9<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<f64>, __JniErr> {
     Ok({
-        if !v.is_null() {
-            let __unboxed: jni::sys::jdouble = env
-                .call_method(&v, "doubleValue", "()D", &[])
-                .and_then(|val| val.d())
-                .map(|__x| __x as jni::sys::jdouble)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Option unbox: {}", e)))?;
-            Some(jdouble_to_f64_9e4a8f70(env, &__unboxed)?)
-        } else {
-            None
-        }
+        let __v: ::core::option::Option<f64> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jdouble = env
+                    .call_method(&v, "doubleValue", "()D", &[])
+                    .and_then(|val| val.d())
+                    .map(|__x| __x as jni::sys::jdouble)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some(jdouble_to_f64_9e4a8f70(env, &__unboxed)?)
+            } else {
+                None
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -2375,7 +2520,9 @@ pub(crate) unsafe fn JObject_to_Option_f64_b3f3e9a9<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2386,18 +2533,21 @@ pub(crate) unsafe fn JObject_to_Option_i64_2ba9a5ed<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<i64>, __JniErr> {
     Ok({
-        if !v.is_null() {
-            let __unboxed: jni::sys::jlong = env
-                .call_method(&v, "longValue", "()J", &[])
-                .and_then(|val| val.j())
-                .map(|__x| __x as jni::sys::jlong)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Option unbox: {}", e)))?;
-            Some(jlong_to_i64_fbf9a9bc(env, &__unboxed)?)
-        } else {
-            None
-        }
+        let __v: ::core::option::Option<i64> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jlong = env
+                    .call_method(&v, "longValue", "()J", &[])
+                    .and_then(|val| val.j())
+                    .map(|__x| __x as jni::sys::jlong)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some(jlong_to_i64_fbf9a9bc(env, &__unboxed)?)
+            } else {
+                None
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -2405,7 +2555,9 @@ pub(crate) unsafe fn JObject_to_Option_i64_2ba9a5ed<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2416,18 +2568,21 @@ pub(crate) unsafe fn JObject_to_Option_u64_32be16a2<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<u64>, __JniErr> {
     Ok({
-        if !v.is_null() {
-            let __unboxed: jni::sys::jlong = env
-                .call_method(&v, "longValue", "()J", &[])
-                .and_then(|val| val.j())
-                .map(|__x| __x as jni::sys::jlong)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Option unbox: {}", e)))?;
-            Some(jlong_to_u64_4384a5d6(env, &__unboxed)?)
-        } else {
-            None
-        }
+        let __v: ::core::option::Option<u64> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jlong = env
+                    .call_method(&v, "longValue", "()J", &[])
+                    .and_then(|val| val.j())
+                    .map(|__x| __x as jni::sys::jlong)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some(jlong_to_u64_4384a5d6(env, &__unboxed)?)
+            } else {
+                None
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -2435,7 +2590,9 @@ pub(crate) unsafe fn JObject_to_Option_u64_32be16a2<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2496,7 +2653,9 @@ pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2654,7 +2813,9 @@ pub(crate) unsafe fn JObject_to_Reading_2261050f<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2696,7 +2857,9 @@ pub(crate) unsafe fn JObject_to_RepliesConfig_eb8e9079<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2732,7 +2895,9 @@ pub(crate) unsafe fn JObject_to_Stamp_f6b1e942<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2768,7 +2933,9 @@ pub(crate) unsafe fn JObject_to_Tagged_641b984c<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2838,7 +3005,9 @@ pub(crate) unsafe fn JObject_to_Unsigned_7e3cc618<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2876,7 +3045,7 @@ pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'v>(
             };
             __out.push(__elem);
         }
-        __out
+        __out.into()
     })
 }
 #[allow(
@@ -2884,7 +3053,9 @@ pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2918,7 +3089,7 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
             )?;
             __out.push(__elem);
         }
-        __out
+        __out.into()
     })
 }
 #[allow(
@@ -2926,7 +3097,9 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2957,7 +3130,7 @@ pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
             let __elem: Vec<u8> = JByteArray_to_Vec_u8_7936d5de(env, &__elem_wire)?;
             __out.push(__elem);
         }
-        __out
+        __out.into()
     })
 }
 #[allow(
@@ -2965,7 +3138,9 @@ pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -3058,7 +3233,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Duration_Send_Sync_static_98c9f460<'env,
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -3721,7 +3898,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Ledger_Send_Sync_static_c76008cc<'env, '
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -3859,7 +4038,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Lookup_Send_Sync_static_4a65bc23<'env, '
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -4134,7 +4315,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_95073668<'env, 
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -4308,7 +4491,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -4544,7 +4729,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -4793,7 +4980,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -4878,7 +5067,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Storage_Send_Sync_static_2f26edcf<'env, 
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -4958,7 +5149,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_u64_Send_Sync_static_c7830b57<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5005,7 +5198,37 @@ pub(crate) unsafe fn JShortArray_to_i16_2_098f4ad5<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JString_to_Box_String_027f6250<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JString<'v>,
+) -> ::core::result::Result<Box<String>, __JniErr> {
+    Ok({
+        let s = env
+            .get_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("decode_string: {}", e))
+            })?;
+        ::std::string::String::from(s).into()
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5016,11 +5239,14 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
     v: &jni::objects::JString<'v>,
 ) -> ::core::result::Result<Option<Box<String>>, __JniErr> {
     Ok({
-        if v.is_null() {
-            None
-        } else {
-            Some(JString_to_std_boxed_Box_std_string_String_cfbab680(env, v)?)
-        }
+        let __v: ::core::option::Option<Box<String>> = {
+            if v.is_null() {
+                None
+            } else {
+                Some(JString_to_Box_String_027f6250(env, v)?)
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -5028,7 +5254,9 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5054,33 +5282,9 @@ pub(crate) unsafe fn JString_to_String_c7f3ca43<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JString_to_std_boxed_Box_std_string_String_cfbab680<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JString<'v>,
-) -> ::core::result::Result<::std::boxed::Box<::std::string::String>, __JniErr> {
-    Ok({
-        let s = env
-            .get_string(v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("decode_string: {}", e))
-            })?;
-        ::std::boxed::Box::new(::std::string::String::from(s))
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5097,7 +5301,9 @@ pub(crate) unsafe fn Label_to_String_63dec766<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5114,7 +5320,9 @@ pub(crate) unsafe fn Millis_to_i64_61ecf054<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5225,7 +5433,9 @@ pub(crate) unsafe fn ObjectBoundary16_to_JObject_e9d41606<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5266,7 +5476,9 @@ pub(crate) unsafe fn ObjectBoundary2_to_JObject_a8f288cc<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5457,7 +5669,9 @@ pub(crate) unsafe fn ObjectBoundary32_to_JObject_ed80fac3<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5508,7 +5722,9 @@ pub(crate) unsafe fn ObjectBoundary4_to_JObject_ea3fd497<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -5920,7 +6136,9 @@ pub(crate) unsafe fn ObjectBoundary63_to_JObject_29aa82ff<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -6355,7 +6573,9 @@ pub(crate) unsafe fn ObjectBoundary64_to_JObject_b2751ca5<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -6426,7 +6646,9 @@ pub(crate) unsafe fn ObjectBoundary8_to_JObject_55b82b02<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -6457,7 +6679,9 @@ pub(crate) unsafe fn ObjectBoundaryLeaf_to_JObject_93531764<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7347,7 +7571,9 @@ pub(crate) unsafe fn ObjectBoundary_to_JObject_dc5ac22b<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7576,7 +7802,9 @@ pub(crate) unsafe fn Observation_to_JObject_435b0724<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7587,11 +7815,12 @@ pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
     v: Option<Box<String>>,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                std_boxed_Box_std_string_String_to_JString_cfbab680(env, value)?
+        let v: Option<Box<String>> = v;
+        {
+            match v {
+                Some(value) => Box_String_to_JString_027f6250(env, value)?,
+                None => jni::objects::JObject::null().into(),
             }
-            None => jni::objects::JObject::null().into(),
         }
     })
 }
@@ -7600,7 +7829,9 @@ pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7611,15 +7842,18 @@ pub(crate) unsafe fn Option_Duration_to_jlong_1cfa4d44<'a>(
     v: Option<perftest_flat::Duration>,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                let __inner_s0 = Duration_to_u64_e3980876(env, value)
-                    .map_err(|__e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(__e.to_string()))?;
-                u64_to_jlong_4384a5d6(env, __inner_s0)?
+        let v: Option<perftest_flat::Duration> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __inner_s0 = Duration_to_u64_e3980876(env, value)
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    u64_to_jlong_4384a5d6(env, __inner_s0)?
+                }
+                None => -1i64,
             }
-            None => -1i64,
         }
     })
 }
@@ -7628,7 +7862,9 @@ pub(crate) unsafe fn Option_Duration_to_jlong_1cfa4d44<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7639,9 +7875,12 @@ pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
     v: Option<perftest_flat::Payload>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => Payload_to_JObject_98f64326(env, value)?,
-            None => jni::objects::JObject::null().into(),
+        let v: Option<perftest_flat::Payload> = v;
+        {
+            match v {
+                Some(value) => Payload_to_JObject_98f64326(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
         }
     })
 }
@@ -7650,7 +7889,9 @@ pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7661,21 +7902,24 @@ pub(crate) unsafe fn Option_Percent_to_JObject_544dd364<'a>(
     v: Option<perftest_flat::Percent>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                let __raw: jni::sys::jint = {
-                    let __inner_s0 = Percent_to_i32_01484801(env, value)
-                        .map_err(|__e| <__JniErr as ::core::convert::From<
+        let v: Option<perftest_flat::Percent> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jint = {
+                        let __inner_s0 = Percent_to_i32_01484801(env, value)
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        i32_to_jint_a3e3b6ef(env, __inner_s0)?
+                    };
+                    ::prebindgen::lang::box_jint(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
                             String,
-                        >>::from(__e.to_string()))?;
-                    i32_to_jint_a3e3b6ef(env, __inner_s0)?
-                };
-                ::prebindgen::lang::box_jint(env, __raw)
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Option box: {}", e)))?
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
             }
-            None => jni::objects::JObject::null(),
         }
     })
 }
@@ -7684,7 +7928,9 @@ pub(crate) unsafe fn Option_Percent_to_JObject_544dd364<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7695,15 +7941,18 @@ pub(crate) unsafe fn Option_Priority_to_JObject_ad5cbb32<'a>(
     v: Option<perftest_flat::Priority>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                let __raw: jni::sys::jint = Priority_to_jint_447102d2(env, value)?;
-                ::prebindgen::lang::box_jint(env, __raw)
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Option box: {}", e)))?
+        let v: Option<perftest_flat::Priority> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jint = Priority_to_jint_447102d2(env, value)?;
+                    ::prebindgen::lang::box_jint(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
             }
-            None => jni::objects::JObject::null(),
         }
     })
 }
@@ -7712,7 +7961,9 @@ pub(crate) unsafe fn Option_Priority_to_JObject_ad5cbb32<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7723,9 +7974,12 @@ pub(crate) unsafe fn Option_Stamp_to_JObject_6375b503<'a>(
     v: Option<perftest_flat::Stamp>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => Stamp_to_JObject_f6b1e942(env, value)?,
-            None => jni::objects::JObject::null().into(),
+        let v: Option<perftest_flat::Stamp> = v;
+        {
+            match v {
+                Some(value) => Stamp_to_JObject_f6b1e942(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
         }
     })
 }
@@ -7734,7 +7988,9 @@ pub(crate) unsafe fn Option_Stamp_to_JObject_6375b503<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7745,9 +8001,12 @@ pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     v: Option<&perftest_flat::Summary>,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok({
-        match v {
-            Some(value) => Summary_to_jlong_ccacdeac(env, value)?,
-            None => 0i64,
+        let v: Option<&perftest_flat::Summary> = v;
+        {
+            match v {
+                Some(value) => Summary_to_jlong_ccacdeac(env, value)?,
+                None => 0i64,
+            }
         }
     })
 }
@@ -7756,7 +8015,9 @@ pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7767,9 +8028,12 @@ pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
     v: Option<Vec<perftest_flat::Payload>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => Vec_Payload_to_JObject_8b7084d2(env, value)?,
-            None => jni::objects::JObject::null().into(),
+        let v: Option<Vec<perftest_flat::Payload>> = v;
+        {
+            match v {
+                Some(value) => Vec_Payload_to_JObject_8b7084d2(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
         }
     })
 }
@@ -7778,7 +8042,9 @@ pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7789,15 +8055,18 @@ pub(crate) unsafe fn Option_f64_to_JObject_b3f3e9a9<'a>(
     v: Option<f64>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                let __raw: jni::sys::jdouble = f64_to_jdouble_9e4a8f70(env, value)?;
-                ::prebindgen::lang::box_jdouble(env, __raw)
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Option box: {}", e)))?
+        let v: Option<f64> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jdouble = f64_to_jdouble_9e4a8f70(env, value)?;
+                    ::prebindgen::lang::box_jdouble(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
             }
-            None => jni::objects::JObject::null(),
         }
     })
 }
@@ -7806,7 +8075,9 @@ pub(crate) unsafe fn Option_f64_to_JObject_b3f3e9a9<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7817,15 +8088,18 @@ pub(crate) unsafe fn Option_i64_to_JObject_2ba9a5ed<'a>(
     v: Option<i64>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                let __raw: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, value)?;
-                ::prebindgen::lang::box_jlong(env, __raw)
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Option box: {}", e)))?
+        let v: Option<i64> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, value)?;
+                    ::prebindgen::lang::box_jlong(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
             }
-            None => jni::objects::JObject::null(),
         }
     })
 }
@@ -7834,7 +8108,9 @@ pub(crate) unsafe fn Option_i64_to_JObject_2ba9a5ed<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7845,15 +8121,18 @@ pub(crate) unsafe fn Option_u64_to_JObject_32be16a2<'a>(
     v: Option<u64>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                let __raw: jni::sys::jlong = u64_to_jlong_4384a5d6(env, value)?;
-                ::prebindgen::lang::box_jlong(env, __raw)
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Option box: {}", e)))?
+        let v: Option<u64> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jlong = u64_to_jlong_4384a5d6(env, value)?;
+                    ::prebindgen::lang::box_jlong(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
             }
-            None => jni::objects::JObject::null(),
         }
     })
 }
@@ -7862,7 +8141,9 @@ pub(crate) unsafe fn Option_u64_to_JObject_32be16a2<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7879,7 +8160,9 @@ pub(crate) unsafe fn PayloadHandler_to_jlong_d61fd890<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7896,7 +8179,9 @@ pub(crate) unsafe fn PayloadVecHandler_to_jlong_b32d2812<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7936,7 +8221,9 @@ pub(crate) unsafe fn Payload_to_JObject_25cd94ea<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -7984,7 +8271,9 @@ pub(crate) unsafe fn Payload_to_JObject_98f64326<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8001,7 +8290,9 @@ pub(crate) unsafe fn Percent_to_i32_01484801<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8018,7 +8309,9 @@ pub(crate) unsafe fn Priority_to_jint_447102d2<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8059,7 +8352,9 @@ pub(crate) unsafe fn RepliesConfig_to_JObject_eb8e9079<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8076,7 +8371,9 @@ pub(crate) unsafe fn Report_to_jlong_eaed4ba1<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8093,7 +8390,9 @@ pub(crate) unsafe fn Result_Storage_StorageError_to_Storage_7ccce404<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8110,7 +8409,9 @@ pub(crate) unsafe fn Result_Summary_String_to_Summary_dfdf7f9e<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8145,7 +8446,9 @@ pub(crate) unsafe fn Stamp_to_JObject_f6b1e942<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8162,7 +8465,9 @@ pub(crate) unsafe fn StorageError_to_jlong_26b2d298<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8179,7 +8484,9 @@ pub(crate) unsafe fn StorageHandler_to_jlong_3b4d3ed3<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8196,7 +8503,9 @@ pub(crate) unsafe fn Storage_to_jlong_1b233abd<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8211,7 +8520,7 @@ pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
             .map_err(|e| {
                 <__JniErr as ::core::convert::From<
                     String,
-                >>::from(format!("encode_string: {}", e))
+                >>::from(format!("encode_str: {}", e))
             })?
     })
 }
@@ -8220,7 +8529,9 @@ pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8237,7 +8548,9 @@ pub(crate) unsafe fn String_to_Label_c1a79668<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8254,7 +8567,9 @@ pub(crate) unsafe fn Summary_to_jlong_3cb103b9<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8271,7 +8586,9 @@ pub(crate) unsafe fn Summary_to_jlong_ccacdeac<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8322,7 +8639,9 @@ pub(crate) unsafe fn Tagged_to_JObject_641b984c<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8366,7 +8685,9 @@ pub(crate) unsafe fn Unsigned_to_JObject_7e3cc618<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8377,6 +8698,7 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
     v: Vec<perftest_flat::Label>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let v: Vec<perftest_flat::Label> = v;
         let __list_obj = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -8409,7 +8731,9 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8420,6 +8744,7 @@ pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     v: Vec<perftest_flat::Payload>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let v: Vec<perftest_flat::Payload> = v;
         let __list_obj = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -8446,7 +8771,9 @@ pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8457,6 +8784,7 @@ pub(crate) unsafe fn Vec_Stamp_to_JObject_8954d9be<'a>(
     v: Vec<perftest_flat::Stamp>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let v: Vec<perftest_flat::Stamp> = v;
         let __list_obj = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -8483,7 +8811,9 @@ pub(crate) unsafe fn Vec_Stamp_to_JObject_8954d9be<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8494,6 +8824,7 @@ pub(crate) unsafe fn Vec_String_to_JObject_1e282499<'a>(
     v: Vec<String>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let v: Vec<String> = v;
         let __list_obj = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -8520,7 +8851,9 @@ pub(crate) unsafe fn Vec_String_to_JObject_1e282499<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8531,6 +8864,7 @@ pub(crate) unsafe fn Vec_Vec_u8_to_JObject_43404875<'a>(
     v: Vec<Vec<u8>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let v: Vec<Vec<u8>> = v;
         let __list_obj = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -8557,7 +8891,9 @@ pub(crate) unsafe fn Vec_Vec_u8_to_JObject_43404875<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8581,7 +8917,9 @@ pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8617,7 +8955,9 @@ pub(crate) unsafe fn bool_3_to_JBooleanArray_3f960c58<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8634,7 +8974,9 @@ pub(crate) unsafe fn bool_to_jboolean_31306d98<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8670,7 +9012,9 @@ pub(crate) unsafe fn f64_2_to_JDoubleArray_dc30d1f9<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8687,7 +9031,9 @@ pub(crate) unsafe fn f64_to_jdouble_9e4a8f70<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8723,7 +9069,9 @@ pub(crate) unsafe fn i16_2_to_JShortArray_098f4ad5<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8759,7 +9107,9 @@ pub(crate) unsafe fn i32_3_to_JIntArray_60e5e35a<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8776,7 +9126,9 @@ pub(crate) unsafe fn i32_to_Celsius_8c363100<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8796,7 +9148,9 @@ pub(crate) unsafe fn i32_to_Percent_db3641cc<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8813,7 +9167,9 @@ pub(crate) unsafe fn i32_to_jint_a3e3b6ef<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8849,7 +9205,9 @@ pub(crate) unsafe fn i64_2_to_JLongArray_73596912<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8866,7 +9224,9 @@ pub(crate) unsafe fn i64_to_Millis_bb88777a<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8883,7 +9243,9 @@ pub(crate) unsafe fn i64_to_jlong_fbf9a9bc<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8900,7 +9262,9 @@ pub(crate) unsafe fn jboolean_to_bool_31306d98<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8917,7 +9281,9 @@ pub(crate) unsafe fn jdouble_to_f64_9e4a8f70<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8947,7 +9313,9 @@ pub(crate) unsafe fn jint_to_Priority_447102d2<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8964,7 +9332,9 @@ pub(crate) unsafe fn jint_to_i32_a3e3b6ef<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -8988,7 +9358,9 @@ pub(crate) unsafe fn jint_to_u16_28edf527<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9012,7 +9384,9 @@ pub(crate) unsafe fn jint_to_u8_553cf6ec<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9036,7 +9410,9 @@ pub(crate) unsafe fn jlong_to_Archive_cd73502c<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9060,7 +9436,9 @@ pub(crate) unsafe fn jlong_to_EscapeProbe_416aab42<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9071,18 +9449,21 @@ pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<Option<perftest_flat::Duration>, __JniErr> {
     Ok({
-        if *v == -1i64 {
-            None
-        } else {
-            Some({
-                let __inner_s0 = jlong_to_u64_4384a5d6(env, v)?;
-                let __inner_s1 = u64_to_Duration_7c0845f9(env, __inner_s0)
-                    .map_err(|__e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(__e.to_string()))?;
-                __inner_s1
-            })
-        }
+        let __v: ::core::option::Option<perftest_flat::Duration> = {
+            if *v == -1i64 {
+                None
+            } else {
+                Some({
+                    let __inner_s0 = jlong_to_u64_4384a5d6(env, v)?;
+                    let __inner_s1 = u64_to_Duration_7c0845f9(env, __inner_s0)
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    __inner_s1
+                })
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -9090,7 +9471,9 @@ pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9101,7 +9484,7 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<Option<perftest_flat::Summary>, __JniErr> {
     Ok({
-        if *v == 0 {
+        let __v: ::core::option::Option<perftest_flat::Summary> = if *v == 0 {
             None
         } else if (*v & 1) == 1 {
             return ::core::result::Result::Err(
@@ -9111,7 +9494,8 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
             );
         } else {
             Some(*std::boxed::Box::from_raw(*v as *mut perftest_flat::Summary))
-        }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -9119,7 +9503,9 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9136,7 +9522,9 @@ pub(crate) unsafe fn jlong_to_Option_Summary_828826f3<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9160,7 +9548,9 @@ pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9184,7 +9574,9 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9208,7 +9600,9 @@ pub(crate) unsafe fn jlong_to_Report_eaed4ba1<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9232,7 +9626,9 @@ pub(crate) unsafe fn jlong_to_StorageError_26b2d298<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9256,7 +9652,9 @@ pub(crate) unsafe fn jlong_to_StorageHandler_3b4d3ed3<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9280,7 +9678,9 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9304,7 +9704,9 @@ pub(crate) unsafe fn jlong_to_Summary_3cb103b9<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9321,7 +9723,9 @@ pub(crate) unsafe fn jlong_to_i64_fbf9a9bc<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9345,7 +9749,9 @@ pub(crate) unsafe fn jlong_to_u32_9594a230<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9362,31 +9768,9 @@ pub(crate) unsafe fn jlong_to_u64_4384a5d6<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn std_boxed_Box_std_string_String_to_JString_cfbab680<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: ::std::boxed::Box<::std::string::String>,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(v.as_str())
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9410,7 +9794,9 @@ pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9427,7 +9813,9 @@ pub(crate) unsafe fn u16_to_jint_28edf527<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9444,7 +9832,9 @@ pub(crate) unsafe fn u32_to_jlong_9594a230<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9480,7 +9870,9 @@ pub(crate) unsafe fn u64_2_to_JLongArray_60bcc6a5<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9511,7 +9903,9 @@ pub(crate) unsafe fn u64_to_Duration_7c0845f9<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9528,7 +9922,9 @@ pub(crate) unsafe fn u64_to_jlong_4384a5d6<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9552,7 +9948,9 @@ pub(crate) unsafe fn u8_4_to_JByteArray_39abedfa<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -9569,7 +9967,9 @@ pub(crate) unsafe fn u8_to_jint_553cf6ec<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1579,6 +1579,37 @@ pub fn ledger_archived(l: &Ledger) -> Option<Report> {
     l.archived.map(ledger_report)
 }
 
+/// A **transparent wrapper**, and its unwrapped control.
+///
+/// The model erases `Box`, so `Box<Box<Option<String>>>` classifies `Optional`
+/// exactly as a bare `Option<String>` does — one thing to every destination
+/// language, two spellings to Rust. That gap is the whole of #270: the adapter
+/// used to decide what a type *was* by rebuilding a pattern from its spelling,
+/// so a wrapped `Option` reconstructed as `Box<_>`, matched nothing, and got no
+/// converter at all.
+///
+/// Declared here rather than only in a unit test because this crate's generated
+/// binding is `include!`d and **compiled**: a converter that named
+/// `Option<String>` for a `Box<Box<Option<String>>>` value, or bridged it with
+/// the wrong number of dereferences, fails to build. Nested deliberately — one
+/// dereference leaves a `Box<Option<String>>`, which still compiles as a
+/// *type* and would only fail here.
+///
+/// A `Cow` payload is the other half and cannot appear in a compiled fixture:
+/// it must be REFUSED, which only
+/// `a_transparent_wrapper_is_bridged_only_where_it_can_be` can assert.
+#[prebindgen]
+pub fn boxed_note_echo(note: Option<String>) -> Box<Box<Option<String>>> {
+    Box::new(Box::new(note))
+}
+
+/// The same crossing with nothing wrapped — the control the wrapped form must
+/// match, since the model says the two returns are the same type.
+#[prebindgen]
+pub fn plain_note_echo(note: Option<String>) -> Option<String> {
+    note
+}
+
 /// Deliver a [`Ledger`] to a callback, so both conditional decompositions cross
 /// in ONE call — including the sum (`Report::outcome`) each one carries, whose
 /// `match` belongs inside the arm that binds the report.

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -248,7 +248,35 @@ pub(crate) unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_payloadVec
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<String>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(v.as_str())
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -284,7 +312,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary16_e9d41606<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -320,7 +350,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary2_a8f288cc<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -356,7 +388,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary32_ed80fac3<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -392,7 +426,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary4_ea3fd497<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -428,7 +464,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary64Object_ecaf00ac<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -464,7 +502,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary64_b2751ca5<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -500,7 +540,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundary8_55b82b02<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -528,7 +570,9 @@ pub(crate) unsafe fn JObject_to_ObjectBoundaryLeaf_93531764<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -589,7 +633,9 @@ pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -623,7 +669,7 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
             )?;
             __out.push(__elem);
         }
-        __out
+        __out.into()
     })
 }
 #[allow(
@@ -631,7 +677,9 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -906,7 +954,9 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_95073668<'env, 
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1080,7 +1130,37 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JString_to_Box_String_027f6250<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JString<'v>,
+) -> ::core::result::Result<Box<String>, __JniErr> {
+    Ok({
+        let s = env
+            .get_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("decode_string: {}", e))
+            })?;
+        ::std::string::String::from(s).into()
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1091,11 +1171,14 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
     v: &jni::objects::JString<'v>,
 ) -> ::core::result::Result<Option<Box<String>>, __JniErr> {
     Ok({
-        if v.is_null() {
-            None
-        } else {
-            Some(JString_to_std_boxed_Box_std_string_String_cfbab680(env, v)?)
-        }
+        let __v: ::core::option::Option<Box<String>> = {
+            if v.is_null() {
+                None
+            } else {
+                Some(JString_to_Box_String_027f6250(env, v)?)
+            }
+        };
+        __v.into()
     })
 }
 #[allow(
@@ -1103,33 +1186,9 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JString_to_std_boxed_Box_std_string_String_cfbab680<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JString<'v>,
-) -> ::core::result::Result<::std::boxed::Box<::std::string::String>, __JniErr> {
-    Ok({
-        let s = env
-            .get_string(v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("decode_string: {}", e))
-            })?;
-        ::std::boxed::Box::new(::std::string::String::from(s))
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1240,7 +1299,9 @@ pub(crate) unsafe fn ObjectBoundary16_to_JObject_e9d41606<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1281,7 +1342,9 @@ pub(crate) unsafe fn ObjectBoundary2_to_JObject_a8f288cc<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1472,7 +1535,9 @@ pub(crate) unsafe fn ObjectBoundary32_to_JObject_ed80fac3<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1523,7 +1588,9 @@ pub(crate) unsafe fn ObjectBoundary4_to_JObject_ea3fd497<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -1958,7 +2025,9 @@ pub(crate) unsafe fn ObjectBoundary64Object_to_JObject_ecaf00ac<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2393,7 +2462,9 @@ pub(crate) unsafe fn ObjectBoundary64_to_JObject_b2751ca5<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2464,7 +2535,9 @@ pub(crate) unsafe fn ObjectBoundary8_to_JObject_55b82b02<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2495,7 +2568,9 @@ pub(crate) unsafe fn ObjectBoundaryLeaf_to_JObject_93531764<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2506,11 +2581,12 @@ pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
     v: Option<Box<String>>,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => {
-                std_boxed_Box_std_string_String_to_JString_cfbab680(env, value)?
+        let v: Option<Box<String>> = v;
+        {
+            match v {
+                Some(value) => Box_String_to_JString_027f6250(env, value)?,
+                None => jni::objects::JObject::null().into(),
             }
-            None => jni::objects::JObject::null().into(),
         }
     })
 }
@@ -2519,7 +2595,9 @@ pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2530,9 +2608,12 @@ pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
     v: Option<perftest_flat::Payload>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => Payload_to_JObject_98f64326(env, value)?,
-            None => jni::objects::JObject::null().into(),
+        let v: Option<perftest_flat::Payload> = v;
+        {
+            match v {
+                Some(value) => Payload_to_JObject_98f64326(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
         }
     })
 }
@@ -2541,7 +2622,9 @@ pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2552,9 +2635,12 @@ pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
     v: Option<Vec<perftest_flat::Payload>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
-        match v {
-            Some(value) => Vec_Payload_to_JObject_8b7084d2(env, value)?,
-            None => jni::objects::JObject::null().into(),
+        let v: Option<Vec<perftest_flat::Payload>> = v;
+        {
+            match v {
+                Some(value) => Vec_Payload_to_JObject_8b7084d2(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
         }
     })
 }
@@ -2563,7 +2649,9 @@ pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2580,7 +2668,9 @@ pub(crate) unsafe fn PayloadHandler_to_jlong_d61fd890<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2597,7 +2687,9 @@ pub(crate) unsafe fn PayloadVecHandler_to_jlong_b32d2812<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2637,7 +2729,9 @@ pub(crate) unsafe fn Payload_to_JObject_25cd94ea<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2685,7 +2779,9 @@ pub(crate) unsafe fn Payload_to_JObject_98f64326<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2702,7 +2798,9 @@ pub(crate) unsafe fn Storage_to_jlong_1b233abd<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2719,7 +2817,9 @@ pub(crate) unsafe fn TokenGc_to_jlong_5e58352a<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2736,7 +2836,9 @@ pub(crate) unsafe fn Token_to_jlong_4f7adafa<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2747,6 +2849,7 @@ pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     v: Vec<perftest_flat::Payload>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
+        let v: Vec<perftest_flat::Payload> = v;
         let __list_obj = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
@@ -2773,7 +2876,9 @@ pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2790,7 +2895,9 @@ pub(crate) unsafe fn bool_to_jboolean_31306d98<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2807,7 +2914,9 @@ pub(crate) unsafe fn f64_to_jdouble_9e4a8f70<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2824,7 +2933,9 @@ pub(crate) unsafe fn i32_to_jint_a3e3b6ef<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2841,7 +2952,9 @@ pub(crate) unsafe fn i64_to_jlong_fbf9a9bc<'a>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2858,7 +2971,9 @@ pub(crate) unsafe fn jboolean_to_bool_31306d98<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2875,7 +2990,9 @@ pub(crate) unsafe fn jdouble_to_f64_9e4a8f70<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2892,7 +3009,9 @@ pub(crate) unsafe fn jint_to_i32_a3e3b6ef<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2916,7 +3035,9 @@ pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2940,7 +3061,9 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2964,7 +3087,9 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -2988,7 +3113,9 @@ pub(crate) unsafe fn jlong_to_TokenGc_5e58352a<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -3012,7 +3139,9 @@ pub(crate) unsafe fn jlong_to_Token_4f7adafa<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,
@@ -3029,31 +3158,9 @@ pub(crate) unsafe fn jlong_to_i64_fbf9a9bc<'env, 'v>(
     unused_mut,
     unused_variables,
     unused_braces,
+    unused_parens,
     dead_code,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn std_boxed_Box_std_string_String_to_JString_cfbab680<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: ::std::boxed::Box<::std::string::String>,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(v.as_str())
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    dead_code,
+    clippy::useless_conversion,
     clippy::needless_question_mark,
     clippy::let_and_return,
     clippy::nonminimal_bool,

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -669,7 +669,7 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
             )?;
             __out.push(__elem);
         }
-        __out.into()
+        __out
     })
 }
 #[allow(
@@ -1178,7 +1178,7 @@ pub(crate) unsafe fn JString_to_Option_Box_String_071e4c8c<'env, 'v>(
                 Some(JString_to_Box_String_027f6250(env, v)?)
             }
         };
-        __v.into()
+        __v
     })
 }
 #[allow(

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -67,8 +67,8 @@
 3	api/lang/jnigen/jni/prim_array.rs
 8	api/lang/jnigen/jni/render.rs
 3	api/lang/jnigen/jni/selector.rs
-12	api/lang/jnigen/jni/trait_impl.rs
+11	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 131
+# total: 130

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -67,8 +67,8 @@
 3	api/lang/jnigen/jni/prim_array.rs
 8	api/lang/jnigen/jni/render.rs
 3	api/lang/jnigen/jni/selector.rs
-11	api/lang/jnigen/jni/trait_impl.rs
+12	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 130
+# total: 131

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -66,9 +66,9 @@
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 8	api/lang/jnigen/jni/render.rs
-8	api/lang/jnigen/jni/selector.rs
+3	api/lang/jnigen/jni/selector.rs
 11	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 135
+# total: 130

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -181,7 +181,10 @@ pub use self::{
     },
     origin::Origin,
     spelling::{canonical_spelling, canonical_type, type_from_ident},
-    ty::{RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType, UnsupportedTypeReason},
+    ty::{
+        peel_transparent, RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType,
+        UnsupportedTypeReason, TRANSPARENT_WRAPPERS,
+    },
 };
 use crate::SourceLocation;
 

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -548,6 +548,38 @@ impl std::error::Error for UnsupportedType {}
 /// `at` is the origin of the item this type was written in — the location every
 /// node lowered from that item shares, and the crate an array extent's const
 /// must come from.
+/// The wrappers this language **erases**: `W<T>` classifies as whatever `T`
+/// classifies as, because no destination language can tell them apart.
+///
+/// The single source of truth for that set. [`lower_type`] erases exactly these,
+/// and an adapter that has to *undo* one in generated Rust reads the same list —
+/// so the question "which wrappers are transparent?" has one answer instead of a
+/// copy per consumer that can drift out of step.
+///
+/// Adding one is adding a row here. What it means for a given destination is
+/// that adapter's business: erasing a wrapper says nothing about whether Rust
+/// can move a value out of it, which is why `Cow` is on this list and is still
+/// refused where a converter would have to move its payload.
+pub const TRANSPARENT_WRAPPERS: &[&str] = &["Box", "Cow"];
+
+/// Strip one [transparent wrapper](TRANSPARENT_WRAPPERS) from a **spelling**,
+/// naming the one removed — `Box<Option<T>>` → `("Box", Option<T>)`.
+///
+/// Spelling in, spelling out: this is the inverse of the erasure, for a consumer
+/// that must reconstruct in Rust what the classification dropped.
+pub fn peel_transparent(ty: &syn::Type) -> Option<(&'static str, syn::Type)> {
+    let syn::Type::Path(tp) = ty else { return None };
+    let seg = tp.path.segments.last()?;
+    let name = TRANSPARENT_WRAPPERS.iter().find(|w| seg.ident == **w)?;
+    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
+        return None;
+    };
+    ab.args.iter().find_map(|a| match a {
+        syn::GenericArgument::Type(inner) => Some((*name, inner.clone())),
+        _ => None,
+    })
+}
+
 pub(crate) fn lower_type(
     ty: &syn::Type,
     consts: &ConstIndex,
@@ -715,23 +747,10 @@ fn lower_path(
                 // `Box` survives in `TypeRef::origin`, which is what generated
                 // Rust spells. (A shared-ownership handle would classify as a
                 // `Ref` for the same reason, when the language accepts one.)
-                "Box" => {
-                    arity(1)?;
-                    return Ok(args.remove(0).kind);
-                }
-                // `Cow<'_, T>` **is** `T`, for the same reason `Box<T>` is: borrowed
-                // or owned, and no destination language can tell. Both adapters
-                // already say exactly that — cbindgen lowers it "just like `Vec<T>`
-                // outputs", and jnigen's converter body is
-                // `byte_array_from_slice(&v)`, which works by deref and is identical
-                // to the `Vec<u8>` one. So this classification *predicts* their
-                // behaviour instead of leaving it a special case.
-                //
-                // The `Cow` survives in `TypeRef::origin`, which is where an adapter
-                // reads the param type its generated fn must spell — and it must,
-                // since `Cow<'_, [u8]>` is not interchangeable with `Vec<u8>` in a
-                // Rust signature.
-                "Cow" => {
+                // `Box` and `Cow` are erased — see `TRANSPARENT_WRAPPERS`,
+                // which is the list this arm consults so the set cannot drift
+                // from the one adapters undo.
+                w if TRANSPARENT_WRAPPERS.contains(&w) => {
                     arity(1)?;
                     return Ok(args.remove(0).kind);
                 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/mod.rs
@@ -106,10 +106,12 @@ mod destructure_ledger {
     const LEDGER: &[(&str, usize)] = &[
         ("callback.rs", 0),
         // The `Option<T>` output converters' niche and boxed-primitive arms.
-        // They destructure `v`, the converter's own parameter — whose Rust type
-        // is the crossing's SPELLING. Correct today only because a wrapped
-        // spelling gets no converter at all (#270); if that is fixed and
-        // `Box<Option<T>>` becomes a crossing, these two need coercing.
+        // They destructure `v`, the converter's own parameter — and #270 made a
+        // wrapped spelling a real crossing, so that prediction came due. They
+        // are correct now for the reason the note said they were not: the
+        // caller (`output_wrapper_shape`) binds the CANONICAL `Option<T>` from
+        // the spelling before handing the body `v`, so what these destructure
+        // is an `Option` by construction rather than by luck.
         ("convert.rs", 2),
         // 2 fn-return matches (owned), 2 leaf reaches (one coerced, one owned
         // accessor return), 1 owned identity move, 1 emitter-bound local.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -236,9 +236,12 @@ pub(crate) fn annotate_jobject_with_lifetime(ty: &syn::Type, life: &str) -> syn:
 // Helpers
 // ──────────────────────────────────────────────────────────────────────
 
-pub(crate) fn pat_match(ty: &syn::Type, pat: &str) -> bool {
-    ty.to_token_stream().to_string() == pat
-}
+// `pat_match` lived here — `ty.to_token_stream().to_string() == pat` — and was
+// how the converter selector decided what a type WAS: rebuild a wildcard
+// pattern from the spelling, render it to a string, compare. That made the
+// answer depend on how Rust happened to spell the type, so `Box<Option<T>>`
+// reconstructed as `Box<_>`, matched nothing, and got no converter at all
+// (#270). Dispatch reads `TypeKind` now; nothing needs it.
 
 /// `true` if `ty` is a path whose final segment is `name` (e.g. `Vec<_>` for
 /// `name = "Vec"`, `Option<&T>` for `name = "Option"`). Ignores generic args.

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -635,7 +635,7 @@ mod prim_array;
 mod selector;
 #[cfg(test)]
 mod tests;
-mod trait_impl;
+pub(crate) mod trait_impl;
 
 mod fn_plan;
 mod fold;

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -83,6 +83,21 @@ impl Declarations {
                     return Some(c);
                 }
             }
+            // An optional BORROW is the deep handler's alone. It declined —
+            // either the inner is not a handle (then the shallow handler below
+            // is right, and only for the canonical spelling) or the spelling
+            // carries a wrapper it cannot bridge. The shallow handler cannot
+            // tell those apart and would decode the jlong as a `*mut &T`, so a
+            // wrapped optional borrow stops here rather than resolving wrong.
+            if inner.borrow_target().is_some() {
+                let canonical: syn::Type = {
+                    let b = &inner.origin.syntax;
+                    syn::parse_quote!(Option<#b>)
+                };
+                if syntax.to_token_stream().to_string() != canonical.to_token_stream().to_string() {
+                    return None;
+                }
+            }
             let inner_ty = inner.origin.syntax.clone();
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Optional, syntax, &inner_ty, registry)

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -1,37 +1,7 @@
 //! Structural converter-selection policy for [`Declarations`].
 
-use super::*;
+use super::{trait_impl::WrapperShape, *};
 use crate::api::core::registry::Conversions;
-
-/// Clone a single-type-arg generic (`Option<X>` / `Vec<X>` / any `Path<X, …>`)
-/// replacing its last segment's first type argument with `repl` — yielding the
-/// canonical shape (`Option<_>`) the built-in wrapper handlers key on, with the
-/// type's own path/qualification preserved exactly.
-fn with_first_arg(ty: &syn::Type, repl: syn::Type) -> syn::Type {
-    let mut out = ty.clone();
-    if let syn::Type::Path(tp) = &mut out {
-        if let Some(seg) = tp.path.segments.last_mut() {
-            if let syn::PathArguments::AngleBracketed(ab) = &mut seg.arguments {
-                for a in ab.args.iter_mut() {
-                    if let syn::GenericArgument::Type(t) = a {
-                        *t = repl;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-    out
-}
-
-/// Clone a reference type replacing its referent with the `_` wildcard,
-/// preserving the lifetime and mutability (`&'a T` → `&'a _`, `&mut T` →
-/// `&mut _`) so the reconstructed pattern matches what the enumerator emitted.
-fn ref_wildcard(r: &syn::TypeReference) -> syn::Type {
-    let mut pr = r.clone();
-    *pr.elem = syn::parse_quote!(_);
-    syn::Type::Reference(pr)
-}
 
 /// Whether a decoded `Vec<T>` local can be borrowed where `referent` is expected.
 ///
@@ -52,6 +22,20 @@ fn decoded_vec_satisfies(referent: &syn::Type) -> bool {
     }
 }
 
+/// Whether a spelling has no size, so no by-value converter can name it.
+///
+/// A **spelling** question, like [`decoded_vec_satisfies`]: `[T]` and `Vec<T>`
+/// are one concept to the model — both `Sequence` — and Rust can return only
+/// one of them. A bare slice is reached exclusively through a borrow, whose own
+/// arm handles it; claiming it here would generate `fn f(..) -> [T]`.
+///
+/// `str` is the same shape of fact and is handled the same way, one layer up:
+/// its terminal arm resolves it to the borrowed `&str` converter rather than
+/// pretending an owned `str` exists.
+fn is_unsized_spelling(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Slice(_))
+}
+
 impl Declarations {
     /// Select the input converter for `ty`: terminals, user wrappers, then
     /// built-in structural wrappers.
@@ -62,13 +46,14 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         use crate::api::core::flat::RefMode;
 
-        // The spelling, for the wildcard patterns this selector builds. Those are
-        // the adapter's own — `Option<_>`, `&_` — so composing them from tokens is
-        // spelling, not reasoning. What the type *is* comes from `ty` below.
+        // What the type IS comes from `kind`; what generated Rust must SPELL it
+        // comes from here. The converter yields this spelling, so a
+        // `Box<Option<T>>` crossing produces a `Box<Option<T>>` — the shape it
+        // is dispatched as no longer decides what it is called.
         let syntax = &ty.origin.syntax;
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
-        if let Some(c) = self.input_terminal(syntax, registry) {
+        if let Some(c) = self.input_terminal(ty, registry) {
             return Some(c);
         }
         // 3. Built-in wrapper shapes, read one layer at a time rather than as a
@@ -76,31 +61,42 @@ impl Declarations {
         //    through `subs` to be selected on its own. Peeling further here would
         //    claim a shape this selector does not emit.
         if let Some(inner) = ty.optional_inner() {
-            // `Option<&T>` tries the DEEP `Option<&_>` (borrowed-handle →
-            // `Option<OwnedObject<T>>`) before the shallow `Option<_>`; the shape
+            // `Option<&T>` tries the DEEP `OptionRef` (borrowed-handle →
+            // `Option<OwnedObject<T>>`) before the shallow `Optional`; the shape
             // that resolves correctly wins.
             if let Some(target) = inner.borrow_target() {
-                if let syn::Type::Reference(r) = &inner.origin.syntax {
-                    let pat = with_first_arg(syntax, ref_wildcard(r));
-                    let t1 = target.origin.syntax.clone();
-                    if let Some(mut c) = self.input_wrapper_shape(&pat, &t1, registry) {
-                        c.subs = vec![t1];
-                        return Some(c);
+                let mutable = matches!(
+                    inner.kind,
+                    crate::api::core::flat::TypeKind::Ref {
+                        mode: RefMode::Exclusive,
+                        ..
                     }
+                );
+                let t1 = target.origin.syntax.clone();
+                if let Some(mut c) = self.input_wrapper_shape(
+                    WrapperShape::OptionRef { mutable },
+                    syntax,
+                    &t1,
+                    registry,
+                ) {
+                    c.subs = vec![t1];
+                    return Some(c);
                 }
             }
-            let pat = with_first_arg(syntax, syn::parse_quote!(_));
             let inner_ty = inner.origin.syntax.clone();
-            if let Some(mut c) = self.input_wrapper_shape(&pat, &inner_ty, registry) {
+            if let Some(mut c) =
+                self.input_wrapper_shape(WrapperShape::Optional, syntax, &inner_ty, registry)
+            {
                 c.subs = vec![inner_ty];
                 return Some(c);
             }
             return None;
         }
-        if let Some(elem) = ty.sequence_elem() {
-            let pat = with_first_arg(syntax, syn::parse_quote!(_));
+        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(syntax)) {
             let elem_ty = elem.origin.syntax.clone();
-            if let Some(mut c) = self.input_wrapper_shape(&pat, &elem_ty, registry) {
+            if let Some(mut c) =
+                self.input_wrapper_shape(WrapperShape::Sequence, syntax, &elem_ty, registry)
+            {
                 c.subs = vec![elem_ty];
                 return Some(c);
             }
@@ -130,21 +126,29 @@ impl Declarations {
             if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(&inner.origin.syntax) {
                 if let Some(elem) = inner.sequence_elem() {
                     let elem_ty = elem.origin.syntax.clone();
-                    let pat: syn::Type = syn::parse_quote!(Vec<_>);
-                    if let Some(mut c) = self.input_wrapper_shape(&pat, &elem_ty, registry) {
+                    // The one place `produced` is NOT the crossing's spelling:
+                    // there is no owned `[T]` to decode into, so the converter
+                    // yields an owned `Vec<T>` and the call site borrows it.
+                    let produced: syn::Type = syn::parse_quote!(Vec<#elem_ty>);
+                    if let Some(mut c) = self.input_wrapper_shape(
+                        WrapperShape::Sequence,
+                        &produced,
+                        &elem_ty,
+                        registry,
+                    ) {
                         c.subs = vec![elem_ty];
                         return Some(c);
                     }
                     return None;
                 }
             }
-            if let syn::Type::Reference(r) = syntax {
-                let pat = ref_wildcard(r);
-                let t1 = inner.origin.syntax.clone();
-                if let Some(mut c) = self.input_wrapper_shape(&pat, &t1, registry) {
-                    c.subs = vec![t1];
-                    return Some(c);
-                }
+            let mutable = matches!(mode, RefMode::Exclusive);
+            let t1 = inner.origin.syntax.clone();
+            if let Some(mut c) =
+                self.input_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, &t1, registry)
+            {
+                c.subs = vec![t1];
+                return Some(c);
             }
         }
         None
@@ -154,9 +158,19 @@ impl Declarations {
     /// built-in structural wrappers.
     pub(crate) fn select_output_type(
         &self,
-        ty: &syn::Type,
+        ty: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
+        use crate::api::core::flat::RefMode;
+
+        // What the type IS comes from `kind`; the spelling is what generated
+        // Rust must say. This direction used to be handed only the spelling —
+        // `convert_crossing` fetched the reading and threw it away — so it
+        // detected its layers with `option_inner_type`/`vec_inner_type`, which
+        // read the last path segment's ident. A `Box<Option<T>>` answered
+        // "neither", and got no converter at all (#270).
+        let syntax = &ty.origin.syntax;
+
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
         if let Some(c) = self.output_terminal(ty, registry) {
             return Some(c);
@@ -165,42 +179,51 @@ impl Declarations {
         //    Read off the model, which calls this shape `TypeKind::Fallible`.
         //    `result_parts` covers a `Result` the adapter composed itself, which
         //    the frontend never read.
-        if let Some((ok, err)) = fallible_parts(ty, registry) {
-            if let Some(c) = self.result_peel(ty, &ok, &err, registry) {
+        if let Some((ok, err)) = fallible_parts(syntax, registry) {
+            if let Some(c) = self.result_peel(syntax, &ok, &err, registry) {
                 return Some(c);
             }
         }
-        // 3. Built-in wrapper shapes (`Option<_>`, `Vec<_>`, `&T` borrow). An
-        //    `Option<&Handle>` resolves via the shallow `Option<_>` whose inner
-        //    converter is the `&Handle` borrow entry (no deep output handler).
-        if let Some(inner) = option_inner_type(ty) {
-            let pat = with_first_arg(ty, syn::parse_quote!(_));
-            if let Some(mut c) = self.output_wrapper_shape(&pat, &inner, registry) {
-                c.subs = vec![inner];
-                return Some(c);
-            }
-            return None;
-        }
-        if let Some(elem) = vec_inner_type(ty) {
-            let pat = with_first_arg(ty, syn::parse_quote!(_));
-            if let Some(mut c) = self.output_wrapper_shape(&pat, &elem, registry) {
-                c.subs = vec![elem];
+        // 3. Built-in wrapper shapes, dispatched on what the model says the
+        //    type IS. An `Option<&Handle>` resolves via the shallow `Optional`
+        //    whose inner converter is the `&Handle` borrow entry (no deep
+        //    output handler).
+        if let Some(inner) = ty.optional_inner() {
+            let inner_ty = inner.origin.syntax.clone();
+            if let Some(mut c) =
+                self.output_wrapper_shape(WrapperShape::Optional, syntax, &inner_ty, registry)
+            {
+                c.subs = vec![inner_ty];
                 return Some(c);
             }
             return None;
         }
-        if let syn::Type::Reference(r) = ty {
-            // `&[T]` shared slice (a callback argument crossing native→JVM): build a
-            // `List<T>` from the borrowed slice. Dual of the `&[T]` input branch.
-            if r.mutability.is_none() {
-                if let syn::Type::Slice(s) = &*r.elem {
-                    let elem = (*s.elem).clone();
-                    return self.output_slice(&elem, registry);
+        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(syntax)) {
+            let elem_ty = elem.origin.syntax.clone();
+            if let Some(mut c) =
+                self.output_wrapper_shape(WrapperShape::Sequence, syntax, &elem_ty, registry)
+            {
+                c.subs = vec![elem_ty];
+                return Some(c);
+            }
+            return None;
+        }
+        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = &ty.kind {
+            // `&[T]` shared slice (a callback argument crossing native→JVM):
+            // build a `List<T>` from the borrowed slice. Dual of the `&[T]`
+            // input branch, and the same split: `kind` says it is a borrow of a
+            // run of values; whether the generated Rust can iterate the borrow
+            // directly is a question about the SPELLING.
+            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(&inner.origin.syntax) {
+                if let Some(elem) = inner.sequence_elem() {
+                    return self.output_slice(&elem.origin.syntax, registry);
                 }
             }
-            let pat = ref_wildcard(r);
-            let t1 = (*r.elem).clone();
-            if let Some(mut c) = self.output_wrapper_shape(&pat, &t1, registry) {
+            let mutable = matches!(mode, RefMode::Exclusive);
+            let t1 = inner.origin.syntax.clone();
+            if let Some(mut c) =
+                self.output_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, &t1, registry)
+            {
                 c.subs = vec![t1];
                 return Some(c);
             }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2578,3 +2578,83 @@ fn a_transparent_wrapper_is_bridged_only_where_it_can_be() {
         "the refusal names the unsupported representation: {cow}"
     );
 }
+
+/// A wrapper cannot be bridged where the converter does not produce the spelled
+/// type at all — the **borrow** shapes — so those refuse rather than resolve.
+///
+/// `&T` and `Option<&T>` are served by handing back the inner type's own
+/// converter (or an `OwnedObject`) and letting the call site add `&` /
+/// `.as_deref()`. There is no value in hand to unwrap a representation from, so
+/// `Box<&T>` would pass an owned `T` where `Box<&T>` is expected, and
+/// `Box<Option<&T>>` would decode the handle as `*mut &T`. Both used to resolve
+/// (#272 review).
+///
+/// The canonical spellings are asserted alongside, because a guard that also
+/// refused those would be worse than no guard.
+#[test]
+fn a_wrapped_borrow_has_nothing_to_bridge_and_refuses() {
+    let loc = myflat_loc();
+    let build = |param_ty: syn::Type| -> Result<String, String> {
+        let items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZThing {
+                        pub v: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_take(t: #param_ty) -> i64 {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZThing))
+                    .fun(crate::fun!(z_take)),
+            );
+        let dir = unique_test_dir("jnigen_wrapped_borrow");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        match jni.build_with(registry) {
+            Ok(g) => Ok(std::fs::read_to_string(
+                g.write_rust(dir.join("g.rs")).expect("write_rust"),
+            )
+            .expect("read rust")),
+            Err(e) => Err(format!("{e}")),
+        }
+    };
+
+    // The canonical borrows still resolve, and still adapt at the call site.
+    let borrowed = build(syn::parse_quote!(&ZThing)).expect("a plain borrow resolves");
+    assert!(
+        borrowed.contains("myflat::z_take(&t)"),
+        "the call site adds the borrow:\n{borrowed}"
+    );
+    let opt = build(syn::parse_quote!(Option<&ZThing>)).expect("an optional borrow resolves");
+    assert!(
+        opt.contains("myflat::z_take(t.as_deref())"),
+        "the call site derefs the OwnedObject:\n{opt}"
+    );
+
+    // Wrapped, they have nothing to bridge and must not resolve.
+    for spelling in [
+        syn::parse_quote!(Box<&ZThing>),
+        syn::parse_quote!(Box<Option<&ZThing>>),
+    ] {
+        let err = build(spelling).expect_err("a wrapped borrow must not resolve");
+        assert!(
+            err.contains("could not be resolved"),
+            "the refusal names the type: {err}"
+        );
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2483,3 +2483,98 @@ fn an_owned_string_crosses_the_same_however_rust_spells_it() {
         );
     }
 }
+
+/// A transparent wrapper is bridged only where generated Rust **can** bridge
+/// it, and an unsupported representation is refused at selection rather than
+/// emitted as code that will not compile.
+///
+/// The model erases more than `Box`: `Cow<'_, T>` *is* `T` too. But a converter
+/// that MOVES its payload has to undo the exact wrapper the source wrote, and
+/// there is no trait for that — `Box<T> → T` is `*b`, `Cow<'_, T> → T::Owned`
+/// is `into_owned()`, and a `Cow` cannot be moved through at all (`E0507`).
+/// Layers are counted, too: `Box<Box<Option<T>>>` is `Optional`, and one
+/// dereference leaves `Box<Option<T>>`.
+///
+/// Both shapes used to RESOLVE and emit `let v: Option<String> = (*v);` — the
+/// worst outcome available, because resolution succeeding is what tells the
+/// binding its type is supported. Failing to resolve names the type; emitting
+/// unbuildable Rust names nothing (#270 review).
+#[test]
+fn a_transparent_wrapper_is_bridged_only_where_it_can_be() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| -> Result<String, String> {
+        let items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZSampleStruct {
+                        pub f: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)));
+        let dir = unique_test_dir("jnigen_vf_bridge");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        match jni.build_with(registry) {
+            Ok(g) => Ok(std::fs::read_to_string(
+                g.write_rust(dir.join("g.rs")).expect("write_rust"),
+            )
+            .expect("read rust")),
+            Err(e) => Err(format!("{e}")),
+        }
+    };
+
+    // One box: bridged with one dereference.
+    let one = build(syn::parse_quote!(Box<Option<String>>)).expect("a single box is bridgeable");
+    let oc: String = one.split_whitespace().collect();
+    assert!(
+        oc.contains("letv:Option<String>=(*v);"),
+        "one layer, one dereference:\n{one}"
+    );
+
+    // Two boxes: bridged with TWO. This is the case a single deref got wrong,
+    // silently — `(*v)` on `Box<Box<_>>` is still a `Box<_>`.
+    let two =
+        build(syn::parse_quote!(Box<Box<Option<String>>>)).expect("nested boxes are bridgeable");
+    let tc: String = two.split_whitespace().collect();
+    assert!(
+        tc.contains("letv:Option<String>=(*(*v));"),
+        "two layers, two dereferences:\n{two}"
+    );
+
+    // `Cow` is erased by the model and CANNOT be moved through, so the crossing
+    // must not resolve. The diagnosis names the type.
+    let cow = build(syn::parse_quote!(Cow<'static, Option<String>>))
+        .expect_err("a Cow payload cannot be moved out, so it must not resolve");
+    assert!(
+        cow.contains("could not be resolved") && cow.contains("Cow"),
+        "the refusal names the unsupported representation: {cow}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2308,3 +2308,178 @@ fn the_declarator_and_the_accessor_s_receiver_must_agree() {
         "`.fields` on a by-value accessor must be refused, naming it: {msg:?}"
     );
 }
+
+/// A field's optional-ness is `kind`'s; how Rust spells it is the source's,
+/// and a **whole-value crossing** must not care either — the half #268 could
+/// not reach.
+///
+/// #268 fixed the *access path* for a decomposed child. A field with no
+/// deconstructor needs its own converter, and converter selection dispatched by
+/// rebuilding a pattern from the spelling: `with_first_arg(Box<Option<T>>)`
+/// yielded `Box<_>`, which matched no handler, so the crossing got no converter
+/// at all and failed resolution by name (#270).
+///
+/// Both spellings now resolve, and the converter takes the type the source
+/// actually wrote — declaring `Option<T>` for a `Box<Option<T>>` value would
+/// mismatch its own call site.
+#[test]
+fn a_whole_value_crossing_ignores_how_rust_spells_it() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| -> String {
+        let items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZStamp {
+                        pub secs: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZSampleStruct {
+                        pub stamp: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .class(crate::data_class!(ZStamp))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)));
+        let dir = unique_test_dir("jnigen_vf_whole_boxed");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Resolving at all is half the assertion: this is what #270 reported as
+        // `Unresolved { key: "Box < Option < ZStamp > >" }`.
+        let gen = jni.build_with(registry).expect("resolve");
+        std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+            .expect("read rust")
+    };
+
+    let plain = build(syn::parse_quote!(Option<ZStamp>));
+    let boxed = build(syn::parse_quote!(Box<Option<ZStamp>>));
+
+    let bc: String = boxed.split_whitespace().collect();
+    // The converter takes what the source wrote...
+    assert!(
+        bc.contains("v:Box<Option<myflat::ZStamp>>"),
+        "the converter takes the spelled type:\n{boxed}"
+    );
+    // ...and reads the canonical shape out of it before destructuring.
+    assert!(
+        bc.contains("letv:Option<myflat::ZStamp>="),
+        "the spelling is read as the canonical shape:\n{boxed}"
+    );
+    // The Kotlin surface is the wrapper's business only in Rust: both
+    // spellings deliver the same nullable data class.
+    for (label, rust) in [("Option<T>", &plain), ("Box<Option<T>>", &boxed)] {
+        assert!(
+            rust.contains("ZStamp_to_JObject"),
+            "{label}: the field still crosses as its own converter:\n{rust}"
+        );
+    }
+}
+
+/// An owned string crosses the same however Rust spells it, with no
+/// per-spelling arm behind it.
+///
+/// `Box<String>` used to work only because two `TypeKey == "Box < String >"`
+/// matches were written by hand — one per direction. That is what a
+/// spelling-keyed converter table costs: a hardcoded case for every
+/// representation someone happens to write. Both are deleted; `kind == Str`
+/// dispatches, the signature comes from the spelling, and `.into()` constructs
+/// it.
+#[test]
+fn an_owned_string_crosses_the_same_however_rust_spells_it() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| -> String {
+        let items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZSampleStruct {
+                        pub label: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZSample))
+                    .fun(crate::fun!(z_sample_sub)),
+            )
+            .expand(crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_struct)));
+        let dir = unique_test_dir("jnigen_vf_boxed_string");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let gen = jni.build_with(registry).expect("resolve");
+        let (rust, kotlin) = (
+            std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+                .expect("read rust"),
+            gen.write_kotlin(&dir.join("kotlin"))
+                .expect("write_kotlin")
+                .iter()
+                .map(|p| std::fs::read_to_string(p).unwrap())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        format!("{rust}\n// ---KOTLIN---\n{kotlin}")
+    };
+
+    for spelling in [
+        syn::parse_quote!(String),
+        syn::parse_quote!(Box<String>),
+        syn::parse_quote!(Cow<'static, str>),
+    ] {
+        let out = build(spelling);
+        assert!(
+            out.contains("String"),
+            "every owned-string spelling crosses as a Kotlin String:\n{out}"
+        );
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -644,33 +644,73 @@ pub(crate) enum WrapperShape {
     Optional,
 }
 
-/// Read the converter's `v` as the **canonical** shape when the source spelled
-/// it some other way — the output-side peer of the input `.into()`.
+/// How many `Box` layers stand between a **spelling** and the canonical shape
+/// its `kind` names — `None` when the spelling cannot be bridged **by value**
+/// at all.
 ///
-/// The two directions are not symmetric, and pretending otherwise would
-/// generate code that does not compile. **Input** builds a value and then
-/// constructs the spelling, and `Into` states that requirement for every
-/// representation at once. **Output** is handed the spelling and must get the
-/// canonical value *out*, by value — the bodies move the payload — and std has
-/// no trait for that: `Box<T> → T` is `*b` and `Cow → T` is `into_owned()` —
-/// different operations with no shared name.
+/// The model erases more than one wrapper (`Box<T>` *is* `T`, and so is
+/// `Cow<'_, T>`), and a converter that moves the payload has to undo exactly
+/// the wrapper the source wrote. There is no trait for that: `Box<T> → T` is
+/// `*b`, `Cow<'_, T> → T::Owned` is `into_owned()` — different operations with
+/// no shared name — and `Cow` cannot be moved through at all (`E0507`).
 ///
-/// So this asks a **spelling** question — is what the source wrote already the
-/// canonical form? — and derefs once when it is not. That is a legitimate
-/// question about generated Rust, the same one `decoded_vec_satisfies` asks;
-/// what the type *means* still comes from `kind` and is already settled by the
-/// time this is called.
+/// So the bridge is built only where it can be, and the layers are counted
+/// rather than assumed: `Box<Box<Option<T>>>` is `Optional` too, and one
+/// dereference leaves `Box<Option<T>>`.
 ///
-/// A representation that is not deref-movable fails to compile, naming the
-/// type. That is the same contract as the input side: the adapter states what
-/// it needs of a representation and rustc enforces it, rather than the adapter
-/// guessing which wrappers exist.
-fn read_as_canonical(produced: &syn::Type, canonical: &syn::Type) -> TokenStream {
-    if produced.to_token_stream().to_string() == canonical.to_token_stream().to_string() {
-        quote!(v)
-    } else {
-        quote!((*v))
+/// A **spelling** question, in the same family as [`decoded_vec_satisfies`] and
+/// `is_unsized_spelling`: what the type *means* is `kind`'s and is settled
+/// before this is called; this asks only what generated Rust is able to write.
+///
+/// `None` makes the crossing **unresolved**, naming the type — the failure that
+/// says "this representation is not supported here". Emitting a bridge that
+/// cannot compile would be worse: resolution would succeed and the consumer's
+/// build would break instead (#270 review).
+fn box_layers_to(spelling: &syn::Type, canonical: &syn::Type) -> Option<usize> {
+    if spelling.to_token_stream().to_string() == canonical.to_token_stream().to_string() {
+        return Some(0);
     }
+    let syn::Type::Path(tp) = spelling else {
+        return None;
+    };
+    let seg = tp.path.segments.last()?;
+    if seg.ident != "Box" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
+        return None;
+    };
+    let syn::GenericArgument::Type(inner) = ab.args.first()? else {
+        return None;
+    };
+    box_layers_to(inner, canonical).map(|d| d + 1)
+}
+
+/// Read the converter's `v` as the canonical shape — one dereference per
+/// [`box_layers_to`] layer, and none at all when the source already wrote the
+/// canonical form.
+fn read_as_canonical(produced: &syn::Type, canonical: &syn::Type) -> Option<TokenStream> {
+    let depth = box_layers_to(produced, canonical)?;
+    let mut e = quote!(v);
+    for _ in 0..depth {
+        e = quote!((*#e));
+    }
+    Some(e)
+}
+
+/// Build the spelling from a canonical value — the input-side peer, wrapping
+/// once per [`box_layers_to`] layer.
+fn build_from_canonical(
+    produced: &syn::Type,
+    canonical: &syn::Type,
+    value: TokenStream,
+) -> Option<TokenStream> {
+    let depth = box_layers_to(produced, canonical)?;
+    let mut e = value;
+    for _ in 0..depth {
+        e = quote!(::std::boxed::Box::new(#e));
+    }
+    Some(e)
 }
 
 /// Per-shape **input** wrapper converter builders (`&`/`Option<&>`/`Vec`/
@@ -815,6 +855,9 @@ impl Declarations {
             quote::quote!(&__elem_wire),
         );
         let outer_ty = produced.clone();
+        let canonical: syn::Type = syn::parse_quote!(Vec<#t1>);
+        // Bridgeable first — see `box_layers_to`.
+        let build = build_from_canonical(produced, &canonical, quote::quote!(__out))?;
         let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
         let body: syn::Expr = syn::parse_quote!({
             let __list = jni::objects::JList::from_env(env, v)
@@ -829,10 +872,7 @@ impl Declarations {
                 let __elem: #t1 = #inner_conv;
                 __out.push(__elem);
             }
-            // The canonical value, then the spelling. `From<T> for T` is
-            // reflexive, so a plain `Vec<T>` is a no-op and a wrapped spelling
-            // (`Box<Vec<T>>`) is constructed — see `WrapperShape`.
-            __out.into()
+            #build
         });
         let inner_kotlin = inner.metadata.kotlin_name.clone()?;
         let kotlin_name = self.override_kotlin_name(
@@ -871,6 +911,8 @@ impl Declarations {
             if inner.metadata.is_direct_handle() {
                 let inner_wire = inner.destination.clone();
                 let outer_ty = produced.clone();
+                let canonical: syn::Type = syn::parse_quote!(Option<#t1>);
+                let build = build_from_canonical(produced, &canonical, quote::quote!(__v))?;
                 let name = input_name(&outer_ty, &inner_wire);
                 let gen_allow = generated_converter_attr();
                 let function: syn::ItemFn = syn::parse_quote!(
@@ -894,8 +936,7 @@ impl Declarations {
                             } else {
                                 Some(*std::boxed::Box::from_raw(*v as *mut #t1))
                             };
-                            // Canonical value first, then the spelling.
-                            __v.into()
+                            #build
                         })
                     }
                 );
@@ -925,12 +966,14 @@ impl Declarations {
         }
         if shape == WrapperShape::Optional {
             let outer_ty = produced.clone();
+            let canonical: syn::Type = syn::parse_quote!(Option<#t1>);
+            let build = build_from_canonical(produced, &canonical, quote::quote!(__v))?;
             let (wire, inner_body, niches) = option_input(t1, registry)?;
             // `option_input` yields the canonical `Option<T>`; the converter
-            // yields the spelling. Reflexive when they are the same.
+            // yields the spelling.
             let body: syn::Expr = syn::parse_quote!({
                 let __v: ::core::option::Option<#t1> = #inner_body;
-                __v.into()
+                #build
             });
             // Inherit the inner's name; user pins on `Option<T>` win.
             // The nullability marker (`?`) is added by the use site.
@@ -2108,11 +2151,10 @@ impl Declarations {
         if shape == WrapperShape::Optional {
             let outer_ty = produced.clone();
             let canonical: syn::Type = syn::parse_quote!(Option<#t1>);
+            // Bridgeable first: an unsupported representation must not resolve
+            // and then emit code the consumer cannot compile.
+            let read = read_as_canonical(produced, &canonical)?;
             let (wire, inner_body, niches) = option_output(t1, registry)?;
-            // `option_output` reads `v` as the canonical `Option<T>`; bind that
-            // first so a wrapped spelling is deref'd once. See
-            // [`read_as_canonical`].
-            let read = read_as_canonical(produced, &canonical);
             let body: syn::Expr = syn::parse_quote!({
                 let v: #canonical = #read;
                 #inner_body
@@ -2177,7 +2219,7 @@ impl Declarations {
             );
             let outer_ty = produced.clone();
             let canonical: syn::Type = syn::parse_quote!(Vec<#t1>);
-            let read = read_as_canonical(produced, &canonical);
+            let read = read_as_canonical(produced, &canonical)?;
             let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
             let body: syn::Expr = syn::parse_quote!({
                 let v: #canonical = #read;

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -644,73 +644,107 @@ pub(crate) enum WrapperShape {
     Optional,
 }
 
-/// How many `Box` layers stand between a **spelling** and the canonical shape
-/// its `kind` names — `None` when the spelling cannot be bridged **by value**
-/// at all.
+/// What generated Rust can do with one wrapper the model
+/// [erases](crate::api::core::flat::TRANSPARENT_WRAPPERS).
 ///
-/// The model erases more than one wrapper (`Box<T>` *is* `T`, and so is
-/// `Cow<'_, T>`), and a converter that moves the payload has to undo exactly
-/// the wrapper the source wrote. There is no trait for that: `Box<T> → T` is
-/// `*b`, `Cow<'_, T> → T::Owned` is `into_owned()` — different operations with
-/// no shared name — and `Cow` cannot be moved through at all (`E0507`).
+/// Erasure and reconstruction are different questions, and only the first is the
+/// model's. `Box<T>` *is* `T` to every destination language — but undoing it in
+/// Rust is `*b`, undoing a `Cow` is `into_owned()`, and undoing an `Rc` is not
+/// possible at all. There is no trait spanning those, so the operations live
+/// here, one row per wrapper, instead of as a special case per converter.
 ///
-/// So the bridge is built only where it can be, and the layers are counted
-/// rather than assumed: `Box<Box<Option<T>>>` is `Optional` too, and one
-/// dereference leaves `Box<Option<T>>`.
-///
-/// A **spelling** question, in the same family as [`decoded_vec_satisfies`] and
-/// `is_unsized_spelling`: what the type *means* is `kind`'s and is settled
-/// before this is called; this asks only what generated Rust is able to write.
-///
-/// `None` makes the crossing **unresolved**, naming the type — the failure that
-/// says "this representation is not supported here". Emitting a bridge that
-/// cannot compile would be worse: resolution would succeed and the consumer's
-/// build would break instead (#270 review).
-fn box_layers_to(spelling: &syn::Type, canonical: &syn::Type) -> Option<usize> {
-    if spelling.to_token_stream().to_string() == canonical.to_token_stream().to_string() {
-        return Some(0);
-    }
-    let syn::Type::Path(tp) = spelling else {
-        return None;
-    };
-    let seg = tp.path.segments.last()?;
-    if seg.ident != "Box" {
-        return None;
-    }
-    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
-        return None;
-    };
-    let syn::GenericArgument::Type(inner) = ab.args.first()? else {
-        return None;
-    };
-    box_layers_to(inner, canonical).map(|d| d + 1)
+/// **Adding a wrapper is adding a row.** Put its name in
+/// `TRANSPARENT_WRAPPERS` (the model decides what it erases) and a row here
+/// (the adapter decides what it can rebuild); `every_erased_wrapper_has_ops`
+/// fails if the two disagree, so a wrapper cannot become transparent without
+/// this file having an answer for it.
+struct WrapperOps {
+    /// Its last path segment, as `TRANSPARENT_WRAPPERS` spells it.
+    name: &'static str,
+    /// Move the inner value **out**. `None` when the representation does not
+    /// permit it — a `Cow` payload cannot be moved through `Deref` (`E0507`),
+    /// and neither can an `Rc`'s.
+    read: Option<fn(TokenStream) -> TokenStream>,
+    /// Build it **from** the inner value. `None` when not supported.
+    build: Option<fn(TokenStream) -> TokenStream>,
 }
 
-/// Read the converter's `v` as the canonical shape — one dereference per
-/// [`box_layers_to`] layer, and none at all when the source already wrote the
-/// canonical form.
+/// The operations table. One row per wrapper the model erases.
+const WRAPPER_OPS: &[WrapperOps] = &[
+    WrapperOps {
+        name: "Box",
+        // `*b` moves out of a box, and `Box::new` puts it back.
+        read: Some(|e| quote!((*#e))),
+        build: Some(|e| quote!(::std::boxed::Box::new(#e))),
+    },
+    WrapperOps {
+        name: "Cow",
+        // Reading would be `into_owned()`, which needs `B: ToOwned` — not
+        // implied by anything the model knows about the payload. Refused until
+        // something needs it; that is one row, not a redesign.
+        read: None,
+        build: None,
+    },
+];
+
+fn wrapper_ops(name: &str) -> Option<&'static WrapperOps> {
+    WRAPPER_OPS.iter().find(|w| w.name == name)
+}
+
+/// The chain of wrappers standing between a **spelling** and the canonical
+/// shape its `kind` names, outermost first — empty when the source already
+/// wrote the canonical form.
+///
+/// `None` means the spelling is not a wrapping of the canonical one at all, so
+/// no converter should claim it.
+fn bridge_layers(spelling: &syn::Type, canonical: &syn::Type) -> Option<Vec<&'static WrapperOps>> {
+    if spelling.to_token_stream().to_string() == canonical.to_token_stream().to_string() {
+        return Some(Vec::new());
+    }
+    let (name, inner) = crate::api::core::flat::peel_transparent(spelling)?;
+    let ops = wrapper_ops(name)?;
+    let mut rest = bridge_layers(&inner, canonical)?;
+    rest.insert(0, ops);
+    Some(rest)
+}
+
+/// Read the converter's `v` as the canonical shape, undoing each layer
+/// outside-in. `None` when any layer cannot be read through — the crossing then
+/// stays **unresolved**, naming the type, rather than resolving and emitting
+/// Rust the consumer cannot build (#270 review).
 fn read_as_canonical(produced: &syn::Type, canonical: &syn::Type) -> Option<TokenStream> {
-    let depth = box_layers_to(produced, canonical)?;
+    let layers = bridge_layers(produced, canonical)?;
     let mut e = quote!(v);
-    for _ in 0..depth {
-        e = quote!((*#e));
+    for w in layers {
+        e = (w.read?)(e);
     }
     Some(e)
 }
 
-/// Build the spelling from a canonical value — the input-side peer, wrapping
-/// once per [`box_layers_to`] layer.
+/// Build the spelling from a canonical value — the input-side peer, applying
+/// each layer inside-out.
 fn build_from_canonical(
     produced: &syn::Type,
     canonical: &syn::Type,
     value: TokenStream,
 ) -> Option<TokenStream> {
-    let depth = box_layers_to(produced, canonical)?;
+    let layers = bridge_layers(produced, canonical)?;
     let mut e = value;
-    for _ in 0..depth {
-        e = quote!(::std::boxed::Box::new(#e));
+    for w in layers.into_iter().rev() {
+        e = (w.build?)(e);
     }
     Some(e)
+}
+
+/// Whether the source wrote the canonical spelling itself — no wrapper to undo.
+///
+/// Required by the converters that do **not** produce the spelled type by
+/// construction: the borrow shapes hand back the inner type's own converter (or
+/// an `OwnedObject`) and let the call site add `&` / `.as_deref()`. There is no
+/// value in hand to wrap or unwrap, so a wrapped spelling cannot be served
+/// here at all and must not resolve.
+fn is_canonical_spelling(produced: &syn::Type, canonical: &syn::Type) -> bool {
+    bridge_layers(produced, canonical).is_some_and(|l| l.is_empty())
 }
 
 /// Per-shape **input** wrapper converter builders (`&`/`Option<&>`/`Vec`/
@@ -738,7 +772,20 @@ impl Declarations {
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        if !matches!(shape, WrapperShape::Borrow { .. }) {
+        let WrapperShape::Borrow { mutable } = shape else {
+            return None;
+        };
+        // This converter does NOT produce the spelled type: it hands back the
+        // inner type's own entry, and the call site adds the `&`. So there is no
+        // value in hand to unwrap a representation from, and a wrapped spelling
+        // — `Box<&T>` — must not resolve here (it would pass an owned `T` where
+        // `Box<&T>` is expected).
+        let canonical: syn::Type = if mutable {
+            syn::parse_quote!(&mut #t1)
+        } else {
+            syn::parse_quote!(&#t1)
+        };
+        if !is_canonical_spelling(produced, &canonical) {
             return None;
         }
         let inner = registry.input_entry(t1)?;
@@ -781,7 +828,18 @@ impl Declarations {
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        if !matches!(shape, WrapperShape::OptionRef { .. }) {
+        let WrapperShape::OptionRef { mutable } = shape else {
+            return None;
+        };
+        // Produces `Option<OwnedObject<T>>`, which the call site adapts with
+        // `.as_deref()` — again not the spelled type, so a wrapped spelling has
+        // nothing to bridge and must not resolve. See `input_borrow`.
+        let canonical: syn::Type = if mutable {
+            syn::parse_quote!(Option<&mut #t1>)
+        } else {
+            syn::parse_quote!(Option<&#t1>)
+        };
+        if !is_canonical_spelling(produced, &canonical) {
             return None;
         }
         let inner = registry.input_entry(t1)?;
@@ -2508,5 +2566,53 @@ impl Declarations {
                     .map(|(k, _)| k.clone()),
             )
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod wrapper_ops_tests {
+    use super::*;
+
+    /// Every wrapper the model erases has a row here.
+    ///
+    /// The two lists answer different questions — the model's is "what do I
+    /// erase", this file's is "what can I rebuild" — and they are allowed to
+    /// disagree about *capability* (`Cow` is erased and cannot be read through).
+    /// They are not allowed to disagree about *membership*: a wrapper that
+    /// becomes transparent without a row here would be silently unbridgeable
+    /// everywhere, which looks exactly like a type the binding got wrong.
+    ///
+    /// So adding `Rc` is: one entry in `TRANSPARENT_WRAPPERS`, one row in
+    /// `WRAPPER_OPS` (`read: None` — an `Rc`'s payload cannot be moved out —
+    /// and `build: Some(Rc::new)`). This test is what says so out loud instead
+    /// of leaving the second step to be discovered.
+    #[test]
+    fn every_erased_wrapper_has_ops() {
+        let missing: Vec<&str> = crate::api::core::flat::TRANSPARENT_WRAPPERS
+            .iter()
+            .copied()
+            .filter(|w| wrapper_ops(w).is_none())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "the model erases {missing:?}, and this adapter has no `WrapperOps` row for them — \
+             add one (`read`/`build` may be `None` when the representation does not allow it, \
+             which refuses the shape instead of mis-generating it)"
+        );
+    }
+
+    /// …and nothing here claims a wrapper the model does not erase, which would
+    /// be an operation that can never run.
+    #[test]
+    fn no_ops_for_a_wrapper_the_model_keeps() {
+        let stray: Vec<&str> = WRAPPER_OPS
+            .iter()
+            .map(|w| w.name)
+            .filter(|n| !crate::api::core::flat::TRANSPARENT_WRAPPERS.contains(n))
+            .collect();
+        assert!(
+            stray.is_empty(),
+            "`WRAPPER_OPS` rows for non-erased {stray:?}"
+        );
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -23,7 +23,14 @@ fn generated_converter_attr() -> syn::Attribute {
         unused_mut,
         unused_variables,
         unused_braces,
+        // A representation-agnostic converter says the same thing for every
+        // spelling, so the plain spelling gets the degenerate form of it: a
+        // reflexive `.into()`, a deref that is a no-op, parens around a value
+        // that needed none. Suppressing per-shape would mean asking which
+        // spelling this is, which is the guessing #270 removed.
+        unused_parens,
         dead_code,
+        clippy::useless_conversion,
         clippy::needless_question_mark,
         clippy::let_and_return,
         clippy::nonminimal_bool,
@@ -612,13 +619,73 @@ pub(crate) fn build_handle_destructor_items(
     named.into_iter().map(|(_, item)| item).collect()
 }
 
+/// Which built-in wrapper a converter is being built for — **the model's
+/// answer, not a guess from the spelling**.
+///
+/// This used to be a `&syn::Type` wildcard pattern (`Option<_>`, `& mut _`)
+/// rebuilt from the type's tokens and compared as a *string*. That made the
+/// dispatch depend on how Rust happened to spell the type: `Box<Option<T>>`
+/// reconstructed as `Box<_>`, matched no pattern, and got no converter at all
+/// (#270) — even though the model classifies it `Optional` and says so.
+///
+/// So the shape comes from [`TypeKind`](crate::api::core::flat::TypeKind) and
+/// the spelling comes from `origin.syntax`, which is the same split the rest of
+/// the pipeline follows: classify off `kind`, spell off `syntax`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum WrapperShape {
+    /// `Ref` — a borrow of its inner.
+    Borrow { mutable: bool },
+    /// `Optional` whose inner is a `Ref` — the deep handle-borrow form, tried
+    /// before [`Self::Optional`].
+    OptionRef { mutable: bool },
+    /// `Sequence` — a run of its element.
+    Sequence,
+    /// `Optional` — its inner, or absent.
+    Optional,
+}
+
+/// Read the converter's `v` as the **canonical** shape when the source spelled
+/// it some other way — the output-side peer of the input `.into()`.
+///
+/// The two directions are not symmetric, and pretending otherwise would
+/// generate code that does not compile. **Input** builds a value and then
+/// constructs the spelling, and `Into` states that requirement for every
+/// representation at once. **Output** is handed the spelling and must get the
+/// canonical value *out*, by value — the bodies move the payload — and std has
+/// no trait for that: `Box<T> → T` is `*b` and `Cow → T` is `into_owned()` —
+/// different operations with no shared name.
+///
+/// So this asks a **spelling** question — is what the source wrote already the
+/// canonical form? — and derefs once when it is not. That is a legitimate
+/// question about generated Rust, the same one `decoded_vec_satisfies` asks;
+/// what the type *means* still comes from `kind` and is already settled by the
+/// time this is called.
+///
+/// A representation that is not deref-movable fails to compile, naming the
+/// type. That is the same contract as the input side: the adapter states what
+/// it needs of a representation and rustc enforces it, rather than the adapter
+/// guessing which wrappers exist.
+fn read_as_canonical(produced: &syn::Type, canonical: &syn::Type) -> TokenStream {
+    if produced.to_token_stream().to_string() == canonical.to_token_stream().to_string() {
+        quote!(v)
+    } else {
+        quote!((*v))
+    }
+}
+
 /// Per-shape **input** wrapper converter builders (`&`/`Option<&>`/`Vec`/
-/// `Option`). Each returns `Some(ConverterImpl)` only for the wildcard pattern
-/// it claims; [`JniGenBuilder::input_wrapper_shape`] chains them in priority order.
-/// Because [`pat_match`] is an exact match, the patterns are disjoint — except
-/// the two `Option<_>` sub-cases (direct-handle-by-value vs general), which
-/// share a pattern and so live together in [`JniGenBuilder::input_option`] to keep
-/// their original fall-through.
+/// `Option`). Each returns `Some(ConverterImpl)` only for the [`WrapperShape`]
+/// it claims; [`Declarations::input_wrapper_shape`] chains them in priority
+/// order. The shapes are disjoint — except the two `Optional` sub-cases
+/// (direct-handle-by-value vs general), which share one and so live together in
+/// [`Declarations::input_option`] to keep their original fall-through.
+///
+/// Each takes `produced`: the Rust type the converter's function **yields**.
+/// Normally that is the crossing's own spelling, so a `Box<Option<T>>` crossing
+/// produces a `Box<Option<T>>` rather than silently declaring `Option<T>` and
+/// mismatching its call site. The one deliberate exception is a `&[T]`
+/// parameter, which decodes to an owned `Vec<T>` the call site borrows — see
+/// [`Declarations::select_input_type`].
 impl Declarations {
     /// `& _` / `& mut _` borrow: share T's resolved converter — `&T`'s entry
     /// points at the same `ItemFn` (the fn returns owned `T`; the call site in
@@ -626,19 +693,16 @@ impl Declarations {
     /// wildcard-substitution machinery marks T required transitively from `&T`.
     fn input_borrow(
         &self,
-        pat: &syn::Type,
+        shape: WrapperShape,
+        produced: &syn::Type,
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        if !(pat_match(pat, "& _") || pat_match(pat, "& mut _")) {
+        if !matches!(shape, WrapperShape::Borrow { .. }) {
             return None;
         }
         let inner = registry.input_entry(t1)?;
-        let outer_ty: syn::Type = if pat_match(pat, "& mut _") {
-            syn::parse_quote!(&mut #t1)
-        } else {
-            syn::parse_quote!(&#t1)
-        };
+        let outer_ty = produced.clone();
         // `&T` / `&mut T` are Kotlin-side no-ops — inherit the inner
         // type's name, unless the user pinned an explicit override
         // on the outer form itself (rare but legal).
@@ -672,11 +736,12 @@ impl Declarations {
     /// over `&T` and the general handler takes it.
     fn input_option_ref(
         &self,
-        pat: &syn::Type,
+        shape: WrapperShape,
+        produced: &syn::Type,
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        if !(pat_match(pat, "Option < & _ >") || pat_match(pat, "Option < & mut _ >")) {
+        if !matches!(shape, WrapperShape::OptionRef { .. }) {
             return None;
         }
         let inner = registry.input_entry(t1)?;
@@ -684,14 +749,9 @@ impl Declarations {
             // Non-opaque: let the general `Option<_>` handler take it.
             return None;
         }
-        let is_mut = pat_match(pat, "Option < & mut _ >");
         let inner_wire = inner.destination.clone();
         let inner_conv = inner.function.sig.ident.clone();
-        let outer_ty: syn::Type = if is_mut {
-            syn::parse_quote!(Option<&mut #t1>)
-        } else {
-            syn::parse_quote!(Option<&#t1>)
-        };
+        let outer_ty = produced.clone();
         let name = input_name(&outer_ty, &inner_wire);
         let gen_allow = generated_converter_attr();
         let function: syn::ItemFn = syn::parse_quote!(
@@ -733,11 +793,12 @@ impl Declarations {
     /// collect into a `Vec`. (`Vec<u8>` is special-cased at rank-0.)
     fn input_vec(
         &self,
-        pat: &syn::Type,
+        shape: WrapperShape,
+        produced: &syn::Type,
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        if !pat_match(pat, "Vec < _ >") {
+        if shape != WrapperShape::Sequence {
             return None;
         }
         let inner = registry.input_entry(t1)?;
@@ -753,7 +814,7 @@ impl Declarations {
             inner,
             quote::quote!(&__elem_wire),
         );
-        let outer_ty: syn::Type = syn::parse_quote!(Vec<#t1>);
+        let outer_ty = produced.clone();
         let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
         let body: syn::Expr = syn::parse_quote!({
             let __list = jni::objects::JList::from_env(env, v)
@@ -768,7 +829,10 @@ impl Declarations {
                 let __elem: #t1 = #inner_conv;
                 __out.push(__elem);
             }
-            __out
+            // The canonical value, then the spelling. `From<T> for T` is
+            // reflexive, so a plain `Vec<T>` is a no-op and a wrapped spelling
+            // (`Box<Vec<T>>`) is constructed — see `WrapperShape`.
+            __out.into()
         });
         let inner_kotlin = inner.metadata.kotlin_name.clone()?;
         let kotlin_name = self.override_kotlin_name(
@@ -797,15 +861,16 @@ impl Declarations {
     /// the original sequential fall-through.
     fn input_option(
         &self,
-        pat: &syn::Type,
+        shape: WrapperShape,
+        produced: &syn::Type,
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        if pat_match(pat, "Option < _ >") {
+        if shape == WrapperShape::Optional {
             let inner = registry.input_entry(t1)?;
             if inner.metadata.is_direct_handle() {
                 let inner_wire = inner.destination.clone();
-                let outer_ty: syn::Type = syn::parse_quote!(Option<#t1>);
+                let outer_ty = produced.clone();
                 let name = input_name(&outer_ty, &inner_wire);
                 let gen_allow = generated_converter_attr();
                 let function: syn::ItemFn = syn::parse_quote!(
@@ -813,9 +878,9 @@ impl Declarations {
                     pub(crate) unsafe fn #name<'env, 'v>(
                         env: &mut jni::JNIEnv<'env>,
                         v: &#inner_wire,
-                    ) -> ::core::result::Result<Option<#t1>, __JniErr> {
+                    ) -> ::core::result::Result<#outer_ty, __JniErr> {
                         Ok({
-                            if *v == 0 {
+                            let __v: ::core::option::Option<#t1> = if *v == 0 {
                                 None
                             } else if (*v & 1) == 1 {
                                 // Tagged (closed) handle raced past the Kotlin
@@ -828,7 +893,9 @@ impl Declarations {
                                 );
                             } else {
                                 Some(*std::boxed::Box::from_raw(*v as *mut #t1))
-                            }
+                            };
+                            // Canonical value first, then the spelling.
+                            __v.into()
                         })
                     }
                 );
@@ -856,9 +923,15 @@ impl Declarations {
             }
             // Non-opaque inner: fall through to the general Option handler.
         }
-        if pat_match(pat, "Option < _ >") {
-            let outer_ty: syn::Type = syn::parse_quote!(Option<#t1>);
-            let (wire, body, niches) = option_input(t1, registry)?;
+        if shape == WrapperShape::Optional {
+            let outer_ty = produced.clone();
+            let (wire, inner_body, niches) = option_input(t1, registry)?;
+            // `option_input` yields the canonical `Option<T>`; the converter
+            // yields the spelling. Reflexive when they are the same.
+            let body: syn::Expr = syn::parse_quote!({
+                let __v: ::core::option::Option<#t1> = #inner_body;
+                __v.into()
+            });
             // Inherit the inner's name; user pins on `Option<T>` win.
             // The nullability marker (`?`) is added by the use site.
             let inherited = registry
@@ -1014,7 +1087,7 @@ impl Declarations {
                 let args: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
                 self.dispatch_fn_input(&args, built)
             }),
-            Direction::Output => self.select_output_type(&ty, built),
+            Direction::Output => self.select_output_type(&reading, built),
         }
     }
 
@@ -1588,9 +1661,13 @@ impl Declarations {
     /// empty.
     pub(crate) fn input_terminal(
         &self,
-        ty: &syn::Type,
+        reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
+        // Classify off `kind`, spell off `syntax`: the arms below that ask what
+        // a type IS use `reading`, and everything that has to name it in
+        // generated Rust uses this.
+        let ty = &reading.origin.syntax;
         // Structured-config overrides first (opaque handles, then user-
         // registered rank-0 wrappers, then built-ins).
         let key = TypeKey::from_type(ty);
@@ -1673,12 +1750,17 @@ impl Declarations {
                 metadata: self.framework_meta(kotlin_name),
             });
         }
-        // `Box<String>`: a heap string carried as an opaque-pointer struct field
-        // (e.g. an FFI-safe `#[repr(C)]` struct's `Option<Box<String>>`). Decode
-        // the `JString` to an owned `String` and box it; surfaces as Kotlin
-        // `String` (and `Option<Box<String>>` composes to `String?` via the
-        // `Option<_>` wrapper). Dual of the `Box<String>` output arm.
-        if TypeKey::from_type(ty).as_str() == "Box < String >" {
+        // Any OWNED string, however Rust spells it — `String`, `Box<String>`,
+        // `Cow<'_, str>`. The model classifies each of them `Str`; the spelling is
+        // the source's business, and `.into()` constructs it from the decoded
+        // `String`. This used to be one hardcoded `TypeKey == "Box < String >"`
+        // arm, which is what a spelling-keyed converter table costs: one
+        // hand-written case per representation anyone happened to write (#270).
+        //
+        // `str` is handled above, separately and deliberately: it is unsized,
+        // so its converter yields an owned `String` the call site borrows —
+        // a different contract, not a different spelling.
+        if matches!(reading.kind, crate::api::core::flat::TypeKind::Str) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 let s = env.get_string(v).map_err(|e| {
@@ -1687,9 +1769,10 @@ impl Declarations {
                         e
                     ))
                 })?;
-                ::std::boxed::Box::new(::std::string::String::from(s))
+                // The canonical value, then the spelling.
+                ::std::string::String::from(s).into()
             });
-            let rust_ty: syn::Type = syn::parse_quote!(::std::boxed::Box<::std::string::String>);
+            let rust_ty = ty.clone();
             let kotlin_name = self.override_kotlin_name(ty, Some(kt::KtType::string()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
@@ -1784,17 +1867,18 @@ impl Declarations {
     /// handlers.
     pub(crate) fn input_wrapper_shape(
         &self,
-        pat: &syn::Type,
+        shape: WrapperShape,
+        produced: &syn::Type,
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Disjoint wildcard patterns (see the `impl JniGenBuilder` block above), tried
-        // in priority order. The borrow/option-ref/vec patterns are exact and
-        // mutually exclusive; the two `Option<_>` sub-cases share a method.
-        self.input_borrow(pat, t1, registry)
-            .or_else(|| self.input_option_ref(pat, t1, registry))
-            .or_else(|| self.input_vec(pat, t1, registry))
-            .or_else(|| self.input_option(pat, t1, registry))
+        // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
+        // borrow/option-ref/vec shapes are mutually exclusive; the two
+        // `Optional` sub-cases share a method.
+        self.input_borrow(shape, produced, t1, registry)
+            .or_else(|| self.input_option_ref(shape, produced, t1, registry))
+            .or_else(|| self.input_vec(shape, produced, t1, registry))
+            .or_else(|| self.input_option(shape, produced, t1, registry))
     }
 
     // ── Output converters ────────────────────────────────────────────
@@ -1804,9 +1888,11 @@ impl Declarations {
     /// `str`, `Cow<[u8]>`, unit, primitive, struct) — `subs` empty.
     pub(crate) fn output_terminal(
         &self,
-        ty: &syn::Type,
+        reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
+        // Classify off `kind`, spell off `syntax` — see `input_terminal`.
+        let ty = &reading.origin.syntax;
         // Structured-config overrides first (opaque handles, then built-ins).
         let key = TypeKey::from_type(ty);
         if let Some(cfg) = self.types.get(&key) {
@@ -1867,19 +1953,23 @@ impl Declarations {
         if TypeKey::from_type(ty).as_str() == "str" {
             return Some(self.str_ref_output());
         }
-        // `Box<String>`: read the heap string through the box and encode it as a
-        // `JString`; surfaces as Kotlin `String` (and `Option<Box<String>>` →
-        // `String?` via the `Option<_>` wrapper). Dual of the `Box<String>`
-        // input arm — together they let an opaque-pointer `String` struct field
-        // map to a plain Kotlin `String`.
-        if TypeKey::from_type(ty).as_str() == "Box < String >" {
+        // An owned string in any representation the model erases — `Box<String>`,
+        // `Cow<'_, str>`. It classifies each of them `Str`, and the body was
+        // already representation-agnostic: `v.as_str()` reaches through any of
+        // them by `Deref`. Only the *dispatch* was spelling-keyed, as one
+        // hardcoded `TypeKey == "Box < String >"` arm (#270).
+        //
+        // Plain `String` keeps its own earlier arm in `primitive_output`, whose
+        // body this matches exactly; this one is reached for the wrapped
+        // spellings that arm's key cannot name.
+        if matches!(reading.kind, crate::api::core::flat::TypeKind::Str) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 env.new_string(v.as_str()).map_err(|e| {
                     <__JniErr as ::core::convert::From<String>>::from(format!("encode_str: {}", e))
                 })?
             });
-            let rust_ty: syn::Type = syn::parse_quote!(::std::boxed::Box<::std::string::String>);
+            let rust_ty = ty.clone();
             let kotlin_name = self.override_kotlin_name(ty, Some(kt::KtType::string()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
@@ -1904,7 +1994,7 @@ impl Declarations {
         // Wire is `()`. Body just returns `v`. No Kotlin name — Unit
         // returns are dropped from emitted signatures, so metadata stays
         // empty.
-        if pat_match(ty, "()") {
+        if matches!(reading.kind, crate::api::core::flat::TypeKind::Unit) {
             let wire: syn::Type = syn::parse_quote!(());
             let body: syn::Expr = syn::parse_quote!(v);
             return Some(ConverterImpl {
@@ -1964,7 +2054,8 @@ impl Declarations {
     /// `Option<&Handle>` resolves via the shallow `Option<_>`.
     pub(crate) fn output_wrapper_shape(
         &self,
-        pat: &syn::Type,
+        shape: WrapperShape,
+        produced: &syn::Type,
         t1: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
@@ -1977,7 +2068,7 @@ impl Declarations {
         // with a `.clone()`; `Option<&T>` then composes through the `Option`
         // arm below (it looks up this `&T` entry as its inner). Matched
         // structurally so the lifetime variant `&'static _` is covered too.
-        if let syn::Type::Reference(r) = pat {
+        if let syn::Type::Reference(r) = produced {
             if r.mutability.is_none()
                 && self
                     .types
@@ -2006,7 +2097,7 @@ impl Declarations {
         // expansion). The single copy into the JVM is `&str → jstring` (no
         // intermediate owned `String`). The unsized `str` sub resolves via the
         // rank-0 arm to the same fn (see [`Self::str_ref_output`]).
-        if let syn::Type::Reference(r) = pat {
+        if let syn::Type::Reference(r) = produced {
             if r.mutability.is_none() && TypeKey::from_type(t1).as_str() == "str" {
                 return Some(self.str_ref_output());
             }
@@ -2014,9 +2105,18 @@ impl Declarations {
         // `Result<T, E>` is peeled by the selector, off the model's
         // `TypeKind::Fallible`. Bindings declare the `Err` type via
         // `.throwable()`.
-        if pat_match(pat, "Option < _ >") {
-            let outer_ty: syn::Type = syn::parse_quote!(Option<#t1>);
-            let (wire, body, niches) = option_output(t1, registry)?;
+        if shape == WrapperShape::Optional {
+            let outer_ty = produced.clone();
+            let canonical: syn::Type = syn::parse_quote!(Option<#t1>);
+            let (wire, inner_body, niches) = option_output(t1, registry)?;
+            // `option_output` reads `v` as the canonical `Option<T>`; bind that
+            // first so a wrapped spelling is deref'd once. See
+            // [`read_as_canonical`].
+            let read = read_as_canonical(produced, &canonical);
+            let body: syn::Expr = syn::parse_quote!({
+                let v: #canonical = #read;
+                #inner_body
+            });
             let inherited = registry
                 .output_entry(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
@@ -2059,7 +2159,7 @@ impl Declarations {
         // `Vec<T>` (output side): encode as a `java.util.ArrayList<InnerWire>`.
         // Symmetric to the input handler. `Vec<u8>` is special-cased at
         // rank-0 (primitive_output → JByteArray) so rank-1 never sees it.
-        if pat_match(pat, "Vec < _ >") {
+        if shape == WrapperShape::Sequence {
             let inner = registry.output_entry(t1)?;
             // `Vec<opaque-handle>` output is delivered by the Kotlin-side leaf
             // fold (`apply_leaf_vec_folds` → typed-handle wrap), so this
@@ -2075,9 +2175,12 @@ impl Declarations {
                 inner,
                 quote::quote!(__elem),
             );
-            let outer_ty: syn::Type = syn::parse_quote!(Vec<#t1>);
+            let outer_ty = produced.clone();
+            let canonical: syn::Type = syn::parse_quote!(Vec<#t1>);
+            let read = read_as_canonical(produced, &canonical);
             let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
             let body: syn::Expr = syn::parse_quote!({
+                let v: #canonical = #read;
                 let __list_obj = env
                     .new_object("java/util/ArrayList", "()V", &[])
                     .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: new ArrayList: {}", e)))?;


### PR DESCRIPTION
Closes #270.

## The issue was wrong about its own cause

I filed #270 guessing this was `TypeKey` identity — two spellings of one meaning not sharing a converter. It isn't. The selector decided **what a type is** by manufacturing a string from its spelling and comparing it, and then rebuilt the type it generates **by name**:

| Site | What it did | What the model already said |
|---|---|---|
| `with_first_arg` | rebuilt a wildcard off the spelling's last segment — `Box<Option<T>>` → `Box<_>` | `kind` is `Optional` |
| `pat_match(pat, "Option < _ >")` ×10 | dispatch by **string comparison** | `TypeKind::{Optional,Sequence,Ref,Unit}` |
| `parse_quote!(Option<#t1>)` ×7 | the generated signature **rebuilt by name** | `origin.syntax` |
| `option_inner_type` / `vec_inner_type` | peel by segment ident | `optional_inner()` / `sequence_elem()` |
| `TypeKey == "Box < String >"` ×2 | one hardcoded arm per direction | `kind` is `Str` |

`select_output_type` was the clearest: `convert_crossing` **fetched the reading and threw it away**, passing a bare spelling.

## The rule

`classify off kind, spell off syntax`, applied to converter construction. #268 fixed an emitter that classified correctly and then *spelled* off `kind`; this is the same rule broken the other way — classifying off the spelling.

Dispatch now comes from `TypeKind` (a `WrapperShape`, not a rendered string) and the signature from `origin.syntax`, so a `Box<Option<T>>` converter takes a `Box<Option<T>>` instead of declaring `Option<T>` and mismatching its own call site.

## Representations: state the requirement, let rustc check

Rather than listing wrappers by name — which is the guessing being removed:

- **Input** builds the canonical value and `.into()`s the spelling. Reflexive when they match.
- **Output** binds the canonical *out of* the spelling. This direction is genuinely asymmetric and I did not pretend otherwise: the bodies **move** the payload, and std has no trait for `Box<T> → T`. So `read_as_canonical` asks the one honest spelling question — is this already canonical? — and derefs once if not. Anything not deref-movable is a rustc error naming the type.

Both `Box<String>` arms are **deleted** — the evidence the mechanism generalizes. `kind == Str` covers `Box<String>` and `Cow<'_, str>` alike; the output body already read through either (`v.as_str()` derefs), only the dispatch was spelling-keyed.

## Two corrections the tests forced

- **`Rc` is not transparent.** Only `Box` and `Cow` are erased by the model. My first doc comments claimed `Rc<String>` would work; the model rejects it outright. Comments and tests corrected.
- **A bare `[T]` is `Sequence` but unsized.** Dispatching on `kind` alone tried to build `fn f(..) -> [T]`, which broke the example crates. `is_unsized_spelling` is the guard — a spelling question in the same family as the existing `decoded_vec_satisfies`.

## Result

`pat_match` is gone, and `with_first_arg` / `ref_wildcard` with it. Boundary ledger **135 → 130**, all of it `selector.rs` (8 → 3) — the #229 L4 "layer questions" item, whose stated payoff was retiring `option_inner_type` / `vec_inner_type` from the selector.

## Verification

- 609 lib tests; `cargo test --all --all-features` 14/14; clippy `--deny warnings`; fmt.
- **The generated Rust compiles.** `regen-check.sh` builds the four example crates, which `include!` their generated bindings — so this change's output type-checks for every shape those examples use. That is a real compile check, and worth noting given #269.
- covertest-kotlin **48/48** on the JVM.
- `Box<Option<T>>` and `Box<String>` output hand-checked against `rustc` on reduced cases.

**Goldens move**, and the diff is large but mechanical: `.into()` wrappers, canonical bindings, and two new `#[allow]`s (`unused_parens`, `clippy::useless_conversion`) — the degenerate form a representation-agnostic converter takes for the plain spelling. Suppressing those per-shape would mean asking which spelling this is. The `Box<String>` converter is renamed because its signature now comes from the source's spelling rather than a hardcoded `::std::boxed::Box<::std::string::String>`.

The `convert.rs` note in #268's destructure census predicted this change and is now resolved: those two destructures are correct *by construction*, because the caller binds the canonical `Option<T>` before handing the body `v`.
