### PR TITLE
Core's plan leaves carry the reading

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -297,7 +297,7 @@ fn process_expand<M>(
     // The boundary layers: `Option<&T>` → optional + by_ref, `Option<T>` →
     // optional, `&T` → by_ref, and `target` is what is left under them.
     let (optional, by_ref, target) = constructed_value_layers(&param_ty);
-    let target_key = TypeKey::from_type(&target);
+    let target_key = target.key();
 
     let variants = resolve_constructor(exp, registry, &target_key, ed)?;
     let mut visited: HashSet<TypeKey> = HashSet::new();
@@ -313,7 +313,7 @@ fn process_expand<M>(
     )?;
 
     for leaf in &plan.leaves {
-        registry.require_input(&leaf.ty);
+        registry.require_input(&leaf.ty.origin.syntax);
     }
     registry
         .expansion_plans
@@ -394,7 +394,7 @@ fn build_plan<M>(
     ed: &ExpandDecl,
     optional: bool,
     by_ref: bool,
-    target: &syn::Type,
+    target: &crate::api::core::flat::TypeRef,
     variants: &[Variant],
     visited: &mut HashSet<TypeKey>,
 ) -> Result<FoldPlan, ExpandError> {
@@ -414,7 +414,7 @@ fn build_plan<M>(
     if optional {
         let [Variant::Ctor(func)] = variants else {
             // Combined-selector dispatch under `Optional`.
-            visited.insert(TypeKey::from_type(target));
+            visited.insert(target.key());
             let prefix = param.to_string();
             let (selector, fold_variants) = build_core(
                 exp,
@@ -427,9 +427,9 @@ fn build_plan<M>(
                 &mut leaves,
                 visited,
             )?;
-            visited.remove(&TypeKey::from_type(target));
+            visited.remove(&target.key());
             return Ok(FoldPlan {
-                target: target.clone(),
+                target: target.origin.syntax.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -439,15 +439,15 @@ fn build_plan<M>(
             });
         };
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, target)?;
+        check_target(func, &sig.target, &target.origin.syntax)?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
             leaves.push(FoldLeaf {
                 name: param.clone(),
-                ty: opt(&pty.origin.syntax),
+                ty: pty.optional(),
             });
             return Ok(FoldPlan {
-                target: target.clone(),
+                target: target.origin.syntax.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -464,7 +464,8 @@ fn build_plan<M>(
         // Multi-arg: presence flag (leaf 0) + one flat leaf per ctor arg.
         leaves.push(FoldLeaf {
             name: ident(&format!("{}_present", param)),
-            ty: syn::parse_quote!(bool),
+            // A presence flag no source wrote — placeless by construction.
+            ty: crate::api::core::flat::TypeRef::scalar(crate::api::core::flat::ScalarKind::Bool),
         });
         let prefix = param.to_string();
         let mut inputs = Vec::new();
@@ -490,7 +491,7 @@ fn build_plan<M>(
             inputs.push(arg);
         }
         return Ok(FoldPlan {
-            target: target.clone(),
+            target: target.origin.syntax.clone(),
             by_ref,
             shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
             leaves,
@@ -507,7 +508,7 @@ fn build_plan<M>(
 
     // Non-optional: build the (possibly recursive) construct core. The target is
     // on the cycle chain so a constructor parameter of the same type is rejected.
-    visited.insert(TypeKey::from_type(target));
+    visited.insert(target.key());
     let prefix = param.to_string();
     let (selector, fold_variants) = build_core(
         exp,
@@ -520,9 +521,9 @@ fn build_plan<M>(
         &mut leaves,
         visited,
     )?;
-    visited.remove(&TypeKey::from_type(target));
+    visited.remove(&target.key());
     Ok(FoldPlan {
-        target: target.clone(),
+        target: target.origin.syntax.clone(),
         by_ref,
         shape: FoldShape::Base,
         leaves,
@@ -542,7 +543,7 @@ fn build_core<M>(
     exp: &Expansions,
     registry: &Registry<M>,
     ed: &ExpandDecl,
-    target: &syn::Type,
+    target: &crate::api::core::flat::TypeRef,
     variants: &[Variant],
     by_ref: bool,
     prefix: &str,
@@ -552,7 +553,7 @@ fn build_core<M>(
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, target)?;
+        check_target(func, &sig.target, &target.origin.syntax)?;
         let np = sig.params.len();
         let mut args = Vec::new();
         for (pname, pty) in &sig.params {
@@ -579,14 +580,15 @@ fn build_core<M>(
         let sel_idx = leaves.len();
         leaves.push(FoldLeaf {
             name: ident(&format!("{}_sel", prefix)),
-            ty: syn::parse_quote!(i32),
+            // The selector, likewise composed and placeless.
+            ty: crate::api::core::flat::TypeRef::scalar(crate::api::core::flat::ScalarKind::I32),
         });
         let mut fold_variants: Vec<FoldVariant> = Vec::new();
         for (vi, v) in variants.iter().enumerate() {
             match v {
                 Variant::Ctor(func) => {
                     let sig = ctor_signature(registry, func)?;
-                    check_target(func, &sig.target, target)?;
+                    check_target(func, &sig.target, &target.origin.syntax)?;
                     let np = sig.params.len();
                     let mut args = Vec::new();
                     for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
@@ -612,9 +614,9 @@ fn build_core<M>(
                 Variant::Identity => {
                     let idx = leaves.len();
                     let leaf_ty = if by_ref {
-                        opt(&syn::parse_quote!(&#target))
+                        target.borrowed().optional()
                     } else {
-                        opt(target)
+                        target.optional()
                     };
                     leaves.push(FoldLeaf {
                         name: ident(&format!("{}_{}", prefix, vi)),
@@ -649,7 +651,7 @@ fn build_arg<M>(
 ) -> Result<FoldArg, ExpandError> {
     // The boundary layers down to the parameter's core type.
     let (popt, pby_ref, bare) = constructed_value_layers(pty);
-    let key = TypeKey::from_type(&bare);
+    let key = bare.key();
     // A default constructor for the parameter's type ⇒ recursive nested build.
     let canon = exp
         .constructors
@@ -687,7 +689,7 @@ fn build_arg<M>(
         )?;
         visited.remove(&key);
         Ok(FoldArg::Build(Box::new(FoldBuild {
-            target: bare,
+            target: bare.origin.syntax.clone(),
             by_ref: pby_ref,
             selector,
             variants: vars,
@@ -703,9 +705,9 @@ fn build_arg<M>(
         leaves.push(FoldLeaf {
             name,
             ty: if dispatched && !passthrough {
-                opt(&pty.origin.syntax)
+                pty.optional()
             } else {
-                pty.origin.syntax.clone()
+                pty.clone()
             },
         });
         Ok(FoldArg::Leaf(idx, passthrough))
@@ -1089,17 +1091,22 @@ fn constructed_value(reading: &crate::api::core::flat::TypeRef) -> syn::Type {
 }
 
 /// [`constructed_value`], plus which of the two layers were there.
-fn constructed_value_layers(reading: &crate::api::core::flat::TypeRef) -> (bool, bool, syn::Type) {
+fn constructed_value_layers(
+    reading: &crate::api::core::flat::TypeRef,
+) -> (bool, bool, crate::api::core::flat::TypeRef) {
     let optional = reading.optional_inner().is_some();
     let after_opt = reading.optional_inner().unwrap_or(reading);
     let by_ref = after_opt.borrow_target().is_some();
     let core = after_opt.borrow_target().unwrap_or(after_opt);
-    (optional, by_ref, core.origin.syntax.clone())
+    // The core READING, not its spelling: the plan composes `Option<&T>` over
+    // it, and composing from a reading keeps the kind and the syntax paired.
+    (optional, by_ref, core.clone())
 }
 
-fn opt(ty: &syn::Type) -> syn::Type {
-    syn::parse_quote!(Option<#ty>)
-}
+// `opt` lived here — `parse_quote!(Option<#ty>)` — and built a spelling with no
+// classification beside it, so every consumer had to hand it back to the
+// registry to learn it was an optional. `TypeRef::optional` composes both at
+// once (#275).
 
 #[cfg(test)]
 mod tests;

--- a/prebindgen/src/api/core/expand/plan.rs
+++ b/prebindgen/src/api/core/expand/plan.rs
@@ -60,10 +60,18 @@ impl FoldPlan {
 pub struct FoldLeaf {
     /// Foreign-side parameter name.
     pub name: syn::Ident,
-    /// Rust type whose resolved **input** converter decodes this leaf. For a
-    /// single constructor these are the raw constructor parameter types; for a
-    /// combined one the selector (`i32`) and `Option`-wrapped variant inputs.
-    pub ty: syn::Type,
+    /// The **reading** of the type whose resolved input converter decodes this
+    /// leaf. For a single constructor these are the raw constructor parameter
+    /// types; for a combined one the selector (`i32`) and `Option`-wrapped
+    /// variant inputs. Spell it with `ty.origin.syntax`.
+    ///
+    /// A reading rather than a spelling for the reason [`UnfoldLeaf::out_ty`]
+    /// gives: a consumer asking what this leaf's type MEANS had to hand the
+    /// spelling back to the registry (#275). The leaves no source wrote — the
+    /// presence flag, the selector — are built by
+    /// [`TypeRef::scalar`](crate::api::core::flat::TypeRef::scalar), which
+    /// pairs the kind with its own spelling and is placeless by construction.
+    pub ty: crate::api::core::flat::TypeRef,
 }
 
 /// One dispatch arm of a [`FoldPlan`].

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -1,6 +1,16 @@
 use quote::ToTokens;
 
 use super::*;
+
+/// A reading for a fixture type — see the twin in `core/unfold/tests.rs`.
+/// Plan leaves carry `TypeRef`s, and a fixture naming a type inline needs one.
+fn tref(ty: syn::Type) -> crate::api::core::flat::TypeRef {
+    crate::api::core::flat::Flat::builder()
+        .build()
+        .expect("an empty model")
+        .classify(&ty)
+        .expect("a fixture type the language accepts")
+}
 use crate::api::{core::registry::Registry, test_util::scanned_with as reg_with};
 
 fn src_qualify(id: &syn::Ident) -> syn::Path {
@@ -40,7 +50,15 @@ fn single_constructor_plan_and_fold() {
     assert_eq!(plan.selector, None);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(plan.leaves[0].name.to_string(), "a");
-    assert_eq!(plan.leaves[0].ty.to_token_stream().to_string(), "String");
+    assert_eq!(
+        plan.leaves[0]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "String"
+    );
 
     let locals = vec![ident("a")];
     let folded = emit_fold(plan, &locals, &src_qualify);
@@ -87,14 +105,32 @@ fn constructor_plan_and_fold() {
     assert_eq!(plan.selector, Some(0));
     // selector + try_from(String) + identity(ZKeyExpr) = 3 leaves
     assert_eq!(plan.leaves.len(), 3);
-    assert_eq!(plan.leaves[0].ty.to_token_stream().to_string(), "i32");
     assert_eq!(
-        plan.leaves[1].ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "i32"
+    );
+    assert_eq!(
+        plan.leaves[1]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < String >"
     );
     // `&ZKeyExpr` consumer ⇒ borrowed identity leaf (clone-preserving).
     assert_eq!(
-        plan.leaves[2].ty.to_token_stream().to_string(),
+        plan.leaves[2]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < & ZKeyExpr >"
     );
     assert_eq!(plan.variants.len(), 2);
@@ -104,7 +140,7 @@ fn constructor_plan_and_fold() {
 
     // Leaf types registered as required inputs (so the resolver builds
     // their converters).
-    assert!(reg.input_types[&TypeKey::from_type(&plan.leaves[1].ty)].root);
+    assert!(reg.input_types[&plan.leaves[1].ty.key()].root);
 
     let locals = vec![ident("sel"), ident("v0"), ident("vid")];
     let folded = emit_fold(plan, &locals, &src_qualify);
@@ -150,7 +186,12 @@ fn optional_byvalue_single_ctor() {
     assert_eq!(plan.leaves.len(), 1);
     // nullable leaf wrapping the ctor param
     assert_eq!(
-        plan.leaves[0].ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < Vec < u8 > >"
     );
 
@@ -201,7 +242,12 @@ fn optional_byref_single_ctor() {
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
     assert_eq!(
-        plan.leaves[0].ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < String >"
     );
     assert_eq!(
@@ -254,12 +300,33 @@ fn optional_byref_multi_arg_ctor() {
     // leaf 0 = present:bool, leaf 1 = id:i32, leaf 2 = schema:Option<String>
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_present");
-    assert_eq!(plan.leaves[0].ty.to_token_stream().to_string(), "bool");
+    assert_eq!(
+        plan.leaves[0]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "bool"
+    );
     assert_eq!(plan.leaves[1].name.to_string(), "encoding_id");
-    assert_eq!(plan.leaves[1].ty.to_token_stream().to_string(), "i32");
+    assert_eq!(
+        plan.leaves[1]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "i32"
+    );
     assert_eq!(plan.leaves[2].name.to_string(), "encoding_schema");
     assert_eq!(
-        plan.leaves[2].ty.to_token_stream().to_string(),
+        plan.leaves[2]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < String >"
     );
 
@@ -332,18 +399,41 @@ fn optional_combined_selector_encodes_absence() {
     // (passthrough), identity:Option<&ZEncoding>.
     assert_eq!(plan.leaves.len(), 4);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_sel");
-    assert_eq!(plan.leaves[0].ty.to_token_stream().to_string(), "i32");
     assert_eq!(
-        plan.leaves[1].ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "i32"
+    );
+    assert_eq!(
+        plan.leaves[1]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < i32 >"
     );
     assert_eq!(
-        plan.leaves[2].ty.to_token_stream().to_string(),
+        plan.leaves[2]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < String >",
         "already-Option ctor arg is NOT double-wrapped"
     );
     assert_eq!(
-        plan.leaves[3].ty.to_token_stream().to_string(),
+        plan.leaves[3]
+            .ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < & ZEncoding >"
     );
     assert!(
@@ -386,7 +476,7 @@ fn iterable_emit_shape() {
         shape: FoldShape::Iterable(Box::new(FoldShape::Base)),
         leaves: vec![FoldLeaf {
             name: ident("kes"),
-            ty: syn::parse_quote!(Vec<String>),
+            ty: tref(syn::parse_quote!(Vec<String>)),
         }],
         selector: None,
         present: None,
@@ -584,7 +674,7 @@ fn recursive_input_nests_param_constructors() {
     let leaf_tys: Vec<String> = plan
         .leaves
         .iter()
-        .map(|l| l.ty.to_token_stream().to_string())
+        .map(|l| l.ty.origin.syntax.to_token_stream().to_string())
         .collect();
     assert!(
         leaf_tys.iter().any(|t| t.contains("i32")),

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -1833,3 +1833,34 @@ fn a_composed_type_keys_as_its_spelling() {
     // that value.
     assert_eq!(&*borrowed.origin.location, &*t.origin.location);
 }
+
+/// A **raw** identifier survives the round trip through `TypeId`.
+///
+/// `TypeId::name` is a `String`, so an enum legitimately named `r#type` is
+/// stored as `"r#type"` — and `Ident::new` *rejects* that spelling, panicking
+/// rather than returning an error. A consumer rebuilding an ident from the name
+/// therefore has to parse, and gets no warning until a source happens to use a
+/// keyword. `TypeId::ident` is where that recovery lives (#278 review).
+#[test]
+fn a_raw_identifier_survives_typeid() {
+    use crate::api::core::flat::{TypeKind, TypeRef};
+
+    let raw: syn::Ident = syn::parse_quote!(r#type);
+    assert_eq!(raw.to_string(), "r#type", "the hash is part of the name");
+
+    let t = TypeRef::named(&raw);
+    let TypeKind::Named { id } = &t.kind else {
+        panic!("named")
+    };
+    // Recovered, and it spells itself back the way it was written.
+    let back = id.ident().expect("a raw ident is still an ident");
+    assert_eq!(back, raw);
+    assert_eq!(tokens(&t.origin.syntax), "r#type");
+
+    // A path-qualified name is not a single identifier — the same answer the
+    // old `bare_path_ident` gave.
+    let qualified = crate::api::core::flat::TypeId {
+        name: "foreign::Option".to_string(),
+    };
+    assert!(qualified.ident().is_none());
+}

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -1770,3 +1770,66 @@ fn the_layer_stack_stops_at_an_out_of_order_layer() {
         ("Optional(Iterable(Base))".into(), "& Sample".into(), 3)
     );
 }
+
+/// A **composed** type keys exactly as the spelling it replaces, and classifies
+/// as what it was built from.
+///
+/// The decomposition plans compose types no source wrote — the borrow of a
+/// value, a presence flag, a selector — and those types are registered as
+/// crossings like any other. If a composed `&T` keyed differently from
+/// `parse_quote!(&#t)`, it would register a *different cell* and resolution
+/// would silently change. So the identity is pinned, not assumed.
+///
+/// The pairing is the point: `kind` and `origin.syntax` are built together in
+/// one place, so a consumer classifying off one and spelling off the other
+/// cannot be handed a disagreement.
+#[test]
+fn a_composed_type_keys_as_its_spelling() {
+    use crate::api::core::{
+        flat::{ScalarKind, TypeKind, TypeRef},
+        registry::TypeKey,
+    };
+
+    let t = lower(quote::quote!(u64)).expect("in the language");
+
+    let borrowed = t.borrowed();
+    assert_eq!(borrowed.key(), TypeKey::from_type(&syn::parse_quote!(&u64)));
+    assert!(matches!(borrowed.kind, TypeKind::Ref { .. }));
+    // The layer wraps the reading it was built from, so peeling gets it back.
+    assert_eq!(borrowed.borrow_target().expect("a borrow").key(), t.key());
+
+    let optional = t.optional();
+    assert_eq!(
+        optional.key(),
+        TypeKey::from_type(&syn::parse_quote!(Option<u64>))
+    );
+    assert_eq!(optional.optional_inner().expect("optional").key(), t.key());
+
+    // A scalar the binding invented: spelled from its own kind, so the two
+    // cannot drift.
+    assert_eq!(
+        TypeRef::scalar(ScalarKind::Bool).key(),
+        TypeKey::from_type(&syn::parse_quote!(bool))
+    );
+    assert_eq!(
+        TypeRef::scalar(ScalarKind::I32).key(),
+        TypeKey::from_type(&syn::parse_quote!(i32))
+    );
+    assert_eq!(
+        TypeRef::named(&syn::parse_quote!(ZEnum)).key(),
+        TypeKey::from_type(&syn::parse_quote!(ZEnum))
+    );
+
+    // Composed-from-nothing is PLACELESS: no file wrote it, and claiming a
+    // location would make a fabricated one indistinguishable from a real one.
+    assert!(
+        !TypeRef::scalar(ScalarKind::Bool)
+            .origin
+            .location
+            .has_position(),
+        "a scalar no source wrote carries no position"
+    );
+    // A layered one keeps the inner's location — the borrow exists because of
+    // that value.
+    assert_eq!(&*borrowed.origin.location, &*t.origin.location);
+}

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -140,6 +140,83 @@ impl TypeRef {
         }
     }
 
+    // ── Composition ───────────────────────────────────────────────
+    //
+    // Building a type the SOURCE did not write, as opposed to reading one it
+    // did. The decomposition plans need this: a leaf may be the borrow of a
+    // value, a presence flag, or a selector — none of which any source spelled,
+    // and all of which have to carry a reading like everything else.
+    //
+    // Here rather than at the callers, and not via
+    // [`Flat::classify`](super::Flat::classify), because the two acts are
+    // different. `classify` lowers *source syntax* — it is the frontend reading
+    // what a crate wrote, and `classify_has_no_caller_outside_the_registry`
+    // keeps it that way. These compose a type from parts already understood,
+    // which needs no lowering at all: each builds `kind` **and** the matching
+    // `origin.syntax` in one place, so the classification and the spelling
+    // cannot disagree — the invariant every consumer of a `TypeRef` relies on.
+
+    /// A borrow of this type — `&T` from `T`.
+    ///
+    /// Keeps this type's location: the borrow exists *because of* this value,
+    /// so a diagnostic about it should point where the value came from.
+    pub fn borrowed(&self) -> TypeRef {
+        let inner = &self.origin.syntax;
+        TypeRef {
+            kind: TypeKind::Ref {
+                mode: RefMode::Shared,
+                inner: Box::new(self.clone()),
+            },
+            origin: self.origin.with(syn::parse_quote!(&#inner)),
+        }
+    }
+
+    /// An optional of this type — `Option<T>` from `T`. Location as
+    /// [`Self::borrowed`].
+    pub fn optional(&self) -> TypeRef {
+        let inner = &self.origin.syntax;
+        TypeRef {
+            kind: TypeKind::Optional(Box::new(self.clone())),
+            origin: self.origin.with(syn::parse_quote!(Option<#inner>)),
+        }
+    }
+
+    /// A scalar the binding invented — a presence flag, a selector.
+    ///
+    /// **Placeless**, and deliberately: no file wrote it, so claiming a location
+    /// would make a fabricated one indistinguishable from a real one.
+    /// [`Flat::classify`](super::Flat::classify) does exactly this for a
+    /// composed spelling, and `ensure_entry` gives adapter-authored cells the
+    /// same treatment — `has_position` already gates what a diagnostic prints.
+    pub fn scalar(kind: ScalarKind) -> TypeRef {
+        // The spelling comes from the kind, so the two cannot drift.
+        let ident = syn::Ident::new(kind.as_str(), proc_macro2::Span::call_site());
+        TypeRef {
+            kind: TypeKind::Scalar(kind),
+            origin: Origin::new(
+                syn::parse_quote!(#ident),
+                std::rc::Rc::new(crate::SourceLocation::default()),
+            ),
+        }
+    }
+
+    /// A nominal reference to a declared type, by name. Placeless for the same
+    /// reason as [`Self::scalar`] — this is the binding naming a type, not a
+    /// source mentioning one.
+    pub fn named(ident: &syn::Ident) -> TypeRef {
+        TypeRef {
+            kind: TypeKind::Named {
+                id: TypeId {
+                    name: ident.to_string(),
+                },
+            },
+            origin: Origin::new(
+                syn::parse_quote!(#ident),
+                std::rc::Rc::new(crate::SourceLocation::default()),
+            ),
+        }
+    }
+
     /// This type's identity as a table key.
     ///
     /// The canonical spelling is what a key *is* (#113), and reading it is

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -441,7 +441,28 @@ pub struct TypeId {
     /// The path as written, minus any generic arguments — `Foo`,
     /// `foreign::Option`. Normalized, so a reducible std or source-module path
     /// has already collapsed to its final segment.
+    ///
+    /// A `String`, so a **raw** identifier is stored the way `Ident` prints
+    /// it — `r#type`, hashes and all. Recover it with [`Self::ident`] rather
+    /// than `Ident::new`, which rejects that spelling.
     pub name: String,
+}
+
+impl TypeId {
+    /// This name as an identifier, **raw forms included**.
+    ///
+    /// `Ident::new("r#type", …)` *panics* — it takes a bare name, not a
+    /// spelling — so a consumer rebuilding an ident from [`Self::name`] has to
+    /// parse rather than construct. Here so that recovery is written once: the
+    /// caller that gets it wrong does not fail until a source happens to use a
+    /// keyword, which is exactly the kind of bug that ships.
+    ///
+    /// `None` for a name that is not a single identifier at all (a
+    /// path-qualified `foreign::Option`), which is the same answer
+    /// `bare_path_ident` gave for one.
+    pub fn ident(&self) -> Option<syn::Ident> {
+        syn::parse_str::<syn::Ident>(&self.name).ok()
+    }
 }
 
 /// The primitives the source language accepts. Mirrors the set every adapter

--- a/prebindgen/src/api/core/registry/order.rs
+++ b/prebindgen/src/api/core/registry/order.rs
@@ -106,7 +106,7 @@ impl<M> Registry<M> {
         for arg in args {
             if let Some(plan) = self.callback_arg_plans.get(&TypeKey::from_type(&arg)) {
                 for leaf in &plan.leaves {
-                    out.push((Direction::Output, leaf.out_ty.clone()));
+                    out.push((Direction::Output, leaf.out_ty.origin.syntax.clone()));
                 }
             }
         }

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -459,7 +459,7 @@ pub fn apply<M>(
                     continue;
                 }
                 for leaf in &plan.leaves {
-                    registry.require_output(&leaf.out_ty);
+                    registry.require_output(&leaf.out_ty.origin.syntax);
                 }
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -640,7 +640,7 @@ fn wire_fixed_returns<M>(
             }
         }
         for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-            registry.require_output(&leaf.out_ty);
+            registry.require_output(&leaf.out_ty.origin.syntax);
         }
         let plan = UnfoldPlan {
             source: vd.source.clone(),
@@ -707,7 +707,7 @@ fn wire_fixed_callbacks<M>(
                     continue;
                 }
                 for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-                    registry.require_output(&leaf.out_ty);
+                    registry.require_output(&leaf.out_ty.origin.syntax);
                 }
                 let plan = UnfoldPlan {
                     source: vd.source.clone(),
@@ -1036,7 +1036,7 @@ fn process_decl<M>(
                 register_decon_spec(registry, acc, &decon, &records, element)?;
                 let plan = build_plan(acc, registry, ed, by_ref, element, shape, &records, decon)?;
                 for leaf in &plan.leaves {
-                    registry.require_output(&leaf.out_ty);
+                    registry.require_output(&leaf.out_ty.origin.syntax);
                 }
                 plan
             } else {
@@ -1082,7 +1082,7 @@ fn process_decl<M>(
             register_decon_spec(registry, acc, &decon, &records, source)?;
             let plan = build_plan(acc, registry, ed, by_ref, source, shape, &records, decon)?;
             for leaf in &plan.leaves {
-                registry.require_output(&leaf.out_ty);
+                registry.require_output(&leaf.out_ty.origin.syntax);
             }
             plan
         };
@@ -1110,7 +1110,7 @@ fn process_decl<M>(
             && plan.leaves.len() == 1
             && !plan.leaves[0].nullable;
         let plan = if single_return {
-            let leaf_ty = plan.leaves[0].out_ty.clone();
+            let leaf_ty = plan.leaves[0].out_ty.origin.syntax.clone();
             let cv_ty: syn::Type = if matches!(plan.shape, UnfoldShape::Optional((), _)) {
                 syn::parse_quote!(Option<#leaf_ty>)
             } else {
@@ -1357,11 +1357,13 @@ fn flatten<M>(
                 // A plan field: the drop to spelling happens here, where the value
                 // is stored for emission, and the borrowed form is composed rather
                 // than looked up because no source wrote it.
-                let src = &source.origin.syntax;
-                let out_ty: syn::Type = if place_is_owned(hoists, path_prefix, by_ref) {
-                    src.clone()
+                // The borrowed form is COMPOSED — no source wrote it — and the
+                // composition pairs the kind with its own spelling, so nothing
+                // downstream has to look either up.
+                let out_ty = if place_is_owned(hoists, path_prefix, by_ref) {
+                    source.clone()
                 } else {
-                    syn::parse_quote!(&#src)
+                    source.borrowed()
                 };
                 leaves.push(UnfoldLeaf {
                     name: if path_prefix.is_empty() {
@@ -1554,7 +1556,7 @@ fn flatten<M>(
                         leaves.push(UnfoldLeaf {
                             name: seg_name(&fr.name).join("__"),
                             path: field_path,
-                            out_ty: fr.ty.origin.syntax.clone(),
+                            out_ty: fr.ty.clone(),
                             identity: false,
                             nullable,
                             source: LeafSource::Field,
@@ -1647,9 +1649,9 @@ fn flatten<M>(
                     // A plan field: the spelling is taken here, once, where the
                     // leaf is stored for emission.
                     let (out_ty, nullable, identity) = if cond_handle {
-                        (core.origin.syntax.clone(), true, true)
+                        (core.clone(), true, true)
                     } else {
-                        (ret.origin.syntax.clone(), nullable, false)
+                        (ret.clone(), nullable, false)
                     };
                     let mut path = path_prefix.to_vec();
                     path.push(PathStep::call(func.clone(), opt, !core_by_ref));

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -296,10 +296,19 @@ pub struct UnfoldLeaf {
     /// `[Call(f)]` = `f(&root)`; longer = nested records, M3). Steps of both
     /// kinds may mix — see [`PathStep`].
     pub path: Vec<PathStep>,
-    /// Type whose resolved **output** converter encodes this leaf — a
-    /// reference type for accessors (`&str`, `&F`), `&Source` for the identity
-    /// leaf (so the borrowed-opaque clone converter / projection is reused).
-    pub out_ty: syn::Type,
+    /// The **reading** of the type whose resolved output converter encodes this
+    /// leaf — a reference type for accessors (`&str`, `&F`), `&Source` for the
+    /// identity leaf (so the borrowed-opaque clone converter / projection is
+    /// reused). Spell it with `out_ty.origin.syntax`.
+    ///
+    /// A reading rather than a spelling because a consumer asking what this
+    /// leaf's type *means* had to hand the spelling back to the registry and
+    /// hope for a cell — the round trip #263 removed from `api/core`, surviving
+    /// in the plans, and answering "no layer" for a type it had never seen
+    /// (#275). The composed ones (`&Source`) are built by
+    /// [`TypeRef::borrowed`](crate::api::core::flat::TypeRef::borrowed), which
+    /// pairs the kind with its own spelling.
+    pub out_ty: crate::api::core::flat::TypeRef,
     /// `true` for the move/clone-the-value handle leaf, emitted **last** (after
     /// every reference leaf's JVM conversion has ended its borrow).
     pub identity: bool,

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -6,6 +6,22 @@ use crate::api::{
     test_util::scanned_with as reg_with,
 };
 
+/// A reading for a fixture type, lowered by the model.
+///
+/// Plan leaves carry `TypeRef`s, and these fixtures assert on plan STRUCTURE —
+/// so they need a reading for a type they name inline. Lowering it through an
+/// empty `Flat` gives the same classification the pipeline would, without
+/// standing up a source crate for it. Legitimate here and nowhere else: the
+/// `classify` guard exempts tests precisely because a fixture composing its own
+/// input is not a consumer reasoning from `origin`.
+fn tref(ty: syn::Type) -> crate::api::core::flat::TypeRef {
+    crate::api::core::flat::Flat::builder()
+        .build()
+        .expect("an empty model")
+        .classify(&ty)
+        .expect("a fixture type the language accepts")
+}
+
 /// A generous `.fun_accessor` set covering every function used as a
 /// deconstructor record across these tests (a superset is fine — `apply`
 /// only checks records are members). The `nested_record_*` tests that
@@ -95,7 +111,15 @@ fn accessor_optional_primitive() {
         plan.leaves[0].path[0].ident().to_string(),
         "z_timestamp_ntp64"
     );
-    assert_eq!(plan.leaves[0].out_ty.to_token_stream().to_string(), "i64");
+    assert_eq!(
+        plan.leaves[0]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "i64"
+    );
     assert!(
         reg.output_types[&TypeKey::from_type(&syn::parse_quote!(i64))].root,
         "the leaf type must be a root"
@@ -151,7 +175,12 @@ fn accessor_plan_byref() {
     assert!(plan.leaves[0].identity);
     assert!(plan.leaves[0].path.is_empty());
     assert_eq!(
-        plan.leaves[0].out_ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "& ZKeyExpr"
     );
     // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
@@ -161,7 +190,15 @@ fn accessor_plan_byref() {
         plan.leaves[1].path[0].ident().to_string(),
         "z_keyexpr_as_str"
     );
-    assert_eq!(plan.leaves[1].out_ty.to_token_stream().to_string(), "& str");
+    assert_eq!(
+        plan.leaves[1]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
+        "& str"
+    );
 
     // Leaf out_tys registered as required outputs so the resolver builds
     // their converters.
@@ -505,7 +542,12 @@ fn nested_accessor_flatten() {
     assert_eq!(path(&plan.leaves[2]), "z_sample_payload.z_zbytes_to_bytes");
     assert_eq!(path(&plan.leaves[3]), "z_sample_kind");
     assert_eq!(
-        plan.leaves[3].out_ty.to_token_stream().to_string(),
+        plan.leaves[3]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "SampleKind"
     );
     assert_eq!(
@@ -643,7 +685,12 @@ fn reply_product_double_option_flatten() {
     // Acc leaf keeping its full `Option<…>` return — not a nesting step.
     assert_eq!(path(&plan.leaves[0]), "z_reply_replier_zid");
     assert_eq!(
-        plan.leaves[0].out_ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "Option < ZZenohId >"
     );
     assert!(!plan.leaves[0].nullable && !plan.leaves[0].identity);
@@ -809,7 +856,12 @@ fn iterable_decomposed_plan() {
         "z_zenoh_id_to_string"
     );
     assert_eq!(
-        plan.leaves[0].out_ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "String"
     );
     // Identity leaf: owned value (`ZZenohId`, not `&ZZenohId`) since the Vec
@@ -817,7 +869,12 @@ fn iterable_decomposed_plan() {
     assert!(plan.leaves[1].identity);
     assert!(plan.leaves[1].path.is_empty());
     assert_eq!(
-        plan.leaves[1].out_ty.to_token_stream().to_string(),
+        plan.leaves[1]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "ZZenohId"
     );
 }
@@ -1076,7 +1133,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
         path: vec![PathStep::field(ident(name), false)],
-        out_ty: ty,
+        out_ty: tref(ty),
         identity: false,
         nullable: false,
         source: LeafSource::Field,
@@ -1129,7 +1186,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
         path: vec![PathStep::field(ident(name), false)],
-        out_ty: ty,
+        out_ty: tref(ty),
         identity: false,
         nullable: false,
         source: LeafSource::Field,
@@ -1221,7 +1278,12 @@ fn convert_error_decomposes_result_e() {
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(
-        plan.leaves[0].out_ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "String"
     );
     assert_eq!(plan.source.to_token_stream().to_string(), "ZError");
@@ -1341,7 +1403,12 @@ fn callback_arg_plan_derived() {
         "z_sample_key_expr"
     );
     assert_eq!(
-        plan.leaves[0].out_ty.to_token_stream().to_string(),
+        plan.leaves[0]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "& ZKeyExpr"
     );
     assert_eq!(
@@ -1349,7 +1416,12 @@ fn callback_arg_plan_derived() {
         "z_keyexpr_as_str"
     );
     assert_eq!(
-        plan.leaves[2].out_ty.to_token_stream().to_string(),
+        plan.leaves[2]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "SampleKind"
     );
     // Leaf out_tys registered so the resolver builds their converters.
@@ -1424,7 +1496,12 @@ fn callback_arg_borrowed_decomposed() {
         "z_sample_key_expr"
     );
     assert_eq!(
-        plan.leaves[2].out_ty.to_token_stream().to_string(),
+        plan.leaves[2]
+            .out_ty
+            .origin
+            .syntax
+            .to_token_stream()
+            .to_string(),
         "SampleKind"
     );
 }
@@ -1671,7 +1748,7 @@ fn reading_sum_decon() -> SumDecon {
     let tag = UnfoldLeaf {
         name: "tag".to_string(),
         path: vec![],
-        out_ty: syn::parse_quote!(i32),
+        out_ty: tref(syn::parse_quote!(i32)),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,
@@ -1680,7 +1757,7 @@ fn reading_sum_decon() -> SumDecon {
     let field = |name: &str, variant: &str, idx: u32, ty: syn::Type, group: i32| UnfoldLeaf {
         name: name.to_string(),
         path: vec![],
-        out_ty: ty,
+        out_ty: tref(ty),
         identity: false,
         nullable: false,
         source: LeafSource::VariantField {
@@ -1854,7 +1931,7 @@ fn a_vec_of_optionals_installs_no_fixed_fold() {
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
         path: vec![PathStep::field(ident(name), false)],
-        out_ty: ty,
+        out_ty: tref(ty),
         identity: false,
         nullable: false,
         source: LeafSource::Field,

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1056,10 +1056,13 @@ impl Declarations {
                     let crate::api::core::flat::TypeKind::Named { id } = &probe.kind else {
                         panic!("a sum type is a named type")
                     };
-                    let item_enum = registry
+                    let crate::api::core::flat::Type::Variant(sum) = registry
                         .flat()
-                        .enum_item(&id.name)
-                        .expect("TypeKind::Sum implies an indexed enum");
+                        .declared_type(&id.name)
+                        .expect("TypeKind::Sum implies an indexed enum")
+                    else {
+                        panic!("TypeKind::Sum implies a payload-carrying enum")
+                    };
                     let sum_cfg = self.types[&probe.key()]
                         .sum()
                         .expect("TypeKind::Sum implies a sealed-class config");
@@ -1068,7 +1071,7 @@ impl Declarations {
                         name,
                         ty: field.ty.clone(),
                         decon: FieldDecon::Leaves(crate::api::lang::jnigen::jni::synth_sum_leaves(
-                            self, sum_cfg, item_enum,
+                            self, sum_cfg, sum,
                         )),
                     });
                     continue;

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -77,7 +77,7 @@ pub(crate) fn callback_input(
             // Every leaf converter must already be resolved (deferral safety).
             // A synthesized leaf (a sum's tag) has no converter to wait for.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                registry.output_entry(&leaf.out_ty)?;
+                registry.output_entry(&leaf.out_ty.origin.syntax)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             let holder_slash =
@@ -170,7 +170,7 @@ pub(crate) fn callback_input(
             // would make the trampoline wait forever on an `i32` crossing the
             // binding may not have.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                let e = registry.output_entry(&leaf.out_ty)?;
+                let e = registry.output_entry(&leaf.out_ty.origin.syntax)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;
                 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -478,7 +478,7 @@ pub(crate) fn reach_leaf_flat(
     // `single_return` in `core/unfold.rs`. `is_plain_field` is what that rules
     // out, and it stays as the local statement of the same fact.
     let reached_is_ours = if leaf.identity {
-        !matches!(leaf.out_ty, syn::Type::Reference(_))
+        !matches!(leaf.out_ty.origin.syntax, syn::Type::Reference(_))
     } else {
         consuming
     };
@@ -979,12 +979,14 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
-        let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
-            panic!(
-                "jnigen unfold: leaf `{}` has no registered output converter",
-                TypeKey::from_type(&leaf.out_ty)
-            )
-        });
+        let out_entry = registry
+            .output_entry(&leaf.out_ty.origin.syntax)
+            .unwrap_or_else(|| {
+                panic!(
+                    "jnigen unfold: leaf `{}` has no registered output converter",
+                    TypeKey::from_type(&leaf.out_ty.origin.syntax)
+                )
+            });
         let conv_fail = fail(quote!(__e.to_string()));
         // The leaf's COMPLETE Rust -> wire chain: the rust-side stages a custom
         // `convert!` declaration inserts (`Duration -> u64`), then the
@@ -1045,7 +1047,7 @@ pub(crate) fn encode_plan_leaves(
                 panic!(
                     "jnigen unfold: identity leaf `{}` has no projection — \
                      `.accessor_record_id()` requires a ptr_class type",
-                    TypeKey::from_type(&leaf.out_ty)
+                    TypeKey::from_type(&leaf.out_ty.origin.syntax)
                 )
             });
             // The place this handle lives, when it is OURS to give away — the
@@ -1061,7 +1063,9 @@ pub(crate) fn encode_plan_leaves(
             // `Option` through the nullable branch's `match`, which moves the
             // whole `Option` in rather than borrowing it.
             let owned_place: Option<TokenStream> =
-                if !matches!(leaf.out_ty, syn::Type::Reference(_)) && steps_are_movable(&path) {
+                if !matches!(leaf.out_ty.origin.syntax, syn::Type::Reference(_))
+                    && steps_are_movable(&path)
+                {
                     let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
                     Some(quote!(#value #(.#segs)*))
                 } else {
@@ -1372,7 +1376,7 @@ pub(crate) fn leaf_is_prim(
     if leaf.nullable {
         return false;
     }
-    leaf_ty_is_prim(registry, &leaf.out_ty)
+    leaf_ty_is_prim(registry, &leaf.out_ty.origin.syntax)
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -146,7 +146,7 @@ pub(crate) fn synth_value_struct_leaves(
         leaves.push(UnfoldLeaf {
             name: leaf_name,
             path,
-            out_ty: effective_ty,
+            out_ty: field.ty.clone(),
             identity: false,
             nullable: false,
             source: LeafSource::Field,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -193,7 +193,14 @@ pub(crate) fn encode_sum_group(
             tag_leaf.out_ty.key()
         )
     };
-    let ident = syn::Ident::new(&id.name, proc_macro2::Span::call_site());
+    // Raw-aware: a sum may legitimately be named `r#type`, and `Ident::new`
+    // rejects that spelling.
+    let ident = id.ident().unwrap_or_else(|| {
+        panic!(
+            "jnigen sum unfold: selector type `{}` is not a single identifier",
+            id.name
+        )
+    });
     let module = ext.fn_module(registry, &ident);
     let source: syn::Path = syn::parse_quote!(#module::#ident);
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -43,38 +43,45 @@ pub(crate) const SUM_TAG_LEAF: &str = "tag";
 pub(crate) fn synth_sum_leaves(
     ext: &Declarations,
     sum_cfg: &SumConfig,
-    item_enum: &syn::ItemEnum,
+    sum: &crate::api::core::flat::Variant,
 ) -> Vec<crate::api::core::unfold::UnfoldLeaf> {
     use crate::api::core::{
         types_util::SumSpec,
         unfold::{LeafSource, UnfoldLeaf},
     };
 
-    let spec = SumSpec::from_item_enum(item_enum);
+    // `SumSpec` still reads the item — it owns the leaf-NAMING convention, which
+    // is jnigen's own. The payload TYPES come from the element beside it, whose
+    // fields are already readings, so nothing here has to compose or look one up.
+    let spec = SumSpec::from_item_enum(&sum.origin.syntax);
     // The selector rides ahead of the groups it chooses between, and carries
     // **which sum** it selects over as its `out_ty` — that is how the emitter
     // finds the enum to `match` when the sum is a field rather than the whole
     // returned value. Nothing looks up a converter for it (`has_converter()` is
     // false for a `SumTag`): there is no value to convert, the emitter assigns
     // the tag literal per arm. Its wire is a `jint` by definition.
-    let enum_ident = &item_enum.ident;
+    let enum_ident = &sum.name;
     let mut leaves = vec![UnfoldLeaf {
         name: SUM_TAG_LEAF.to_string(),
         path: Vec::new(),
-        out_ty: syn::parse_quote!(#enum_ident),
+        // Composed: the tag names WHICH sum it selects over, and no source
+        // wrote that as a standalone type. Nothing resolves a converter for it
+        // (`has_converter()` is false), but the emitter reads it back to find
+        // the enum to `match`.
+        out_ty: crate::api::core::flat::TypeRef::named(enum_ident),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,
         group: None,
     }];
-    for variant in &spec.variants {
+    for (variant, alt) in spec.variants.iter().zip(&sum.alternatives) {
         let kotlin_name = ext.sum_variant_class_name(sum_cfg, &variant.ident);
-        for field in &variant.fields {
+        for (field, alt_field) in variant.fields.iter().zip(&alt.fields) {
             let prop = sum_field_prop_name(field);
             leaves.push(UnfoldLeaf {
                 name: sum_slot_fragment(&kotlin_name, &prop),
                 path: Vec::new(),
-                out_ty: field.ty.clone(),
+                out_ty: alt_field.ty.clone(),
                 identity: false,
                 nullable: false,
                 source: LeafSource::VariantField {
@@ -122,7 +129,7 @@ pub(crate) fn leaf_slot(
         ("I", format_ident!("i"))
     } else {
         let wire = registry
-            .output_entry(&leaf.out_ty)
+            .output_entry(&leaf.out_ty.origin.syntax)
             .expect("leaf_is_prim implies a resolved output entry")
             .destination
             .clone();
@@ -178,12 +185,15 @@ pub(crate) fn encode_sum_group(
         .iter()
         .find(|l| l.source == LeafSource::SumTag)
         .expect("a sum segment carries its selector leaf");
-    let ident = bare_path_ident(&tag_leaf.out_ty).unwrap_or_else(|| {
+    // The name off the reading — `TypeId` IS the name, so nothing takes a path
+    // apart to re-derive one.
+    let crate::api::core::flat::TypeKind::Named { id } = &tag_leaf.out_ty.kind else {
         panic!(
-            "jnigen sum unfold: selector type `{}` is not a path type",
-            TypeKey::from_type(&tag_leaf.out_ty)
+            "jnigen sum unfold: selector type `{}` is not a named type",
+            tag_leaf.out_ty.key()
         )
-    });
+    };
+    let ident = syn::Ident::new(&id.name, proc_macro2::Span::call_site());
     let module = ext.fn_module(registry, &ident);
     let source: syn::Path = syn::parse_quote!(#module::#ident);
 
@@ -328,13 +338,15 @@ fn encode_group_leaf(
     bind: &syn::Ident,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
-    let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
-        panic!(
-            "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
-            leaf.name,
-            TypeKey::from_type(&leaf.out_ty)
-        )
-    });
+    let out_entry = registry
+        .output_entry(&leaf.out_ty.origin.syntax)
+        .unwrap_or_else(|| {
+            panic!(
+                "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
+                leaf.name,
+                TypeKey::from_type(&leaf.out_ty.origin.syntax)
+            )
+        });
     let wire = out_entry.destination.clone();
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -754,7 +754,7 @@ pub(crate) fn emit_expanded_param(
 
     debug_assert_eq!(plan.leaves.len(), leaves.len());
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
-        let leaf_ty = &leaf.ty;
+        let leaf_ty = &leaf.ty.origin.syntax;
         let lookup_entry = || {
             registry.input_entry(leaf_ty).unwrap_or_else(|| {
                 panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -438,27 +438,11 @@ impl JniFunctionPlan {
             {
                 let mut leaves = Vec::new();
                 for leaf in &plan.leaves {
-                    // The ONE lookup left on this path: `FoldLeaf::ty` is a
-                    // `syn::Type` in core, so the reading has to be fetched
-                    // rather than carried. #275's second half removes it by
-                    // making the plan leaves carry `TypeRef`; until then a miss
-                    // means the leaf's type never entered the pipeline, which
-                    // is worth naming rather than absorbing.
-                    let leaf_reading = registry.reading(&leaf.ty).unwrap_or_else(|| {
-                        panic!(
-                            "fold leaf `{}` of `{}`: type `{}` never entered the pipeline",
-                            leaf.name,
-                            f.name,
-                            quote::ToTokens::to_token_stream(&leaf.ty),
-                        )
-                    });
+                    // The lookup that stood here is gone: the fold leaf carries
+                    // its own reading now, so there is nothing to fetch and
+                    // nothing that can miss.
                     leaves.push(classify_leaf(
-                        ext,
-                        registry,
-                        &leaf.name,
-                        &leaf_reading,
-                        /*expanded=*/ true,
-                        &ident,
+                        ext, registry, &leaf.name, &leaf.ty, /*expanded=*/ true, &ident,
                     )?);
                 }
                 ParamForm::Expanded(leaves)

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -720,12 +720,13 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
+    let inert_nullable =
+        leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty.origin.syntax);
     leaf_iface_param(
         ext,
         registry,
         name,
-        &leaf.out_ty,
+        &leaf.out_ty.origin.syntax,
         leaf.nullable || inert_nullable,
         true,
     )
@@ -1166,11 +1167,12 @@ pub(crate) fn callback_iface_spec(
                     };
                     if leaf.source == LeafSource::SumTag {
                         any_fixed = true;
-                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(&leaf.out_ty))?;
+                        let fqn =
+                            ext.kotlin_fqn(&TypeKey::from_type(&leaf.out_ty.origin.syntax))?;
                         let (reassemble, imports) = fixed_reassembly(
                             ext,
                             registry,
-                            &leaf.out_ty,
+                            &leaf.out_ty.origin.syntax,
                             &plan.leaves[k..seg],
                             &fqn,
                         );

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1505,7 +1505,9 @@ impl Declarations {
         name: &str,
         imports: &mut BTreeSet<String>,
     ) -> String {
-        let optional = registry.is_optional(&leaf.out_ty);
+        // Off the leaf's own reading — no lookup, and a wrapped spelling
+        // answers as the bare one does.
+        let optional = leaf.out_ty.optional_inner().is_some();
         let arg = if param.raw.is_nullable() && !optional {
             format!("{name}!!")
         } else {
@@ -1515,8 +1517,9 @@ impl Declarations {
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
-        if self.is_kotlin_enum(&enum_probe_type(&leaf.out_ty)) {
-            let inner = option_inner_type(&leaf.out_ty).unwrap_or_else(|| leaf.out_ty.clone());
+        if self.is_kotlin_enum(&enum_probe_type(&leaf.out_ty.origin.syntax)) {
+            let inner = option_inner_type(&leaf.out_ty.origin.syntax)
+                .unwrap_or_else(|| leaf.out_ty.origin.syntax.clone());
             let name = registry
                 .output_entry(&inner)
                 .and_then(|e| e.metadata.kotlin_name.clone())

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1623,3 +1623,66 @@ fn slice_of_sum_callback_arg_is_rejected_with_its_reason() {
         "…and point at the two shapes that do work: {err}"
     );
 }
+
+/// A sum named with a **raw** identifier generates, rather than aborting.
+///
+/// `r#type` is a legal `#[prebindgen]` enum name, and `TypeId::name` stores it
+/// as the string `"r#type"`. The sum encoder rebuilds an ident from that name
+/// to spell the `match`'s path — and `Ident::new` *panics* on that spelling
+/// rather than erroring, so the whole generation aborted (#278 review). The
+/// unit-level guarantee is `a_raw_identifier_survives_typeid`; this is the path
+/// that would actually have blown up.
+#[test]
+fn a_raw_named_sum_generates() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum r#type {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_read(v: &ZThing) -> r#type {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_emit(cb: impl Fn(ZThing) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZThing))
+                .class(crate::sealed_class!(r#type))
+                .fun(crate::fun!(z_emit)),
+        );
+    let dir = unique_test_dir("jnigen_raw_sum");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Resolving AND writing the Rust is the point: the encoder is where the
+    // ident was rebuilt.
+    let gen = jni.build_with(registry).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+        .expect("read rust");
+    assert!(
+        rust.contains("r#type"),
+        "the raw name is spelled back as written:\n{rust}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1624,14 +1624,20 @@ fn slice_of_sum_callback_arg_is_rejected_with_its_reason() {
     );
 }
 
-/// A sum named with a **raw** identifier generates, rather than aborting.
+/// A sum named with a **raw** identifier generates, rather than aborting — and
+/// specifically through the OUTPUT encoder, which is the site that broke.
 ///
 /// `r#type` is a legal `#[prebindgen]` enum name, and `TypeId::name` stores it
 /// as the string `"r#type"`. The sum encoder rebuilds an ident from that name
-/// to spell the `match`'s path — and `Ident::new` *panics* on that spelling
-/// rather than erroring, so the whole generation aborted (#278 review). The
-/// unit-level guarantee is `a_raw_identifier_survives_typeid`; this is the path
-/// that would actually have blown up.
+/// to spell the `match`'s path, and `Ident::new` *panics* on that spelling
+/// rather than erroring, so the whole generation aborted (#278 review).
+///
+/// The sum is a value-form FIELD here, not just a declared type: that is what
+/// puts it through `encode_sum_group`. A first version of this test declared
+/// the sum and a callback only — the raw name appeared in the generated file
+/// via the *input* converter, the assertion passed, and reverting the fix left
+/// it passing. A regression test that survives its own regression is worse than
+/// none, so this one asserts the output-side `match` path.
 #[test]
 fn a_raw_named_sum_generates() {
     let loc = myflat_loc();
@@ -1646,8 +1652,16 @@ fn a_raw_named_sum_generates() {
             loc.clone(),
         ),
         (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThingStruct {
+                    pub reading: r#type,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
             syn::Item::Fn(syn::parse_quote!(
-                pub fn z_read(v: &ZThing) -> r#type {
+                pub fn z_thing_to_struct(t: &ZThing) -> ZThingStruct {
                     unimplemented!()
                 }
             )),
@@ -1671,18 +1685,20 @@ fn a_raw_named_sum_generates() {
                 .class(crate::ptr_class!(ZThing))
                 .class(crate::sealed_class!(r#type))
                 .fun(crate::fun!(z_emit)),
-        );
+        )
+        .expand(crate::expand_return!(ZThing).fields(crate::fields!(z_thing_to_struct)));
+
     let dir = unique_test_dir("jnigen_raw_sum");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
-
-    // Resolving AND writing the Rust is the point: the encoder is where the
-    // ident was rebuilt.
     let gen = jni.build_with(registry).expect("resolve");
     let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
         .expect("read rust");
+
+    // The output-side match, spelled with the raw name — this is what
+    // `encode_sum_group` emits, and what `Ident::new` could not produce.
     assert!(
-        rust.contains("r#type"),
-        "the raw name is spelled back as written:\n{rust}"
+        rust.contains("myflat::r#type::Missing") && rust.contains("myflat::r#type::Exact"),
+        "the sum encoder matches the raw-named enum by its real path:\n{rust}"
     );
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -238,7 +238,12 @@ fn deriving_matches_the_equivalent_hand_written_list() {
             .callback_arg_plans
             .values()
             .flat_map(|p| p.leaves.iter())
-            .map(|l| (l.name.clone(), l.out_ty.to_token_stream().to_string()))
+            .map(|l| {
+                (
+                    l.name.clone(),
+                    l.out_ty.origin.syntax.to_token_stream().to_string(),
+                )
+            })
             .collect()
     };
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1326,13 +1326,15 @@ impl Declarations {
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident) else {
+            let Some(crate::api::core::flat::Type::Variant(sum)) =
+                registry.flat().declared_type(&ident)
+            else {
                 continue;
             };
             out.push(crate::api::core::unfold::SumDecon {
                 key: key.clone(),
                 source,
-                leaves: crate::api::lang::jnigen::jni::synth_sum_leaves(self, sum_cfg, item_enum),
+                leaves: crate::api::lang::jnigen::jni::synth_sum_leaves(self, sum_cfg, sum),
             });
         }
         out

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -348,7 +348,13 @@ impl Declarations {
                 // `#[prebindgen]` item; else the default module (a declared
                 // type re-exported by the primary source, or a deliberately
                 // unmarked type like a convert!-only newtype).
-                let ident = syn::Ident::new(&short, Span::call_site());
+                // Parsed, not constructed: a short name is whatever the source
+                // wrote, and `Ident::new` PANICS on a raw one (`r#type`)
+                // rather than erroring. Pre-existing; found by the raw-name
+                // regression added for the sum encoder's twin of this bug.
+                let Ok(ident) = syn::parse_str::<syn::Ident>(&short) else {
+                    return;
+                };
                 let module = registry
                     .origin_module(&ident)
                     .unwrap_or_else(|| self.default_module(registry));


### PR DESCRIPTION
Second of three for #275 (#276 was the first). The last part deletes `is_optional` and closes the issue.

## Why

`UnfoldLeaf::out_ty` and `FoldLeaf::ty` were `syn::Type`, so an adapter consuming a decomposition had to hand the spelling back to the registry to learn what it meant — the round trip #263 removed from `api/core`, surviving in the plans.

And the reading was **discarded at construction**: `flatten` peels `TypeRef`s and stored `origin.syntax`.

## `flat` composes its own types

Most producers just stop discarding. Five genuinely compose a type no source wrote — the borrow of a value, two `Option` layers, a presence flag, a selector — and **`Flat::classify` is not available** for them: it lowers *source syntax*, and `classify_has_no_caller_outside_the_registry` keeps it that way. Correctly, in my view: composing is a different act from classifying.

So the model composes:

```rust
TypeRef::{borrowed, optional, scalar, named}
```

Each builds `kind` **and** the matching `origin.syntax` in one place, so the classification and the spelling cannot disagree — the invariant every `TypeRef` consumer relies on.

**`scalar`/`named` are placeless by construction.** No file wrote a presence flag, and claiming a location would make a fabricated one indistinguishable from a real one. That is the call `Flat::classify` already makes for a composed spelling and `ensure_entry` for adapter-authored cells (pinned by `an_adapter_authored_type_cell_is_classified_but_placeless`). The layered ones keep the inner's location — a borrow exists *because of* that value.

## The risk I pinned rather than assumed

A composed `&T` must key **exactly** as `parse_quote!(&#t)` did, or `require_output` registers a different cell and resolution silently changes. `a_composed_type_keys_as_its_spelling` checks all five forms plus the placeless/inherited location split. Verified before writing the migration, not after.

## Two things that fell out

- **`synth_sum_leaves` takes `flat::Variant`** and zips its alternatives, so payload types are readings rather than syn fields — and the sum tag's readback now reads `TypeId` (*`TypeId` **is** the name*) instead of taking a path apart with `bare_path_ident`.
- **`opt()` is deleted** — the `parse_quote!(Option<#ty>)` helper whose whole problem was building a spelling with no classification beside it.

**The lookup #276 added** in `fn_plan` is deleted with its comment: the fold leaf carries its own reading, so there is nothing to fetch and nothing that can miss.

## Verification

- **Goldens byte-identical.** The bar for a refactor this size, and the number to judge it on.
- 546 lib tests; `cargo test --all --all-features` 14/14; clippy `--deny warnings`; fmt.
- covertest-kotlin **48/48** on the JVM.
- Both ledgers (boundary, spelling census) **unmoved**.

## What's left

`is_optional` goes 4 → 3. The remaining callers need the adapter-side reading *sources* — `SumSpec` still building from `syn::ItemEnum`, and callback args reconstructed from `TypeKey`s rather than read off `TypeKind::Callback`. That is #275's last part, and deleting the accessor is its acceptance test.

One composition site is left alone deliberately: `unfold.rs`'s `convert_out_ty` still composes `Option<#leaf_ty>` as a `syn::Type` field. Noting it so it is not mistaken for an oversight.
