### PR TITLE
core: the model says what it erased, and one rebuild stops guessing

### DIFF
--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -65,6 +65,7 @@ classification stays small and genuinely neutral:
 | `Foo<'a, T>` | `TypeRef::origin.syntax` | generated Rust only |
 | "it is a `Foo`" | `TypeKind::Named` | every adapter |
 | `[u8; TAG_LEN]` — spelling / number / const identity | `TypeRef::origin.syntax` / `ArrayExtent::value` / `ExtentSource::Const` | C header / Kotlin / both |
+| the `Box` in `Box<Option<T>>`, and the `Option<T>` under it | `TypeRef::erased_wrappers()` / `stripped_syntax()` — derived from the syntax, not stored | an emitter that **rebuilds or destructures** a Rust value |
 | where an item came from | `Origin::location` — **absent for a synthesized one** | diagnostics |
 
 ### The rule
@@ -451,6 +452,48 @@ The long pole — 97 sites, down from 106 because #248 took `jni/builder` from 1
 - [ ] `prim_array_of` reads `ArrayExtent` instead of re-matching `Type::Array`
 - [ ] Generated Rust and Kotlin byte-identical
 
+#### What L4 taught: an erasure sits outside the layer it wraps
+
+The model erases `Box` and `Cow`, and that erasure is right — `Box<Option<T>>`
+is one optional to every destination. But **conversion follows the syntax**, and
+the two facts a rebuild needs were not on the model: what was taken off, and what
+is left under it. #292 added them as derived readings, `TypeRef::erased_wrappers()`
+and `stripped_syntax()`, defined by an invariant rather than by a loop — the
+stripped spelling is *the one whose own lowering yields exactly this `kind`*, so
+the peel runs to a fixed point (`Box<Box<T>>` classifies as `T`, and one strip
+leaves a `Box<T>` that does not match).
+
+The rule, which outlives the stage:
+
+> **`kind` is precisely the thing the wrapper is missing from, so interpreting
+> `kind` before checking for a wrapper always discards one.**
+
+`Box<&Vec<T>>` classifies as `Ref`; peel that first and the wrapper is gone from
+everywhere a consumer will look. `&Box<Vec<T>>` hides it on the referent, where a
+question asked of the outer `syn::Type::Reference` cannot see it. Neither check
+subsumes the other, so a walk must ask at **every layer, on the way down** —
+which is also why the wrapper is a *list*, gathered as the walk descends.
+
+The audit that came with it found the population is two, and only one has to ask:
+a site that **classifies** must never consult the wrapper — that is the erasure
+working, and every cbindgen site and all but one jnigen site are of that kind. A
+site that **binds a source value and destructures or rebuilds it** must. There
+was exactly one unguarded instance, and it was a live miscompilation: builder
+delivery bound the returned value and matched it against `Option`'s patterns,
+which match ergonomics does not see through a `Box`. Fixed at the single point
+the value enters the delivery, not at each of the four matches downstream.
+
+Two things it taught about evidence:
+
+* **#290's guards were hand-maintained and wrong twice in one PR.** "Are all the
+  peel sites guarded?" is answered by inspection until the model carries the
+  facts and one shared helper consumes them.
+* **The suite could not see the defect.** 737 `contains(..)` assertions pass on
+  Rust that does not compile (#269). The fixture that proves this one is in
+  `perftest-flat`, whose generated binding covertest `include!`s and **builds** —
+  the only place in the tree where an `E0308` is a test failure. It was verified
+  by disabling the fix and watching the build break.
+
 ### L5 — close the seam
 
 The public contract stops being `syn`, which is what stops the population from
@@ -467,6 +510,12 @@ growing back.
       `on_enum` split into `on_variant` + `on_enum` along the model's own
       distinction. Done as #275's first half rather than waiting for this stage,
       because it was the last thing keeping the spelling accessors alive
+- [x] **What a spelling adds over its classification is the model's answer, not
+      a peel each adapter writes** (#292): `erased_wrappers()` / `stripped_syntax()`.
+      Belongs here because the alternative was every rebuilding emitter taking a
+      `syn::Type` apart for itself, which is the population growing back — the
+      completion criterion below already forbids reconstructing a spelling from a
+      classification, and this is the fact that makes obeying it possible
 - [ ] `Prebindgen::post_process_item(&mut syn::Item)` — the hook that let
       qualification live in an adapter in the first place
 - [ ] `ConverterImpl::function` / `TypeEntry::function` as `syn::ItemFn`;

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -522,6 +522,12 @@ fn main() {
                 // with the wrong number of dereferences fails the build (#270).
                 .fun(fun!(boxed_note_echo))
                 .fun(fun!(plain_note_echo))
+                // The same wrapper over a DECOMPOSED return (#292). `Summary`
+                // has an output expansion, so this return takes no converter to
+                // name the spelling for it — the extern binds the value and
+                // matches it, and a `Box` match ergonomics cannot see through
+                // is an `E0308` that only compiling this crate catches.
+                .fun(fun!(boxed_latest))
                 .fun(fun!(ledger_new))
                 .fun(fun!(archive_set_reading))
                 .fun(fun!(archive_reading))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -63,6 +63,8 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
 - `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue>): BlobValue`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
+- `boxed_latest` — `fun <R> boxedLatest(a: SummaryVault, onError: JniErrorHandler<R?>, build: SummaryBuilder<R>): R?`
+  - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
 - `boxed_note_echo` — `fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): String?`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -894,6 +894,8 @@ internal object CovNative {
         errorSink: Any,
     ): Any?
 
+    external fun boxedLatest(a: Long, build: Any, errorSink: Any): Any?
+
     external fun boxedNoteEcho(note: String?, errorSink: Any): String?
 
     external fun cacheConfigWeight(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -12,6 +12,7 @@ import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.__u64FolderRawHolder
 import io.prebindgen.covertest.analytics.Summary
+import io.prebindgen.covertest.analytics.SummaryBuilder
 import io.prebindgen.covertest.analytics.SummaryVault
 import io.prebindgen.covertest.asRaw
 import io.prebindgen.covertest.u64Callback
@@ -1621,6 +1622,39 @@ public fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): Stri
     val __ret = CovNative.plainNoteEcho(note, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
+}
+
+/**
+ * A transparent wrapper over a **decomposed** return — the shape `boxed_note_echo`
+ * does not reach.
+ *
+ * `boxed_note_echo`'s return takes an output *converter*, which is selected for
+ * the spelling and therefore names `Box<Option<String>>` itself. This one has
+ * no converter at all: `Summary` carries a declared output expansion, so the
+ * extern **binds the returned value and matches it** to deliver the leaves to a
+ * builder. Match ergonomics does not see through a `Box`, so the emitter has to
+ * move the value out of the wrappers the classification erased before it can
+ * destructure — the defect #292's audit found, and one this crate compiles.
+ *
+ * The unwrapped twin is [`archive_latest`], which crosses as the same
+ * `Summary?`.
+ *
+ * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <R> boxedLatest(
+    a: SummaryVault,
+    onError: JniErrorHandler<R?>,
+    build: SummaryBuilder<R>,
+): R? {
+    if (a.isClosed()) return onError.run("Operation on a closed native handle.")
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = withSortedHandleLocks(a) {
+        val a_ptr = a.ptr
+        CovNative.boxedLatest(a_ptr, build, __bcap)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as R?
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -44,6 +44,9 @@ import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.arraysEcho
 import io.prebindgen.covertest.model.blobValueEcho
+import io.prebindgen.covertest.model.boxedLatest
+import io.prebindgen.covertest.model.boxedNoteEcho
+import io.prebindgen.covertest.model.plainNoteEcho
 import io.prebindgen.covertest.model.blobValueNew
 import io.prebindgen.covertest.model.annotatedAlternateValue
 import io.prebindgen.covertest.model.celsiusDouble
@@ -1422,6 +1425,29 @@ fun main() {
         val fourth = archiveLatest(a, boom)!!
         check(fourth.count(boom) == 3L && fourth.total(boom) == 60.0)
         fourth.close()
+        a.close()
+    }
+
+    // ── transparent wrappers: the spelling changes, the crossing must not ───
+    // The model erases `Box`/`Cow`, so a wrapped spelling and its unwrapped
+    // twin are ONE type to Kotlin. Compiling this crate already proves the
+    // generated Rust is well-typed; these assert the surfaces are the same and
+    // the values actually make the round trip.
+    section("transparent wrapper crossings") {
+        // Converted return: the converter is selected for the spelling, so it
+        // names `Box<Option<String>>` itself.
+        for (note in listOf("wrapped", null)) {
+            check(boxedNoteEcho(note, boom) == note)
+            check(plainNoteEcho(note, boom) == note)
+        }
+
+        // DECOMPOSED return: no converter names the spelling — the extern binds
+        // the value and matches it, so the `Box` has to come off first (#292).
+        // Same delivery as `archiveLatest`, one wrapper apart.
+        val a: SummaryVault = archiveNew(boom)
+        check(boxedLatest(a, boom) { count, total -> count to total } == null)
+        archiveStore(a, 0, 5L, 100.0, null, boom)
+        check(boxedLatest(a, boom) { count, total -> count to total } == 5L to 100.0)
         a.close()
     }
 

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -662,11 +662,38 @@ pub(crate) unsafe fn Box_Box_Option_String_to_JString_299999e0<'a>(
     v: Box<Box<Option<String>>>,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
-        let v: Option<String> = (*(*v));
+        let v: Option<String> = **v;
         {
             match v {
                 Some(value) => String_to_JString_c7f3ca43(env, value)?,
                 None => jni::objects::JObject::null().into(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Box_Option_Summary_to_jlong_75560ba9<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<Option<perftest_flat::Summary>>,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok({
+        let v: Option<perftest_flat::Summary> = *v;
+        {
+            match v {
+                Some(value) => Summary_to_jlong_3cb103b9(env, value)?,
+                None => 0i64,
             }
         }
     })
@@ -12704,6 +12731,111 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
             );
             jni::objects::JObject::null().into()
         }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedLatest<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    a: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let a = match jlong_to_Archive_cd73502c(&mut env, &a) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/analytics/SummaryBuilder";
+    const __CB_DESCR: &str = "(JD)Ljava/lang/Object;";
+    let __out = *perftest_flat::boxed_latest(&a);
+    match __out {
+        ::core::option::Option::Some(__inner) => {
+            let __obj0: jni::sys::jvalue = {
+                let __enc0 = match i64_to_jlong_fbf9a9bc(
+                    &mut env,
+                    perftest_flat::summary_count(&__inner),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                jni::sys::jvalue { j: __enc0 }
+            };
+            let __obj1: jni::sys::jvalue = {
+                let __enc1 = match f64_to_jdouble_9e4a8f70(
+                    &mut env,
+                    perftest_flat::summary_total(&__inner),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                jni::sys::jvalue { d: __enc1 }
+            };
+            match __CB_MID
+                .call_object(
+                    &mut env,
+                    __CB_FQN,
+                    "run",
+                    __CB_DESCR,
+                    &__builder,
+                    &[__obj0, __obj1],
+                )
+            {
+                ::core::result::Result::Ok(__o) => __o,
+                ::core::result::Result::Err(__e) => {
+                    let _ = env.exception_describe();
+                    let __e2 = <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string());
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e2.to_string(),
+                    );
+                    jni::objects::JObject::null().into()
+                }
+            }
+        }
+        ::core::option::Option::None => jni::objects::JObject::null().into(),
     }
 }
 #[no_mangle]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1618,6 +1618,24 @@ pub fn plain_note_echo(note: Option<String>) -> Option<String> {
     note
 }
 
+/// A transparent wrapper over a **decomposed** return — the shape `boxed_note_echo`
+/// does not reach.
+///
+/// `boxed_note_echo`'s return takes an output *converter*, which is selected for
+/// the spelling and therefore names `Box<Option<String>>` itself. This one has
+/// no converter at all: `Summary` carries a declared output expansion, so the
+/// extern **binds the returned value and matches it** to deliver the leaves to a
+/// builder. Match ergonomics does not see through a `Box`, so the emitter has to
+/// move the value out of the wrappers the classification erased before it can
+/// destructure — the defect #292's audit found, and one this crate compiles.
+///
+/// The unwrapped twin is [`archive_latest`], which crosses as the same
+/// `Summary?`.
+#[prebindgen]
+pub fn boxed_latest(a: &Archive) -> Box<Option<Summary>> {
+    Box::new(a.latest.clone())
+}
+
 /// Deliver a [`Ledger`] to a callback, so both conditional decompositions cross
 /// in ONE call — including the sum (`Report::outcome`) each one carries, whose
 /// `match` belongs inside the arm that binds the report.

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -110,6 +110,113 @@ fn a_box_classifies_as_what_it_wraps() {
     assert_eq!(tokens(&inner.origin.syntax), "Box < String >");
 }
 
+/// The erasure, stated as something the model can be **asked**: what was taken
+/// off, and what is left under it.
+///
+/// The invariant is not "the loop peels until it stops" — it is that
+/// [`TypeRef::stripped_syntax`] is *the spelling whose own lowering yields
+/// exactly this type's `kind`*. That is what makes it a safe base for a
+/// reconstruction, and it is why the peel must run to a **fixed point**:
+/// `Box<Box<T>>` classifies as `T`, so one strip leaves a `Box<T>` that does
+/// not match.
+#[test]
+fn the_stripped_spelling_is_the_one_that_lowers_to_this_kind() {
+    // The property, asserted as a property: strip, lower again, get the same
+    // classification. A one-layer implementation fails the nested rows.
+    for spelling in [
+        quote::quote!(Box<Option<Sample>>),
+        quote::quote!(Box<Box<String>>),
+        quote::quote!(Box<Box<Box<Vec<u8>>>>),
+        quote::quote!(Box<Cow<'_, [u8]>>),
+        quote::quote!(Cow<'_, str>),
+        // The control: nothing erased, so stripping is the identity and the
+        // comparison cannot pass by both sides being trivially equal elsewhere.
+        quote::quote!(Option<Sample>),
+    ] {
+        let ty = lower(spelling).expect("in the language");
+        let stripped = ty.stripped_syntax();
+        assert_eq!(
+            format!("{:?}", kind(quote::quote!(#stripped))),
+            format!("{:?}", ty.kind),
+            "`{}` strips to `{}`, which must classify identically",
+            tokens(&ty.origin.syntax),
+            tokens(&stripped),
+        );
+    }
+
+    // The wrappers themselves, outermost first — the list a rebuild applies in
+    // reverse. `Box<Cow<..>>` is two DIFFERENT operations, which is why one
+    // name and a count would not do.
+    let wrappers =
+        |t: proc_macro2::TokenStream| lower(t).expect("in the language").erased_wrappers();
+    assert_eq!(wrappers(quote::quote!(Box<Box<String>>)), ["Box", "Box"]);
+    assert_eq!(wrappers(quote::quote!(Box<Cow<'_, [u8]>>)), ["Box", "Cow"]);
+    assert_eq!(wrappers(quote::quote!(Option<Sample>)), [] as [&str; 0]);
+
+    // Unwrapped, the stripped spelling is the spelling — token-identical, not
+    // merely equivalent, since it is what generated Rust would emit.
+    let plain = lower(quote::quote!(Option<Sample>)).expect("in the language");
+    assert_eq!(
+        tokens(&plain.stripped_syntax()),
+        tokens(&plain.origin.syntax)
+    );
+    assert_eq!(
+        tokens(
+            &lower(quote::quote!(Box<Box<Option<Sample>>>))
+                .expect("in the language")
+                .stripped_syntax()
+        ),
+        "Option < Sample >"
+    );
+}
+
+/// **An erasure sits outside the layer it wraps**, so the question has to be
+/// asked on the way *down* — at every layer — and never once at the top.
+///
+/// This is the pair that pins it, and each row is invisible to the other's
+/// vantage point: `Box<&Vec<T>>` classifies as `Ref`, so a consumer that
+/// interprets `kind` first is left holding a clean `Vec<T>` with the `Box`
+/// unreachable; `&Box<Vec<T>>` puts the wrapper on the referent, where a
+/// question asked of a `syn::Type::Reference` cannot see it.
+#[test]
+fn a_wrapper_is_found_only_at_the_layer_that_spells_it() {
+    let outside = lower(quote::quote!(Box<&Vec<Sample>>)).expect("in the language");
+    assert_eq!(outside.erased_wrappers(), ["Box"]);
+    let referent = outside.borrow_target().expect("a borrow");
+    assert_eq!(
+        referent.erased_wrappers(),
+        [] as [&str; 0],
+        "peeling `kind` first reaches a clean `Vec<T>` — the `Box` is only \
+         visible before the peel"
+    );
+
+    let inside = lower(quote::quote!(&Box<Vec<Sample>>)).expect("in the language");
+    assert_eq!(
+        inside.erased_wrappers(),
+        [] as [&str; 0],
+        "a reference cannot be peeled as a transparent wrapper"
+    );
+    assert_eq!(
+        inside.borrow_target().expect("a borrow").erased_wrappers(),
+        ["Box"],
+        "the wrapper is on the referent, after the peel"
+    );
+
+    // Both classify the same shape, which is the whole reason neither check
+    // alone is enough: the difference between them lives in a spelling, and the
+    // classification is exactly the thing it is missing from.
+    for ty in [&outside, &inside] {
+        let TypeKind::Ref { mode, inner } = &ty.kind else {
+            panic!("a borrow");
+        };
+        assert_eq!(*mode, RefMode::Shared);
+        let TypeKind::Sequence(elem) = &inner.kind else {
+            panic!("a run");
+        };
+        assert!(matches!(elem.kind, TypeKind::Named { .. }));
+    }
+}
+
 /// A builtin must be spelled BARE **after normalization**: the real std path
 /// reduces and classifies, while a path-qualified lookalike is a foreign type
 /// that merely shares the name, and collapsing it would silently retype the

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -334,16 +334,80 @@ impl TypeRef {
     /// parameter spelled `Box<..>` is an `E0308` in the generated crate.
     ///
     /// Only the outermost wrapper is named. That is enough to decide *whether*
-    /// a spelling was erased — which is the question a reconstruction asks —
-    /// but a consumer that wants to rebuild a nested `Box<Cow<'_, T>>` needs to
-    /// peel repeatedly with [`peel_transparent`], the same list this reads.
+    /// a spelling was erased — which is the question a **refusal** asks — but a
+    /// consumer that rebuilds a nested `Box<Cow<'_, T>>` needs every layer, and
+    /// asks [`erased_wrappers`](Self::erased_wrappers) for the whole list plus
+    /// [`stripped_syntax`](Self::stripped_syntax) for what sits under it.
     ///
     /// Erased says nothing about **rebuildable**: `Box` reconstructs as
     /// `Box::new(v)`, while `Cow`'s `Owned`/`Borrowed` choice is not determined
     /// by any fact the model holds. Which wrappers an emitter can rebuild is
     /// that emitter's policy; this only stops the wrapper from being invisible.
     pub fn erased_wrapper(&self) -> Option<&'static str> {
-        peel_transparent(&self.origin.syntax).map(|(name, _)| name)
+        self.erased_wrappers().into_iter().next()
+    }
+
+    /// Every [transparent wrapper](TRANSPARENT_WRAPPERS) this type's **spelling**
+    /// adds over its classification, outermost first — `Box<Box<T>>` →
+    /// `["Box", "Box"]`, `Box<Cow<'_, T>>` → `["Box", "Cow"]`, an unwrapped
+    /// spelling → `[]`.
+    ///
+    /// The list [`erased_wrapper`](Self::erased_wrapper) names the head of. A
+    /// consumer deciding *whether* to refuse needs only that head; one that
+    /// **rebuilds** needs all of them, because it has to apply an operation per
+    /// layer — and `Box<Cow<'_, T>>` is two different operations, not one
+    /// repeated.
+    ///
+    /// # This answers for one layer's spelling
+    ///
+    /// **An erasure sits outside the layer it wraps**, so this is a question
+    /// that has to be asked on the way *down*, at every layer, and never once at
+    /// the top:
+    ///
+    /// | Spelling | here | on [`borrow_target`](Self::borrow_target) |
+    /// |---|---|---|
+    /// | `Box<&Vec<T>>` | `["Box"]` | `[]` — `kind` is `Ref`, and peeling it first drops the `Box` |
+    /// | `&Box<Vec<T>>` | `[]` — a `syn::Type::Reference` cannot be peeled | `["Box"]` |
+    ///
+    /// A rebuild therefore collects wrappers **as it descends**: by the time it
+    /// reaches the leaf they are gone from `kind`, which is precisely the thing
+    /// they are missing from.
+    pub fn erased_wrappers(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        let mut ty = std::borrow::Cow::Borrowed(&self.origin.syntax);
+        while let Some((name, inner)) = peel_transparent(&ty) {
+            names.push(name);
+            ty = std::borrow::Cow::Owned(inner);
+        }
+        names
+    }
+
+    /// This type's spelling with every [transparent
+    /// wrapper](TRANSPARENT_WRAPPERS) removed — `Box<Box<Option<T>>>` →
+    /// `Option<T>`, an unwrapped spelling → itself.
+    ///
+    /// The spelling a reconstruction builds *before* it puts the wrappers back:
+    /// rebuilding from [`kind`](Self::kind) alone yields this, so an emitter
+    /// that hands it to a parameter spelled `Box<..>` writes an `E0308`. Paired
+    /// with [`erased_wrappers`](Self::erased_wrappers), which says exactly what
+    /// has to go back on.
+    ///
+    /// **The invariant, which is what defines this rather than the loop that
+    /// computes it**: it is the spelling whose own lowering yields exactly this
+    /// type's `kind`. So the peel runs to a **fixed point** — `Box<Box<T>>`
+    /// classifies as `T`, and stripping one layer leaves a `Box<T>` that does
+    /// not match.
+    ///
+    /// Per-layer, for the reason [`erased_wrappers`](Self::erased_wrappers)
+    /// tabulates: this strips what stands over *this* node's classification, and
+    /// a wrapper under a borrow or inside an `Option` belongs to that inner
+    /// node's own spelling.
+    pub fn stripped_syntax(&self) -> syn::Type {
+        let mut ty = self.origin.syntax.clone();
+        while let Some((_, inner)) = peel_transparent(&ty) {
+            ty = inner;
+        }
+        ty
     }
 
     /// The `Ok` and `Err` sides when this is a `Result`, else `None`.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -2,7 +2,10 @@
 //! params, and the expanded-param path.
 
 use super::*;
-use crate::api::core::{registry::Conversions, types_util::result_ok_type};
+use crate::api::{
+    core::{registry::Conversions, types_util::result_ok_type},
+    lang::jnigen::jni::trait_impl::read_through_erased_wrappers,
+};
 
 pub(crate) fn emit_jni_function_wrapper(
     ext: &Declarations,
@@ -352,6 +355,34 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // Decompose/Optional: a single `__builder` callback.
         let uplan = unfold_plan.expect("Unfold output ⇒ unfold plan present");
         builder_param = Some(unfold_builder_param(u.iterable_fold));
+        // The delivery **binds** the returned value and matches it against the
+        // canonical shape its `kind` names (`Option`, then a run). Conversion
+        // follows the SYNTAX, and this position takes no converter — nothing
+        // between the source call and the match re-spells anything — so the
+        // wrappers the classification erased have to come off here, at the
+        // emitter's own binding, or the match is an `E0308` on a spelling the
+        // model deliberately reads as optional (#292).
+        //
+        // The value delivered is the `Ok` side when the error plan applied the
+        // `?`, and the return itself otherwise — the wrappers questioned are
+        // those over whatever `call_expr` actually yields.
+        let delivered = match error_plan {
+            Some(_) => f.ret.fallible_parts().map_or(&f.ret, |(ok, _)| ok),
+            None => &f.ret,
+        };
+        let call_expr =
+            read_through_erased_wrappers(delivered, call_expr.clone()).unwrap_or_else(|| {
+                panic!(
+                    "`{original_ident}` returns `{}`, whose leaves are delivered to a builder: \
+                     the value has to be moved out of `{}` to be decomposed, and that wrapper \
+                     does not permit it (a `Cow` payload cannot be moved through `Deref`). \
+                     Reserved rather than refused for good: rebuilding through every \
+                     transparent wrapper is #292 item 3 — until then, spell the return \
+                     without it.",
+                    delivered.syntax().to_token_stream(),
+                    delivered.erased_wrappers().join("<"),
+                )
+            });
         emit_unfold_delivery(
             ext,
             registry,

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2500,7 +2500,7 @@ fn an_owned_string_crosses_the_same_however_rust_spells_it() {
 /// Layers are counted, too: `Box<Box<Option<T>>>` is `Optional`, and one
 /// dereference leaves `Box<Option<T>>`.
 ///
-/// Both shapes used to RESOLVE and emit `let v: Option<String> = (*v);` — the
+/// Both shapes used to RESOLVE and emit `let v: Option<String> = *v;` — the
 /// worst outcome available, because resolution succeeding is what tells the
 /// binding its type is supported. Failing to resolve names the type; emitting
 /// unbuildable Rust names nothing (#270 review).
@@ -2556,21 +2556,23 @@ fn a_transparent_wrapper_is_bridged_only_where_it_can_be() {
         }
     };
 
-    // One box: bridged with one dereference.
+    // One box: bridged with one dereference. Unparenthesized — the bind is a
+    // `let` initializer, where a wrapping paren is `unused_parens`, and
+    // generated code runs through the consumer's own lints (#292).
     let one = build(syn::parse_quote!(Box<Option<String>>)).expect("a single box is bridgeable");
     let oc: String = one.split_whitespace().collect();
     assert!(
-        oc.contains("letv:Option<String>=(*v);"),
+        oc.contains("letv:Option<String>=*v;"),
         "one layer, one dereference:\n{one}"
     );
 
     // Two boxes: bridged with TWO. This is the case a single deref got wrong,
-    // silently — `(*v)` on `Box<Box<_>>` is still a `Box<_>`.
+    // silently — one `*` on `Box<Box<_>>` still leaves a `Box<_>`.
     let two =
         build(syn::parse_quote!(Box<Box<Option<String>>>)).expect("nested boxes are bridgeable");
     let tc: String = two.split_whitespace().collect();
     assert!(
-        tc.contains("letv:Option<String>=(*(*v));"),
+        tc.contains("letv:Option<String>=**v;"),
         "two layers, two dereferences:\n{two}"
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -678,6 +678,12 @@ struct WrapperOps {
     /// Move the inner value **out**. `None` when the representation does not
     /// permit it — a `Cow` payload cannot be moved through `Deref` (`E0507`),
     /// and neither can an `Rc`'s.
+    ///
+    /// Emitted **unparenthesized**: every consumer splices the result into a
+    /// `let` initializer, where a wrapping paren is `unused_parens` — and
+    /// generated code runs through the consumer's own lints, where that is a
+    /// denial. A consumer that splices into a tighter position (a method
+    /// receiver, a field base) parenthesizes at its own site.
     read: Option<fn(TokenStream) -> TokenStream>,
     /// Build it **from** the inner value. `None` when not supported.
     build: Option<fn(TokenStream) -> TokenStream>,
@@ -688,7 +694,7 @@ const WRAPPER_OPS: &[WrapperOps] = &[
     WrapperOps {
         name: "Box",
         // `*b` moves out of a box, and `Box::new` puts it back.
-        read: Some(|e| quote!((*#e))),
+        read: Some(|e| quote!(*#e)),
         build: Some(|e| quote!(::std::boxed::Box::new(#e))),
     },
     WrapperOps {
@@ -748,6 +754,37 @@ fn build_from_canonical(
         e = (w.build?)(e);
     }
     Some(e)
+}
+
+/// Move a value the **source** produced out of the transparent wrappers its
+/// spelling adds over its classification, so an emitter that binds it holds the
+/// canonical shape — `Box<Option<T>>` → `(*e)`, an unwrapped spelling → `e`
+/// unchanged.
+///
+/// The counterpart of [`bind_as_option`](super::emit::bind_as_option) for an
+/// **owned** position. A type-ascribed `let` is a coercion site and serves any
+/// representation, but coercion applies to *references*: a value whose payload
+/// downstream moves has to be moved out of the wrapper instead, which is what
+/// [`WrapperOps::read`] does and what only some wrappers permit.
+///
+/// `None` when a layer cannot be read through (`Cow`, whose payload cannot be
+/// moved out by `Deref`) — the caller then has an unrepresentable crossing to
+/// report, and must not emit the match anyway.
+///
+/// **This answers for one layer's spelling.** It undoes the wrappers standing
+/// over `ty`'s own classification; a wrapper *inside* — the `Box` of
+/// `Option<Box<Vec<T>>>` — belongs to the inner reading and is that layer's
+/// question, per [`TypeRef::erased_wrappers`](crate::api::core::flat::TypeRef::erased_wrappers).
+pub(crate) fn read_through_erased_wrappers(
+    ty: &crate::api::core::flat::TypeRef,
+    e: TokenStream,
+) -> Option<TokenStream> {
+    let mut out = e;
+    // Outermost first, which is the order they have to come off in.
+    for name in ty.erased_wrappers() {
+        out = (wrapper_ops(name)?.read?)(out);
+    }
+    Some(out)
 }
 
 /// Whether the source wrote the canonical spelling itself — no wrapper to undo.


### PR DESCRIPTION
Item 1 of #292, plus the audit its comment asked for — which turned up one live miscompilation, fixed here.

## The model

`TypeKind` erases `Box` and `Cow`, and that erasure is right: `Box<Option<T>>` is one optional string to every destination language. But **conversion follows the syntax**, and the two facts a rebuild needs were not on the model. #290 shipped `erased_wrapper()` — the outermost wrapper of the top layer — which is enough to decide *whether* to refuse and not enough to rebuild.

* `TypeRef::erased_wrappers() -> Vec<&'static str>` — every wrapper, outermost first. `Box<Cow<'_, T>>` is two *different* operations, so a name and a count would not do.
* `TypeRef::stripped_syntax() -> syn::Type` — the spelling under them.

**Derived, never stored.** `lower_type` keeps discarding the wrapper into `kind`; these recompute from `origin.syntax` at the point of use, exactly as the shipped `erased_wrapper()` already does. A stored spelling is a second thing that can disagree with `syntax`, and a representation detail recorded back into the model is what the flat model exists to avoid.

`stripped_syntax` is defined by its **invariant**, not by its loop: *the spelling whose own lowering yields exactly this `kind`*. So the peel runs to a **fixed point** — `Box<Box<T>>` classifies as `T`, and one strip leaves a `Box<T>` that does not match. The test asserts the property (strip, lower again, compare classifications) over five wrapped rows plus an unwrapped control, and was seen to fail against a one-layer implementation before being trusted.

Both carry the #290 ordering finding on their docs, because **an erasure sits outside the layer it wraps**:

| Spelling | at the top | on `borrow_target()` |
|---|---|---|
| `Box<&Vec<T>>` | `["Box"]` | `[]` — `kind` is `Ref`; peeling first drops the wrapper |
| `&Box<Vec<T>>` | `[]` — a `Type::Reference` cannot be peeled | `["Box"]` |

Neither check subsumes the other and the two classify identically, so a walk must ask at every layer on the way down. That pair is a test.

## The audit

The #290 comment left this explicitly unchecked: the guards were in jnigen's **input** lowerings only; the output side and cbindgen were not looked at.

The population is two, and only one has to ask. A site that **classifies** must never consult the wrapper — that is the erasure working. A site that **binds a source value and destructures or rebuilds it** must.

| Site | Kind | Verdict |
|---|---|---|
| cbindgen — all 27 non-test peels (`opaque_ptr_payload_inner`, `box_inner`, `is_option`, `produces_array`) | classify → a C wire | correct as is; the `Box`-derived wire is #230's question, not this one |
| jnigen `selector` / `struct_plan` / `fn_plan` / `iface` / `builder` / `render` / `fold` / `kotlin_emit` | classify → a Kotlin type, a JNI wire, a plan shape | correct as is |
| jnigen `emit/flat_input` ×3, `emit/vec_build` ×3 | rebuild | guarded by #290 |
| `delivery.rs` field reaches | destructure | coerced via `bind_as_option` (#268) |
| wrapper.rs `is_convert` → `raw.map(..)` | destructure | **compiles** — method resolution auto-derefs, verified against `rustc` |
| **wrapper.rs → `emit_unfold_delivery`** | **destructure** | **unguarded — `E0308`** |

Builder delivery binds the returned value and matches it against `Option`'s patterns, and match ergonomics does not see through a `Box`. `read_through_erased_wrappers` undoes the wrappers at the **single point the value enters the delivery**, not at each of the four matches downstream; `Cow` panics with a message that names #292 item 3 as where it becomes possible, per the reserved-vs-refused convention.

## Evidence

#269 means 737 `contains(..)` assertions pass on Rust that does not compile, so the fixture is where an `E0308` is actually a failure: `perftest_flat::boxed_latest`, whose generated binding covertest `include!`s and CI builds. `Summary` carries an output expansion, so its return takes no converter to name the spelling for it — the shape `boxed_note_echo` (a converted return) does not reach.

- **Verified by disabling the fix**: the build breaks with `expected Box<Option<Summary>>, found Option<_>` at `generated_bindings.rs:12768`.
- **Round-tripped on the JVM**: new `transparent wrapper crossings` section in `Test.kt`, asserting the wrapped and unwrapped twins have the same surface and the same values. `PASS - 49 sections`.
- `cargo test` and `cargo test --all --all-features` green; clippy `--deny warnings` clean; fmt with the CI config clean.

## One golden line moved

`Box`'s `read` op drops its parens: `let v: Option<String> = (*(*v));` → `**v`. Every consumer splices into a `let` initializer. Converters happen to `#[allow(unused_parens)]` and wrapper externs do not, which is why the lint surfaced only at the new site — fixing it at the op's one definition rather than special-casing the caller is the right altitude. `value_form.rs` pinned the old spelling and is updated with the reason.

Regen drift is confined to covertest's three artifacts (the new fixture plus that line); `example_flat_aarch64.{rs,h}` did **not** move.

## Ledger

Unchanged — no watched `syn` variant site is added or removed. `erased_wrappers`/`stripped_syntax` live in `core::flat`, where classification belongs, and `read_through_erased_wrappers` consults the model rather than matching syntax.

Registered on #229: a row in the *Why the syntax rides along* table, a `What L4 taught` subsection, and an L5 bullet.

Items 2 (#230, cbindgen's wire from `kind`) and 3 (jnigen rebuilds instead of refusing) stay on their issues and consume this.