### PR TITLE
Registry lookups take the reading, not a spelling

### DIFF
--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -427,14 +427,18 @@ impl<M> RegistryBuilder<M> {
 ///
 /// [`conversion`]: Conversions::conversion
 impl<M> Conversions<M> for RegistryBuilder<M> {
-    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
-        self.registry.reading(ty)
+    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef> {
+        self.registry.reading(key)
     }
     fn flat(&self) -> &crate::api::core::flat::Flat {
         &self.registry.flat
     }
-    fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        self.built.get(&(dir, TypeKey::from_type(ty)))
+    fn conversion(
+        &self,
+        dir: Direction,
+        reading: &crate::api::core::flat::TypeRef,
+    ) -> Option<&TypeEntry<M>> {
+        self.built.get(&(dir, reading.key()))
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
         self.order

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -502,11 +502,10 @@ impl<M> Registry<M> {
     ///
     /// `None` therefore means the type never entered the pipeline — a caller
     /// asking out of order, not a cache miss to paper over.
-    pub(crate) fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
-        let key = TypeKey::from_type(ty);
+    pub(crate) fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef> {
         self.input_types
-            .get(&key)
-            .or_else(|| self.output_types.get(&key))
+            .get(key)
+            .or_else(|| self.output_types.get(key))
             .map(|cell| (*cell.subject).clone())
     }
 
@@ -573,18 +572,31 @@ impl<M> Registry<M> {
         }
     }
 
-    /// Look up the resolved input entry for `ty`, returning `None` if it
+    /// Look up the resolved input entry for `reading`, returning `None` if it
     /// was never registered or is still unresolved. The returned entry's
     /// `function.sig.ident` is the converter's call name; `destination` is
     /// its wire form.
-    pub fn input_entry(&self, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        let key = TypeKey::from_type(ty);
-        self.type_table(Direction::Input).get(&key)?.entry.as_ref()
+    ///
+    /// Takes a `TypeRef` for the reason the trait methods do (#284) — and this
+    /// pair matters more than they do, because an **inherent** method wins over
+    /// a trait method on a concrete `Registry`. While these took a spelling they
+    /// were a second door into the table that the trait's signature could not
+    /// close, and every caller with a `Registry` in hand silently used it. The
+    /// same "second door inside the room" that hid `classify` behind
+    /// `Registry::reading` until #267.
+    pub fn input_entry(&self, reading: &crate::api::core::flat::TypeRef) -> Option<&TypeEntry<M>> {
+        self.type_table(Direction::Input)
+            .get(&reading.key())?
+            .entry
+            .as_ref()
     }
 
-    /// Look up the resolved output entry for `ty`. See [`Self::input_entry`].
-    pub fn output_entry(&self, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        let key = TypeKey::from_type(ty);
-        self.type_table(Direction::Output).get(&key)?.entry.as_ref()
+    /// Look up the resolved output entry for `reading`. See
+    /// [`Self::input_entry`].
+    pub fn output_entry(&self, reading: &crate::api::core::flat::TypeRef) -> Option<&TypeEntry<M>> {
+        self.type_table(Direction::Output)
+            .get(&reading.key())?
+            .entry
+            .as_ref()
     }
 }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -872,7 +872,7 @@ fn a_composed_reading_reaches_the_cell_unchanged() {
 
     // The source's own reading for `Thing`, which carries where it was written.
     let thing = reg
-        .reading(&syn::parse_quote!(Thing))
+        .reading(&TypeKey::parse("Thing").unwrap())
         .expect("the declared struct is registered");
     assert_eq!(thing.location(), &loc, "fixture precondition");
 
@@ -922,13 +922,13 @@ fn reading_is_a_lookup_not_a_classification() {
 
     // Registered by the declared fn — the lookup hits.
     assert!(
-        reg.reading(&syn::parse_quote!(u64)).is_some(),
+        reg.reading(&TypeKey::parse("u64").unwrap()).is_some(),
         "a type the scan registered has its reading in a cell"
     );
     // Never registered, and perfectly expressible. The grammar's answer is not
     // this method's to give.
     assert!(
-        reg.reading(&syn::parse_quote!(i64)).is_none(),
+        reg.reading(&TypeKey::parse("i64").unwrap()).is_none(),
         "`reading` answers from the type table; it must not classify on a miss"
     );
 }

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -35,19 +35,49 @@ pub trait Conversions<M> {
     /// rebuilding a spelling from the key and classifying that — the round trip
     /// `api/core` removed from itself in #263, which is the same defect one layer
     /// out.
-    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef>;
+    ///
+    /// **Keyed**, because that is the one thing a caller has before it has a
+    /// reading. This is the door FROM identity TO the model's answer, and the
+    /// only lookup on this trait that does not already take a `TypeRef` — the
+    /// rest take one precisely because this exists to hand them one (#284).
+    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef>;
 
-    /// The conversion for `ty` in `dir`, if there is one.
-    fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>>;
+    /// The conversion for `reading` in `dir`, if there is one.
+    ///
+    /// Takes the **reading**, not a spelling. A caller that has to ask what a
+    /// type converts to has already established what the type *is*; asking with
+    /// tokens instead let a spelling nobody classified reach the table, and cost
+    /// a `TypeKey::from_type` on every call for an identity the reading already
+    /// carries.
+    fn conversion(
+        &self,
+        dir: Direction,
+        reading: &crate::api::core::flat::TypeRef,
+    ) -> Option<&TypeEntry<M>>;
+
+    /// The reading for a **spelling** — identify, then look up.
+    ///
+    /// The door for a caller holding tokens it peeled or composed itself, which
+    /// is a real position: an adapter may strip a `&` or name a wire type, and
+    /// #280 sealed minting so it cannot make a reading for the result. It asks
+    /// instead, and `None` means the registry never saw that type.
+    ///
+    /// Kept separate from the entry lookups on purpose. Those take a `TypeRef`,
+    /// so they cannot be called about a type the registry does not know — which
+    /// is the guarantee, and it survives only while getting a reading from
+    /// tokens is a visible step with a `None` to handle.
+    fn reading_of(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
+        self.reading(&TypeKey::from_type(ty))
+    }
 
     /// Wire → rust.
-    fn input_entry(&self, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        self.conversion(Direction::Input, ty)
+    fn input_entry(&self, reading: &crate::api::core::flat::TypeRef) -> Option<&TypeEntry<M>> {
+        self.conversion(Direction::Input, reading)
     }
 
     /// Rust → wire.
-    fn output_entry(&self, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        self.conversion(Direction::Output, ty)
+    fn output_entry(&self, reading: &crate::api::core::flat::TypeRef) -> Option<&TypeEntry<M>> {
+        self.conversion(Direction::Output, reading)
     }
 
     /// The decomposition of a callback argument type, if it has one.
@@ -93,11 +123,15 @@ impl<M> Conversions<M> for Building<'_, M> {
     fn flat(&self) -> &crate::api::core::flat::Flat {
         &self.registry.flat
     }
-    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
-        self.registry.reading(ty)
+    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef> {
+        self.registry.reading(key)
     }
-    fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        self.built.get(&(dir, TypeKey::from_type(ty)))
+    fn conversion(
+        &self,
+        dir: Direction,
+        reading: &crate::api::core::flat::TypeRef,
+    ) -> Option<&TypeEntry<M>> {
+        self.built.get(&(dir, reading.key()))
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&crate::api::core::unfold::UnfoldPlan> {
         self.registry.callback_arg_plans.get(key)
@@ -129,14 +163,15 @@ impl<M> Conversions<M> for Registry<M> {
     fn flat(&self) -> &crate::api::core::flat::Flat {
         &self.flat
     }
-    fn reading(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
-        Registry::reading(self, ty)
+    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef> {
+        Registry::reading(self, key)
     }
-    fn conversion(&self, dir: Direction, ty: &syn::Type) -> Option<&TypeEntry<M>> {
-        self.type_table(dir)
-            .get(&TypeKey::from_type(ty))?
-            .entry
-            .as_ref()
+    fn conversion(
+        &self,
+        dir: Direction,
+        reading: &crate::api::core::flat::TypeRef,
+    ) -> Option<&TypeEntry<M>> {
+        self.type_table(dir).get(&reading.key())?.entry.as_ref()
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&crate::api::core::unfold::UnfoldPlan> {
         self.callback_arg_plans.get(key)

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -9,24 +9,31 @@ impl CbindgenBuilder {
         let string_ty: syn::Type = syn::parse_quote!(String);
         // A `String` return hands out a `char*` — unless `String` is declared
         // `opaque_ptr` (then it crosses as `string_t *`, freed by `string_drop`).
-        if registry.output_entry(&string_ty).is_some()
+        if registry
+            .reading_of(&string_ty)
+            .and_then(|tr| registry.output_entry(&tr))
+            .is_some()
             && !self.opaque.contains_key(&TypeKey::from_type(&string_ty))
         {
             return true;
         }
         // Opaque error types are marshalled to a malloc'd `char*` message.
-        if self
-            .opaque_errors
-            .keys()
-            .any(|key| registry.output_entry(&key.to_type()).is_some())
-        {
+        if self.opaque_errors.keys().any(|key| {
+            registry
+                .reading(key)
+                .and_then(|tr| registry.output_entry(&tr))
+                .is_some()
+        }) {
             return true;
         }
         // A tagged union with a `String` payload hands out a `char*` per active
         // arm — allocated by its output converter, released by its typed drop.
         if self.tagged_unions.keys().any(|key| {
             let ty = key.to_type();
-            registry.output_entry(&ty).is_some()
+            registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.output_entry(&tr))
+                .is_some()
                 && self
                     .enum_variants(registry, &ty)
                     .map(|vs| {
@@ -40,7 +47,10 @@ impl CbindgenBuilder {
         }
         self.data.keys().any(|key| {
             let ty = key.to_type();
-            registry.output_entry(&ty).is_some()
+            registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.output_entry(&tr))
+                .is_some()
                 && self
                     .struct_fields(registry, &ty)
                     .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))
@@ -132,7 +142,7 @@ impl CbindgenBuilder {
         // legitimately differ (a `String`'s const-ness above), which is why a
         // disagreement is `None` — a rejection naming the payload — rather
         // than a silent pick of one side.
-        let out_entry = registry.output_entry(fty).ok_or_else(|| {
+        let out_entry = registry.reading_of(fty).and_then(|tr| registry.output_entry(&tr)).ok_or_else(|| {
             "no resolved OUTPUT converter — a payload crosses as its converter's destination, so \
              it must be a scalar, a `String`, or a type this binding declares (`enum_type`, \
              `data_struct`, `opaque_ptr`, or a `convert!` conversion)"
@@ -149,7 +159,10 @@ impl CbindgenBuilder {
             );
         }
         let out = out_entry.destination.clone();
-        if let Some(inp) = registry.input_entry(fty) {
+        if let Some(inp) = registry
+            .reading_of(fty)
+            .and_then(|tr| registry.input_entry(&tr))
+        {
             if TypeKey::from_type(&inp.destination) != TypeKey::from_type(&out) {
                 return Err(format!(
                     "its input and output converters disagree on the wire (`{}` in, `{}` out) \
@@ -264,7 +277,10 @@ impl CbindgenBuilder {
     /// anything that is not a declared tagged union.
     pub(super) fn tagged_union_has_drop(&self, fty: &syn::Type, registry: &Registry<()>) -> bool {
         if !self.tagged_unions.contains_key(&TypeKey::from_type(fty))
-            || registry.output_entry(fty).is_none()
+            || registry
+                .reading_of(fty)
+                .and_then(|tr| registry.output_entry(&tr))
+                .is_none()
         {
             return false;
         }
@@ -447,7 +463,8 @@ impl CbindgenBuilder {
                 return false;
             };
             registry
-                .input_entry(&pt.ty)
+                .reading_of(&pt.ty)
+                .and_then(|tr| registry.input_entry(&tr))
                 .map(|e| returns_result(&e.function.sig.output))
                 .unwrap_or(false)
         });
@@ -470,13 +487,16 @@ impl CbindgenBuilder {
                 TypeKey::from_type(err_ty),
                 TypeKey::from_type(err_ty),
             );
-            let entry = registry.output_entry(err_ty).unwrap_or_else(|| {
-                panic!(
-                    "Cbindgen::on_function: error type `{}` of `{}` has no output converter",
-                    TypeKey::from_type(err_ty),
-                    orig
-                )
-            });
+            let entry = registry
+                .reading_of(err_ty)
+                .and_then(|tr| registry.output_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen::on_function: error type `{}` of `{}` has no output converter",
+                        TypeKey::from_type(err_ty),
+                        orig
+                    )
+                });
             (
                 entry.destination.clone(),
                 entry.function.sig.ident.clone(),
@@ -665,12 +685,15 @@ impl CbindgenBuilder {
                  (scalar, data struct, String, or handle), not a composite",
                 TypeKey::from_type(&elem),
             );
-            let entry = registry.output_entry(&elem).unwrap_or_else(|| {
-                panic!(
-                    "Cbindgen: `Vec` element `{}` has no output converter",
-                    TypeKey::from_type(&elem)
-                )
-            });
+            let entry = registry
+                .reading_of(&elem)
+                .and_then(|tr| registry.output_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen: `Vec` element `{}` has no output converter",
+                        TypeKey::from_type(&elem)
+                    )
+                });
             let elem_wire = entry.destination.clone();
             return ValueShape {
                 fields: vec![
@@ -689,12 +712,15 @@ impl CbindgenBuilder {
         // `Cow<'_, [T]>` → `T_wire* + size_t`. The C side receives an owned
         // malloc'd copy, just like `Vec<T>` outputs.
         if let Some(elem) = cow_slice_elem(ty) {
-            let entry = registry.output_entry(&elem).unwrap_or_else(|| {
-                panic!(
-                    "Cbindgen: `Cow` slice element `{}` has no output converter",
-                    TypeKey::from_type(&elem)
-                )
-            });
+            let entry = registry
+                .reading_of(&elem)
+                .and_then(|tr| registry.output_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen: `Cow` slice element `{}` has no output converter",
+                        TypeKey::from_type(&elem)
+                    )
+                });
             let elem_wire = entry.destination.clone();
             return ValueShape {
                 fields: vec![
@@ -735,12 +761,15 @@ impl CbindgenBuilder {
         // Base value: one wire component from its rank-0/1 converter. Custom
         // conversions may declare scalar niches; otherwise a pointer wire
         // (String, opaque handle, `&'static`) carries a free NULL niche.
-        let entry = registry.output_entry(ty).unwrap_or_else(|| {
-            panic!(
-                "Cbindgen::on_function: type `{}` has no output converter",
-                TypeKey::from_type(ty)
-            )
-        });
+        let entry = registry
+            .reading_of(ty)
+            .and_then(|tr| registry.output_entry(&tr))
+            .unwrap_or_else(|| {
+                panic!(
+                    "Cbindgen::on_function: type `{}` has no output converter",
+                    TypeKey::from_type(ty)
+                )
+            });
         let wire = entry.destination.clone();
         let niches = if entry.niches.is_empty() && matches!(wire, syn::Type::Ptr(_)) {
             let null = null_for(&wire);
@@ -769,7 +798,10 @@ impl CbindgenBuilder {
         }
         if is_vec(ty) {
             let elem = first_type_arg(ty).expect("Vec<T> has a type argument");
-            let entry = registry.output_entry(&elem).expect("Vec element converter");
+            let entry = registry
+                .reading_of(&elem)
+                .and_then(|tr| registry.output_entry(&tr))
+                .expect("Vec element converter");
             let elem_conv = entry.function.sig.ident.clone();
             let elem_wire = entry.destination.clone();
             let t_ptr = &targets[0];
@@ -797,7 +829,8 @@ impl CbindgenBuilder {
         }
         if let Some(elem) = cow_slice_elem(ty) {
             let entry = registry
-                .output_entry(&elem)
+                .reading_of(&elem)
+                .and_then(|tr| registry.output_entry(&tr))
                 .expect("Cow slice element converter");
             let elem_conv = entry.function.sig.ident.clone();
             let elem_wire = entry.destination.clone();
@@ -851,7 +884,10 @@ impl CbindgenBuilder {
             );
         }
         // Base value: run its output converter into the single target.
-        let entry = registry.output_entry(ty).expect("base value converter");
+        let entry = registry
+            .reading_of(ty)
+            .and_then(|tr| registry.output_entry(&tr))
+            .expect("base value converter");
         let conv = entry.function.sig.ident.clone();
         let t0 = &targets[0];
         if returns_result(&entry.function.sig.output) {
@@ -871,7 +907,8 @@ impl CbindgenBuilder {
             return Self::output_is_fallible(&inner, registry);
         }
         registry
-            .output_entry(ty)
+            .reading_of(ty)
+            .and_then(|tr| registry.output_entry(&tr))
             .is_some_and(|entry| returns_result(&entry.function.sig.output))
     }
 
@@ -1057,13 +1094,16 @@ impl CbindgenBuilder {
                 continue;
             }
 
-            let entry = registry.input_entry(arg_ty).unwrap_or_else(|| {
-                panic!(
-                    "Cbindgen::on_function: input type `{}` of `{}` has no input converter",
-                    TypeKey::from_type(arg_ty),
-                    orig
-                )
-            });
+            let entry = registry
+                .reading_of(arg_ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen::on_function: input type `{}` of `{}` has no input converter",
+                        TypeKey::from_type(arg_ty),
+                        orig
+                    )
+                });
             let wire = &entry.destination;
             let conv = &entry.function.sig.ident;
 

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -533,7 +533,15 @@ impl CbindgenBuilder {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.opaque) {
             let ty = key.to_type();
-            if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+            if registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_none()
+                && registry
+                    .reading_of(&ty)
+                    .and_then(|tr| registry.output_entry(&tr))
+                    .is_none()
+            {
                 continue;
             }
             let c_struct = self.c_type_ident(&ty);
@@ -568,7 +576,15 @@ impl CbindgenBuilder {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.data) {
             let ty = key.to_type();
-            if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+            if registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_none()
+                && registry
+                    .reading_of(&ty)
+                    .and_then(|tr| registry.output_entry(&tr))
+                    .is_none()
+            {
                 continue;
             }
             let Some(fields) = self.struct_fields(registry, &ty) else {
@@ -610,7 +626,15 @@ impl CbindgenBuilder {
         vo.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
         for (key, cfg) in vo {
             let ty = key.to_type();
-            if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+            if registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_none()
+                && registry
+                    .reading_of(&ty)
+                    .and_then(|tr| registry.output_entry(&tr))
+                    .is_none()
+            {
                 continue;
             }
             let src = self.src_ty(&ty);
@@ -807,7 +831,15 @@ impl CbindgenBuilder {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.enums) {
             let ty = key.to_type();
-            if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+            if registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_none()
+                && registry
+                    .reading_of(&ty)
+                    .and_then(|tr| registry.output_entry(&tr))
+                    .is_none()
+            {
                 continue;
             }
             let Some(e) = enum_item(registry, &ty) else {
@@ -849,7 +881,15 @@ impl CbindgenBuilder {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.tagged_unions) {
             let ty = key.to_type();
-            if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+            if registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_none()
+                && registry
+                    .reading_of(&ty)
+                    .and_then(|tr| registry.output_entry(&tr))
+                    .is_none()
+            {
                 continue;
             }
             let Some(e) = enum_item(registry, &ty) else {
@@ -1079,7 +1119,11 @@ impl CbindgenBuilder {
         // degrades to a passthrough and the generated code does not compile.
         for v in &e.variants {
             for f in &v.fields {
-                if self.payload_needs_converter(&f.ty) && r.input_entry(&f.ty).is_none() {
+                if self.payload_needs_converter(&f.ty)
+                    && r.reading_of(&f.ty)
+                        .and_then(|tr| r.input_entry(&tr))
+                        .is_none()
+                {
                     return None;
                 }
             }
@@ -1204,7 +1248,11 @@ impl CbindgenBuilder {
         // Deferral, as in `in_tagged_union` — the output counterpart.
         for v in &e.variants {
             for f in &v.fields {
-                if self.payload_needs_converter(&f.ty) && r.output_entry(&f.ty).is_none() {
+                if self.payload_needs_converter(&f.ty)
+                    && r.reading_of(&f.ty)
+                        .and_then(|tr| r.output_entry(&tr))
+                        .is_none()
+                {
                     return None;
                 }
             }
@@ -1319,7 +1367,10 @@ impl CbindgenBuilder {
         // came from that converter's destination, so the two cannot disagree.
         // A fallible one propagates with `?`, which the union's own `Result`
         // already provides.
-        match registry.input_entry(fty) {
+        match registry
+            .reading_of(fty)
+            .and_then(|tr| registry.input_entry(&tr))
+        {
             Some(entry) => {
                 let conv = &entry.function.sig.ident;
                 if returns_result(&entry.function.sig.output) {
@@ -1372,7 +1423,10 @@ impl CbindgenBuilder {
         // including the refusal of a FALLIBLE output converter, which a union
         // cannot report through — is decided once in `payload_field_wire`, so
         // this site only emits the call.
-        match registry.output_entry(fty) {
+        match registry
+            .reading_of(fty)
+            .and_then(|tr| registry.output_entry(&tr))
+        {
             Some(entry) => {
                 let conv = entry.function.sig.ident.clone();
                 quote!(#conv(#b))
@@ -1397,7 +1451,11 @@ impl CbindgenBuilder {
             let args: Vec<syn::Type> = key.iter().map(|t| t.to_type()).collect();
             // Emit only if the callback is required (its input resolved); skip a
             // declared-but-unused signature.
-            if registry.input_entry(&callback_fn_type(&args)).is_none() {
+            if registry
+                .reading_of(&callback_fn_type(&args))
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_none()
+            {
                 continue;
             }
             let takeable = &self.callbacks.get(key).expect("callback cfg").takeable;
@@ -1411,7 +1469,8 @@ impl CbindgenBuilder {
                     continue;
                 }
                 let wire = registry
-                    .output_entry(a)
+                    .reading_of(a)
+                    .and_then(|tr| registry.output_entry(&tr))
                     .unwrap_or_else(|| {
                         panic!(
                             "Cbindgen: callback arg `{}` has no output converter (declare it \
@@ -1583,7 +1642,9 @@ impl CbindgenBuilder {
                 call_args.push(quote!(#ai.len()));
                 continue;
             }
-            let entry = registry.output_entry(arg)?;
+            let entry = registry
+                .reading_of(arg)
+                .and_then(|tr| registry.output_entry(&tr))?;
             let conv = entry.function.sig.ident.clone();
             let opaque = entry.destination.clone();
             let fallible = matches!(
@@ -1985,7 +2046,7 @@ impl CbindgenBuilder {
         // converter, never the owned one.
         if is_option(ty) {
             let inner = first_type_arg(ty)?;
-            let entry = r.input_entry(&inner)?;
+            let entry = r.reading_of(&inner).and_then(|tr| r.input_entry(&tr))?;
             let inner_wire = entry.destination.clone();
             let inner_conv = entry.function.sig.ident.clone();
             let (inner_ok, fallible): (syn::Type, bool) = match &entry.function.sig.output {
@@ -2301,7 +2362,7 @@ impl CbindgenBuilder {
         // `Option<T>` / `Vec<T>` marker.
         if is_option(ty) || is_vec(ty) {
             let inner = first_type_arg(ty)?;
-            r.output_entry(&inner)?;
+            r.reading_of(&inner).and_then(|tr| r.output_entry(&tr))?;
             let kind = if is_option(ty) { "option" } else { "vec" };
             let name = format_ident!(
                 "__cbg_outmark_{}_{}",
@@ -2324,7 +2385,7 @@ impl CbindgenBuilder {
         // `Cow<'_, [T]>` marker. The actual C ABI shape is structural in
         // `lower_shape`/`encode_value`, like `Vec<T>`.
         if let Some(inner) = cow_slice_elem(ty) {
-            r.output_entry(&inner)?;
+            r.reading_of(&inner).and_then(|tr| r.output_entry(&tr))?;
             let name = format_ident!(
                 "__cbg_outmark_cow_slice_{}",
                 sanitize(&TypeKey::from_type(&inner))
@@ -2352,7 +2413,7 @@ impl CbindgenBuilder {
             .value_opaque_slice_elem(ty)
             .or_else(|| scalar_slice_elem(ty))
         {
-            r.output_entry(&elem)?;
+            r.reading_of(&elem).and_then(|tr| r.output_entry(&tr))?;
             let name = format_ident!(
                 "__cbg_outmark_slice_{}",
                 sanitize(&TypeKey::from_type(&elem))

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1756,7 +1756,7 @@ impl Declarations {
                 // demand a bare one does. Walking the reading also drops the
                 // re-lookup the old loop did: it peeled a spelling and re-keyed
                 // each result, where the layers are already right here (#273).
-                let Some(mut reading) = registry.reading(&candidate.to_type()) else {
+                let Some(mut reading) = registry.reading(candidate) else {
                     return 0;
                 };
                 let mut depth = 0;
@@ -1840,7 +1840,9 @@ impl Declarations {
         let inner = if is_self {
             None
         } else {
-            registry.input_entry(&ty)
+            registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.input_entry(&tr))
         };
         match inner {
             None if is_self || is_wire_type(&ty) => {
@@ -1976,14 +1978,17 @@ impl Declarations {
         let inner = if is_self {
             None
         } else {
-            registry.output_entry(&ty)
+            registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.output_entry(&tr))
         };
         match inner {
             None if is_self || is_wire_type(&ty) => {
                 // Terminal: `ty` is the wire; the body produces it from `outer`.
                 let (kotlin_name, value_rust_key) = if let Some(a0) = arg0 {
                     registry
-                        .output_entry(a0)
+                        .reading_of(a0)
+                        .and_then(|tr| registry.output_entry(&tr))
                         .map(|e| (e.metadata.kotlin_name.clone(), Some(TypeKey::from_type(a0))))
                         .unwrap_or((None, None))
                 } else {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -83,7 +83,7 @@ pub(crate) fn callback_input(
             // Every leaf converter must already be resolved (deferral safety).
             // A synthesized leaf (a sum's tag) has no converter to wait for.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                registry.output_entry(leaf.out_ty.syntax())?;
+                registry.output_entry(&leaf.out_ty)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             let holder_slash =
@@ -176,7 +176,7 @@ pub(crate) fn callback_input(
             // would make the trampoline wait forever on an `i32` crossing the
             // binding may not have.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                let e = registry.output_entry(leaf.out_ty.syntax())?;
+                let e = registry.output_entry(&leaf.out_ty)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;
                 }
@@ -199,7 +199,7 @@ pub(crate) fn callback_input(
         // converter and clone the borrow (the callback only borrows the value). The
         // `data_class` converter composes the whole object via `fromParts`, so the
         // Kotlin `run(t: T)` receives a ready-made `T`.
-        let (cb_val, arg_entry) = match registry.output_entry(arg_ty.syntax()) {
+        let (cb_val, arg_entry) = match registry.output_entry(arg_ty) {
             Some(e) => (quote!(#cb_arg), e),
             // A borrow: the callback hands out a reference, and the value is
             // cloned for the JVM.
@@ -225,10 +225,7 @@ pub(crate) fn callback_input(
             // classification that never fires.
             None => {
                 let core = arg_ty.borrow_target()?;
-                (
-                    quote!((#cb_arg).clone()),
-                    registry.output_entry(core.syntax())?,
-                )
+                (quote!((#cb_arg).clone()), registry.output_entry(core)?)
             }
         };
         let arg_wire = arg_entry.destination.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -245,7 +245,9 @@ pub(crate) fn option_input(
     t1: &syn::Type,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry.input_entry(t1)?;
+    let inner_entry = registry
+        .reading_of(t1)
+        .and_then(|tr| registry.input_entry(&tr))?;
     let inner_wire = inner_entry.destination.clone();
     let inner_decode = composed_inner_input(inner_entry, quote!(v));
 
@@ -311,7 +313,9 @@ pub(crate) fn option_output(
     t1: &syn::Type,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry.output_entry(t1)?;
+    let inner_entry = registry
+        .reading_of(t1)
+        .and_then(|tr| registry.output_entry(&tr))?;
     let inner_wire = inner_entry.destination.clone();
     let inner_encode = composed_inner_output(inner_entry, quote!(value));
 
@@ -488,7 +492,8 @@ pub(crate) fn nullable_kind_for(
     registry: &impl Conversions<KotlinMeta>,
 ) -> NullableKind {
     let inner_dest = registry
-        .input_entry(inner_ty)
+        .reading_of(inner_ty)
+        .and_then(|tr| registry.input_entry(&tr))
         .map(|e| e.destination.clone())
         .expect(
             "nullable_kind_for: Option<_> input handler reached here only after option_input \
@@ -507,7 +512,8 @@ pub(crate) fn nullable_kind_for_output(
     registry: &impl Conversions<KotlinMeta>,
 ) -> NullableKind {
     let inner_dest = registry
-        .output_entry(inner_ty)
+        .reading_of(inner_ty)
+        .and_then(|tr| registry.output_entry(&tr))
         .map(|e| e.destination.clone())
         .expect(
             "nullable_kind_for_output: Option<_> output handler reached here only after \

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -142,12 +142,15 @@ pub(crate) fn emit_unfold_delivery(
             // a raw typed jvalue for a primitive-wire element, a JObject
             // otherwise (mirrors `leaf_is_prim`; the folder interface
             // declares the matching typed param).
-            let out_entry = registry.output_entry(element).unwrap_or_else(|| {
-                panic!(
-                    "emit_unfold_delivery: Vec element `{}` has no registered output converter",
-                    TypeKey::from_type(element)
-                )
-            });
+            let out_entry = registry
+                .reading_of(element)
+                .and_then(|tr| registry.output_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "emit_unfold_delivery: Vec element `{}` has no registered output converter",
+                        TypeKey::from_type(element)
+                    )
+                });
             // The element's COMPLETE Rust -> wire chain. No `convert!` type is
             // known to reach THIS path today (a fold element is single-leaf and
             // whole, and the collection converters claim the shapes a converted
@@ -979,14 +982,12 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
-        let out_entry = registry
-            .output_entry(leaf.out_ty.syntax())
-            .unwrap_or_else(|| {
-                panic!(
-                    "jnigen unfold: leaf `{}` has no registered output converter",
-                    TypeKey::from_type(leaf.out_ty.syntax())
-                )
-            });
+        let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+            panic!(
+                "jnigen unfold: leaf `{}` has no registered output converter",
+                TypeKey::from_type(leaf.out_ty.syntax())
+            )
+        });
         let conv_fail = fail(quote!(__e.to_string()));
         // The leaf's COMPLETE Rust -> wire chain: the rust-side stages a custom
         // `convert!` declaration inserts (`Duration -> u64`), then the
@@ -1384,7 +1385,10 @@ pub(crate) fn leaf_is_prim(
 /// about a leaf whose own `nullable` flag it is in the middle of computing (an
 /// inert sum group slot).
 pub(crate) fn leaf_ty_is_prim(registry: &impl Conversions<KotlinMeta>, out_ty: &syn::Type) -> bool {
-    let Some(entry) = registry.output_entry(out_ty) else {
+    let Some(entry) = registry
+        .reading_of(out_ty)
+        .and_then(|tr| registry.output_entry(&tr))
+    else {
         return false;
     };
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -29,7 +29,9 @@ pub(crate) fn struct_input_body(
 
         // Defer if any field's input converter isn't resolved yet — the
         // fixed-point loop will retry on the next iteration.
-        let field_entry = registry.input_entry(&field.ty)?;
+        let field_entry = registry
+            .reading_of(&field.ty)
+            .and_then(|tr| registry.input_entry(&tr))?;
         let field_wire = field_entry.destination.clone();
         // The field's COMPLETE decode, stages included — a `convert!` type
         // reaches its Rust value through them (`jlong -> u64 -> Duration`).
@@ -98,7 +100,9 @@ pub(crate) fn struct_input_body(
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
                         let inner_conv = composed_entry_decode(
-                            registry.input_entry(&inner_ty)?,
+                            registry
+                                .reading_of(&inner_ty)
+                                .and_then(|tr| registry.input_entry(&tr))?,
                             &raw_ident,
                             &fname_ident,
                         );
@@ -159,7 +163,9 @@ pub(crate) fn struct_input_body(
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
                 let inner_conv = composed_entry_decode(
-                    registry.input_entry(&f_inner)?,
+                    registry
+                        .reading_of(&f_inner)
+                        .and_then(|tr| registry.input_entry(&tr))?,
                     &raw_ident,
                     &fname_ident,
                 );
@@ -222,7 +228,8 @@ pub(crate) fn struct_input_body(
                 // `Vec` field.
                 let slot_ty = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
                 let sig = registry
-                    .input_entry(&slot_ty)
+                    .reading_of(&slot_ty)
+                    .and_then(|tr| registry.input_entry(&tr))
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {
@@ -385,7 +392,9 @@ fn read_kotlin_property(
     bind: &syn::Ident,
     err_prefix: &str,
 ) -> Option<(TokenStream, TokenStream)> {
-    let entry = registry.input_entry(ty)?;
+    let entry = registry
+        .reading_of(ty)
+        .and_then(|tr| registry.input_entry(&tr))?;
     let wire = entry.destination.clone();
     let raw = format_ident!("{}_raw", bind);
     // The COMPLETE wire → Rust chain, not just the wire-facing converter: a
@@ -461,7 +470,13 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if option_inner_type(ty).is_some() {
-            let inner_conv = composed_entry_decode(registry.input_entry(&enum_inner)?, &raw, bind);
+            let inner_conv = composed_entry_decode(
+                registry
+                    .reading_of(&enum_inner)
+                    .and_then(|tr| registry.input_entry(&tr))?,
+                &raw,
+                bind,
+            );
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None
@@ -908,7 +923,9 @@ fn build_flat_sum_field(
         let kotlin = ext.sum_variant_class_name(sum_cfg, &v.ident);
         let mut fields = Vec::new();
         for (f, item_field) in v.fields.iter().zip(item_variant.fields.iter()) {
-            let entry = registry.input_entry(&item_field.ty)?;
+            let entry = registry
+                .reading_of(&item_field.ty)
+                .and_then(|tr| registry.input_entry(&tr))?;
             // A projection payload (handle) carries ownership
             // and locking rules the tag-gated group does not model yet.
             if entry.metadata.projection.is_some() {
@@ -1154,7 +1171,10 @@ pub(crate) fn build_flat_input_plan(
     // surfaces as `"Any"` Dispatch or a foreign source type). The resolved
     // param's Kotlin type (compared by short name, since metadata carries the
     // FQN) must equal the struct's data-class name.
-    let Some(entry) = registry.input_entry(arg_ty) else {
+    let Some(entry) = registry
+        .reading_of(arg_ty)
+        .and_then(|tr| registry.input_entry(&tr))
+    else {
         return Ok(None);
     };
     if entry.metadata.projection.is_some() {
@@ -1305,7 +1325,10 @@ fn build_flat_struct_node(
         }
 
         let path = child_native.clone();
-        let Some(fentry) = registry.input_entry(&field.ty) else {
+        let Some(fentry) = registry
+            .reading_of(&field.ty)
+            .and_then(|tr| registry.input_entry(&tr))
+        else {
             return Err(flat_error(
                 root,
                 &path,
@@ -1320,7 +1343,10 @@ fn build_flat_struct_node(
         // `(present, value)` representation at every recursion depth.
         if let Some(inner_ty) = option_inner_type(&field.ty) {
             if !matches!(inner_ty, syn::Type::Reference(_)) {
-                if let Some(inner) = registry.input_entry(&inner_ty) {
+                if let Some(inner) = registry
+                    .reading_of(&inner_ty)
+                    .and_then(|tr| registry.input_entry(&tr))
+                {
                     if let Some(prim) = JniPrim::from_wire(&inner.destination) {
                         if inner.niches.clone().carve().is_none()
                             && inner.metadata.projection.is_none()
@@ -1370,16 +1396,19 @@ fn build_flat_struct_node(
             if proj.kind == ProjectionKind::Unsigned64 {
                 if let Some(inner_ty) = option_inner_type(&field.ty) {
                     if JniPrim::from_wire(&fentry.destination).is_none() {
-                        let inner = registry.input_entry(&inner_ty).ok_or_else(|| {
-                            flat_error(
-                                root,
-                                &path,
-                                format!(
-                                    "unsigned field representation `{}` has no input converter",
-                                    TypeKey::from_type(&inner_ty)
-                                ),
-                            )
-                        })?;
+                        let inner = registry
+                            .reading_of(&inner_ty)
+                            .and_then(|tr| registry.input_entry(&tr))
+                            .ok_or_else(|| {
+                                flat_error(
+                                    root,
+                                    &path,
+                                    format!(
+                                        "unsigned field representation `{}` has no input converter",
+                                        TypeKey::from_type(&inner_ty)
+                                    ),
+                                )
+                            })?;
                         let present_index = push_present_leaf(
                             leaves,
                             &format!("{child_native}_present"),
@@ -1807,7 +1836,9 @@ pub(crate) fn build_option_scalar_input_plan(
     if matches!(inner, syn::Type::Reference(_)) {
         return None;
     }
-    let inner_entry = registry.input_entry(&inner)?;
+    let inner_entry = registry
+        .reading_of(&inner)
+        .and_then(|tr| registry.input_entry(&tr))?;
     let value_wire = inner_entry.destination.clone();
     // Only the boxed-primitive fallback shape: primitive wire, no niche,
     // no projection, no composed pre-stages.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -129,7 +129,7 @@ pub(crate) fn leaf_slot(
         ("I", format_ident!("i"))
     } else {
         let wire = registry
-            .output_entry(leaf.out_ty.syntax())
+            .output_entry(&leaf.out_ty)
             .expect("leaf_is_prim implies a resolved output entry")
             .destination
             .clone();
@@ -345,15 +345,13 @@ fn encode_group_leaf(
     bind: &syn::Ident,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
-    let out_entry = registry
-        .output_entry(leaf.out_ty.syntax())
-        .unwrap_or_else(|| {
-            panic!(
-                "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
-                leaf.name,
-                TypeKey::from_type(leaf.out_ty.syntax())
-            )
-        });
+    let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+        panic!(
+            "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
+            leaf.name,
+            TypeKey::from_type(leaf.out_ty.syntax())
+        )
+    });
     let wire = out_entry.destination.clone();
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -111,7 +111,7 @@ pub(crate) fn const_expr_getter_fn(
     // no element carries it. A miss means the declared type never entered the
     // pipeline, which is a binding error worth naming rather than a `None` to
     // absorb.
-    let ret = registry.reading(ty).unwrap_or_else(|| {
+    let ret = registry.reading_of(ty).unwrap_or_else(|| {
         panic!(
             "constant_expr `{kotlin_name}`: type `{}` is not a type this binding crosses — \
              declare it, or name one that is",
@@ -221,7 +221,8 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let output_entry = match &plan.output {
         FnOutputPlan::Value(v) => Some(
             registry
-                .output_entry(&v.target_ty)
+                .reading_of(&v.target_ty)
+                .and_then(|tr| registry.output_entry(&tr))
                 .expect("output entry validated at plan build"),
         ),
         FnOutputPlan::Unfold(_) => None,
@@ -581,7 +582,8 @@ fn emit_input_param(
         // the pre-lock guard — is rejected before any dereference.
         InputKind::Handle { direct: true } if !matches!(arg_ty, syn::Type::Reference(_)) => {
             let entry = registry
-                .input_entry(arg_ty)
+                .reading_of(arg_ty)
+                .and_then(|tr| registry.input_entry(&tr))
                 .expect("plan classified Handle ⇒ entry present");
             let wire_ident = if matches!(&entry.destination, syn::Type::Ptr(_)) {
                 format_ident!("{}_ptr", arg_ident)
@@ -608,13 +610,16 @@ fn emit_input_param(
         | InputKind::Handle { .. }
         | InputKind::Unsigned64 { .. }
         | InputKind::Plain => {
-            let entry = registry.input_entry(arg_ty).unwrap_or_else(|| {
-                panic!(
-                    "JniGen::on_function: input type `{}` for `{}` is unresolved",
-                    TypeKey::from_type(arg_ty),
-                    original_ident,
-                )
-            });
+            let entry = registry
+                .reading_of(arg_ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "JniGen::on_function: input type `{}` for `{}` is unresolved",
+                        TypeKey::from_type(arg_ty),
+                        original_ident,
+                    )
+                });
             emit_plain_decode(entry, arg_ident, arg_ty, on_err)
         }
     }
@@ -756,13 +761,16 @@ pub(crate) fn emit_expanded_param(
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
         let leaf_ty = leaf.ty.syntax();
         let lookup_entry = || {
-            registry.input_entry(leaf_ty).unwrap_or_else(|| {
-                panic!(
-                    "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
-                    TypeKey::from_type(leaf_ty),
-                    orig_param,
-                )
-            })
+            registry
+                .reading_of(leaf_ty)
+                .and_then(|tr| registry.input_entry(&tr))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
+                        TypeKey::from_type(leaf_ty),
+                        orig_param,
+                    )
+                })
         };
         let local = format_ident!("__exp_{}", leaf.name);
 

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -495,7 +495,7 @@ impl JniFunctionPlan {
                 InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,
                 InputKind::Callback { .. } => 1,
                 InputKind::Unsigned64 { .. } | InputKind::Plain => registry
-                    .input_entry(leaf.reading.syntax())
+                    .input_entry(&leaf.reading)
                     .and_then(|entry| JniPrim::from_wire(&entry.destination))
                     .map_or(1, |prim| match prim {
                         JniPrim::Long | JniPrim::Double => 2,
@@ -551,7 +551,8 @@ fn classify_leaf(
             kt_name,
             kt_public: None,
             kt_meta: registry
-                .input_entry(ty)
+                .reading_of(ty)
+                .and_then(|tr| registry.input_entry(&tr))
                 .and_then(|e| e.metadata.kotlin_name.clone()),
             optional,
             as_enum_value,
@@ -561,7 +562,10 @@ fn classify_leaf(
 
     // Every non-callback leaf requires a resolved input entry — the same
     // hard boundary the Rust emitter has always enforced.
-    let Some(entry) = registry.input_entry(ty) else {
+    let Some(entry) = registry
+        .reading_of(ty)
+        .and_then(|tr| registry.input_entry(&tr))
+    else {
         let key = TypeKey::from_type(ty);
         return Err(if expanded {
             PlanError::UnresolvedLeaf {
@@ -690,7 +694,10 @@ fn build_output(
             .expect("Return delivery carries convert_out_ty"),
         None => ok_ty.unwrap_or(return_ty),
     };
-    let Some(entry) = registry.output_entry(&target_ty) else {
+    let Some(entry) = registry
+        .reading_of(&target_ty)
+        .and_then(|tr| registry.output_entry(&tr))
+    else {
         return Err(PlanError::UnresolvedOutput {
             ty: TypeKey::from_type(&target_ty),
         });
@@ -737,7 +744,10 @@ impl ReturnSurface {
             syn::ReturnType::Default => return (Self::Unit, syn::parse_quote!(())),
             syn::ReturnType::Type(_, t) => &**t,
         };
-        let outer_meta = registry.output_entry(ty).map(|e| e.metadata.clone());
+        let outer_meta = registry
+            .reading_of(ty)
+            .and_then(|tr| registry.output_entry(&tr))
+            .map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
         // `value_rust_key`) declare no Kotlin return type. The peeled type
         // comes straight off the stored key — no reparse, no silent

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -757,7 +757,11 @@ fn leaf_iface_param(
     // entry was never required.
     let mut out_ty = out_ty;
     let peeled: syn::Type;
-    if registry.output_entry(out_ty).is_none() {
+    if registry
+        .reading_of(out_ty)
+        .and_then(|tr| registry.output_entry(&tr))
+        .is_none()
+    {
         if let syn::Type::Reference(r) = out_ty {
             peeled = (*r.elem).clone();
             out_ty = &peeled;
@@ -766,7 +770,8 @@ fn leaf_iface_param(
     let (builder_kt, _wire_kt, _wrap, is_value_projection) =
         unfold_leaf_kt(ext, registry, out_ty, nullable, "x")?;
     let proj = registry
-        .output_entry(out_ty)
+        .reading_of(out_ty)
+        .and_then(|tr| registry.output_entry(&tr))
         .and_then(|e| e.metadata.projection.as_ref());
     let nullable_kt = |t: kt::KtType| {
         if builder_kt.is_nullable() {
@@ -861,7 +866,12 @@ pub(crate) fn owned_handle_iface_param(
     out_ty: &syn::Type,
     nullable: bool,
 ) -> Option<IfaceParam> {
-    let proj = registry.output_entry(out_ty)?.metadata.projection.clone()?;
+    let proj = registry
+        .reading_of(out_ty)
+        .and_then(|tr| registry.output_entry(&tr))?
+        .metadata
+        .projection
+        .clone()?;
     let fqn = ext.kotlin_fqn(&proj.leaf_key)?.to_string();
     let typed = kt::KtType::cls(fqn.clone());
     let (typed, raw) = if nullable {
@@ -997,7 +1007,7 @@ fn derive_iface_spec(
             // the accessor used to do here.
             let args: Vec<crate::api::core::flat::TypeRef> = arg_keys
                 .iter()
-                .map(|k| registry.reading(&k.to_type()))
+                .map(|k| registry.reading(k))
                 .collect::<Option<_>>()?;
             callback_iface_spec(ext, registry, &args)
         }
@@ -1227,7 +1237,7 @@ pub(crate) fn callback_iface_spec(
             // A plan-less opaque-handle arg is delivered as a raw `jlong` and
             // wrapped + closed Kotlin-side (Phase 3 — no Rust `new_object`).
             let owned_handle = registry
-                .output_entry(t.syntax())
+                .output_entry(t)
                 .and_then(|e| e.metadata.projection.as_ref())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -793,15 +793,18 @@ impl Declarations {
         // nothing is looked up (#275).
         let field_ty = field.ty.syntax();
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
-        let out = registry.output_entry(field_ty).unwrap_or_else(|| {
-            panic!(
-                "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
+        let out = registry
+            .reading_of(field_ty)
+            .and_then(|tr| registry.output_entry(&tr))
+            .unwrap_or_else(|| {
+                panic!(
+                    "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
                  cannot be derived — register converters for the payload type before \
                  declaring the sealed class",
-                where_(),
-                field_ty.to_token_stream(),
-            )
-        });
+                    where_(),
+                    field_ty.to_token_stream(),
+                )
+            });
 
         if let Some(h) = out.metadata.projection.clone() {
             let leaf = projection_leaf_kt(self, &h).unwrap_or_else(|| {
@@ -833,7 +836,10 @@ impl Declarations {
         // boxed value, a present flag, a niche) rather than in the type name.
         // Comparing the rendered types would reject that legitimate shape —
         // which is what an `Option<enum>` payload does.
-        if let Some(inp) = registry.input_entry(field_ty) {
+        if let Some(inp) = registry
+            .reading_of(field_ty)
+            .and_then(|tr| registry.input_entry(&tr))
+        {
             if let (Some(in_ty), (Some(a), Some(b))) = (
                 inp.metadata.kotlin_name.clone(),
                 (
@@ -1523,7 +1529,8 @@ impl Declarations {
             let inner = option_inner_type(leaf.out_ty.syntax())
                 .unwrap_or_else(|| leaf.out_ty.syntax().clone());
             let name = registry
-                .output_entry(&inner)
+                .reading_of(&inner)
+                .and_then(|tr| registry.output_entry(&tr))
                 .and_then(|e| e.metadata.kotlin_name.clone())
                 .and_then(|t| t.leaf_name().map(str::to_string))
                 .unwrap_or_else(|| {

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -156,7 +156,8 @@ fn rust_type_erased(
         }
     }
     if let Some(kt) = registry
-        .input_entry(peeled)
+        .reading_of(peeled)
+        .and_then(|tr| registry.input_entry(&tr))
         .and_then(|e| e.metadata.kotlin_name.clone())
     {
         return erase_kt_type(&[], &kt);

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -123,7 +123,7 @@ pub(crate) fn build_data_class(
         // disagreed. Reject it at the declaration instead.
         if !matches!(pf.kind, PlanFieldKind::Projection { .. }) {
             if let Some(proj) = registry
-                .input_entry(field.ty.syntax())
+                .input_entry(&field.ty)
                 .and_then(|e| e.metadata.projection.clone())
             {
                 panic!(
@@ -2007,7 +2007,8 @@ pub(crate) fn unfold_leaf_kt(
     pk: &str,
 ) -> Option<(kt::KtType, String, String, bool)> {
     let proj = registry
-        .output_entry(out_ty)
+        .reading_of(out_ty)
+        .and_then(|tr| registry.output_entry(&tr))
         .and_then(|e| e.metadata.projection.clone());
     let is_value_projection = proj
         .as_ref()

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -132,7 +132,8 @@ impl super::JniGen {
                 .kotlin_fqn(key)
                 .unwrap_or_else(|| key.as_str().to_string());
             let wire = registry
-                .output_entry(&key.to_type())
+                .reading(key)
+                .and_then(|tr| registry.output_entry(&tr))
                 .map(|e| e.wire_type().to_token_stream().to_string())
                 .unwrap_or_else(|| "?".to_string());
             out.push_str(&format!(

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -261,7 +261,9 @@ pub(crate) fn classify_field(
         return sum_plan_kind(ext, registry, &bare, owner, optional_inner.is_some(), depth);
     }
 
-    let field_entry = registry.output_entry(&effective_ty)?;
+    let field_entry = registry
+        .reading_of(&effective_ty)
+        .and_then(|tr| registry.output_entry(&tr))?;
     let conv = ConvChain::of(field_entry);
 
     {
@@ -285,7 +287,8 @@ pub(crate) fn classify_field(
         if let Some(inner) = optional_inner.map(|i| i.syntax().clone()) {
             if ext.is_kotlin_enum(&inner) {
                 let kotlin = registry
-                    .output_entry(&inner)?
+                    .reading_of(&inner)
+                    .and_then(|tr| registry.output_entry(&tr))?
                     .metadata
                     .kotlin_name
                     .clone()?;
@@ -325,7 +328,8 @@ pub(crate) fn classify_field(
                 let slot_ty =
                     optional_inner.map_or_else(|| effective_ty.clone(), |i| i.syntax().clone());
                 let descriptor = registry
-                    .output_entry(&slot_ty)
+                    .reading_of(&slot_ty)
+                    .and_then(|tr| registry.output_entry(&tr))
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -572,7 +572,15 @@ pub(crate) fn build_handle_destructor_items(
         // Skip handles the (feature-aware) scan never references — their
         // type may not be in scope in the generated module.
         let ty = key.to_type();
-        if registry.input_entry(&ty).is_none() && registry.output_entry(&ty).is_none() {
+        if registry
+            .reading_of(&ty)
+            .and_then(|tr| registry.input_entry(&tr))
+            .is_none()
+            && registry
+                .reading_of(&ty)
+                .and_then(|tr| registry.output_entry(&tr))
+                .is_none()
+        {
             continue;
         }
         let class_fqn = cfg
@@ -797,7 +805,7 @@ impl Declarations {
         if !is_canonical_spelling(produced, &canonical) {
             return None;
         }
-        let inner = registry.input_entry(t1_ty)?;
+        let inner = registry.input_entry(t1)?;
         let outer_ty = produced.clone();
         // `&T` / `&mut T` are Kotlin-side no-ops — inherit the inner
         // type's name, unless the user pinned an explicit override
@@ -854,7 +862,7 @@ impl Declarations {
         if !is_canonical_spelling(produced, &canonical) {
             return None;
         }
-        let inner = registry.input_entry(t1_ty)?;
+        let inner = registry.input_entry(t1)?;
         if !inner.metadata.is_direct_handle() {
             // Non-opaque: let the general `Option<_>` handler take it.
             return None;
@@ -914,7 +922,7 @@ impl Declarations {
         if shape != WrapperShape::Sequence {
             return None;
         }
-        let inner = registry.input_entry(t1_ty)?;
+        let inner = registry.input_entry(t1)?;
         reject_vec_of_handle(&inner.metadata.projection, t1_ty);
         let inner_wire = inner.destination.clone();
         if !is_jobject_shaped_wire(&inner_wire) {
@@ -983,7 +991,7 @@ impl Declarations {
         // READING stays in `t1` for the lookups (#284).
         let t1_ty = t1.syntax();
         if shape == WrapperShape::Optional {
-            let inner = registry.input_entry(t1_ty)?;
+            let inner = registry.input_entry(t1)?;
             if inner.metadata.is_direct_handle() {
                 let inner_wire = inner.destination.clone();
                 let outer_ty = produced.clone();
@@ -1054,7 +1062,7 @@ impl Declarations {
             // Inherit the inner's name; user pins on `Option<T>` win.
             // The nullability marker (`?`) is added by the use site.
             let inherited = registry
-                .input_entry(t1_ty)
+                .input_entry(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
             let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
             // Fold a Nullable layer over the inner projection (if any). The
@@ -1064,7 +1072,7 @@ impl Declarations {
             // fallback widens the wire to `JObject`.
             let nullable_kind = nullable_kind_for(&wire, t1_ty, registry);
             let projection = registry
-                .input_entry(t1_ty)
+                .input_entry(t1)
                 .and_then(|e| e.metadata.projection.clone())
                 .map(|h| Projection {
                     strategy: FoldStrategy::Optional(nullable_kind, Box::new(h.strategy)),
@@ -1188,11 +1196,12 @@ impl Declarations {
         built: &Building<'_, KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
-        let ty = key.to_type();
-        // The reading the scan already took for this crossing. Rebuilding a
-        // spelling from the key and classifying *that* is the round trip #263
-        // removed from `api/core`; this is the same door, one layer out.
-        let reading = built.reading(&ty)?;
+        // The reading the scan already took for this crossing, fetched by the
+        // key the crossing IS. This used to go `key -> to_type() -> reading`,
+        // and its own comment called that "the same door, one layer out" as the
+        // round trip #263 removed from `api/core`. The door is now keyed, so
+        // there is no spelling to rebuild (#284).
+        let reading = built.reading(key)?;
         match dir {
             Direction::Input => self.select_input_type(&reading, built).or_else(|| {
                 // `impl Fn(args)` that nothing else claimed. Callback args cross
@@ -2257,7 +2266,7 @@ impl Declarations {
                 #inner_body
             });
             let inherited = registry
-                .output_entry(t1_ty)
+                .output_entry(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
             let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
             // Fold a Nullable layer over the inner projection (if any). The
@@ -2267,7 +2276,7 @@ impl Declarations {
             // and uses JVM null.
             let nullable_kind = nullable_kind_for_output(&wire, t1_ty, registry);
             let projection = registry
-                .output_entry(t1_ty)
+                .output_entry(t1)
                 .and_then(|e| e.metadata.projection.clone())
                 .map(|h| Projection {
                     strategy: FoldStrategy::Optional(nullable_kind, Box::new(h.strategy)),
@@ -2299,7 +2308,7 @@ impl Declarations {
         // Symmetric to the input handler. `Vec<u8>` is special-cased at
         // rank-0 (primitive_output → JByteArray) so rank-1 never sees it.
         if shape == WrapperShape::Sequence {
-            let inner = registry.output_entry(t1_ty)?;
+            let inner = registry.output_entry(t1)?;
             // `Vec<opaque-handle>` output is delivered by the Kotlin-side leaf
             // fold (`apply_leaf_vec_folds` → typed-handle wrap), so this
             // whole-`ArrayList` converter is bypassed for it. A handle's `jlong`
@@ -2382,7 +2391,9 @@ impl Declarations {
         elem: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let inner = registry.output_entry(elem)?;
+        let inner = registry
+            .reading_of(elem)
+            .and_then(|tr| registry.output_entry(&tr))?;
         // A `&[opaque-handle]` callback arg is delivered by the Kotlin-side leaf
         // fold (typed-handle wrap), bypassing this whole-`ArrayList` converter; a
         // handle's `jlong` wire isn't JObject-shaped, so it returns `None` here.


### PR DESCRIPTION
Second of #284's three steps. **Stacked on #285** — targets `wrapper-shape-readings`, to be merged together.

| | |
|---|---|
| `reading(&TypeKey)` | the one keyed door |
| `conversion` / `input_entry` / `output_entry` | take `&TypeRef` |
| `reading_of(&syn::Type)` | the visible *"I only had tokens"* step |

## The guarantee

An entry lookup **cannot be called about a type the registry does not know**. #280 sealed minting, so a `TypeRef` can only come from the model or from `reading`/`reading_of` — and those answer `None` for an unregistered type, which the caller must handle. Before, any tokens could be passed and got a silent `None` back.

## The important find was not in the trait

`Registry` carried **inherent** `input_entry` / `output_entry` taking a `&syn::Type` (`scan.rs:579/585`), and an inherent method wins over a trait method on a concrete receiver. So every caller holding a `Registry` used the spelling door, and the trait's signature could not close it.

**Changing the trait alone left 104 sites silently compiling against the old path.** Closing the inherent pair is what surfaced them — and it is why this PR is larger than #284 predicted.

Same *"second door inside the room"* that hid `classify` behind `Registry::reading` until #267. Worth noting that a green build was not evidence here: the code compiled precisely *because* the old door was still open.

## #285's payoff lands here

Every `t1_ty` in the wrapper-shape handlers became `t1` — the handler already holds the reading. That is exactly what #285 was for, and it is why the two want to merge together.

## Honest numbers

| | before | after |
|---|---|---|
| `to_type()` (prod) | 45 | **37** |
| `boundary_ledger` | 127 | 127 |

The ledger is unchanged and **structurally so** — it counts syn *variant mentions*, and a signature change names none. The 37 remaining `to_type()` are spelling needs (C type names, `quote!` targets, diagnostics).

**Acceptance test, as a command** — none of them feeds a lookup:

```
grep -rn "to_type()" prebindgen/src | grep -v tests \
  | grep -E "input_entry|output_entry|conversion|reading"     # empty
```

## One deliberate non-shortcut

`reading_of` returns a **reading**, not an entry. A spelling-taking `entry_of` would have been far less churn at ~80 call sites — and would have restored exactly the door being removed. Keeping the two steps separate is what makes the `None` visible where a caller has only tokens.

## Verification

- 551 lib tests · `--all --all-features` 14/14 suites
- clippy `--deny warnings` clean · fmt (CI CLI config)
- regen-check **byte-identical** after `git clean -fd examples/` + `cargo clean -p`
- covertest-kotlin 48/48

## Next

#284 step 3 — the remaining callers that hold only a key go through `reading(&key)` first. Most of the `reading_of` sites introduced here are the honest inventory of where an adapter still peels or composes tokens; each is a candidate for carrying a reading instead.