### PR TITLE
The `Prebindgen` trait hands over elements, not syn items

### DIFF
--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -228,17 +228,50 @@ pub trait Prebindgen {
     }
 
     // ── Item methods ───────────────────────────────────────────────
+    //
+    // Each takes the **element**, not the `syn` item it was parsed from.
+    //
+    // The element is the model's own node: its types are `TypeRef`s, already
+    // classified. An adapter handed one therefore cannot ask what a type means
+    // and be told "no reading" — the question a `&syn::ItemFn` forced it to ask
+    // the registry, and which answered wrongly for a type that never entered
+    // the pipeline (#275). What generated Rust must *spell* is still exactly
+    // available, on `origin.syntax`: classify off `kind`, spell off `syntax`.
 
     /// Wrap a `#[prebindgen]` fn into the destination-language wrapper
     /// (e.g. JNI `extern "C"` fn).
-    fn on_function(&self, f: &syn::ItemFn, registry: &Registry<Self::Metadata>) -> TokenStream;
+    fn on_function(
+        &self,
+        f: &crate::api::core::flat::Function,
+        registry: &Registry<Self::Metadata>,
+    ) -> TokenStream;
 
     /// Per-struct emission. Typically empty for languages that get
     /// everything they need from auto-generated converters.
-    fn on_struct(&self, s: &syn::ItemStruct, registry: &Registry<Self::Metadata>) -> TokenStream;
+    fn on_struct(
+        &self,
+        s: &crate::api::core::flat::Struct,
+        registry: &Registry<Self::Metadata>,
+    ) -> TokenStream;
 
-    /// Per-enum emission.
-    fn on_enum(&self, e: &syn::ItemEnum, registry: &Registry<Self::Metadata>) -> TokenStream;
+    /// Per-sum emission — an `enum` whose alternatives carry payloads.
+    ///
+    /// Separate from [`Self::on_enum`] because the model separates them: the
+    /// two are numbered differently and consumed as different constructs. An
+    /// adapter with nothing to say about one shape returns an empty stream, as
+    /// both in-tree adapters do for both.
+    fn on_variant(
+        &self,
+        v: &crate::api::core::flat::Variant,
+        registry: &Registry<Self::Metadata>,
+    ) -> TokenStream;
+
+    /// Per-enum emission — the fieldless shape, a named set of integers.
+    fn on_enum(
+        &self,
+        e: &crate::api::core::flat::Enum,
+        registry: &Registry<Self::Metadata>,
+    ) -> TokenStream;
 
     /// Per-const emission. Default: a named const re-emits as a path-alias
     /// (see [`const_path_alias`]) when [`Self::source_module`] is available —
