### PR TITLE
struct_plan peels off the model instead of the tokens

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -261,9 +261,7 @@ pub(crate) fn classify_field(
         return sum_plan_kind(ext, registry, &bare, owner, optional_inner.is_some(), depth);
     }
 
-    let field_entry = registry
-        .reading_of(&effective_ty)
-        .and_then(|tr| registry.output_entry(&tr))?;
+    let field_entry = registry.output_entry(reading)?;
     let conv = ConvChain::of(field_entry);
 
     {
@@ -284,14 +282,9 @@ pub(crate) fn classify_field(
             return Some(PlanFieldKind::Enum { conv, kotlin });
         }
         // `Option<enum>` leaf.
-        if let Some(inner) = optional_inner.map(|i| i.syntax().clone()) {
-            if ext.is_kotlin_enum(&inner) {
-                let kotlin = registry
-                    .reading_of(&inner)
-                    .and_then(|tr| registry.output_entry(&tr))?
-                    .metadata
-                    .kotlin_name
-                    .clone()?;
+        if let Some(inner) = optional_inner {
+            if ext.is_kotlin_enum(inner.syntax()) {
+                let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
                 return Some(PlanFieldKind::OptionEnum { conv, kotlin });
             }
         }
@@ -325,11 +318,11 @@ pub(crate) fn classify_field(
             None => {
                 // Object-shaped wire with no fixed descriptor; the JVM slot
                 // must be the field's actual declared type (Option-stripped).
-                let slot_ty =
-                    optional_inner.map_or_else(|| effective_ty.clone(), |i| i.syntax().clone());
+                // Option-stripped off the MODEL: `optional_inner` is the
+                // layer's own reading, so there is nothing to re-look-up.
+                let slot = optional_inner.unwrap_or(reading);
                 let descriptor = registry
-                    .reading_of(&slot_ty)
-                    .and_then(|tr| registry.output_entry(&tr))
+                    .output_entry(slot)
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {
@@ -344,13 +337,23 @@ pub(crate) fn classify_field(
                         }
                     })
                     .or_else(|| {
-                        bare_path_ident(&slot_ty).and_then(|name| {
+                        // The NAME off the classification, not off the last
+                        // path segment: `Box<T>` IS `T` here, and taking the
+                        // spelling apart would answer about the wrapper.
+                        match slot.kind() {
+                            crate::api::core::flat::TypeKind::Named { id } => id.ident(),
+                            _ => None,
+                        }
+                        .and_then(|name| {
                             ext.kotlin_fqn(&TypeKey::from_ident(&name))
                                 .map(|v| format!("L{};", v.replace('.', "/")))
                         })
                     })
                     .or_else(|| {
-                        if pat_match_top(&slot_ty, "Vec") {
+                        // A run of values is what `kind` says it is.
+                        // `pat_match_top(.., "Vec")` compared the last path
+                        // segment, so a `Box<Vec<T>>` answered false.
+                        if slot.sequence_elem().is_some() {
                             Some("Ljava/util/List;".to_string())
                         } else {
                             // The wire table already names every reference wire's


### PR DESCRIPTION
Replaces #287, which GitHub auto-closed when its base branch (`lookups-take-readings`, #286) was deleted on merge. Same content, rebased onto `language-integration`.

Third piece of the #284 chain — #285 and #286 are merged.

## Three round trips

`struct_plan.rs` already held `reading`, `optional_inner` and `bare_ref` as `TypeRef`s, then downgraded all three and looked them back up:

```rust
let effective_ty = reading.syntax().clone();
...
registry.reading_of(&effective_ty).and_then(|tr| registry.output_entry(&tr))?
```

Gone. **The file now has zero `reading_of` calls.**

## Two latent defects, not round trips

Two of the five sites were asking a *spelling* a question the model answers — the #270/#272 family:

| | |
|---|---|
| `pat_match_top(&slot_ty, "Vec")` | compares the **last path segment**, so `Box<Vec<T>>` answered **false**. Now `slot.sequence_elem().is_some()` |
| `bare_path_ident(&slot_ty)` | takes the spelling apart for a name, which answers about the **wrapper** for `Box<T>`. Now the name comes off `TypeKind::Named { id }` |

Neither is reachable from the in-tree examples — goldens byte-identical — so these are the "correct output, no signal" shape of #266/#273, not observed breakage. Reporting them as latent rather than claiming a fixed bug.

## Finding: the rest of step 3 is bigger than #284 assumed

`emit/flat_input.rs` holds **20 of the 34 `option_inner_type` callers and 12 `reading_of` sites**. I planned it as a peel substitution. It is not:

**the file walks `syn::Fields::Named` directly**, while `flat::Struct::fields` already carries a `TypeRef` per field.

So it needs the **element-walking** change — take `&flat::Struct`, walk `struct.fields` — which is exactly the follow-up the umbrella already records from #283 for `scan_struct`/`scan_enum`. Tracked as its own issue rather than rushed in here.

## Ledger

Unchanged at 127, and honestly so: `types_util` only falls when its callers stop needing it, and `option_inner_type` still has 34.

## Verification

- 551 lib tests · `--all --all-features` 14/14 suites
- clippy `--deny warnings` clean · fmt (CI CLI config)
- regen-check **byte-identical** after `git clean -fd examples/` + `cargo clean -p`
- covertest-kotlin 48/48