### PR TITLE
Ask the model whether a type is optional, not the spelling

### DIFF
--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1596,6 +1596,14 @@ public fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Un
  * A `Cow` payload is the other half and cannot appear in a compiled fixture:
  * it must be REFUSED, which only
  * `a_transparent_wrapper_is_bridged_only_where_it_can_be` can assert.
+ *
+ * The **parameter** is wrapped too, and that half is #273: nullability was
+ * decided by asking the spelling whether its last path segment read `Option`,
+ * so this rendered `note: String` while `plain_note_echo` rendered
+ * `note: String?`. A non-null Kotlin parameter for an optional value is a
+ * wrong contract rather than a cosmetic one — Kotlin rejects `null` at the
+ * call site, so the absent case becomes unexpressible. The two externs must
+ * come out **identical**.
  */
 public fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): String? {
     val __bcap = JniErrorHandlerCapture.acquire()
@@ -1606,7 +1614,7 @@ public fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): Stri
 
 /**
  * The same crossing with nothing wrapped — the control the wrapped form must
- * match, since the model says the two returns are the same type.
+ * match, since the model says the two signatures are the same type.
  */
 public fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): String? {
     val __bcap = JniErrorHandlerCapture.acquire()

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -5233,6 +5233,30 @@ pub(crate) unsafe fn JShortArray_to_i16_2_098f4ad5<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JString_to_Box_Option_String_caeff346<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JString<'v>,
+) -> ::core::result::Result<Box<Option<String>>, __JniErr> {
+    Ok({
+        let __v: ::core::option::Option<String> = {
+            if v.is_null() { None } else { Some(JString_to_String_c7f3ca43(env, v)?) }
+        };
+        ::std::boxed::Box::new(__v)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JString_to_Box_String_027f6250<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JString<'v>,
@@ -12694,7 +12718,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedNoteEcho<'a
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let note = match JString_to_Option_String_56d5e304(&mut env, &note) {
+    let note = match JString_to_Box_Option_String_caeff346(&mut env, &note) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1598,13 +1598,21 @@ pub fn ledger_archived(l: &Ledger) -> Option<Report> {
 /// A `Cow` payload is the other half and cannot appear in a compiled fixture:
 /// it must be REFUSED, which only
 /// `a_transparent_wrapper_is_bridged_only_where_it_can_be` can assert.
+///
+/// The **parameter** is wrapped too, and that half is #273: nullability was
+/// decided by asking the spelling whether its last path segment read `Option`,
+/// so this rendered `note: String` while `plain_note_echo` rendered
+/// `note: String?`. A non-null Kotlin parameter for an optional value is a
+/// wrong contract rather than a cosmetic one — Kotlin rejects `null` at the
+/// call site, so the absent case becomes unexpressible. The two externs must
+/// come out **identical**.
 #[prebindgen]
-pub fn boxed_note_echo(note: Option<String>) -> Box<Box<Option<String>>> {
-    Box::new(Box::new(note))
+pub fn boxed_note_echo(note: Box<Option<String>>) -> Box<Box<Option<String>>> {
+    Box::new(note)
 }
 
 /// The same crossing with nothing wrapped — the control the wrapped form must
-/// match, since the model says the two returns are the same type.
+/// match, since the model says the two signatures are the same type.
 #[prebindgen]
 pub fn plain_note_echo(note: Option<String>) -> Option<String> {
     note

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -45,7 +45,7 @@
 # gaps are listed here rather than implied away.
 
 2	api/core/registry/scan.rs
-10	api/core/types_util.rs
+9	api/core/types_util.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
@@ -71,4 +71,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 130
+# total: 129

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -37,6 +37,54 @@ pub trait Conversions<M> {
     /// out.
     fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef>;
 
+    /// Whether `ty` crosses as **optional** — the model's answer, not the
+    /// spelling's.
+    ///
+    /// The question every consumer actually means, and the one they could not
+    /// ask: they reached for `is_option_type`, which is `path_tail_is(ty,
+    /// "Option")`. But the model **erases** transparent wrappers — `Box<T>` *is*
+    /// `T`, and so is `Cow<'_, T>` — so `Box<Option<String>>` is `Optional` and
+    /// that check answers `false`. Kotlin then lost the `?`, which is not a
+    /// cosmetic slip: a non-null parameter for an optional value makes the
+    /// absent case unexpressible (#273).
+    ///
+    /// Here rather than at each consumer so the rule has **one** home. A new
+    /// transparent wrapper — an `Rc`, say — is then a change to
+    /// [`TRANSPARENT_WRAPPERS`](crate::api::core::flat::TRANSPARENT_WRAPPERS)
+    /// and nothing else; every site asking this question follows automatically.
+    fn is_optional(&self, ty: &syn::Type) -> bool {
+        self.reading(ty)
+            .is_some_and(|r| r.optional_inner().is_some())
+    }
+
+    /// What an optional wraps, **spelled as generated Rust must spell it**.
+    ///
+    /// Classify off `kind`, spell off `syntax`: the decision that this *is* an
+    /// optional comes from the model, and what comes back is the inner's own
+    /// spelling — which is what a converter signature or a `quote!` needs.
+    fn optional_inner(&self, ty: &syn::Type) -> Option<syn::Type> {
+        self.reading(ty)
+            .and_then(|r| r.optional_inner().map(|i| i.origin.syntax.clone()))
+    }
+
+    /// The element of a run of values (`Vec<T>`, `[T]`, `Cow<'_, [T]>`), spelled
+    /// as generated Rust must spell it. The sequence peer of
+    /// [`Self::optional_inner`].
+    fn sequence_elem(&self, ty: &syn::Type) -> Option<syn::Type> {
+        self.reading(ty)
+            .and_then(|r| r.sequence_elem().map(|e| e.origin.syntax.clone()))
+    }
+
+    /// Whether `ty` is a borrow of an optional (`Option<&T>`) — the shape a
+    /// handle parameter locks differently. Reads both layers off the model, so
+    /// a wrapped spelling answers the same as the bare one.
+    fn is_optional_borrow(&self, ty: &syn::Type) -> bool {
+        self.reading(ty).is_some_and(|r| {
+            r.optional_inner()
+                .is_some_and(|i| i.borrow_target().is_some())
+        })
+    }
+
     /// The conversion for `ty` in `dir`, if there is one.
     fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>>;
 

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -113,10 +113,10 @@ pub fn first_type_arg(ty: &syn::Type) -> Option<syn::Type> {
     })
 }
 
-/// True when `ty` is `Option<&T>` / `Option<&mut T>`.
-pub fn is_option_ref(ty: &syn::Type) -> bool {
-    option_inner_type(ty).is_some_and(|inner| matches!(inner, syn::Type::Reference(_)))
-}
+// `is_option_ref` lived here — `option_inner_type(ty)` then a `Type::Reference`
+// match — and decided how a handle parameter locks. Both halves read the
+// spelling, so an optional borrow behind an erased wrapper answered `false`.
+// `Conversions::is_optional_borrow` asks the model instead (#273).
 
 /// The bare ident of a plain path type (`ZThing` → `ZThing`); `None` for
 /// references, generics, or multi-shape types.

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1748,16 +1748,20 @@ impl Declarations {
             .crossing_keys(direction)
             .iter()
             .map(|candidate| {
-                let mut ty = candidate.to_type();
+                // How many `Option` layers this crossing puts over `key` — the
+                // model's count, so a wrapped spelling contributes the same
+                // demand a bare one does. Walking the reading also drops the
+                // re-lookup the old loop did: it peeled a spelling and re-keyed
+                // each result, where the layers are already right here (#273).
+                let Some(mut reading) = registry.reading(&candidate.to_type()) else {
+                    return 0;
+                };
                 let mut depth = 0;
-                while crate::api::core::types_util::is_option_type(&ty) {
-                    let Some(inner) = option_inner_type(&ty) else {
-                        return 0;
-                    };
-                    ty = inner;
+                while let Some(inner) = reading.optional_inner().cloned() {
+                    reading = inner;
                     depth += 1;
                 }
-                if TypeKey::from_type(&ty) == *key {
+                if reading.key() == *key {
                     depth
                 } else {
                     0

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -263,7 +263,7 @@ pub(crate) fn callback_input(
             .projection
             .as_ref()
             .is_none_or(|p| p.kind == ProjectionKind::Unsigned64)
-            && !is_option_type(arg_ty)
+            && !registry.is_optional(arg_ty)
             && matches!(jni_field_access(&arg_wire), Some((_, _, false)));
         if arg_is_prim {
             let letter = jni_field_access(&arg_wire).unwrap().1;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -10,7 +10,7 @@ pub(crate) fn struct_input_body(
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.ident.to_string();
-    let struct_module = struct_module_path(ext, registry, s);
+    let struct_module = struct_module_path(ext, registry, &s.ident);
     let struct_ident = &s.ident;
 
     let syn::Fields::Named(named) = &s.fields else {
@@ -1507,7 +1507,7 @@ fn build_flat_struct_node(
     }
     stack.pop();
     Ok(FlatStructNode {
-        struct_module: struct_module_path(ext, registry, st),
+        struct_module: struct_module_path(ext, registry, &st.ident),
         struct_ident: st.ident.clone(),
         binding: format_ident!("__flat_{native_prefix}"),
         optional,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -83,7 +83,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 pub(crate) fn synth_value_struct_leaves(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    s: &syn::ItemStruct,
+    s: &crate::api::core::flat::Struct,
     path_prefix: &[crate::api::core::unfold::PathStep],
     name_prefix: &str,
     depth: usize,
@@ -92,13 +92,11 @@ pub(crate) fn synth_value_struct_leaves(
     if depth > 16 {
         return None;
     }
-    let syn::Fields::Named(named) = &s.fields else {
-        return None;
-    };
+    // Named by construction — a tuple struct is an `Extern`, not a `Struct`.
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
-    for field in &named.named {
-        let fname = field.ident.as_ref()?.clone();
-        let effective_ty = field.ty.clone();
+    for field in &s.fields {
+        let fname = field.name.as_ref()?.clone();
+        let effective_ty = field.ty.origin.syntax.clone();
         let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
         let leaf_name = if name_prefix.is_empty() {
             camel
@@ -127,7 +125,7 @@ pub(crate) fn synth_value_struct_leaves(
             // converter for it, failing the resolve with the sum named rather
             // than the unsupported position.
             TypeKind::Handle | TypeKind::Enum | TypeKind::Sum => return None,
-            TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.origin.syntax.clone()),
+            TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
             _ => None,
         };
         if let Some(child) = nested {
@@ -173,7 +171,7 @@ pub(crate) fn synth_value_struct_leaves(
 pub(crate) fn flatten_struct_encode(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    s: &syn::ItemStruct,
+    s: &crate::api::core::flat::Struct,
     access: &TokenStream,
     prefix: &str,
     depth: usize,
@@ -588,15 +586,15 @@ fn encode_field(
 
 pub(crate) fn struct_output_body(
     ext: &Declarations,
-    s: &syn::ItemStruct,
+    s: &crate::api::core::flat::Struct,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
-    let struct_name = s.ident.to_string();
+    let struct_name = s.name.to_string();
     // Prefer the registered Kotlin FQN (`io.zenoh.jni.JniSample`) so the
     // mangle closure flows through; fall back to the bare struct ident
     // qualified with the package when no `data_class` /
     // `ptr_class` declaration exists for this Rust type.
-    let struct_ident = &s.ident;
+    let struct_ident = &s.name;
     let struct_ty: syn::Type = syn::parse_quote!(#struct_ident);
     let registered_fqn = ext
         .types
@@ -651,11 +649,13 @@ pub(crate) fn struct_output_body(
 pub(crate) fn struct_module_path(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    s: &syn::ItemStruct,
+    name: &syn::Ident,
 ) -> syn::Path {
     // The module the struct is reachable under from the generated file: its
-    // origin crate (multi-source registries) or the default module.
-    ext.fn_module(registry, &s.ident)
+    // origin crate (multi-source registries) or the default module. Takes the
+    // NAME, which is all it needs — so it serves a caller holding the element
+    // and one still holding the item.
+    ext.fn_module(registry, name)
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -80,8 +80,14 @@ pub(crate) struct PlanLeaf {
     /// `JNINative` extern declares for pass-through leaves (for projections
     /// this is the erased wire name, not the typed surface).
     pub kt_meta: Option<kt::KtType>,
-    /// Raw `is_option_type(ty)` — each site applies its own nullability rule
-    /// (handles stay non-null `Long` on the extern but `T?` on the surface).
+    /// Whether the leaf crosses as optional, **per the model** — so a wrapped
+    /// spelling (`Box<Option<T>>`) answers exactly as the bare one does. Each
+    /// site applies its own nullability rule on top (handles stay non-null
+    /// `Long` on the extern but `T?` on the surface).
+    ///
+    /// This used to be `is_option_type(ty)`, which asks the *spelling* whether
+    /// its last path segment reads `Option` — and the model erases `Box` and
+    /// `Cow`, so an optional behind one lost its `?` (#273).
     pub optional: bool,
     /// `true` when the (probed-through `&`/`Option`) type is an
     /// `enum_class` enum: surface keeps the typed enum, the extern declares
@@ -523,7 +529,7 @@ fn classify_leaf(
     expanded: bool,
     source_param: &syn::Ident,
 ) -> Result<PlanLeaf, PlanError> {
-    let optional = is_option_type(ty);
+    let optional = registry.is_optional(ty);
     let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(ty));
     let kt_name = kt_param_name(&ident.to_string());
 
@@ -576,7 +582,8 @@ fn classify_leaf(
             },
             Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
                 niche: entry.metadata.projection.as_ref().and_then(|p| {
-                    is_option_type(ty)
+                    registry
+                        .is_optional(ty)
                         .then(|| p.niche_sentinels.first().cloned())
                         .flatten()
                 }),

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -171,7 +171,7 @@ pub(crate) fn is_kotlin_primitive_ty(t: &kt::KtType) -> bool {
 pub(crate) fn flatten_struct_factory(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    s: &syn::ItemStruct,
+    s: &crate::api::core::flat::Struct,
     prefix: &str,
     class_name: &str,
     imports: &mut BTreeSet<String>,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -1219,7 +1219,7 @@ pub(crate) fn callback_iface_spec(
             leaf_tys.push(LeafDesc::Whole {
                 name: whole_value_name(t, i),
                 ty: t.clone(),
-                nullable: is_option_type(t),
+                nullable: registry.is_optional(t),
                 owned_handle,
             });
             groups.push(GroupDesc {

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -860,7 +860,7 @@ impl Declarations {
         // field — the Kotlin type must match that slot. Read from the same
         // entry the type came from.
         let primitive_wire = crate::api::lang::jnigen::jni::is_jni_primitive(&out.destination);
-        if is_option_type(&field.ty) && !primitive_wire {
+        if registry.is_optional(&field.ty) && !primitive_wire {
             ty.nullable()
         } else {
             ty
@@ -1517,7 +1517,7 @@ impl Declarations {
         name: &str,
         imports: &mut BTreeSet<String>,
     ) -> String {
-        let optional = is_option_type(&leaf.out_ty);
+        let optional = registry.is_optional(&leaf.out_ty);
         let arg = if param.raw.is_nullable() && !optional {
             format!("{name}!!")
         } else {

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -897,11 +897,7 @@ impl Declarations {
             }) else {
                 continue;
             };
-            let Some(item_struct) = registry
-                .flat()
-                .struct_type(&ident)
-                .map(|st| &st.origin.syntax)
-            else {
+            let Some(item_struct) = registry.flat().struct_type(&ident) else {
                 continue;
             };
 
@@ -909,8 +905,8 @@ impl Declarations {
                 Some((p, c)) => (p.to_string(), c.to_string()),
                 None => (String::new(), kotlin_fqn.clone()),
             };
-            if item_struct.ident != class_name {
-                aliases.push((item_struct.ident.to_string(), class_name.clone()));
+            if item_struct.name != class_name {
+                aliases.push((item_struct.name.to_string(), class_name.clone()));
             }
             let mut class = build_data_class(self, &class_name, item_struct, registry);
             // The data class is self-contained (property/factory types +

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -53,9 +53,7 @@ pub(crate) use crate::api::{
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen, Stage},
         registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
-        types_util::{
-            bare_path_ident, is_option_ref, is_option_type, option_inner_type, vec_inner_type,
-        },
+        types_util::{bare_path_ident, option_inner_type, vec_inner_type},
     },
     gen::kotlin::WriteKotlinError,
     lang::jnigen::{

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -69,18 +69,12 @@ pub(crate) fn build_enum_class(class_name: &str, item_enum: &syn::ItemEnum) -> k
 pub(crate) fn build_data_class(
     ext: &Declarations,
     class_name: &str,
-    item_struct: &syn::ItemStruct,
+    item_struct: &crate::api::core::flat::Struct,
     registry: &Registry<KotlinMeta>,
 ) -> kt::KtClass {
-    let fields_named = match &item_struct.fields {
-        syn::Fields::Named(n) => &n.named,
-        _ => {
-            panic!(
-                "render_data_class_source: struct `{}` must use named fields to map onto Kotlin data class properties",
-                item_struct.ident
-            )
-        }
-    };
+    // A tuple struct is an `Extern` in the model, never a `Struct`, so every
+    // field here is named by construction.
+    let fields_named = &item_struct.fields;
 
     // The class declaration is derived from the SAME plan the `fromParts`
     // factory and the Rust encoder walk. Deriving it separately — a third
@@ -92,7 +86,7 @@ pub(crate) fn build_data_class(
              field needs a resolved OUTPUT converter (that direction declares the slot the \
              encoder fills) AND the Kotlin metadata that converter carries — a `kotlin_name`, \
              or a registered class for a projection leaf",
-            item_struct.ident
+            item_struct.name
         )
     });
 
@@ -105,14 +99,14 @@ pub(crate) fn build_data_class(
     let mut destructible_fields: Vec<(String, crate::api::lang::jnigen::jni::FoldStrategy)> =
         Vec::new();
     for (field, pf) in fields_named.iter().zip(&plan.fields) {
-        let field_ident = field.ident.as_ref().unwrap_or_else(|| {
+        let field_ident = field.name.as_ref().unwrap_or_else(|| {
             panic!(
                 "render_data_class_source: struct `{}` has an unnamed field in named-fields context",
-                item_struct.ident
+                item_struct.name
             )
         });
         let kotlin_field_name = mangle_kotlin_ident(&kt_snake_to_camel(&field_ident.to_string()));
-        let owner = format!("{}.{}", item_struct.ident, field_ident);
+        let owner = format!("{}.{}", item_struct.name, field_ident);
 
         // The declaration reads ONE direction — output — because that is the
         // direction that declares the `fromParts` slots the encoder fills, and
@@ -129,7 +123,7 @@ pub(crate) fn build_data_class(
         // disagreed. Reject it at the declaration instead.
         if !matches!(pf.kind, PlanFieldKind::Projection { .. }) {
             if let Some(proj) = registry
-                .input_entry(&field.ty)
+                .input_entry(&field.ty.origin.syntax)
                 .and_then(|e| e.metadata.projection.clone())
             {
                 panic!(
@@ -172,7 +166,8 @@ pub(crate) fn build_data_class(
     });
 
     let mut class = kt::KtClass::new(kt::ClassKind::Data, class_name).vis(kt::Vis::Public);
-    if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_struct.attrs) {
+    if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_struct.origin.syntax.attrs)
+    {
         class = class.kdoc(doc);
     }
     for p in ctor_params {

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1210,9 +1210,9 @@ fn classify_params(
                 // Handle → Borrow/Consume by Rust syntactic shape (locked);
                 // `Option<&T>` / by-value `Option<T>` mark the param nullable
                 // and the wrapper body branches on null before lock selection.
-                if is_option_ref(arg_ty) {
+                if registry.is_optional_borrow(arg_ty) {
                     ParamMode::BorrowNullable
-                } else if is_option_type(arg_ty) {
+                } else if registry.is_optional(arg_ty) {
                     // by-value `Option<T>` opaque → nullable consume
                     ParamMode::ConsumeNullable
                 } else if matches!(arg_ty, syn::Type::Reference(_)) {
@@ -2116,7 +2116,7 @@ pub(crate) fn whole_value_name(ty: &syn::Type, i: usize) -> String {
 /// Fall-back Kotlin type derived directly from the JNI wire type.
 /// Returns the **non-nullable** Kotlin base name — the use site adds
 /// a `?` suffix when the entry's Rust type is `Option<…>` (via
-/// [`is_option_type`]), so this helper must not double up.
+/// the model), so this helper must not double up.
 pub(crate) fn kotlin_for_wire(wire: &syn::Type) -> Option<kt::KtType> {
     if let Some(p) = JniPrim::from_wire(wire) {
         return Some(kt::KtType::cls(p.kotlin_type()));

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -185,21 +185,20 @@ pub(crate) struct SumPlanField {
 pub(crate) fn build_struct_plan(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    s: &syn::ItemStruct,
+    s: &crate::api::core::flat::Struct,
     depth: usize,
 ) -> Option<StructPlan> {
     assert!(
         depth <= 16,
         "struct fromParts plan: recursion too deep at struct `{}` (cyclic data_class?)",
-        s.ident
+        s.name
     );
-    let syn::Fields::Named(named) = &s.fields else {
-        return None;
-    };
     let mut fields: Vec<PlanField> = Vec::new();
-    for field in &named.named {
-        let fname = field.ident.as_ref()?.clone();
-        let owner = format!("{}.{}", s.ident, fname);
+    for field in &s.fields {
+        // A tuple struct is an `Extern` in the model, never a `Struct`, so a
+        // nameless field cannot reach here.
+        let fname = field.name.as_ref()?.clone();
+        let owner = format!("{}.{}", s.name, fname);
         let kind = classify_field(ext, registry, &field.ty, &owner, depth)?;
         fields.push(PlanField { fname, kind });
     }
@@ -217,11 +216,16 @@ pub(crate) fn build_struct_plan(
 pub(crate) fn classify_field(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    ty: &syn::Type,
+    reading: &crate::api::core::flat::TypeRef,
     owner: &str,
     depth: usize,
 ) -> Option<PlanFieldKind> {
-    let effective_ty = ty.clone();
+    // The **reading**, not a spelling. Every layer question below is answered
+    // from `kind` and cannot fail: holding a `TypeRef` is proof the model
+    // classified this type. Taking a `syn::Type` meant asking the registry per
+    // question, and a type it had never seen answered "no layer" rather than
+    // saying so — which is the missing `?` of #273 waiting to happen again.
+    let effective_ty = reading.origin.syntax.clone();
 
     // A sum is classified FIRST, because it is the one kind with no converter
     // of its own: it crosses as a tag plus one leaf group per variant, never
@@ -238,12 +242,11 @@ pub(crate) fn classify_field(
     // as `Option<T>` does. Peeling by path segment answered "not optional" for
     // it, and the seven peels in this function would then disagree with each
     // other about the same field (#273).
-    let optional_inner = registry.optional_inner(&effective_ty);
-    let bare = optional_inner
-        .clone()
-        .unwrap_or_else(|| effective_ty.clone());
-    let seq_elem = registry.sequence_elem(&bare);
-    let core = seq_elem.clone().unwrap_or_else(|| bare.clone());
+    let optional_inner = reading.optional_inner();
+    let bare_ref = optional_inner.unwrap_or(reading);
+    let bare = bare_ref.origin.syntax.clone();
+    let seq_elem = bare_ref.sequence_elem();
+    let core = seq_elem.map_or_else(|| bare.clone(), |e| e.origin.syntax.clone());
     if matches!(ext.type_kind(registry, &core), TypeKind::Sum) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by
@@ -279,7 +282,7 @@ pub(crate) fn classify_field(
             return Some(PlanFieldKind::Enum { conv, kotlin });
         }
         // `Option<enum>` leaf.
-        if let Some(inner) = optional_inner.clone() {
+        if let Some(inner) = optional_inner.map(|i| i.origin.syntax.clone()) {
             if ext.is_kotlin_enum(&inner) {
                 let kotlin = registry
                     .output_entry(&inner)?
@@ -302,7 +305,7 @@ pub(crate) fn classify_field(
             let child_fqn = cfg
                 .and_then(|c| c.name_spec.as_ref())
                 .map(|s| ext.fqn_of(s));
-            let plan = build_struct_plan(ext, registry, &st.origin.syntax, depth + 1)?;
+            let plan = build_struct_plan(ext, registry, st, depth + 1)?;
             return Some(PlanFieldKind::Nested {
                 optional: optional_inner.is_some(),
                 child_fqn,
@@ -320,8 +323,7 @@ pub(crate) fn classify_field(
                 // Object-shaped wire with no fixed descriptor; the JVM slot
                 // must be the field's actual declared type (Option-stripped).
                 let slot_ty = optional_inner
-                    .clone()
-                    .unwrap_or_else(|| effective_ty.clone());
+                    .map_or_else(|| effective_ty.clone(), |i| i.origin.syntax.clone());
                 let descriptor = registry
                     .output_entry(&slot_ty)
                     .and_then(|e| jni_field_access(&e.destination))
@@ -495,6 +497,13 @@ fn sum_plan_kind(
     let item_enum = registry.flat().enum_item(&ident).unwrap_or_else(|| {
         panic!("fromParts bridge: sealed-class field `{owner}` has no indexed enum `{ident}`")
     });
+    // The sum as the MODEL holds it: its alternatives' payloads are `TypeRef`s
+    // already, so classifying one asks nothing and cannot be asked about a type
+    // the model never saw.
+    let Some(crate::api::core::flat::Type::Variant(sum)) = registry.flat().declared_type(&ident)
+    else {
+        panic!("fromParts bridge: sealed-class field `{owner}`: `{ident}` is not a sum")
+    };
     let key = TypeKey::from_ident(&ident);
     let cfg = ext
         .types
@@ -511,16 +520,16 @@ fn sum_plan_kind(
 
     let spec = SumSpec::from_item_enum(item_enum);
     let mut variants: Vec<SumPlanVariant> = Vec::new();
-    for (v, item_variant) in spec.variants.iter().zip(&item_enum.variants) {
+    for (v, alt) in spec.variants.iter().zip(&sum.alternatives) {
         let kotlin_name = ext.sum_variant_class_name(sum_cfg, &v.ident);
         let mut fields: Vec<SumPlanField> = Vec::new();
-        for (f, item_field) in v.fields.iter().zip(item_variant.fields.iter()) {
+        for (f, alt_field) in v.fields.iter().zip(alt.fields.iter()) {
             let prop = sum_field_prop_name(f);
             let slot = sum_slot_fragment(&kotlin_name, &prop);
             let owner = format!("{ident}::{}.{prop}", v.ident);
             // `?` — a payload whose converter has not resolved yet defers the
             // whole plan to the next iteration, it does not fail the build.
-            let kind = classify_field(ext, registry, &item_field.ty, &owner, depth + 1)?;
+            let kind = classify_field(ext, registry, &alt_field.ty, &owner, depth + 1)?;
             fields.push(SumPlanField {
                 member: f.member.clone(),
                 slot,

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -233,27 +233,29 @@ pub(crate) fn classify_field(
     // answers about a bare ident, so it reports `Vec<Reading>` as `Other` and
     // a rejection guarded on the unpeeled type could never fire. Peeling first
     // is what makes the `Vec<sum>` error reachable at all.
-    let bare = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
-    let core = vec_inner_type(&bare).unwrap_or_else(|| bare.clone());
+    // Every layer question below is the MODEL's, asked once: a field spelled
+    // `Box<Option<T>>` is `Optional` and must classify, nest and render exactly
+    // as `Option<T>` does. Peeling by path segment answered "not optional" for
+    // it, and the seven peels in this function would then disagree with each
+    // other about the same field (#273).
+    let optional_inner = registry.optional_inner(&effective_ty);
+    let bare = optional_inner
+        .clone()
+        .unwrap_or_else(|| effective_ty.clone());
+    let seq_elem = registry.sequence_elem(&bare);
+    let core = seq_elem.clone().unwrap_or_else(|| bare.clone());
     if matches!(ext.type_kind(registry, &core), TypeKind::Sum) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by
         // construction.
-        if vec_inner_type(&bare).is_some() {
+        if seq_elem.is_some() {
             panic!(
                 "fromParts bridge: `Vec<{}>` sealed-class field (`{owner}`) is not supported \
                  (variable arity)",
                 core.to_token_stream(),
             );
         }
-        return sum_plan_kind(
-            ext,
-            registry,
-            &bare,
-            owner,
-            option_inner_type(&effective_ty).is_some(),
-            depth,
-        );
+        return sum_plan_kind(ext, registry, &bare, owner, optional_inner.is_some(), depth);
     }
 
     let field_entry = registry.output_entry(&effective_ty)?;
@@ -277,7 +279,7 @@ pub(crate) fn classify_field(
             return Some(PlanFieldKind::Enum { conv, kotlin });
         }
         // `Option<enum>` leaf.
-        if let Some(inner) = option_inner_type(&effective_ty) {
+        if let Some(inner) = optional_inner.clone() {
             if ext.is_kotlin_enum(&inner) {
                 let kotlin = registry
                     .output_entry(&inner)?
@@ -302,7 +304,7 @@ pub(crate) fn classify_field(
                 .map(|s| ext.fqn_of(s));
             let plan = build_struct_plan(ext, registry, &st.origin.syntax, depth + 1)?;
             return Some(PlanFieldKind::Nested {
-                optional: option_inner_type(&effective_ty).is_some(),
+                optional: optional_inner.is_some(),
                 child_fqn,
                 plan,
             });
@@ -317,8 +319,9 @@ pub(crate) fn classify_field(
             None => {
                 // Object-shaped wire with no fixed descriptor; the JVM slot
                 // must be the field's actual declared type (Option-stripped).
-                let slot_ty =
-                    option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
+                let slot_ty = optional_inner
+                    .clone()
+                    .unwrap_or_else(|| effective_ty.clone());
                 let descriptor = registry
                     .output_entry(&slot_ty)
                     .and_then(|e| jni_field_access(&e.destination))
@@ -353,7 +356,7 @@ pub(crate) fn classify_field(
                 (LeafForm::Object, descriptor)
             }
         };
-        let nullable = is_option_type(&effective_ty) && !is_jni_primitive(&wire);
+        let nullable = optional_inner.is_some() && !is_jni_primitive(&wire);
         Some(PlanFieldKind::Leaf {
             conv,
             wire: Box::new(wire),

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2658,3 +2658,77 @@ fn a_wrapped_borrow_has_nothing_to_bridge_and_refuses() {
         );
     }
 }
+
+/// Nullability is the **model's** answer, so an optional behind an erased
+/// wrapper renders exactly as the bare one does — everywhere, not only in the
+/// positions a compiled fixture reaches.
+///
+/// `is_option_type` asked the spelling whether its last path segment read
+/// `Option`. The model erases `Box` and `Cow`, so `Box<Option<T>>` answered
+/// "not optional" and Kotlin lost its `?`. That is a wrong contract rather than
+/// a cosmetic slip: a non-null parameter for an optional value makes the absent
+/// case unexpressible (#273).
+///
+/// covertest's `boxed_note_echo` covers the parameter and return positions and
+/// compiles them; this covers the **data-class field** and **callback** ones,
+/// which it does not reach.
+#[test]
+fn nullability_ignores_how_rust_spells_the_optional() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| -> String {
+        let items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZRec {
+                        pub note: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_rec_emit(cb: impl Fn(ZRec) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::data_class!(ZRec))
+                    .fun(crate::fun!(z_rec_emit)),
+            );
+        let dir = unique_test_dir("jnigen_nullability");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let gen = jni.build_with(registry).expect("resolve");
+        let _ = gen.write_rust(dir.join("g.rs")).expect("write_rust");
+        gen.write_kotlin(&dir.join("kotlin"))
+            .expect("write_kotlin")
+            .iter()
+            .map(|p| std::fs::read_to_string(p).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let plain = build(syn::parse_quote!(Option<String>));
+    let boxed = build(syn::parse_quote!(Box<Option<String>>));
+
+    for (label, kotlin) in [("Option<T>", &plain), ("Box<Option<T>>", &boxed)] {
+        assert!(
+            kotlin.contains("note: String?"),
+            "{label}: an optional field is nullable in Kotlin:\n{kotlin}"
+        );
+    }
+    // The wrapper is a Rust spelling and nothing else: the Kotlin surface of
+    // the two is identical, character for character.
+    assert_eq!(
+        plain, boxed,
+        "a transparent wrapper must not change the Kotlin surface"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1277,7 +1277,7 @@ impl Declarations {
     ) -> Vec<crate::api::core::unfold::ValueDecon> {
         let mut out = Vec::new();
         for (ident, item_struct) in registry.flat().types().filter_map(|t| match t {
-            crate::api::core::flat::Type::Struct(s) => Some((&s.name, &s.origin.syntax)),
+            crate::api::core::flat::Type::Struct(s) => Some((&s.name, s)),
             _ => None,
         }) {
             let source: syn::Type = syn::parse_quote!(#ident);
@@ -1931,12 +1931,8 @@ impl Declarations {
                     });
                 }
             }
-            if let Some(s) = registry
-                .flat()
-                .struct_type(&name)
-                .map(|st| &st.origin.syntax)
-            {
-                let (wire, body) = struct_input_body(self, s, registry)?;
+            if let Some(s) = registry.flat().struct_type(&name) {
+                let (wire, body) = struct_input_body(self, &s.origin.syntax, registry)?;
                 let niches = default_niches_for_wire(&wire);
                 // Auto-generated struct: the value-context Kotlin name is
                 // whatever the user pinned via `data_class`. If
@@ -2125,11 +2121,7 @@ impl Declarations {
             });
         }
         if let Some(name) = bare_path_ident(ty) {
-            if let Some(s) = registry
-                .flat()
-                .struct_type(&name)
-                .map(|st| &st.origin.syntax)
-            {
+            if let Some(s) = registry.flat().struct_type(&name) {
                 let (wire, body) = struct_output_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);
                 let kotlin_name = self

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -52,3 +52,151 @@ pub use jni::{
 // unchanged (`KotlinFile` aliases the model's `KtFile`).
 pub use crate::api::gen::kotlin::KtFile as KotlinFile;
 pub use crate::api::gen::kotlin::WriteKotlinError;
+
+#[cfg(test)]
+mod spelling_census {
+    //! A committed census of every place this adapter asks a **spelling** what
+    //! a type's layers are, instead of asking the model.
+    //!
+    //! `is_option_type` is `path_tail_is(ty, "Option")`, and
+    //! `option_inner_type`/`vec_inner_type` peel by last path segment. The model
+    //! **erases** transparent wrappers — `Box<T>` *is* `T`, and so is
+    //! `Cow<'_, T>` — so every one of these answers "no layer" for a type the
+    //! model says is `Optional` or `Sequence`.
+    //!
+    //! That is how #273 happened: Kotlin nullability was decided this way, so a
+    //! `Box<Option<String>>` **parameter** rendered non-null while the
+    //! identical-meaning `Option<String>` rendered `String?` — and a non-null
+    //! parameter for an optional value makes the absent case unexpressible.
+    //! `Conversions::{is_optional, optional_inner, sequence_elem,
+    //! is_optional_borrow}` ask the model, and every site with a registry in
+    //! scope should use those.
+    //!
+    //! ## What this is for
+    //!
+    //! The counts go **down**. A file at zero has been migrated and must not
+    //! regress; a file above zero is remaining work, and #229's L4 "layer
+    //! questions" is where it is tracked. Either way a NEW call cannot appear
+    //! without moving a number, which is what stops the next site from reaching
+    //! for the spelling because it was the easiest thing in scope.
+    //!
+    //! It does not say the remaining calls are wrong *today* — some may be
+    //! legitimate spelling questions, the way `decoded_vec_satisfies` and
+    //! `is_unsized_spelling` are. It says each one is a decision someone made,
+    //! and moving the number is what puts it in front of review.
+    //!
+    //! ## Why it walks tokens
+    //!
+    //! A text scan is the wrong instrument for anything with more than one
+    //! spelling: `option_inner_type(..)`,
+    //! `types_util::option_inner_type(..)` and a `use`-aliased call are the same
+    //! call. #271's first guard matched text and missed a bare `Some(..)` that
+    //! turned out to be a live bug, so this counts **call expressions by callee
+    //! name**, whatever path qualifies them.
+
+    use proc_macro2::{Delimiter, TokenTree};
+
+    /// The helpers that read a spelling where the model has the answer.
+    const SPELLING_HELPERS: &[&str] = &[
+        "is_option_type",
+        "is_option_ref",
+        "option_inner_type",
+        "vec_inner_type",
+        "peel_ref_option_vec",
+    ];
+
+    /// `(file, call count)` — every `.rs` under `api/lang/jnigen`, checked
+    /// against the directory tree so a new module cannot sit outside the census.
+    const CENSUS: &[(&str, usize)] = &[
+        // The L4 "layer questions" remainder — #229. Not migrated here because
+        // it is a separate consumer and bundling it would make one review of
+        // both impossible.
+        ("jni/emit/flat_input.rs", 20),
+        ("jni/emit/struct_out.rs", 2),
+        ("jni/emit/vec_build.rs", 1),
+        ("jni/emit/wrapper.rs", 2),
+        ("jni/fold.rs", 1),
+        ("jni/iface.rs", 2),
+        ("jni/kotlin_emit.rs", 1),
+        ("jni/trait_impl.rs", 4),
+        // Down from 2: the nullability decisions now ask the model. The one
+        // left probes for an enum through its layers.
+        ("jni/fn_plan.rs", 1),
+    ];
+
+    /// Count `name(` call expressions, ignoring how the path is qualified.
+    fn count(ts: proc_macro2::TokenStream, n: &mut usize) {
+        let toks: Vec<TokenTree> = ts.into_iter().collect();
+        for (i, t) in toks.iter().enumerate() {
+            if let TokenTree::Ident(id) = t {
+                let called = matches!(
+                    toks.get(i + 1),
+                    Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Parenthesis
+                );
+                if called && SPELLING_HELPERS.iter().any(|h| id == h) {
+                    *n += 1;
+                }
+            }
+            if let TokenTree::Group(g) = t {
+                count(g.stream(), n);
+            }
+        }
+    }
+
+    fn rs_files(dir: &std::path::Path, root: &std::path::Path, out: &mut Vec<String>) {
+        for e in std::fs::read_dir(dir).expect("jnigen dir") {
+            let p = e.expect("dir entry").path();
+            if p.is_dir() {
+                rs_files(&p, root, out);
+            } else if p.extension().is_some_and(|x| x == "rs") {
+                out.push(
+                    p.strip_prefix(root)
+                        .expect("under jnigen")
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn spelling_helper_calls_are_accounted_for() {
+        let root =
+            std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/src/api/lang/jnigen"));
+        let mut files = Vec::new();
+        rs_files(root, root, &mut files);
+        files.sort();
+
+        let mut drift: Vec<String> = Vec::new();
+        for f in &files {
+            // Tests may exercise the helpers directly.
+            if f.contains("tests") {
+                continue;
+            }
+            let src = std::fs::read_to_string(root.join(f)).expect("read source");
+            let ts: proc_macro2::TokenStream =
+                src.parse().unwrap_or_else(|e| panic!("tokenize {f}: {e}"));
+            let mut found = 0usize;
+            count(ts, &mut found);
+            let expected = CENSUS
+                .iter()
+                .find(|(name, _)| name == f)
+                .map(|(_, n)| *n)
+                .unwrap_or(0);
+            if found != expected {
+                drift.push(format!("  {f}: {expected} -> {found}"));
+            }
+        }
+        assert!(
+            drift.is_empty(),
+            "SPELLING-CENSUS DRIFT:\n{}\n\n\
+             These helpers read a type's layers off its SPELLING, which the model \
+             erases wrappers from — see this module's docs. A count going DOWN is \
+             the goal: drop the row (or lower it) in the same commit. A count going \
+             UP needs a reason in review: prefer `Conversions::{{is_optional, \
+             optional_inner, sequence_elem, is_optional_borrow}}`, which ask the \
+             model, wherever a registry is in scope.",
+            drift.join("\n"),
+        );
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -92,7 +92,9 @@ mod spelling_census {
     //! `types_util::option_inner_type(..)` and a `use`-aliased call are the same
     //! call. #271's first guard matched text and missed a bare `Some(..)` that
     //! turned out to be a live bug, so this counts **call expressions by callee
-    //! name**, whatever path qualifies them.
+    //! name**, whatever path qualifies them — and resolves `use … as …` first,
+    //! because an alias rewrites the call site and would otherwise be the same
+    //! blind spot one form over (see [`tracked_names`]).
 
     use proc_macro2::{Delimiter, TokenTree};
 
@@ -125,7 +127,42 @@ mod spelling_census {
     ];
 
     /// Count `name(` call expressions, ignoring how the path is qualified.
-    fn count(ts: proc_macro2::TokenStream, n: &mut usize) {
+    /// Collect the local names a file can call a tracked helper by: the helper's
+    /// own name, plus anything a `use … as …` renamed it to.
+    ///
+    /// Without this the census counts the wrong thing. Qualifying a call leaves
+    /// the tracked ident in place (`types_util::option_inner_type(..)` still
+    /// ends in it), but **aliasing rewrites the call site**: after
+    /// `use …::option_inner_type as peel_optional;` the call reads
+    /// `peel_optional(ty)` and nothing in `SPELLING_HELPERS` matches it.
+    ///
+    /// That is not hypothetical — the sibling adapter does exactly this today
+    /// (`api/lang/cbindgen/mod.rs`: `is_option_type as is_option`, called at a
+    /// dozen sites), so anyone writing jnigen code in that style would have
+    /// walked straight through this guard.
+    ///
+    /// Found in tokens rather than by parsing `use` items, for the reason the
+    /// module docs give: a token walk sees macro bodies and nested `use` groups
+    /// alike. The shape is `<tracked> as <alias>`, wherever it appears.
+    fn tracked_names(ts: proc_macro2::TokenStream, out: &mut Vec<String>) {
+        let toks: Vec<TokenTree> = ts.into_iter().collect();
+        for (i, t) in toks.iter().enumerate() {
+            if let TokenTree::Ident(id) = t {
+                let renamed = matches!(toks.get(i + 1), Some(TokenTree::Ident(kw)) if kw == "as");
+                if renamed && SPELLING_HELPERS.iter().any(|h| id == h) {
+                    if let Some(TokenTree::Ident(alias)) = toks.get(i + 2) {
+                        out.push(alias.to_string());
+                    }
+                }
+            }
+            if let TokenTree::Group(g) = t {
+                tracked_names(g.stream(), out);
+            }
+        }
+    }
+
+    /// Count calls to any name in `tracked`, ignoring how the path qualifies it.
+    fn count(ts: proc_macro2::TokenStream, tracked: &[String], n: &mut usize) {
         let toks: Vec<TokenTree> = ts.into_iter().collect();
         for (i, t) in toks.iter().enumerate() {
             if let TokenTree::Ident(id) = t {
@@ -133,12 +170,12 @@ mod spelling_census {
                     toks.get(i + 1),
                     Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Parenthesis
                 );
-                if called && SPELLING_HELPERS.iter().any(|h| id == h) {
+                if called && tracked.iter().any(|h| id == h) {
                     *n += 1;
                 }
             }
             if let TokenTree::Group(g) = t {
-                count(g.stream(), n);
+                count(g.stream(), tracked, n);
             }
         }
     }
@@ -159,6 +196,65 @@ mod spelling_census {
         }
     }
 
+    /// The census counts a helper **however the file names it** — including a
+    /// `use … as …` rename, which rewrites the call site.
+    ///
+    /// The reviewer's case (#274), and it was not hypothetical: the sibling
+    /// adapter aliases these exact helpers today
+    /// (`cbindgen/mod.rs`: `is_option_type as is_option`), so the idiom is
+    /// established and would have slipped a new jnigen call past a guard whose
+    /// whole claim is that it cannot happen.
+    ///
+    /// A guard is only worth its docs if it has been seen to fail, so this
+    /// asserts the aliased form counts, the qualified form counts, and the two
+    /// things that must NOT count still do not.
+    #[test]
+    fn the_census_sees_through_a_use_alias() {
+        let census = |src: &str| -> usize {
+            let ts: proc_macro2::TokenStream = src.parse().expect("tokenize");
+            let mut tracked: Vec<String> =
+                SPELLING_HELPERS.iter().map(|h| (*h).to_string()).collect();
+            tracked_names(ts.clone(), &mut tracked);
+            let mut n = 0usize;
+            count(ts, &tracked, &mut n);
+            n
+        };
+
+        // Bare, qualified, and aliased are one call.
+        assert_eq!(census("fn f(t: &T) { option_inner_type(t); }"), 1, "bare");
+        assert_eq!(
+            census("fn f(t: &T) { crate::api::core::types_util::option_inner_type(t); }"),
+            1,
+            "qualified"
+        );
+        assert_eq!(
+            census(
+                "use crate::api::core::types_util::option_inner_type as peel_optional;\n\
+                 fn f(t: &T) { peel_optional(t); }"
+            ),
+            1,
+            "aliased — the case that used to pass silently"
+        );
+        // An alias inside a nested `use` group, the shape cbindgen actually writes.
+        assert_eq!(
+            census(
+                "use crate::api::core::types_util::{first_type_arg, is_option_type as is_option};\n\
+                 fn f(t: &T) { is_option(t); }"
+            ),
+            1,
+            "aliased inside a use group"
+        );
+
+        // Naming a helper without calling it is not a call; an unrelated alias
+        // is not tracked.
+        assert_eq!(census("use x::option_inner_type;"), 0, "import alone");
+        assert_eq!(
+            census("use x::something_else as option_probe;\nfn f(t: &T) { option_probe(t); }"),
+            0,
+            "an alias of an untracked fn stays untracked"
+        );
+    }
+
     #[test]
     fn spelling_helper_calls_are_accounted_for() {
         let root =
@@ -176,8 +272,12 @@ mod spelling_census {
             let src = std::fs::read_to_string(root.join(f)).expect("read source");
             let ts: proc_macro2::TokenStream =
                 src.parse().unwrap_or_else(|e| panic!("tokenize {f}: {e}"));
+            // The helpers' own names, plus whatever this file renamed them to.
+            let mut tracked: Vec<String> =
+                SPELLING_HELPERS.iter().map(|h| (*h).to_string()).collect();
+            tracked_names(ts.clone(), &mut tracked);
             let mut found = 0usize;
-            count(ts, &mut found);
+            count(ts, &tracked, &mut found);
             let expected = CENSUS
                 .iter()
                 .find(|(name, _)| name == f)


### PR DESCRIPTION
Closes #273.

## The bug, proven

Kotlin nullability was decided by `is_option_type` — literally `path_tail_is(ty, "Option")`. The model **erases** transparent wrappers, so `Box<Option<String>>` classifies `Optional` and that check answers `false`.

Verified against the base commit by putting the wrapped parameter through it:

```kotlin
external fun boxedNoteEcho(note: String,  errorSink: Any): String?   // 237ee8c
external fun plainNoteEcho(note: String?, errorSink: Any): String?
```

**Not cosmetic.** A non-null Kotlin parameter for an optional value is a wrong *contract*: Kotlin rejects `null` at the call site, so the absent case becomes unexpressible.

## The fix has one home

`Conversions` gains `is_optional` / `optional_inner` / `sequence_elem` / `is_optional_borrow` as **default methods over `reading`** — the way `input_entry` and `output_entry` already sit over `conversion`.

That is deliberate rather than eight copies of `reading(ty)?.optional_inner()`: adding a transparent wrapper (an `Rc`) becomes a change to `TRANSPARENT_WRAPPERS` and **nothing else**, because every site asking the question follows automatically. Same shape as #272's `WRAPPER_OPS`, one layer out.

All eight sites already had a registry in scope, so nothing needed plumbing.

**Two are not `?` decisions**, and are worth flagging for review: `render.rs` picks a handle's **lock mode** and `emit/callback.rs` picks a **jvalue union member** — a deadlock and an ABI mismatch respectively, not a missing question mark. covertest's handle-locking and callback sections cover both.

## The cluster and the loop

`struct_plan::classify_field` peeled the same field **seven times** by name, right beside the nullability decision it would then disagree with. One reading at the top serves all seven.

`builder.rs`'s niche-depth loop peeled a spelling and re-keyed each result; it walks the reading instead, which drops the re-lookup.

`is_option_ref` is **deleted** — both halves read the spelling, and nothing called it once `is_optional_borrow` existed.

## The census

A token-walking count of the remaining spelling helpers under `api/lang/jnigen`, counted **by callee name** so a qualified or aliased call cannot hide. That is the #271 lesson: its first guard matched text, missed a bare spelling, and that spelling turned out to be a live bug.

Proven both ways — a call added to a zero-count file fails, and so does a brand-new module:

```
  jni/render.rs: 0 -> 1
  jni/probe_new.rs: 0 -> 1
```

`flat_input.rs`'s 20 calls stay **listed** as the L4 remainder rather than bundled here; the census is what keeps them visible instead of forgotten.

## Verification

- 543 lib tests; `cargo test --all --all-features` 14/14; clippy `--deny warnings`; fmt.
- **The regen diff is the interesting part.** The fixture's parameter is now `Box<Option<String>>`, and `covertest.kt` **is not in the diff at all** — wrapping a parameter changes nothing the JVM can see, which is the invariant. The Rust converter correctly takes `Box<Option<String>>`; the only Kotlin change is my own doc comment.
- covertest-kotlin **48/48** on the JVM. This carries real weight here: a wrong `?` is a Kotlin *compile* error in the harness, which is how the bug was found in the first place.
- Boundary ledger 130 → 129.

## Scope left open

`emit/flat_input.rs` (20 calls) is the L4 "layer questions" remainder — a separate consumer, and bundling it would have made one review of both impossible. It is in the census with its count, so it cannot drift quietly.
