### PR TITLE
The registration path carries readings instead of re-deriving them

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -313,7 +313,7 @@ fn process_expand<M>(
     )?;
 
     for leaf in &plan.leaves {
-        registry.require_input(leaf.ty.syntax());
+        registry.require_input(&leaf.ty);
     }
     registry
         .expansion_plans

--- a/prebindgen/src/api/core/registry/order.rs
+++ b/prebindgen/src/api/core/registry/order.rs
@@ -64,15 +64,21 @@ impl<M> Registry<M> {
         let mut edges: Vec<Crossing> = self
             .immediate_edges(dir, &ty)
             .into_iter()
-            .chain(self.plan_edges(dir, &ty))
+            // The structural edges arrive as readings, so the key is the
+            // model's own answer rather than one re-derived from a spelling.
+            .map(|(d, t)| (d, t.key()))
+            .chain(
+                self.plan_edges(dir, &ty)
+                    .into_iter()
+                    .map(|(d, t)| (d, TypeKey::from_type(&t))),
+            )
             .chain(
                 self.declared
                     .edges
                     .iter()
                     .filter(|(from, _)| *from == node)
-                    .map(|(_, on)| (on.0, on.1.to_type())),
+                    .map(|(_, on)| (on.0, on.1.clone())),
             )
-            .map(|(d, t)| (d, TypeKey::from_type(&t)))
             // Only crossings the scan actually registered: a structural edge to
             // a type nothing asked for is not a crossing.
             .filter(|c| self.type_table(c.0).contains_key(&c.1))

--- a/prebindgen/src/api/core/registry/run.rs
+++ b/prebindgen/src/api/core/registry/run.rs
@@ -59,9 +59,10 @@ impl<M> Registry<M> {
         // Drop it both ways; the cell stays, so a converter is still produced
         // if one happens to resolve.
         for key in &declared.decompositions.replaces {
-            let ty = key.to_type();
-            self.unrequire_input(&ty);
-            self.unrequire_output(&ty);
+            // The key is what a root flag is stored under, so it goes straight
+            // in — no `to_type()` round trip to be re-keyed on the far side.
+            self.clear_root(Direction::Input, key);
+            self.clear_root(Direction::Output, key);
         }
         Ok(())
     }

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -316,6 +316,22 @@ impl<M> Registry<M> {
         ty: &syn::Type,
         root: bool,
     ) -> Result<crate::api::core::flat::TypeRef, ScanError> {
+        // The registry's own answer first, in EITHER direction — a reading is
+        // direction-free, and a cell that exists already holds the authoritative
+        // one. Classifying anyway would derive a second reading for a key that
+        // has one, which `ensure_entry` would then discard: the same
+        // two-answers-that-never-meet shape this PR removes, surviving as
+        // redundant work rather than as a replaced cell.
+        let key = TypeKey::from_type(ty);
+        if let Some(known) = self
+            .input_types
+            .get(&key)
+            .or_else(|| self.output_types.get(&key))
+            .map(|c| (*c.subject).clone())
+        {
+            self.ensure_entry(dir, &known, root);
+            return Ok(known);
+        }
         let reading = self
             .flat
             .classify(ty)
@@ -523,25 +539,20 @@ impl<M> Registry<M> {
     /// the whole-collection converter is genuinely not needed — and for a
     /// `Vec<opaque-handle>` it cannot resolve at all (a `jlong` wire is not
     /// JObject-shaped), so requiring it would wrongly fail resolution.
-    pub(crate) fn unrequire_output(&mut self, ty: &syn::Type) {
-        self.clear_root(Direction::Output, ty);
+    pub(crate) fn unrequire_output(&mut self, reading: &crate::api::core::flat::TypeRef) {
+        self.clear_root(Direction::Output, &reading.key());
     }
 
-    /// Drop `ty` from the required-input scan set — the input-side peer of
-    /// [`Self::unrequire_output`]. Used by [`Self::apply_adapter_plans`] for
-    /// the adapter's boundary-only types: a fold plan replaces every direct
-    /// crossing of the type with its ingredients, so the type's own input
-    /// converter is genuinely not needed (and for an undeclared type cannot
-    /// resolve at all).
-    pub(crate) fn unrequire_input(&mut self, ty: &syn::Type) {
-        self.clear_root(Direction::Input, ty);
-    }
-
-    /// Stop treating `ty` as a root. The cell stays, so the resolver still fills
-    /// it if it can — only the demand that it *must* resolve is dropped.
-    pub(super) fn clear_root(&mut self, dir: Direction, ty: &syn::Type) {
-        let key = TypeKey::from_type(ty);
-        if let Some(cell) = self.type_table_mut(dir).get_mut(&key) {
+    /// Stop treating `key` as a root. The cell stays, so the resolver still
+    /// fills it if it can — only the demand that it *must* resolve is dropped.
+    ///
+    /// Keyed, because that is genuinely all this needs: un-requiring creates no
+    /// cell and classifies nothing, so it is the one registration-adjacent
+    /// operation with no reading to carry. `unrequire_*` take a `TypeRef` anyway
+    /// — they pair with `require_*`, and a caller holding one should not have to
+    /// know which of the two wants a key.
+    pub(super) fn clear_root(&mut self, dir: Direction, key: &TypeKey) {
+        if let Some(cell) = self.type_table_mut(dir).get_mut(key) {
             cell.root = false;
         }
     }

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -302,7 +302,15 @@ impl<M> Registry<M> {
     ///
     /// A spelling the grammar refuses is reported by name here, rather than
     /// becoming a cell that quietly means less than its neighbours.
-    pub(crate) fn intern(
+    ///
+    /// **`pub(in crate::api::core)` deliberately**, matching
+    /// `Flat::classify` and the `TypeRef` composers. Classifying a spelling
+    /// *mints a reading*, and #280 sealed that to `api::core`: an adapter under
+    /// `api::lang` must not be able to hand the registry tokens of its own and
+    /// receive a `TypeRef` back. A one-door design that widened the door would
+    /// have re-opened exactly the capability #280 closed — so this must stay no
+    /// wider than the composers it replaces as an entry point.
+    pub(in crate::api::core) fn intern(
         &mut self,
         dir: Direction,
         ty: &syn::Type,

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -102,7 +102,7 @@ impl<M> Registry<M> {
         // the type is required in the output direction only.
         for ident in declared.consts.iter().flatten() {
             if let Some(item_const) = self.flat.constant(&ident).map(|c| c.origin.syntax.clone()) {
-                self.ensure_entry(Direction::Output, &item_const.ty, true)?;
+                self.intern(Direction::Output, &item_const.ty, true)?;
             } else {
                 missing.push(("constant", ident.to_string()));
             }
@@ -116,7 +116,7 @@ impl<M> Registry<M> {
         // Declared crossings with no element behind them (a foreign class type,
         // a synthesized constant's value type), each in its own direction.
         for (dir, ty) in &declared.crossings {
-            self.ensure_entry(*dir, ty, true)?;
+            self.intern(*dir, ty, true)?;
         }
 
         // Scan declared types.
@@ -130,13 +130,13 @@ impl<M> Registry<M> {
                     .map(|s| s.origin.syntax.clone())
                 {
                     self.scan_struct(&s)?;
-                    self.ensure_entry(Direction::Input, &ty, true)?;
-                    self.ensure_entry(Direction::Output, &ty, true)?;
+                    self.intern(Direction::Input, &ty, true)?;
+                    self.intern(Direction::Output, &ty, true)?;
                     matched = true;
                 } else if let Some(e) = self.flat.enum_item(&ident).cloned() {
                     self.scan_enum(&e)?;
-                    self.ensure_entry(Direction::Input, &ty, true)?;
-                    self.ensure_entry(Direction::Output, &ty, true)?;
+                    self.intern(Direction::Input, &ty, true)?;
+                    self.intern(Direction::Output, &ty, true)?;
                     matched = true;
                 }
             }
@@ -145,8 +145,8 @@ impl<M> Registry<M> {
                 // `ptr_class(ZKeyExpr<'static>)` on a re-exported
                 // foreign type). Still mark required so the resolver
                 // tries to produce a converter for it.
-                self.ensure_entry(Direction::Input, &ty, true)?;
-                self.ensure_entry(Direction::Output, &ty, true)?;
+                self.intern(Direction::Input, &ty, true)?;
+                self.intern(Direction::Output, &ty, true)?;
             }
         }
 
@@ -168,7 +168,7 @@ impl<M> Registry<M> {
             match input {
                 syn::FnArg::Receiver(_) => continue,
                 syn::FnArg::Typed(pt) => {
-                    self.register_type_recursive(Direction::Input, &pt.ty, true)?;
+                    self.intern_recursive(Direction::Input, &pt.ty, true)?;
                 }
             }
         }
@@ -176,20 +176,20 @@ impl<M> Registry<M> {
             syn::ReturnType::Default => syn::parse_quote!(()),
             syn::ReturnType::Type(_, ty) => (**ty).clone(),
         };
-        self.register_type_recursive(Direction::Output, &ret_ty, true)?;
+        self.intern_recursive(Direction::Output, &ret_ty, true)?;
         Ok(())
     }
 
     pub(super) fn scan_struct(&mut self, s: &syn::ItemStruct) -> Result<(), ScanError> {
         // The struct itself can appear in either direction.
         let ty: syn::Type = crate::api::core::flat::type_from_ident(&s.ident);
-        self.ensure_entry(Direction::Input, &ty, false)?;
-        self.ensure_entry(Direction::Output, &ty, false)?;
+        self.intern(Direction::Input, &ty, false)?;
+        self.intern(Direction::Output, &ty, false)?;
 
         if let syn::Fields::Named(named) = &s.fields {
             for field in &named.named {
-                self.register_type_recursive(Direction::Input, &field.ty, false)?;
-                self.register_type_recursive(Direction::Output, &field.ty, false)?;
+                self.intern_recursive(Direction::Input, &field.ty, false)?;
+                self.intern_recursive(Direction::Output, &field.ty, false)?;
             }
         }
         Ok(())
@@ -197,13 +197,13 @@ impl<M> Registry<M> {
 
     pub(super) fn scan_enum(&mut self, e: &syn::ItemEnum) -> Result<(), ScanError> {
         let ty: syn::Type = crate::api::core::flat::type_from_ident(&e.ident);
-        self.ensure_entry(Direction::Input, &ty, false)?;
-        self.ensure_entry(Direction::Output, &ty, false)?;
+        self.intern(Direction::Input, &ty, false)?;
+        self.intern(Direction::Output, &ty, false)?;
 
         for variant in &e.variants {
             for field in &variant.fields {
-                self.register_type_recursive(Direction::Input, &field.ty, false)?;
-                self.register_type_recursive(Direction::Output, &field.ty, false)?;
+                self.intern_recursive(Direction::Input, &field.ty, false)?;
+                self.intern_recursive(Direction::Output, &field.ty, false)?;
             }
         }
         Ok(())
@@ -215,72 +215,100 @@ impl<M> Registry<M> {
     pub(super) fn register_type_recursive(
         &mut self,
         dir: Direction,
-        ty: &syn::Type,
+        reading: &crate::api::core::flat::TypeRef,
         root: bool,
-    ) -> Result<(), ScanError> {
+    ) {
         let mut visited: HashSet<TypeKey> = HashSet::new();
-        self.register_type_inner(dir, ty, root, &mut visited)
+        self.register_type_inner(dir, reading, root, &mut visited)
     }
 
+    /// Infallible, and structurally so: every type reached here is a reading —
+    /// the caller's, or one the model already holds for a child — so there is
+    /// nothing left to classify and nothing left to refuse.
     pub(super) fn register_type_inner(
         &mut self,
         dir: Direction,
-        ty: &syn::Type,
+        reading: &crate::api::core::flat::TypeRef,
         is_top: bool,
         visited: &mut HashSet<TypeKey>,
-    ) -> Result<(), ScanError> {
-        // A disallowed `impl Trait` cannot reach here: every fn whose signature
-        // reaches this point passed the frontend's grammar — captured items at
-        // ingestion, binding-local ones at synthesis — and it names the
-        // parameter the bad type sits on.
-
-        let key = TypeKey::from_type(ty);
-        if !visited.insert(key.clone()) {
-            return Ok(()); // cycle guard
+    ) {
+        let key = reading.key();
+        if !visited.insert(key) {
+            return; // cycle guard
         }
 
-        self.ensure_entry(dir, ty, is_top)?;
+        self.ensure_entry(dir, reading, is_top);
 
-        for (child_dir, sub) in self.immediate_edges(dir, ty) {
-            self.register_type_inner(child_dir, &sub, false, visited)?;
+        for (child_dir, sub) in self.immediate_edges(dir, reading.syntax()) {
+            self.register_type_inner(child_dir, &sub, false, visited);
         }
-        Ok(())
     }
 
-    /// Create the cell for `ty` in `dir` if it has none, and mark it a root when
-    /// the binding asked for it directly.
+    /// Create the cell for `reading` in `dir` if it has none, and mark it a root
+    /// when the binding asked for it directly.
     ///
     /// The one place a cell is born, and therefore the one place a type **enters
-    /// the pipeline** — including a spelling the source never wrote, since expansion
-    /// composes those (an `Option<T>` around a `T` it found) and hands them straight
-    /// here via `require_input` / `require_output`.
+    /// the pipeline** — including a spelling the source never wrote, since
+    /// expansion composes those (an `Option<T>` around a `T` it found) and hands
+    /// them straight here via `require_input` / `require_output`.
     ///
-    /// The reading is taken **here, once**, and lives in the cell. The model is
-    /// consulted for it — [`Flat::classify`](crate::api::core::flat::Flat::classify)
-    /// is the grammar's one answer — but the model is not extended: a composed
-    /// spelling is an intermediate in *this binding's* crossing graph, not something
-    /// the source API mentions, and the table that tracks crossings is where it
-    /// belongs. So `Flat` stays what the source said, and every type the pipeline
-    /// works with has its reading in the table by the time the builder is finished.
+    /// **The caller's reading is what gets stored.** It is not re-derived from
+    /// the spelling, and that is the point (#281): the reading a caller holds and
+    /// the one `classify` would produce for its spelling are two answers from two
+    /// paths, and nothing was comparing them. Now there is only one answer,
+    /// because there is only one classification.
     ///
-    /// A spelling the grammar refuses is reported by name, rather than becoming a
-    /// cell that quietly means less than its neighbours. Only an *entry point* can
-    /// reach that: a type the walk found came from an existing reading's
-    /// `origin.syntax`, so it lowered once already.
+    /// Which is also why this is **infallible**. It was fallible for exactly one
+    /// reason — `classify` refusing a spelling — and a reading has already been
+    /// through that. Only [`intern`](Self::intern), the door for a spelling
+    /// nobody has classified yet, can still fail.
+    ///
+    /// The model is consulted, never extended: a composed spelling is an
+    /// intermediate in *this binding's* crossing graph, not something the source
+    /// API mentions, so `Flat` stays what the source said while every type the
+    /// pipeline works with has its reading in the table.
     pub(super) fn ensure_entry(
+        &mut self,
+        dir: Direction,
+        reading: &crate::api::core::flat::TypeRef,
+        root: bool,
+    ) {
+        let key = reading.key();
+        // The reading of a given key cannot change, so an existing cell already
+        // holds an equal one — only the root flag can still move.
+        if let Some(cell) = self.type_table_mut(dir).get_mut(&key) {
+            cell.root |= root;
+            return;
+        }
+        self.type_table_mut(dir).insert(
+            key,
+            TypeCell {
+                subject: Box::new(reading.clone()),
+                root,
+                entry: None,
+            },
+        );
+    }
+
+    /// Classify a **spelling** and register it — the one door for a type that
+    /// has no reading yet, and the only fallible way into the table.
+    ///
+    /// Everything the pipeline composes or walks already holds a
+    /// [`TypeRef`](crate::api::core::flat::TypeRef) and goes through
+    /// [`ensure_entry`](Self::ensure_entry) instead. What genuinely arrives as
+    /// tokens is a spelling *authored outside the model*: a build script's
+    /// declared crossing, a constant's declared type, a `syn` type the plan
+    /// engines assemble for their own wire shape.
+    ///
+    /// A spelling the grammar refuses is reported by name here, rather than
+    /// becoming a cell that quietly means less than its neighbours.
+    pub(crate) fn intern(
         &mut self,
         dir: Direction,
         ty: &syn::Type,
         root: bool,
-    ) -> Result<(), ScanError> {
-        let key = TypeKey::from_type(ty);
-        // Classify only when the cell is actually new: the reading of a given key
-        // cannot change, so an existing cell already holds it.
-        if let Some(cell) = self.type_table_mut(dir).get_mut(&key) {
-            cell.root |= root;
-            return Ok(());
-        }
-        let subject = self
+    ) -> Result<crate::api::core::flat::TypeRef, ScanError> {
+        let reading = self
             .flat
             .classify(ty)
             .map_err(|source| ScanError::NotExpressible {
@@ -290,14 +318,24 @@ impl<M> Registry<M> {
                     location: SourceLocation::default(),
                 }],
             })?;
-        self.type_table_mut(dir).insert(
-            key,
-            TypeCell {
-                subject: Box::new(subject),
-                root,
-                entry: None,
-            },
-        );
+        self.ensure_entry(dir, &reading, root);
+        Ok(reading)
+    }
+
+    /// [`intern`](Self::intern), then register every nested position — the
+    /// recursive door, for a spelling whose children must become crossings too
+    /// (a parameter, a return, a declared field).
+    ///
+    /// Only the top type is classified: the walk below it takes each child's
+    /// reading off the parent's, so nothing under here is re-derived.
+    pub(super) fn intern_recursive(
+        &mut self,
+        dir: Direction,
+        ty: &syn::Type,
+        root: bool,
+    ) -> Result<(), ScanError> {
+        let reading = self.intern(dir, ty, root)?;
+        self.register_type_recursive(dir, &reading, root);
         Ok(())
     }
 
@@ -327,10 +365,10 @@ impl<M> Registry<M> {
         &self,
         dir: Direction,
         ty: &syn::Type,
-    ) -> Vec<(Direction, syn::Type)> {
+    ) -> Vec<(Direction, crate::api::core::flat::TypeRef)> {
         use crate::api::core::flat::TypeKind;
 
-        let mut out: Vec<(Direction, syn::Type)> = Vec::new();
+        let mut out: Vec<(Direction, crate::api::core::flat::TypeRef)> = Vec::new();
         if let Some(reading) = self
             .type_table(dir)
             .get(&TypeKey::from_type(ty))
@@ -353,8 +391,12 @@ impl<M> Registry<M> {
                     | TypeKind::Str
                     | TypeKind::Unit => (Vec::new(), dir),
                 };
+            // The child reading itself, not its spelling: it has already been
+            // classified — by the model, or by whoever composed the parent — so
+            // handing back tokens for the caller to re-classify is the discard
+            // this walk exists to avoid (#281).
             for child in children {
-                out.push((child_dir, child.syntax().clone()));
+                out.push((child_dir, child.clone()));
             }
         }
         // A declared type's own fields, read off the element rather than off its
@@ -387,7 +429,7 @@ impl<M> Registry<M> {
                 Some(Type::Enum(_) | Type::Extern(_)) | None => Vec::new(),
             };
             for field in fields {
-                out.push((dir, field.ty.syntax().clone()));
+                out.push((dir, field.ty.clone()));
             }
         }
         out
@@ -409,7 +451,7 @@ impl<M> Registry<M> {
         root: bool,
         entry: Option<TypeEntry<M>>,
     ) {
-        self.ensure_entry(dir, &key.to_type(), root)
+        self.intern(dir, &key.to_type(), root)
             .unwrap_or_else(|e| panic!("fixture key `{key}` is not expressible: {e}"));
         self.type_table_mut(dir)
             .get_mut(key)
@@ -444,21 +486,24 @@ impl<M> Registry<M> {
             .map(|cell| (*cell.subject).clone())
     }
 
-    /// Register `ty` (and its nested positions) as a required **input** so
+    /// Register `reading` (and its nested positions) as a required **input** so
     /// the resolver produces a converter for it. Used by
     /// [`crate::api::core::expand`] to pull in the leaf types a fold needs.
-    pub(crate) fn require_input(&mut self, ty: &syn::Type) {
-        // Leaf/expansion types are concrete (no disallowed `impl Trait`), so
-        // the recursive registration cannot fail here.
-        let _ = self.register_type_recursive(Direction::Input, ty, true);
+    ///
+    /// Takes the **reading**, not its spelling. Every caller already holds one —
+    /// a plan leaf's `ty` — and used to call `.syntax()` on it here, which is the
+    /// discard #281 is about: the registry would then re-classify the tokens and
+    /// store its own answer beside the caller's.
+    pub(crate) fn require_input(&mut self, reading: &crate::api::core::flat::TypeRef) {
+        self.register_type_recursive(Direction::Input, reading, true);
     }
 
     /// Register `ty` (and its nested positions) as a required **output** so the
     /// resolver produces a converter for it. The output-side peer of
     /// [`Self::require_input`]; used by [`crate::api::core::unfold`] to pull in
     /// the leaf types a decomposition delivers.
-    pub(crate) fn require_output(&mut self, ty: &syn::Type) {
-        let _ = self.register_type_recursive(Direction::Output, ty, true);
+    pub(crate) fn require_output(&mut self, reading: &crate::api::core::flat::TypeRef) {
+        self.register_type_recursive(Direction::Output, reading, true);
     }
 
     /// Drop `ty` from the required-output scan set. The type's table entry is

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -819,6 +819,81 @@ fn a_source_type_cell_carries_the_models_typeref() {
     assert!(matches!(inner.subject.kind(), TypeKind::Scalar(_)));
 }
 
+/// A **composed** reading reaches the cell intact, rather than being thrown away
+/// and re-derived from its spelling.
+///
+/// #281's acceptance test, and it needs a case where the two answers visibly
+/// differ or it would pass on a coincidence. `Option<Thing>` is a spelling the
+/// source never writes, so:
+///
+/// * composing it keeps the **source location** of the `Thing` it layers over —
+///   the composer pairs `kind` with spelling and inherits the place;
+/// * re-deriving it hands the tokens to `Flat::classify`, which finds nothing in
+///   the model index for that spelling and builds a **placeless** reading.
+///
+/// So the location is the discriminator, and it is not decorative: it is what a
+/// diagnostic about this crossing prints. Verified to fail with the fix
+/// reverted.
+///
+/// Nothing in the tree could have caught the old path: the composed reading
+/// lived in the plan leaf, the re-derived one lived in the cell, and the two
+/// were never compared. Byte-identical goldens say the answers agree for every
+/// type the examples exercise; this says the mechanism no longer permits them to
+/// differ.
+#[test]
+fn a_composed_reading_reaches_the_cell_unchanged() {
+    use crate::api::core::flat::TypeKind;
+
+    let loc = SourceLocation {
+        file: "src/lib.rs".into(),
+        line: 11,
+        column: 3,
+        crate_name: Some("myflat".into()),
+    };
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_str("pub struct Thing { pub v: u64 }").unwrap(),
+            loc.clone(),
+        ),
+        (
+            syn::parse_str("pub fn f(t: Thing) -> u64 { t.v }").unwrap(),
+            loc.clone(),
+        ),
+    ];
+    let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
+    let mut ext = StubExt::default();
+    ext.functions.insert(syn::parse_str("f").unwrap());
+    ext.types.insert(TypeKey::parse("Thing").unwrap());
+    let mut reg = ext
+        .declare_into_any(reg)
+        .expect("declare")
+        .scanned()
+        .unwrap();
+
+    // The source's own reading for `Thing`, which carries where it was written.
+    let thing = reg
+        .reading(&syn::parse_quote!(Thing))
+        .expect("the declared struct is registered");
+    assert_eq!(thing.location(), &loc, "fixture precondition");
+
+    // `Option<Thing>` — composed here, written nowhere.
+    let composed = thing.optional();
+    assert!(matches!(composed.kind(), TypeKind::Optional(_)));
+    assert_eq!(composed.location(), &loc, "the layer inherits the place");
+
+    reg.require_output(&composed);
+
+    let cell = &reg.output_types[&composed.key()];
+    assert!(matches!(cell.subject.kind(), TypeKind::Optional(_)));
+    assert_eq!(
+        cell.subject.location(),
+        &loc,
+        "the cell holds the reading that was handed to it. A re-derivation would \
+         classify the `Option<Thing>` tokens, find no such spelling in the model \
+         index, and store a PLACELESS reading instead"
+    );
+}
+
 /// `Registry::reading` is a **lookup**. A type with no cell answers `None`, even
 /// when the grammar would classify it happily.
 ///
@@ -1658,7 +1733,7 @@ fn a_recursive_type_is_handed_out_once_and_terminates() {
             next.extend(
                 reg.immediate_edges(Direction::Output, &t)
                     .into_iter()
-                    .map(|(_, sub)| sub),
+                    .map(|(_, sub)| sub.syntax().clone()),
             );
         }
         if revisited {

--- a/prebindgen/src/api/core/resolve.rs
+++ b/prebindgen/src/api/core/resolve.rs
@@ -132,7 +132,7 @@ fn collect_unresolved_descendants<M>(
          seen: &mut std::collections::HashSet<(Direction, TypeKey)>| {
             let ty = key.to_type();
             for (child_dir, sub) in registry.immediate_edges(dir, &ty) {
-                let dep = (child_dir, TypeKey::from_type(&sub));
+                let dep = (child_dir, sub.key());
                 if seen.insert(dep.clone()) {
                     queue.push_back(dep);
                 }

--- a/prebindgen/src/api/core/resolve/tests.rs
+++ b/prebindgen/src/api/core/resolve/tests.rs
@@ -17,7 +17,14 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
     // under test is one the pipeline can actually produce.
     let mut reg: Registry<()> =
         crate::api::test_util::scanned_with(&["pub struct Outer { pub inner: ZKeyExpr }"]);
-    reg.require_input(&syn::parse_quote!(Outer));
+    let outer = reg
+        .intern(
+            crate::api::core::registry::Direction::Input,
+            &syn::parse_quote!(Outer),
+            true,
+        )
+        .expect("fixture type");
+    reg.require_input(&outer);
 
     let zke_key = TypeKey::parse("ZKeyExpr").expect("test type");
     assert!(!reg.input_types[&zke_key].root, "the field is not a root");

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -787,7 +787,7 @@ pub fn apply_leaf_vec_folds<M>(
                     // opaque-handle element it cannot resolve (`jlong` wire isn't
                     // JObject-shaped), and de-requiring keeps that `None` from
                     // being flagged as an unresolved-required error.
-                    registry.unrequire_output(ret.syntax());
+                    registry.unrequire_output(&ret);
                     registry
                         .unfold_plans
                         .insert(func.clone(), whole_leaf_fold_plan(vec_elem, shape));
@@ -905,7 +905,7 @@ struct Layered {
     /// The arity layers, outermost first.
     shape: UnfoldShape,
     /// Every type on the way down, outermost first — what a registration walks.
-    layer_types: Vec<syn::Type>,
+    layer_types: Vec<crate::api::core::flat::TypeRef>,
     /// Past the borrow too: what actually crosses.
     core: syn::Type,
     /// Whether the core is reached through a borrow.
@@ -924,11 +924,7 @@ fn peel(ty: &crate::api::core::flat::TypeRef) -> Layered {
     let borrowed = layered.borrow_target();
     Layered {
         shape,
-        layer_types: ty
-            .layer_types()
-            .iter()
-            .map(|t| t.syntax().clone())
-            .collect(),
+        layer_types: ty.layer_types().into_iter().cloned().collect(),
         core: borrowed.unwrap_or(layered).syntax().clone(),
         by_ref: borrowed.is_some(),
     }
@@ -1024,9 +1020,9 @@ fn process_decl<M>(
             // recursive registration also required) — same reasoning as
             // [`apply_leaf_vec_folds`] for the fixed folds.
             if ed.target == DeconTarget::Output {
-                registry.unrequire_output(ret_ty.syntax());
+                registry.unrequire_output(&ret_ty);
                 if optional {
-                    registry.unrequire_output(after_opt.syntax());
+                    registry.unrequire_output(after_opt);
                 }
             }
             // Element type peeled of a leading `&` (accessors take `&Element`).

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -462,7 +462,7 @@ pub fn apply<M>(
                     continue;
                 }
                 for leaf in &plan.leaves {
-                    registry.require_output(leaf.out_ty.syntax());
+                    registry.require_output(&leaf.out_ty);
                 }
                 registry.callback_arg_plans.insert(key, plan);
             }
@@ -643,7 +643,7 @@ fn wire_fixed_returns<M>(
             }
         }
         for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-            registry.require_output(leaf.out_ty.syntax());
+            registry.require_output(&leaf.out_ty);
         }
         let plan = UnfoldPlan {
             source: vd.source.clone(),
@@ -710,7 +710,7 @@ fn wire_fixed_callbacks<M>(
                     continue;
                 }
                 for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-                    registry.require_output(leaf.out_ty.syntax());
+                    registry.require_output(&leaf.out_ty);
                 }
                 let plan = UnfoldPlan {
                     source: vd.source.clone(),
@@ -779,7 +779,7 @@ pub fn apply_leaf_vec_folds<M>(
                     } else {
                         inner_shape
                     };
-                    registry.require_output(vec_elem.syntax());
+                    registry.require_output(vec_elem);
                     // The fold delivers the return element-by-element, so the
                     // whole `Vec<T>` / `Option<Vec<T>>` converter is not needed.
                     // De-require it: for String / scalar elements it still
@@ -814,7 +814,7 @@ pub fn apply_leaf_vec_folds<M>(
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                registry.require_output(elem.syntax());
+                registry.require_output(elem);
                 let plan =
                     whole_leaf_fold_plan(elem, UnfoldShape::Iterable(Box::new(UnfoldShape::Base)));
                 registry.callback_arg_plans.insert(key, plan);
@@ -1039,7 +1039,7 @@ fn process_decl<M>(
                 register_decon_spec(registry, acc, &decon, &records, element)?;
                 let plan = build_plan(acc, registry, ed, by_ref, element, shape, &records, decon)?;
                 for leaf in &plan.leaves {
-                    registry.require_output(leaf.out_ty.syntax());
+                    registry.require_output(&leaf.out_ty);
                 }
                 plan
             } else {
@@ -1048,7 +1048,7 @@ fn process_decl<M>(
                 // No declaration is involved (`decon: None`) — the element
                 // crosses whole through its own converter.
                 let by_ref = peel_borrow(inner).0;
-                registry.require_output(inner.syntax());
+                registry.require_output(inner);
                 UnfoldPlan {
                     source: inner.syntax().clone(),
                     decon: None,
@@ -1085,7 +1085,7 @@ fn process_decl<M>(
             register_decon_spec(registry, acc, &decon, &records, source)?;
             let plan = build_plan(acc, registry, ed, by_ref, source, shape, &records, decon)?;
             for leaf in &plan.leaves {
-                registry.require_output(leaf.out_ty.syntax());
+                registry.require_output(&leaf.out_ty);
             }
             plan
         };
@@ -1113,16 +1113,19 @@ fn process_decl<M>(
             && plan.leaves.len() == 1
             && !plan.leaves[0].nullable;
         let plan = if single_return {
-            let leaf_ty = plan.leaves[0].out_ty.syntax().clone();
-            let cv_ty: syn::Type = if matches!(plan.shape, UnfoldShape::Optional((), _)) {
-                syn::parse_quote!(Option<#leaf_ty>)
+            // Composed with the model's own layering rather than by spelling
+            // `Option<#leaf_ty>` and handing the tokens over: `optional()` pairs
+            // the `kind` with its spelling in one place, so the reading that
+            // reaches the table is the one this plan carries (#281).
+            let cv = if matches!(plan.shape, UnfoldShape::Optional((), _)) {
+                plan.leaves[0].out_ty.optional()
             } else {
-                leaf_ty
+                plan.leaves[0].out_ty.clone()
             };
-            registry.require_output(&cv_ty);
+            registry.require_output(&cv);
             UnfoldPlan {
                 delivery: Delivery::Return,
-                convert_out_ty: Some(cv_ty),
+                convert_out_ty: Some(cv.syntax().clone()),
                 ..plan
             }
         } else {

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1813,7 +1813,10 @@ fn sum_return_layers_ride_the_shape_fold() {
 fn a_vec_only_sum_return_drops_the_bare_requirement() {
     let mut reg: Registry<()> = reg_with(&["fn read_all(n: i32) -> Vec<Reading> { todo!() }"]);
     let bare: syn::Type = syn::parse_quote!(Reading);
-    reg.require_output(&bare);
+    let bare_reading = reg
+        .intern(crate::api::core::registry::Direction::Output, &bare, true)
+        .expect("fixture type");
+    reg.require_output(&bare_reading);
     assert!(
         reg.output_types[&TypeKey::from_type(&bare)].root,
         "fixture precondition: the bare element starts out required"


### PR DESCRIPTION
Closes #281.

## The defect

A composed reading was built, thrown away, and independently re-derived:

```rust
FoldLeaf { ty: pty.optional() }                  // expand.rs — kind + spelling, paired
registry.require_output(leaf.out_ty.syntax());   // unfold.rs — only the SPELLING crosses
let subject = self.flat.classify(ty)?;           // scan.rs   — classified again, own twin stored
```

Two classifications of one type, by two paths that never met. Nothing compared them.

## The issue proposed the wrong mechanism, and I said so on it first

#281 said the fix was to move the composers behind a `Registry` API. Exploration showed that would **not** close it:

1. **The loss is at the door, not at the composer.** `require_output(&syn::Type)` discards the reading its caller already holds.
2. **It happened again at every recursion step.** `immediate_edges` had each child as a `&TypeRef` and did `child.syntax().clone()` so the next level could re-classify it.
3. **The relocation buys no sealing either** — #280 already sealed minting to `api::core`, and `expand`/`unfold` *are* `api::core`.

[Correction posted on the issue](https://github.com/milyin/prebindgen/issues/281#issuecomment-5157878046) before implementing.

## The change

**One rule: a type enters the registry as a reading; only a spelling nobody has classified yet goes through `classify`.**

| | |
|---|---|
| `ensure_entry(dir, &TypeRef, root)` | stores the caller's reading — **infallible** |
| `register_type_{recursive,inner}` | take `&TypeRef`, infallible |
| `require_*` / `unrequire_*` | take `&TypeRef` |
| `immediate_edges` | returns `(Direction, TypeRef)` |
| `intern` / `intern_recursive` | the one fallible door, for a spelling |

**Infallibility falls out rather than being claimed.** `ensure_entry` was fallible for exactly one reason — `classify` refusing a spelling — and a reading has already been through that. #281 planned to assert that layering is total and pin it with a test; carrying the reading makes the question not arise.

**Mostly deletions:** 10 of the 12 `require_*` sites already held a `TypeRef` and called `.syntax()` at the door. `unfold.rs`'s composed `cv_ty` now uses `optional()` instead of `parse_quote!(Option<#leaf_ty>)`.

**`Flat::classify` is down to one production caller**, `intern`.

## Acceptance test — verified to fail when reverted

`a_composed_reading_reaches_the_cell_unchanged` composes `Option<Thing>`, a spelling the source never writes, and asserts the cell keeps the source location. With re-derivation restored:

```
left:  SourceLocation { file: "", line: 0, column: 0, crate_name: None }
right: SourceLocation { file: "src/lib.rs", line: 11, column: 3, crate_name: Some("myflat") }
```

The placeless reading is what a diagnostic about that crossing would have printed. The location is the discriminator because `classify` returns the model's reading when the spelling is indexed and a **placeless** one when it is not — and a composed spelling never is.

## Two mistakes caught in progress

- `intern` does not recurse, but six sites I converted were `register_type_recursive`. Caught by **cbindgen's example panicking**, not by a test — the unit suite passed. Fixed with `intern_recursive`.
- The regex that dropped `.syntax()` added `&` to values already references (`needless_borrow`).

## Verification

- 551 lib tests · `--all --all-features` 14/14 suites
- clippy `--deny warnings` clean · fmt (CI CLI config)
- **regen-check byte-identical** after `git clean -fd examples/` + `cargo clean -p`, with the forced rebuild confirmed by the `Compiling`/`Generated` lines. Here that is **evidence, not a regression check**: the cell used to hold `classify(spelling)` and now holds the caller's reading, so identical output is the first confirmation that the two answers agree for every type the examples exercise
- covertest-kotlin 48/48
- boundary ledger **unchanged at 127** — this migration is invisible to it (it counts syn *variant mentions*; a signature change names none)

## Follow-up

`scan_fn` / `scan_struct` / `scan_enum` still take `syn` items and walk `field.ty` / `pt.ty` / `sig.output` as raw syntax, while `flat::Field::ty`, `Param::ty` and `Function::ret` are already `TypeRef`s — the same discard for the source-declared population. Same rule, separately reviewable, its own PR.