### PR TITLE
The adapter's reading sources, and the last accessor goes

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -52,7 +52,6 @@
 5	api/lang/cbindgen/mod.rs
 6	api/lang/cbindgen/trait_impl.rs
 4	api/lang/jnigen/jni/builder.rs
-1	api/lang/jnigen/jni/emit/callback.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 2	api/lang/jnigen/jni/emit/delivery.rs
 10	api/lang/jnigen/jni/emit/flat_input.rs
@@ -60,7 +59,7 @@
 2	api/lang/jnigen/jni/emit/vec_build.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
-5	api/lang/jnigen/jni/iface.rs
+4	api/lang/jnigen/jni/iface.rs
 2	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
@@ -71,4 +70,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 129
+# total: 127

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -37,26 +37,6 @@ pub trait Conversions<M> {
     /// out.
     fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef>;
 
-    /// Whether `ty` crosses as **optional** — the model's answer, not the
-    /// spelling's.
-    ///
-    /// The question every consumer actually means, and the one they could not
-    /// ask: they reached for `is_option_type`, which is `path_tail_is(ty,
-    /// "Option")`. But the model **erases** transparent wrappers — `Box<T>` *is*
-    /// `T`, and so is `Cow<'_, T>` — so `Box<Option<String>>` is `Optional` and
-    /// that check answers `false`. Kotlin then lost the `?`, which is not a
-    /// cosmetic slip: a non-null parameter for an optional value makes the
-    /// absent case unexpressible (#273).
-    ///
-    /// Here rather than at each consumer so the rule has **one** home. A new
-    /// transparent wrapper — an `Rc`, say — is then a change to
-    /// [`TRANSPARENT_WRAPPERS`](crate::api::core::flat::TRANSPARENT_WRAPPERS)
-    /// and nothing else; every site asking this question follows automatically.
-    fn is_optional(&self, ty: &syn::Type) -> bool {
-        self.reading(ty)
-            .is_some_and(|r| r.optional_inner().is_some())
-    }
-
     /// The conversion for `ty` in `dir`, if there is one.
     fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>>;
 

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -116,7 +116,8 @@ pub fn first_type_arg(ty: &syn::Type) -> Option<syn::Type> {
 // `is_option_ref` lived here — `option_inner_type(ty)` then a `Type::Reference`
 // match — and decided how a handle parameter locks. Both halves read the
 // spelling, so an optional borrow behind an erased wrapper answered `false`.
-// `Conversions::is_optional_borrow` asks the model instead (#273).
+// The reading answers it instead: `TypeRef::optional_inner().borrow_target()`
+// (#273, #275).
 
 /// The bare ident of a plain path type (`ZThing` → `ZThing`); `None` for
 /// references, generics, or multi-shape types.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -21,14 +21,14 @@ use crate::api::core::registry::Conversions;
 /// returned), so they are converted to `__JniErr` and logged via `tracing`.
 pub(crate) fn callback_input(
     ext: &Declarations,
-    args: &[syn::Type],
+    args: &[crate::api::core::flat::TypeRef],
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
     // Human-readable tag for attach/log messages.
     let name = format!(
         "Fn({})",
         args.iter()
-            .map(|t| TypeKey::from_type(t).to_string())
+            .map(|t| t.key().to_string())
             .collect::<Vec<_>>()
             .join(", ")
     );
@@ -46,7 +46,13 @@ pub(crate) fn callback_input(
     let arg_names: Vec<syn::Ident> = (0..args.len())
         .map(|i| format_ident!("__cb_arg{}", i))
         .collect();
-    let arg_pat_ty: Vec<TokenStream> = args.iter().map(|t| quote!(#t)).collect();
+    let arg_pat_ty: Vec<TokenStream> = args
+        .iter()
+        .map(|t| {
+            let t = &t.origin.syntax;
+            quote!(#t)
+        })
+        .collect();
 
     // Per-arg encode preludes binding the typed `run`'s args in declared
     // order (a decomposed arg contributes one arg per leaf). Each entry of
@@ -71,7 +77,7 @@ pub(crate) fn callback_input(
         // user callback's `run(List<T>)`. Reuses the OUTPUT fold's folder
         // interface + appender singleton, driven from the trampoline.
         if let Some(plan) = registry
-            .callback_arg_plan(&TypeKey::from_type(arg_ty))
+            .callback_arg_plan(&arg_ty.key())
             .filter(|p| super::render::is_iterable_fold(&p.shape))
         {
             // Every leaf converter must already be resolved (deferral safety).
@@ -162,7 +168,7 @@ pub(crate) fn callback_input(
 
         // Decomposed arg: deliver the leaves of its type-level canonical
         // output, exactly like a return delivery.
-        if let Some(plan) = registry.callback_arg_plan(&TypeKey::from_type(arg_ty)) {
+        if let Some(plan) = registry.callback_arg_plan(&arg_ty.key()) {
             // Deferral safety: every leaf converter (and identity-leaf
             // projection) must already be resolved — return None so the rank
             // resolver retries this converter later otherwise. A synthesized
@@ -193,15 +199,18 @@ pub(crate) fn callback_input(
         // converter and clone the borrow (the callback only borrows the value). The
         // `data_class` converter composes the whole object via `fromParts`, so the
         // Kotlin `run(t: T)` receives a ready-made `T`.
-        let (cb_val, arg_entry) = match registry.output_entry(arg_ty) {
+        let (cb_val, arg_entry) = match registry.output_entry(&arg_ty.origin.syntax) {
             Some(e) => (quote!(#cb_arg), e),
-            None => match arg_ty {
-                syn::Type::Reference(r) => {
-                    let core = (*r.elem).clone();
-                    (quote!((#cb_arg).clone()), registry.output_entry(&core)?)
-                }
-                _ => return None,
-            },
+            // A borrow: the callback hands out a reference, and the value is
+            // cloned for the JVM. Off the reading — `borrow_target` is the
+            // model's answer, not a syn match.
+            None => {
+                let core = arg_ty.borrow_target()?;
+                (
+                    quote!((#cb_arg).clone()),
+                    registry.output_entry(&core.origin.syntax)?,
+                )
+            }
         };
         let arg_wire = arg_entry.destination.clone();
         let enc_ident = format_ident!("__cb{}_enc", i);
@@ -263,7 +272,7 @@ pub(crate) fn callback_input(
             .projection
             .as_ref()
             .is_none_or(|p| p.kind == ProjectionKind::Unsigned64)
-            && !registry.is_optional(arg_ty)
+            && arg_ty.optional_inner().is_none()
             && matches!(jni_field_access(&arg_wire), Some((_, _, false)));
         if arg_is_prim {
             let letter = jni_field_access(&arg_wire).unwrap().1;
@@ -286,7 +295,12 @@ pub(crate) fn callback_input(
     // Typed `run` descriptor of the generated callback interface — the SAME
     // memoized spec (`SpecKey::Callback`) the wrapper surface and the
     // interface declaration read, so it cannot drift from the jvalues above.
-    let spec = ext.iface_spec(registry, &SpecKey::callback(args))?;
+    // The memo key is spellings — `SpecKey` needs `Ord`, which a `TypeRef`
+    // cannot give. Keyed off each arg's own `origin.syntax`, which
+    // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax` pins as
+    // the SAME identity the signature-derived key produces.
+    let arg_spellings: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
+    let spec = ext.iface_spec(registry, &SpecKey::callback(&arg_spellings))?;
     let descr_lit = syn::LitStr::new(&spec.descr, Span::call_site());
     // Local-frame capacity: roughly an encoded wire + a wrapped object per
     // delivered leaf, plus call temporaries.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -202,8 +202,27 @@ pub(crate) fn callback_input(
         let (cb_val, arg_entry) = match registry.output_entry(&arg_ty.origin.syntax) {
             Some(e) => (quote!(#cb_arg), e),
             // A borrow: the callback hands out a reference, and the value is
-            // cloned for the JVM. Off the reading — `borrow_target` is the
-            // model's answer, not a syn match.
+            // cloned for the JVM.
+            //
+            // That this is a borrow is the model's answer (`borrow_target`) —
+            // no spelling is inspected here, which is the point of #229.
+            //
+            // `(#cb_arg).clone()` is nonetheless only well-typed for a
+            // DIRECTLY-spelled `&T`: `#cb_arg` carries the source's spelling,
+            // so a transparent wrapper — `Box<&T>`, `Ref` all the same —
+            // would clone to `Box<&T>`, which the `T` converter rejects. That
+            // case is refused before it reaches here: a callback arg's
+            // whole-value output converter is a *required* type, and
+            // `output_wrapper_shape`'s borrowed-opaque arm matches
+            // `syn::Type::Reference` on `produced` structurally, so `Box<&T>`
+            // (a `Type::Path`) never gets one.
+            //
+            // MEASURED, not assumed — `a_wrapped_borrow_callback_arg_declines`
+            // fails, on exactly this clone, if that arm is made
+            // spelling-blind. A local re-check here was tried (#279 review)
+            // and dropped: it changed no output on `Box<&String>` or
+            // `Box<&ZThing>`, and cost a `boundary.ledger` entry for a
+            // classification that never fires.
             None => {
                 let core = arg_ty.borrow_target()?;
                 (

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -983,7 +983,23 @@ fn derive_iface_spec(
 ) -> Option<IfaceSpec> {
     match key {
         SpecKey::Callback(arg_keys) => {
-            let args: Vec<syn::Type> = arg_keys.iter().map(TypeKey::to_type).collect();
+            // The one deliberate round trip in this file, and the memo forces
+            // it: `SpecKey` needs `Ord`, so it holds `TypeKey`s — a `TypeRef`
+            // could not go in one (its `Origin` carries a `SourceLocation`, so
+            // two identical readings from different files would compare
+            // unequal), and `derive_iface_spec` is contractually a pure
+            // function of the key.
+            //
+            // A LOOKUP, not a classification: `Registry::reading` has answered
+            // only from the type table since #267. `None` means the arg has
+            // not entered the pipeline yet, which is the same "not yet
+            // derivable" state `iface_spec` already documents and retries —
+            // so it defers rather than answering "not optional", which is what
+            // the accessor used to do here.
+            let args: Vec<crate::api::core::flat::TypeRef> = arg_keys
+                .iter()
+                .map(|k| registry.reading(&k.to_type()))
+                .collect::<Option<_>>()?;
             callback_iface_spec(ext, registry, &args)
         }
         SpecKey::Builder(d) => builder_iface_spec(ext, registry, d),
@@ -1073,7 +1089,7 @@ fn fixed_reassembly(
 pub(crate) fn callback_iface_spec(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    cb_args: &[syn::Type],
+    cb_args: &[crate::api::core::flat::TypeRef],
 ) -> Option<IfaceSpec> {
     // Per-arg grouping over the flat raw leaves. A **fixed-builder** (by-value
     // `data_class`) arg crosses the wire as decoupled leaves but the user
@@ -1124,7 +1140,7 @@ pub(crate) fn callback_iface_spec(
         // arg into the callback's `run` params here.
         let plan = registry
             .callback_arg_plans()
-            .get(&TypeKey::from_type(t))
+            .get(&t.key())
             .filter(|p| !super::render::is_iterable_fold(&p.shape));
         if let Some(plan) = plan {
             let leaf_names = plan_leaf_names(&plan.leaves);
@@ -1133,15 +1149,14 @@ pub(crate) fn callback_iface_spec(
             }
             if plan.fixed_builder {
                 any_fixed = true;
-                let core = match t {
-                    syn::Type::Reference(r) => (*r.elem).clone(),
-                    other => other.clone(),
-                };
+                // Peeled off the reading — `borrow_target` is the model's
+                // answer to "is this a borrow", not a syn match.
+                let core = t.borrow_target().unwrap_or(t).origin.syntax.clone();
                 let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
                 let (reassemble, imports) =
                     fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
                 groups.push(GroupDesc {
-                    name: whole_value_name(t, i),
+                    name: whole_value_name(&t.origin.syntax, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
                     reassemble: Some(reassemble),
                     imports,
@@ -1214,18 +1229,18 @@ pub(crate) fn callback_iface_spec(
             // A plan-less opaque-handle arg is delivered as a raw `jlong` and
             // wrapped + closed Kotlin-side (Phase 3 — no Rust `new_object`).
             let owned_handle = registry
-                .output_entry(t)
+                .output_entry(&t.origin.syntax)
                 .and_then(|e| e.metadata.projection.as_ref())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
-                name: whole_value_name(t, i),
-                ty: t.clone(),
-                nullable: registry.is_optional(t),
+                name: whole_value_name(&t.origin.syntax, i),
+                ty: t.origin.syntax.clone(),
+                nullable: t.optional_inner().is_some(),
                 owned_handle,
             });
             groups.push(GroupDesc {
-                name: whole_value_name(t, i),
+                name: whole_value_name(&t.origin.syntax, i),
                 typed: None,
                 reassemble: None,
                 imports: Vec::new(),
@@ -1282,14 +1297,14 @@ pub(crate) fn callback_iface_spec(
             "{}Callback",
             cb_args
                 .iter()
-                .map(subject_short)
+                .map(|t| subject_short(&t.origin.syntax))
                 .collect::<Vec<_>>()
                 .join("")
         )
     };
     let package = cb_args
         .first()
-        .map(|t| subject_package(ext, t))
+        .map(|t| subject_package(ext, &t.origin.syntax))
         .unwrap_or_else(|| ext.package.clone());
     Some(IfaceSpec {
         typed_groups,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -534,7 +534,7 @@ impl Declarations {
         &self,
         registry: &Registry<KotlinMeta>,
     ) -> Result<Vec<kt::KtFile>, WriteKotlinError> {
-        use crate::api::core::types_util::{enum_shape, EnumShape, SumSpec};
+        use crate::api::core::types_util::SumSpec;
 
         let mut written = Vec::new();
         // Deterministic order by canonical Rust type-key.
@@ -552,11 +552,17 @@ impl Declarations {
             let Some(ident) = bare_path_ident(&ty) else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident) else {
-                continue;
-            };
+            // The sum as the MODEL holds it: its alternatives' payloads are
+            // `TypeRef`s, so the Kotlin type of one asks nothing and cannot be
+            // asked about a type the model never saw.
+            //
+            // A FIELDLESS enum is `Type::Enum`, not `Type::Variant` — the model
+            // already draws the distinction this arm used to re-derive with
+            // `enum_shape`. It is a declaration error rather than a skip, so it
+            // keeps its diagnosis; only the source of the answer changed.
+            let declared = registry.flat().declared_type(&ident);
             assert!(
-                enum_shape(item_enum) == EnumShape::Sum,
+                matches!(declared, Some(crate::api::core::flat::Type::Variant(_))),
                 "`{}` has no payload variants: declare it with `enum_class!({})`, not \
                  `sealed_class!({})` — a fieldless enum crosses as a bare discriminant and \
                  needs no sealed hierarchy",
@@ -564,8 +570,11 @@ impl Declarations {
                 ident,
                 ident
             );
+            let Some(crate::api::core::flat::Type::Variant(sum)) = declared else {
+                unreachable!("asserted just above")
+            };
 
-            let spec = SumSpec::from_item_enum(item_enum);
+            let spec = SumSpec::from_item_enum(&sum.origin.syntax);
             // Every declared `.variant(...)` must name a real variant —
             // a typo would otherwise silently do nothing.
             for declared in sum_cfg.variant_names.keys() {
@@ -580,8 +589,7 @@ impl Declarations {
                 Some((p, c)) => (p.to_string(), c.to_string()),
                 None => (String::new(), kotlin_fqn.clone()),
             };
-            let mut class =
-                self.build_sealed_class(registry, &class_name, item_enum, &spec, sum_cfg);
+            let mut class = self.build_sealed_class(registry, &class_name, sum, &spec, sum_cfg);
             let mut file = kt::KtFile::new(package);
             if let Some(iface) =
                 self.apply_class_interface(key, &mut class, &class_name, &[], Vec::new(), true)
@@ -602,10 +610,14 @@ impl Declarations {
         &self,
         registry: &Registry<KotlinMeta>,
         class_name: &str,
-        item_enum: &syn::ItemEnum,
+        sum: &crate::api::core::flat::Variant,
         spec: &crate::api::core::types_util::SumSpec,
         sum_cfg: &SumConfig,
     ) -> KtClass {
+        // `SumSpec` owns the leaf-NAMING convention, which is jnigen's own; the
+        // payload TYPES come from the element beside it. Same split #278 drew
+        // in `synth_sum_leaves`.
+        let item_enum = &sum.origin.syntax;
         let framework_line = format!(
             "JVM-side surface for the native Rust `{}` sum: exactly one alternative is live.",
             item_enum.ident
@@ -619,7 +631,7 @@ impl Declarations {
             .kdoc(kdoc);
 
         // Nested variant classes, in declaration (tag) order.
-        for (variant, item_variant) in spec.variants.iter().zip(&item_enum.variants) {
+        for (variant, alt) in spec.variants.iter().zip(&sum.alternatives) {
             let vname = self.sum_variant_class_name(sum_cfg, &variant.ident);
             let mut vclass = if variant.is_unit() {
                 KtClass::new(ClassKind::DataObject, &vname)
@@ -628,19 +640,15 @@ impl Declarations {
             }
             .vis(Vis::Public)
             .supertype(KtType::cls(class_name), None);
-            if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_variant.attrs) {
+            if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&alt.origin.syntax.attrs)
+            {
                 vclass = vclass.kdoc(doc);
             }
             let mut vprops: Vec<(String, KtType)> = Vec::new();
-            for (field, item_field) in variant.fields.iter().zip(item_variant.fields.iter()) {
+            for (field, alt_field) in variant.fields.iter().zip(alt.fields.iter()) {
                 let prop = sum_field_property_name(field);
-                let ty = self.sum_payload_kt_type(
-                    registry,
-                    item_enum,
-                    &variant.ident,
-                    &prop,
-                    item_field,
-                );
+                let ty =
+                    self.sum_payload_kt_type(registry, &sum.name, &variant.ident, &prop, alt_field);
                 vprops.push((prop.clone(), ty.clone()));
                 vclass = vclass.ctor_param(KtCtorParam::new(&prop, ty).val().vis(Vis::Public));
             }
@@ -663,17 +671,12 @@ impl Declarations {
             .annotation("JvmStatic")
             .param(KtParam::new("tag", KtType::int()))
             .returns(KtType::cls(class_name));
-        for (variant, item_variant) in spec.variants.iter().zip(&item_enum.variants) {
+        for (variant, alt) in spec.variants.iter().zip(&sum.alternatives) {
             let vname = self.sum_variant_class_name(sum_cfg, &variant.ident);
-            for (field, item_field) in variant.fields.iter().zip(item_variant.fields.iter()) {
+            for (field, alt_field) in variant.fields.iter().zip(alt.fields.iter()) {
                 let prop = sum_field_property_name(field);
-                let ty = self.sum_payload_kt_type(
-                    registry,
-                    item_enum,
-                    &variant.ident,
-                    &prop,
-                    item_field,
-                );
+                let ty =
+                    self.sum_payload_kt_type(registry, &sum.name, &variant.ident, &prop, alt_field);
                 factory = factory.param(KtParam::new(sum_slot_name(&vname, &prop), ty));
             }
         }
@@ -780,24 +783,23 @@ impl Declarations {
     fn sum_payload_kt_type(
         &self,
         registry: &Registry<KotlinMeta>,
-        item_enum: &syn::ItemEnum,
+        sum_name: &syn::Ident,
         variant: &syn::Ident,
         prop: &str,
-        field: &syn::Field,
+        field: &crate::api::core::flat::Field,
     ) -> KtType {
-        let where_ = || {
-            format!(
-                "sealed_class!({}) payload `{variant}.{prop}`",
-                item_enum.ident
-            )
-        };
-        let out = registry.output_entry(&field.ty).unwrap_or_else(|| {
+        // The field's own reading: the nullability question below is answered
+        // from `kind`, so a wrapped spelling answers as the bare one does and
+        // nothing is looked up (#275).
+        let field_ty = &field.ty.origin.syntax;
+        let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
+        let out = registry.output_entry(field_ty).unwrap_or_else(|| {
             panic!(
                 "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
                  cannot be derived — register converters for the payload type before \
                  declaring the sealed class",
                 where_(),
-                field.ty.to_token_stream(),
+                field_ty.to_token_stream(),
             )
         });
 
@@ -816,7 +818,7 @@ impl Declarations {
             panic!(
                 "{}: `{}` has no Kotlin type mapping on its output converter",
                 where_(),
-                field.ty.to_token_stream(),
+                field_ty.to_token_stream(),
             )
         });
         // The input side must agree on WHICH TYPE the property is — Kotlin
@@ -831,7 +833,7 @@ impl Declarations {
         // boxed value, a present flag, a niche) rather than in the type name.
         // Comparing the rendered types would reject that legitimate shape —
         // which is what an `Option<enum>` payload does.
-        if let Some(inp) = registry.input_entry(&field.ty) {
+        if let Some(inp) = registry.input_entry(field_ty) {
             if let (Some(in_ty), (Some(a), Some(b))) = (
                 inp.metadata.kotlin_name.clone(),
                 (
@@ -849,7 +851,7 @@ impl Declarations {
                      type (`{}` in, `{}` out) — a sealed class's properties are read by both \
                      directions, so they must map to one type",
                     where_(),
-                    field.ty.to_token_stream(),
+                    field_ty.to_token_stream(),
                     in_ty,
                     ty,
                 );
@@ -860,7 +862,7 @@ impl Declarations {
         // field — the Kotlin type must match that slot. Read from the same
         // entry the type came from.
         let primitive_wire = crate::api::lang::jnigen::jni::is_jni_primitive(&out.destination);
-        if registry.is_optional(&field.ty) && !primitive_wire {
+        if field.ty.optional_inner().is_some() && !primitive_wire {
             ty.nullable()
         } else {
             ty

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -578,3 +578,72 @@ fn fn_plan_memo_shares_one_derivation() {
     assert_eq!(a.native_symbol, fresh.native_symbol);
     assert_eq!(a.jni_method, fresh.jni_method);
 }
+
+/// A callback identity is the same whether its args come from the **reading**
+/// or from the signature's syntax.
+///
+/// `SpecKey::Callback` is a memo key, so it holds `TypeKey`s — a `TypeRef`
+/// could not go in it (`Ord` is required, and an `Origin` carries a
+/// `SourceLocation`, so two identical readings from different files would
+/// compare unequal). That means the args reach `SpecKey::callback` as
+/// spellings, and #275's last part changes *which* spelling: from
+/// `extract_fn_trait_args(&pt.ty)` to each arg `TypeRef`'s `origin.syntax`.
+///
+/// If those two disagreed, the memo would split one interface identity into
+/// two — an extra generated `fun interface` and a descriptor mismatch. Nothing
+/// else would fail: not a panic, not an unresolved type, just a duplicate. So
+/// it is pinned here rather than trusted.
+#[test]
+fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
+    use crate::SourceLocation;
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn z_sub(cb: impl Fn(ZThing) + Send + Sync + 'static) {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZThing))
+                .fun(crate::fun!(z_sub)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    let registry = gen.registry();
+
+    let f = registry.flat().function("z_sub").expect("the declared fn");
+    let cb = f
+        .params
+        .iter()
+        .find_map(|p| match &p.ty.kind {
+            crate::api::core::flat::TypeKind::Callback { args } => Some((p, args)),
+            _ => None,
+        })
+        .expect("z_sub takes a callback");
+    let (param, arg_readings) = cb;
+
+    // The two routes to the same identity.
+    let from_reading = SpecKey::callback(
+        &arg_readings
+            .iter()
+            .map(|a| a.origin.syntax.clone())
+            .collect::<Vec<_>>(),
+    );
+    let from_syntax = SpecKey::callback(
+        &crate::api::core::registry::extract_fn_trait_args(&param.ty.origin.syntax)
+            .expect("the param is an impl Fn"),
+    );
+
+    assert_eq!(
+        from_reading, from_syntax,
+        "a callback keyed off its readings must be the SAME memo identity as one \
+         keyed off the signature's syntax — otherwise the memo silently emits two \
+         interfaces for one callback"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -647,3 +647,87 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
          interfaces for one callback"
     );
 }
+
+/// A callback argument spelled as a **wrapped** borrow — `Box<&T>` — is refused,
+/// rather than generating a trampoline the consumer cannot compile.
+///
+/// `Box` is transparent, so `Box<&T>`'s kind is `Ref` exactly as `&T`'s is: the
+/// model answers "borrow" for both, and that answer is correct. What differs is
+/// the *spelling*, and the generated trampoline is written in the spelling. Neutralise
+/// the guard — pass the canonical `&T` as `produced` at `selector.rs`'s borrow arm
+/// instead of the crossing's own `syntax` — and this test fails on emitted code that
+/// hands a `Box<&ZThing>` to a `ZThing_to_jlong(v: &myflat::ZThing)`:
+///
+/// ```ignore
+/// Box::new(move |__cb_arg0: Box<&myflat::ZThing>| {
+///     let __cb0_enc = ZThing_to_jlong_11822692(&mut env, __cb_arg0)?;
+/// ```
+///
+/// The guard that holds is [`Declarations::output_wrapper_shape`]'s borrowed-opaque
+/// arm, which matches `syn::Type::Reference` on `produced` structurally: `Box<&T>`
+/// is a `Type::Path`, so it gets no whole-value output converter, and a callback
+/// arg's is a required type. Same `kind`-classifies / spelling-decides split as
+/// #272's `decoded_vec_satisfies` and `is_unsized_spelling`.
+///
+/// A local re-check inside `emit/callback.rs` was tried and dropped (#279 review):
+/// it changed no output, and cost a `boundary.ledger` entry for a spelling
+/// classification that never fires. This test is the protection instead.
+#[test]
+fn a_wrapped_borrow_callback_arg_declines() {
+    use crate::SourceLocation;
+    let loc = myflat_loc();
+    let build = |argty: syn::Type| -> Result<String, String> {
+        let items: Vec<(syn::Item, SourceLocation)> = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZThing {
+                        pub v: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_sub(cb: impl Fn(#argty) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZThing))
+                    .fun(crate::fun!(z_sub)),
+            );
+        let dir = unique_test_dir("jnigen_wrapped_cb");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        match jni.build_with(registry) {
+            Ok(g) => Ok(std::fs::read_to_string(
+                g.write_rust(dir.join("g.rs")).expect("write_rust"),
+            )
+            .expect("read rust")),
+            Err(e) => Err(format!("{e}")),
+        }
+    };
+
+    // The canonical borrow still resolves and still clones through the core.
+    let plain = build(syn::parse_quote!(&ZThing)).expect("a plain borrow resolves");
+    assert!(
+        plain.contains("__cb_arg0: &myflat::ZThing"),
+        "the trampoline takes the borrow as written:\n{plain}"
+    );
+
+    // Wrapped, the clone is inexpressible, so nothing claims it.
+    let err = build(syn::parse_quote!(Box<&ZThing>))
+        .expect_err("a wrapped borrow callback arg must not resolve");
+    assert!(
+        err.contains("could not be resolved"),
+        "the refusal names the type: {err}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1191,8 +1191,7 @@ impl Declarations {
                 let crate::api::core::flat::TypeKind::Callback { args } = &reading.kind else {
                     return None;
                 };
-                let args: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
-                self.dispatch_fn_input(&args, built)
+                self.dispatch_fn_input(args, built)
             }),
             Direction::Output => self.select_output_type(&reading, built),
         }
@@ -1391,10 +1390,11 @@ impl Declarations {
 impl Declarations {
     fn dispatch_fn_input(
         &self,
-        args: &[syn::Type],
+        args: &[crate::api::core::flat::TypeRef],
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let outer_ty = build_fn_type(args);
+        let spellings: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
+        let outer_ty = build_fn_type(&spellings);
         let (wire, body) = callback_input(self, args, registry)?;
         let niches = default_niches_for_wire(&wire);
         // `impl Fn(...)` crosses the extern tier as the erased lambda object

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -68,9 +68,13 @@ mod spelling_census {
     //! `Box<Option<String>>` **parameter** rendered non-null while the
     //! identical-meaning `Option<String>` rendered `String?` — and a non-null
     //! parameter for an optional value makes the absent case unexpressible.
-    //! `Conversions::{is_optional, optional_inner, sequence_elem,
-    //! is_optional_borrow}` ask the model, and every site with a registry in
-    //! scope should use those.
+    //! The fix is to **carry the reading** rather than the spelling: a
+    //! `TypeRef` answers `optional_inner()` / `sequence_elem()` /
+    //! `borrow_target()` itself, infallibly, because holding one is proof the
+    //! model classified the type. `Conversions` briefly grew accessors that
+    //! took a spelling and looked the reading up; they are gone (#275), because
+    //! a type with no cell answered "no layer" instead of saying it had never
+    //! entered the pipeline.
     //!
     //! ## What this is for
     //!
@@ -293,9 +297,9 @@ mod spelling_census {
              These helpers read a type's layers off its SPELLING, which the model \
              erases wrappers from — see this module's docs. A count going DOWN is \
              the goal: drop the row (or lower it) in the same commit. A count going \
-             UP needs a reason in review: prefer `Conversions::{{is_optional, \
-             optional_inner, sequence_elem, is_optional_borrow}}`, which ask the \
-             model, wherever a registry is in scope.",
+             UP needs a reason in review: take the `TypeRef` instead and ask it \
+             directly (`optional_inner`, `sequence_elem`, `borrow_target`), which \
+             cannot miss.",
             drift.join("\n"),
         );
     }


### PR DESCRIPTION
Closes #275 — the last of four PRs (#274, #276, #278).

## Why

`Conversions::is_optional` took a spelling and asked the registry for its reading. A type with no cell answered `false` — *"not optional"* — rather than saying it never entered the pipeline. That is #266's shape, and its symptom is #273's missing `?`.

Three callers remained, all at places where the adapter **obtains** a type rather than consumes one. **Deleting the accessor is this issue's acceptance test.**

## Sum payload

`write_sealed_classes` holds the `flat::Variant` beside the `SumSpec` — the split #278 drew in `synth_sum_leaves` — so `build_sealed_class` zips the alternatives in and `sum_payload_kt_type` takes the alternative's own `flat::Field`.

**`SumSpec` is untouched**, deliberately: it owns the leaf-*naming* convention, which is jnigen's own, and rebuilding it on the model would touch 8 production sites and 5 tests for no gain here.

**The existing tests caught a regression I introduced**: a fieldless enum declared `sealed_class!` used to panic with a diagnosis, and my first `else { continue }` made it a silent skip. It keeps the diagnosis — now sourced from the model's own `Type::Variant` / `Type::Enum` distinction rather than re-derived with `enum_shape`, which is unused here as a result.

## Callback args

`convert_crossing` destructured `TypeKind::Callback { args }` — **already `Vec<TypeRef>`** — and immediately discarded it with `.map(|a| a.origin.syntax.clone())`. That line is gone; `dispatch_fn_input` and `callback_input` take `&[TypeRef]`, and the borrow peel reads `borrow_target()` instead of matching `syn::Type::Reference`.

### The one judgement call

`callback_iface_spec` is reached **only** through the `SpecKey`-keyed memo, and `SpecKey` needs `Ord` — which a `TypeRef` cannot give, since its `Origin` carries a `SourceLocation` and two identical readings from different files would compare unequal. `derive_iface_spec` is also contractually a pure function of the key (`iface_spec` debug-asserts it).

So `derive_iface_spec` resolves the key's `TypeKey`s back to readings. That is a **lookup, not a classification** — `reading` has been a pure lookup since #267, and `convert_crossing` is the existing precedent.

**It changes behaviour, deliberately:** a missing reading now *defers* the spec (the "not yet derivable, retried" state `iface_spec` already documents) instead of answering "not optional" and rendering a non-null Kotlin param. The old answer was the #273 bug shape.

## The risk with no other signal

A `SpecKey` built from `TypeRef::origin.syntax` must equal one built from `extract_fn_trait_args`, or the memo silently emits **two** interfaces for one callback — not a panic, not an unresolved type, just a duplicate.

`a_callback_identity_is_the_same_from_the_reading_or_the_syntax` pins it. Written **before** the migration, and verified to fail when the two disagree.

## Stale docs, mine

Three references named `Conversions::{optional_inner, sequence_elem, is_optional_borrow}` — all deleted in #276. The worst was the spelling-census **panic message**, which handed a developer that list at the exact moment they tripped the guard. They now point at the `TypeRef` methods that exist.

## Verification

- **Goldens byte-identical** — which is also what says the `SpecKey` identity did not split.
- 549 lib tests; `cargo test --all --all-features` 14/14; clippy `--deny warnings`; fmt.
- covertest-kotlin **48/48** on the JVM — callbacks and sealed classes are both heavily exercised there, which is exactly this PR's blast radius.
- Boundary ledger **129 → 127**, `emit/callback.rs` off it entirely.
- Acceptance, as a command: `grep -rn "is_optional" prebindgen/src` returns only `PathStep::is_optional`, an unrelated inherent method.
