### PR TITLE
Seal `TypeRef`: only the model may mint one

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -313,7 +313,7 @@ fn process_expand<M>(
     )?;
 
     for leaf in &plan.leaves {
-        registry.require_input(&leaf.ty.origin.syntax);
+        registry.require_input(leaf.ty.syntax());
     }
     registry
         .expansion_plans
@@ -365,8 +365,8 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
     // The model already read this return; `fallible_parts` is that reading, not a
     // second look at the spelling.
     let (target, fallible) = match f.ret.fallible_parts() {
-        Some((ok, _)) => (ok.origin.syntax.clone(), true),
-        None => (f.ret.origin.syntax.clone(), false),
+        Some((ok, _)) => (ok.syntax().clone(), true),
+        None => (f.ret.syntax().clone(), false),
     };
     Ok(CtorSig {
         params,
@@ -429,7 +429,7 @@ fn build_plan<M>(
             )?;
             visited.remove(&target.key());
             return Ok(FoldPlan {
-                target: target.origin.syntax.clone(),
+                target: target.syntax().clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -439,7 +439,7 @@ fn build_plan<M>(
             });
         };
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, &target.origin.syntax)?;
+        check_target(func, &sig.target, target.syntax())?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
             leaves.push(FoldLeaf {
@@ -447,7 +447,7 @@ fn build_plan<M>(
                 ty: pty.optional(),
             });
             return Ok(FoldPlan {
-                target: target.origin.syntax.clone(),
+                target: target.syntax().clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -491,7 +491,7 @@ fn build_plan<M>(
             inputs.push(arg);
         }
         return Ok(FoldPlan {
-            target: target.origin.syntax.clone(),
+            target: target.syntax().clone(),
             by_ref,
             shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
             leaves,
@@ -523,7 +523,7 @@ fn build_plan<M>(
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
-        target: target.origin.syntax.clone(),
+        target: target.syntax().clone(),
         by_ref,
         shape: FoldShape::Base,
         leaves,
@@ -553,7 +553,7 @@ fn build_core<M>(
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, &target.origin.syntax)?;
+        check_target(func, &sig.target, target.syntax())?;
         let np = sig.params.len();
         let mut args = Vec::new();
         for (pname, pty) in &sig.params {
@@ -588,7 +588,7 @@ fn build_core<M>(
             match v {
                 Variant::Ctor(func) => {
                     let sig = ctor_signature(registry, func)?;
-                    check_target(func, &sig.target, &target.origin.syntax)?;
+                    check_target(func, &sig.target, target.syntax())?;
                     let np = sig.params.len();
                     let mut args = Vec::new();
                     for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
@@ -689,7 +689,7 @@ fn build_arg<M>(
         )?;
         visited.remove(&key);
         Ok(FoldArg::Build(Box::new(FoldBuild {
-            target: bare.origin.syntax.clone(),
+            target: bare.syntax().clone(),
             by_ref: pby_ref,
             selector,
             variants: vars,
@@ -1085,8 +1085,7 @@ fn constructed_value(reading: &crate::api::core::flat::TypeRef) -> syn::Type {
     after_opt
         .borrow_target()
         .unwrap_or(after_opt)
-        .origin
-        .syntax
+        .syntax()
         .clone()
 }
 

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -51,12 +51,7 @@ fn single_constructor_plan_and_fold() {
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(plan.leaves[0].name.to_string(), "a");
     assert_eq!(
-        plan.leaves[0]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
         "String"
     );
 
@@ -106,31 +101,16 @@ fn constructor_plan_and_fold() {
     // selector + try_from(String) + identity(ZKeyExpr) = 3 leaves
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(
-        plan.leaves[0]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
         "i32"
     );
     assert_eq!(
-        plan.leaves[1]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[1].ty.syntax().to_token_stream().to_string(),
         "Option < String >"
     );
     // `&ZKeyExpr` consumer ⇒ borrowed identity leaf (clone-preserving).
     assert_eq!(
-        plan.leaves[2]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[2].ty.syntax().to_token_stream().to_string(),
         "Option < & ZKeyExpr >"
     );
     assert_eq!(plan.variants.len(), 2);
@@ -186,12 +166,7 @@ fn optional_byvalue_single_ctor() {
     assert_eq!(plan.leaves.len(), 1);
     // nullable leaf wrapping the ctor param
     assert_eq!(
-        plan.leaves[0]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
         "Option < Vec < u8 > >"
     );
 
@@ -242,12 +217,7 @@ fn optional_byref_single_ctor() {
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
     assert_eq!(
-        plan.leaves[0]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
         "Option < String >"
     );
     assert_eq!(
@@ -301,32 +271,17 @@ fn optional_byref_multi_arg_ctor() {
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_present");
     assert_eq!(
-        plan.leaves[0]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
         "bool"
     );
     assert_eq!(plan.leaves[1].name.to_string(), "encoding_id");
     assert_eq!(
-        plan.leaves[1]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[1].ty.syntax().to_token_stream().to_string(),
         "i32"
     );
     assert_eq!(plan.leaves[2].name.to_string(), "encoding_schema");
     assert_eq!(
-        plan.leaves[2]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[2].ty.syntax().to_token_stream().to_string(),
         "Option < String >"
     );
 
@@ -400,40 +355,20 @@ fn optional_combined_selector_encodes_absence() {
     assert_eq!(plan.leaves.len(), 4);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_sel");
     assert_eq!(
-        plan.leaves[0]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
         "i32"
     );
     assert_eq!(
-        plan.leaves[1]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[1].ty.syntax().to_token_stream().to_string(),
         "Option < i32 >"
     );
     assert_eq!(
-        plan.leaves[2]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[2].ty.syntax().to_token_stream().to_string(),
         "Option < String >",
         "already-Option ctor arg is NOT double-wrapped"
     );
     assert_eq!(
-        plan.leaves[3]
-            .ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[3].ty.syntax().to_token_stream().to_string(),
         "Option < & ZEncoding >"
     );
     assert!(
@@ -674,7 +609,7 @@ fn recursive_input_nests_param_constructors() {
     let leaf_tys: Vec<String> = plan
         .leaves
         .iter()
-        .map(|l| l.ty.origin.syntax.to_token_stream().to_string())
+        .map(|l| l.ty.syntax().to_token_stream().to_string())
         .collect();
     assert!(
         leaf_tys.iter().any(|t| t.contains("i32")),

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -228,6 +228,20 @@ pub struct Variant {
     /// Alternatives in declaration order; `alternatives[i].index == i`.
     pub alternatives: Vec<Alternative>,
     pub origin: Origin<syn::ItemEnum>,
+    /// This sum **as a type**, taken at parse time — see [`Self::type_ref`].
+    ///
+    /// **Stored, not computed**, and that is what makes the accessor safe: a
+    /// method composing `TypeRef::named(&self.name)` would answer for whatever
+    /// name a caller put in the struct, so a `Variant` named `String` would
+    /// yield `Named` over the spelling `String` — which the model reads as
+    /// `Str`. A stored reading cannot disagree with the model, because the
+    /// model is what put it there, and an assembler has no way to mint a
+    /// different one.
+    ///
+    /// `pub(super)` is the second line, not the first: it also stops a
+    /// `Variant` being assembled at all outside `flat` (`E0451`), so `name` and
+    /// `reading` cannot be paired inconsistently with *each other*.
+    pub(super) reading: TypeRef,
 }
 
 impl Variant {
@@ -235,11 +249,47 @@ impl Variant {
     /// has to name the sum rather than walk it (jnigen's `SumTag` selector,
     /// which carries *which* sum it chooses between).
     ///
-    /// The declaration answers, so the composer stays inside the model: a
-    /// consumer holding the element does not have to mint a reading from the
-    /// name and hope it matches what the model would have said.
-    pub fn type_ref(&self) -> TypeRef {
-        TypeRef::named(&self.name)
+    /// The **declaration** answers, so no consumer has to mint a reading from
+    /// the name and hope it matches what the model would have said.
+    ///
+    /// This returns state the parser took, **not** a fresh composition, and the
+    /// difference is the difference between sealing and appearing to.
+    ///
+    /// A version that composed `TypeRef::named(&self.name)` would hand a
+    /// `Variant` assembled with the name `String` a
+    /// [`Named`](super::TypeKind::Named) over the spelling `String` — which the
+    /// model reads as [`Str`](super::TypeKind::Str). That is the `kind`/`syntax`
+    /// disagreement [`TypeRef`]'s private fields exist to prevent, and it was
+    /// reachable from outside the crate while being invisible to every doctest
+    /// there, because assembling the *element* is not minting the *type*.
+    ///
+    /// Reading a stored value closes it: whatever a caller does with the other
+    /// fields, the reading here is the one the model made, and no caller can
+    /// mint a different one to put in its place.
+    ///
+    /// The `Variant` is sealed as well — its `reading` field is `pub(super)` —
+    /// so the two cannot even be paired inconsistently:
+    ///
+    /// ```compile_fail
+    /// # use prebindgen::core::flat::{Origin, Variant};
+    /// let assembled = Variant {
+    ///     name: syn::parse_str("String").unwrap(),
+    ///     alternatives: vec![],
+    ///     origin: Origin::new(
+    ///         syn::parse_str("enum String { A(u8) }").unwrap(),
+    ///         std::rc::Rc::new(Default::default()),
+    ///     ),
+    /// };
+    /// let mismatched = assembled.type_ref();
+    /// ```
+    ///
+    /// That doctest pins *"a consumer cannot assemble a `Variant`"* and nothing
+    /// finer: measured, it still fails with the field made `pub` — as `E0063`
+    /// (missing field) rather than `E0451` (private field), since a consumer
+    /// cannot produce a `TypeRef` to supply either way. The visibility itself
+    /// is the check the compiler runs on every build.
+    pub fn type_ref(&self) -> &TypeRef {
+        &self.reading
     }
 }
 

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -230,6 +230,19 @@ pub struct Variant {
     pub origin: Origin<syn::ItemEnum>,
 }
 
+impl Variant {
+    /// A reference to this sum **as a type** — what a consumer needs when it
+    /// has to name the sum rather than walk it (jnigen's `SumTag` selector,
+    /// which carries *which* sum it chooses between).
+    ///
+    /// The declaration answers, so the composer stays inside the model: a
+    /// consumer holding the element does not have to mint a reading from the
+    /// name and hope it matches what the model would have said.
+    pub fn type_ref(&self) -> TypeRef {
+        TypeRef::named(&self.name)
+    }
+}
+
 /// One alternative of a [`Variant`].
 #[derive(Clone, Debug)]
 pub struct Alternative {

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -687,7 +687,10 @@ impl Flat {
     ///
     /// `Err` means the spelling is outside the accepted grammar — a real diagnosis
     /// about a type the *binding* built, not a cache miss.
-    pub(crate) fn classify(&self, ty: &syn::Type) -> Result<TypeRef, UnsupportedType> {
+    pub(in crate::api::core) fn classify(
+        &self,
+        ty: &syn::Type,
+    ) -> Result<TypeRef, UnsupportedType> {
         if let Some(indexed) = self.type_ref(ty) {
             return Ok(indexed.clone());
         }

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -1404,6 +1404,7 @@ fn lower_variant(
         });
     }
     Ok(Variant {
+        reading: TypeRef::named(&e.ident),
         name: e.ident.clone(),
         alternatives,
         origin: Origin::new(e.clone(), Rc::clone(at)),

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -30,19 +30,30 @@ use crate::SourceLocation;
 /// # The invariant
 ///
 /// > **Every `TypeRef` was classified by the model.** [`Flat`](super::Flat)
-/// > classified it from source syntax, or the registry composed it by layering
-/// > over something already classified. Nothing above the model can mint one.
+/// > classified it from source syntax, or `api::core` composed it by layering
+/// > over something already classified. Nothing above `api::core` can mint one.
 ///
-/// That is what the private fields buy, and public fields would not: a public
-/// field **is** a constructor, so leaving them public while restricting the
-/// composers would block nothing. Read through [`kind`](Self::kind),
-/// [`syntax`](Self::syntax) and [`location`](Self::location).
+/// **Scoped to what is enforced, not to what is intended.** The boundary is
+/// `api::core`, and it is drawn by visibility at four places, each checked by
+/// the compiler on every build:
+///
+/// | | |
+/// |---|---|
+/// | the `kind` and `origin` fields | `pub(super)` — a public field **is** a constructor, so restricting only the composers would block nothing |
+/// | `borrowed` / `optional` / `scalar` | `pub(in crate::api::core)` |
+/// | `named` | `pub(super)` — `flat` alone |
+/// | `Flat::classify` | `pub(in crate::api::core)` |
+///
+/// So a language adapter under `api::lang` cannot mint a reading at all — not
+/// by field, not by composer, not by classifying a spelling of its own. Where
+/// one needs a type the model already declares, the **declaration** answers:
+/// see [`Variant::type_ref`](super::Variant::type_ref), which is what the
+/// `SumTag` selector uses instead of composing a reading from an ident.
 ///
 /// The invariant is unconditional — no phase, no lifetime, no direction — so it
 /// holds for a **stored** value. That is the point: a `TypeRef` lives in
 /// `UnfoldLeaf::out_ty` and `FoldLeaf::ty`, inside plans the registry itself
-/// stores, so a
-/// borrow-carrying token would make the registry self-referential.
+/// stores, so a borrow-carrying token would make the registry self-referential.
 ///
 /// It deliberately does **not** claim the type's converters exist. That is
 /// false by design for stored readings — `unrequire_output` leaves a cell whose
@@ -66,23 +77,27 @@ pub struct TypeRef {
 impl TypeRef {
     /// What the type means. **Classify off this**, never off the spelling.
     ///
-    /// The seal, as a compiled assertion — an out-of-crate adapter cannot
-    /// assemble a reading, because the fields it would have to name are
-    /// private:
+    /// The seal, as a compiled assertion. An out-of-crate consumer cannot
+    /// assemble a reading, because the fields it would have to name are private
+    /// (`E0451`):
     ///
     /// ```compile_fail
     /// # use prebindgen::core::flat::{TypeKind, TypeRef};
     /// let forged = TypeRef { kind: TypeKind::Unit, origin: todo!() };
     /// ```
     ///
-    /// The composers are `pub(crate)` for the same reason, so this is the whole
-    /// surface: a `TypeRef` can only be obtained from the model that classified
-    /// it.
+    /// …nor through a composer, which is not visible either (`E0624`):
     ///
     /// ```compile_fail
     /// # use prebindgen::core::flat::{ScalarKind, TypeRef};
     /// let forged = TypeRef::scalar(ScalarKind::Bool);
     /// ```
+    ///
+    /// These two prove only the **crate** boundary. The stronger claim — that
+    /// nothing above `api::core` can mint one either — is enforced by the
+    /// visibilities tabulated on [`TypeRef`], and a doctest cannot reach inside
+    /// the crate to test it. The compiler checks it on every build instead: an
+    /// `api::lang` adapter naming any of the four routes fails with `E0624`.
     pub fn kind(&self) -> &TypeKind {
         &self.kind
     }
@@ -230,7 +245,7 @@ impl TypeRef {
     ///
     /// Keeps this type's location: the borrow exists *because of* this value,
     /// so a diagnostic about it should point where the value came from.
-    pub(crate) fn borrowed(&self) -> TypeRef {
+    pub(in crate::api::core) fn borrowed(&self) -> TypeRef {
         let inner = &self.origin.syntax;
         TypeRef {
             kind: TypeKind::Ref {
@@ -243,7 +258,7 @@ impl TypeRef {
 
     /// An optional of this type — `Option<T>` from `T`. Location as
     /// [`Self::borrowed`].
-    pub(crate) fn optional(&self) -> TypeRef {
+    pub(in crate::api::core) fn optional(&self) -> TypeRef {
         let inner = &self.origin.syntax;
         TypeRef {
             kind: TypeKind::Optional(Box::new(self.clone())),
@@ -258,7 +273,7 @@ impl TypeRef {
     /// [`Flat::classify`](super::Flat::classify) does exactly this for a
     /// composed spelling, and `ensure_entry` gives adapter-authored cells the
     /// same treatment — `has_position` already gates what a diagnostic prints.
-    pub(crate) fn scalar(kind: ScalarKind) -> TypeRef {
+    pub(in crate::api::core) fn scalar(kind: ScalarKind) -> TypeRef {
         // The spelling comes from the kind, so the two cannot drift.
         let ident = syn::Ident::new(kind.as_str(), proc_macro2::Span::call_site());
         TypeRef {
@@ -273,7 +288,7 @@ impl TypeRef {
     /// A nominal reference to a declared type, by name. Placeless for the same
     /// reason as [`Self::scalar`] — this is the binding naming a type, not a
     /// source mentioning one.
-    pub(crate) fn named(ident: &syn::Ident) -> TypeRef {
+    pub(super) fn named(ident: &syn::Ident) -> TypeRef {
         TypeRef {
             kind: TypeKind::Named {
                 id: TypeId {

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -26,10 +26,32 @@ use crate::SourceLocation;
 /// lossless: a lifetime, an elided argument, a `Box` that changes nothing
 /// outside Rust all survive there at zero modelling cost, so `kind` can stay
 /// language-neutral and small.
+///
+/// # The invariant
+///
+/// > **Every `TypeRef` was classified by the model.** [`Flat`](super::Flat)
+/// > classified it from source syntax, or the registry composed it by layering
+/// > over something already classified. Nothing above the model can mint one.
+///
+/// That is what the private fields buy, and public fields would not: a public
+/// field **is** a constructor, so leaving them public while restricting the
+/// composers would block nothing. Read through [`kind`](Self::kind),
+/// [`syntax`](Self::syntax) and [`location`](Self::location).
+///
+/// The invariant is unconditional — no phase, no lifetime, no direction — so it
+/// holds for a **stored** value. That is the point: a `TypeRef` lives in
+/// `UnfoldLeaf::out_ty` and `FoldLeaf::ty`, inside plans the registry itself
+/// stores, so a
+/// borrow-carrying token would make the registry self-referential.
+///
+/// It deliberately does **not** claim the type's converters exist. That is
+/// false by design for stored readings — `unrequire_output` leaves a cell whose
+/// converter genuinely cannot resolve, and a `SumTag` leaf never has one — so
+/// converter existence stays a lookup that answers `Option`.
 #[derive(Clone, Debug)]
 pub struct TypeRef {
     /// What the type means — the closed, destination-neutral classification.
-    pub kind: TypeKind,
+    pub(super) kind: TypeKind,
     /// The type as generated Rust must spell it — the source's own tokens,
     /// normalized to the flat namespace the generated crate can name (see
     /// [`Flat::parse`](super::Flat::parse)) — plus the source they came
@@ -38,7 +60,55 @@ pub struct TypeRef {
     /// The syntax can say strictly more than `kind` does — `Box<String>` is a
     /// `Str` here — which is the point: what Rust needs and no destination
     /// language can see lives in the tokens, not in the classification.
-    pub origin: Origin<syn::Type>,
+    pub(super) origin: Origin<syn::Type>,
+}
+
+impl TypeRef {
+    /// What the type means. **Classify off this**, never off the spelling.
+    ///
+    /// The seal, as a compiled assertion — an out-of-crate adapter cannot
+    /// assemble a reading, because the fields it would have to name are
+    /// private:
+    ///
+    /// ```compile_fail
+    /// # use prebindgen::core::flat::{TypeKind, TypeRef};
+    /// let forged = TypeRef { kind: TypeKind::Unit, origin: todo!() };
+    /// ```
+    ///
+    /// The composers are `pub(crate)` for the same reason, so this is the whole
+    /// surface: a `TypeRef` can only be obtained from the model that classified
+    /// it.
+    ///
+    /// ```compile_fail
+    /// # use prebindgen::core::flat::{ScalarKind, TypeRef};
+    /// let forged = TypeRef::scalar(ScalarKind::Bool);
+    /// ```
+    pub fn kind(&self) -> &TypeKind {
+        &self.kind
+    }
+
+    /// The tokens generated Rust must spell. **Spell off this**, never off
+    /// `kind` — the syntax says strictly more, and re-deriving it from the
+    /// classification is how `Box<Option<T>>` becomes an `E0308`.
+    pub fn syntax(&self) -> &syn::Type {
+        &self.origin.syntax
+    }
+
+    /// Where the type was written, for diagnostics. A composed type is
+    /// **placeless** — [`SourceLocation::has_position`] gates what is printed.
+    pub fn location(&self) -> &SourceLocation {
+        &self.origin.location
+    }
+
+    /// An [`Origin`] for a node that exists **because of** this type, sharing
+    /// its location — a synthesized getter built from a return type, say.
+    ///
+    /// Deliberately narrower than handing out the origin: it lends provenance
+    /// without lending the field, so a `TypeRef`'s own `Origin` still cannot be
+    /// obtained from outside the model.
+    pub(crate) fn origin_with<S>(&self, syntax: S) -> Origin<S> {
+        self.origin.with(syntax)
+    }
 }
 
 impl TypeRef {
@@ -160,7 +230,7 @@ impl TypeRef {
     ///
     /// Keeps this type's location: the borrow exists *because of* this value,
     /// so a diagnostic about it should point where the value came from.
-    pub fn borrowed(&self) -> TypeRef {
+    pub(crate) fn borrowed(&self) -> TypeRef {
         let inner = &self.origin.syntax;
         TypeRef {
             kind: TypeKind::Ref {
@@ -173,7 +243,7 @@ impl TypeRef {
 
     /// An optional of this type — `Option<T>` from `T`. Location as
     /// [`Self::borrowed`].
-    pub fn optional(&self) -> TypeRef {
+    pub(crate) fn optional(&self) -> TypeRef {
         let inner = &self.origin.syntax;
         TypeRef {
             kind: TypeKind::Optional(Box::new(self.clone())),
@@ -188,7 +258,7 @@ impl TypeRef {
     /// [`Flat::classify`](super::Flat::classify) does exactly this for a
     /// composed spelling, and `ensure_entry` gives adapter-authored cells the
     /// same treatment — `has_position` already gates what a diagnostic prints.
-    pub fn scalar(kind: ScalarKind) -> TypeRef {
+    pub(crate) fn scalar(kind: ScalarKind) -> TypeRef {
         // The spelling comes from the kind, so the two cannot drift.
         let ident = syn::Ident::new(kind.as_str(), proc_macro2::Span::call_site());
         TypeRef {
@@ -203,7 +273,7 @@ impl TypeRef {
     /// A nominal reference to a declared type, by name. Placeless for the same
     /// reason as [`Self::scalar`] — this is the binding naming a type, not a
     /// source mentioning one.
-    pub fn named(ident: &syn::Ident) -> TypeRef {
+    pub(crate) fn named(ident: &syn::Ident) -> TypeRef {
         TypeRef {
             kind: TypeKind::Named {
                 id: TypeId {
@@ -221,7 +291,7 @@ impl TypeRef {
     ///
     /// The canonical spelling is what a key *is* (#113), and reading it is
     /// legitimate — but it should be the model's answer rather than every caller
-    /// reaching into [`origin`](Self::origin) for it, since a caller that reaches
+    /// reaching into [`syntax`](Self::syntax) for it, since a caller that reaches
     /// into `origin` to *reason* is the thing this model exists to stop.
     pub fn key(&self) -> crate::api::core::registry::TypeKey {
         crate::api::core::registry::TypeKey::from_type(&self.origin.syntax)
@@ -285,7 +355,7 @@ impl TypeRef {
     ///
     /// A [`Named`](TypeKind::Named)'s generic arguments are **not** among them:
     /// [`TypeId`] keeps a name and nothing else, so `MyBox<Foo>` reaches no `Foo`
-    /// here. The full spelling is in [`Self::origin`] for whoever needs it.
+    /// here. The full spelling is in [`Self::syntax`] for whoever needs it.
     pub fn walk(&self) -> Vec<&TypeRef> {
         let mut out = Vec::new();
         self.collect_refs(&mut out);
@@ -333,7 +403,7 @@ impl TypeRef {
 /// One Rust spelling per concept is **not** the rule here — several are. A
 /// concept earns a variant when a destination language would act on it; a
 /// spelling that changes nothing outside Rust folds into the concept it carries
-/// and survives in [`TypeRef::origin`]:
+/// and survives in [`TypeRef::syntax`]:
 ///
 /// | Spelling | Kind | Why |
 /// |---|---|---|
@@ -369,7 +439,7 @@ pub enum TypeKind {
     /// this module has to take a path apart to learn what a type is. The last
     /// segment's generic arguments live in `args`, and only the *type*
     /// arguments: a lifetime argument says nothing a destination language can
-    /// act on. The full spelling is in [`TypeRef::origin`] for whoever re-emits it.
+    /// act on. The full spelling is in [`TypeRef::syntax`] for whoever re-emits it.
     Named { id: TypeId },
     /// `[T; N]` — a run of `T` whose length is known at compile time.
     ///
@@ -385,7 +455,7 @@ pub enum TypeKind {
         extent: Box<ArrayExtent>,
     },
     /// A borrow — `&T`, `&mut T`, or `&mut MaybeUninit<T>`. The lifetime is
-    /// spelling, so it lives in [`TypeRef::origin`] rather than here.
+    /// spelling, so it lives in [`TypeRef::syntax`] rather than here.
     ///
     /// This is the ownership layer for every concept underneath it: `&str` is
     /// `Ref(Str)`, `&[T]` is `Ref(Sequence)`. A shared-ownership handle

--- a/prebindgen/src/api/core/registry/order.rs
+++ b/prebindgen/src/api/core/registry/order.rs
@@ -106,7 +106,7 @@ impl<M> Registry<M> {
         for arg in args {
             if let Some(plan) = self.callback_arg_plans.get(&TypeKey::from_type(&arg)) {
                 for leaf in &plan.leaves {
-                    out.push((Direction::Output, leaf.out_ty.origin.syntax.clone()));
+                    out.push((Direction::Output, leaf.out_ty.syntax().clone()));
                 }
             }
         }

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -337,7 +337,7 @@ impl<M> Registry<M> {
             .map(|c| &c.subject)
         {
             let (children, child_dir): (Vec<&crate::api::core::flat::TypeRef>, Direction) =
-                match &reading.kind {
+                match reading.kind() {
                     TypeKind::Optional(t)
                     | TypeKind::Sequence(t)
                     | TypeKind::Ref { inner: t, .. } => (vec![t], dir),
@@ -354,7 +354,7 @@ impl<M> Registry<M> {
                     | TypeKind::Unit => (Vec::new(), dir),
                 };
             for child in children {
-                out.push((child_dir, child.origin.syntax.clone()));
+                out.push((child_dir, child.syntax().clone()));
             }
         }
         // A declared type's own fields, read off the element rather than off its
@@ -371,7 +371,7 @@ impl<M> Registry<M> {
         if let Some(name) = self
             .type_table(dir)
             .get(&TypeKey::from_type(ty))
-            .and_then(|c| match &c.subject.kind {
+            .and_then(|c| match &c.subject.kind() {
                 TypeKind::Named { id } => Some(id.name.clone()),
                 _ => None,
             })
@@ -387,7 +387,7 @@ impl<M> Registry<M> {
                 Some(Type::Enum(_) | Type::Extern(_)) | None => Vec::new(),
             };
             for field in fields {
-                out.push((dir, field.ty.origin.syntax.clone()));
+                out.push((dir, field.ty.syntax().clone()));
             }
         }
         out

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -371,7 +371,7 @@ impl<M> Registry<M> {
         if let Some(name) = self
             .type_table(dir)
             .get(&TypeKey::from_type(ty))
-            .and_then(|c| match &c.subject.kind() {
+            .and_then(|c| match c.subject.kind() {
                 TypeKind::Named { id } => Some(id.name.clone()),
                 _ => None,
             })

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -807,16 +807,16 @@ fn a_source_type_cell_carries_the_models_typeref() {
     let cell = &reg.input_types[&key];
     assert!(cell.root, "a top-level parameter is a root");
     assert!(
-        matches!(cell.subject.kind, TypeKind::Optional(_)),
+        matches!(cell.subject.kind(), TypeKind::Optional(_)),
         "the frontend classified it, so the cell has that classification"
     );
     // One location per cell, and it is the model's — not a copy the scan made.
-    assert_eq!(&*cell.subject.origin.location, &loc);
+    assert_eq!(cell.subject.location(), &loc);
 
     // The nested position is in the model too, and is not a root.
     let inner = &reg.input_types[&TypeKey::parse("u64").expect("test type")];
     assert!(!inner.root);
-    assert!(matches!(inner.subject.kind, TypeKind::Scalar(_)));
+    assert!(matches!(inner.subject.kind(), TypeKind::Scalar(_)));
 }
 
 /// `Registry::reading` is a **lookup**. A type with no cell answers `None`, even
@@ -892,11 +892,11 @@ fn an_adapter_authored_type_cell_is_classified_but_placeless() {
     let cell = &reg.input_types[&TypeKey::parse("Foreign").expect("test type")];
     assert!(cell.root, "the binding asked for it directly");
     assert!(
-        matches!(&cell.subject.kind, TypeKind::Named { id } if id.name == "Foreign"),
+        matches!(&cell.subject.kind(), TypeKind::Named { id } if id.name == "Foreign"),
         "a declared name is a name, and the grammar can say so"
     );
     assert!(
-        !cell.subject.origin.location.has_position(),
+        !cell.subject.location().has_position(),
         "nothing wrote it, so there is no position to report"
     );
 }
@@ -1425,12 +1425,12 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         .flat()
         .type_ref(&syn::parse_quote!(Option<u64>))
         .expect("a local fn's parameter type is in the model");
-    assert!(matches!(read.kind, TypeKind::Optional(_)));
+    assert!(matches!(read.kind(), TypeKind::Optional(_)));
 
     // … and the cell scanned from that parameter carries that same reading,
     // rather than a second one made at the table.
     let cell = &reg.input_types[&TypeKey::parse("Option<u64>").expect("test type")];
-    assert!(matches!(cell.subject.kind, TypeKind::Optional(_)));
+    assert!(matches!(cell.subject.kind(), TypeKind::Optional(_)));
 }
 
 /// A type with no source position must not get an invented one.

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -892,7 +892,7 @@ fn an_adapter_authored_type_cell_is_classified_but_placeless() {
     let cell = &reg.input_types[&TypeKey::parse("Foreign").expect("test type")];
     assert!(cell.root, "the binding asked for it directly");
     assert!(
-        matches!(&cell.subject.kind(), TypeKind::Named { id } if id.name == "Foreign"),
+        matches!(cell.subject.kind(), TypeKind::Named { id } if id.name == "Foreign"),
         "a declared name is a name, and the grammar can say so"
     );
     assert!(

--- a/prebindgen/src/api/core/resolve.rs
+++ b/prebindgen/src/api/core/resolve.rs
@@ -150,7 +150,7 @@ fn collect_unresolved_descendants<M>(
                 out.push(UnresolvedEntry {
                     key: key.clone(),
                     direction: dir,
-                    location: Some(&*cell.subject.origin.location)
+                    location: Some(cell.subject.location())
                         .filter(|l| l.has_position())
                         .cloned(),
                 });
@@ -191,7 +191,7 @@ pub(crate) fn check_complete<M>(registry: &Registry<M>) -> Result<(), ResolveErr
             entries.push(UnresolvedEntry {
                 key: key.clone(),
                 direction: dir,
-                location: Some(&*cell.subject.origin.location)
+                location: Some(cell.subject.location())
                     .filter(|l| l.has_position())
                     .cloned(),
             });

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -405,7 +405,7 @@ pub fn apply<M>(
             // The callback's argument types, read off the parameter's
             // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
             // there is nothing to re-extract from the signature's syntax.
-            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind() else {
+            let crate::api::core::flat::TypeKind::Callback { args } = param.ty.kind() else {
                 continue;
             };
             for arg_ty in args {
@@ -681,7 +681,7 @@ fn wire_fixed_callbacks<M>(
             // The callback's argument types, read off the parameter's
             // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
             // there is nothing to re-extract from the signature's syntax.
-            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind() else {
+            let crate::api::core::flat::TypeKind::Callback { args } = param.ty.kind() else {
                 continue;
             };
             for arg_ty in args {
@@ -799,7 +799,7 @@ pub fn apply_leaf_vec_folds<M>(
             // The callback's argument types, read off the parameter's
             // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
             // there is nothing to re-extract from the signature's syntax.
-            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind() else {
+            let crate::api::core::flat::TypeKind::Callback { args } = param.ty.kind() else {
                 continue;
             };
             for arg_ty in args {
@@ -1726,7 +1726,7 @@ fn accessor_signature<M>(
         .params
         .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
-    let takes = match &first.ty.kind() {
+    let takes = match first.ty.kind() {
         crate::api::core::flat::TypeKind::Ref { inner, .. } => inner.syntax().clone(),
         _ => first.ty.syntax().clone(),
     };

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -312,7 +312,7 @@ pub fn apply<M>(
                     func: ed.func.clone(),
                     declared: TypeKey::from_type(declared).as_str().to_string(),
                     actual: {
-                        let s = &ret.origin.syntax;
+                        let s = ret.syntax();
                         quote::quote!(#s).to_string()
                     },
                 });
@@ -405,7 +405,7 @@ pub fn apply<M>(
             // The callback's argument types, read off the parameter's
             // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
             // there is nothing to re-extract from the signature's syntax.
-            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind else {
+            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind() else {
                 continue;
             };
             for arg_ty in args {
@@ -420,7 +420,10 @@ pub fn apply<M>(
                 // `Option<T>` / `Vec<T>` / tuple arg is delivered whole. The model
                 // says which, so a wrapper the language sees through — `Box<T>` —
                 // no longer reads as un-nameable.
-                if !matches!(core_ty.kind, crate::api::core::flat::TypeKind::Named { .. }) {
+                if !matches!(
+                    core_ty.kind(),
+                    crate::api::core::flat::TypeKind::Named { .. }
+                ) {
                     continue;
                 }
                 let key = arg_ty.key();
@@ -459,7 +462,7 @@ pub fn apply<M>(
                     continue;
                 }
                 for leaf in &plan.leaves {
-                    registry.require_output(&leaf.out_ty.origin.syntax);
+                    registry.require_output(leaf.out_ty.syntax());
                 }
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -640,7 +643,7 @@ fn wire_fixed_returns<M>(
             }
         }
         for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-            registry.require_output(&leaf.out_ty.origin.syntax);
+            registry.require_output(leaf.out_ty.syntax());
         }
         let plan = UnfoldPlan {
             source: vd.source.clone(),
@@ -678,7 +681,7 @@ fn wire_fixed_callbacks<M>(
             // The callback's argument types, read off the parameter's
             // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
             // there is nothing to re-extract from the signature's syntax.
-            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind else {
+            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind() else {
                 continue;
             };
             for arg_ty in args {
@@ -707,7 +710,7 @@ fn wire_fixed_callbacks<M>(
                     continue;
                 }
                 for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-                    registry.require_output(&leaf.out_ty.origin.syntax);
+                    registry.require_output(leaf.out_ty.syntax());
                 }
                 let plan = UnfoldPlan {
                     source: vd.source.clone(),
@@ -776,7 +779,7 @@ pub fn apply_leaf_vec_folds<M>(
                     } else {
                         inner_shape
                     };
-                    registry.require_output(&vec_elem.origin.syntax);
+                    registry.require_output(vec_elem.syntax());
                     // The fold delivers the return element-by-element, so the
                     // whole `Vec<T>` / `Option<Vec<T>>` converter is not needed.
                     // De-require it: for String / scalar elements it still
@@ -784,7 +787,7 @@ pub fn apply_leaf_vec_folds<M>(
                     // opaque-handle element it cannot resolve (`jlong` wire isn't
                     // JObject-shaped), and de-requiring keeps that `None` from
                     // being flagged as an unresolved-required error.
-                    registry.unrequire_output(&ret.origin.syntax);
+                    registry.unrequire_output(ret.syntax());
                     registry
                         .unfold_plans
                         .insert(func.clone(), whole_leaf_fold_plan(vec_elem, shape));
@@ -796,7 +799,7 @@ pub fn apply_leaf_vec_folds<M>(
             // The callback's argument types, read off the parameter's
             // classification. `TypeKind::Callback` carries them as `TypeRef`s, so
             // there is nothing to re-extract from the signature's syntax.
-            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind else {
+            let crate::api::core::flat::TypeKind::Callback { args } = &param.ty.kind() else {
                 continue;
             };
             for arg_ty in args {
@@ -811,7 +814,7 @@ pub fn apply_leaf_vec_folds<M>(
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                registry.require_output(&elem.origin.syntax);
+                registry.require_output(elem.syntax());
                 let plan =
                     whole_leaf_fold_plan(elem, UnfoldShape::Iterable(Box::new(UnfoldShape::Base)));
                 registry.callback_arg_plans.insert(key, plan);
@@ -829,12 +832,12 @@ fn whole_leaf_fold_plan(
     shape: UnfoldShape,
 ) -> UnfoldPlan {
     UnfoldPlan {
-        source: vec_elem.origin.syntax.clone(),
+        source: vec_elem.syntax().clone(),
         decon: None,
         by_ref: peel_borrow(vec_elem).0,
         shape,
         leaves: vec![],
-        element: Some(vec_elem.origin.syntax.clone()),
+        element: Some(vec_elem.syntax().clone()),
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
@@ -924,9 +927,9 @@ fn peel(ty: &crate::api::core::flat::TypeRef) -> Layered {
         layer_types: ty
             .layer_types()
             .iter()
-            .map(|t| t.origin.syntax.clone())
+            .map(|t| t.syntax().clone())
             .collect(),
-        core: borrowed.unwrap_or(layered).origin.syntax.clone(),
+        core: borrowed.unwrap_or(layered).syntax().clone(),
         by_ref: borrowed.is_some(),
     }
 }
@@ -1021,9 +1024,9 @@ fn process_decl<M>(
             // recursive registration also required) — same reasoning as
             // [`apply_leaf_vec_folds`] for the fixed folds.
             if ed.target == DeconTarget::Output {
-                registry.unrequire_output(&ret_ty.origin.syntax);
+                registry.unrequire_output(ret_ty.syntax());
                 if optional {
-                    registry.unrequire_output(&after_opt.origin.syntax);
+                    registry.unrequire_output(after_opt.syntax());
                 }
             }
             // Element type peeled of a leading `&` (accessors take `&Element`).
@@ -1036,7 +1039,7 @@ fn process_decl<M>(
                 register_decon_spec(registry, acc, &decon, &records, element)?;
                 let plan = build_plan(acc, registry, ed, by_ref, element, shape, &records, decon)?;
                 for leaf in &plan.leaves {
-                    registry.require_output(&leaf.out_ty.origin.syntax);
+                    registry.require_output(leaf.out_ty.syntax());
                 }
                 plan
             } else {
@@ -1045,14 +1048,14 @@ fn process_decl<M>(
                 // No declaration is involved (`decon: None`) — the element
                 // crosses whole through its own converter.
                 let by_ref = peel_borrow(inner).0;
-                registry.require_output(&inner.origin.syntax);
+                registry.require_output(inner.syntax());
                 UnfoldPlan {
-                    source: inner.origin.syntax.clone(),
+                    source: inner.syntax().clone(),
                     decon: None,
                     by_ref,
                     shape,
                     leaves: vec![],
-                    element: Some(inner.origin.syntax.clone()),
+                    element: Some(inner.syntax().clone()),
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
@@ -1082,7 +1085,7 @@ fn process_decl<M>(
             register_decon_spec(registry, acc, &decon, &records, source)?;
             let plan = build_plan(acc, registry, ed, by_ref, source, shape, &records, decon)?;
             for leaf in &plan.leaves {
-                registry.require_output(&leaf.out_ty.origin.syntax);
+                registry.require_output(leaf.out_ty.syntax());
             }
             plan
         };
@@ -1110,7 +1113,7 @@ fn process_decl<M>(
             && plan.leaves.len() == 1
             && !plan.leaves[0].nullable;
         let plan = if single_return {
-            let leaf_ty = plan.leaves[0].out_ty.origin.syntax.clone();
+            let leaf_ty = plan.leaves[0].out_ty.syntax().clone();
             let cv_ty: syn::Type = if matches!(plan.shape, UnfoldShape::Optional((), _)) {
                 syn::parse_quote!(Option<#leaf_ty>)
             } else {
@@ -1173,11 +1176,11 @@ fn register_decon_spec<M>(
         // derived from it, never emitted code — so its hoists are discarded.
         &mut Vec::new(),
     )?;
-    require_unique_leaf_names(&source.origin.syntax, &leaves)?;
+    require_unique_leaf_names(source.syntax(), &leaves)?;
     registry.decon_plans.insert(
         decon.clone(),
         DeconSpec {
-            source: source.origin.syntax.clone(),
+            source: source.syntax().clone(),
             leaves,
         },
     );
@@ -1250,11 +1253,11 @@ fn build_plan<M>(
         &mut leaves,
         &mut hoists,
     )?;
-    require_unique_leaf_names(&source.origin.syntax, &leaves)?;
-    require_root_identity_last(by_ref, &source.origin.syntax, &leaves)?;
+    require_unique_leaf_names(source.syntax(), &leaves)?;
+    require_root_identity_last(by_ref, source.syntax(), &leaves)?;
 
     Ok(UnfoldPlan {
-        source: source.origin.syntax.clone(),
+        source: source.syntax().clone(),
         decon: Some(decon),
         by_ref,
         shape,
@@ -1389,7 +1392,7 @@ fn flatten<M>(
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
                 let (takes, _ret) = accessor_signature(registry, func)?;
-                check_takes(func, &takes, &source.origin.syntax)?;
+                check_takes(func, &takes, source.syntax())?;
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
@@ -1576,7 +1579,7 @@ fn flatten<M>(
                     DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
                 let (takes, ret) = accessor_signature(registry, &func)?;
-                check_takes(&func, &takes, &source.origin.syntax)?;
+                check_takes(&func, &takes, source.syntax())?;
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
@@ -1723,9 +1726,9 @@ fn accessor_signature<M>(
         .params
         .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
-    let takes = match &first.ty.kind {
-        crate::api::core::flat::TypeKind::Ref { inner, .. } => inner.origin.syntax.clone(),
-        _ => first.ty.origin.syntax.clone(),
+    let takes = match &first.ty.kind() {
+        crate::api::core::flat::TypeKind::Ref { inner, .. } => inner.syntax().clone(),
+        _ => first.ty.syntax().clone(),
     };
     Ok((takes, f.ret.clone()))
 }
@@ -1761,7 +1764,7 @@ fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
         .flat()
         .function(&func)
         .and_then(|f| f.params.first())
-        .is_some_and(|p| !matches!(p.ty.kind, crate::api::core::flat::TypeKind::Ref { .. }))
+        .is_some_and(|p| !matches!(p.ty.kind(), crate::api::core::flat::TypeKind::Ref { .. }))
 }
 
 fn check_takes(

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -112,12 +112,7 @@ fn accessor_optional_primitive() {
         "z_timestamp_ntp64"
     );
     assert_eq!(
-        plan.leaves[0]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
         "i64"
     );
     assert!(
@@ -175,12 +170,7 @@ fn accessor_plan_byref() {
     assert!(plan.leaves[0].identity);
     assert!(plan.leaves[0].path.is_empty());
     assert_eq!(
-        plan.leaves[0]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
         "& ZKeyExpr"
     );
     // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
@@ -191,12 +181,7 @@ fn accessor_plan_byref() {
         "z_keyexpr_as_str"
     );
     assert_eq!(
-        plan.leaves[1]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[1].out_ty.syntax().to_token_stream().to_string(),
         "& str"
     );
 
@@ -542,12 +527,7 @@ fn nested_accessor_flatten() {
     assert_eq!(path(&plan.leaves[2]), "z_sample_payload.z_zbytes_to_bytes");
     assert_eq!(path(&plan.leaves[3]), "z_sample_kind");
     assert_eq!(
-        plan.leaves[3]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[3].out_ty.syntax().to_token_stream().to_string(),
         "SampleKind"
     );
     assert_eq!(
@@ -685,12 +665,7 @@ fn reply_product_double_option_flatten() {
     // Acc leaf keeping its full `Option<…>` return — not a nesting step.
     assert_eq!(path(&plan.leaves[0]), "z_reply_replier_zid");
     assert_eq!(
-        plan.leaves[0]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
         "Option < ZZenohId >"
     );
     assert!(!plan.leaves[0].nullable && !plan.leaves[0].identity);
@@ -856,12 +831,7 @@ fn iterable_decomposed_plan() {
         "z_zenoh_id_to_string"
     );
     assert_eq!(
-        plan.leaves[0]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
         "String"
     );
     // Identity leaf: owned value (`ZZenohId`, not `&ZZenohId`) since the Vec
@@ -869,12 +839,7 @@ fn iterable_decomposed_plan() {
     assert!(plan.leaves[1].identity);
     assert!(plan.leaves[1].path.is_empty());
     assert_eq!(
-        plan.leaves[1]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[1].out_ty.syntax().to_token_stream().to_string(),
         "ZZenohId"
     );
 }
@@ -1278,12 +1243,7 @@ fn convert_error_decomposes_result_e() {
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(
-        plan.leaves[0]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
         "String"
     );
     assert_eq!(plan.source.to_token_stream().to_string(), "ZError");
@@ -1403,12 +1363,7 @@ fn callback_arg_plan_derived() {
         "z_sample_key_expr"
     );
     assert_eq!(
-        plan.leaves[0]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
         "& ZKeyExpr"
     );
     assert_eq!(
@@ -1416,12 +1371,7 @@ fn callback_arg_plan_derived() {
         "z_keyexpr_as_str"
     );
     assert_eq!(
-        plan.leaves[2]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[2].out_ty.syntax().to_token_stream().to_string(),
         "SampleKind"
     );
     // Leaf out_tys registered so the resolver builds their converters.
@@ -1496,12 +1446,7 @@ fn callback_arg_borrowed_decomposed() {
         "z_sample_key_expr"
     );
     assert_eq!(
-        plan.leaves[2]
-            .out_ty
-            .origin
-            .syntax
-            .to_token_stream()
-            .to_string(),
+        plan.leaves[2].out_ty.syntax().to_token_stream().to_string(),
         "SampleKind"
     );
 }

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -297,7 +297,7 @@ impl CbindgenBuilder {
                     f.ret
                         .walk()
                         .iter()
-                        .any(|t| matches!(t.kind, crate::api::core::flat::TypeKind::Sequence(_)))
+                        .any(|t| matches!(t.kind(), crate::api::core::flat::TypeKind::Sequence(_)))
                 })
                 .unwrap_or(false)
         })

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -852,17 +852,17 @@ impl Declarations {
         // model already normalized them.
         let ret = accessor.ret.borrow_target().unwrap_or(&accessor.ret);
         assert!(
-            !matches!(ret.kind, crate::api::core::flat::TypeKind::Unit),
+            !matches!(ret.kind(), crate::api::core::flat::TypeKind::Unit),
             "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
              value form returns the struct holding this type's fields",
             key.as_str(),
         );
-        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, &ret.origin.syntax) else {
+        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, ret.syntax()) else {
             panic!(
                 "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
                  not a struct — a value form returns a struct whose fields become the leaves",
                 key.as_str(),
-                ret.origin.syntax.to_token_stream(),
+                ret.syntax().to_token_stream(),
             )
         };
         let st = st.clone();
@@ -1001,7 +1001,7 @@ impl Declarations {
             // must decompose into its selector and groups wherever it appears.
             let bare = field.ty.optional_inner().unwrap_or(&field.ty);
             let probe = bare.sequence_elem().unwrap_or(bare);
-            match self.type_kind(registry, &probe.origin.syntax) {
+            match self.type_kind(registry, probe.syntax()) {
                 TypeKind::DataStruct { st, cfg: Some(_) }
                     if field.ty.optional_inner().is_none()
                         && field.ty.sequence_elem().is_none() =>
@@ -1035,7 +1035,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.origin.syntax.to_token_stream(),
+                        probe.syntax().to_token_stream(),
                     );
                     assert!(
                         field.ty.optional_inner().is_none(),
@@ -1048,12 +1048,12 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.origin.syntax.to_token_stream(),
+                        probe.syntax().to_token_stream(),
                         dotted,
                     );
                     // The name is the reading's, not a path taken apart to
                     // re-derive one.
-                    let crate::api::core::flat::TypeKind::Named { id } = &probe.kind else {
+                    let crate::api::core::flat::TypeKind::Named { id } = probe.kind() else {
                         panic!("a sum type is a named type")
                     };
                     let crate::api::core::flat::Type::Variant(sum) = registry

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -49,7 +49,7 @@ pub(crate) fn callback_input(
     let arg_pat_ty: Vec<TokenStream> = args
         .iter()
         .map(|t| {
-            let t = &t.origin.syntax;
+            let t = t.syntax();
             quote!(#t)
         })
         .collect();
@@ -83,7 +83,7 @@ pub(crate) fn callback_input(
             // Every leaf converter must already be resolved (deferral safety).
             // A synthesized leaf (a sum's tag) has no converter to wait for.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                registry.output_entry(&leaf.out_ty.origin.syntax)?;
+                registry.output_entry(leaf.out_ty.syntax())?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             let holder_slash =
@@ -176,7 +176,7 @@ pub(crate) fn callback_input(
             // would make the trampoline wait forever on an `i32` crossing the
             // binding may not have.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                let e = registry.output_entry(&leaf.out_ty.origin.syntax)?;
+                let e = registry.output_entry(leaf.out_ty.syntax())?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;
                 }
@@ -199,7 +199,7 @@ pub(crate) fn callback_input(
         // converter and clone the borrow (the callback only borrows the value). The
         // `data_class` converter composes the whole object via `fromParts`, so the
         // Kotlin `run(t: T)` receives a ready-made `T`.
-        let (cb_val, arg_entry) = match registry.output_entry(&arg_ty.origin.syntax) {
+        let (cb_val, arg_entry) = match registry.output_entry(arg_ty.syntax()) {
             Some(e) => (quote!(#cb_arg), e),
             // A borrow: the callback hands out a reference, and the value is
             // cloned for the JVM.
@@ -227,7 +227,7 @@ pub(crate) fn callback_input(
                 let core = arg_ty.borrow_target()?;
                 (
                     quote!((#cb_arg).clone()),
-                    registry.output_entry(&core.origin.syntax)?,
+                    registry.output_entry(core.syntax())?,
                 )
             }
         };
@@ -318,7 +318,7 @@ pub(crate) fn callback_input(
     // cannot give. Keyed off each arg's own `origin.syntax`, which
     // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax` pins as
     // the SAME identity the signature-derived key produces.
-    let arg_spellings: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
+    let arg_spellings: Vec<syn::Type> = args.iter().map(|a| a.syntax().clone()).collect();
     let spec = ext.iface_spec(registry, &SpecKey::callback(&arg_spellings))?;
     let descr_lit = syn::LitStr::new(&spec.descr, Span::call_site());
     // Local-frame capacity: roughly an encoded wire + a wrapped object per

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -478,7 +478,7 @@ pub(crate) fn reach_leaf_flat(
     // `single_return` in `core/unfold.rs`. `is_plain_field` is what that rules
     // out, and it stays as the local statement of the same fact.
     let reached_is_ours = if leaf.identity {
-        !matches!(leaf.out_ty.origin.syntax, syn::Type::Reference(_))
+        !matches!(leaf.out_ty.syntax(), syn::Type::Reference(_))
     } else {
         consuming
     };
@@ -980,11 +980,11 @@ pub(crate) fn encode_plan_leaves(
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
         let out_entry = registry
-            .output_entry(&leaf.out_ty.origin.syntax)
+            .output_entry(leaf.out_ty.syntax())
             .unwrap_or_else(|| {
                 panic!(
                     "jnigen unfold: leaf `{}` has no registered output converter",
-                    TypeKey::from_type(&leaf.out_ty.origin.syntax)
+                    TypeKey::from_type(leaf.out_ty.syntax())
                 )
             });
         let conv_fail = fail(quote!(__e.to_string()));
@@ -1047,7 +1047,7 @@ pub(crate) fn encode_plan_leaves(
                 panic!(
                     "jnigen unfold: identity leaf `{}` has no projection — \
                      `.accessor_record_id()` requires a ptr_class type",
-                    TypeKey::from_type(&leaf.out_ty.origin.syntax)
+                    TypeKey::from_type(leaf.out_ty.syntax())
                 )
             });
             // The place this handle lives, when it is OURS to give away — the
@@ -1063,7 +1063,7 @@ pub(crate) fn encode_plan_leaves(
             // `Option` through the nullable branch's `match`, which moves the
             // whole `Option` in rather than borrowing it.
             let owned_place: Option<TokenStream> =
-                if !matches!(leaf.out_ty.origin.syntax, syn::Type::Reference(_))
+                if !matches!(leaf.out_ty.syntax(), syn::Type::Reference(_))
                     && steps_are_movable(&path)
                 {
                     let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
@@ -1376,7 +1376,7 @@ pub(crate) fn leaf_is_prim(
     if leaf.nullable {
         return false;
     }
-    leaf_ty_is_prim(registry, &leaf.out_ty.origin.syntax)
+    leaf_ty_is_prim(registry, leaf.out_ty.syntax())
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -96,7 +96,7 @@ pub(crate) fn synth_value_struct_leaves(
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     for field in &s.fields {
         let fname = field.name.as_ref()?.clone();
-        let effective_ty = field.ty.origin.syntax.clone();
+        let effective_ty = field.ty.syntax().clone();
         let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
         let leaf_name = if name_prefix.is_empty() {
             camel

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -187,7 +187,7 @@ pub(crate) fn encode_sum_group(
         .expect("a sum segment carries its selector leaf");
     // The name off the reading — `TypeId` IS the name, so nothing takes a path
     // apart to re-derive one.
-    let crate::api::core::flat::TypeKind::Named { id } = &tag_leaf.out_ty.kind() else {
+    let crate::api::core::flat::TypeKind::Named { id } = tag_leaf.out_ty.kind() else {
         panic!(
             "jnigen sum unfold: selector type `{}` is not a named type",
             tag_leaf.out_ty.key()

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -129,7 +129,7 @@ pub(crate) fn leaf_slot(
         ("I", format_ident!("i"))
     } else {
         let wire = registry
-            .output_entry(&leaf.out_ty.origin.syntax)
+            .output_entry(leaf.out_ty.syntax())
             .expect("leaf_is_prim implies a resolved output entry")
             .destination
             .clone();
@@ -187,7 +187,7 @@ pub(crate) fn encode_sum_group(
         .expect("a sum segment carries its selector leaf");
     // The name off the reading — `TypeId` IS the name, so nothing takes a path
     // apart to re-derive one.
-    let crate::api::core::flat::TypeKind::Named { id } = &tag_leaf.out_ty.kind else {
+    let crate::api::core::flat::TypeKind::Named { id } = &tag_leaf.out_ty.kind() else {
         panic!(
             "jnigen sum unfold: selector type `{}` is not a named type",
             tag_leaf.out_ty.key()
@@ -346,12 +346,12 @@ fn encode_group_leaf(
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
     let out_entry = registry
-        .output_entry(&leaf.out_ty.origin.syntax)
+        .output_entry(leaf.out_ty.syntax())
         .unwrap_or_else(|| {
             panic!(
                 "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
                 leaf.name,
-                TypeKey::from_type(&leaf.out_ty.origin.syntax)
+                TypeKey::from_type(leaf.out_ty.syntax())
             )
         });
     let wire = out_entry.destination.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -60,15 +60,15 @@ pub(crate) fn synth_sum_leaves(
     // returned value. Nothing looks up a converter for it (`has_converter()` is
     // false for a `SumTag`): there is no value to convert, the emitter assigns
     // the tag literal per arm. Its wire is a `jint` by definition.
-    let enum_ident = &sum.name;
     let mut leaves = vec![UnfoldLeaf {
         name: SUM_TAG_LEAF.to_string(),
         path: Vec::new(),
-        // Composed: the tag names WHICH sum it selects over, and no source
-        // wrote that as a standalone type. Nothing resolves a converter for it
-        // (`has_converter()` is false), but the emitter reads it back to find
-        // the enum to `match`.
-        out_ty: crate::api::core::flat::TypeRef::named(enum_ident),
+        // The tag names WHICH sum it selects over, and no source wrote that as
+        // a standalone type — so the DECLARATION answers, rather than this
+        // emitter minting a reading from the name. Nothing resolves a converter
+        // for it (`has_converter()` is false), but the emitter reads it back to
+        // find the enum to `match`.
+        out_ty: sum.type_ref(),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -68,7 +68,7 @@ pub(crate) fn synth_sum_leaves(
         // emitter minting a reading from the name. Nothing resolves a converter
         // for it (`has_converter()` is false), but the emitter reads it back to
         // find the enum to `match`.
-        out_ty: sum.type_ref(),
+        out_ty: sum.type_ref().clone(),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -754,7 +754,7 @@ pub(crate) fn emit_expanded_param(
 
     debug_assert_eq!(plan.leaves.len(), leaves.len());
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
-        let leaf_ty = &leaf.ty.syntax();
+        let leaf_ty = leaf.ty.syntax();
         let lookup_entry = || {
             registry.input_entry(leaf_ty).unwrap_or_else(|| {
                 panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -137,7 +137,7 @@ pub(crate) fn synthetic_getter(
     ident: syn::Ident,
     ret: crate::api::core::flat::TypeRef,
 ) -> crate::api::core::flat::Function {
-    let ret_syntax = &ret.origin.syntax;
+    let ret_syntax = ret.syntax();
     let item: syn::ItemFn = syn::parse_quote! {
         pub fn #ident() -> #ret_syntax {
             unimplemented!()
@@ -146,7 +146,7 @@ pub(crate) fn synthetic_getter(
     crate::api::core::flat::Function {
         name: ident,
         params: Vec::new(),
-        origin: ret.origin.with(item),
+        origin: ret.origin_with(item),
         ret,
     }
 }
@@ -754,7 +754,7 @@ pub(crate) fn emit_expanded_param(
 
     debug_assert_eq!(plan.leaves.len(), leaves.len());
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
-        let leaf_ty = &leaf.ty.origin.syntax;
+        let leaf_ty = &leaf.ty.syntax();
         let lookup_entry = || {
             registry.input_entry(leaf_ty).unwrap_or_else(|| {
                 panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -430,7 +430,7 @@ impl JniFunctionPlan {
         // fail to yield a type.
         for param in &f.params {
             let ident = param.name.clone();
-            let ty = param.ty.origin.syntax.clone();
+            let ty = param.ty.syntax().clone();
 
             let form = if let Some(plan) = registry
                 .expansion_plans()
@@ -495,7 +495,7 @@ impl JniFunctionPlan {
                 InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,
                 InputKind::Callback { .. } => 1,
                 InputKind::Unsigned64 { .. } | InputKind::Plain => registry
-                    .input_entry(&leaf.reading.origin.syntax)
+                    .input_entry(leaf.reading.syntax())
                     .and_then(|entry| JniPrim::from_wire(&entry.destination))
                     .map_or(1, |prim| match prim {
                         JniPrim::Long | JniPrim::Double => 2,
@@ -537,7 +537,7 @@ fn classify_leaf(
 ) -> Result<PlanLeaf, PlanError> {
     // The reading, so the layer questions cannot miss. What generated Rust must
     // spell is `origin.syntax`, unchanged.
-    let ty = &reading.origin.syntax;
+    let ty = reading.syntax();
     let optional = reading.optional_inner().is_some();
     let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(ty));
     let kt_name = kt_param_name(&ident.to_string());
@@ -680,7 +680,7 @@ fn build_output(
     let is_convert = unfold_plan.is_some();
     // The element normalizes an elided return and a written `-> ()` to one
     // `Unit` reading, so there is no `ReturnType` match here.
-    let return_ty: syn::Type = f.ret.origin.syntax.clone();
+    let return_ty: syn::Type = f.ret.syntax().clone();
     let error_plan = registry.error_plans().get(ident);
     let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
     let target_ty = match unfold_plan {
@@ -704,7 +704,7 @@ fn build_output(
     let ret_decl: syn::ReturnType = if is_convert {
         syn::parse_quote!(-> #target_ty)
     } else {
-        let ret = &f.ret.origin.syntax;
+        let ret = &f.ret.syntax();
         syn::parse_quote!(-> #ret)
     };
     let (surface, canonical) = ReturnSurface::classify(ext, registry, &ret_decl);

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -704,7 +704,7 @@ fn build_output(
     let ret_decl: syn::ReturnType = if is_convert {
         syn::parse_quote!(-> #target_ty)
     } else {
-        let ret = &f.ret.syntax();
+        let ret = f.ret.syntax();
         syn::parse_quote!(-> #ret)
     };
     let (surface, canonical) = ReturnSurface::classify(ext, registry, &ret_decl);

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -720,13 +720,12 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable =
-        leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty.origin.syntax);
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, leaf.out_ty.syntax());
     leaf_iface_param(
         ext,
         registry,
         name,
-        &leaf.out_ty.origin.syntax,
+        leaf.out_ty.syntax(),
         leaf.nullable || inert_nullable,
         true,
     )
@@ -1151,12 +1150,12 @@ pub(crate) fn callback_iface_spec(
                 any_fixed = true;
                 // Peeled off the reading — `borrow_target` is the model's
                 // answer to "is this a borrow", not a syn match.
-                let core = t.borrow_target().unwrap_or(t).origin.syntax.clone();
+                let core = t.borrow_target().unwrap_or(t).syntax().clone();
                 let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
                 let (reassemble, imports) =
                     fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
                 groups.push(GroupDesc {
-                    name: whole_value_name(&t.origin.syntax, i),
+                    name: whole_value_name(t.syntax(), i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
                     reassemble: Some(reassemble),
                     imports,
@@ -1182,12 +1181,11 @@ pub(crate) fn callback_iface_spec(
                     };
                     if leaf.source == LeafSource::SumTag {
                         any_fixed = true;
-                        let fqn =
-                            ext.kotlin_fqn(&TypeKey::from_type(&leaf.out_ty.origin.syntax))?;
+                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(leaf.out_ty.syntax()))?;
                         let (reassemble, imports) = fixed_reassembly(
                             ext,
                             registry,
-                            &leaf.out_ty.origin.syntax,
+                            leaf.out_ty.syntax(),
                             &plan.leaves[k..seg],
                             &fqn,
                         );
@@ -1229,18 +1227,18 @@ pub(crate) fn callback_iface_spec(
             // A plan-less opaque-handle arg is delivered as a raw `jlong` and
             // wrapped + closed Kotlin-side (Phase 3 — no Rust `new_object`).
             let owned_handle = registry
-                .output_entry(&t.origin.syntax)
+                .output_entry(t.syntax())
                 .and_then(|e| e.metadata.projection.as_ref())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
-                name: whole_value_name(&t.origin.syntax, i),
-                ty: t.origin.syntax.clone(),
+                name: whole_value_name(t.syntax(), i),
+                ty: t.syntax().clone(),
                 nullable: t.optional_inner().is_some(),
                 owned_handle,
             });
             groups.push(GroupDesc {
-                name: whole_value_name(&t.origin.syntax, i),
+                name: whole_value_name(t.syntax(), i),
                 typed: None,
                 reassemble: None,
                 imports: Vec::new(),
@@ -1297,14 +1295,14 @@ pub(crate) fn callback_iface_spec(
             "{}Callback",
             cb_args
                 .iter()
-                .map(|t| subject_short(&t.origin.syntax))
+                .map(|t| subject_short(t.syntax()))
                 .collect::<Vec<_>>()
                 .join("")
         )
     };
     let package = cb_args
         .first()
-        .map(|t| subject_package(ext, &t.origin.syntax))
+        .map(|t| subject_package(ext, t.syntax()))
         .unwrap_or_else(|| ext.package.clone());
     Some(IfaceSpec {
         typed_groups,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -791,7 +791,7 @@ impl Declarations {
         // The field's own reading: the nullability question below is answered
         // from `kind`, so a wrapped spelling answers as the bare one does and
         // nothing is looked up (#275).
-        let field_ty = &field.ty.syntax();
+        let field_ty = field.ty.syntax();
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
         let out = registry.output_entry(field_ty).unwrap_or_else(|| {
             panic!(

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -791,7 +791,7 @@ impl Declarations {
         // The field's own reading: the nullability question below is answered
         // from `kind`, so a wrapped spelling answers as the bare one does and
         // nothing is looked up (#275).
-        let field_ty = &field.ty.origin.syntax;
+        let field_ty = &field.ty.syntax();
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
         let out = registry.output_entry(field_ty).unwrap_or_else(|| {
             panic!(
@@ -1519,9 +1519,9 @@ impl Declarations {
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
-        if self.is_kotlin_enum(&enum_probe_type(&leaf.out_ty.origin.syntax)) {
-            let inner = option_inner_type(&leaf.out_ty.origin.syntax)
-                .unwrap_or_else(|| leaf.out_ty.origin.syntax.clone());
+        if self.is_kotlin_enum(&enum_probe_type(leaf.out_ty.syntax())) {
+            let inner = option_inner_type(leaf.out_ty.syntax())
+                .unwrap_or_else(|| leaf.out_ty.syntax().clone());
             let name = registry
                 .output_entry(&inner)
                 .and_then(|e| e.metadata.kotlin_name.clone())

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1069,7 +1069,7 @@ fn classify_params(
     let mut params: Vec<Param> = Vec::new();
     for leaf in fplan.leaves() {
         let mut name = leaf.kt_name.clone();
-        let arg_ty = &leaf.reading.syntax();
+        let arg_ty = leaf.reading.syntax();
 
         // Instance-method receiver: the first parameter whose peeled Rust type
         // is the owning class binds to `this` (so `this_ptr`/`this.ptr`/lock or

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -123,7 +123,7 @@ pub(crate) fn build_data_class(
         // disagreed. Reject it at the declaration instead.
         if !matches!(pf.kind, PlanFieldKind::Projection { .. }) {
             if let Some(proj) = registry
-                .input_entry(&field.ty.origin.syntax)
+                .input_entry(field.ty.syntax())
                 .and_then(|e| e.metadata.projection.clone())
             {
                 panic!(
@@ -1069,7 +1069,7 @@ fn classify_params(
     let mut params: Vec<Param> = Vec::new();
     for leaf in fplan.leaves() {
         let mut name = leaf.kt_name.clone();
-        let arg_ty = &leaf.reading.origin.syntax;
+        let arg_ty = &leaf.reading.syntax();
 
         // Instance-method receiver: the first parameter whose peeled Rust type
         // is the owning class binds to `this` (so `this_ptr`/`this.ptr`/lock or

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -50,7 +50,7 @@ impl Declarations {
         // comes from here. The converter yields this spelling, so a
         // `Box<Option<T>>` crossing produces a `Box<Option<T>>` — the shape it
         // is dispatched as no longer decides what it is called.
-        let syntax = &ty.origin.syntax;
+        let syntax = ty.syntax();
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
         if let Some(c) = self.input_terminal(ty, registry) {
@@ -66,13 +66,13 @@ impl Declarations {
             // that resolves correctly wins.
             if let Some(target) = inner.borrow_target() {
                 let mutable = matches!(
-                    inner.kind,
+                    inner.kind(),
                     crate::api::core::flat::TypeKind::Ref {
                         mode: RefMode::Exclusive,
                         ..
                     }
                 );
-                let t1 = target.origin.syntax.clone();
+                let t1 = target.syntax().clone();
                 if let Some(mut c) = self.input_wrapper_shape(
                     WrapperShape::OptionRef { mutable },
                     syntax,
@@ -91,14 +91,14 @@ impl Declarations {
             // wrapped optional borrow stops here rather than resolving wrong.
             if inner.borrow_target().is_some() {
                 let canonical: syn::Type = {
-                    let b = &inner.origin.syntax;
+                    let b = inner.syntax();
                     syn::parse_quote!(Option<#b>)
                 };
                 if syntax.to_token_stream().to_string() != canonical.to_token_stream().to_string() {
                     return None;
                 }
             }
-            let inner_ty = inner.origin.syntax.clone();
+            let inner_ty = inner.syntax().clone();
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Optional, syntax, &inner_ty, registry)
             {
@@ -108,7 +108,7 @@ impl Declarations {
             return None;
         }
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(syntax)) {
-            let elem_ty = elem.origin.syntax.clone();
+            let elem_ty = elem.syntax().clone();
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Sequence, syntax, &elem_ty, registry)
             {
@@ -117,7 +117,7 @@ impl Declarations {
             }
             return None;
         }
-        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = &ty.kind {
+        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = ty.kind() {
             // `&[T]` shared slice borrow: there is no owned `[T]` to decode, so
             // reuse the `Vec<_>` shape — decode the Java `List<T>` into an owned
             // `Vec<T>`; the call site borrows it (`&Vec<T>` deref-coerces to
@@ -138,9 +138,9 @@ impl Declarations {
             // NOT: passing `&Vec<T>` there does not compile. Those fall through to
             // the plain borrow arm below, which hands the whole spelling on as the
             // sub, exactly as the old syntactic slice check did.
-            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(&inner.origin.syntax) {
+            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(inner.syntax()) {
                 if let Some(elem) = inner.sequence_elem() {
-                    let elem_ty = elem.origin.syntax.clone();
+                    let elem_ty = elem.syntax().clone();
                     // The one place `produced` is NOT the crossing's spelling:
                     // there is no owned `[T]` to decode into, so the converter
                     // yields an owned `Vec<T>` and the call site borrows it.
@@ -158,7 +158,7 @@ impl Declarations {
                 }
             }
             let mutable = matches!(mode, RefMode::Exclusive);
-            let t1 = inner.origin.syntax.clone();
+            let t1 = inner.syntax().clone();
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, &t1, registry)
             {
@@ -184,7 +184,7 @@ impl Declarations {
         // detected its layers with `option_inner_type`/`vec_inner_type`, which
         // read the last path segment's ident. A `Box<Option<T>>` answered
         // "neither", and got no converter at all (#270).
-        let syntax = &ty.origin.syntax;
+        let syntax = ty.syntax();
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
         if let Some(c) = self.output_terminal(ty, registry) {
@@ -204,7 +204,7 @@ impl Declarations {
         //    whose inner converter is the `&Handle` borrow entry (no deep
         //    output handler).
         if let Some(inner) = ty.optional_inner() {
-            let inner_ty = inner.origin.syntax.clone();
+            let inner_ty = inner.syntax().clone();
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Optional, syntax, &inner_ty, registry)
             {
@@ -214,7 +214,7 @@ impl Declarations {
             return None;
         }
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(syntax)) {
-            let elem_ty = elem.origin.syntax.clone();
+            let elem_ty = elem.syntax().clone();
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Sequence, syntax, &elem_ty, registry)
             {
@@ -223,19 +223,19 @@ impl Declarations {
             }
             return None;
         }
-        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = &ty.kind {
+        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = ty.kind() {
             // `&[T]` shared slice (a callback argument crossing native→JVM):
             // build a `List<T>` from the borrowed slice. Dual of the `&[T]`
             // input branch, and the same split: `kind` says it is a borrow of a
             // run of values; whether the generated Rust can iterate the borrow
             // directly is a question about the SPELLING.
-            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(&inner.origin.syntax) {
+            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(inner.syntax()) {
                 if let Some(elem) = inner.sequence_elem() {
-                    return self.output_slice(&elem.origin.syntax, registry);
+                    return self.output_slice(elem.syntax(), registry);
                 }
             }
             let mutable = matches!(mode, RefMode::Exclusive);
-            let t1 = inner.origin.syntax.clone();
+            let t1 = inner.syntax().clone();
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, &t1, registry)
             {
@@ -264,8 +264,8 @@ fn fallible_parts(
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Type)> {
     use crate::api::core::flat::TypeKind;
-    if let Some(TypeKind::Fallible { ok, err }) = registry.flat().type_ref(ty).map(|t| &t.kind) {
-        return Some((ok.origin.syntax.clone(), err.origin.syntax.clone()));
+    if let Some(TypeKind::Fallible { ok, err }) = registry.flat().type_ref(ty).map(|t| t.kind()) {
+        return Some((ok.syntax().clone(), err.syntax().clone()));
     }
     crate::api::core::types_util::result_parts(ty)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -225,7 +225,7 @@ pub(crate) fn classify_field(
     // classified this type. Taking a `syn::Type` meant asking the registry per
     // question, and a type it had never seen answered "no layer" rather than
     // saying so — which is the missing `?` of #273 waiting to happen again.
-    let effective_ty = reading.origin.syntax.clone();
+    let effective_ty = reading.syntax().clone();
 
     // A sum is classified FIRST, because it is the one kind with no converter
     // of its own: it crosses as a tag plus one leaf group per variant, never
@@ -244,9 +244,9 @@ pub(crate) fn classify_field(
     // other about the same field (#273).
     let optional_inner = reading.optional_inner();
     let bare_ref = optional_inner.unwrap_or(reading);
-    let bare = bare_ref.origin.syntax.clone();
+    let bare = bare_ref.syntax().clone();
     let seq_elem = bare_ref.sequence_elem();
-    let core = seq_elem.map_or_else(|| bare.clone(), |e| e.origin.syntax.clone());
+    let core = seq_elem.map_or_else(|| bare.clone(), |e| e.syntax().clone());
     if matches!(ext.type_kind(registry, &core), TypeKind::Sum) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by
@@ -282,7 +282,7 @@ pub(crate) fn classify_field(
             return Some(PlanFieldKind::Enum { conv, kotlin });
         }
         // `Option<enum>` leaf.
-        if let Some(inner) = optional_inner.map(|i| i.origin.syntax.clone()) {
+        if let Some(inner) = optional_inner.map(|i| i.syntax().clone()) {
             if ext.is_kotlin_enum(&inner) {
                 let kotlin = registry
                     .output_entry(&inner)?
@@ -322,8 +322,8 @@ pub(crate) fn classify_field(
             None => {
                 // Object-shaped wire with no fixed descriptor; the JVM slot
                 // must be the field's actual declared type (Option-stripped).
-                let slot_ty = optional_inner
-                    .map_or_else(|| effective_ty.clone(), |i| i.origin.syntax.clone());
+                let slot_ty =
+                    optional_inner.map_or_else(|| effective_ty.clone(), |i| i.syntax().clone());
                 let descriptor = registry
                     .output_entry(&slot_ty)
                     .and_then(|e| jni_field_access(&e.destination))

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -621,7 +621,7 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
     let cb = f
         .params
         .iter()
-        .find_map(|p| match &p.ty.kind() {
+        .find_map(|p| match p.ty.kind() {
             crate::api::core::flat::TypeKind::Callback { args } => Some((p, args)),
             _ => None,
         })

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -621,7 +621,7 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
     let cb = f
         .params
         .iter()
-        .find_map(|p| match &p.ty.kind {
+        .find_map(|p| match &p.ty.kind() {
             crate::api::core::flat::TypeKind::Callback { args } => Some((p, args)),
             _ => None,
         })
@@ -632,11 +632,11 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
     let from_reading = SpecKey::callback(
         &arg_readings
             .iter()
-            .map(|a| a.origin.syntax.clone())
+            .map(|a| a.syntax().clone())
             .collect::<Vec<_>>(),
     );
     let from_syntax = SpecKey::callback(
-        &crate::api::core::registry::extract_fn_trait_args(&param.ty.origin.syntax)
+        &crate::api::core::registry::extract_fn_trait_args(param.ty.syntax())
             .expect("the param is an impl Fn"),
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -241,7 +241,7 @@ fn deriving_matches_the_equivalent_hand_written_list() {
             .map(|l| {
                 (
                     l.name.clone(),
-                    l.out_ty.origin.syntax.to_token_stream().to_string(),
+                    l.out_ty.syntax().to_token_stream().to_string(),
                 )
             })
             .collect()

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1188,7 +1188,7 @@ impl Declarations {
                 // rides `immediate_edges` rather than this converter's `subs`.
                 // The arguments are `TypeRef`s on the classification, so nothing
                 // is re-extracted from the signature's syntax.
-                let crate::api::core::flat::TypeKind::Callback { args } = &reading.kind else {
+                let crate::api::core::flat::TypeKind::Callback { args } = reading.kind() else {
                     return None;
                 };
                 self.dispatch_fn_input(args, built)
@@ -1361,7 +1361,7 @@ impl Declarations {
             // `Vec<T>` / `Option<Vec<T>>` return. The model's `ret` already
             // normalizes an elided return to `()`, so there is no arm for it.
             {
-                let ret = &f.ret.origin.syntax;
+                let ret = f.ret.syntax();
                 let after_opt =
                     crate::api::core::types_util::option_inner_type(ret).unwrap_or(ret.clone());
                 if let Some(elem) = crate::api::core::types_util::vec_inner_type(&after_opt) {
@@ -1393,7 +1393,7 @@ impl Declarations {
         args: &[crate::api::core::flat::TypeRef],
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let spellings: Vec<syn::Type> = args.iter().map(|a| a.origin.syntax.clone()).collect();
+        let spellings: Vec<syn::Type> = args.iter().map(|a| a.syntax().clone()).collect();
         let outer_ty = build_fn_type(&spellings);
         let (wire, body) = callback_input(self, args, registry)?;
         let niches = default_niches_for_wire(&wire);
@@ -1800,7 +1800,7 @@ impl Declarations {
         // Classify off `kind`, spell off `syntax`: the arms below that ask what
         // a type IS use `reading`, and everything that has to name it in
         // generated Rust uses this.
-        let ty = &reading.origin.syntax;
+        let ty = reading.syntax();
         // Structured-config overrides first (opaque handles, then user-
         // registered rank-0 wrappers, then built-ins).
         let key = TypeKey::from_type(ty);
@@ -1893,7 +1893,7 @@ impl Declarations {
         // `str` is handled above, separately and deliberately: it is unsized,
         // so its converter yields an owned `String` the call site borrows —
         // a different contract, not a different spelling.
-        if matches!(reading.kind, crate::api::core::flat::TypeKind::Str) {
+        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Str) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 let s = env.get_string(v).map_err(|e| {
@@ -2021,7 +2021,7 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell off `syntax` — see `input_terminal`.
-        let ty = &reading.origin.syntax;
+        let ty = reading.syntax();
         // Structured-config overrides first (opaque handles, then built-ins).
         let key = TypeKey::from_type(ty);
         if let Some(cfg) = self.types.get(&key) {
@@ -2091,7 +2091,7 @@ impl Declarations {
         // Plain `String` keeps its own earlier arm in `primitive_output`, whose
         // body this matches exactly; this one is reached for the wrapped
         // spellings that arm's key cannot name.
-        if matches!(reading.kind, crate::api::core::flat::TypeKind::Str) {
+        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Str) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 env.new_string(v.as_str()).map_err(|e| {
@@ -2123,7 +2123,7 @@ impl Declarations {
         // Wire is `()`. Body just returns `v`. No Kotlin name — Unit
         // returns are dropped from emitted signatures, so metadata stays
         // empty.
-        if matches!(reading.kind, crate::api::core::flat::TypeKind::Unit) {
+        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Unit) {
             let wire: syn::Type = syn::parse_quote!(());
             let body: syn::Expr = syn::parse_quote!(v);
             return Some(ConverterImpl {


### PR DESCRIPTION
## What

`TypeRef` was `pub struct { pub kind, pub origin }`, re-exported at `prebindgen::core::flat`, plus four public composers from #278. Anyone could assemble one, and nothing checked `kind` agreed with `origin.syntax` — so holding a `TypeRef` proved nothing.

**The invariant it now carries:**

> Every `TypeRef` was classified by the model. `Flat` classified it from source syntax, or the registry composed it by layering over something already classified. Nothing above the model can mint one.

Fields are `pub(super)`, composers `pub(crate)`, reads go through `kind()` / `syntax()` / `location()`. **There is no cheaper version**: a public field *is* a constructor, so restricting only the composers would block nothing.

## Why this shape, and not a handle

The invariant is **unconditional** — no phase, no lifetime, no direction — which is what makes it hold for a **stored** value. That was the requirement, and it rules out the alternatives considered:

- **`TypeRef` as a registry index** would push a registry argument into ~242 read sites, contradicting "`TypeRef` carries all information about the type".
- **A borrow-carrying `Resolved<'r, D>` token** cannot be stored — and `TypeRef` lives in `UnfoldLeaf::out_ty` / `FoldLeaf::ty`, inside plans *the registry itself stores*, so it would make the registry self-referential.

## What it deliberately does not claim

Not *"the converters exist"*. That is **false by design** for stored readings, and both mechanisms are load-bearing:

- `unrequire_output` exists precisely to leave a cell whose converter cannot resolve — for a `Vec<opaque-handle>` delivered element-by-element, "a `jlong` wire is not JObject-shaped, so requiring it would wrongly fail resolution" (`scan.rs:464-472`).
- `SumTag` leaves never have one (`unfold/plan.rs:342`).

So converter existence stays a lookup answering `Option`. The relation is **0..2, not 1-to-1**: separate input/output tables; `normalize_type` does *not* erase transparent wrappers (that is a `kind` rule), so `String` and `Box<String>` are two cells with **identical `kind`**; and distinct entries can share one emitted converter (`input_borrow`). Identity stays `TypeKey`.

## Acceptance

Two `compile_fail` doctests, each **verified to fail on privacy specifically** rather than incidentally:

- `E0451` — fields `kind` and `origin` of struct `TypeRef` are private
- `E0624` — associated function `scalar` is private

`grep -rn "TypeRef {"` shows construction only under `api/core/flat/`.

## Mechanics

172 read sites migrated by walking **rustc's own E0616 spans**, not by pattern-matching text — so no site was missed and none was guessed. Two `&`-artifacts of the rename would have compiled while cloning a *reference* instead of a value; `suspicious_double_ref_op` caught both. A third only appeared under `--all-features`.

Also fixes 6 doc links this would have broken, plus 2 already broken (rustdoc errors 37 → 35).

## Verification

- `cargo test` and `cargo test --all --all-features` — 14/14 suites, 550 lib tests
- `cargo clippy --all-targets --no-default-features --all-features -- --deny warnings` — clean
- `cargo fmt --check` with the CI CLI config
- **`./examples/regen-check.sh` after `git clean -fd examples/` + `cargo clean -p` — byte-identical**
- `covertest-kotlin` — 48/48
- `boundary_ledger` unchanged at 127 (this migration is invisible to it — the ledger counts syn *variant mentions*, and a field access names none; that gap is what step 3 of the plan addresses)

## Next

Part of #229. Follow-ups, in order: composition moves into `Registry` as total (infallible) layering methods, closing the bug where a composed reading is discarded and independently re-derived; then a new token-walking census for `syn::Type` stored/composed above the model, which the existing ledger structurally cannot see.