@@ -249,11 +282,15 @@ pub trait Prebindgen {
     /// A const reaching here is always named: prebindgen's own injected feature
     /// checks are [`Guard`](crate::api::core::flat::Guard)s, not consts, so this
     /// never has to recognise one.
-    fn on_const(&self, c: &syn::ItemConst, _registry: &Registry<Self::Metadata>) -> TokenStream {
+    fn on_const(
+        &self,
+        c: &crate::api::core::flat::Constant,
+        _registry: &Registry<Self::Metadata>,
+    ) -> TokenStream {
         use quote::ToTokens;
         match self.source_module() {
-            Some(m) => const_path_alias(c, m),
-            None => c.to_token_stream(),
+            Some(m) => const_path_alias(&c.origin.syntax, m),
+            None => c.origin.syntax.to_token_stream(),
         }
     }
 }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -94,13 +94,28 @@ impl StubExt {
 impl Prebindgen for StubExt {
     type Metadata = ();
 
-    fn on_function(&self, _f: &syn::ItemFn, _registry: &Registry<()>) -> TokenStream {
+    fn on_function(
+        &self,
+        _f: &crate::api::core::flat::Function,
+        _registry: &Registry<()>,
+    ) -> TokenStream {
         TokenStream::new()
     }
-    fn on_struct(&self, _s: &syn::ItemStruct, _registry: &Registry<()>) -> TokenStream {
+    fn on_struct(
+        &self,
+        _s: &crate::api::core::flat::Struct,
+        _registry: &Registry<()>,
+    ) -> TokenStream {
         TokenStream::new()
     }
-    fn on_enum(&self, _e: &syn::ItemEnum, _registry: &Registry<()>) -> TokenStream {
+    fn on_variant(
+        &self,
+        _v: &crate::api::core::flat::Variant,
+        _registry: &Registry<()>,
+    ) -> TokenStream {
+        TokenStream::new()
+    }
+    fn on_enum(&self, _e: &crate::api::core::flat::Enum, _registry: &Registry<()>) -> TokenStream {
         TokenStream::new()
     }
 }
@@ -398,13 +413,20 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn validate(&self, _binding: &Building<'_, ()>) -> Result<(), String> {
             Err("member fun `f` has no receiver".to_string())
         }
-        fn on_function(&self, f: &syn::ItemFn, r: &Registry<()>) -> TokenStream {
+        fn on_function(
+            &self,
+            f: &crate::api::core::flat::Function,
+            r: &Registry<()>,
+        ) -> TokenStream {
             self.0.on_function(f, r)
         }
-        fn on_struct(&self, s: &syn::ItemStruct, r: &Registry<()>) -> TokenStream {
+        fn on_struct(&self, s: &crate::api::core::flat::Struct, r: &Registry<()>) -> TokenStream {
             self.0.on_struct(s, r)
         }
-        fn on_enum(&self, e: &syn::ItemEnum, r: &Registry<()>) -> TokenStream {
+        fn on_variant(&self, v: &crate::api::core::flat::Variant, r: &Registry<()>) -> TokenStream {
+            self.0.on_variant(v, r)
+        }
+        fn on_enum(&self, e: &crate::api::core::flat::Enum, r: &Registry<()>) -> TokenStream {
             self.0.on_enum(e, r)
         }
     }
@@ -1355,13 +1377,20 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
     }
     impl Prebindgen for AnyConverterExt {
         type Metadata = ();
-        fn on_function(&self, f: &syn::ItemFn, r: &Registry<()>) -> TokenStream {
+        fn on_function(
+            &self,
+            f: &crate::api::core::flat::Function,
+            r: &Registry<()>,
+        ) -> TokenStream {
             self.0.on_function(f, r)
         }
-        fn on_struct(&self, st: &syn::ItemStruct, r: &Registry<()>) -> TokenStream {
+        fn on_struct(&self, st: &crate::api::core::flat::Struct, r: &Registry<()>) -> TokenStream {
             self.0.on_struct(st, r)
         }
-        fn on_enum(&self, e: &syn::ItemEnum, r: &Registry<()>) -> TokenStream {
+        fn on_variant(&self, v: &crate::api::core::flat::Variant, r: &Registry<()>) -> TokenStream {
+            self.0.on_variant(v, r)
+        }
+        fn on_enum(&self, e: &crate::api::core::flat::Enum, r: &Registry<()>) -> TokenStream {
             self.0.on_enum(e, r)
         }
     }

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -57,34 +57,6 @@ pub trait Conversions<M> {
             .is_some_and(|r| r.optional_inner().is_some())
     }
 
-    /// What an optional wraps, **spelled as generated Rust must spell it**.
-    ///
-    /// Classify off `kind`, spell off `syntax`: the decision that this *is* an
-    /// optional comes from the model, and what comes back is the inner's own
-    /// spelling — which is what a converter signature or a `quote!` needs.
-    fn optional_inner(&self, ty: &syn::Type) -> Option<syn::Type> {
-        self.reading(ty)
-            .and_then(|r| r.optional_inner().map(|i| i.origin.syntax.clone()))
-    }
-
-    /// The element of a run of values (`Vec<T>`, `[T]`, `Cow<'_, [T]>`), spelled
-    /// as generated Rust must spell it. The sequence peer of
-    /// [`Self::optional_inner`].
-    fn sequence_elem(&self, ty: &syn::Type) -> Option<syn::Type> {
-        self.reading(ty)
-            .and_then(|r| r.sequence_elem().map(|e| e.origin.syntax.clone()))
-    }
-
-    /// Whether `ty` is a borrow of an optional (`Option<&T>`) — the shape a
-    /// handle parameter locks differently. Reads both layers off the model, so
-    /// a wrapped spelling answers the same as the bare one.
-    fn is_optional_borrow(&self, ty: &syn::Type) -> bool {
-        self.reading(ty).is_some_and(|r| {
-            r.optional_inner()
-                .is_some_and(|i| i.borrow_target().is_some())
-        })
-    }
-
     /// The conversion for `ty` in `dir`, if there is one.
     fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>>;
 

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -85,7 +85,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     let flat = registry.flat();
     items.extend(parse_items_from_tokens(
         "on_function",
-        sorted_by_name(flat.functions().map(|f| (&f.name, &f.origin.syntax)))
+        sorted_by_name(flat.functions().map(|f| (&f.name, f)))
             .into_iter()
             .filter(|(ident, _)| declared_fns.contains(*ident))
             .map(|(_, item)| ext.on_function(item, registry)),
@@ -93,7 +93,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     items.extend(parse_items_from_tokens(
         "on_struct",
         sorted_by_name(flat.types().filter_map(|t| match t {
-            crate::api::core::flat::Type::Struct(s) => Some((&s.name, &s.origin.syntax)),
+            crate::api::core::flat::Type::Struct(s) => Some((&s.name, s)),
             _ => None,
         }))
         .into_iter()
@@ -101,18 +101,24 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
         .map(|(_, item)| ext.on_struct(item, registry)),
     )?);
     // Both enum shapes emit through `on_enum` and sort together: they were one
-    // map here before they were two elements, and an adapter re-emitting the
-    // item does not branch on the distinction.
+    // map here before they were two elements. They still SORT together — the
+    // emission order is one sequence — but they dispatch to their own methods
+    // now, because handing an adapter a `Type` it has to re-match is worse than
+    // handing it the element the model already decided on.
     items.extend(parse_items_from_tokens(
         "on_enum",
         sorted_by_name(flat.types().filter_map(|t| match t {
-            crate::api::core::flat::Type::Variant(v) => Some((&v.name, &v.origin.syntax)),
-            crate::api::core::flat::Type::Enum(e) => Some((&e.name, &e.origin.syntax)),
+            crate::api::core::flat::Type::Variant(v) => Some((&v.name, t)),
+            crate::api::core::flat::Type::Enum(e) => Some((&e.name, t)),
             _ => None,
         }))
         .into_iter()
         .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
-        .map(|(_, item)| ext.on_enum(item, registry)),
+        .map(|(_, t)| match t {
+            crate::api::core::flat::Type::Variant(v) => ext.on_variant(v, registry),
+            crate::api::core::flat::Type::Enum(e) => ext.on_enum(e, registry),
+            _ => unreachable!("filtered to the two enum shapes above"),
+        }),
     )?);
     // Consts: an adapter WITH a const declaration mechanism
     // (`declared_consts() == Some(set)`) emits declared consts only,
@@ -122,7 +128,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     let declared_consts = &declared.consts;
     items.extend(parse_items_from_tokens(
         "on_const",
-        sorted_by_name(flat.constants().map(|c| (&c.name, &c.origin.syntax)))
+        sorted_by_name(flat.constants().map(|c| (&c.name, c)))
             .into_iter()
             .filter(|(ident, _)| {
                 declared_consts

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -26,16 +26,36 @@ impl IdentityExt {
 impl Prebindgen for IdentityExt {
     type Metadata = ();
 
-    fn on_function(&self, f: &syn::ItemFn, _registry: &Registry<Self::Metadata>) -> TokenStream {
-        f.to_token_stream()
+    fn on_function(
+        &self,
+        f: &crate::api::core::flat::Function,
+        _registry: &Registry<Self::Metadata>,
+    ) -> TokenStream {
+        f.origin.syntax.to_token_stream()
     }
 
-    fn on_struct(&self, s: &syn::ItemStruct, _registry: &Registry<Self::Metadata>) -> TokenStream {
-        s.to_token_stream()
+    fn on_struct(
+        &self,
+        s: &crate::api::core::flat::Struct,
+        _registry: &Registry<Self::Metadata>,
+    ) -> TokenStream {
+        s.origin.syntax.to_token_stream()
     }
 
-    fn on_enum(&self, e: &syn::ItemEnum, _registry: &Registry<Self::Metadata>) -> TokenStream {
-        e.to_token_stream()
+    fn on_variant(
+        &self,
+        v: &crate::api::core::flat::Variant,
+        _registry: &Registry<Self::Metadata>,
+    ) -> TokenStream {
+        v.origin.syntax.to_token_stream()
+    }
+
+    fn on_enum(
+        &self,
+        e: &crate::api::core::flat::Enum,
+        _registry: &Registry<Self::Metadata>,
+    ) -> TokenStream {
+        e.origin.syntax.to_token_stream()
     }
 }
 
@@ -217,14 +237,25 @@ fn guards_emit_ungated_and_in_stream_order() {
     impl Prebindgen for ConstGatingExt {
         type Metadata = ();
 
-        fn on_function(&self, f: &syn::ItemFn, _r: &Registry<()>) -> TokenStream {
-            f.to_token_stream()
+        fn on_function(
+            &self,
+            f: &crate::api::core::flat::Function,
+            _r: &Registry<()>,
+        ) -> TokenStream {
+            f.origin.syntax.to_token_stream()
         }
-        fn on_struct(&self, s: &syn::ItemStruct, _r: &Registry<()>) -> TokenStream {
-            s.to_token_stream()
+        fn on_struct(&self, s: &crate::api::core::flat::Struct, _r: &Registry<()>) -> TokenStream {
+            s.origin.syntax.to_token_stream()
         }
-        fn on_enum(&self, e: &syn::ItemEnum, _r: &Registry<()>) -> TokenStream {
-            e.to_token_stream()
+        fn on_variant(
+            &self,
+            v: &crate::api::core::flat::Variant,
+            _r: &Registry<()>,
+        ) -> TokenStream {
+            v.origin.syntax.to_token_stream()
+        }
+        fn on_enum(&self, e: &crate::api::core::flat::Enum, _r: &Registry<()>) -> TokenStream {
+            e.origin.syntax.to_token_stream()
         }
     }
 

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1724,17 +1724,33 @@ impl Prebindgen for CbindgenBuilder {
 
     // ── Item emission ──────────────────────────────────────────────────
 
-    fn on_function(&self, f: &syn::ItemFn, registry: &Registry<()>) -> TokenStream {
-        self.emit_function_wrapper(f, registry)
+    fn on_function(
+        &self,
+        f: &crate::api::core::flat::Function,
+        registry: &Registry<()>,
+    ) -> TokenStream {
+        self.emit_function_wrapper(&f.origin.syntax, registry)
     }
 
-    fn on_struct(&self, _s: &syn::ItemStruct, _registry: &Registry<()>) -> TokenStream {
+    fn on_struct(
+        &self,
+        _s: &crate::api::core::flat::Struct,
+        _registry: &Registry<()>,
+    ) -> TokenStream {
         // The `#[repr(C)]` mirror + converters come from prerequisites /
         // on_output_type; the original (non-FFI-safe) struct is dropped.
         TokenStream::new()
     }
 
-    fn on_enum(&self, _e: &syn::ItemEnum, _registry: &Registry<()>) -> TokenStream {
+    fn on_variant(
+        &self,
+        _v: &crate::api::core::flat::Variant,
+        _registry: &Registry<()>,
+    ) -> TokenStream {
+        TokenStream::new()
+    }
+
+    fn on_enum(&self, _e: &crate::api::core::flat::Enum, _registry: &Registry<()>) -> TokenStream {
         TokenStream::new()
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -6,7 +6,7 @@ use crate::api::core::{registry::Conversions, types_util::result_ok_type};
 
 pub(crate) fn emit_jni_function_wrapper(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
 ) -> TokenStream {
     emit_jni_function_wrapper_with_callee(ext, f, registry, None)
@@ -18,14 +18,12 @@ pub(crate) fn emit_jni_function_wrapper(
 /// [`emit_jni_function_wrapper_with_callee`]) and the Kotlin `val`
 /// initializer (`render_const_val`) — derive the extern symbol from this one
 /// ident, so they stay in sync by construction. The body is never used.
-pub(crate) fn const_getter_fn(c: &syn::ItemConst) -> syn::ItemFn {
-    let ident = format_ident!("const_get_{}", c.ident.to_string().to_lowercase());
-    let ty = &c.ty;
-    syn::parse_quote! {
-        pub fn #ident() -> #ty {
-            unimplemented!()
-        }
-    }
+pub(crate) fn const_getter_fn(
+    c: &crate::api::core::flat::Constant,
+) -> crate::api::core::flat::Function {
+    let ident = format_ident!("const_get_{}", c.name.to_string().to_lowercase());
+    // No lookup: a constant element carries its own `TypeRef`.
+    synthetic_getter(ident, c.ty.clone())
 }
 
 /// A const whose (peeled) type is a declared opaque handle is rejected: a
@@ -103,12 +101,53 @@ pub(crate) fn validate_constant_fn(ext: &Declarations, f: &syn::ItemFn) {
 /// `pub fn const_get_<val_name_lower>() -> <ty>` — the same convention as
 /// const-backed getters, so both sides derive the extern symbol from the one
 /// val name. The body is never used.
-pub(crate) fn const_expr_getter_fn(kotlin_name: &str, ty: &syn::Type) -> syn::ItemFn {
+pub(crate) fn const_expr_getter_fn(
+    kotlin_name: &str,
+    ty: &syn::Type,
+    registry: &impl Conversions<KotlinMeta>,
+) -> crate::api::core::flat::Function {
     let ident = format_ident!("const_get_{}", kotlin_name.to_lowercase());
-    syn::parse_quote! {
-        pub fn #ident() -> #ty {
+    // The one lookup this path needs: the type is named by a build script, so
+    // no element carries it. A miss means the declared type never entered the
+    // pipeline, which is a binding error worth naming rather than a `None` to
+    // absorb.
+    let ret = registry.reading(ty).unwrap_or_else(|| {
+        panic!(
+            "constant_expr `{kotlin_name}`: type `{}` is not a type this binding crosses — \
+             declare it, or name one that is",
+            quote::ToTokens::to_token_stream(ty),
+        )
+    });
+    synthetic_getter(ident, ret)
+}
+/// A nullary getter as the MODEL would hold it — the one function no source
+/// wrote.
+///
+/// A declared constant crosses as a getter extern, and that getter goes through
+/// exactly the same emitter a real function does. So it needs a
+/// [`flat::Function`](crate::api::core::flat::Function), not a `syn::ItemFn`:
+/// the emitter classifies off `kind` now, and a synthesized item would have no
+/// reading to classify from.
+///
+/// `ret` is supplied by the caller because the two callers get it from
+/// different places — a declared const carries its own `TypeRef`, an
+/// expression constant names a type in the build script — and only the second
+/// has to look one up.
+pub(crate) fn synthetic_getter(
+    ident: syn::Ident,
+    ret: crate::api::core::flat::TypeRef,
+) -> crate::api::core::flat::Function {
+    let ret_syntax = &ret.origin.syntax;
+    let item: syn::ItemFn = syn::parse_quote! {
+        pub fn #ident() -> #ret_syntax {
             unimplemented!()
         }
+    };
+    crate::api::core::flat::Function {
+        name: ident,
+        params: Vec::new(),
+        origin: ret.origin.with(item),
+        ret,
     }
 }
 
@@ -132,11 +171,11 @@ pub(crate) fn validate_constant_expr(ext: &Declarations, kotlin_name: &str, ty: 
 /// `<origin module>::<CONST_IDENT>` — a path, not a call.
 pub(crate) fn emit_jni_function_wrapper_with_callee(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
     callee: Option<syn::Expr>,
 ) -> TokenStream {
-    let original_ident = &f.sig.ident;
+    let original_ident = &f.name;
 
     let mut wire_params: Vec<TokenStream> = Vec::new();
     // Each entry is a per-input decode statement. Fallible decodes are

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -65,7 +65,10 @@ pub(crate) enum ParamForm {
 
 /// One classified effective parameter (a source param, or one expansion leaf).
 pub(crate) struct PlanLeaf {
-    pub ty: syn::Type,
+    /// The leaf's **reading** — classification and spelling in one value, so
+    /// the two cannot disagree and no consumer has to look the type up. Spell
+    /// with `reading.origin.syntax`.
+    pub reading: crate::api::core::flat::TypeRef,
     /// Kotlin parameter name (`kt_param_name(ident)`: camelCase +
     /// hard-keyword escaping) — shared by the wrapper signature and the
     /// `external fun` declaration.
@@ -313,8 +316,7 @@ pub(crate) fn validate_bindings(
         if !declared.contains(ident) {
             continue;
         }
-        let item_fn = &f.origin.syntax;
-        match ext.fn_plan(registry, item_fn) {
+        match ext.fn_plan(registry, f) {
             Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
             Err(e) => errors.push(e.message(ident)),
         }
@@ -331,10 +333,10 @@ pub(crate) fn validate_bindings(
             if !declared_consts.contains(ident) {
                 continue;
             }
-            let getter = const_getter_fn(&c.origin.syntax);
+            let getter = const_getter_fn(c);
             match ext.fn_plan(registry, &getter) {
                 Ok(plan) => record_symbol(&plan.native_symbol, ident.to_string(), &mut errors),
-                Err(e) => errors.push(e.message(&getter.sig.ident)),
+                Err(e) => errors.push(e.message(&getter.name)),
             }
         }
     }
@@ -348,10 +350,10 @@ pub(crate) fn validate_bindings(
         .collect();
     expr_decls.sort_by(|a, b| a.kotlin_name.cmp(&b.kotlin_name));
     for decl in expr_decls {
-        let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
+        let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
         match ext.fn_plan(registry, &getter) {
             Ok(plan) => record_symbol(&plan.native_symbol, decl.kotlin_name.clone(), &mut errors),
-            Err(e) => errors.push(e.message(&getter.sig.ident)),
+            Err(e) => errors.push(e.message(&getter.name)),
         }
     }
 
@@ -393,15 +395,15 @@ impl Declarations {
     pub(crate) fn fn_plan(
         &self,
         registry: &Registry<KotlinMeta>,
-        f: &syn::ItemFn,
+        f: &crate::api::core::flat::Function,
     ) -> Result<std::rc::Rc<JniFunctionPlan>, PlanError> {
-        if let Some(hit) = self.fn_plans.borrow().get(&f.sig.ident).cloned() {
+        if let Some(hit) = self.fn_plans.borrow().get(&f.name).cloned() {
             return Ok(hit);
         }
         let plan = std::rc::Rc::new(JniFunctionPlan::build(self, registry, f)?);
         self.fn_plans
             .borrow_mut()
-            .insert(f.sig.ident.clone(), plan.clone());
+            .insert(f.name.clone(), plan.clone());
         Ok(plan)
     }
 }
@@ -413,40 +415,56 @@ impl JniFunctionPlan {
     pub fn build(
         ext: &Declarations,
         registry: &Registry<KotlinMeta>,
-        f: &syn::ItemFn,
+        f: &crate::api::core::flat::Function,
     ) -> Result<Self, PlanError> {
-        let jni_method = ext.mangle_jni_method(&kt_snake_to_camel(&f.sig.ident.to_string()));
+        let jni_method = ext.mangle_jni_method(&kt_snake_to_camel(&f.name.to_string()));
         let native_symbol = ext.native_method_symbol(&jni_method);
-        let onerror_iface = onerror_iface_spec(ext, registry, &f.sig.ident);
+        let onerror_iface = onerror_iface_spec(ext, registry, &f.name);
         // Output first: the Rust emitter historically resolved the output
         // before the inputs, so an unresolved-output failure takes precedence
         // over an unresolved-input one.
         let output = build_output(ext, registry, f)?;
         let mut params = Vec::new();
-        for input in &f.sig.inputs {
-            let syn::FnArg::Typed(pt) = input else {
-                continue;
-            };
-            let syn::Pat::Ident(pid) = &*pt.pat else {
-                continue;
-            };
-            let ident = pid.ident.clone();
-            let ty = (*pt.ty).clone();
+        // The element's parameters: each already a name and a `TypeRef`, so
+        // there is no `FnArg`/`Pat` destructuring and no position that could
+        // fail to yield a type.
+        for param in &f.params {
+            let ident = param.name.clone();
+            let ty = param.ty.origin.syntax.clone();
 
             let form = if let Some(plan) = registry
                 .expansion_plans()
-                .get(&(f.sig.ident.clone(), ident.clone()))
+                .get(&(f.name.clone(), ident.clone()))
             {
                 let mut leaves = Vec::new();
                 for leaf in &plan.leaves {
+                    // The ONE lookup left on this path: `FoldLeaf::ty` is a
+                    // `syn::Type` in core, so the reading has to be fetched
+                    // rather than carried. #275's second half removes it by
+                    // making the plan leaves carry `TypeRef`; until then a miss
+                    // means the leaf's type never entered the pipeline, which
+                    // is worth naming rather than absorbing.
+                    let leaf_reading = registry.reading(&leaf.ty).unwrap_or_else(|| {
+                        panic!(
+                            "fold leaf `{}` of `{}`: type `{}` never entered the pipeline",
+                            leaf.name,
+                            f.name,
+                            quote::ToTokens::to_token_stream(&leaf.ty),
+                        )
+                    });
                     leaves.push(classify_leaf(
-                        ext, registry, &leaf.name, &leaf.ty, /*expanded=*/ true, &ident,
+                        ext,
+                        registry,
+                        &leaf.name,
+                        &leaf_reading,
+                        /*expanded=*/ true,
+                        &ident,
                     )?);
                 }
                 ParamForm::Expanded(leaves)
             } else {
                 ParamForm::Single(Box::new(classify_leaf(
-                    ext, registry, &ident, &ty, /*expanded=*/ false, &ident,
+                    ext, registry, &ident, &param.ty, /*expanded=*/ false, &ident,
                 )?))
             };
             params.push(PlanParam { ident, ty, form });
@@ -474,7 +492,11 @@ impl JniFunctionPlan {
         })
     }
 
-    fn jvm_parameter_slots(&self, registry: &Registry<KotlinMeta>, f: &syn::ItemFn) -> usize {
+    fn jvm_parameter_slots(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        f: &crate::api::core::flat::Function,
+    ) -> usize {
         // `JNINative` is a Kotlin object, so its external methods are instance
         // methods and the JVM counts the implicit receiver as one unit.
         let mut slots = 1usize;
@@ -489,7 +511,7 @@ impl JniFunctionPlan {
                 InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,
                 InputKind::Callback { .. } => 1,
                 InputKind::Unsigned64 { .. } | InputKind::Plain => registry
-                    .input_entry(&leaf.ty)
+                    .input_entry(&leaf.reading.origin.syntax)
                     .and_then(|entry| JniPrim::from_wire(&entry.destination))
                     .map_or(1, |prim| match prim {
                         JniPrim::Long | JniPrim::Double => 2,
@@ -503,7 +525,7 @@ impl JniFunctionPlan {
             FnOutputPlan::Value(_) => 0,
         };
         slots += 1; // binding-error sink
-        if registry.error_plans().contains_key(&f.sig.ident) {
+        if registry.error_plans().contains_key(&f.name) {
             slots += 1;
         }
         slots
@@ -525,11 +547,14 @@ fn classify_leaf(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     ident: &syn::Ident,
-    ty: &syn::Type,
+    reading: &crate::api::core::flat::TypeRef,
     expanded: bool,
     source_param: &syn::Ident,
 ) -> Result<PlanLeaf, PlanError> {
-    let optional = registry.is_optional(ty);
+    // The reading, so the layer questions cannot miss. What generated Rust must
+    // spell is `origin.syntax`, unchanged.
+    let ty = &reading.origin.syntax;
+    let optional = reading.optional_inner().is_some();
     let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(ty));
     let kt_name = kt_param_name(&ident.to_string());
 
@@ -538,7 +563,7 @@ fn classify_leaf(
     if let Some(args) = extract_fn_trait_args(ty) {
         let iface = ext.iface_spec(registry, &SpecKey::callback(&args));
         return Ok(PlanLeaf {
-            ty: ty.clone(),
+            reading: reading.clone(),
             kt_name,
             kt_public: None,
             kt_meta: registry
@@ -582,8 +607,9 @@ fn classify_leaf(
             },
             Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
                 niche: entry.metadata.projection.as_ref().and_then(|p| {
-                    registry
-                        .is_optional(ty)
+                    reading
+                        .optional_inner()
+                        .is_some()
                         .then(|| p.niche_sentinels.first().cloned())
                         .flatten()
                 }),
@@ -601,7 +627,7 @@ fn classify_leaf(
     };
 
     Ok(PlanLeaf {
-        ty: ty.clone(),
+        reading: reading.clone(),
         kt_name,
         kt_public,
         kt_meta,
@@ -619,13 +645,13 @@ fn classify_leaf(
 fn build_output(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
 ) -> Result<FnOutputPlan, PlanError> {
     use crate::api::core::{
         types_util::result_ok_type,
         unfold::{Delivery, UnfoldShape},
     };
-    let ident = &f.sig.ident;
+    let ident = &f.name;
     let unfold_plan = registry.unfold_plans().get(ident);
 
     // Callback delivery: the return is decomposed to a foreign builder/fold
@@ -668,10 +694,9 @@ fn build_output(
     // `Return` delivery, the `Result` Ok type when an error plan peels, else
     // the function's own return.
     let is_convert = unfold_plan.is_some();
-    let return_ty: syn::Type = match &f.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, ty) => (**ty).clone(),
-    };
+    // The element normalizes an elided return and a written `-> ()` to one
+    // `Unit` reading, so there is no `ReturnType` match here.
+    let return_ty: syn::Type = f.ret.origin.syntax.clone();
     let error_plan = registry.error_plans().get(ident);
     let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
     let target_ty = match unfold_plan {
@@ -695,7 +720,8 @@ fn build_output(
     let ret_decl: syn::ReturnType = if is_convert {
         syn::parse_quote!(-> #target_ty)
     } else {
-        f.sig.output.clone()
+        let ret = &f.ret.origin.syntax;
+        syn::parse_quote!(-> #ret)
     };
     let (surface, canonical) = ReturnSurface::classify(ext, registry, &ret_decl);
     let is_enum = ext.is_kotlin_enum(&canonical);

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -925,11 +925,7 @@ impl Declarations {
                 imports.insert(format!("{}.{}", self.package, self.jni_native_class_name()));
             }
             for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
-                if let Some(item_fn) = registry
-                    .flat()
-                    .function(&m.rust_ident)
-                    .map(|func| &func.origin.syntax)
-                {
+                if let Some(item_fn) = registry.flat().function(&m.rust_ident) {
                     if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                         self,
                         item_fn,
@@ -959,11 +955,7 @@ impl Declarations {
                     .map(|c| *c)
                     .unwrap_or_else(|| KtClass::companion_object().vis(Vis::Public));
                 for m in ctors {
-                    if let Some(item_fn) = registry
-                        .flat()
-                        .function(&m.rust_ident)
-                        .map(|func| &func.origin.syntax)
-                    {
+                    if let Some(item_fn) = registry.flat().function(&m.rust_ident) {
                         if let Some(f) = crate::api::lang::jnigen::jni::render_wrapper_fn(
                             self,
                             item_fn,
@@ -1604,7 +1596,6 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            let item_fn = &item_fn.origin.syntax;
             let kotlin_name = self.effective_function_name(subpackage, entry);
             if let Some(f) = render_wrapper_fn(self, item_fn, registry, Some(&kotlin_name), None) {
                 // #52: idiomatic typed overloads for `.split_on_param`
@@ -1621,7 +1612,6 @@ impl Declarations {
             let item_const = registry
                 .flat()
                 .constant(&entry.rust_ident)
-                .map(|konst| &konst.origin.syntax)
                 .unwrap_or_else(|| {
                     panic!(
                         "write_jni_package: const `{}` registered via .constant(...) is \
@@ -1630,7 +1620,7 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            reject_handle_const(self, item_const);
+            reject_handle_const(self, &item_const.origin.syntax);
             if let Some((helper, prop)) = render_const_val(
                 self,
                 &package,
@@ -1658,8 +1648,7 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            let item_fn = &item_fn.origin.syntax;
-            validate_constant_fn(self, item_fn);
+            validate_constant_fn(self, &item_fn.origin.syntax);
             if let Some((helper, prop)) = render_constant_fn_val(
                 self,
                 &package,
@@ -1717,7 +1706,7 @@ impl Declarations {
             if !declared.contains(&f.name) {
                 continue;
             }
-            if let Some(fun) = render_extern_decl(self, &f.origin.syntax, registry) {
+            if let Some(fun) = render_extern_decl(self, f, registry) {
                 externs.push(fun);
             }
         }
@@ -1733,11 +1722,7 @@ impl Declarations {
             .collect();
         const_idents.sort_by_key(|i| i.to_string());
         for ident in const_idents {
-            let Some(item_const) = registry
-                .flat()
-                .constant(&ident)
-                .map(|konst| &konst.origin.syntax)
-            else {
+            let Some(item_const) = registry.flat().constant(&ident) else {
                 continue; // missing decl already warned by the scan
             };
             let getter = crate::api::lang::jnigen::jni::const_getter_fn(item_const);
@@ -1755,7 +1740,7 @@ impl Declarations {
             .collect();
         expr_decls.sort_by(|a, b| a.kotlin_name.cmp(&b.kotlin_name));
         for decl in expr_decls {
-            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
+            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
             if let Some(fun) = render_extern_decl(self, &getter, registry) {
                 externs.push(fun);
             }

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -318,7 +318,7 @@ fn find_block(params: &[kt::KtParam], leaf_names: &[String]) -> Option<usize> {
 /// hard errors — the user explicitly asked to split it).
 fn resolve_split<'a>(
     registry: &'a Registry<KotlinMeta>,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     sel_fun: &kt::KtFun,
     param_name: &str,
     multi: bool,
@@ -326,25 +326,25 @@ fn resolve_split<'a>(
     let param = syn::Ident::new(param_name, Span::call_site());
     let plan = registry
         .expansion_plans()
-        .get(&(f.sig.ident.clone(), param.clone()))
+        .get(&(f.name.clone(), param.clone()))
         .unwrap_or_else(|| {
             panic!(
                 "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` is not an expandable \
                  parameter (it has no `expand_param!` variants)",
-                f.sig.ident
+                f.name
             )
         });
     assert!(
         plan.selector.is_some(),
         "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` has a single variant — there \
          is nothing to split (it already flattens to one signature)",
-        f.sig.ident
+        f.name
     );
     assert!(
         plan_in_scope(plan),
         "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` has a recursively-built arm — \
          it cannot be overloaded; keep the selector form",
-        f.sig.ident
+        f.name
     );
     let leaf_names: Vec<String> = plan
         .leaves
@@ -356,7 +356,7 @@ fn resolve_split<'a>(
         panic!(
             "fun!({}).split_on_param(\"{param_name}\"): could not locate the parameter's leaf \
              block in the generated wrapper",
-            f.sig.ident
+            f.name
         )
     });
     let block = &sel_fun.params[start..start + len];
@@ -376,7 +376,7 @@ fn resolve_split<'a>(
                     panic!(
                         "fun!({}).split_on_param(\"{param_name}\"): an arm has a non-flat input; \
                          it cannot be overloaded",
-                        f.sig.ident
+                        f.name
                     )
                 });
             (vi, typed)
@@ -387,7 +387,7 @@ fn resolve_split<'a>(
         "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` is an `Option<_>` parameter \
          and none of its arms is a single leaf — its overload has no clean nullable type; keep \
          the selector form",
-        f.sig.ident
+        f.name
     );
     Split {
         param,
@@ -406,7 +406,7 @@ fn resolve_split<'a>(
 /// error) if the product has two combinations with the same JVM signature.
 pub(crate) fn render_param_overloads(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
     sel_fun: &kt::KtFun,
 ) -> Vec<kt::KtFun> {
@@ -415,33 +415,25 @@ pub(crate) fn render_param_overloads(
         let want: std::collections::HashSet<&str> = ext
             .fn_split_params
             .iter()
-            .filter(|(func, _)| func == &f.sig.ident)
+            .filter(|(func, _)| func == &f.name)
             .map(|(_, p)| p.as_str())
             .collect();
         if want.is_empty() {
             return Vec::new();
         }
-        f.sig
-            .inputs
+        f.params
             .iter()
-            .filter_map(|a| match a {
-                syn::FnArg::Typed(pt) => match &*pt.pat {
-                    syn::Pat::Ident(pid) if want.contains(pid.ident.to_string().as_str()) => {
-                        Some(pid.ident.to_string())
-                    }
-                    _ => None,
-                },
-                _ => None,
-            })
+            .filter(|p| want.contains(p.name.to_string().as_str()))
+            .map(|p| p.name.to_string())
             .collect()
     };
     // Any requested name that didn't match a real parameter is a typo — surface
     // it rather than silently dropping.
     for (func, p) in &ext.fn_split_params {
-        if func == &f.sig.ident && !requested.iter().any(|r| r == p) {
+        if func == &f.name && !requested.iter().any(|r| r == p) {
             panic!(
                 "fun!({}).split_on_param(\"{p}\"): no parameter named `{p}` on this function",
-                f.sig.ident
+                f.name
             );
         }
     }
@@ -477,7 +469,7 @@ pub(crate) fn render_param_overloads(
                     "fun!({}): split_on_param product is ambiguous — combinations {} and {} both \
                      surface as `({})`; add .no_split() intent is not enough here, disambiguate \
                      the constructors or drop one .split_on_param",
-                    f.sig.ident,
+                    f.name,
                     combo_label(&splits, &combos[i]),
                     combo_label(&splits, &combos[j]),
                     sigs[i]
@@ -534,7 +526,7 @@ pub(crate) fn render_param_overloads(
                 seen.insert(p.name.clone()),
                 "fun!({}): split overload has a duplicate parameter name `{}` — rename the \
                  constructor parameter",
-                f.sig.ident,
+                f.name,
                 p.name
             );
         }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -305,11 +305,7 @@ pub(crate) fn build_typed_handle(
             .param(kt::KtParam::new("ptr", kt::KtType::long())),
     );
     for m in members.iter().filter(|m| m.kind == MemberKind::Constructor) {
-        if let Some(item_fn) = registry
-            .flat()
-            .function(&m.rust_ident)
-            .map(|func| &func.origin.syntax)
-        {
+        if let Some(item_fn) = registry.flat().function(&m.rust_ident) {
             if let Some(f) = render_wrapper_fn(
                 ext,
                 item_fn,
@@ -418,11 +414,7 @@ pub(crate) fn build_typed_handle(
     // (receiver bound to `this`), delegating to the same centralized
     // `JNINative` extern as a free wrapper would.
     for m in members.iter().filter(|m| m.kind == MemberKind::Method) {
-        if let Some(item_fn) = registry
-            .flat()
-            .function(&m.rust_ident)
-            .map(|func| &func.origin.syntax)
-        {
+        if let Some(item_fn) = registry.flat().function(&m.rust_ident) {
             if let Some(f) = render_wrapper_fn(
                 ext,
                 item_fn,
@@ -460,7 +452,7 @@ pub(crate) fn is_iterable_fold(shape: &crate::api::core::unfold::UnfoldShape) ->
 /// resolved. Full-FQN types throughout — no derivation-time shortening.
 pub(crate) fn render_extern_decl(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
 ) -> Option<kt::KtFun> {
     // The name and wire params come straight off the lowered plan — the
@@ -545,7 +537,7 @@ pub(crate) fn render_extern_decl(
     // erased to `Any` (JObject) on the wire; the wrapper passes a capture for
     // each. A domain plan ⇒ `error_plans` has this fn.
     params.push(kt::KtParam::new("errorSink", kt::KtType::any()));
-    if registry.error_plans().contains_key(&f.sig.ident) {
+    if registry.error_plans().contains_key(&f.name) {
         params.push(kt::KtParam::new("domainSink", kt::KtType::any()));
     }
 
@@ -748,7 +740,7 @@ pub(crate) struct WrapperSurface {
 /// (`build_native_call` / `render_body` / KDoc / opaque-lock collection).
 pub(crate) fn build_wrapper_surface(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
@@ -761,7 +753,7 @@ pub(crate) fn build_wrapper_surface(
     // to hit the one extern that the Rust extern actually emits.
     let kt_name = match kotlin_name_override {
         Some(n) => n.to_string(),
-        None => kt_snake_to_camel(&f.sig.ident.to_string()),
+        None => kt_snake_to_camel(&f.name.to_string()),
     };
     let jni_call = fplan.jni_method.clone();
     let (params, receiver_idx) =
@@ -827,7 +819,7 @@ pub(crate) fn build_wrapper_surface(
 
 pub(crate) fn render_wrapper_fn(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
@@ -885,24 +877,24 @@ pub(crate) fn render_wrapper_fn(
 pub(crate) fn render_const_val(
     ext: &Declarations,
     package: &str,
-    c: &syn::ItemConst,
+    c: &crate::api::core::flat::Constant,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
     let getter = const_getter_fn(c);
-    let default = kt_snake_to_camel(&getter.sig.ident.to_string());
+    let default = kt_snake_to_camel(&getter.name.to_string());
     let helper_name = ext.mangle_fun(package, &default);
     let helper = render_wrapper_fn(ext, &getter, registry, Some(&helper_name), None)?;
     let val_name = kotlin_name_override
         .map(str::to_string)
-        .unwrap_or_else(|| c.ident.to_string());
+        .unwrap_or_else(|| c.name.to_string());
     let framework_line = format!(
         "Mirrors the Rust `#[prebindgen]` const `{}` (read lazily, once, through \
          the generated JNI getter on first use).",
-        c.ident
+        c.name
     );
-    let kdoc = crate::api::lang::jnigen::util::doc_string(&c.attrs)
+    let kdoc = crate::api::lang::jnigen::util::doc_string(&c.origin.syntax.attrs)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
@@ -916,23 +908,23 @@ pub(crate) fn render_const_val(
 pub(crate) fn render_constant_fn_val(
     ext: &Declarations,
     package: &str,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
-    let default = kt_snake_to_camel(&f.sig.ident.to_string());
+    let default = kt_snake_to_camel(&f.name.to_string());
     let helper_name = ext.mangle_fun(package, &default);
     let helper = render_wrapper_fn(ext, f, registry, Some(&helper_name), None)?;
     let val_name = kotlin_name_override
         .map(str::to_string)
-        .unwrap_or_else(|| f.sig.ident.to_string());
+        .unwrap_or_else(|| f.name.to_string());
     let framework_line = format!(
         "Mirrors the Rust `#[prebindgen]` fn `{}()` (evaluated lazily, once, \
          through the generated JNI wrapper on first use).",
-        f.sig.ident
+        f.name
     );
-    let kdoc = crate::api::lang::jnigen::util::doc_string(&f.attrs)
+    let kdoc = crate::api::lang::jnigen::util::doc_string(&f.origin.syntax.attrs)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
@@ -950,8 +942,8 @@ pub(crate) fn render_const_expr_val(
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
 ) -> Option<(kt::KtFun, kt::KtProperty)> {
-    let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
-    let default = kt_snake_to_camel(&getter.sig.ident.to_string());
+    let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
+    let default = kt_snake_to_camel(&getter.name.to_string());
     let helper_name = ext.mangle_fun(package, &default);
     let helper = render_wrapper_fn(ext, &getter, registry, Some(&helper_name), None)?;
     let expr = decl.expr.to_token_stream();
@@ -1077,7 +1069,7 @@ fn classify_params(
     let mut params: Vec<Param> = Vec::new();
     for leaf in fplan.leaves() {
         let mut name = leaf.kt_name.clone();
-        let arg_ty = &leaf.ty;
+        let arg_ty = &leaf.reading.origin.syntax;
 
         // Instance-method receiver: the first parameter whose peeled Rust type
         // is the owning class binds to `this` (so `this_ptr`/`this.ptr`/lock or
@@ -1205,9 +1197,15 @@ fn classify_params(
                 // Handle → Borrow/Consume by Rust syntactic shape (locked);
                 // `Option<&T>` / by-value `Option<T>` mark the param nullable
                 // and the wrapper body branches on null before lock selection.
-                if registry.is_optional_borrow(arg_ty) {
+                // Both read off the leaf's own reading — no lookup, and a
+                // wrapped spelling answers as the bare one does.
+                if leaf
+                    .reading
+                    .optional_inner()
+                    .is_some_and(|i| i.borrow_target().is_some())
+                {
                     ParamMode::BorrowNullable
-                } else if registry.is_optional(arg_ty) {
+                } else if leaf.reading.optional_inner().is_some() {
                     // by-value `Option<T>` opaque → nullable consume
                     ParamMode::ConsumeNullable
                 } else if matches!(arg_ty, syn::Type::Reference(_)) {
@@ -1258,12 +1256,12 @@ fn classify_params(
 /// unchanged).
 fn classify_output(
     ext: &Declarations,
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
 ) -> Option<OutputPlan> {
-    let unfold = registry.unfold_plans().get(&f.sig.ident);
+    let unfold = registry.unfold_plans().get(&f.name);
     // `builder_param` is the trailing **lambda** param (build / fold) as a
     // `(name, function-type)` pair. For the `Iterable` shape, the non-lambda
     // accumulator (`acc: A`) goes in `builder_lead` — it must precede
@@ -1607,7 +1605,7 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
 /// separate SAM param; the wrapper passes a per-thread capture to the extern,
 /// then after the native call redispatches to whichever channel fired.
 fn error_sink_parts(
-    f: &syn::ItemFn,
+    f: &crate::api::core::flat::Function,
     fplan: &JniFunctionPlan,
     registry: &Registry<KotlinMeta>,
     imports: &mut BTreeSet<String>,
@@ -1624,7 +1622,7 @@ fn error_sink_parts(
     let domain = if let Some(domain_spec) = &ifaces.domain {
         let error_plan = registry
             .error_plans()
-            .get(&f.sig.ident)
+            .get(&f.name)
             .expect("domain handler ⇒ error plan");
         // Per ze leaf: (raw capture Kotlin type, raw→typed wrap). The CAPTURE
         // is the raw twin (what the native side calls); the user's handler is
@@ -2223,8 +2221,11 @@ pub(crate) fn kt_param_name(rust_ident: &str) -> String {
 /// documenting the REAL prototype after all expansions — one note per
 /// position a plan reshaped, phrased for the caller. `None` for an
 /// undocumented, unshaped fn.
-fn wrapper_kdoc(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
-    let prose = crate::api::lang::jnigen::util::doc_string(&f.attrs);
+fn wrapper_kdoc(
+    f: &crate::api::core::flat::Function,
+    registry: &Registry<KotlinMeta>,
+) -> Option<String> {
+    let prose = crate::api::lang::jnigen::util::doc_string(&f.origin.syntax.attrs);
     let notes = shape_notes(f, registry);
     match (prose, notes) {
         (Some(p), Some(n)) => Some(format!("{p}\n\n{n}")),
@@ -2239,8 +2240,11 @@ fn wrapper_kdoc(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<Stri
 /// returns (what the builder/fold receives), and error decompositions
 /// (what `onError` receives). Reads the same resolved plan maps the C7
 /// report uses.
-fn shape_notes(f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> Option<String> {
-    let fn_ident = &f.sig.ident;
+fn shape_notes(
+    f: &crate::api::core::flat::Function,
+    registry: &Registry<KotlinMeta>,
+) -> Option<String> {
+    let fn_ident = &f.name;
     let mut notes: Vec<String> = Vec::new();
 
     let mut plans: Vec<(&syn::Ident, &crate::api::core::expand::FoldPlan)> = registry

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -189,11 +189,7 @@ impl super::JniGen {
     ) {
         let ext = self.declarations();
         let registry = self.registry();
-        let Some(item_fn) = registry
-            .flat()
-            .function(&rust_ident)
-            .map(|func| &func.origin.syntax)
-        else {
+        let Some(item_fn) = registry.flat().function(&rust_ident) else {
             return;
         };
         let Some(f) = render_wrapper_fn(ext, item_fn, registry, kotlin_name, receiver_key) else {

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -172,11 +172,7 @@ pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMet
             // surface signature (base + `.split_on_param` shells) comes from
             // the SAME `build_wrapper_surface` emission uses — a body-less
             // prototype, so the validator doesn't pay for body codegen.
-            if let Some(item_fn) = registry
-                .flat()
-                .function(&entry.rust_ident)
-                .map(|func| &func.origin.syntax)
-            {
+            if let Some(item_fn) = registry.flat().function(&entry.rust_ident) {
                 if let Some(s) = build_wrapper_surface(ext, item_fn, registry, Some(&name), None) {
                     for ov in render_param_overloads(ext, item_fn, registry, &s.fun) {
                         add_overload(&fn_scope, &ov, &origin, &mut errors);
@@ -217,11 +213,7 @@ pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMet
         for m in &ext.class_members[key] {
             let name = ext.effective_method_name(key, m);
             check_ident(&name, &format!("method `{}`", m.rust_ident), &mut errors);
-            let Some(item_fn) = registry
-                .flat()
-                .function(&m.rust_ident)
-                .map(|func| &func.origin.syntax)
-            else {
+            let Some(item_fn) = registry.flat().function(&m.rust_ident) else {
                 continue;
             };
             let (scope, receiver) = match m.kind {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -565,12 +565,7 @@ fn fn_plan_memo_shares_one_derivation() {
     // resolve runs validation, which builds and stores every function's plan.
     let gen = jni.build_with(registry).expect("resolve");
     let (ext, registry) = (gen.declarations(), gen.registry());
-    let f = &registry
-        .flat()
-        .function("z_do_thing")
-        .expect("indexed")
-        .origin
-        .syntax;
+    let f = registry.flat().function("z_do_thing").expect("indexed");
 
     // The plan is already in the memo (populated at resolve by validation) —
     // repeated lookups return the SAME allocation, and it equals what a fresh

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1690,7 +1690,7 @@ impl Prebindgen for Declarations {
         }
         for decl in self.packages.values().flat_map(|p| &p.constant_exprs) {
             validate_constant_expr(self, &decl.kotlin_name, &decl.ty);
-            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty);
+            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
             let expr = &decl.expr;
             let callee: syn::Expr = syn::parse_quote!({
                 #(
@@ -1714,18 +1714,38 @@ impl Prebindgen for Declarations {
 
     // ── Item methods ─────────────────────────────────────────────────
 
-    fn on_function(&self, f: &syn::ItemFn, registry: &Registry<KotlinMeta>) -> TokenStream {
+    fn on_function(
+        &self,
+        f: &crate::api::core::flat::Function,
+        registry: &Registry<KotlinMeta>,
+    ) -> TokenStream {
         emit_jni_function_wrapper(self, f, registry)
     }
 
-    fn on_struct(&self, _s: &syn::ItemStruct, _registry: &Registry<KotlinMeta>) -> TokenStream {
+    fn on_struct(
+        &self,
+        _s: &crate::api::core::flat::Struct,
+        _registry: &Registry<KotlinMeta>,
+    ) -> TokenStream {
         // Struct converter bodies are emitted by the resolver via
         // input_terminal / output_terminal below; no separate
         // per-struct item is needed.
         TokenStream::new()
     }
 
-    fn on_enum(&self, _e: &syn::ItemEnum, _registry: &Registry<KotlinMeta>) -> TokenStream {
+    fn on_variant(
+        &self,
+        _v: &crate::api::core::flat::Variant,
+        _registry: &Registry<KotlinMeta>,
+    ) -> TokenStream {
+        TokenStream::new()
+    }
+
+    fn on_enum(
+        &self,
+        _e: &crate::api::core::flat::Enum,
+        _registry: &Registry<KotlinMeta>,
+    ) -> TokenStream {
         TokenStream::new()
     }
 
@@ -1736,14 +1756,18 @@ impl Prebindgen for Declarations {
     /// extern. The getter reuses the whole function-wrapper pipeline (so the
     /// const's type flows through the ordinary output-converter machinery);
     /// only the callee expression differs — a path to the const, not a call.
-    fn on_const(&self, c: &syn::ItemConst, registry: &Registry<KotlinMeta>) -> TokenStream {
-        reject_handle_const(self, c);
+    fn on_const(
+        &self,
+        c: &crate::api::core::flat::Constant,
+        registry: &Registry<KotlinMeta>,
+    ) -> TokenStream {
+        reject_handle_const(self, &c.origin.syntax);
         let getter = const_getter_fn(c);
-        let const_ident = &c.ident;
+        let const_ident = &c.name;
         let source_module = self.fn_module(registry, const_ident);
         let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
         let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
-        let alias = crate::api::core::const_path_alias(c, &source_module);
+        let alias = crate::api::core::const_path_alias(&c.origin.syntax, &source_module);
         quote! {
             #alias
             #wrapper


### PR DESCRIPTION
First of **two** for #275. Split because ~60 sites plus a public-API break in one diff would not review well; the issue closes on PR 2.

## Why

The `Conversions` spelling accessors exist only because adapters hold `syn::Type` / `syn::ItemFn` where they mean *"a type the model classified"*. A type with no cell answers `false` — "not optional" — instead of saying it never entered the pipeline. That is the #266 shape, and its symptom is the missing `?` of #273.

#274 proved the fix on the struct chain. This does it for functions, constants, and the trait itself.

## The change

`on_function` / `on_struct` / `on_enum` / `on_const` take `flat::Function` / `Struct` / `Enum` / `Constant`. An adapter handed an element **cannot** ask what a type means and be told "no reading" — the guarantee `&syn::ItemFn` could not give. What generated Rust must *spell* is unchanged, on `origin.syntax`.

**Public-API break with zero external cost:** all six implementors are in-crate, no `examples/*/build.rs` implements the trait, and the `lib.rs` doc examples are `no_run`/`ignore` and only call the built-in builders. Per the standing rule, a justified API change is fine — and this one is the *last* reason the accessors exist.

**`write.rs` was already holding the elements** and reaching into `.origin.syntax` purely to satisfy the signatures. So were eight other sites, each spelled `.map(|f| &f.origin.syntax)` — the #267 pattern. They now stop discarding what they fetched.

jnigen's fn chain follows. The param walk reads `f.params` — a name and a `TypeRef` each — instead of destructuring `FnArg`/`Pat`, so **a position that yields no type is no longer representable**. The return reads `f.ret`, which the model already normalized (elided and `-> ()` are one `Unit`).

## The judgement call, flagged

`on_enum` **split into `on_variant` + `on_enum`**, because the model separates the two shapes deliberately — numbered differently, consumed as different constructs — and there is no single element to pass. They still **sort together** (emission order is one sequence); only dispatch differs. Both in-tree adapters already returned an empty stream for the merged method, so each gains one three-line stub.

The alternative — one method taking `&flat::Type` — makes every implementor re-match a type it was just handed. If this reads wrong, the fix is local.

## The synthetic const getter

The one function no source wrote. `synthetic_getter` builds a `flat::Function` for it: a declared const needs **no lookup** (`flat::Constant.ty` is already a `TypeRef`), while an expression constant names its type in a build script, so that path looks it up and **panics on a miss** rather than absorbing it.

## Accessors: 4 → 1

- `optional_inner`, `sequence_elem` — **deleted**; I added them speculatively in #274 and they were never called. My over-build, removed.
- `is_optional_borrow` — **deleted**; `PlanLeaf` now carries the reading, so `render`'s handle lock-mode decisions read layers off the leaf.
- `is_optional` — 4 callers left, all needing `UnfoldLeaf::out_ty` / `FoldLeaf::ty` to carry readings. That is PR 2.

The one lookup this PR *adds* is at exactly that boundary (a `FoldLeaf.ty`), commented as such and panicking on a miss.

## Verification

- **Goldens byte-identical.** That is the bar for a refactor this size, and it is the number to judge this PR on — a pure signature migration must not move a single generated byte.
- 545 lib tests; `cargo test --all --all-features` 14/14; clippy `--deny warnings`; fmt.
- covertest-kotlin **48/48** on the JVM. The const paths are the likeliest breakage — they feed the same emitter as real functions — and covertest exercises every const flavour (`COVER_MAGIC`, `COVER_TAG`, `COVER_VERSION`, `COVER_BANNER`).
- Both ledgers (boundary, spelling census) **unmoved**.
