### PR TITLE
jnigen: the enum probe peels off the model, then `syn::Type` parameter cleanup

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -54,9 +54,8 @@
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 2	api/lang/jnigen/jni/emit/delivery.rs
-10	api/lang/jnigen/jni/emit/flat_input.rs
+8	api/lang/jnigen/jni/emit/flat_input.rs
 17	api/lang/jnigen/jni/emit/names.rs
-2	api/lang/jnigen/jni/emit/vec_build.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 4	api/lang/jnigen/jni/iface.rs
@@ -70,4 +69,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 127
+# total: 123

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -54,7 +54,7 @@
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 2	api/lang/jnigen/jni/emit/delivery.rs
-8	api/lang/jnigen/jni/emit/flat_input.rs
+7	api/lang/jnigen/jni/emit/flat_input.rs
 17	api/lang/jnigen/jni/emit/names.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
@@ -69,4 +69,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 123
+# total: 122

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -312,6 +312,40 @@ impl TypeRef {
         crate::api::core::registry::TypeKey::from_type(&self.origin.syntax)
     }
 
+    /// The [transparent wrapper](TRANSPARENT_WRAPPERS) this type's **spelling**
+    /// adds over its classification, if any — `Box<Option<T>>` → `Some("Box")`,
+    /// `Option<T>` → `None`.
+    ///
+    /// This exists because [`kind`](Self::kind) and [`syntax`](Self::syntax)
+    /// answer different questions, and only one of them is about the
+    /// destination:
+    ///
+    /// * `kind` decides what the **destination** sees — the surface type and the
+    ///   wire. `Box<Option<String>>` and `Option<String>` are one optional
+    ///   string to every destination language, which is why the wrapper is
+    ///   erased.
+    /// * `syntax` decides how the value is **converted** — and Rust does tell
+    ///   them apart. A converter that rebuilds a value must produce the type
+    ///   the source actually spelled.
+    ///
+    /// So a consumer that *classifies* should never consult this; a consumer
+    /// that **reconstructs a Rust value** must, because rebuilding from the
+    /// classification alone yields the stripped type and handing that to a
+    /// parameter spelled `Box<..>` is an `E0308` in the generated crate.
+    ///
+    /// Only the outermost wrapper is named. That is enough to decide *whether*
+    /// a spelling was erased — which is the question a reconstruction asks —
+    /// but a consumer that wants to rebuild a nested `Box<Cow<'_, T>>` needs to
+    /// peel repeatedly with [`peel_transparent`], the same list this reads.
+    ///
+    /// Erased says nothing about **rebuildable**: `Box` reconstructs as
+    /// `Box::new(v)`, while `Cow`'s `Owned`/`Borrowed` choice is not determined
+    /// by any fact the model holds. Which wrappers an emitter can rebuild is
+    /// that emitter's policy; this only stops the wrapper from being invisible.
+    pub fn erased_wrapper(&self) -> Option<&'static str> {
+        peel_transparent(&self.origin.syntax).map(|(name, _)| name)
+    }
+
     /// The `Ok` and `Err` sides when this is a `Result`, else `None`.
     pub fn fallible_parts(&self) -> Option<(&TypeRef, &TypeRef)> {
         match &self.kind {

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -320,6 +320,31 @@ impl TypeRef {
         }
     }
 
+    /// The argument types when this is a callback, else `None` — the reading
+    /// counterpart of
+    /// [`extract_fn_trait_args`](super::extract_fn_trait_args).
+    ///
+    /// The two are the same question asked of different things, and that is the
+    /// whole difference. `extract_fn_trait_args` takes an
+    /// `impl Fn(..) + Send + Sync + 'static` **apart**: it walks the bounds,
+    /// checks the three markers, and refuses a written return type — it is a
+    /// classifier, and the one the model itself runs to build
+    /// [`TypeKind::Callback`]. This reads the result of that classification,
+    /// already made. A consumer holding a reading has no reason to redo the
+    /// walk, and every reason not to: a `Vec<syn::Type>` of *arguments* has lost
+    /// which of them the model accepted and how, while each `TypeRef` here
+    /// carries its own classification and its own spelling.
+    ///
+    /// Consequently this answers `None` for a type that merely *looks* like a
+    /// callback but was refused (a missing `Send`, an `impl Fn() -> u8`): the
+    /// acceptance already happened, and asking again is how the two drift.
+    pub fn callback_args(&self) -> Option<&[TypeRef]> {
+        match &self.kind {
+            TypeKind::Callback { args } => Some(args),
+            _ => None,
+        }
+    }
+
     /// The extent of this type when it is an array, else `None`.
     pub fn array_extent(&self) -> Option<&ArrayExtent> {
         match &self.kind {

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -3,9 +3,11 @@
 
 use std::collections::HashMap;
 
-use crate::api::core::{flat::{Flat, TypeRef}, unfold::{DeconId, DeconSpec, UnfoldPlan}};
-
 use super::*;
+use crate::api::core::{
+    flat::{Flat, TypeRef},
+    unfold::{DeconId, DeconSpec, UnfoldPlan},
+};
 
 /// One `(direction, type)` pair that crosses the boundary.
 ///
@@ -51,11 +53,7 @@ pub trait Conversions<M> {
     /// tokens instead let a spelling nobody classified reach the table, and cost
     /// a `TypeKey::from_type` on every call for an identity the reading already
     /// carries.
-    fn conversion(
-        &self,
-        dir: Direction,
-        reading: &TypeRef,
-    ) -> Option<&TypeEntry<M>>;
+    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>>;
 
     /// The reading for a **spelling** — identify, then look up.
     ///
@@ -100,9 +98,7 @@ pub trait Conversions<M> {
     fn error_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan>;
 
     /// The declaration-default decomposition behind each deconstructor.
-    fn decon_plans(
-        &self,
-    ) -> &HashMap<DeconId, DeconSpec>;
+    fn decon_plans(&self) -> &HashMap<DeconId, DeconSpec>;
 
     /// Every type key that crosses in `dir`.
     ///
@@ -128,11 +124,7 @@ impl<M> Conversions<M> for Building<'_, M> {
     fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         self.registry.reading(key)
     }
-    fn conversion(
-        &self,
-        dir: Direction,
-        reading: &TypeRef,
-    ) -> Option<&TypeEntry<M>> {
+    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>> {
         self.built.get(&(dir, reading.key()))
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
@@ -147,9 +139,7 @@ impl<M> Conversions<M> for Building<'_, M> {
     fn error_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan> {
         &self.registry.error_plans
     }
-    fn decon_plans(
-        &self,
-    ) -> &HashMap<DeconId, DeconSpec> {
+    fn decon_plans(&self) -> &HashMap<DeconId, DeconSpec> {
         &self.registry.decon_plans
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
@@ -168,11 +158,7 @@ impl<M> Conversions<M> for Registry<M> {
     fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         Registry::reading(self, key)
     }
-    fn conversion(
-        &self,
-        dir: Direction,
-        reading: &TypeRef,
-    ) -> Option<&TypeEntry<M>> {
+    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>> {
         self.type_table(dir).get(&reading.key())?.entry.as_ref()
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
@@ -187,9 +173,7 @@ impl<M> Conversions<M> for Registry<M> {
     fn error_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan> {
         &self.error_plans
     }
-    fn decon_plans(
-        &self,
-    ) -> &HashMap<DeconId, DeconSpec> {
+    fn decon_plans(&self) -> &HashMap<DeconId, DeconSpec> {
         &self.decon_plans
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
@@ -234,10 +218,7 @@ impl<'a, M> Building<'a, M> {
 
 /// Shared by [`Registry::origin_module`] and [`Building::origin_module`], so the
 /// two cannot answer differently.
-pub(super) fn origin_module_of(
-    flat: &Flat,
-    ident: &syn::Ident,
-) -> Option<syn::Path> {
+pub(super) fn origin_module_of(flat: &Flat, ident: &syn::Ident) -> Option<syn::Path> {
     let crate_name = flat.element(ident)?.location().crate_name.as_ref()?;
     syn::parse_str(&crate_name.replace('-', "_")).ok()
 }

--- a/prebindgen/src/api/core/registry/view.rs
+++ b/prebindgen/src/api/core/registry/view.rs
@@ -3,6 +3,8 @@
 
 use std::collections::HashMap;
 
+use crate::api::core::{flat::{Flat, TypeRef}, unfold::{DeconId, DeconSpec, UnfoldPlan}};
+
 use super::*;
 
 /// One `(direction, type)` pair that crosses the boundary.
@@ -22,7 +24,7 @@ pub type Crossing = (Direction, TypeKey);
 /// `&impl Conversions<M>` and works either side of the boundary.
 pub trait Conversions<M> {
     /// The model.
-    fn flat(&self) -> &crate::api::core::flat::Flat;
+    fn flat(&self) -> &Flat;
 
     /// The reading for `ty` — what the frontend made of it.
     ///
@@ -40,7 +42,7 @@ pub trait Conversions<M> {
     /// reading. This is the door FROM identity TO the model's answer, and the
     /// only lookup on this trait that does not already take a `TypeRef` — the
     /// rest take one precisely because this exists to hand them one (#284).
-    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef>;
+    fn reading(&self, key: &TypeKey) -> Option<TypeRef>;
 
     /// The conversion for `reading` in `dir`, if there is one.
     ///
@@ -52,7 +54,7 @@ pub trait Conversions<M> {
     fn conversion(
         &self,
         dir: Direction,
-        reading: &crate::api::core::flat::TypeRef,
+        reading: &TypeRef,
     ) -> Option<&TypeEntry<M>>;
 
     /// The reading for a **spelling** — identify, then look up.
@@ -66,17 +68,17 @@ pub trait Conversions<M> {
     /// so they cannot be called about a type the registry does not know — which
     /// is the guarantee, and it survives only while getting a reading from
     /// tokens is a visible step with a `None` to handle.
-    fn reading_of(&self, ty: &syn::Type) -> Option<crate::api::core::flat::TypeRef> {
+    fn reading_of(&self, ty: &syn::Type) -> Option<TypeRef> {
         self.reading(&TypeKey::from_type(ty))
     }
 
     /// Wire → rust.
-    fn input_entry(&self, reading: &crate::api::core::flat::TypeRef) -> Option<&TypeEntry<M>> {
+    fn input_entry(&self, reading: &TypeRef) -> Option<&TypeEntry<M>> {
         self.conversion(Direction::Input, reading)
     }
 
     /// Rust → wire.
-    fn output_entry(&self, reading: &crate::api::core::flat::TypeRef) -> Option<&TypeEntry<M>> {
+    fn output_entry(&self, reading: &TypeRef) -> Option<&TypeEntry<M>> {
         self.conversion(Direction::Output, reading)
     }
 
@@ -85,22 +87,22 @@ pub trait Conversions<M> {
     /// On the trait because a callback converter needs it while being built,
     /// and the emitter needs it again afterwards. Plans are applied by
     /// `prepare`, so they are complete either side of that line.
-    fn callback_arg_plan(&self, key: &TypeKey) -> Option<&crate::api::core::unfold::UnfoldPlan>;
+    fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan>;
 
     /// Every callback-argument decomposition, for the emitters that enumerate
     /// them rather than look one up.
-    fn callback_arg_plans(&self) -> &HashMap<TypeKey, crate::api::core::unfold::UnfoldPlan>;
+    fn callback_arg_plans(&self) -> &HashMap<TypeKey, UnfoldPlan>;
 
     /// The return decomposition of a function, if it has one.
-    fn unfold_plans(&self) -> &HashMap<syn::Ident, crate::api::core::unfold::UnfoldPlan>;
+    fn unfold_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan>;
 
     /// The error-position decomposition of a fallible function.
-    fn error_plans(&self) -> &HashMap<syn::Ident, crate::api::core::unfold::UnfoldPlan>;
+    fn error_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan>;
 
     /// The declaration-default decomposition behind each deconstructor.
     fn decon_plans(
         &self,
-    ) -> &HashMap<crate::api::core::unfold::DeconId, crate::api::core::unfold::DeconSpec>;
+    ) -> &HashMap<DeconId, DeconSpec>;
 
     /// Every type key that crosses in `dir`.
     ///
@@ -120,34 +122,34 @@ pub trait Conversions<M> {
 }
 
 impl<M> Conversions<M> for Building<'_, M> {
-    fn flat(&self) -> &crate::api::core::flat::Flat {
+    fn flat(&self) -> &Flat {
         &self.registry.flat
     }
-    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef> {
+    fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         self.registry.reading(key)
     }
     fn conversion(
         &self,
         dir: Direction,
-        reading: &crate::api::core::flat::TypeRef,
+        reading: &TypeRef,
     ) -> Option<&TypeEntry<M>> {
         self.built.get(&(dir, reading.key()))
     }
-    fn callback_arg_plan(&self, key: &TypeKey) -> Option<&crate::api::core::unfold::UnfoldPlan> {
+    fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
         self.registry.callback_arg_plans.get(key)
     }
-    fn callback_arg_plans(&self) -> &HashMap<TypeKey, crate::api::core::unfold::UnfoldPlan> {
+    fn callback_arg_plans(&self) -> &HashMap<TypeKey, UnfoldPlan> {
         &self.registry.callback_arg_plans
     }
-    fn unfold_plans(&self) -> &HashMap<syn::Ident, crate::api::core::unfold::UnfoldPlan> {
+    fn unfold_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan> {
         &self.registry.unfold_plans
     }
-    fn error_plans(&self) -> &HashMap<syn::Ident, crate::api::core::unfold::UnfoldPlan> {
+    fn error_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan> {
         &self.registry.error_plans
     }
     fn decon_plans(
         &self,
-    ) -> &HashMap<crate::api::core::unfold::DeconId, crate::api::core::unfold::DeconSpec> {
+    ) -> &HashMap<DeconId, DeconSpec> {
         &self.registry.decon_plans
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
@@ -160,34 +162,34 @@ impl<M> Conversions<M> for Building<'_, M> {
 }
 
 impl<M> Conversions<M> for Registry<M> {
-    fn flat(&self) -> &crate::api::core::flat::Flat {
+    fn flat(&self) -> &Flat {
         &self.flat
     }
-    fn reading(&self, key: &TypeKey) -> Option<crate::api::core::flat::TypeRef> {
+    fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         Registry::reading(self, key)
     }
     fn conversion(
         &self,
         dir: Direction,
-        reading: &crate::api::core::flat::TypeRef,
+        reading: &TypeRef,
     ) -> Option<&TypeEntry<M>> {
         self.type_table(dir).get(&reading.key())?.entry.as_ref()
     }
-    fn callback_arg_plan(&self, key: &TypeKey) -> Option<&crate::api::core::unfold::UnfoldPlan> {
+    fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
         self.callback_arg_plans.get(key)
     }
-    fn callback_arg_plans(&self) -> &HashMap<TypeKey, crate::api::core::unfold::UnfoldPlan> {
+    fn callback_arg_plans(&self) -> &HashMap<TypeKey, UnfoldPlan> {
         &self.callback_arg_plans
     }
-    fn unfold_plans(&self) -> &HashMap<syn::Ident, crate::api::core::unfold::UnfoldPlan> {
+    fn unfold_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan> {
         &self.unfold_plans
     }
-    fn error_plans(&self) -> &HashMap<syn::Ident, crate::api::core::unfold::UnfoldPlan> {
+    fn error_plans(&self) -> &HashMap<syn::Ident, UnfoldPlan> {
         &self.error_plans
     }
     fn decon_plans(
         &self,
-    ) -> &HashMap<crate::api::core::unfold::DeconId, crate::api::core::unfold::DeconSpec> {
+    ) -> &HashMap<DeconId, DeconSpec> {
         &self.decon_plans
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
@@ -233,14 +235,14 @@ impl<'a, M> Building<'a, M> {
 /// Shared by [`Registry::origin_module`] and [`Building::origin_module`], so the
 /// two cannot answer differently.
 pub(super) fn origin_module_of(
-    flat: &crate::api::core::flat::Flat,
+    flat: &Flat,
     ident: &syn::Ident,
 ) -> Option<syn::Path> {
     let crate_name = flat.element(ident)?.location().crate_name.as_ref()?;
     syn::parse_str(&crate_name.replace('-', "_")).ok()
 }
 
-pub(super) fn default_module_of(flat: &crate::api::core::flat::Flat) -> Option<syn::Path> {
+pub(super) fn default_module_of(flat: &Flat) -> Option<syn::Path> {
     flat.source_modules()
         .first()
         .and_then(|m| syn::parse_str(m).ok())

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -7,7 +7,7 @@
 //! JNI module; shares the `jni` namespace via `use super::*`.
 
 use super::*;
-use crate::api::core::registry::Conversions;
+use crate::api::core::{flat::{TypeKind, TypeRef}, registry::Conversions};
 
 impl DeclaredKind {
     /// The declaring macro's name, for the conflict message.
@@ -97,9 +97,34 @@ impl Declarations {
     /// Kotlin wrapper generator to decide if a parameter needs a `.value`
     /// projection between the typed enum (Kotlin signature) and the `Int`
     /// wire (JNI `external fun`).
+    ///
+    /// Keyed on the canonical **spelling**, so it answers about the wrapper for
+    /// a transparently-wrapped type: `Box<Priority>` is `false` here.
+    /// [`is_kotlin_enum_reading`](Self::is_kotlin_enum_reading) is the same
+    /// question asked of the model, and is what a caller holding a reading
+    /// should use.
     pub(crate) fn is_kotlin_enum(&self, ty: &syn::Type) -> bool {
         let key = TypeKey::from_type(ty);
         self.types.get(&key).is_some_and(|c| c.is_enum_class())
+    }
+
+    /// Whether this value's core is a type registered via an `EnumClassDecl`,
+    /// asked of the **reading**: [`enum_probe`] peels the borrow/optional
+    /// layers off the model, and the name comes off the classification.
+    ///
+    /// The name off `TypeKind::Named` rather than the spelling is the whole
+    /// difference from [`is_kotlin_enum`](Self::is_kotlin_enum). A declaration
+    /// names a type (`enum_class!(Priority)` keys `Priority`), and the model
+    /// erases the wrappers no destination language can see — so
+    /// `Box<Option<&Priority>>` reaches the same declaration `Priority` does,
+    /// where taking the spelling apart finds `Box` and answers about it.
+    pub(crate) fn is_kotlin_enum_reading(&self, reading: &TypeRef) -> bool {
+        let TypeKind::Named { id } = enum_probe(reading).kind() else {
+            return false;
+        };
+        id.ident()
+            .and_then(|i| self.types.get(&TypeKey::from_ident(&i)))
+            .is_some_and(|c| c.is_enum_class())
     }
 }
 
@@ -1053,7 +1078,7 @@ impl Declarations {
                     );
                     // The name is the reading's, not a path taken apart to
                     // re-derive one.
-                    let crate::api::core::flat::TypeKind::Named { id } = probe.kind() else {
+                    let TypeKind::Named { id } = probe.kind() else {
                         panic!("a sum type is a named type")
                     };
                     let crate::api::core::flat::Type::Variant(sum) = registry

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -7,7 +7,15 @@
 //! JNI module; shares the `jni` namespace via `use super::*`.
 
 use super::*;
-use crate::api::core::{flat::{TypeKind, TypeRef}, registry::Conversions};
+// `flat` as a module, not `flat::TypeKind` directly: the bare `TypeKind` in this
+// file is jnigen's OWN classifier (`classify.rs`, reached through `use super::*`
+// above), and an explicit import beats a glob — importing the model's would
+// silently retarget the `TypeKind::Sum` / `TypeKind::DataStruct` matches below.
+// One qualifier keeps both names short and says which of the two it is.
+use crate::api::core::{
+    flat::{self, TypeRef},
+    registry::Conversions,
+};
 
 impl DeclaredKind {
     /// The declaring macro's name, for the conflict message.
@@ -119,7 +127,7 @@ impl Declarations {
     /// `Box<Option<&Priority>>` reaches the same declaration `Priority` does,
     /// where taking the spelling apart finds `Box` and answers about it.
     pub(crate) fn is_kotlin_enum_reading(&self, reading: &TypeRef) -> bool {
-        let TypeKind::Named { id } = enum_probe(reading).kind() else {
+        let flat::TypeKind::Named { id } = enum_probe(reading).kind() else {
             return false;
         };
         id.ident()
@@ -877,7 +885,7 @@ impl Declarations {
         // model already normalized them.
         let ret = accessor.ret.borrow_target().unwrap_or(&accessor.ret);
         assert!(
-            !matches!(ret.kind(), crate::api::core::flat::TypeKind::Unit),
+            !matches!(ret.kind(), flat::TypeKind::Unit),
             "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
              value form returns the struct holding this type's fields",
             key.as_str(),
@@ -939,7 +947,7 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
         key: &TypeKey,
         decl: &FieldsDecl,
-        st: &crate::api::core::flat::Struct,
+        st: &flat::Struct,
         members: &[syn::Ident],
         name_prefix: &str,
         depth: usize,
@@ -1078,10 +1086,10 @@ impl Declarations {
                     );
                     // The name is the reading's, not a path taken apart to
                     // re-derive one.
-                    let TypeKind::Named { id } = probe.kind() else {
+                    let flat::TypeKind::Named { id } = probe.kind() else {
                         panic!("a sum type is a named type")
                     };
-                    let crate::api::core::flat::Type::Variant(sum) = registry
+                    let flat::Type::Variant(sum) = registry
                         .flat()
                         .declared_type(&id.name)
                         .expect("TypeKind::Sum implies an indexed enum")

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -744,6 +744,46 @@ pub(crate) struct FlatSumVariant {
     pub fields: Vec<(syn::Member, usize)>,
 }
 
+/// Peel `&` then `Option<…>` off the model to reach the value a specialized
+/// lowering would **rebuild**, refusing at any layer whose spelling adds a
+/// wrapper the classification erased.
+///
+/// One function because it is one rule. `kind` decides what the destination
+/// sees; the **conversion** follows the syntax, and these lowerings do not
+/// decode their parameter — they emit a literal `S { .. }`, wrap it in
+/// `Option::Some`, and hand it to the source function. Rebuilding from the
+/// classification alone produces the stripped type, so a parameter spelled
+/// `Box<Option<S>>` receives an `Option<S>`: `E0308` in the generated crate.
+///
+/// Refusing rather than rebuilding is a **gap, not a requirement**:
+/// `Box::new(v)` is exactly what the syntax asks for and is trivially
+/// emittable. It is left out here because doing it properly means teaching the
+/// converters to rebuild each wrapper, and `Cow` cannot be rebuilt from an
+/// owned payload at all. A wrapped spelling therefore keeps the general
+/// converter path, which is correct if less direct.
+///
+/// The wrapper question goes to [`TypeRef::erased_wrapper`] — the model holds
+/// both halves, so it is the only thing that can answer it, and no spelling is
+/// taken apart here.
+fn rebuildable_target(arg: &TypeRef) -> Option<(bool, bool, &TypeRef)> {
+    if arg.erased_wrapper().is_some() {
+        return None;
+    }
+    let by_ref = arg.borrow_target().is_some();
+    let t1 = arg.borrow_target().unwrap_or(arg);
+    if t1.erased_wrapper().is_some() {
+        return None;
+    }
+    let optional = t1.optional_inner().is_some();
+    let inner = t1.optional_inner().unwrap_or(t1);
+    // The struct is rebuilt BY NAME (`S { .. }`), so its own spelling must name
+    // it — a `Box<S>` target would need the `Box::new` this emitter never writes.
+    if inner.erased_wrapper().is_some() {
+        return None;
+    }
+    Some((by_ref, optional, inner))
+}
+
 /// A flattened plan for one struct input parameter. Built once by
 /// [`build_flat_input_plan`] and consumed by all three codegen sites.
 pub(crate) struct FlatInputPlan {
@@ -1132,13 +1172,11 @@ pub(crate) fn build_flat_input_plan(
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
-    // 1. Resolve the struct target through `&` and `Option<…>` — both off the
-    //    MODEL, so a transparently-wrapped spelling (`Box<Option<S>>`) peels
-    //    exactly as the bare one does instead of defeating a path-segment probe.
-    let by_ref = arg.borrow_target().is_some();
-    let t1 = arg.borrow_target().unwrap_or(arg);
-    let optional = t1.optional_inner().is_some();
-    let inner = t1.optional_inner().unwrap_or(t1);
+    // 1. Resolve the struct target through `&` and `Option<…>` — off the model,
+    //    and refusing any layer whose spelling the rebuild could not satisfy.
+    let Some((by_ref, optional, inner)) = rebuildable_target(arg) else {
+        return Ok(None);
+    };
     // `impl Into<S>` is NOT peeled here, and cannot be: the model refuses
     // `impl Trait` that is not the callback form (`DisallowedImplTrait`), so a
     // parameter spelled that way never becomes a reading and never reaches this
@@ -1830,8 +1868,13 @@ pub(crate) fn build_option_scalar_input_plan(
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Option<OptionScalarInputPlan> {
-    // The optional layer off the model, so a wrapped spelling (`Box<Option<T>>`)
-    // peels exactly as the bare one does.
+    // The optional layer off the model — but the emitter rebuilds a bare
+    // `Option::Some(v)` and hands it to the source fn, so a spelling the model
+    // erased a wrapper from could not receive it. Conversion follows the syntax;
+    // see [`rebuildable_target`], which applies the same rule to the struct path.
+    if arg.erased_wrapper().is_some() {
+        return None;
+    }
     let inner = arg.optional_inner()?;
     // `Option<&T>` is the nullable-borrow / handle path, not a scalar.
     if inner.borrow_target().is_some() {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -1828,16 +1828,17 @@ pub(crate) fn build_option_scalar_input_plan(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
-    arg_ty: &syn::Type,
+    arg: &TypeRef,
 ) -> Option<OptionScalarInputPlan> {
-    let inner = option_inner_type(arg_ty)?;
+    // The optional layer off the model, so a wrapped spelling (`Box<Option<T>>`)
+    // peels exactly as the bare one does.
+    let inner = arg.optional_inner()?;
     // `Option<&T>` is the nullable-borrow / handle path, not a scalar.
-    if matches!(inner, syn::Type::Reference(_)) {
+    if inner.borrow_target().is_some() {
         return None;
     }
-    let inner_entry = registry
-        .reading_of(&inner)
-        .and_then(|tr| registry.input_entry(&tr))?;
+    // The layer's own reading straight to its entry — no spell-and-look-back.
+    let inner_entry = registry.input_entry(inner)?;
     let value_wire = inner_entry.destination.clone();
     // Only the boxed-primitive fallback shape: primitive wire, no niche,
     // no projection, no composed pre-stages.
@@ -1851,7 +1852,13 @@ pub(crate) fn build_option_scalar_input_plan(
     if !inner_entry.pre_stages.is_empty() {
         return None;
     }
-    let is_enum = ext.is_kotlin_enum(&inner);
+    // The reading-taking probe: `Option<Box<Priority>>` now answers TRUE, where
+    // keying on the spelling asked about `Box < Priority >` and found nothing —
+    // the #270/#272 family again. The probe also peels an optional, which cannot
+    // matter here: a nested `Option<Option<enum>>` has a BOXED wire, and
+    // `JniPrim::from_wire` above accepts only the eight `j*` primitives, so it
+    // has already returned by this line.
+    let is_enum = ext.is_kotlin_enum_reading(inner);
     Some(OptionScalarInputPlan {
         present_ident: format_ident!("{}_present", param_name),
         value_ident: format_ident!("{}_value", param_name),

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -2,7 +2,12 @@
 //! expressions, and the Rust-side reconstruct.
 
 use super::*;
-use crate::api::core::registry::Conversions;
+// `flat` as a module for `TypeKind`: the bare name in this scope is jnigen's own
+// classifier (via `use super::*`), and an explicit import would shadow it.
+use crate::api::core::{
+    flat::{self, TypeRef},
+    registry::Conversions,
+};
 
 pub(crate) fn struct_input_body(
     ext: &Declarations,
@@ -751,26 +756,15 @@ pub(crate) struct FlatInputPlan {
     pub contains_nested: bool,
 }
 
-/// Extract `S` from an `impl Into<S> + …` parameter type.
-pub(crate) fn impl_into_target(ty: &syn::Type) -> Option<syn::Type> {
-    let syn::Type::ImplTrait(it) = ty else {
-        return None;
-    };
-    for b in &it.bounds {
-        if let syn::TypeParamBound::Trait(tb) = b {
-            if let Some(seg) = tb.path.segments.last() {
-                if seg.ident == "Into" {
-                    if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
-                        if let Some(syn::GenericArgument::Type(t)) = ab.args.first() {
-                            return Some(t.clone());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
-}
+// `impl_into_target` lived here: it extracted `S` from an `impl Into<S> + …`
+// spelling for `build_flat_input_plan`'s struct-target peel. It is gone because
+// that peel now takes a reading, and the model REFUSES `impl Trait` that is not
+// the callback form (`UnsupportedTypeReason::DisallowedImplTrait`) — so a
+// parameter spelled `impl Into<S>` never becomes a `TypeRef` and never reached
+// the call. `cargo check` confirmed it dead rather than the reasoning alone.
+// jnigen's actual `impl Into<…>` support is elsewhere: plugin wrapper exts build
+// a `ConverterImpl::function` by hand via `Declarations::input_converter_name`,
+// which never consults this.
 
 /// Peel a leading `&`/`&mut` then an `Option<…>` to expose the inner type used
 /// for enum/struct detection (`&Priority`, `Option<Priority>` → `Priority`).
@@ -1136,19 +1130,26 @@ pub(crate) fn build_flat_input_plan(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
-    arg_ty: &syn::Type,
+    arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
-    // 1. Resolve the struct target through `&`, `Option<…>`, and `impl Into<S>`.
-    let (by_ref, t1) = match arg_ty {
-        syn::Type::Reference(r) => (true, (*r.elem).clone()),
-        other => (false, other.clone()),
+    // 1. Resolve the struct target through `&` and `Option<…>` — both off the
+    //    MODEL, so a transparently-wrapped spelling (`Box<Option<S>>`) peels
+    //    exactly as the bare one does instead of defeating a path-segment probe.
+    let by_ref = arg.borrow_target().is_some();
+    let t1 = arg.borrow_target().unwrap_or(arg);
+    let optional = t1.optional_inner().is_some();
+    let inner = t1.optional_inner().unwrap_or(t1);
+    // `impl Into<S>` is NOT peeled here, and cannot be: the model refuses
+    // `impl Trait` that is not the callback form (`DisallowedImplTrait`), so a
+    // parameter spelled that way never becomes a reading and never reaches this
+    // function. The former `impl_into_target` call was already unreachable from
+    // every caller — see the sibling helper's doc.
+    // The name off the classification, not off the last path segment: `Box<S>`
+    // IS `S` here, and taking the spelling apart would answer about the wrapper.
+    let flat::TypeKind::Named { id } = inner.kind() else {
+        return Ok(None);
     };
-    let (optional, inner) = match option_inner_type(&t1) {
-        Some(i) => (true, i),
-        None => (false, t1.clone()),
-    };
-    let struct_ty = impl_into_target(&inner).unwrap_or_else(|| inner.clone());
-    let Some(name) = bare_path_ident(&struct_ty) else {
+    let Some(name) = id.ident() else {
         return Ok(None);
     };
     let Some(st) = registry
@@ -1158,7 +1159,7 @@ pub(crate) fn build_flat_input_plan(
     else {
         return Ok(None);
     };
-    let key = TypeKey::from_type(&struct_ty);
+    let key = inner.key();
     let Some(cfg) = ext.types.get(&key) else {
         return Ok(None);
     };
@@ -1171,10 +1172,8 @@ pub(crate) fn build_flat_input_plan(
     // surfaces as `"Any"` Dispatch or a foreign source type). The resolved
     // param's Kotlin type (compared by short name, since metadata carries the
     // FQN) must equal the struct's data-class name.
-    let Some(entry) = registry
-        .reading_of(arg_ty)
-        .and_then(|tr| registry.input_entry(&tr))
-    else {
+    // The parameter's own reading straight to its entry — no spell-and-look-back.
+    let Some(entry) = registry.input_entry(arg) else {
         return Ok(None);
     };
     if entry.metadata.projection.is_some() {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -33,12 +33,27 @@ pub(crate) fn vec_build_elem(
     // The run and its element off the MODEL. `&mut [T]` is still refused —
     // mutate-back semantics keep the `input_vec` path — and that is the one
     // fact the layer accessors do not carry, so `RefMode` is read directly.
-    let (elem, by_ref) = match arg.kind() {
-        flat::TypeKind::Ref { mode, inner } if *mode == RefMode::Shared => {
-            (inner.sequence_elem()?, true)
-        }
-        _ => (arg.sequence_elem()?, false),
+    //
+    // The conversion follows the SYNTAX, and must: this path builds a Rust-side
+    // `Vec<T>` and hands the source fn a borrow of it (or `mem::take`s it), so
+    // the referent has to be a form that built value satisfies. `&[T]`
+    // deref-coerces and `Vec<T>` is the thing itself; `Box<Vec<T>>` and
+    // `Cow<'_, [T]>` classify identically and cannot be rebuilt from the local.
+    // `decoded_vec_satisfies` in `selector.rs` is the same rule guarding the
+    // general converter path — asked here of the model, which holds both halves.
+    let (run, by_ref) = match arg.kind() {
+        flat::TypeKind::Ref { mode, inner } if *mode == RefMode::Shared => (&**inner, true),
+        _ => (arg, false),
     };
+    if run.erased_wrapper().is_some() {
+        return None;
+    }
+    let elem = run.sequence_elem()?;
+    // The element is spelled into `Vec<#elem>` and rebuilt per push, so a
+    // wrapped element spelling is unbuildable for the same reason.
+    if elem.erased_wrapper().is_some() {
+        return None;
+    }
     // The element must flatten; the probe ident is irrelevant here.
     let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
         .ok()

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -2,22 +2,18 @@
 //! (`New`/`Push`/`Free` helper trio).
 
 use super::*;
+// `flat` as a module for `TypeKind`: the bare name in this scope is jnigen's own
+// classifier (reached through `use super::*`), and an explicit import would win
+// over the glob and silently retarget it.
+use crate::api::core::flat::{self, RefMode, TypeRef};
 
-/// Classify a slice/`Vec` **input** param for the "build the Rust-side Vec
-/// incrementally" path: an immutable slice `&[T]` (`by_ref = true`, the target
-/// borrows the boxed Vec) or a by-value `Vec<T>` (`by_ref = false`, the target
-/// moves it out via `mem::take`). `&mut [T]` (mutate-back semantics) and every
-/// other shape return `None`, keeping the existing `input_vec` `List<JObject>`
-/// path. (Element flattenability is checked separately by [`vec_build_elem`].)
-pub(crate) fn slice_or_vec_elem(arg_ty: &syn::Type) -> Option<(syn::Type, bool)> {
-    match arg_ty {
-        syn::Type::Reference(r) if r.mutability.is_none() => match &*r.elem {
-            syn::Type::Slice(s) => Some(((*s.elem).clone(), true)),
-            _ => None,
-        },
-        _ => vec_inner_type(arg_ty).map(|t| (t, false)),
-    }
-}
+// `slice_or_vec_elem` lived here: it matched `&[T]` / `Vec<T>` off the SPELLING
+// and returned the element. `vec_build_elem` was its only caller and now reads
+// the same two facts off the model (`sequence_elem`, through `borrow_target`),
+// where a `Box<Vec<T>>` answers as `Vec<T>` does instead of failing a
+// last-path-segment test. Its one non-structural rule — `&mut [T]` is refused,
+// because mutate-back semantics keep the `input_vec` path — survives as the
+// `RefMode::Shared` guard on that match.
 
 /// `Some((element_type, by_ref))` when `arg_ty` is a slice/`Vec` input whose
 /// element is a **flattenable `data_class`** — i.e. it decomposes into the
@@ -32,11 +28,19 @@ pub(crate) fn slice_or_vec_elem(arg_ty: &syn::Type) -> Option<(syn::Type, bool)>
 pub(crate) fn vec_build_elem(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    arg_ty: &syn::Type,
-) -> Option<(syn::Type, bool)> {
-    let (elem, by_ref) = slice_or_vec_elem(arg_ty)?;
+    arg: &TypeRef,
+) -> Option<(TypeRef, bool)> {
+    // The run and its element off the MODEL. `&mut [T]` is still refused —
+    // mutate-back semantics keep the `input_vec` path — and that is the one
+    // fact the layer accessors do not carry, so `RefMode` is read directly.
+    let (elem, by_ref) = match arg.kind() {
+        flat::TypeKind::Ref { mode, inner } if *mode == RefMode::Shared => {
+            (inner.sequence_elem()?, true)
+        }
+        _ => (arg.sequence_elem()?, false),
+    };
     // The element must flatten; the probe ident is irrelevant here.
-    let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), &elem)
+    let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
         .ok()
         .flatten()?;
     // Recursive/optional element decomposition is intentionally outside this
@@ -51,7 +55,7 @@ pub(crate) fn vec_build_elem(
     {
         return None;
     }
-    Some((elem, by_ref))
+    Some((elem.clone(), by_ref))
 }
 
 /// Every distinct flattenable element type `T` that a scanned, declared function
@@ -62,22 +66,18 @@ pub(crate) fn vec_build_elem(
 pub(crate) fn collect_vec_build_elem_types(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-) -> Vec<syn::Type> {
+) -> Vec<TypeRef> {
     let declared = ext.declared_functions();
-    let mut seen: std::collections::BTreeMap<String, syn::Type> = std::collections::BTreeMap::new();
-    for (ident, item_fn) in registry
-        .flat()
-        .functions()
-        .map(|f| (&f.name, &f.origin.syntax))
-    {
-        if !declared.contains(ident) {
+    let mut seen: std::collections::BTreeMap<String, TypeRef> = std::collections::BTreeMap::new();
+    // Over the model's params, which already carry a reading each — the
+    // `sig.inputs` walk had to re-derive one per argument.
+    for f in registry.flat().functions() {
+        if !declared.contains(&f.name) {
             continue;
         }
-        for input in &item_fn.sig.inputs {
-            if let syn::FnArg::Typed(pt) = input {
-                if let Some((elem, _)) = vec_build_elem(ext, registry, &pt.ty) {
-                    seen.insert(TypeKey::from_type(&elem).as_str().to_string(), elem);
-                }
+        for p in &f.params {
+            if let Some((elem, _)) = vec_build_elem(ext, registry, &p.ty) {
+                seen.insert(elem.key().as_str().to_string(), elem);
             }
         }
     }
@@ -101,7 +101,7 @@ pub(crate) struct VecBuildHelpers {
 pub(crate) fn vec_build_helpers(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    elem: &syn::Type,
+    elem: &TypeRef,
 ) -> Option<VecBuildHelpers> {
     let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
         .ok()
@@ -115,7 +115,7 @@ pub(crate) fn vec_build_helpers(
     {
         return None;
     }
-    let key = TypeKey::from_type(elem);
+    let key = elem.key();
     let kt_fqn = ext
         .types
         .get(&key)
@@ -168,8 +168,11 @@ pub(crate) fn build_vec_build_helper_items(
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
-    for elem in collect_vec_build_elem_types(ext, registry) {
-        let Some(h) = vec_build_helpers(ext, registry, &elem) else {
+    for elem_reading in collect_vec_build_elem_types(ext, registry) {
+        // Generated Rust spells `origin.syntax`; the reading is what the plan
+        // and the key are taken from.
+        let elem = elem_reading.syntax();
+        let Some(h) = vec_build_helpers(ext, registry, &elem_reading) else {
             continue;
         };
         let new_sym = vec_helper_symbol(ext, &h.base, "New");

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -41,10 +41,22 @@ pub(crate) fn vec_build_elem(
     // `Cow<'_, [T]>` classify identically and cannot be rebuilt from the local.
     // `decoded_vec_satisfies` in `selector.rs` is the same rule guarding the
     // general converter path — asked here of the model, which holds both halves.
+    //
+    // BEFORE the peel as well as after, and the order is the whole point: the
+    // erasure happens OUTSIDE the layer it wraps, so `Box<&Vec<T>>` classifies
+    // as `Ref` and interpreting `kind` first would replace `arg` with the inner
+    // sequence — whose spelling is a clean `Vec<T>` — and let the outer `Box`
+    // through unseen. Every layer is checked on the way down, the way
+    // `rebuildable_target` does it.
+    if arg.erased_wrapper().is_some() {
+        return None;
+    }
     let (run, by_ref) = match arg.kind() {
         flat::TypeKind::Ref { mode, inner } if *mode == RefMode::Shared => (&**inner, true),
         _ => (arg, false),
     };
+    // Still needed after the peel: `&Box<Vec<T>>` puts the wrapper on the
+    // referent, where the check above (a `syn::Type::Reference`) cannot see it.
     if run.erased_wrapper().is_some() {
         return None;
     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -553,6 +553,8 @@ fn emit_input_param(
         // Vec the Kotlin `finally` frees). Decode is infallible, like the
         // by-value-handle consume below.
         InputKind::VecBuild { elem, by_ref } => {
+            // Generated Rust spells the reading's own tokens.
+            let elem = elem.syntax();
             let handle_ident = format_ident!("{}_handle", arg_ident);
             wire_params.push(quote!(#handle_ident: jni::sys::jlong));
             if *by_ref {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -761,16 +761,15 @@ pub(crate) fn emit_expanded_param(
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
         let leaf_ty = leaf.ty.syntax();
         let lookup_entry = || {
-            registry
-                .reading_of(leaf_ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .unwrap_or_else(|| {
-                    panic!(
-                        "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
-                        TypeKey::from_type(leaf_ty),
-                        orig_param,
-                    )
-                })
+            // The leaf's own reading goes straight to the entry: spelling it and
+            // looking the same reading back up is the round trip #286 removed.
+            registry.input_entry(&leaf.ty).unwrap_or_else(|| {
+                panic!(
+                    "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
+                    leaf.ty.key(),
+                    orig_param,
+                )
+            })
         };
         let local = format_ident!("__exp_{}", leaf.name);
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -610,16 +610,20 @@ fn emit_input_param(
         | InputKind::Handle { .. }
         | InputKind::Unsigned64 { .. }
         | InputKind::Plain => {
-            let entry = registry
-                .reading_of(arg_ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .unwrap_or_else(|| {
-                    panic!(
-                        "JniGen::on_function: input type `{}` for `{}` is unresolved",
-                        TypeKey::from_type(arg_ty),
-                        original_ident,
-                    )
-                });
+            // The leaf's reading — for `ParamForm::Single` it is the very
+            // reading `param.ty` was spelled from, so this is the same lookup
+            // without the round trip. The panic now CALLS the shared message
+            // instead of restating it, which is what `PlanError::message`'s doc
+            // has always claimed and hand-duplication did not deliver.
+            let entry = registry.input_entry(&leaf.reading).unwrap_or_else(|| {
+                panic!(
+                    "{}",
+                    PlanError::Unresolved {
+                        ty: Box::new(leaf.reading.clone())
+                    }
+                    .message(original_ident)
+                )
+            });
             emit_plain_decode(entry, arg_ident, arg_ty, on_err)
         }
     }
@@ -764,10 +768,14 @@ pub(crate) fn emit_expanded_param(
             // The leaf's own reading goes straight to the entry: spelling it and
             // looking the same reading back up is the round trip #286 removed.
             registry.input_entry(&leaf.ty).unwrap_or_else(|| {
+                // Shared wording, not restated — see the sibling backstop above.
                 panic!(
-                    "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
-                    leaf.ty.key(),
-                    orig_param,
+                    "{}",
+                    PlanError::UnresolvedLeaf {
+                        ty: Box::new(leaf.ty.clone()),
+                        param: orig_param.clone(),
+                    }
+                    .message(orig_param)
                 )
             })
         };

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -596,9 +596,8 @@ fn classify_leaf(
     expanded: bool,
     source_param: &syn::Ident,
 ) -> Result<PlanLeaf, PlanError> {
-    // The reading, so the layer questions cannot miss. What generated Rust must
-    // spell is `origin.syntax`, unchanged.
-    let ty = reading.syntax();
+    // Every question below is the model's now — the local spelling this function
+    // opened with has no users left.
     let optional = reading.optional_inner().is_some();
     // The enum probe off the reading — the layers it peels are the model's own
     // (`&`, `Option`), so there is nothing to re-spell and nothing to look up.
@@ -653,7 +652,7 @@ fn classify_leaf(
         .flatten()
     {
         InputKind::VecBuild { elem, by_ref }
-    } else if let Some(sp) = build_option_scalar_input_plan(ext, registry, ident, ty) {
+    } else if let Some(sp) = build_option_scalar_input_plan(ext, registry, ident, reading) {
         InputKind::OptionScalar(sp)
     } else if let Some(plan) = flat_plan {
         InputKind::FlattenStruct(plan)

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -11,7 +11,7 @@
 //! plan to function granularity; the output side follows in a later stage.
 
 use super::*;
-use crate::api::core::registry::Conversions;
+use crate::api::core::{flat::TypeRef, registry::Conversions};
 
 /// The lowered plan for one bound function: one [`PlanParam`] per source
 /// `syn::Signature` parameter (non-`Typed`/non-`Ident` args — `self`,
@@ -68,7 +68,7 @@ pub(crate) struct PlanLeaf {
     /// The leaf's **reading** — classification and spelling in one value, so
     /// the two cannot disagree and no consumer has to look the type up. Spell
     /// with `reading.origin.syntax`.
-    pub reading: crate::api::core::flat::TypeRef,
+    pub reading: TypeRef,
     /// Kotlin parameter name (`kt_param_name(ident)`: camelCase +
     /// hard-keyword escaping) — shared by the wrapper signature and the
     /// `external fun` declaration.
@@ -531,7 +531,7 @@ fn classify_leaf(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     ident: &syn::Ident,
-    reading: &crate::api::core::flat::TypeRef,
+    reading: &TypeRef,
     expanded: bool,
     source_param: &syn::Ident,
 ) -> Result<PlanLeaf, PlanError> {
@@ -539,7 +539,9 @@ fn classify_leaf(
     // spell is `origin.syntax`, unchanged.
     let ty = reading.syntax();
     let optional = reading.optional_inner().is_some();
-    let as_enum_value = ext.is_kotlin_enum(&enum_probe_type(ty));
+    // The enum probe off the reading — the layers it peels are the model's own
+    // (`&`, `Option`), so there is nothing to re-spell and nothing to look up.
+    let as_enum_value = ext.is_kotlin_enum_reading(reading);
     let kt_name = kt_param_name(&ident.to_string());
 
     // `impl Fn(args)` first: typed entirely from the interface spec — the

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -546,15 +546,20 @@ fn classify_leaf(
 
     // `impl Fn(args)` first: typed entirely from the interface spec — the
     // erased entry exists but its metadata carries no surface type.
-    if let Some(args) = extract_fn_trait_args(ty) {
-        let iface = ext.iface_spec(registry, &SpecKey::callback(&args));
+    if let Some(args) = reading.callback_args() {
+        // `SpecKey` is a memo key and holds `TypeKey`s, so the args reach it as
+        // spellings either way — but as each arg reading's OWN spelling now,
+        // rather than one re-extracted from the parameter's bounds.
+        // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax`
+        // pins that the two routes are one memo identity.
+        let arg_tys: Vec<syn::Type> = args.iter().map(|a| a.syntax().clone()).collect();
+        let iface = ext.iface_spec(registry, &SpecKey::callback(&arg_tys));
         return Ok(PlanLeaf {
             reading: reading.clone(),
             kt_name,
             kt_public: None,
             kt_meta: registry
-                .reading_of(ty)
-                .and_then(|tr| registry.input_entry(&tr))
+                .input_entry(reading)
                 .and_then(|e| e.metadata.kotlin_name.clone()),
             optional,
             as_enum_value,

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -110,7 +110,9 @@ pub(crate) enum InputKind {
     Callback { iface: Option<Arc<IfaceSpec>> },
     /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
     /// Vec-handle on the wire, built by pushing element leaves.
-    VecBuild { elem: syn::Type, by_ref: bool },
+    /// The element as a **reading**: the vec-helper plan and the element key
+    /// are both taken from it, and generated Rust spells `elem.syntax()`.
+    VecBuild { elem: TypeRef, by_ref: bool },
     /// Bare `Option<primitive>` / `Option<enum>`: a decoupled
     /// `(present: jboolean, value: <wire>)` pair.
     OptionScalar(OptionScalarInputPlan),
@@ -644,10 +646,10 @@ fn classify_leaf(
         });
     };
 
-    let flat_plan = build_flat_input_plan(ext, registry, ident, ty)
+    let flat_plan = build_flat_input_plan(ext, registry, ident, reading)
         .map_err(PlanError::UnflattenableDataClass)?;
     let kind = if let Some((elem, by_ref)) = (!expanded)
-        .then(|| vec_build_elem(ext, registry, ty))
+        .then(|| vec_build_elem(ext, registry, reading))
         .flatten()
     {
         InputKind::VecBuild { elem, by_ref }

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -569,11 +569,8 @@ fn classify_leaf(
 
     // Every non-callback leaf requires a resolved input entry — the same
     // hard boundary the Rust emitter has always enforced.
-    let Some(entry) = registry
-        .reading_of(ty)
-        .and_then(|tr| registry.input_entry(&tr))
-    else {
-        let key = TypeKey::from_type(ty);
+    let Some(entry) = registry.input_entry(reading) else {
+        let key = reading.key();
         return Err(if expanded {
             PlanError::UnresolvedLeaf {
                 ty: key,

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -222,11 +222,32 @@ pub(crate) enum ReturnSurface {
 #[derive(Debug)]
 pub(crate) enum PlanError {
     /// `registry.input_entry` has no converter for a source param type.
-    Unresolved { ty: TypeKey },
+    ///
+    /// The **reading**, not a key: the registry knew the type well enough to
+    /// classify it — what it lacks is a converter — so the reading is in hand,
+    /// and it carries the source position [`Self::message`] points at.
+    ///
+    /// **Boxed**, and it has to be. A `TypeRef` holds a `syn::Type` inline and
+    /// runs to ~264 bytes; a `Result` is sized by its largest variant, so an
+    /// unboxed reading here would widen every `Result<_, PlanError>` on this
+    /// path — the *success* return included, which is the one that always
+    /// happens (`clippy::result_large_err`). An error is rare enough to afford
+    /// the allocation; the plans it returns beside are not.
+    Unresolved { ty: Box<TypeRef> },
     /// No converter for a constructor-expansion leaf type.
-    UnresolvedLeaf { ty: TypeKey, param: syn::Ident },
-    /// `registry.output_entry` has no converter for the output target type.
-    UnresolvedOutput { ty: TypeKey },
+    UnresolvedLeaf { ty: Box<TypeRef>, param: syn::Ident },
+    /// The output target type is known but `registry.output_entry` has no
+    /// converter for it — the failure `output_wrapper` fixes.
+    UnresolvedOutput { ty: Box<TypeRef> },
+    /// The output target type is not in the registry **at all**, so there is no
+    /// reading to hold and `output_wrapper` is not the answer.
+    ///
+    /// Split from [`Self::UnresolvedOutput`] because the two want opposite
+    /// advice: one type needs a converter written for it, the other needs to
+    /// reach the registry first. Collapsed together, the `output_wrapper`
+    /// message sent the reader to write a converter for a type the resolver
+    /// would still never ask about.
+    UnknownOutputType { ty: TypeKey },
     /// An unmarked declared data class could not produce a complete recursive
     /// input plan. Silent `JObject` fallback is forbidden.
     UnflattenableDataClass(FlatInputError),
@@ -236,25 +257,63 @@ pub(crate) enum PlanError {
 }
 
 impl PlanError {
+    /// Where the offending type was written, when a file wrote it — the
+    /// suffix [`Self::message`] appends.
+    ///
+    /// `has_position` gates it exactly as `resolve.rs` gates
+    /// `UnresolvedEntry::location`: a composed type and a test's hand-built
+    /// stream are lowered against `SourceLocation::default`, and printing
+    /// `:0:0` for them would make a fabricated position look like a real one.
+    fn location_suffix(&self) -> String {
+        let reading = match self {
+            PlanError::Unresolved { ty }
+            | PlanError::UnresolvedLeaf { ty, .. }
+            | PlanError::UnresolvedOutput { ty } => ty,
+            PlanError::UnknownOutputType { .. }
+            | PlanError::UnflattenableDataClass(_)
+            | PlanError::JvmParameterLimit { .. } => return String::new(),
+        };
+        let loc = reading.location();
+        if loc.has_position() {
+            format!(" (declared at {loc})")
+        } else {
+            String::new()
+        }
+    }
+
     /// The historical emission-panic message for this failure, shared by the
     /// validation boundary and the Rust emitter's backstop panics so the
     /// wording cannot drift.
+    ///
+    /// The base wording is unchanged; a source position is appended when the
+    /// reading has one, so a backstop that reaches the same failure without a
+    /// reading still prints a prefix of this.
     pub fn message(&self, fn_ident: &syn::Ident) -> String {
+        let at = self.location_suffix();
         match self {
             PlanError::Unresolved { ty } => format!(
-                "JniGen::on_function: input type `{}` for `{}` is unresolved",
-                ty, fn_ident,
+                "JniGen::on_function: input type `{}` for `{}` is unresolved{at}",
+                ty.key(),
+                fn_ident,
             ),
             PlanError::UnresolvedLeaf { ty, param } => format!(
-                "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved",
-                ty, param,
+                "JniGen expand: leaf type `{}` (parameter `{}`) is unresolved{at}",
+                ty.key(),
+                param,
             ),
             PlanError::UnresolvedOutput { ty } => format!(
                 "JniGen::on_function: return type `{}` of `{}` has no registered output \
                  converter — register one via `Declarations::output_wrapper(pat, |…| Some((ty, exc, body)))` \
                  (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
-                  to bind a domain exception)",
-                ty, fn_ident,
+                  to bind a domain exception){at}",
+                ty.key(),
+                fn_ident,
+            ),
+            PlanError::UnknownOutputType { ty } => format!(
+                "JniGen::on_function: return type `{}` of `{}` is not registered — the \
+                 resolver never saw this type, so no converter can be selected for it. \
+                 Declare the type (or the function that produces it) before binding `{}`",
+                ty, fn_ident, fn_ident,
             ),
             PlanError::UnflattenableDataClass(error) => {
                 format!("JniGen::on_function `{fn_ident}`: {}", error.message())
@@ -570,14 +629,18 @@ fn classify_leaf(
     // Every non-callback leaf requires a resolved input entry — the same
     // hard boundary the Rust emitter has always enforced.
     let Some(entry) = registry.input_entry(reading) else {
-        let key = reading.key();
+        // The reading itself, so the diagnostic can say where the type was
+        // written. Reaching here means the type IS classified and merely has no
+        // converter, which is why there is something to carry.
         return Err(if expanded {
             PlanError::UnresolvedLeaf {
-                ty: key,
+                ty: Box::new(reading.clone()),
                 param: source_param.clone(),
             }
         } else {
-            PlanError::Unresolved { ty: key }
+            PlanError::Unresolved {
+                ty: Box::new(reading.clone()),
+            }
         });
     };
 
@@ -698,12 +761,19 @@ fn build_output(
             .expect("Return delivery carries convert_out_ty"),
         None => ok_ty.unwrap_or(return_ty),
     };
-    let Some(entry) = registry
-        .reading_of(&target_ty)
-        .and_then(|tr| registry.output_entry(&tr))
-    else {
-        return Err(PlanError::UnresolvedOutput {
+    // Two failures, told apart. `target_ty` is composed here (`convert_out_ty`,
+    // or the `Result` peeled to its `Ok`), so unlike the input side there may
+    // genuinely be no reading — and "not registered" wants different advice
+    // from "registered, no converter". Collapsed into one `and_then`, both got
+    // the `output_wrapper` message and the first one got it wrong.
+    let Some(target) = registry.reading_of(&target_ty) else {
+        return Err(PlanError::UnknownOutputType {
             ty: TypeKey::from_type(&target_ty),
+        });
+    };
+    let Some(entry) = registry.output_entry(&target) else {
+        return Err(PlanError::UnresolvedOutput {
+            ty: Box::new(target),
         });
     };
     let wire_ty = entry.destination.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -5,8 +5,6 @@
 //! via `use super::*`.
 
 use super::*;
-// Not through the `jni` prelude: `TypeKind` there is jnigen's own classifier
-// (`classify.rs`), so the model's types are named on their own path.
 use crate::api::core::flat::TypeRef;
 
 /// Peel the layers that never change whether a value's core is a Kotlin enum,

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -5,12 +5,43 @@
 //! via `use super::*`.
 
 use super::*;
+// Not through the `jni` prelude: `TypeKind` there is jnigen's own classifier
+// (`classify.rs`), so the model's types are named on their own path.
+use crate::api::core::flat::TypeRef;
 
-/// Peel a leading `&`/`&mut` and an `Option<…>` layer to expose the inner type
-/// used for enum detection. So `&Priority`, `Priority`, and `Option<Priority>`
-/// all probe as `Priority` — letting nullable enum params (`Option<enum>`) wire
-/// as `Int?` + `?.value` just like a non-null enum wires as `Int` + `.value`,
-/// instead of leaking the enum object to the (boxed-int-expecting) Rust converter.
+/// Peel the layers that never change whether a value's core is a Kotlin enum,
+/// **off the model**: a borrow and an optional, in any nesting. So `&Priority`,
+/// `Priority`, `Option<Priority>` and `Option<&Priority>` all probe as
+/// `Priority` — letting nullable enum params (`Option<enum>`) wire as `Int?` +
+/// `?.value` just like a non-null enum wires as `Int` + `.value`, instead of
+/// leaking the enum object to the (boxed-int-expecting) Rust converter.
+///
+/// A **run is not peeled**. `Vec<Priority>` is a `List<Priority>`, not an enum,
+/// so this is deliberately not [`TypeRef::layer_stack`], which strips the
+/// sequence layer too.
+///
+/// Borrowing rather than composing is not a shortcut: every layer of a reading
+/// already holds the next as a `TypeRef` of its own, so there is nothing to
+/// mint — which is also why this needs no registry. What it returns spells
+/// itself (`origin.syntax`) and classifies itself (`kind`), and the two cannot
+/// disagree.
+pub(crate) fn enum_probe(reading: &TypeRef) -> &TypeRef {
+    let mut cur = reading;
+    while let Some(inner) = cur.borrow_target().or_else(|| cur.optional_inner()) {
+        cur = inner;
+    }
+    cur
+}
+
+/// [`enum_probe`] over a bare spelling, for the one caller that does not have a
+/// reading to peel: [`unfold_leaf_kt`](super::render::unfold_leaf_kt), whose
+/// `out_ty` arrives as `syn::Type` through `leaf_iface_param` from
+/// `UnfoldPlan::element` and `LeafDesc::Whole`. Both must become `TypeRef`s
+/// before this can go — an element-walking change, not a helper swap.
+///
+/// It answers about the WRAPPER where the model answers about the type:
+/// `Box<Priority>` probes as `Box<Priority>` here and as `Priority` there.
+/// Prefer [`enum_probe`] wherever a reading is in hand.
 pub(crate) fn enum_probe_type(ty: &syn::Type) -> syn::Type {
     let stripped = match ty {
         syn::Type::Reference(r) => (*r.elem).clone(),

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1079,19 +1079,17 @@ impl Declarations {
             .collect();
         for ident in &declared_idents {
             {
-                let Some(item_fn) = registry
-                    .flat()
-                    .function(&ident)
-                    .map(|func| &func.origin.syntax)
-                else {
+                // The ELEMENT, so the callback params come off the model's own
+                // classification rather than a second walk of the bounds.
+                let Some(func) = registry.flat().function(&ident) else {
                     continue;
                 };
-                for input in &item_fn.sig.inputs {
-                    let syn::FnArg::Typed(pt) = input else {
-                        continue;
-                    };
-                    if let Some(cb_args) = extract_fn_trait_args(&pt.ty) {
-                        uses.insert(SpecKey::callback(&cb_args));
+                let item_fn = &func.origin.syntax;
+                for p in &func.params {
+                    if let Some(cb_args) = p.ty.callback_args() {
+                        let arg_tys: Vec<syn::Type> =
+                            cb_args.iter().map(|a| a.syntax().clone()).collect();
+                        uses.insert(SpecKey::callback(&arg_tys));
                     }
                 }
                 if let Some(plan) = registry

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -793,18 +793,15 @@ impl Declarations {
         // nothing is looked up (#275).
         let field_ty = field.ty.syntax();
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
-        let out = registry
-            .reading_of(field_ty)
-            .and_then(|tr| registry.output_entry(&tr))
-            .unwrap_or_else(|| {
-                panic!(
-                    "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
+        let out = registry.output_entry(&field.ty).unwrap_or_else(|| {
+            panic!(
+                "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
                  cannot be derived — register converters for the payload type before \
                  declaring the sealed class",
-                    where_(),
-                    field_ty.to_token_stream(),
-                )
-            });
+                where_(),
+                field_ty.to_token_stream(),
+            )
+        });
 
         if let Some(h) = out.metadata.projection.clone() {
             let leaf = projection_leaf_kt(self, &h).unwrap_or_else(|| {
@@ -836,10 +833,7 @@ impl Declarations {
         // boxed value, a present flag, a niche) rather than in the type name.
         // Comparing the rendered types would reject that legitimate shape —
         // which is what an `Option<enum>` payload does.
-        if let Some(inp) = registry
-            .reading_of(field_ty)
-            .and_then(|tr| registry.input_entry(&tr))
-        {
+        if let Some(inp) = registry.input_entry(&field.ty) {
             if let (Some(in_ty), (Some(a), Some(b))) = (
                 inp.metadata.kotlin_name.clone(),
                 (

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1525,12 +1525,12 @@ impl Declarations {
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
-        if self.is_kotlin_enum(&enum_probe_type(leaf.out_ty.syntax())) {
-            let inner = option_inner_type(leaf.out_ty.syntax())
-                .unwrap_or_else(|| leaf.out_ty.syntax().clone());
+        if self.is_kotlin_enum_reading(&leaf.out_ty) {
+            // The `Option` layer peeled off the model, so the entry lookup takes
+            // the layer's own reading instead of a spelling to look back up.
+            let inner = leaf.out_ty.optional_inner().unwrap_or(&leaf.out_ty);
             let name = registry
-                .reading_of(&inner)
-                .and_then(|tr| registry.output_entry(&tr))
+                .output_entry(inner)
                 .and_then(|e| e.metadata.kotlin_name.clone())
                 .and_then(|t| t.leaf_name().map(str::to_string))
                 .unwrap_or_else(|| {

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use crate::api::{
         domain::ScalarValue,
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen, Stage},
-        registry::{extract_fn_trait_args, Direction, Registry, TypeKey},
+        registry::{Direction, Registry, TypeKey},
         types_util::{bare_path_ident, option_inner_type, vec_inner_type},
     },
     gen::kotlin::WriteKotlinError,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1610,3 +1610,103 @@ fn a_borrowed_transparent_sequence_wrapper_is_not_decoded_as_a_vec() {
         "the refusal must name the wrapper spelling the binding cannot convert:\n{msg}"
     );
 }
+
+/// The enum probe answers about the **type**, not about the wrapper around it.
+///
+/// `is_kotlin_enum_reading` peels with [`enum_probe`], which walks the model's
+/// own layers, and then keys on `TypeKind::Named` — so every spelling of "a
+/// `Priority`, held some way" reaches the `enum_class!(Priority)` declaration.
+/// The spelling-keyed `is_kotlin_enum` cannot: `Box<Priority>` canonicalizes to
+/// `Box < Priority >`, which no declaration ever registered, and the answer is
+/// `false` about a type that IS a Kotlin enum. Both are asserted here, because
+/// the difference between them is the reason the reading-taking one exists.
+///
+/// A **run is not peeled**, and that is the half a `layer_stack`-based probe
+/// would get wrong: `Vec<Priority>` is a `List<Priority>` on the Kotlin side, so
+/// treating it as an enum would wire a list to a `.value` discriminant.
+///
+/// `Probe` is deliberately undeclared — jnigen is opt-in, so it emits nothing,
+/// and it exists only to give the model a field per spelling to classify.
+#[test]
+fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 1,
+                    High = 2,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    pub plain: Priority,
+                    pub borrowed: Box<Priority>,
+                    pub optional: Option<Priority>,
+                    pub boxed_optional: Box<Option<Priority>>,
+                    pub optional_borrow: Option<Box<Priority>>,
+                    pub run: Vec<Priority>,
+                    pub unrelated: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().class(crate::enum_class!(Priority)))
+        .build_with(registry)
+        .expect("resolve");
+    let (ext, registry) = (gen.declarations(), gen.registry());
+
+    let crate::api::core::flat::Type::Struct(probe) =
+        registry.flat().declared_type("Probe").expect("indexed")
+    else {
+        panic!("Probe is a struct");
+    };
+    let field = |name: &str| {
+        &probe
+            .fields
+            .iter()
+            .find(|f| f.name.as_ref().is_some_and(|n| n == name))
+            .unwrap_or_else(|| panic!("field `{name}`"))
+            .ty
+    };
+
+    for name in [
+        "plain",
+        "borrowed",
+        "optional",
+        "boxed_optional",
+        "optional_borrow",
+    ] {
+        let reading = field(name);
+        assert!(
+            ext.is_kotlin_enum_reading(reading),
+            "`{name}` holds a declared Kotlin enum, however it is wrapped — the \
+             probe peels the model's layers, so it must say so"
+        );
+    }
+
+    for name in ["run", "unrelated"] {
+        assert!(
+            !ext.is_kotlin_enum_reading(field(name)),
+            "`{name}` is not an enum value: a run of enums is a `List`, and the \
+             probe must not peel the sequence layer to reach the element"
+        );
+    }
+
+    // The difference from the spelling-keyed probe, pinned: a transparent
+    // wrapper is invisible to the model and decisive for a canonical key.
+    assert!(
+        !ext.is_kotlin_enum(field("borrowed").syntax()),
+        "if the spelling key ever started seeing through `Box`, this test would \
+         stop distinguishing the two probes"
+    );
+    assert!(ext.is_kotlin_enum(field("plain").syntax()));
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1815,3 +1815,108 @@ fn a_transparently_wrapped_option_does_not_take_the_present_value_pair() {
     // spelling guards.
     assert!(kc.contains("zBoxed(mode:Int?"), "{kotlin}");
 }
+
+/// The transparent-wrapper guard runs **before** the model's layers are
+/// interpreted, not after.
+///
+/// An erasure sits *outside* the layer it wraps, so `Box<&Vec<Foo>>` classifies
+/// as `TypeKind::Ref` — the `Box` is gone from `kind` and survives only in the
+/// spelling. A guard that reads `kind` first replaces the argument with the
+/// inner sequence reading, whose own spelling is a clean `Vec<Foo>`, and the
+/// outer wrapper is never seen: the Vec-build plan is selected, its emitter
+/// hands the source fn a `&[Foo]` built from the transient Rust-side `Vec`, and
+/// the parameter still spells `Box<&Vec<Foo>>`. That is the same `E0308` class
+/// [`a_transparently_wrapped_option_does_not_take_the_present_value_pair`]
+/// covers, reached by peeling in the wrong order.
+///
+/// So this pins the **ordering**, which the shape-by-shape tests cannot: every
+/// layer is checked on the way down, and the outermost is checked first.
+#[test]
+fn an_outer_wrapper_around_a_reference_is_seen_before_the_layers_are_read() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Foo {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_bare(v: &[Foo]) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_wrapped(v: Box<&Vec<Foo>>) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("foo")
+                .class(crate::data_class!(Foo))
+                .fun(crate::fun!(put_bare))
+                .fun(crate::fun!(put_wrapped)),
+        );
+
+    let dir = unique_test_dir("jnigen_outer_wrapper_ref");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // The wrapped spelling may legitimately resolve no converter of its own —
+    // that is a refusal too, and equally not an `E0308`.
+    let Ok(gen) = jni.build_with(registry) else {
+        return;
+    };
+    let kdir = dir.join("kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+    let kotlin: String = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    // The control: the bare `&[Foo]` twin still takes the Vec-build handle path,
+    // so a refusal below is about the wrapper and not about the fixture failing
+    // to reach the specialized path at all.
+    assert!(
+        kc.contains("fooVecNew"),
+        "the bare `&[Foo]` must still take the Vec-build path — otherwise this \
+         test proves nothing about the wrapped one:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("val__vec_v=JNINative.fooVecNew(v.size)"),
+        "{kotlin}"
+    );
+
+    // The finding: `Box<&Vec<Foo>>` must not reach the Vec-build call site. Its
+    // wrapper is invisible to `kind` (which says `Ref`), so only a check made
+    // before the layers are read can catch it.
+    // Split on the WRAPPER, not on `externalfunputWrapped(` in `JNINative` —
+    // the extern block is followed by the shared `fooVecNew` declarations, so a
+    // looser split would read them as this function's body and pass falsely.
+    let wrapped_body = kc
+        .split("publicfunputWrapped(")
+        .nth(1)
+        .map(|s| s.split("publicfun").next().unwrap_or(s).to_string())
+        .unwrap_or_default();
+    assert!(
+        !wrapped_body.contains("fooVecNew"),
+        "`Box<&Vec<Foo>>` took the Vec-build path, which hands the source fn a \
+         `&[Foo]` built from a transient Vec while the parameter spells \
+         `Box<&Vec<Foo>>` — an E0308 in the generated crate:\n{kotlin}"
+    );
+}

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1629,6 +1629,8 @@ fn a_borrowed_transparent_sequence_wrapper_is_not_decoded_as_a_vec() {
 /// and it exists only to give the model a field per spelling to classify.
 #[test]
 fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
+    use crate::api::core::flat;
+
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
@@ -1664,9 +1666,7 @@ fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
         .expect("resolve");
     let (ext, registry) = (gen.declarations(), gen.registry());
 
-    let crate::api::core::flat::Type::Struct(probe) =
-        registry.flat().declared_type("Probe").expect("indexed")
-    else {
+    let flat::Type::Struct(probe) = registry.flat().declared_type("Probe").expect("indexed") else {
         panic!("Probe is a struct");
     };
     let field = |name: &str| {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1710,3 +1710,108 @@ fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
     );
     assert!(ext.is_kotlin_enum(field("plain").syntax()));
 }
+
+/// A **transparently-wrapped** parameter spelling does not take a specialized
+/// lowering that would rebuild the unwrapped type.
+///
+/// The model erases `Box`/`Cow` ([`TRANSPARENT_WRAPPERS`]), so
+/// `Box<Option<Mode>>` classifies as `Optional` exactly as `Option<Mode>` does —
+/// and reading the layers off the model is what the reading-based probes were
+/// changed to do. But `build_option_scalar_input_plan` does not *decode* the
+/// parameter, it **rebuilds** it: the emitter writes a literal
+/// `Option::Some(v)` / `Option::None` and hands that to the source function.
+/// Handing a bare `Option<Mode>` to a parameter spelled `Box<Option<Mode>>` is
+/// an `E0308` in the generated crate.
+///
+/// So the selection asks the spelling too ([`rebuilt_value_satisfies`]) and
+/// declines, exactly as `decoded_vec_satisfies` makes the general converter path
+/// decline `&Box<Vec<T>>` (see
+/// `a_borrowed_transparent_sequence_wrapper_is_not_decoded_as_a_vec`).
+///
+/// **What this pins is the refusal**, and it is asserted on the *pair* so it
+/// cannot pass vacuously: the bare twin must still take the decoupled
+/// `(present, value)` wire, and the wrapped one must not. The generated Rust is
+/// never compiled by this suite (#269), so the `E0308` itself is out of reach —
+/// the reachable property is that the emitter is never asked to write it.
+#[test]
+fn a_transparently_wrapped_option_does_not_take_the_present_value_pair() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Mode {
+                    A,
+                    B,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_bare(mode: Option<Mode>) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_boxed(mode: Box<Option<Mode>>) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().class(crate::enum_class!(Mode)))
+        .package(
+            crate::package!("cfg")
+                .fun(crate::fun!(z_bare))
+                .fun(crate::fun!(z_boxed)),
+        );
+
+    let dir = unique_test_dir("jnigen_wrapped_optscalar");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // The wrapped spelling may legitimately fail to resolve a converter of its
+    // own — that is a refusal too, and equally not an `E0308`. Only a build that
+    // SUCCEEDS can be asked what it emitted.
+    let Ok(gen) = jni.build_with(registry) else {
+        return;
+    };
+    let kdir = dir.join("kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+    let kotlin: String = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    // The control: the bare twin still takes the decoupled pair, so a refusal
+    // below is about the wrapper and not about the fixture failing to reach the
+    // specialized path at all.
+    assert!(
+        kc.contains("zBare(modePresent:Boolean,modeValue:Int"),
+        "the bare `Option<Mode>` must still cross as (present, value) — \
+         otherwise this test proves nothing about the wrapped one:\n{kotlin}"
+    );
+
+    // The finding: `Box<Option<Mode>>` must NOT, because the emitter would
+    // rebuild a bare `Option<Mode>` for a parameter that is not one.
+    assert!(
+        !kc.contains("zBoxed(modePresent"),
+        "`Box<Option<Mode>>` took the present/value lowering, which rebuilds a \
+         bare `Option<Mode>` and hands it to a fn expecting `Box<Option<Mode>>` \
+         — an E0308 in the generated crate:\n{kotlin}"
+    );
+    // What it takes instead: the ordinary boxed-`Int?` optional wire, whose
+    // converter is selected by `selector.rs` — the path that carries its own
+    // spelling guards.
+    assert!(kc.contains("zBoxed(mode:Int?"), "{kotlin}");
+}

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1378,7 +1378,6 @@ impl Declarations {
             }
         };
         for f in registry.flat().functions() {
-            let item_fn = &f.origin.syntax;
             // `Vec<T>` / `Option<Vec<T>>` return. The model's `ret` already
             // normalizes an elided return to `()`, so there is no arm for it.
             {
@@ -1389,16 +1388,15 @@ impl Declarations {
                     consider(peel_leading_ref(&elem));
                 }
             }
-            // `impl Fn(&[T])` / `impl Fn([T])` callback arg.
-            for input in &item_fn.sig.inputs {
-                let syn::FnArg::Typed(pt) = input else {
-                    continue;
-                };
-                let Some(args) = crate::api::core::registry::extract_fn_trait_args(&pt.ty) else {
+            // `impl Fn(&[T])` / `impl Fn([T])` callback arg. Over the model's
+            // params, whose readings already say which ones ARE callbacks —
+            // walking `sig.inputs` re-extracted that from the bounds.
+            for p in &f.params {
+                let Some(args) = p.ty.callback_args() else {
                     continue;
                 };
                 for arg in args {
-                    if let syn::Type::Slice(s) = &peel_leading_ref(&arg) {
+                    if let syn::Type::Slice(s) = &peel_leading_ref(arg.syntax()) {
                         consider(peel_leading_ref(&s.elem));
                     }
                 }
@@ -1533,13 +1531,12 @@ impl Prebindgen for Declarations {
         // something that must not exist. Reject them here, where the message
         // can say what is actually unsupported and what to write instead.
         for ident in self.declared_functions() {
-            let Some(item_fn) = binding
-                .flat()
-                .function(&ident)
-                .map(|func| &func.origin.syntax)
-            else {
+            // The ELEMENT, not just its syntax: check (3) below asks its params
+            // which are callbacks, which is the model's answer, not the tokens'.
+            let Some(func) = binding.flat().function(&ident) else {
                 continue;
             };
+            let item_fn = &func.origin.syntax;
             // (1) A sum in the `Ok` position of a fallible return. A sum is
             // delivered DECOMPOSED through a builder callback, and the
             // `Result` lane has no builder: a `Result` return deliberately
@@ -1617,15 +1614,12 @@ impl Prebindgen for Declarations {
             // (`impl Fn(&[E])`): the element fold would need the sum's
             // folder-appender singleton, which is emitted per `Vec<E>` RETURN
             // position, so the shape resolves to nothing.
-            for input in &item_fn.sig.inputs {
-                let syn::FnArg::Typed(pt) = input else {
-                    continue;
-                };
-                let Some(args) = extract_fn_trait_args(&pt.ty) else {
+            for p in &func.params {
+                let Some(args) = p.ty.callback_args() else {
                     continue;
                 };
                 for arg in args {
-                    let after_ref = match &arg {
+                    let after_ref = match arg.syntax() {
                         syn::Type::Reference(r) => (*r.elem).clone(),
                         other => other.clone(),
                     };

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -117,12 +117,14 @@ mod spelling_census {
         // The L4 "layer questions" remainder — #229. Not migrated here because
         // it is a separate consumer and bundling it would make one review of
         // both impossible.
-        ("jni/emit/flat_input.rs", 19),
+        ("jni/emit/flat_input.rs", 18),
         ("jni/emit/struct_out.rs", 2),
         ("jni/emit/wrapper.rs", 2),
-        // vec_build.rs is off the census, and off the boundary ledger too: its
-        // element peel reads `sequence_elem`/`borrow_target` off the model now.
-        // The one left is inside `enum_probe_type`, the spelling twin of
+        //
+        // vec_build.rs is absent, and off the boundary ledger too: its element
+        // peel reads `sequence_elem`/`borrow_target` off the model now.
+        //
+        // fold.rs's one call is inside `enum_probe_type`, the spelling twin of
         // `enum_probe` kept for `unfold_leaf_kt`'s `syn::Type` callers.
         ("jni/fold.rs", 1),
         ("jni/iface.rs", 2),

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -117,10 +117,11 @@ mod spelling_census {
         // The L4 "layer questions" remainder — #229. Not migrated here because
         // it is a separate consumer and bundling it would make one review of
         // both impossible.
-        ("jni/emit/flat_input.rs", 20),
+        ("jni/emit/flat_input.rs", 19),
         ("jni/emit/struct_out.rs", 2),
-        ("jni/emit/vec_build.rs", 1),
         ("jni/emit/wrapper.rs", 2),
+        // vec_build.rs is off the census, and off the boundary ledger too: its
+        // element peel reads `sequence_elem`/`borrow_target` off the model now.
         // The one left is inside `enum_probe_type`, the spelling twin of
         // `enum_probe` kept for `unfold_leaf_kt`'s `syn::Type` callers.
         ("jni/fold.rs", 1),

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -121,9 +121,12 @@ mod spelling_census {
         ("jni/emit/struct_out.rs", 2),
         ("jni/emit/vec_build.rs", 1),
         ("jni/emit/wrapper.rs", 2),
+        // The one left is inside `enum_probe_type`, the spelling twin of
+        // `enum_probe` kept for `unfold_leaf_kt`'s `syn::Type` callers.
         ("jni/fold.rs", 1),
         ("jni/iface.rs", 2),
-        ("jni/kotlin_emit.rs", 1),
+        // kotlin_emit.rs is off the census: `sum_ctor_arg`'s enum payload peels
+        // its `Option` off the leaf's own reading.
         ("jni/trait_impl.rs", 4),
         // Down from 2: the nullability decisions now ask the model. The one
         // left probes for an enum through its layers.


### PR DESCRIPTION
Continues #284 step 3, in the shape #288's finding described: the remaining
`option_inner_type` / `reading_of` sites are not a helper swap, so they come
one consumer at a time.

**This PR is a working branch** — the enum probe below is the first piece, and
manual cleanup of `syn::Type` parameters follows in later pushes. The list at
the bottom tracks what has landed.

## The enum probe peels off the model

`enum_probe_type` peeled `&` and `Option` off a SPELLING and handed the result
to `is_kotlin_enum`, which keys on the canonical spelling. Both halves answer
about the wrapper for a transparently-wrapped type — the #270/#272 family, and
the same shape #288 fixed in `struct_plan`.

Two pieces, because the peel alone would not have fixed it:

* `enum_probe(&TypeRef) -> &TypeRef` walks `borrow_target`/`optional_inner`.
  It **borrows** the sub-reading the model already holds — nothing is minted
  (the #280 seal makes that impossible from `api::lang` anyway) and no registry
  is needed, since every layer of a reading is a `TypeRef` of its own.
* `Declarations::is_kotlin_enum_reading` takes the name off
  `TypeKind::Named { id }` rather than the spelling, so `Box<Priority>` reaches
  the `enum_class!(Priority)` declaration instead of missing on a
  `Box < Priority >` key.

**Not `layer_stack`**, which strips the sequence layer too: `Vec<Priority>` is a
`List<Priority>`, and probing it as an enum would wire a list to a `.value`
discriminant. The new test pins that half as well as the wrapper half.

Two of the three `enum_probe_type` callers convert. `sum_ctor_arg` also drops
an `option_inner_type` + `reading_of` round trip on the line below it
(spelling census: `kotlin_emit.rs` 1 → 0, row dropped).

### What did NOT convert, and why

`unfold_leaf_kt` is not a helper swap: its `out_ty` arrives as `syn::Type`
through `leaf_iface_param` from `UnfoldPlan::element` (`Option<syn::Type>`, in
core) and `LeafDesc::Whole`. Both have to become readings first — the
element-walking change #288 recorded for `emit/flat_input.rs` — and it takes
`leaf_iface_param`'s own `syn::Type::Reference` peel with it. So
`enum_probe_type` stays for that one caller, documented as the spelling twin,
and the ledger holds at 127.

`fn_plan.rs`'s hand-inlined probe over `canonical` rides the same follow-up: it
needs `ReturnSurface::classify` to return a reading.

## `syn::Type` parameter cleanup: `callback_args`

`TypeKind::Callback { args: Vec<TypeRef> }` has existed all along with no
accessor, so every consumer either matched the variant by hand or fell back to
`extract_fn_trait_args` on the spelling. `TypeRef::callback_args() ->
Option<&[TypeRef]>` is the reading counterpart, sibling to `fallible_parts`.

The two are **not** interchangeable, and the doc says so. `extract_fn_trait_args`
is a *classifier*: it walks the bounds, checks `Send`/`Sync`/`'static`, and
refuses a written return type — it is the function the model itself runs to
build `TypeKind::Callback`. `callback_args` reads that decision, already made.
So it answers `None` for a type that merely looks like a callback but was
refused, which is correct: asking again is how the two drift.

Four callers converted, and two of them stopped walking `sig.inputs` for a
`func.params` walk — the element-walking shape, not a helper swap:

| Site | Change |
|---|---|
| `fn_plan.rs` `classify_leaf` | `reading.callback_args()`; the now-pointless `reading_of(ty)` round trip below it becomes `input_entry(reading)` |
| `trait_impl.rs` (slice-elem scan) | walks `f.params`; the `item_fn` binding became dead |
| `trait_impl.rs` check (3) | binds the `func` ELEMENT instead of mapping straight to `.origin.syntax` |
| `kotlin_emit.rs` (callback spec uses) | same rebind, `func.params` |

**jnigen production code now has zero `extract_fn_trait_args` calls** — it is
gone from the `jni` prelude. Only `callbacks.rs`'s
`a_callback_identity_is_the_same_from_the_reading_or_the_syntax` still names it,
deliberately, since pinning that both routes give one memo identity is exactly
what makes these conversions safe.

## `syn::Type` parameter cleanup: entry lookups that round-tripped

Four lookups spelled a reading they already held, canonicalized the spelling to
a `TypeKey`, found the same reading in the index, and asked it for its key
again — `registry.reading_of(x.syntax()).and_then(|tr| entry(&tr))`, where
`conversion` is `built[(dir, reading.key())]` and `key()` is
`TypeKey::from_type(origin.syntax)`. Both routes compute the identical key.

The round trip is not merely redundant: it adds an intermediate `None`. If the
reading index lacked the key, the old form returned "unresolved" **without ever
consulting `built`** — it could only turn a success into an error, never the
reverse.

| Site | Now |
|---|---|
| `fn_plan.rs` `classify_leaf` | `input_entry(reading)`; the error names `reading.key()`. The function now has **zero** `reading_of` calls |
| `kotlin_emit.rs` sum payload | `output_entry(&field.ty)` |
| `kotlin_emit.rs` in/out agreement check | `input_entry(&field.ty)` |
| `emit/wrapper.rs` expand leaf | `input_entry(&leaf.ty)`; the panic names `leaf.ty.key()` |

## `syn::Type` parameter cleanup: `PlanError` carries the reading

`Unresolved`, `UnresolvedLeaf` and `UnresolvedOutput` hold `Box<TypeRef>`
instead of `TypeKey`. Reaching any of them means the registry classified the
type and merely has no converter for it, so the reading is in hand — and it
carries the source position the message can now name.

**Boxed, and it has to be.** clippy `result_large_err` is right: a `TypeRef`
holds a `syn::Type` inline (~264 bytes) and a `Result` is sized by its largest
variant, so an unboxed reading widens every `Result<JniFunctionPlan, PlanError>`
on the path — the **success** return included, which is the one that always
happens. An error is rare enough to afford the allocation; the plans returned
beside it are not.

### The output failure was two failures

`build_output` collapsed both into one `and_then`:

```rust
reading_of(&target_ty).and_then(|tr| output_entry(&tr))
```

`target_ty` is composed there (`convert_out_ty`, or the `Result` peeled to its
`Ok`), so unlike the input side there may genuinely be no reading — which is
also why this variant could not simply hold one. Both cases got *"has no
registered output converter — register one via `output_wrapper`"*: correct
advice for one, actively wrong for the other, where it sent the reader to write
a converter for a type the resolver would never ask about.

Now `UnknownOutputType { ty: TypeKey }` says the type is not registered at all,
and `UnresolvedOutput { ty: Box<TypeRef> }` keeps the `output_wrapper` wording
it earned.

### Locations, and a doc claim made true

Messages append `" (declared at file:line:col)"` when the reading has a
position, gated by `has_position` exactly as `resolve.rs` gates
`UnresolvedEntry::location` — a composed type and a hand-built test stream are
lowered against `SourceLocation::default`, and printing `:0:0` would make a
fabricated position look real.

`PlanError::message`'s doc claimed the wording "cannot drift" because the
emitter backstops share it. They did not: `emit/wrapper.rs` restated both
messages by hand. They now call `message()`, so the claim holds. That also let
the first backstop take `leaf.reading` instead of `reading_of(arg_ty)` — for
`ParamForm::Single` the leaf is classified from `param.ty` and `PlanParam::ty`
is that same `param.ty.syntax()`, so it is the identical reading.

An alternative shape is `{ ty: TypeKey, at: Option<SourceLocation> }` — same
diagnostics, no boxing, and no live model object inside an error type. Recorded
rather than taken; say so in review if you prefer it.

## `syn::Type` parameter cleanup: `build_flat_input_plan` takes a reading

`build_flat_input_plan(.., arg: &TypeRef)`. The struct-target peel reads
`borrow_target`/`optional_inner` off the model, the name comes off
`TypeKind::Named { id }` rather than the last path segment, the key is
`inner.key()`, and the identity guard's
`reading_of(arg_ty).and_then(input_entry)` becomes `input_entry(arg)`.

The signature cascades, as it must — a callee that wants a reading needs callers
that hold one:

| Function | Now |
|---|---|
| `vec_build_elem` | `&TypeRef -> Option<(TypeRef, bool)>`; element via `sequence_elem()` through `borrow_target()` |
| `vec_build_helpers` | `elem: &TypeRef` |
| `collect_vec_build_elem_types` | returns `Vec<TypeRef>`, and walks `f.params` instead of `sig.inputs` — the element walk, not a peel swap |
| `InputKind::VecBuild` | `elem: TypeRef`; the two emit sites spell `elem.syntax()` |

### Two helpers turn out to be dead, and the compiler proved it

`impl_into_target` extracted `S` from `impl Into<S>` for the peel above. The
model **refuses** `impl Trait` that is not the callback form
(`UnsupportedTypeReason::DisallowedImplTrait`), so such a parameter never
becomes a reading — meaning the call was already unreachable from every caller
*before* this change; taking a reading only made `cargo check` say so out loud.
jnigen's real `impl Into<…>` support is elsewhere: plugin wrapper exts hand-build
a `ConverterImpl::function` via `input_converter_name`, which never consulted it.

`slice_or_vec_elem` matched `&[T]`/`Vec<T>` off the spelling; `vec_build_elem`
was its only caller. Its one non-structural rule — `&mut [T]` is refused,
because mutate-back semantics keep the `input_vec` path — survives as the
`RefMode::Shared` guard on the new match.

Both are replaced by a comment recording what stood there and why it went,
rather than vanishing from the diff.

### Both ledgers move down

* **boundary**: `flat_input.rs` 10 → 8, `vec_build.rs` 2 → **gone**.
  Total **127 → 123**.
* **spelling census**: `flat_input.rs` 20 → 19, `vec_build.rs` 1 → **0**, row
  dropped.

## `syn::Type` parameter cleanup: `build_option_scalar_input_plan`

A clean one — `classify_leaf` is the only caller and already held the reading,
so nothing cascades. Four spelling questions become the model's:

| Was | Now |
|---|---|
| `option_inner_type(arg_ty)?` | `arg.optional_inner()?` |
| `matches!(inner, syn::Type::Reference(_))` | `inner.borrow_target().is_some()` |
| `reading_of(&inner).and_then(input_entry)` | `input_entry(inner)` |
| `ext.is_kotlin_enum(&inner)` | `ext.is_kotlin_enum_reading(inner)` |

**The last row changes behaviour, deliberately.** `Option<Box<Priority>>` now
answers `true`: keying on the spelling looked up `Box < Priority >`, which no
declaration ever registered, so an optional boxed enum missed its `.value`
projection — the #270/#272 family again.

The reading probe also peels an optional, which cannot matter at that line: a
nested `Option<Option<enum>>` has a boxed wire, and `JniPrim::from_wire` above
accepts only the eight `j*` primitives, so it has already returned. Checked
rather than assumed.

`classify_leaf`'s opening `let ty = reading.syntax()` had no users left and is
gone — **every question that function asks is the model's now.**

Ledgers down again: boundary `flat_input.rs` 8 → 7 (total **123 → 122**),
spelling census `flat_input.rs` 19 → 18.

## Review round 1: conversion follows the syntax

**The finding (thanks — it was right).** The reading-based probes select
specialized input lowerings for transparently-wrapped spellings, but those
lowerings rebuild only the *unwrapped* type.
`build_option_scalar_input_plan` accepted `Box<Option<Priority>>` while
`emit_input_param` constructs a bare `Option::Some(v)` and hands it to a fn
expecting `Box<Option<Priority>>` — `E0308` in the generated crate. Same shape
for `Box<Option<DataClass>>` and `Box<Vec<DataClass>>`.

**The rule I had been applying was wrong.** "Model peels are always better" is
not unconditional. The sharper split:

* **`kind` decides what the destination sees** — surface type *and wire*.
  `Box<Option<String>>` and `Option<String>` are one optional string to every
  destination language; that is why the wrapper is erased, and the erasure is
  correct.
* **`syntax` decides how the value is converted**, and Rust does tell them
  apart. A converter that rebuilds must produce the type the source spelled.

Reading `kind` was right for the *first* half of these sites. The defect is that
the second half then rebuilt from `kind` too, ignoring the syntax sitting right
there.

**So the question goes to the model**, which is the only thing holding both
halves: `TypeRef::erased_wrapper() -> Option<&'static str>` names the
transparent wrapper a spelling adds over its classification. Its doc carries the
split and separates **erased** from **rebuildable** — `Box` reconstructs as
`Box::new(v)`, while `Cow`'s `Owned`/`Borrowed` choice is not determined by
anything the model holds.

jnigen asks the reading, never a spelling. `rebuildable_target()` does the
`&`/`Option` peel and the check in **one** place. Net spelling probes added:
**zero** — `flat_input.rs` now has no `.syntax()` call at all, and
`vec_build.rs`'s one is the spelling handed to `quote!`. Census and ledger
unmoved.

> A first draft of this fix inlined six `peel_transparent` calls across the two
> files — six copies of one unnamed rule, which would have pushed both ledgers
> back up in the files this branch had just cleaned. Discarded.

**Refusing is a gap, not a requirement**, and the comments say so: `Box::new(v)`
is exactly what the syntax asks for and is trivially emittable. Doing it
properly means teaching the converters to rebuild each wrapper with an explicit
rebuildable-wrapper policy, so it is **#292** rather than a rushed extension
here. A wrapped spelling keeps the general converter path meanwhile — correct,
if less direct.

**The test** pins the refusal on a *control pair* so it cannot pass vacuously:
the bare `Option<Mode>` twin must still take the decoupled `(present, value)`
wire, and `Box<Option<Mode>>` must not (it takes the ordinary boxed `Int?`).

The review asked for a **compile-level** test. Generated Rust is never compiled
by this suite (#269), so the `E0308` itself is out of reach — the reachable
property is that the emitter is never asked to write it. The test's own doc says
that rather than quietly substituting a weaker check.

### Also on this round

* `f69b74e` — `Conversions` trait signatures simplified.
* `eedca45` — **`cargo fmt --check` did not pass at `f69b74e`**, so CI was
  already red on this branch. Whitespace only, kept as its own commit so it
  doesn't hide inside a behaviour change.

## Review round 2: check the wrapper *before* reading the layers

**The finding (correct again).** `vec_build_elem`'s guard ran after interpreting
`kind`, so it missed a wrapper sitting outside a borrow.

An erasure is **outside** the layer it wraps. `Box<&Vec<Foo>>` therefore
classifies as `TypeKind::Ref` — the `Box` is gone from `kind` and survives only
in the spelling — so the match replaced `arg` with the inner sequence reading,
whose own spelling is a clean `Vec<Foo>`, and the outer wrapper was never
examined. Vec-build was selected, its emitter hands the source fn a `&[Foo]`
built from the transient Rust-side `Vec`, and the parameter still spells
`Box<&Vec<Foo>>`: the same `E0308` class round 1 set out to prevent, reached by
peeling in the wrong order.

`rebuildable_target` already had this right — it checks before **and** after
every peel — so this is the sibling site brought into line, not a new rule.

Both checks are load-bearing, and the comments now say which is which:

| Check | Catches | Why the other misses it |
|---|---|---|
| pre-peel `arg.erased_wrapper()` | `Box<&Vec<T>>` | `kind` is `Ref`; peeling first discards the wrapper |
| post-peel `run.erased_wrapper()` | `&Box<Vec<T>>` | the pre-peel check sees a `syn::Type::Reference` and cannot look inside |

**The test pins the ordering**, which the shape-by-shape tests cannot: control
`put_bare(&[Foo])` must still take the Vec-build path (`__vec_v =
JNINative.fooVecNew(v.size)` + push loop), and `put_wrapped(Box<&Vec<Foo>>)`
must not.

Two notes, since a test asserting an **absence** can pass for the wrong reason:

* Verified it actually catches the bug — disabling the new guard makes it fail
  with the intended message; restoring it makes it pass.
* It splits the Kotlin on `publicfunputWrapped(`, not `funputWrapped(`. The
  looser split also matches `externalfunputWrapped(` in the `JNINative` block,
  which is immediately followed by the shared `fooVecNew` declarations — so it
  would have read those as this function's body and **passed falsely**.

### Left alone, each for a different reason

* `order.rs` `plan_edges` — takes `ty: &syn::Type` from `visit_crossing`, which
  only has `key.to_type()`. `immediate_edges` right beside it *already* returns
  readings, so this is the odd one out; converting it means giving
  `visit_crossing` a reading for the crossing key.
* `cbindgen/builder.rs` `.callback(ty)` — public declaration API taking raw
  `syn` before any model exists. A correct classifier use; it should stay.
* `cbindgen/trait_impl.rs` `convert_crossing` — `key.to_type()`, no reading.
* The remaining `reading_of` calls in `emit/flat_input.rs` (18 census calls
  after this branch) — that file still walks `syn::Fields::Named` directly, so
  its `field.ty` is a genuine `syn::Type` and the lookups are legitimate door
  use. It needs the element-walking change #288 recorded (take `&flat::Struct`,
  walk `struct.fields`), which stays its own PR. The remaining ~60 across both
  adapters take peeled or composed spellings, which is what `reading_of` exists
  for.

## Landed so far

- [x] `enum_probe` + `is_kotlin_enum_reading`; `classify_leaf` and
      `sum_ctor_arg` converted (`947b3c8`)
- [x] `TypeKind` imports in `builder.rs` / `fold.rs` — the model's types reached
      through one `flat::` qualifier, since the bare `TypeKind` in those files is
      jnigen's own classifier and an explicit import would silently retarget it
      (`9a158f1`)
- [x] `TypeRef::callback_args`; four callers converted, two of them to an
      element walk; `extract_fn_trait_args` out of the `jni` prelude (`76e3a9f`)
- [x] four entry lookups that spelled a reading to look the same reading back
      up; `classify_leaf` now has zero `reading_of` calls (`eda9508`)
- [x] `PlanError` carries `Box<TypeRef>`; the output failure split into
      "unregistered" vs "no converter"; messages name a source position; the
      emitter backstops share the wording instead of restating it (`0f5c4f7`)
- [x] `build_flat_input_plan` takes `&TypeRef`, cascading through the vec-build
      chain; `impl_into_target` and `slice_or_vec_elem` fall out dead; both
      ledgers drop (boundary 127 → 123) (`ffbae9f`)
- [x] `build_option_scalar_input_plan` takes `&TypeRef`; `classify_leaf` drops
      its last spelling local; `Option<Box<enum>>` fixed (`3bb41ea`)
- [x] **review round 1**: `TypeRef::erased_wrapper()`; the specialized lowerings
      refuse spellings their rebuild cannot satisfy; regression test on a control
      pair; fmt fix for an already-red CI (`eedca45`, `d3bc74e`)
- [x] **review round 2**: the wrapper guard runs before the layers are read, so
      an outer wrapper around a borrow (`Box<&Vec<T>>`) is seen; ordering test
      (`217be1f`)
- [ ] manual cleanup of the remaining `syn::Type` parameters (in progress)

## Verification

`947b3c8` was verified at 552 lib tests, `--all --all-features` 14/14 suites
(624 with cbindgen), clippy `--deny warnings`, fmt (CLI config), regen-check
byte-identical, covertest-kotlin 48/48.

Every commit after `947b3c8` has clippy `--deny warnings` (all-features,
all-targets), fmt, and the lib tests behind it (**554** as of review round 2).
**Not** re-run since: the `--all --all-features` suites, regen-check, and
covertest-kotlin.

Two commits deserve those specifically, and the full sweep goes before this PR
is marked ready:

* `0f5c4f7` changes error **text**. No in-tree example reaches those paths (they
  are binding-time failures), so nothing should move — worth confirming rather
  than assuming.
* `ffbae9f` changes the **vec-build** path, which does have generated output
  (`…VecNew/Push/Free` externs + their Kotlin callers). regen-check is the real
  test that the model peel selects the same elements the spelling peel did.
* `3bb41ea` makes `Option<Box<enum>>` classify as an enum where it previously
  did not. No in-tree example spells that, so the goldens should be unchanged —
  but this is an intentional output-affecting change, so it is one to confirm
  rather than infer.
* `d3bc74e` and `217be1f` **narrow** plan selection (wrapped spellings now
  decline the specialized lowerings). Again no in-tree example spells one, so
  regen-check should be byte-identical; if it is not, the diff is exactly the
  set of functions that were silently emitting ill-typed Rust.
