### PR TITLE
jnigen: rebuild the spelling instead of refusing it (#292 item 3, closes #289)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -522,6 +522,19 @@ fn main() {
                 // with the wrong number of dereferences fails the build (#270).
                 .fun(fun!(boxed_note_echo))
                 .fun(fun!(plain_note_echo))
+                // Transparent wrappers on the INPUT side (#292 item 3), one per
+                // specialized lowering. These rebuild their parameter rather
+                // than decoding it, so the erased wrapper has to go back on
+                // before the value reaches the signature — and each layer is
+                // applied at a different point in the construction, which is why
+                // one shape cannot cover them all. Compiling this crate is the
+                // check: a missing `Box::new` is an `E0308`, invisible to any
+                // text assertion.
+                .fun(fun!(boxed_payload_id))
+                .fun(fun!(boxed_opt_payload_id))
+                .fun(fun!(boxed_opt_priority_weight))
+                .fun(fun!(boxed_elem_id_sum))
+                .fun(fun!(boxed_run_id_sum))
                 // The same wrapper over a DECOMPOSED return (#292). `Summary`
                 // has an output expansion, so this return takes no converter to
                 // name the spelling for it — the extern binds the value and

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -206,6 +206,11 @@ fn main() {
                     .method(fun!(payload_label_len)),
             ),
         )
+        // `Option<Holder>` where `Holder` has a REQUIRED handle field: the
+        // absent case passes pointer 0 for it, so the field decodes must stay
+        // inside the presence gate or `null` becomes a binding error instead of
+        // `None` (PR#294 review).
+        .package(package!().class(data_class!(Holder)))
         // A data class whose FIELDS carry transparent wrappers (#289 + #292):
         // `boxed: Box<Option<i64>>` must cross exactly as `plain: Option<i64>`
         // does — the decoupled `(present, value)` pair — with the `Box` put back
@@ -537,6 +542,7 @@ fn main() {
                 // check: a missing `Box::new` is an `E0308`, invisible to any
                 // text assertion.
                 .fun(fun!(wrapped_fields_sum))
+                .fun(fun!(holder_tag_or))
                 .fun(fun!(boxed_payload_id))
                 .fun(fun!(boxed_opt_payload_id))
                 .fun(fun!(boxed_opt_priority_weight))

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -206,6 +206,12 @@ fn main() {
                     .method(fun!(payload_label_len)),
             ),
         )
+        // A data class whose FIELDS carry transparent wrappers (#289 + #292):
+        // `boxed: Box<Option<i64>>` must cross exactly as `plain: Option<i64>`
+        // does — the decoupled `(present, value)` pair — with the `Box` put back
+        // on the Rust side. Peeling the field by path segment answered "not
+        // optional" and boxed it instead.
+        .package(package!().class(data_class!(WrappedFields)))
         // ── Subpackage `model`: enum + value class + nested data class ──────
         .package(
             package!("model")
@@ -530,6 +536,7 @@ fn main() {
                 // one shape cannot cover them all. Compiling this crate is the
                 // check: a missing `Box::new` is an `E0308`, invisible to any
                 // text assertion.
+                .fun(fun!(wrapped_fields_sum))
                 .fun(fun!(boxed_payload_id))
                 .fun(fun!(boxed_opt_payload_id))
                 .fun(fun!(boxed_opt_priority_weight))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -81,6 +81,7 @@ Base package: `io.prebindgen.covertest`
 - `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy>): HoldPolicy`
+- `holder_tag_or` — `fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
 - `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>>): List<String>`
 - `ledger_each` — `fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Unit>)`
@@ -198,6 +199,7 @@ Base package: `io.prebindgen.covertest`
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
 - `Hold`: sealed_class → `io.prebindgen.covertest.model.Hold` (wire `?`)
 - `HoldPolicy`: data_class → `io.prebindgen.covertest.model.HoldPolicy` (wire `jni :: objects :: JObject`)
+- `Holder`: data_class → `io.prebindgen.covertest.Holder` (wire `jni :: objects :: JObject`)
 - `Lookup`: sealed_class → `io.prebindgen.covertest.model.Lookup` (wire `?`)
 - `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -63,9 +63,14 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
 - `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue>): BlobValue`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
+- `boxed_elem_id_sum` — `fun boxedElemIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `boxed_latest` — `fun <R> boxedLatest(a: SummaryVault, onError: JniErrorHandler<R?>, build: SummaryBuilder<R>): R?`
   - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
 - `boxed_note_echo` — `fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): String?`
+- `boxed_opt_payload_id` — `fun boxedOptPayloadId(p: Payload?, onError: JniErrorHandler<Long>): Long`
+- `boxed_opt_priority_weight` — `fun boxedOptPriorityWeight(p: Priority?, onError: JniErrorHandler<Long>): Long`
+- `boxed_payload_id` — `fun boxedPayloadId(p: Payload, onError: JniErrorHandler<Long>): Long`
+- `boxed_run_id_sum` — `fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -122,6 +122,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Unsigned` decomposed → [byte, short, int, long, maybeLong] (Callback delivery)
 - `unsigned_series` — `fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong>`
   - shaped by: return `u64` decomposed → [] (Callback delivery)
+- `wrapped_fields_sum` — `fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): Long`
 
 ## package `io.prebindgen.covertest.storage`
 
@@ -223,6 +224,7 @@ Base package: `io.prebindgen.covertest`
 - `Summary`: ptr_class → `io.prebindgen.covertest.analytics.Summary` (wire `jni :: sys :: jlong`)
 - `Tagged`: data_class → `io.prebindgen.covertest.model.Tagged` (wire `jni :: objects :: JObject`)
 - `Unsigned`: data_class → `io.prebindgen.covertest.model.Unsigned` (wire `jni :: objects :: JObject`)
+- `WrappedFields`: data_class → `io.prebindgen.covertest.WrappedFields` (wire `jni :: objects :: JObject`)
 
 ## conversions
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -157,6 +157,31 @@ internal inline fun <R> withSortedHandleLocks(
     return synchronized(x) { synchronized(y) { synchronized(z) { body() } } }
 }
 
+/**
+ * An `Option<data class>` whose data class has a **required handle** field.
+ *
+ * The shape that proves an optional node's field decodes stay **inside** its
+ * presence gate. When the Kotlin object is null every leaf carries an inert
+ * placeholder, and a handle leaf's placeholder is pointer `0` — which the
+ * direct-handle decode reads as a closed handle, signals a binding error for,
+ * and returns from. Hoisting the decodes out of the gate therefore turns
+ * `null` into an error instead of `None`, and no fixture whose fields all
+ * decode successfully can tell the difference.
+ *
+ * `Summary` is consumed by value here, as a handle field is: the `Some` case
+ * hands over ownership, and the `None` case must never touch the slot.
+ */
+public data class Holder(val tag: Long, val summary: Summary) : AutoCloseable {
+    override fun close() {
+        summary.close()
+    }
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(tag: Long, summary: Long): Holder = Holder(tag, Summary(summary))
+    }
+}
+
 public interface PayloadApi {
     val id: Long
 
@@ -975,6 +1000,14 @@ internal object CovNative {
         pGrace: io.prebindgen.covertest.model.Hold?,
         errorSink: Any,
     ): HoldPolicy
+
+    external fun holderTagOr(
+        hPresent: Boolean,
+        hTag: Long,
+        hSummary: Long,
+        fallback: Long,
+        errorSink: Any,
+    ): Long
 
     external fun labelReverse(l: String, errorSink: Any): String
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -894,9 +894,34 @@ internal object CovNative {
         errorSink: Any,
     ): Any?
 
+    external fun boxedElemIdSum(ps: List<Payload>, errorSink: Any): Long
+
     external fun boxedLatest(a: Long, build: Any, errorSink: Any): Any?
 
     external fun boxedNoteEcho(note: String?, errorSink: Any): String?
+
+    external fun boxedOptPayloadId(
+        pPresent: Boolean,
+        pId: Long,
+        pSeq: Int,
+        pValue: Double,
+        pFlag: Boolean,
+        pLabel: String?,
+        errorSink: Any,
+    ): Long
+
+    external fun boxedOptPriorityWeight(pPresent: Boolean, pValue: Int, errorSink: Any): Long
+
+    external fun boxedPayloadId(
+        pId: Long,
+        pSeq: Int,
+        pValue: Double,
+        pFlag: Boolean,
+        pLabel: String?,
+        errorSink: Any,
+    ): Long
+
+    external fun boxedRunIdSum(ps: Long, errorSink: Any): Long
 
     external fun cacheConfigWeight(
         cachePresent: Boolean,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -209,6 +209,27 @@ public data class Payload(override val id: Long, override val seq: Int, override
     }
 }
 
+/**
+ * A data class whose **fields** carry transparent wrappers.
+ *
+ * This is what #289 changes and why it could not land alone. The field walk
+ * used to peel with `option_inner_type`, which reads the last path segment: a
+ * field spelled `Box<Option<i64>>` answered "not optional" and crossed as one
+ * boxed `java.lang.Long`. The model says `Optional`, so it now takes the
+ * decoupled `(present, value)` pair its bare twin does — and the emitter has to
+ * put the `Box` back when it rebuilds, or the migration turns a working boxed
+ * crossing into an `E0308`.
+ *
+ * `plain` is the control: the two fields must produce the same wire, since the
+ * model says they are the same type.
+ */
+public data class WrappedFields(val id: Long, val boxed: Long?, val plain: Long?) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(id: Long, boxed: Long?, plain: Long?): WrappedFields = WrappedFields(id, boxed, plain)
+    }
+}
+
 /** Typed handle for a native Zenoh `PayloadHandler`. */
 public class PayloadHandler(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
@@ -1273,6 +1294,15 @@ internal object CovNative {
     ): Any?
 
     external fun unsignedSeries(acc: Any?, fold: Any, errorSink: Any): Any?
+
+    external fun wrappedFieldsSum(
+        wId: Long,
+        wBoxedPresent: Boolean,
+        wBoxedValue: Long,
+        wPlainPresent: Boolean,
+        wPlainValue: Long,
+        errorSink: Any,
+    ): Long
 
     external fun constGetCoverMagic(errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -10,6 +10,7 @@ import io.prebindgen.covertest.LedgerCallback
 import io.prebindgen.covertest.NativeHandle
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
+import io.prebindgen.covertest.WrappedFields
 import io.prebindgen.covertest.__u64FolderRawHolder
 import io.prebindgen.covertest.analytics.Summary
 import io.prebindgen.covertest.analytics.SummaryBuilder
@@ -1620,6 +1621,21 @@ public fun boxedNoteEcho(note: String?, onError: JniErrorHandler<String?>): Stri
 public fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): String? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.plainNoteEcho(note, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/** Round-trip a [`WrappedFields`] so both field spellings cross in one call. */
+public fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.wrappedFieldsSum(
+        w.id,
+        w.boxed != null,
+        w.boxed ?: 0L,
+        w.plain != null,
+        w.plain ?: 0L,
+        __bcap,
+    )
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -3,6 +3,7 @@ package io.prebindgen.covertest.model
 
 import io.prebindgen.covertest.CovNative
 import io.prebindgen.covertest.DurationCallback
+import io.prebindgen.covertest.Holder
 import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.LedgerBuilder
@@ -1636,6 +1637,29 @@ public fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): L
         w.plain ?: 0L,
         __bcap,
     )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * `tag` when the holder is present, `fallback` when it is absent — so the
+ * absent arm is observable as a **value** rather than as an error.
+ */
+public fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long {
+    if (h?.summary?.isClosed() == true) return onError.run("Operation on a closed native handle.")
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        h?.summary?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val hSummary_ptr = h?.summary?.ptr ?: 0L
+            try {
+                CovNative.holderTagOr(h != null, h?.tag ?: 0L, hSummary_ptr, fallback, __bcap)
+            } finally {
+                h?.summary?.markConsumed()
+            }
+        }
+    }
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1625,6 +1625,102 @@ public fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): Stri
 }
 
 /**
+ * Transparent wrappers on the **input** side, one per specialized lowering.
+ *
+ * These lowerings do not *decode* their parameter, they **rebuild** it — a
+ * literal `Payload { .. }`, an `Option::Some(v)`, a `Vec<T>` pushed element by
+ * element — so the wrappers the classification erased have to go back on before
+ * the value reaches the signature. Rebuilding from the classification alone
+ * hands an `Option<Payload>` to a parameter spelled `Box<Option<Payload>>`:
+ * `E0308` (#292 item 3, which replaced #290's refusals).
+ *
+ * Declared here rather than only in unit tests for the reason
+ * [`boxed_note_echo`] is: this crate's generated binding is `include!`d and
+ * **compiled**, so a missing or misplaced `Box::new` fails the build. Each has
+ * an unwrapped twin already declared — the surfaces must come out identical,
+ * since the model says the two spellings are one type.
+ *
+ * The layers are covered separately because each is applied at a different
+ * point in the construction, and only a shape that exercises one can show it:
+ * the core wrap goes inside the present gate, and the optional wrap around it.
+ *
+ * **`Box<&Payload>` is deliberately absent.** The flatten lowering could build
+ * it — it owns a local and `Box::new(&local)` is well-typed — but a declared
+ * parameter also needs a general converter entry, and a converter *produces* an
+ * owned value: there is nothing for a `Box<&T>` to borrow from that outlives
+ * the call (`E0106` on the generated signature). So the shape is refused at
+ * resolution, by the converter's nature rather than the wrapper's.
+ */
+public fun boxedPayloadId(p: Payload, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.boxedPayloadId(p.id, p.seq, p.value, p.flag, p.label, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * The optional layer over the same rebuild — the wrap goes **around** the
+ * present gate, where the core wrap goes inside it.
+ */
+public fun boxedOptPayloadId(p: Payload?, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.boxedOptPayloadId(
+        p != null,
+        p?.id ?: 0L,
+        p?.seq ?: 0,
+        p?.value ?: 0.0,
+        p?.flag ?: false,
+        p?.label,
+        __bcap,
+    )
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * The option-scalar lowering (`(present, value)` raw pair) under a wrapper —
+ * the rebuilt `Option` is re-wrapped before it reaches the signature.
+ */
+public fun boxedOptPriorityWeight(p: Priority?, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.boxedOptPriorityWeight(p != null, p?.value ?: 0, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * A wrapped **element** in the Vec-build path: the storage is `Vec<Box<Payload>>`
+ * and each push wraps its own literal.
+ */
+public fun boxedElemIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.boxedElemIdSum(ps, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * A wrapped **run**, by value: `mem::take` yields the owned `Vec`, so the
+ * `Box` costs nothing. The borrowed twin (`&Box<Vec<Payload>>`) is deliberately
+ * **not** declared — interposing a `Box` between the caller's Vec and the
+ * callee would require copying it, so that shape keeps the ordinary path.
+ */
+public fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __vec_ps = CovNative.payloadVecNew(ps.size)
+    val __ret = try {
+        for (__e in ps) {
+            CovNative.payloadVecPush(__vec_ps, __e.id, __e.seq, __e.value, __e.flag, __e.label)
+        }
+        CovNative.boxedRunIdSum(__vec_ps, __bcap)
+    } finally {
+        CovNative.payloadVecFree(__vec_ps)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * A transparent wrapper over a **decomposed** return — the shape `boxed_note_echo`
  * does not reach.
  *

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -44,12 +44,14 @@ import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.arraysEcho
 import io.prebindgen.covertest.model.blobValueEcho
+import io.prebindgen.covertest.WrappedFields
 import io.prebindgen.covertest.model.boxedElemIdSum
 import io.prebindgen.covertest.model.boxedLatest
 import io.prebindgen.covertest.model.boxedOptPayloadId
 import io.prebindgen.covertest.model.boxedOptPriorityWeight
 import io.prebindgen.covertest.model.boxedPayloadId
 import io.prebindgen.covertest.model.boxedRunIdSum
+import io.prebindgen.covertest.model.wrappedFieldsSum
 import io.prebindgen.covertest.model.boxedNoteEcho
 import io.prebindgen.covertest.model.plainNoteEcho
 import io.prebindgen.covertest.model.blobValueNew
@@ -1468,6 +1470,15 @@ fun main() {
         val many = listOf(payload(1L, 0, 0.0, false, null), payload(2L, 0, 0.0, false, null))
         check(boxedElemIdSum(many, boom) == 3L)           // wrapped element
         check(boxedRunIdSum(many, boom) == 3L)            // wrapped run, by value
+
+        // FIELDS (#289). `boxed: Box<Option<Long>>` and `plain: Option<Long>`
+        // are one type to the model, so both cross as `Long?` on the decoupled
+        // `(present, value)` pair — the boxed one used to be read by path
+        // segment as "not optional" and crossed as one boxed object.
+        check(wrappedFieldsSum(WrappedFields(1L, 2L, 4L), boom) == 7L)
+        check(wrappedFieldsSum(WrappedFields(1L, null, 4L), boom) == 5L)
+        check(wrappedFieldsSum(WrappedFields(1L, 2L, null), boom) == 3L)
+        check(wrappedFieldsSum(WrappedFields(1L, null, null), boom) == 1L)
     }
 
     // ── Vec<String> fold + Option<data-class> input + plain String return ────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -44,6 +44,7 @@ import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.arraysEcho
 import io.prebindgen.covertest.model.blobValueEcho
+import io.prebindgen.covertest.Holder
 import io.prebindgen.covertest.WrappedFields
 import io.prebindgen.covertest.model.boxedElemIdSum
 import io.prebindgen.covertest.model.boxedLatest
@@ -51,6 +52,7 @@ import io.prebindgen.covertest.model.boxedOptPayloadId
 import io.prebindgen.covertest.model.boxedOptPriorityWeight
 import io.prebindgen.covertest.model.boxedPayloadId
 import io.prebindgen.covertest.model.boxedRunIdSum
+import io.prebindgen.covertest.model.holderTagOr
 import io.prebindgen.covertest.model.wrappedFieldsSum
 import io.prebindgen.covertest.model.boxedNoteEcho
 import io.prebindgen.covertest.model.plainNoteEcho
@@ -1479,6 +1481,16 @@ fun main() {
         check(wrappedFieldsSum(WrappedFields(1L, null, 4L), boom) == 5L)
         check(wrappedFieldsSum(WrappedFields(1L, 2L, null), boom) == 3L)
         check(wrappedFieldsSum(WrappedFields(1L, null, null), boom) == 1L)
+
+        // An absent `Option<data class>` must deliver `None`, not an error. Its
+        // leaves are inert placeholders when the object is null, and a required
+        // HANDLE field's placeholder is pointer 0 — which the direct-handle
+        // decode reads as a closed handle. So this is the shape that proves the
+        // field decodes stay inside the presence gate; a fixture whose fields
+        // all decode successfully cannot tell the two orders apart.
+        check(holderTagOr(null, -9L, boom) == -9L)
+        val held = Summary.of(4L, 8.0, boom)
+        check(holderTagOr(Holder(3L, held), -9L, boom) == 7L)  // 3 + count(4)
     }
 
     // ── Vec<String> fold + Option<data-class> input + plain String return ────

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -44,7 +44,12 @@ import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.arraysEcho
 import io.prebindgen.covertest.model.blobValueEcho
+import io.prebindgen.covertest.model.boxedElemIdSum
 import io.prebindgen.covertest.model.boxedLatest
+import io.prebindgen.covertest.model.boxedOptPayloadId
+import io.prebindgen.covertest.model.boxedOptPriorityWeight
+import io.prebindgen.covertest.model.boxedPayloadId
+import io.prebindgen.covertest.model.boxedRunIdSum
 import io.prebindgen.covertest.model.boxedNoteEcho
 import io.prebindgen.covertest.model.plainNoteEcho
 import io.prebindgen.covertest.model.blobValueNew
@@ -1449,6 +1454,20 @@ fun main() {
         archiveStore(a, 0, 5L, 100.0, null, boom)
         check(boxedLatest(a, boom) { count, total -> count to total } == 5L to 100.0)
         a.close()
+
+        // INPUT side (#292 item 3). These lowerings REBUILD their parameter, so
+        // the wrapper has to go back on before the value reaches the signature.
+        // Every surface below is the unwrapped one — a wrapper must not cost a
+        // parameter its lowering, and must not show up in Kotlin either.
+        val p = payload(7L, 1, 2.0, true, "w")
+        check(boxedPayloadId(p, boom) == 7L)              // core wrap
+        check(boxedOptPayloadId(p, boom) == 7L)           // core + optional wrap
+        check(boxedOptPayloadId(null, boom) == -1L)       // …and the absent arm
+        check(boxedOptPriorityWeight(Priority.HIGH, boom) == 10L)  // option-scalar
+        check(boxedOptPriorityWeight(null, boom) == -1L)
+        val many = listOf(payload(1L, 0, 0.0, false, null), payload(2L, 0, 0.0, false, null))
+        check(boxedElemIdSum(many, boom) == 3L)           // wrapped element
+        check(boxedRunIdSum(many, boom) == 3L)            // wrapped run, by value
     }
 
     // ── Vec<String> fold + Option<data-class> input + plain String return ────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1034,6 +1034,46 @@ pub(crate) unsafe fn HoldPolicy_to_JObject_d2a5bcc4<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Holder_to_JObject_c36a9705<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Holder,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___tag: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.tag.clone())?;
+        let ___summary: jni::sys::jlong = Summary_to_jlong_3cb103b9(
+            env,
+            v.summary.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/Holder",
+                "fromParts",
+                "(JJ)Lio/prebindgen/covertest/Holder;",
+                &[
+                    jni::objects::JValue::from(___tag),
+                    jni::objects::JValue::from(___summary),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JBooleanArray_to_bool_3_3f960c58<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JBooleanArray<'v>,
@@ -1947,6 +1987,62 @@ pub(crate) unsafe fn JObject_to_Hold_5f85caaf<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Holder_c36a9705<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Holder, __JniErr> {
+    Ok({
+        let __tag_raw: jni::sys::jlong = env
+            .get_field(v, "tag", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Holder.tag: {}", e)))? as _;
+        let tag = jlong_to_i64_fbf9a9bc(env, &__tag_raw)?;
+        let __summary_jobj: jni::objects::JObject = env
+            .get_field(v, "summary", "Lio/prebindgen/covertest/analytics/Summary;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Holder.summary: {}", e)))?;
+        let __summary_raw: jni::sys::jlong = if __summary_jobj.is_null() {
+            0
+        } else {
+            env.call_method(&__summary_jobj, "peek", "()J", &[])
+                .and_then(|val| val.j())
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Holder.summary: {}", e)))?
+        };
+        if __summary_raw == 0 || (__summary_raw & 1) == 1 {
+            return ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from("Operation on a closed native handle.".to_string()),
+            );
+        }
+        let summary: perftest_flat::Summary = unsafe {
+            *std::boxed::Box::from_raw(__summary_raw as *mut perftest_flat::Summary)
+        };
+        perftest_flat::Holder {
+            tag,
+            summary,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -2598,6 +2694,30 @@ pub(crate) unsafe fn JObject_to_Option_Hold_230d7f9b<'env, 'v>(
     Ok({
         let __v: ::core::option::Option<perftest_flat::Hold> = {
             if v.is_null() { None } else { Some(JObject_to_Hold_5f85caaf(env, v)?) }
+        };
+        __v
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Option_Holder_ca758c1f<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Option<perftest_flat::Holder>, __JniErr> {
+    Ok({
+        let __v: ::core::option::Option<perftest_flat::Holder> = {
+            if v.is_null() { None } else { Some(JObject_to_Holder_c36a9705(env, v)?) }
         };
         __v
     })
@@ -10552,7 +10672,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedAlterna
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = {
+    let __flat_a_alternate = if a_alternate_present != 0u8 {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -10638,17 +10758,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedAlterna
                 return jni::objects::JObject::null().into();
             }
         };
-        if a_alternate_present != 0u8 {
-            ::core::option::Option::Some(perftest_flat::Payload {
-                id: __flat_a_alternate_id,
-                seq: __flat_a_alternate_seq,
-                value: __flat_a_alternate_value,
-                flag: __flat_a_alternate_flag,
-                label: __flat_a_alternate_label,
-            })
-        } else {
-            ::core::option::Option::None
-        }
+        ::core::option::Option::Some(perftest_flat::Payload {
+            id: __flat_a_alternate_id,
+            seq: __flat_a_alternate_seq,
+            value: __flat_a_alternate_value,
+            flag: __flat_a_alternate_flag,
+            label: __flat_a_alternate_label,
+        })
+    } else {
+        ::core::option::Option::None
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -10983,7 +11101,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = {
+    let __flat_a_alternate = if a_alternate_present != 0u8 {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -11069,17 +11187,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
                 return 0.0 as jni::sys::jdouble;
             }
         };
-        if a_alternate_present != 0u8 {
-            ::core::option::Option::Some(perftest_flat::Payload {
-                id: __flat_a_alternate_id,
-                seq: __flat_a_alternate_seq,
-                value: __flat_a_alternate_value,
-                flag: __flat_a_alternate_flag,
-                label: __flat_a_alternate_label,
-            })
-        } else {
-            ::core::option::Option::None
-        }
+        ::core::option::Option::Some(perftest_flat::Payload {
+            id: __flat_a_alternate_id,
+            seq: __flat_a_alternate_seq,
+            value: __flat_a_alternate_value,
+            flag: __flat_a_alternate_flag,
+            label: __flat_a_alternate_label,
+        })
+    } else {
+        ::core::option::Option::None
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -11257,7 +11373,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = {
+    let __flat_a_alternate = if a_alternate_present != 0u8 {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -11343,17 +11459,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
                 return jni::objects::JObject::null().into();
             }
         };
-        if a_alternate_present != 0u8 {
-            ::core::option::Option::Some(perftest_flat::Payload {
-                id: __flat_a_alternate_id,
-                seq: __flat_a_alternate_seq,
-                value: __flat_a_alternate_value,
-                flag: __flat_a_alternate_flag,
-                label: __flat_a_alternate_label,
-            })
-        } else {
-            ::core::option::Option::None
-        }
+        ::core::option::Option::Some(perftest_flat::Payload {
+            id: __flat_a_alternate_id,
+            seq: __flat_a_alternate_seq,
+            value: __flat_a_alternate_value,
+            flag: __flat_a_alternate_flag,
+            label: __flat_a_alternate_label,
+        })
+    } else {
+        ::core::option::Option::None
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -11531,7 +11645,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = {
+    let __flat_a_alternate = if a_alternate_present != 0u8 {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -11617,17 +11731,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
                 return jni::objects::JObject::null().into();
             }
         };
-        if a_alternate_present != 0u8 {
-            ::core::option::Option::Some(perftest_flat::Payload {
-                id: __flat_a_alternate_id,
-                seq: __flat_a_alternate_seq,
-                value: __flat_a_alternate_value,
-                flag: __flat_a_alternate_flag,
-                label: __flat_a_alternate_label,
-            })
-        } else {
-            ::core::option::Option::None
-        }
+        ::core::option::Option::Some(perftest_flat::Payload {
+            id: __flat_a_alternate_id,
+            seq: __flat_a_alternate_seq,
+            value: __flat_a_alternate_value,
+            flag: __flat_a_alternate_flag,
+            label: __flat_a_alternate_label,
+        })
+    } else {
+        ::core::option::Option::None
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -13275,94 +13387,92 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedOptPayloadI
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let __flat_p = {
-        let __flat_p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
-            ::core::result::Result::Ok(__v) => __v,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return 0 as jni::sys::jlong;
-            }
-        };
-        let __flat_p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
-            ::core::result::Result::Ok(__v) => __v,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return 0 as jni::sys::jlong;
-            }
-        };
-        let __flat_p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
-            ::core::result::Result::Ok(__v) => __v,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return 0 as jni::sys::jlong;
-            }
-        };
-        let __flat_p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
-            ::core::result::Result::Ok(__v) => __v,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return 0 as jni::sys::jlong;
-            }
-        };
-        let __flat_p_label = match JString_to_Option_Box_String_071e4c8c(
-            &mut env,
-            &p_label,
-        ) {
-            ::core::result::Result::Ok(__v) => __v,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(
-                    &mut env,
-                    &__error_sink,
-                    &__SINK_MID,
-                    __SINK_FQN,
-                    __SINK_DESCR,
-                    &__e.to_string(),
-                );
-                return 0 as jni::sys::jlong;
-            }
-        };
-        ::std::boxed::Box::new(
-            if p_present != 0u8 {
-                ::core::option::Option::Some(perftest_flat::Payload {
-                    id: __flat_p_id,
-                    seq: __flat_p_seq,
-                    value: __flat_p_value,
-                    flag: __flat_p_flag,
-                    label: __flat_p_label,
-                })
-            } else {
-                ::core::option::Option::None
-            },
-        )
-    };
+    let __flat_p = ::std::boxed::Box::new(
+        if p_present != 0u8 {
+            let __flat_p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            let __flat_p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            let __flat_p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            let __flat_p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            let __flat_p_label = match JString_to_Option_Box_String_071e4c8c(
+                &mut env,
+                &p_label,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            ::core::option::Option::Some(perftest_flat::Payload {
+                id: __flat_p_id,
+                seq: __flat_p_seq,
+                value: __flat_p_value,
+                flag: __flat_p_flag,
+                label: __flat_p_label,
+            })
+        } else {
+            ::core::option::Option::None
+        },
+    );
     let p = __flat_p;
     let __out = perftest_flat::boxed_opt_payload_id(p);
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
@@ -13591,7 +13701,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeigh
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let __flat_cache = {
+    let __flat_cache = if cache_present != 0u8 {
         let __flat_cache_replies_priority = match jint_to_Priority_447102d2(
             &mut env,
             &cache_replies_priority,
@@ -13644,14 +13754,12 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeigh
                 return 0 as jni::sys::jint;
             }
         };
-        if cache_present != 0u8 {
-            ::core::option::Option::Some(perftest_flat::CacheConfig {
-                replies: __flat_cache_replies,
-                ttl: __flat_cache_ttl,
-            })
-        } else {
-            ::core::option::Option::None
-        }
+        ::core::option::Option::Some(perftest_flat::CacheConfig {
+            replies: __flat_cache_replies,
+            ttl: __flat_cache_ttl,
+        })
+    } else {
+        ::core::option::Option::None
     };
     let cache = __flat_cache;
     let __out = perftest_flat::cache_config_weight(cache);
@@ -14271,6 +14379,88 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdPolicyEcho<'
                 &__e.to_string(),
             );
             jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holderTagOr<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    h_present: jni::sys::jboolean,
+    h_tag: jni::sys::jlong,
+    h_summary: jni::sys::jlong,
+    fallback: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_h = if h_present != 0u8 {
+        let __flat_h_tag = match jlong_to_i64_fbf9a9bc(&mut env, &h_tag) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        if h_summary == 0 || (h_summary & 1) == 1 {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                "Operation on a closed native handle.",
+            );
+            return 0 as jni::sys::jlong;
+        }
+        let __flat_h_summary: perftest_flat::Summary = unsafe {
+            *::std::boxed::Box::from_raw(h_summary as *mut perftest_flat::Summary)
+        };
+        ::core::option::Option::Some(perftest_flat::Holder {
+            tag: __flat_h_tag,
+            summary: __flat_h_summary,
+        })
+    } else {
+        ::core::option::Option::None
+    };
+    let h = __flat_h;
+    let fallback = match jlong_to_i64_fbf9a9bc(&mut env, &fallback) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::holder_tag_or(h, fallback);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
         }
     }
 }
@@ -19265,7 +19455,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
             return 0 as jni::sys::jboolean;
         }
     };
-    let __flat_p = {
+    let __flat_p = if p_present != 0u8 {
         let __flat_p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
@@ -19339,17 +19529,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
                 return 0 as jni::sys::jboolean;
             }
         };
-        if p_present != 0u8 {
-            ::core::option::Option::Some(perftest_flat::Payload {
-                id: __flat_p_id,
-                seq: __flat_p_seq,
-                value: __flat_p_value,
-                flag: __flat_p_flag,
-                label: __flat_p_label,
-            })
-        } else {
-            ::core::option::Option::None
-        }
+        ::core::option::Option::Some(perftest_flat::Payload {
+            id: __flat_p_id,
+            seq: __flat_p_seq,
+            value: __flat_p_value,
+            flag: __flat_p_flag,
+            label: __flat_p_label,
+        })
+    } else {
+        ::core::option::Option::None
     };
     let p = __flat_p;
     let __out = perftest_flat::storage_put_opt(&mut s, p);

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -711,6 +711,39 @@ pub(crate) unsafe fn Box_Option_Summary_to_jlong_75560ba9<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Box_Option_i64_to_JObject_cf5a3724<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<Option<i64>>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let v: Option<i64> = *v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, value)?;
+                    ::prebindgen::lang::box_jlong(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Box<String>,
@@ -1587,6 +1620,41 @@ pub(crate) unsafe fn JObject_to_Box_Option_Priority_cb1cb2b5<'env, 'v>(
                         String,
                     >>::from(format!("Option unbox: {}", e)))?;
                 Some(jint_to_Priority_447102d2(env, &__unboxed)?)
+            } else {
+                None
+            }
+        };
+        ::std::boxed::Box::new(__v)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Box_Option_i64_cf5a3724<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Box<Option<i64>>, __JniErr> {
+    Ok({
+        let __v: ::core::option::Option<i64> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jlong = env
+                    .call_method(&v, "longValue", "()J", &[])
+                    .and_then(|val| val.j())
+                    .map(|__x| __x as jni::sys::jlong)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some(jlong_to_i64_fbf9a9bc(env, &__unboxed)?)
             } else {
                 None
             }
@@ -3354,6 +3422,52 @@ pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
             __out.push(__elem);
         }
         __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_WrappedFields_f14f08c1<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::WrappedFields, __JniErr> {
+    Ok({
+        let __id_raw: jni::sys::jlong = env
+            .get_field(v, "id", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.id: {}", e)))? as _;
+        let id = jlong_to_i64_fbf9a9bc(env, &__id_raw)?;
+        let __boxed_raw: jni::objects::JObject = env
+            .get_field(v, "boxed", "Ljava/lang/Object;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.boxed: {}", e)))?;
+        let boxed = JObject_to_Box_Option_i64_cf5a3724(env, &__boxed_raw)?;
+        let __plain_raw: jni::objects::JObject = env
+            .get_field(v, "plain", "Ljava/lang/Long;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.plain: {}", e)))?;
+        let plain = JObject_to_Option_i64_2ba9a5ed(env, &__plain_raw)?;
+        perftest_flat::WrappedFields {
+            id,
+            boxed,
+            plain,
+        }
     })
 }
 #[allow(
@@ -9208,6 +9322,51 @@ pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
                     String,
                 >>::from(format!("encode_byte_array: {}", e))
             })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn WrappedFields_to_JObject_f14f08c1<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::WrappedFields,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.id.clone())?;
+        let ___boxed: jni::objects::JObject = Box_Option_i64_to_JObject_cf5a3724(
+            env,
+            v.boxed.clone(),
+        )?;
+        let ___plain: jni::objects::JObject = Option_i64_to_JObject_2ba9a5ed(
+            env,
+            v.plain.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/WrappedFields",
+                "fromParts",
+                "(JLjava/lang/Long;Ljava/lang/Long;)Lio/prebindgen/covertest/WrappedFields;",
+                &[
+                    jni::objects::JValue::from(___id),
+                    jni::objects::JValue::Object(&___boxed),
+                    jni::objects::JValue::Object(&___plain),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
     })
 }
 #[allow(
@@ -22460,6 +22619,104 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedSeries<'
         };
     }
     __acc
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_wrappedFieldsSum<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    w_id: jni::sys::jlong,
+    w_boxed_present: jni::sys::jboolean,
+    w_boxed_value: jni::sys::jlong,
+    w_plain_present: jni::sys::jboolean,
+    w_plain_value: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_w_id = match jlong_to_i64_fbf9a9bc(&mut env, &w_id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_w_boxed = ::std::boxed::Box::new(
+        if w_boxed_present != 0u8 {
+            let __flat_w_boxed_value = match jlong_to_i64_fbf9a9bc(
+                &mut env,
+                &w_boxed_value,
+            ) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            ::core::option::Option::Some(__flat_w_boxed_value)
+        } else {
+            ::core::option::Option::None
+        },
+    );
+    let __flat_w_plain = if w_plain_present != 0u8 {
+        let __flat_w_plain_value = match jlong_to_i64_fbf9a9bc(
+            &mut env,
+            &w_plain_value,
+        ) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        ::core::option::Option::Some(__flat_w_plain_value)
+    } else {
+        ::core::option::Option::None
+    };
+    let __flat_w = perftest_flat::WrappedFields {
+        id: __flat_w_id,
+        boxed: __flat_w_boxed,
+        plain: __flat_w_plain,
+    };
+    let w = __flat_w;
+    let __out = perftest_flat::wrapped_fields_sum(w);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
 }
 /// The storage capacity limit advertised to bindings (a primitive const).
 pub const COVER_MAGIC: i64 = perftest_flat::COVER_MAGIC;

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1548,6 +1548,131 @@ pub(crate) unsafe fn JObject_to_BlobValue_89b5dab7<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Box_Option_Payload_8d993ebb<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Box<Option<perftest_flat::Payload>>, __JniErr> {
+    Ok({
+        let __v: ::core::option::Option<perftest_flat::Payload> = {
+            if v.is_null() { None } else { Some(JObject_to_Payload_98f64326(env, v)?) }
+        };
+        ::std::boxed::Box::new(__v)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Box_Option_Priority_cb1cb2b5<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Box<Option<perftest_flat::Priority>>, __JniErr> {
+    Ok({
+        let __v: ::core::option::Option<perftest_flat::Priority> = {
+            if !v.is_null() {
+                let __unboxed: jni::sys::jint = env
+                    .call_method(&v, "intValue", "()I", &[])
+                    .and_then(|val| val.i())
+                    .map(|__x| __x as jni::sys::jint)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Option unbox: {}", e)))?;
+                Some(jint_to_Priority_447102d2(env, &__unboxed)?)
+            } else {
+                None
+            }
+        };
+        ::std::boxed::Box::new(__v)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Box_Payload_0d2d19da<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Box<perftest_flat::Payload>, __JniErr> {
+    Ok({
+        let __inner = JObject_to_Payload_98f64326(env, v)?;
+        ::std::boxed::Box::new(__inner)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Box_Vec_Payload_ca25c6a1<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Box<Vec<perftest_flat::Payload>>, __JniErr> {
+    Ok({
+        let __list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __it = __list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __out: Vec<perftest_flat::Payload> = Vec::new();
+        while let Some(__obj) = __it
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            let __elem_wire: jni::objects::JObject = __obj.into();
+            let __elem: perftest_flat::Payload = JObject_to_Payload_98f64326(
+                env,
+                &__elem_wire,
+            )?;
+            __out.push(__elem);
+        }
+        ::std::boxed::Box::new(__out)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_CacheConfig_db89a97c<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -3052,6 +3177,50 @@ pub(crate) unsafe fn JObject_to_Unsigned_7e3cc618<'env, 'v>(
             long,
             maybe_long,
         }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Vec_Box_Payload_ae68babe<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Vec<Box<perftest_flat::Payload>>, __JniErr> {
+    Ok({
+        let __list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __it = __list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __out: Vec<Box<perftest_flat::Payload>> = Vec::new();
+        while let Some(__obj) = __it
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            let __elem_wire: jni::objects::JObject = __obj.into();
+            let __elem: Box<perftest_flat::Payload> = JObject_to_Box_Payload_0d2d19da(
+                env,
+                &__elem_wire,
+            )?;
+            __out.push(__elem);
+        }
+        __out
     })
 }
 #[allow(
@@ -10224,7 +10393,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedAlterna
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = if a_alternate_present != 0u8 {
+    let __flat_a_alternate = {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -10310,15 +10479,17 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedAlterna
                 return jni::objects::JObject::null().into();
             }
         };
-        ::core::option::Option::Some(perftest_flat::Payload {
-            id: __flat_a_alternate_id,
-            seq: __flat_a_alternate_seq,
-            value: __flat_a_alternate_value,
-            flag: __flat_a_alternate_flag,
-            label: __flat_a_alternate_label,
-        })
-    } else {
-        ::core::option::Option::None
+        if a_alternate_present != 0u8 {
+            ::core::option::Option::Some(perftest_flat::Payload {
+                id: __flat_a_alternate_id,
+                seq: __flat_a_alternate_seq,
+                value: __flat_a_alternate_value,
+                flag: __flat_a_alternate_flag,
+                label: __flat_a_alternate_label,
+            })
+        } else {
+            ::core::option::Option::None
+        }
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -10653,7 +10824,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = if a_alternate_present != 0u8 {
+    let __flat_a_alternate = {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -10739,15 +10910,17 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPayload
                 return 0.0 as jni::sys::jdouble;
             }
         };
-        ::core::option::Option::Some(perftest_flat::Payload {
-            id: __flat_a_alternate_id,
-            seq: __flat_a_alternate_seq,
-            value: __flat_a_alternate_value,
-            flag: __flat_a_alternate_flag,
-            label: __flat_a_alternate_label,
-        })
-    } else {
-        ::core::option::Option::None
+        if a_alternate_present != 0u8 {
+            ::core::option::Option::Some(perftest_flat::Payload {
+                id: __flat_a_alternate_id,
+                seq: __flat_a_alternate_seq,
+                value: __flat_a_alternate_value,
+                flag: __flat_a_alternate_flag,
+                label: __flat_a_alternate_label,
+            })
+        } else {
+            ::core::option::Option::None
+        }
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -10925,7 +11098,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = if a_alternate_present != 0u8 {
+    let __flat_a_alternate = {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -11011,15 +11184,17 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedPriorit
                 return jni::objects::JObject::null().into();
             }
         };
-        ::core::option::Option::Some(perftest_flat::Payload {
-            id: __flat_a_alternate_id,
-            seq: __flat_a_alternate_seq,
-            value: __flat_a_alternate_value,
-            flag: __flat_a_alternate_flag,
-            label: __flat_a_alternate_label,
-        })
-    } else {
-        ::core::option::Option::None
+        if a_alternate_present != 0u8 {
+            ::core::option::Option::Some(perftest_flat::Payload {
+                id: __flat_a_alternate_id,
+                seq: __flat_a_alternate_seq,
+                value: __flat_a_alternate_value,
+                flag: __flat_a_alternate_flag,
+                label: __flat_a_alternate_label,
+            })
+        } else {
+            ::core::option::Option::None
+        }
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -11197,7 +11372,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
         flag: __flat_a_payload_flag,
         label: __flat_a_payload_label,
     };
-    let __flat_a_alternate = if a_alternate_present != 0u8 {
+    let __flat_a_alternate = {
         let __flat_a_alternate_id = match jlong_to_i64_fbf9a9bc(
             &mut env,
             &a_alternate_id,
@@ -11283,15 +11458,17 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedTtl<'a>
                 return jni::objects::JObject::null().into();
             }
         };
-        ::core::option::Option::Some(perftest_flat::Payload {
-            id: __flat_a_alternate_id,
-            seq: __flat_a_alternate_seq,
-            value: __flat_a_alternate_value,
-            flag: __flat_a_alternate_flag,
-            label: __flat_a_alternate_label,
-        })
-    } else {
-        ::core::option::Option::None
+        if a_alternate_present != 0u8 {
+            ::core::option::Option::Some(perftest_flat::Payload {
+                id: __flat_a_alternate_id,
+                seq: __flat_a_alternate_seq,
+                value: __flat_a_alternate_value,
+                flag: __flat_a_alternate_flag,
+                label: __flat_a_alternate_label,
+            })
+        } else {
+            ::core::option::Option::None
+        }
     };
     let __flat_a_ttl = if a_ttl_present != 0u8 {
         let __flat_a_ttl_value = match jlong_to_i64_fbf9a9bc(&mut env, &a_ttl_value) {
@@ -12735,6 +12912,48 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedElemIdSum<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    ps: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let ps = match JObject_to_Vec_Box_Payload_ae68babe(&mut env, &ps) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::boxed_elem_id_sum(ps);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedLatest<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -12882,6 +13101,324 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedNoteEcho<'a
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedOptPayloadId<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    p_present: jni::sys::jboolean,
+    p_id: jni::sys::jlong,
+    p_seq: jni::sys::jint,
+    p_value: jni::sys::jdouble,
+    p_flag: jni::sys::jboolean,
+    p_label: jni::objects::JString<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_p = {
+        let __flat_p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        let __flat_p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        let __flat_p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        let __flat_p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        let __flat_p_label = match JString_to_Option_Box_String_071e4c8c(
+            &mut env,
+            &p_label,
+        ) {
+            ::core::result::Result::Ok(__v) => __v,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return 0 as jni::sys::jlong;
+            }
+        };
+        ::std::boxed::Box::new(
+            if p_present != 0u8 {
+                ::core::option::Option::Some(perftest_flat::Payload {
+                    id: __flat_p_id,
+                    seq: __flat_p_seq,
+                    value: __flat_p_value,
+                    flag: __flat_p_flag,
+                    label: __flat_p_label,
+                })
+            } else {
+                ::core::option::Option::None
+            },
+        )
+    };
+    let p = __flat_p;
+    let __out = perftest_flat::boxed_opt_payload_id(p);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedOptPriorityWeight<
+    'a,
+>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    p_present: jni::sys::jboolean,
+    p_value: jni::sys::jint,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let p = ::std::boxed::Box::new(
+        if p_present != 0u8 {
+            let __p_val = match jint_to_Priority_447102d2(&mut env, &p_value) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return 0 as jni::sys::jlong;
+                }
+            };
+            ::core::option::Option::Some(__p_val)
+        } else {
+            ::core::option::Option::None
+        },
+    );
+    let __out = perftest_flat::boxed_opt_priority_weight(p);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedPayloadId<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    p_id: jni::sys::jlong,
+    p_seq: jni::sys::jint,
+    p_value: jni::sys::jdouble,
+    p_flag: jni::sys::jboolean,
+    p_label: jni::objects::JString<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __flat_p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_p_seq = match jint_to_i32_a3e3b6ef(&mut env, &p_seq) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_p_value = match jdouble_to_f64_9e4a8f70(&mut env, &p_value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_p_flag = match jboolean_to_bool_31306d98(&mut env, &p_flag) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_p_label = match JString_to_Option_Box_String_071e4c8c(
+        &mut env,
+        &p_label,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_p = ::std::boxed::Box::new(perftest_flat::Payload {
+        id: __flat_p_id,
+        seq: __flat_p_seq,
+        value: __flat_p_value,
+        flag: __flat_p_flag,
+        label: __flat_p_label,
+    });
+    let p = __flat_p;
+    let __out = perftest_flat::boxed_payload_id(p);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedRunIdSum<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    ps_handle: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let ps = ::std::boxed::Box::new(unsafe {
+        ::core::mem::take(&mut *(ps_handle as *mut Vec<perftest_flat::Payload>))
+    });
+    let __out = perftest_flat::boxed_run_id_sum(ps);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeight<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -12895,7 +13432,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeigh
     static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let __flat_cache = if cache_present != 0u8 {
+    let __flat_cache = {
         let __flat_cache_replies_priority = match jint_to_Priority_447102d2(
             &mut env,
             &cache_replies_priority,
@@ -12948,12 +13485,14 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_cacheConfigWeigh
                 return 0 as jni::sys::jint;
             }
         };
-        ::core::option::Option::Some(perftest_flat::CacheConfig {
-            replies: __flat_cache_replies,
-            ttl: __flat_cache_ttl,
-        })
-    } else {
-        ::core::option::Option::None
+        if cache_present != 0u8 {
+            ::core::option::Option::Some(perftest_flat::CacheConfig {
+                replies: __flat_cache_replies,
+                ttl: __flat_cache_ttl,
+            })
+        } else {
+            ::core::option::Option::None
+        }
     };
     let cache = __flat_cache;
     let __out = perftest_flat::cache_config_weight(cache);
@@ -18567,7 +19106,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
             return 0 as jni::sys::jboolean;
         }
     };
-    let __flat_p = if p_present != 0u8 {
+    let __flat_p = {
         let __flat_p_id = match jlong_to_i64_fbf9a9bc(&mut env, &p_id) {
             ::core::result::Result::Ok(__v) => __v,
             ::core::result::Result::Err(__e) => {
@@ -18641,15 +19180,17 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutOpt<'a
                 return 0 as jni::sys::jboolean;
             }
         };
-        ::core::option::Option::Some(perftest_flat::Payload {
-            id: __flat_p_id,
-            seq: __flat_p_seq,
-            value: __flat_p_value,
-            flag: __flat_p_flag,
-            label: __flat_p_label,
-        })
-    } else {
-        ::core::option::Option::None
+        if p_present != 0u8 {
+            ::core::option::Option::Some(perftest_flat::Payload {
+                id: __flat_p_id,
+                seq: __flat_p_seq,
+                value: __flat_p_value,
+                flag: __flat_p_flag,
+                label: __flat_p_label,
+            })
+        } else {
+            ::core::option::Option::None
+        }
     };
     let p = __flat_p;
     let __out = perftest_flat::storage_put_opt(&mut s, p);

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1636,6 +1636,31 @@ pub fn boxed_latest(a: &Archive) -> Box<Option<Summary>> {
     Box::new(a.latest.clone())
 }
 
+/// A data class whose **fields** carry transparent wrappers.
+///
+/// This is what #289 changes and why it could not land alone. The field walk
+/// used to peel with `option_inner_type`, which reads the last path segment: a
+/// field spelled `Box<Option<i64>>` answered "not optional" and crossed as one
+/// boxed `java.lang.Long`. The model says `Optional`, so it now takes the
+/// decoupled `(present, value)` pair its bare twin does — and the emitter has to
+/// put the `Box` back when it rebuilds, or the migration turns a working boxed
+/// crossing into an `E0308`.
+///
+/// `plain` is the control: the two fields must produce the same wire, since the
+/// model says they are the same type.
+#[prebindgen]
+pub struct WrappedFields {
+    pub id: i64,
+    pub boxed: Box<Option<i64>>,
+    pub plain: Option<i64>,
+}
+
+/// Round-trip a [`WrappedFields`] so both field spellings cross in one call.
+#[prebindgen]
+pub fn wrapped_fields_sum(w: WrappedFields) -> i64 {
+    w.id + w.boxed.unwrap_or(0) + w.plain.unwrap_or(0)
+}
+
 /// Transparent wrappers on the **input** side, one per specialized lowering.
 ///
 /// These lowerings do not *decode* their parameter, they **rebuild** it — a

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1636,6 +1636,34 @@ pub fn boxed_latest(a: &Archive) -> Box<Option<Summary>> {
     Box::new(a.latest.clone())
 }
 
+/// An `Option<data class>` whose data class has a **required handle** field.
+///
+/// The shape that proves an optional node's field decodes stay **inside** its
+/// presence gate. When the Kotlin object is null every leaf carries an inert
+/// placeholder, and a handle leaf's placeholder is pointer `0` — which the
+/// direct-handle decode reads as a closed handle, signals a binding error for,
+/// and returns from. Hoisting the decodes out of the gate therefore turns
+/// `null` into an error instead of `None`, and no fixture whose fields all
+/// decode successfully can tell the difference.
+///
+/// `Summary` is consumed by value here, as a handle field is: the `Some` case
+/// hands over ownership, and the `None` case must never touch the slot.
+#[prebindgen]
+pub struct Holder {
+    pub tag: i64,
+    pub summary: Summary,
+}
+
+/// `tag` when the holder is present, `fallback` when it is absent — so the
+/// absent arm is observable as a **value** rather than as an error.
+#[prebindgen]
+pub fn holder_tag_or(h: Option<Holder>, fallback: i64) -> i64 {
+    match h {
+        Some(h) => h.tag + h.summary.count,
+        None => fallback,
+    }
+}
+
 /// A data class whose **fields** carry transparent wrappers.
 ///
 /// This is what #289 changes and why it could not land alone. The field walk

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1636,6 +1636,85 @@ pub fn boxed_latest(a: &Archive) -> Box<Option<Summary>> {
     Box::new(a.latest.clone())
 }
 
+/// Transparent wrappers on the **input** side, one per specialized lowering.
+///
+/// These lowerings do not *decode* their parameter, they **rebuild** it — a
+/// literal `Payload { .. }`, an `Option::Some(v)`, a `Vec<T>` pushed element by
+/// element — so the wrappers the classification erased have to go back on before
+/// the value reaches the signature. Rebuilding from the classification alone
+/// hands an `Option<Payload>` to a parameter spelled `Box<Option<Payload>>`:
+/// `E0308` (#292 item 3, which replaced #290's refusals).
+///
+/// Declared here rather than only in unit tests for the reason
+/// [`boxed_note_echo`] is: this crate's generated binding is `include!`d and
+/// **compiled**, so a missing or misplaced `Box::new` fails the build. Each has
+/// an unwrapped twin already declared — the surfaces must come out identical,
+/// since the model says the two spellings are one type.
+///
+/// The layers are covered separately because each is applied at a different
+/// point in the construction, and only a shape that exercises one can show it:
+/// the core wrap goes inside the present gate, and the optional wrap around it.
+///
+/// **`Box<&Payload>` is deliberately absent.** The flatten lowering could build
+/// it — it owns a local and `Box::new(&local)` is well-typed — but a declared
+/// parameter also needs a general converter entry, and a converter *produces* an
+/// owned value: there is nothing for a `Box<&T>` to borrow from that outlives
+/// the call (`E0106` on the generated signature). So the shape is refused at
+/// resolution, by the converter's nature rather than the wrapper's.
+#[prebindgen]
+// A boxed parameter IS the point here — clippy is right that the `Box` buys
+// nothing, and that is what makes it a fixture: the binding must cross it as
+// the unwrapped type and put the wrapper back.
+#[allow(clippy::boxed_local)]
+pub fn boxed_payload_id(p: Box<Payload>) -> i64 {
+    p.id
+}
+
+/// The optional layer over the same rebuild — the wrap goes **around** the
+/// present gate, where the core wrap goes inside it.
+#[prebindgen]
+// A boxed parameter IS the point here — clippy is right that the `Box` buys
+// nothing, and that is what makes it a fixture: the binding must cross it as
+// the unwrapped type and put the wrapper back.
+#[allow(clippy::boxed_local)]
+pub fn boxed_opt_payload_id(p: Box<Option<Payload>>) -> i64 {
+    p.as_ref().as_ref().map(|p| p.id).unwrap_or(-1)
+}
+
+/// The option-scalar lowering (`(present, value)` raw pair) under a wrapper —
+/// the rebuilt `Option` is re-wrapped before it reaches the signature.
+#[prebindgen]
+// A boxed parameter IS the point here — clippy is right that the `Box` buys
+// nothing, and that is what makes it a fixture: the binding must cross it as
+// the unwrapped type and put the wrapper back.
+#[allow(clippy::boxed_local)]
+pub fn boxed_opt_priority_weight(p: Box<Option<Priority>>) -> i64 {
+    match *p {
+        Some(v) => priority_weight(v) as i64,
+        None => -1,
+    }
+}
+
+/// A wrapped **element** in the Vec-build path: the storage is `Vec<Box<Payload>>`
+/// and each push wraps its own literal.
+#[prebindgen]
+pub fn boxed_elem_id_sum(ps: Vec<Box<Payload>>) -> i64 {
+    ps.iter().map(|p| p.id).sum()
+}
+
+/// A wrapped **run**, by value: `mem::take` yields the owned `Vec`, so the
+/// `Box` costs nothing. The borrowed twin (`&Box<Vec<Payload>>`) is deliberately
+/// **not** declared — interposing a `Box` between the caller's Vec and the
+/// callee would require copying it, so that shape keeps the ordinary path.
+#[prebindgen]
+// A boxed parameter IS the point here — clippy is right that the `Box` buys
+// nothing, and that is what makes it a fixture: the binding must cross it as
+// the unwrapped type and put the wrapper back.
+#[allow(clippy::boxed_local)]
+pub fn boxed_run_id_sum(ps: Box<Vec<Payload>>) -> i64 {
+    ps.iter().map(|p| p.id).sum()
+}
+
 /// Deliver a [`Ledger`] to a callback, so both conditional decompositions cross
 /// in ONE call — including the sum (`Report::outcome`) each one carries, whose
 /// `match` belongs inside the arm that binds the report.

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -54,7 +54,7 @@
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 2	api/lang/jnigen/jni/emit/delivery.rs
-7	api/lang/jnigen/jni/emit/flat_input.rs
+5	api/lang/jnigen/jni/emit/flat_input.rs
 17	api/lang/jnigen/jni/emit/names.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
@@ -69,4 +69,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 122
+# total: 120

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -382,6 +382,28 @@ impl TypeRef {
         names
     }
 
+    /// This type's identity as a table key with every transparent wrapper
+    /// removed — the key of [`stripped_syntax`](Self::stripped_syntax).
+    ///
+    /// What [`key`](Self::key) answers for a **spelling**, this answers for the
+    /// **type**. The two are different questions and both are legitimate:
+    ///
+    /// * a *conversion* is keyed by `key`, because `Box<Option<T>>` and
+    ///   `Option<T>` genuinely need different converter bodies — one has to put
+    ///   a `Box` back and the other must not;
+    /// * a **declaration** is keyed by this, because a declaration says what a
+    ///   type *is* to the destination language, and a wrapper the model erases
+    ///   cannot change that. A `Box<Payload>` parameter is a `Payload` to
+    ///   Kotlin, so it must find `Payload`'s data-class declaration — keying it
+    ///   by spelling finds nothing and silently costs the parameter its
+    ///   lowering.
+    ///
+    /// Use this wherever the lookup is against declarations the binding author
+    /// wrote, and `key` wherever it is against something derived per spelling.
+    pub fn stripped_key(&self) -> crate::api::core::registry::TypeKey {
+        crate::api::core::registry::TypeKey::from_type(&self.stripped_syntax())
+    }
+
     /// This type's spelling with every [transparent
     /// wrapper](TRANSPARENT_WRAPPERS) removed — `Box<Box<Option<T>>>` →
     /// `Option<T>`, an unwrapped spelling → itself.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -715,6 +715,11 @@ pub(crate) enum FlatFieldNode {
         direct_handle: bool,
         optional_handle: bool,
         rust_ty: Box<syn::Type>,
+        /// The transparent wrappers this field's spelling adds over its
+        /// classification, outermost first — put back wherever the decode
+        /// **rebuilds** the value (an `Option::Some`/`None` literal) rather than
+        /// running the field's own converter, which already yields the spelling.
+        wrappers: Vec<&'static str>,
     },
     Nested {
         field: syn::Ident,
@@ -736,6 +741,11 @@ pub(crate) enum FlatFieldNode {
         /// Variants in declaration order; index == tag.
         variants: Vec<FlatSumVariant>,
         rust_ty: Box<syn::Type>,
+        /// The transparent wrappers this field's spelling adds over its
+        /// classification, outermost first — put back wherever the decode
+        /// **rebuilds** the value (an `Option::Some`/`None` literal) rather than
+        /// running the field's own converter, which already yields the spelling.
+        wrappers: Vec<&'static str>,
     },
 }
 
@@ -886,16 +896,11 @@ pub(crate) struct FlatInputPlan {
 // jnigen's actual `impl Into<…>` support is elsewhere: plugin wrapper exts build
 // a `ConverterImpl::function` by hand via `Declarations::input_converter_name`,
 // which never consults this.
-
-/// Peel a leading `&`/`&mut` then an `Option<…>` to expose the inner type used
-/// for enum/struct detection (`&Priority`, `Option<Priority>` → `Priority`).
-pub(crate) fn flat_probe_inner(ty: &syn::Type) -> syn::Type {
-    let stripped = match ty {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other.clone(),
-    };
-    option_inner_type(&stripped).unwrap_or(stripped)
-}
+// `flat_probe_inner` lived here: it peeled `&` then `Option` off a SPELLING to
+// reach the type an enum probe should ask about. Its last caller now asks
+// `is_kotlin_enum_reading`, whose `enum_probe` peels the same two layers off the
+// model — so `Box<Priority>` probes as `Priority` where this answered about the
+// wrapper (#289).
 
 /// Kotlin literal that fills a leaf slot when its `Option<struct>` parent is
 /// absent (the `present` flag tells Rust to ignore it). `None` for nullable
@@ -1007,9 +1012,10 @@ fn build_flat_sum_field(
     native_prefix: &str,
     field_ref: &str,
     nullable_access: bool,
-    rust_ty: &syn::Type,
+    field_reading: &TypeRef,
     leaves: &mut Vec<FlatLeaf>,
 ) -> Option<FlatFieldNode> {
+    let rust_ty = field_reading.syntax();
     use crate::api::core::types_util::SumSpec;
 
     let ident = bare_path_ident(sum_ty)?;
@@ -1154,6 +1160,7 @@ fn build_flat_sum_field(
 
     let module = ext.fn_module(registry, &ident);
     Some(FlatFieldNode::Sum {
+        wrappers: field_reading.erased_wrappers(),
         field,
         tag_leaf,
         present_leaf,
@@ -1272,11 +1279,9 @@ pub(crate) fn build_flat_input_plan(
     let Some(name) = id.ident() else {
         return Ok(None);
     };
-    let Some(st) = registry
-        .flat()
-        .struct_type(&name)
-        .map(|st| &st.origin.syntax)
-    else {
+    // The ELEMENT, not the item it was parsed from: its fields already carry
+    // readings, which is the whole of #289.
+    let Some(st) = registry.flat().struct_type(&name) else {
         return Ok(None);
     };
     // The DECLARATION is keyed by the type, not by the spelling: a
@@ -1347,10 +1352,21 @@ pub(crate) fn build_flat_input_plan(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Takes the **element**, not the `syn::ItemStruct` it was parsed from (#289):
+/// `flat::Field::ty` is already a `TypeRef`, so every peel below is the model's
+/// answer rather than a last-path-segment test on tokens that had a reading one
+/// level up.
+///
+/// That matters here and not only on principle. `option_inner_type` reads the
+/// last path segment, so a field spelled `Box<Option<T>>` answered "not
+/// optional" and crossed as one boxed object; the model says `Optional` and it
+/// takes the decoupled `(present, value)` pair like its bare twin. The emitter
+/// then has to put the `Box` back — which is why this migration could not land
+/// before the rebuild did.
 fn build_flat_struct_node(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    st: &syn::ItemStruct,
+    st: &flat::Struct,
     optional: bool,
     native_prefix: &str,
     access_prefix: &str,
@@ -1359,7 +1375,7 @@ fn build_flat_struct_node(
     stack: &mut Vec<TypeKey>,
     leaves: &mut Vec<FlatLeaf>,
 ) -> Result<FlatStructNode, FlatInputError> {
-    let node_key = TypeKey::from_ident(&st.ident);
+    let node_key = TypeKey::from_ident(&st.name);
     if stack.contains(&node_key) {
         return Err(flat_error(
             root,
@@ -1374,13 +1390,6 @@ fn build_flat_struct_node(
             "recursive flattening exceeds depth 16",
         ));
     }
-    let syn::Fields::Named(named) = &st.fields else {
-        return Err(flat_error(
-            root,
-            native_prefix,
-            "only named-field structs can flatten",
-        ));
-    };
     stack.push(node_key);
     let present_ident = if optional {
         let native = format!("{native_prefix}_present");
@@ -1390,9 +1399,17 @@ fn build_flat_struct_node(
         None
     };
     let mut fields = Vec::new();
-    for field in &named.named {
-        let Some(fident) = field.ident.clone() else {
-            return Err(flat_error(root, native_prefix, "unnamed field"));
+    for field in &st.fields {
+        // A positional field has no name to derive a Kotlin property from, which
+        // is what "only named-field structs can flatten" used to say one level
+        // up. Said per field now, because the element models a field list rather
+        // than a `syn::Fields` shape.
+        let Some(fident) = field.name.clone() else {
+            return Err(flat_error(
+                root,
+                native_prefix,
+                "only named-field structs can flatten",
+            ));
         };
         let fcamel = mangle_kotlin_ident(&snake_to_camel(&fident.to_string()));
         let child_native = format!("{native_prefix}_{}", fident);
@@ -1401,12 +1418,17 @@ fn build_flat_struct_node(
         } else {
             format!("{access_prefix}.{fcamel}")
         };
-        let nested_ty = option_inner_type(&field.ty).unwrap_or_else(|| field.ty.clone());
+        // The optional layer off the MODEL, asked once and reused: every site
+        // below that wants "is this field optional" reads this, so they cannot
+        // disagree with each other the way seven independent path-segment tests
+        // could (#273).
+        let field_optional = field.ty.optional_inner().is_some();
+        let nested = field.ty.optional_inner().unwrap_or(&field.ty);
+        let nested_ty = nested.syntax().clone();
         // A data-carrying enum flattens into a tag plus one group per variant.
         // `None` means some payload is not leaf-shaped — fall through and let
         // it cross as one object through its own converter.
         if matches!(ext.type_kind(registry, &nested_ty), TypeKind::Sum) {
-            let field_optional = option_inner_type(&field.ty).is_some();
             if let Some(node) = build_flat_sum_field(
                 ext,
                 registry,
@@ -1429,11 +1451,11 @@ fn build_flat_struct_node(
         } = ext.type_kind(registry, &nested_ty)
         {
             if cfg.name_spec.is_some() && !cfg.special_decl() && !cfg.jobject_input {
-                let child_optional = option_inner_type(&field.ty).is_some();
+                let child_optional = field_optional;
                 let node = build_flat_struct_node(
                     ext,
                     registry,
-                    &child.origin.syntax,
+                    child,
                     child_optional,
                     &child_native,
                     &field_ref,
@@ -1451,28 +1473,22 @@ fn build_flat_struct_node(
         }
 
         let path = child_native.clone();
-        let Some(fentry) = registry
-            .reading_of(&field.ty)
-            .and_then(|tr| registry.input_entry(&tr))
-        else {
+        // The field's own reading straight to its entry — the `reading_of` hop
+        // only ever recovered what the field already carried.
+        let Some(fentry) = registry.input_entry(&field.ty) else {
             return Err(flat_error(
                 root,
                 &path,
-                format!(
-                    "field type `{}` has no input converter",
-                    TypeKey::from_type(&field.ty)
-                ),
+                format!("field type `{}` has no input converter", field.ty.key()),
             ));
         };
 
         // Nullable primitive/enum with no niche: keep the allocation-free
         // `(present, value)` representation at every recursion depth.
-        if let Some(inner_ty) = option_inner_type(&field.ty) {
-            if !matches!(inner_ty, syn::Type::Reference(_)) {
-                if let Some(inner) = registry
-                    .reading_of(&inner_ty)
-                    .and_then(|tr| registry.input_entry(&tr))
-                {
+        if let Some(inner_reading) = field.ty.optional_inner() {
+            let inner_ty = inner_reading.syntax().clone();
+            if inner_reading.borrow_target().is_none() {
+                if let Some(inner) = registry.input_entry(inner_reading) {
                     if let Some(prim) = JniPrim::from_wire(&inner.destination) {
                         if inner.niches.clone().carve().is_none()
                             && inner.metadata.projection.is_none()
@@ -1503,7 +1519,8 @@ fn build_flat_struct_node(
                                 present_leaf: Some(present_index),
                                 direct_handle: false,
                                 optional_handle: false,
-                                rust_ty: Box::new(field.ty.clone()),
+                                rust_ty: Box::new(field.ty.syntax().clone()),
+                                wrappers: field.ty.erased_wrappers(),
                             });
                             continue;
                         }
@@ -1520,7 +1537,7 @@ fn build_flat_struct_node(
             // provides a niche already have a primitive destination and stay
             // a single leaf below.
             if proj.kind == ProjectionKind::Unsigned64 {
-                if let Some(inner_ty) = option_inner_type(&field.ty) {
+                if let Some(inner_ty) = field.ty.optional_inner().map(|t| t.syntax().clone()) {
                     if JniPrim::from_wire(&fentry.destination).is_none() {
                         let inner = registry
                             .reading_of(&inner_ty)
@@ -1555,7 +1572,8 @@ fn build_flat_struct_node(
                             present_leaf: Some(present_index),
                             direct_handle: false,
                             optional_handle: false,
-                            rust_ty: Box::new(field.ty.clone()),
+                            rust_ty: Box::new(field.ty.syntax().clone()),
+                            wrappers: field.ty.erased_wrappers(),
                         });
                         continue;
                     }
@@ -1570,7 +1588,7 @@ fn build_flat_struct_node(
                             "collections of handles retain their collection boundary",
                         ));
                     }
-                    let optional_handle = option_inner_type(&field.ty).is_some();
+                    let optional_handle = field_optional;
                     let value_index = push_handle_leaf(
                         leaves,
                         &child_native,
@@ -1584,12 +1602,13 @@ fn build_flat_struct_node(
                         present_leaf: None,
                         direct_handle: true,
                         optional_handle,
-                        rust_ty: Box::new(field.ty.clone()),
+                        rust_ty: Box::new(field.ty.syntax().clone()),
+                        wrappers: field.ty.erased_wrappers(),
                     });
                     continue;
                 }
                 ProjectionKind::Unsigned64 => {
-                    let is_opt = option_inner_type(&field.ty).is_some();
+                    let is_opt = field_optional;
                     let access = if is_opt || nullable_context {
                         let sentinel = proj
                             .niche_sentinels
@@ -1614,19 +1633,23 @@ fn build_flat_struct_node(
                         present_leaf: None,
                         direct_handle: false,
                         optional_handle: false,
-                        rust_ty: Box::new(field.ty.clone()),
+                        rust_ty: Box::new(field.ty.syntax().clone()),
+                        wrappers: field.ty.erased_wrappers(),
                     });
                     continue;
                 }
             }
         }
 
-        let field_is_option = option_inner_type(&field.ty).is_some();
+        let field_is_option = field_optional;
         // The enum branch is self-contained: when it coalesces (`?.value ?: 0`)
         // it already yields a non-null `Int`, so block (B) below must not append
         // a second default (which produced the dead `?: 0 ?: 0`, issue #144).
         let mut enum_coalesced = false;
-        let mut access = if ext.is_kotlin_enum(&flat_probe_inner(&field.ty)) {
+        // The enum probe off the MODEL (`enum_probe` peels the same `&`/`Option`
+        // layers `flat_probe_inner` peeled off tokens), so a `Box<Priority>`
+        // field answers as a `Priority` does.
+        let mut access = if ext.is_kotlin_enum_reading(&field.ty) {
             if field_is_option || nullable_context {
                 enum_coalesced = true;
                 format!("{field_ref}?.value ?: 0")
@@ -1657,13 +1680,14 @@ fn build_flat_struct_node(
             present_leaf: None,
             direct_handle: false,
             optional_handle: false,
-            rust_ty: Box::new(field.ty.clone()),
+            rust_ty: Box::new(field.ty.syntax().clone()),
+            wrappers: field.ty.erased_wrappers(),
         });
     }
     stack.pop();
     Ok(FlatStructNode {
-        struct_module: struct_module_path(ext, registry, &st.ident),
-        struct_ident: st.ident.clone(),
+        struct_module: struct_module_path(ext, registry, &st.name),
+        struct_ident: st.name.clone(),
         binding: format_ident!("__flat_{native_prefix}"),
         optional,
         present_ident,
@@ -1768,6 +1792,7 @@ fn render_flat_struct_node(
             // variant. ONLY that arm's leaves are converted — the inert
             // groups carry wire defaults nobody reads.
             FlatFieldNode::Sum {
+                wrappers,
                 field,
                 tag_leaf,
                 present_leaf,
@@ -1821,21 +1846,33 @@ fn render_flat_struct_node(
                         }
                     }
                 };
+                // The rebuilt value, then the wrappers this FIELD's spelling
+                // adds — the slot is ascribed `#rust_ty`, so a `Box<Option<T>>`
+                // field needs its `Box` back. Only the rebuilding arms wrap: the
+                // fall-through below runs the field's own converter, which
+                // already yields the spelling.
+                let wrap = |e: TokenStream| {
+                    build_through_wrappers(wrappers, e)
+                        .expect("a field spelling the plan accepted is buildable")
+                };
                 if let Some(p) = present_leaf {
                     let present = &plan.leaves[*p].native_ident;
-                    decodes.extend(quote! {
-                        let #tmp: #rust_ty = if #present != 0u8 {
+                    let gated = wrap(quote! {
+                        if #present != 0u8 {
                             ::core::option::Option::Some(#build)
                         } else {
                             ::core::option::Option::None
-                        };
+                        }
                     });
+                    decodes.extend(quote! { let #tmp: #rust_ty = #gated; });
                 } else {
-                    decodes.extend(quote! { let #tmp: #rust_ty = #build; });
+                    let built = wrap(build);
+                    decodes.extend(quote! { let #tmp: #rust_ty = #built; });
                 }
                 inits.push(quote!(#field: #tmp));
             }
             FlatFieldNode::Value {
+                wrappers,
                 field,
                 value_leaf,
                 present_leaf,
@@ -1846,11 +1883,15 @@ fn render_flat_struct_node(
                 let leaf = &plan.leaves[*value_leaf];
                 let wire = &leaf.native_ident;
                 let tmp = format_ident!("{}_{}", node.binding, field);
+                let wrap = |e: TokenStream| {
+                    build_through_wrappers(wrappers, e)
+                        .expect("a field spelling the plan accepted is buildable")
+                };
                 if *direct_handle {
                     let target = option_inner_type(rust_ty).unwrap_or_else(|| (**rust_ty).clone());
                     if *optional_handle {
-                        decodes.extend(quote! {
-                            let #tmp: #rust_ty = if #wire == 0 {
+                        let gated = wrap(quote! {
+                            if #wire == 0 {
                                 ::core::option::Option::None
                             } else {
                                 if (#wire & 1) == 1 {
@@ -1860,8 +1901,9 @@ fn render_flat_struct_node(
                                 ::core::option::Option::Some(unsafe {
                                     *::std::boxed::Box::from_raw(#wire as *mut #target)
                                 })
-                            };
+                            }
                         });
+                        decodes.extend(quote! { let #tmp: #rust_ty = #gated; });
                     } else {
                         decodes.extend(quote! {
                             if #wire == 0 || (#wire & 1) == 1 {
@@ -1882,14 +1924,15 @@ fn render_flat_struct_node(
                         let present = &plan.leaves[*present_index].native_ident;
                         let inner_tmp = format_ident!("{}_value", tmp);
                         let decode = render_entry_decode(entry, wire, &inner_tmp, on_err);
-                        decodes.extend(quote! {
-                            let #tmp = if #present != 0u8 {
+                        let gated = wrap(quote! {
+                            if #present != 0u8 {
                                 #decode
                                 ::core::option::Option::Some(#inner_tmp)
                             } else {
                                 ::core::option::Option::None
-                            };
+                            }
                         });
+                        decodes.extend(quote! { let #tmp = #gated; });
                     } else {
                         decodes.extend(render_entry_decode(entry, wire, &tmp, on_err));
                     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -4,9 +4,12 @@
 use super::*;
 // `flat` as a module for `TypeKind`: the bare name in this scope is jnigen's own
 // classifier (via `use super::*`), and an explicit import would shadow it.
-use crate::api::core::{
-    flat::{self, TypeRef},
-    registry::Conversions,
+use crate::api::{
+    core::{
+        flat::{self, TypeRef},
+        registry::Conversions,
+    },
+    lang::jnigen::jni::trait_impl::{build_through_erased_wrappers, build_through_wrappers},
 };
 
 pub(crate) fn struct_input_body(
@@ -744,44 +747,119 @@ pub(crate) struct FlatSumVariant {
     pub fields: Vec<(syn::Member, usize)>,
 }
 
-/// Peel `&` then `Option<…>` off the model to reach the value a specialized
-/// lowering would **rebuild**, refusing at any layer whose spelling adds a
-/// wrapper the classification erased.
+/// The three layers a specialized struct lowering descends through, each paired
+/// with the reading whose spelling it must satisfy.
 ///
-/// One function because it is one rule. `kind` decides what the destination
-/// sees; the **conversion** follows the syntax, and these lowerings do not
-/// decode their parameter — they emit a literal `S { .. }`, wrap it in
-/// `Option::Some`, and hand it to the source function. Rebuilding from the
-/// classification alone produces the stripped type, so a parameter spelled
-/// `Box<Option<S>>` receives an `Option<S>`: `E0308` in the generated crate.
+/// `kind` decides what the destination sees; the **conversion** follows the
+/// syntax, and this lowering does not decode its parameter — it emits a literal
+/// `S { .. }`, wraps it in `Option::Some`, and hands it to the source function.
+/// Rebuilding from the classification alone produces the *stripped* type, so a
+/// parameter spelled `Box<Option<S>>` would receive an `Option<S>`: `E0308` in
+/// the generated crate.
 ///
-/// Refusing rather than rebuilding is a **gap, not a requirement**:
-/// `Box::new(v)` is exactly what the syntax asks for and is trivially
-/// emittable. It is left out here because doing it properly means teaching the
-/// converters to rebuild each wrapper, and `Cow` cannot be rebuilt from an
-/// owned payload at all. A wrapped spelling therefore keeps the general
-/// converter path, which is correct if less direct.
-///
-/// The wrapper question goes to [`TypeRef::erased_wrapper`] — the model holds
-/// both halves, so it is the only thing that can answer it, and no spelling is
-/// taken apart here.
-fn rebuildable_target(arg: &TypeRef) -> Option<(bool, bool, &TypeRef)> {
-    if arg.erased_wrapper().is_some() {
-        return None;
+/// So each layer keeps its own reading, and the emitter puts that layer's
+/// wrappers back as it builds outward — see [`RebuildTarget::wrap_core`] and its
+/// siblings. Collected on the way **down** because an erasure sits *outside* the
+/// layer it wraps: `Box<&S>` classifies as `Ref`, and reading `kind` first would
+/// leave the `Box` unreachable.
+pub(crate) struct RebuildTarget {
+    /// Wrappers over the borrow, if there is one — the `Box` of `Box<&S>`.
+    arg: Vec<&'static str>,
+    /// Wrappers over the `Option` — the `Box` of `Box<Option<S>>`.
+    under_borrow: Vec<&'static str>,
+    /// Wrappers over the `S { .. }` literal — the `Box` of `Option<Box<S>>`.
+    core: Vec<&'static str>,
+    /// `true` when the source fn takes `&Struct`.
+    pub by_ref: bool,
+    /// `true` when the value is `Option`-wrapped.
+    pub optional: bool,
+}
+
+impl RebuildTarget {
+    /// Put back the wrappers standing over the `S { .. }` literal —
+    /// `Option<Box<S>>` wraps here, not at [`Self::wrap_optional`].
+    pub fn wrap_core(&self, e: TokenStream) -> TokenStream {
+        Self::wrap(&self.core, e)
     }
+
+    /// Put back the wrappers over the `Option<..>` — the `Box` of
+    /// `Box<Option<S>>`.
+    ///
+    /// A no-op when the parameter is not optional, for the same reason
+    /// [`Self::wrap_arg`] is one when it is not a borrow: with no `Option` to
+    /// peel, `under_borrow` and `core` are the *same reading*, and wrapping at
+    /// both would apply one layer twice.
+    ///
+    /// Stated once as the rule the three share: **a layer's wrappers are
+    /// applied only where that layer exists**, and the innermost always applies.
+    pub fn wrap_optional(&self, e: TokenStream) -> TokenStream {
+        if !self.optional {
+            return e;
+        }
+        Self::wrap(&self.under_borrow, e)
+    }
+
+    /// Put back the wrappers over the **borrow** — the `Box` of `Box<&S>`,
+    /// which goes on after the call site has added its `&`.
+    ///
+    /// A no-op when the parameter is not a borrow, and that is not an
+    /// optimisation: with no `&` to peel, `arg` and `under_borrow` are the *same
+    /// reading*, so wrapping at both would apply one layer twice —
+    /// `Box::new(Box::new(v))` for a `Box<Option<S>>` parameter.
+    pub fn wrap_arg(&self, e: TokenStream) -> TokenStream {
+        if !self.by_ref {
+            return e;
+        }
+        Self::wrap(&self.arg, e)
+    }
+
+    /// Every wrap goes through the one helper, and every layer was proved
+    /// buildable by [`rebuildable_target`] before a plan existed — so a `None`
+    /// here would mean the descent and the emission disagree about the same
+    /// reading, which is a bug in this file rather than an unsupported source.
+    fn wrap(names: &[&'static str], e: TokenStream) -> TokenStream {
+        build_through_wrappers(names, e)
+            .expect("every layer was checked buildable when the plan was built")
+    }
+}
+
+/// Descend `&` then `Option<…>` off the model to the struct a specialized
+/// lowering will **rebuild**, keeping each layer's reading so its spelling can
+/// be restored.
+///
+/// One function because it is one rule, and the layers are checked **on the way
+/// down**: an erasure sits outside the layer it wraps, so `Box<&S>` classifies
+/// as `Ref` and interpreting `kind` before asking would discard the `Box`.
+///
+/// The only refusal left is a wrapper the adapter cannot **build** — `Cow`, by
+/// policy rather than by impossibility (see its `WRAPPER_OPS` row). A wrapped
+/// spelling that declines here keeps the general converter path, which is
+/// correct if less direct.
+fn rebuildable_target(arg: &TypeRef) -> Option<(RebuildTarget, &TypeRef)> {
+    // A probe per layer: "can this spelling be rebuilt at all", asked before the
+    // peel that would hide it. The token is irrelevant — only the `Option` is.
+    let buildable = |t: &TypeRef| build_through_erased_wrappers(t, quote!(__probe)).map(|_| ());
+    buildable(arg)?;
     let by_ref = arg.borrow_target().is_some();
     let t1 = arg.borrow_target().unwrap_or(arg);
-    if t1.erased_wrapper().is_some() {
-        return None;
-    }
+    buildable(t1)?;
     let optional = t1.optional_inner().is_some();
     let inner = t1.optional_inner().unwrap_or(t1);
-    // The struct is rebuilt BY NAME (`S { .. }`), so its own spelling must name
-    // it — a `Box<S>` target would need the `Box::new` this emitter never writes.
-    if inner.erased_wrapper().is_some() {
-        return None;
-    }
-    Some((by_ref, optional, inner))
+    // The struct is rebuilt BY NAME (`S { .. }`), and its own spelling may add a
+    // wrapper over that name — `Box<S>` gets its `Box::new` at `wrap_core`.
+    buildable(inner)?;
+    // Only the wrapper LISTS are kept: they are all a rebuild uses, and a
+    // `TypeRef` apiece would put ~800 bytes into every `InputKind`.
+    Some((
+        RebuildTarget {
+            arg: arg.erased_wrappers(),
+            under_borrow: t1.erased_wrappers(),
+            core: inner.erased_wrappers(),
+            by_ref,
+            optional,
+        },
+        inner,
+    ))
 }
 
 /// A flattened plan for one struct input parameter. Built once by
@@ -794,6 +872,9 @@ pub(crate) struct FlatInputPlan {
     /// Vec/slice element lowering deliberately retains its previous
     /// non-recursive ABI; callers use this bit to decline recursive plans.
     pub contains_nested: bool,
+    /// The layer readings the rebuild has to satisfy — carried rather than
+    /// re-derived at the emission sites, so the descent is stated once.
+    pub target: RebuildTarget,
 }
 
 // `impl_into_target` lived here: it extracted `S` from an `impl Into<S> + …`
@@ -1173,10 +1254,11 @@ pub(crate) fn build_flat_input_plan(
     arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
     // 1. Resolve the struct target through `&` and `Option<…>` — off the model,
-    //    and refusing any layer whose spelling the rebuild could not satisfy.
-    let Some((by_ref, optional, inner)) = rebuildable_target(arg) else {
+    //    keeping each layer's reading so the rebuild can restore its spelling.
+    let Some((target, inner)) = rebuildable_target(arg) else {
         return Ok(None);
     };
+    let (by_ref, optional) = (target.by_ref, target.optional);
     // `impl Into<S>` is NOT peeled here, and cannot be: the model refuses
     // `impl Trait` that is not the callback form (`DisallowedImplTrait`), so a
     // parameter spelled that way never becomes a reading and never reaches this
@@ -1197,7 +1279,13 @@ pub(crate) fn build_flat_input_plan(
     else {
         return Ok(None);
     };
-    let key = inner.key();
+    // The DECLARATION is keyed by the type, not by the spelling: a
+    // `Box<Payload>` parameter is a `Payload` to Kotlin and must find
+    // `Payload`'s data-class declaration. Keying by spelling looked up
+    // `Box < Payload >`, found nothing, and silently dropped the parameter to
+    // the general converter — the flatten lowering was unreachable for every
+    // wrapped core.
+    let key = inner.stripped_key();
     let Some(cfg) = ext.types.get(&key) else {
         return Ok(None);
     };
@@ -1254,6 +1342,7 @@ pub(crate) fn build_flat_input_plan(
         root,
         by_ref,
         contains_nested,
+        target,
     }))
 }
 
@@ -1593,18 +1682,21 @@ pub(crate) fn render_flat_input_decode(
     arg_ident: &syn::Ident,
     on_err: &TokenStream,
 ) -> (TokenStream, TokenStream) {
-    let reconstruct = render_flat_struct_node(plan, &plan.root, on_err);
+    let reconstruct = render_flat_struct_node(plan, &plan.root, Some(&plan.target), on_err);
     let root_binding = &plan.root.binding;
     let prelude = quote! {
         #reconstruct
         let #arg_ident = #root_binding;
     };
-    let call_arg = if plan.by_ref {
+    // The borrow, then the wrappers standing OVER it — `Box<&S>` is
+    // `Box::new(&arg)`, in that order, because the erasure sits outside the
+    // layer it wraps and the `&` is that layer.
+    let borrowed = if plan.by_ref {
         quote!(&#arg_ident)
     } else {
         quote!(#arg_ident)
     };
-    (prelude, call_arg)
+    (prelude, plan.target.wrap_arg(borrowed))
 }
 
 fn render_entry_decode(
@@ -1653,9 +1745,14 @@ fn render_entry_decode(
     body
 }
 
+/// `target` is `Some` for the parameter's ROOT node, whose spelling may add
+/// transparent wrappers the rebuild has to restore, and `None` for a nested one
+/// — a nested struct is reached through a field, and a field's own wrappers are
+/// applied where that field is decoded.
 fn render_flat_struct_node(
     plan: &FlatInputPlan,
     node: &FlatStructNode,
+    target: Option<&RebuildTarget>,
     on_err: &TokenStream,
 ) -> TokenStream {
     let mut decodes = TokenStream::new();
@@ -1663,7 +1760,7 @@ fn render_flat_struct_node(
     for field in &node.fields {
         match field {
             FlatFieldNode::Nested { field, node: child } => {
-                decodes.extend(render_flat_struct_node(plan, child, on_err));
+                decodes.extend(render_flat_struct_node(plan, child, None, on_err));
                 let child_binding = &child.binding;
                 inits.push(quote!(#field: #child_binding));
             }
@@ -1804,21 +1901,40 @@ fn render_flat_struct_node(
     let module = &node.struct_module;
     let sid = &node.struct_ident;
     let binding = &node.binding;
-    let built = quote!(#module::#sid { #(#inits),* });
+    // The struct literal, then the wrappers the CORE spelling adds over it —
+    // `Option<Box<S>>` gets its `Box::new` here, inside the present gate, not
+    // around it. `None` for a nested node, whose own layers are its field's
+    // question rather than the parameter's.
+    let built = match target {
+        Some(t) => t.wrap_core(quote!(#module::#sid { #(#inits),* })),
+        None => quote!(#module::#sid { #(#inits),* }),
+    };
+    // …and the wrappers over the `Option` (or over the bare value) go around
+    // the whole gate — the `Box` of `Box<Option<S>>`.
+    let outer = |e: TokenStream| match target {
+        Some(t) => t.wrap_optional(e),
+        None => e,
+    };
     if node.optional {
         let present = node.present_ident.as_ref().expect("optional node has gate");
-        quote! {
-            let #binding = if #present != 0u8 {
-                #decodes
+        let gate = outer(quote! {
+            if #present != 0u8 {
                 ::core::option::Option::Some(#built)
             } else {
                 ::core::option::Option::None
+            }
+        });
+        quote! {
+            let #binding = {
+                #decodes
+                #gate
             };
         }
     } else {
+        let value = outer(built);
         quote! {
             #decodes
-            let #binding = #built;
+            let #binding = #value;
         }
     }
 }
@@ -1852,6 +1968,17 @@ pub(crate) struct OptionScalarInputPlan {
     pub value_kt_type: String,
     /// Kotlin zero literal filling the value leaf when the option is absent.
     pub value_kt_zero: String,
+    /// The transparent wrappers the parameter's spelling adds over `Optional`,
+    /// outermost first — what the emitter puts back.
+    ///
+    /// This plan **rebuilds** its parameter — the emitter writes a literal
+    /// `Option::Some(v)` / `Option::None` and hands it to the source fn — so a
+    /// parameter spelled `Box<Option<T>>` must receive a `Box`, not the bare
+    /// `Option` the classification names. Carried rather than re-derived at the
+    /// two emission sites, which would be the same rule stated twice; the list
+    /// rather than the reading, because that is all a rebuild uses and this
+    /// plan sits in `InputKind`, whose size every variant pays.
+    pub arg_wrappers: Vec<&'static str>,
     /// `true` when the inner is an `enum_class` — the call site reads `?.value`.
     pub is_enum: bool,
 }
@@ -1868,13 +1995,13 @@ pub(crate) fn build_option_scalar_input_plan(
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Option<OptionScalarInputPlan> {
-    // The optional layer off the model — but the emitter rebuilds a bare
-    // `Option::Some(v)` and hands it to the source fn, so a spelling the model
-    // erased a wrapper from could not receive it. Conversion follows the syntax;
-    // see [`rebuildable_target`], which applies the same rule to the struct path.
-    if arg.erased_wrapper().is_some() {
-        return None;
-    }
+    // The wrappers this spelling adds over `Optional` have to be BUILDABLE, not
+    // absent: the emitter rebuilds a bare `Option::Some(v)` and hands it to the
+    // source fn, so a parameter spelled `Box<Option<T>>` receives a `Box`.
+    // Asked here, before the peel, because an erasure sits outside the layer it
+    // wraps — and asked as "can I build it" rather than "is there one", so the
+    // only refusal left is a wrapper `WRAPPER_OPS` declines (`Cow`).
+    build_through_erased_wrappers(arg, quote!(__probe))?;
     let inner = arg.optional_inner()?;
     // `Option<&T>` is the nullable-borrow / handle path, not a scalar.
     if inner.borrow_target().is_some() {
@@ -1912,6 +2039,7 @@ pub(crate) fn build_option_scalar_input_plan(
         value_kt_type: prim.kotlin_type().to_string(),
         value_kt_zero: prim.kotlin_zero().to_string(),
         is_enum,
+        arg_wrappers: arg.erased_wrappers(),
     })
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -1960,18 +1960,28 @@ fn render_flat_struct_node(
     };
     if node.optional {
         let present = node.present_ident.as_ref().expect("optional node has gate");
+        // `#decodes` belongs **inside** the true arm, and that is a correctness
+        // requirement rather than a tidiness one: when the Kotlin object is null
+        // its leaves carry inert placeholders, and decoding them is not
+        // side-effect-free. A required handle field arrives as pointer `0`, so
+        // an unconditional direct-handle decode calls `signal_binding_error` and
+        // returns instead of delivering `None`; an enum with no discriminant `0`
+        // and a fallible custom converter fail on their placeholders the same
+        // way.
+        //
+        // The wrapper goes around the whole conditional, which is what the
+        // `Option` layer wraps — so `outer` applies to the `if`, never between
+        // it and the decodes.
         let gate = outer(quote! {
             if #present != 0u8 {
+                #decodes
                 ::core::option::Option::Some(#built)
             } else {
                 ::core::option::Option::None
             }
         });
         quote! {
-            let #binding = {
-                #decodes
-                #gate
-            };
+            let #binding = #gate;
         }
     } else {
         let value = outer(built);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -5,7 +5,10 @@ use super::*;
 // `flat` as a module for `TypeKind`: the bare name in this scope is jnigen's own
 // classifier (reached through `use super::*`), and an explicit import would win
 // over the glob and silently retarget it.
-use crate::api::core::flat::{self, RefMode, TypeRef};
+use crate::api::{
+    core::flat::{self, RefMode, TypeRef},
+    lang::jnigen::jni::trait_impl::build_through_erased_wrappers,
+};
 
 // `slice_or_vec_elem` lived here: it matched `&[T]` / `Vec<T>` off the SPELLING
 // and returned the element. `vec_build_elem` was its only caller and now reads
@@ -48,22 +51,45 @@ pub(crate) fn vec_build_elem(
     // sequence — whose spelling is a clean `Vec<T>` — and let the outer `Box`
     // through unseen. Every layer is checked on the way down, the way
     // `rebuildable_target` does it.
-    if arg.erased_wrapper().is_some() {
-        return None;
-    }
     let (run, by_ref) = match arg.kind() {
         flat::TypeKind::Ref { mode, inner } if *mode == RefMode::Shared => (&**inner, true),
         _ => (arg, false),
     };
-    // Still needed after the peel: `&Box<Vec<T>>` puts the wrapper on the
-    // referent, where the check above (a `syn::Type::Reference`) cannot see it.
-    if run.erased_wrapper().is_some() {
-        return None;
+    // A wrapper over the RUN is buildable only on the by-value path, and the
+    // reason is a cost rather than a type error. By value the local is owned, so
+    // `Box<Vec<T>>` is `Box::new(mem::take(..))` — free. Borrowed, the local is
+    // a borrow of the Vec the Kotlin side owns, and there is no way to put a
+    // `Box` between that borrow and the callee without **copying** the run
+    // (`&Box::new(v.clone())`) — which needs a `T: Clone` nothing here
+    // guarantees, and silently adds a per-call copy to a path whose entire point
+    // is not having one.
+    //
+    // Definitive, not deferred: the borrowed shape keeps the `input_vec` path,
+    // which is correct. If a binding ever wants the copy, it is a decision to
+    // make on purpose, at the declaration.
+    let wrapped_run = !arg.erased_wrappers().is_empty() || !run.erased_wrappers().is_empty();
+    if wrapped_run {
+        if by_ref {
+            return None;
+        }
+        // By value: both layers must be buildable (`Cow` still declines).
+        build_through_erased_wrappers(arg, quote!(__probe))?;
+        build_through_erased_wrappers(run, quote!(__probe))?;
     }
     let elem = run.sequence_elem()?;
-    // The element is spelled into `Vec<#elem>` and rebuilt per push, so a
-    // wrapped element spelling is unbuildable for the same reason.
-    if elem.erased_wrapper().is_some() {
+    // A wrapped ELEMENT keeps the general converter path, and the obstruction is
+    // naming rather than typing. The helper trio stores a `Vec<#elem>`, so
+    // `Vec<Payload>` and `Vec<Box<Payload>>` are two different storages needing
+    // two trios — but the trio's base name is derived from the element's
+    // **Kotlin class** (`Payload` → `payloadVec`), which the two share, so both
+    // would emit `payloadVecNew`/`Push`/`Free` and collide.
+    //
+    // Definitive as long as the name comes from the Kotlin class: the
+    // alternative is spelling a Rust wrapper into a JNI symbol, which is the
+    // representation leak this whole layer exists to prevent. The general
+    // converter serves the shape correctly (see `input_transparent_bridge`),
+    // just without the per-element push loop.
+    if !elem.erased_wrappers().is_empty() {
         return None;
     }
     // The element must flatten; the probe ident is irrelevant here.
@@ -256,6 +282,7 @@ pub(crate) fn build_vec_build_helper_items(
         }
         let module = &h.plan.root.struct_module;
         let sid = &h.plan.root.struct_ident;
+
         named.push((
             push_sym.clone(),
             syn::parse_quote!(

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -4,7 +4,9 @@
 use super::*;
 use crate::api::{
     core::{registry::Conversions, types_util::result_ok_type},
-    lang::jnigen::jni::trait_impl::read_through_erased_wrappers,
+    lang::jnigen::jni::trait_impl::{
+        build_through_erased_wrappers, build_through_wrappers, read_through_erased_wrappers,
+    },
 };
 
 pub(crate) fn emit_jni_function_wrapper(
@@ -558,19 +560,30 @@ fn emit_input_param(
             wire_params.push(quote!(#vid: #vwire));
             let conv = &sp.inner_conv;
             let tmp = format_ident!("__{}_val", arg_ident);
+            // The rebuilt `Option`, then the wrappers the parameter's spelling
+            // adds over it — `Box<Option<T>>` gets its `Box` back here, because
+            // nothing between this and the source call re-spells the value.
+            // The plan only exists when the build resolves, so this cannot fail.
+            let built = build_through_wrappers(
+                &sp.arg_wrappers,
+                quote! {
+                    if #pid != 0u8 {
+                        let #tmp = match #conv(&mut env, &#vid) {
+                            ::core::result::Result::Ok(__v) => __v,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
+                                return #on_err;
+                            }
+                        };
+                        ::core::option::Option::Some(#tmp)
+                    } else {
+                        ::core::option::Option::None
+                    }
+                },
+            )
+            .expect("an option-scalar plan is built only for a buildable spelling");
             prelude.push(quote! {
-                let #arg_ident = if #pid != 0u8 {
-                    let #tmp = match #conv(&mut env, &#vid) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
-                            return #on_err;
-                        }
-                    };
-                    ::core::option::Option::Some(#tmp)
-                } else {
-                    ::core::option::Option::None
-                };
+                let #arg_ident = #built;
             });
             (wire_params, prelude, quote!(#arg_ident))
         }
@@ -589,15 +602,27 @@ fn emit_input_param(
             let handle_ident = format_ident!("{}_handle", arg_ident);
             wire_params.push(quote!(#handle_ident: jni::sys::jlong));
             if *by_ref {
+                // `vec_build_elem` refuses a wrapped run on this path, so the
+                // borrow is the parameter's own spelling and there is nothing
+                // to put back.
                 prelude.push(quote!(
                     let #arg_ident: &[#elem] =
                         unsafe { &*(#handle_ident as *const Vec<#elem>) };
                 ));
             } else {
-                prelude.push(quote!(
-                    let #arg_ident: Vec<#elem> =
-                        unsafe { ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>)) };
-                ));
+                // By value the local is owned, so the run's wrappers go back on
+                // for free — `Box<Vec<T>>` is `Box::new(mem::take(..))`. The
+                // ascription is dropped rather than restated: the wrapped
+                // spelling is what the expression now produces, and naming it
+                // here would be the same fact written twice.
+                let taken = build_through_erased_wrappers(
+                    &leaf.reading,
+                    quote!(unsafe {
+                        ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>))
+                    }),
+                )
+                .expect("vec_build_elem accepted this run spelling");
+                prelude.push(quote!(let #arg_ident = #taken;));
             }
             (wire_params, prelude, quote!(#arg_ident))
         }
@@ -843,19 +868,31 @@ pub(crate) fn emit_expanded_param(
             let inner_conv = &sp.inner_conv;
             wire_params.push(quote!(#present_ident: jni::sys::jboolean));
             wire_params.push(quote!(#value_ident: #value_wire));
+            // The local is ascribed the leaf's own SPELLING (`leaf_ty`), so the
+            // rebuilt `Option` has to be wrapped back up to match it — the same
+            // rule as the parameter path above, and the reason the ascription
+            // can stay as written rather than being weakened to the stripped
+            // type.
+            let built = build_through_wrappers(
+                &sp.arg_wrappers,
+                quote! {
+                    if #present_ident != 0u8 {
+                        let __v = match #inner_conv(&mut env, &#value_ident) {
+                            ::core::result::Result::Ok(__v) => __v,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
+                                return #on_err;
+                            }
+                        };
+                        ::core::option::Option::Some(__v)
+                    } else {
+                        ::core::option::Option::None
+                    }
+                },
+            )
+            .expect("an option-scalar plan is built only for a buildable spelling");
             prelude.push(quote!(
-                let #local: #leaf_ty = if #present_ident != 0u8 {
-                    let __v = match #inner_conv(&mut env, &#value_ident) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
-                            return #on_err;
-                        }
-                    };
-                    ::core::option::Option::Some(__v)
-                } else {
-                    ::core::option::Option::None
-                };
+                let #local: #leaf_ty = #built;
             ));
             leaf_locals.push(local);
             continue;

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -168,7 +168,10 @@ impl Declarations {
                 return Some(c);
             }
         }
-        None
+        // 4. Last resort: the spelling differs from something convertible only
+        //    by the wrappers the model erased. Nothing that resolves above
+        //    reaches here, so this adds routes rather than changing them.
+        self.input_transparent_bridge(ty, registry)
     }
 
     /// Select the output converter for `ty`: terminals, user wrappers, then

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1711,30 +1711,27 @@ fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
     assert!(ext.is_kotlin_enum(field("plain").syntax()));
 }
 
-/// A **transparently-wrapped** parameter spelling does not take a specialized
-/// lowering that would rebuild the unwrapped type.
+/// A **transparently-wrapped** parameter takes the same specialized lowering as
+/// its bare twin, and the emitter puts the wrapper back.
 ///
 /// The model erases `Box`/`Cow` ([`TRANSPARENT_WRAPPERS`]), so
-/// `Box<Option<Mode>>` classifies as `Optional` exactly as `Option<Mode>` does —
-/// and reading the layers off the model is what the reading-based probes were
-/// changed to do. But `build_option_scalar_input_plan` does not *decode* the
-/// parameter, it **rebuilds** it: the emitter writes a literal
-/// `Option::Some(v)` / `Option::None` and hands that to the source function.
-/// Handing a bare `Option<Mode>` to a parameter spelled `Box<Option<Mode>>` is
-/// an `E0308` in the generated crate.
+/// `Box<Option<Mode>>` classifies as `Optional` exactly as `Option<Mode>` does.
+/// But `build_option_scalar_input_plan` does not *decode* the parameter, it
+/// **rebuilds** it: the emitter writes a literal `Option::Some(v)` /
+/// `Option::None` and hands that to the source function, and handing a bare
+/// `Option<Mode>` to a parameter spelled `Box<Option<Mode>>` is an `E0308`.
 ///
-/// So the selection asks the spelling too ([`rebuilt_value_satisfies`]) and
-/// declines, exactly as `decoded_vec_satisfies` makes the general converter path
-/// decline `&Box<Vec<T>>` (see
-/// `a_borrowed_transparent_sequence_wrapper_is_not_decoded_as_a_vec`).
+/// #290 closed that by **declining** the wrapped spelling. #292 item 3 replaced
+/// the refusal with the rebuild — `Box::new(..)` is exactly what the syntax
+/// asks for — so what this pins flipped: the wrapped parameter must now reach
+/// the decoupled `(present, value)` wire, *and* the Rust side must re-wrap.
 ///
-/// **What this pins is the refusal**, and it is asserted on the *pair* so it
-/// cannot pass vacuously: the bare twin must still take the decoupled
-/// `(present, value)` wire, and the wrapped one must not. The generated Rust is
-/// never compiled by this suite (#269), so the `E0308` itself is out of reach —
-/// the reachable property is that the emitter is never asked to write it.
+/// Asserted on the **pair** in both artifacts so it cannot pass vacuously: the
+/// bare twin must take the same Kotlin surface (or the wrapped one proves
+/// nothing) and must **not** get a `Box::new` (or the wrap assertion would hold
+/// for an emitter that wrapped everything).
 #[test]
-fn a_transparently_wrapped_option_does_not_take_the_present_value_pair() {
+fn a_transparently_wrapped_option_takes_the_present_value_pair_and_is_rebuilt() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
@@ -1802,18 +1799,36 @@ fn a_transparently_wrapped_option_does_not_take_the_present_value_pair() {
          otherwise this test proves nothing about the wrapped one:\n{kotlin}"
     );
 
-    // The finding: `Box<Option<Mode>>` must NOT, because the emitter would
-    // rebuild a bare `Option<Mode>` for a parameter that is not one.
+    // …and so does the wrapped one. The two spellings are one type to Kotlin,
+    // so an identical surface is the whole claim — a wrapper must not cost a
+    // parameter its lowering.
     assert!(
-        !kc.contains("zBoxed(modePresent"),
-        "`Box<Option<Mode>>` took the present/value lowering, which rebuilds a \
-         bare `Option<Mode>` and hands it to a fn expecting `Box<Option<Mode>>` \
-         — an E0308 in the generated crate:\n{kotlin}"
+        kc.contains("zBoxed(modePresent:Boolean,modeValue:Int"),
+        "`Box<Option<Mode>>` must take the same present/value lowering as its \
+         bare twin — the model erases the `Box`, and the emitter puts it back \
+         rather than declining the shape:\n{kotlin}"
     );
-    // What it takes instead: the ordinary boxed-`Int?` optional wire, whose
-    // converter is selected by `selector.rs` — the path that carries its own
-    // spelling guards.
-    assert!(kc.contains("zBoxed(mode:Int?"), "{kotlin}");
+
+    // The Rust half, which is what makes taking that lowering legal: the
+    // rebuilt `Option` is wrapped back up before it reaches the source fn.
+    // Without this the extern hands an `Option<Mode>` to a parameter spelled
+    // `Box<Option<Mode>>` — `E0308`, and no Kotlin assertion could see it.
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+        .expect("read rust");
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("letmode=::std::boxed::Box::new(if"),
+        "the rebuilt `Option` must be re-wrapped for the spelling:\n{rust}"
+    );
+    // The control on the Rust side too: exactly ONE of the two externs wraps,
+    // so the assertion above is about the spelling and not an unconditional
+    // `Box` the emitter adds to everything.
+    assert_eq!(
+        rc.matches("::std::boxed::Box::new(if").count(),
+        1,
+        "only the wrapped spelling gets a `Box::new`; the bare twin builds the \
+         `Option` and passes it as is:\n{rust}"
+    );
 }
 
 /// The transparent-wrapper guard runs **before** the model's layers are
@@ -1826,7 +1841,7 @@ fn a_transparently_wrapped_option_does_not_take_the_present_value_pair() {
 /// outer wrapper is never seen: the Vec-build plan is selected, its emitter
 /// hands the source fn a `&[Foo]` built from the transient Rust-side `Vec`, and
 /// the parameter still spells `Box<&Vec<Foo>>`. That is the same `E0308` class
-/// [`a_transparently_wrapped_option_does_not_take_the_present_value_pair`]
+/// [`a_transparently_wrapped_option_takes_the_present_value_pair_and_is_rebuilt`]
 /// covers, reached by peeling in the wrong order.
 ///
 /// So this pins the **ordering**, which the shape-by-shape tests cannot: every

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -703,6 +703,22 @@ const WRAPPER_OPS: &[WrapperOps] = &[
         // implied by anything the model knows about the payload. Refused until
         // something needs it; that is one row, not a redesign.
         read: None,
+        // Building is a DIFFERENT question, and it is refused for a different
+        // reason — the two `None`s here are not one fact repeated.
+        //
+        // `Cow::Owned(v)` is well-typed: an input rebuild owns its value, and
+        // `Cow<'_, [T]>` takes a `Vec<T>` while `Cow<'_, str>` takes a
+        // `String`. So this is not "cannot", it is **should not**. A source
+        // spells `Cow` to accept borrowed data without copying; a binding that
+        // can only ever hand it `Owned` pays that copy on every call and
+        // silently removes the borrow path — and the callee can see the
+        // difference (`matches!(c, Cow::Borrowed(_))`), so it is observable
+        // rather than merely wasteful.
+        //
+        // **Deliberate, not deferred.** If a binding decides the copy is
+        // acceptable for its own source, this is one line —
+        // `Some(|e| quote!(::std::borrow::Cow::Owned(#e)))` — and nothing else
+        // moves. The refusal is here so that decision is made on purpose.
         build: None,
     },
 ];
@@ -783,6 +799,57 @@ pub(crate) fn read_through_erased_wrappers(
     // Outermost first, which is the order they have to come off in.
     for name in ty.erased_wrappers() {
         out = (wrapper_ops(name)?.read?)(out);
+    }
+    Some(out)
+}
+
+/// Put back the transparent wrappers a **rebuild** dropped, so a value the
+/// emitter constructed from the classification has the type the source spelled
+/// — `Box<Option<S>>` ← `Box::new(v)`, an unwrapped spelling ← `v` unchanged.
+///
+/// The input-side dual of [`read_through_erased_wrappers`], and the reason both
+/// live here rather than at the sites that need them: the specialized input
+/// lowerings do not *decode* their parameter, they **rebuild** it — a literal
+/// `S { .. }`, an `Option::Some(v)`, a `Vec<T>` pushed element by element — and
+/// a rebuild from the classification alone produces the *stripped* type. Handing
+/// that to a parameter spelled `Box<..>` is an `E0308` in the generated crate,
+/// which is why this is one rule in one place instead of three selection sites
+/// each remembering it.
+///
+/// Applied **innermost-out**, the reverse of reading: the value in hand is the
+/// canonical shape, and each layer wraps what the previous one produced.
+///
+/// `None` when any layer has no [`WrapperOps::build`] — `Cow`, by policy rather
+/// than by impossibility; see its row. A caller that gets `None` has a crossing
+/// it cannot serve and must decline or report it, never emit the bare value.
+///
+/// **This answers for one layer's spelling.** It restores the wrappers standing
+/// over `ty`'s own classification; a wrapper *inside* — the `Box` of
+/// `Option<Box<S>>` — belongs to the inner reading, is applied when that layer
+/// is built, and is invisible here. An erasure sits **outside** the layer it
+/// wraps, so a rebuild collects wrappers as it descends and applies them as it
+/// comes back out.
+pub(crate) fn build_through_erased_wrappers(
+    ty: &crate::api::core::flat::TypeRef,
+    value: TokenStream,
+) -> Option<TokenStream> {
+    build_through_wrappers(&ty.erased_wrappers(), value)
+}
+
+/// [`build_through_erased_wrappers`] over a wrapper list already taken off a
+/// reading — for a plan that recorded *what to put back* rather than keeping the
+/// whole `TypeRef` to ask again.
+///
+/// The list is the only part of the reading a rebuild uses, and it is two
+/// pointers instead of a `TypeRef`'s ~264 bytes. That matters because these
+/// plans live in `InputKind`, whose size every variant pays.
+pub(crate) fn build_through_wrappers(
+    names: &[&'static str],
+    value: TokenStream,
+) -> Option<TokenStream> {
+    let mut out = value;
+    for name in names.iter().rev() {
+        out = (wrapper_ops(name)?.build?)(out);
     }
     Some(out)
 }
@@ -2046,6 +2113,79 @@ impl Declarations {
     /// **Input** wrapper shape (`pat` = the reconstructed canonical pattern,
     /// `t1` = its captured inner): the built-in `&`/`Option<&>`/`Vec`/`Option`
     /// handlers.
+    /// **Last resort**: a spelling whose only difference from something this
+    /// adapter can already convert is the transparent wrappers over it.
+    ///
+    /// The layer arms each handle one *classification* layer — `Optional`,
+    /// `Sequence`, `Ref` — and bridge a wrapper as part of doing so. What none of
+    /// them covers is a wrapper over a **terminal**: `Box<Payload>` classifies as
+    /// `Named`, so no layer arm claims it, and `input_terminal` keys on the whole
+    /// spelling and finds no `Payload` config under `Box < Payload >`. Before
+    /// this it resolved to nothing at all — the crossing was refused for a
+    /// wrapper the model exists to make invisible.
+    ///
+    /// So this delegates to the **stripped** spelling's own converter and puts
+    /// the wrappers back on what it produced. The inner type is declared as a
+    /// `sub`, exactly as a layer arm declares its inner, so it is required and
+    /// resolved through the ordinary machinery rather than being resolved here.
+    ///
+    /// Deliberately tried **after** every layer arm, so nothing that resolves
+    /// today changes route: `Box<Option<T>>` keeps the `Optional` arm (which
+    /// bridges via `build_from_canonical`), and only the shapes that previously
+    /// reached `None` arrive here.
+    pub(crate) fn input_transparent_bridge(
+        &self,
+        reading: &crate::api::core::flat::TypeRef,
+        registry: &impl Conversions<KotlinMeta>,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        if reading.erased_wrappers().is_empty() {
+            return None;
+        }
+        let produced = reading.syntax();
+        // The spelling under every wrapper — by the model's own definition, the
+        // one whose lowering yields this `kind`.
+        let stripped = reading.stripped_syntax();
+        // A wrapper over a **borrow** is not bridgeable here, and the reason is
+        // the converter's own shape rather than the wrapper's: this produces an
+        // owned value, and there is nothing for a `Box<&T>` to borrow *from* —
+        // the returned reference would have to outlive the call that made it
+        // (`E0106` on the generated signature). The borrow arms own that case,
+        // and they serve the canonical spelling only.
+        //
+        // Asked of the MODEL, not of `stripped`: an erasure is transparent, so
+        // `Box<&T>` already classifies as `Ref` and `kind` answers this without
+        // anything here matching a `syn` variant.
+        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Ref { .. }) {
+            return None;
+        }
+        // It has to be a type this binding already crosses; if it is not, the
+        // ordinary "unresolved" diagnostic names it, which is the better error.
+        let inner = registry.reading_of(&stripped)?;
+        let entry = registry.input_entry(&inner)?;
+        let wire = entry.destination.clone();
+        let inner_fn = &entry.function.sig.ident;
+        // Wrap what the inner converter produced. `None` here is `Cow`'s policy
+        // refusal — the crossing then stays unresolved and names the type,
+        // rather than resolving and emitting Rust the consumer cannot build.
+        let built = build_through_erased_wrappers(reading, quote!(__inner))?;
+        let body: syn::Expr = syn::parse_quote!({
+            let __inner = #inner_fn(env, v)?;
+            #built
+        });
+        Some(ConverterImpl {
+            subs: vec![stripped],
+            pre_stages: vec![],
+            function: self.build_input_fn(produced, &wire, &body, None),
+            destination: wire,
+            niches: entry.niches.clone(),
+            // The surface is the inner type's: a wrapper is invisible to the
+            // destination language, which is the whole reason the model erases
+            // it. Inheriting rather than recomputing also keeps a projection's
+            // Kotlin class from being lost behind the wrapper.
+            metadata: entry.metadata.clone(),
+        })
+    }
+
     pub(crate) fn input_wrapper_shape(
         &self,
         shape: WrapperShape,
@@ -2695,5 +2835,62 @@ mod wrapper_ops_tests {
             stray.is_empty(),
             "`WRAPPER_OPS` rows for non-erased {stray:?}"
         );
+    }
+
+    /// A rebuild puts the wrappers back **innermost-out**, the reverse of the
+    /// order a read takes them off.
+    ///
+    /// Asserted on a `Box<Box<_>>` rather than a single layer, because a single
+    /// layer cannot tell the two orders apart — which is exactly how a
+    /// composition bug survives. And asserted against `read` on the same type,
+    /// so the two are pinned as duals rather than as two independent claims.
+    #[test]
+    fn a_rebuild_puts_the_wrappers_back_inside_out() {
+        let ty = crate::api::test_util::reading(syn::parse_quote!(Box<Box<Option<String>>>));
+        assert_eq!(ty.erased_wrappers(), ["Box", "Box"]);
+
+        let built = build_through_erased_wrappers(&ty, quote!(v)).expect("Box builds");
+        assert_eq!(
+            built.to_string().replace(' ', ""),
+            ":: std :: boxed :: Box :: new (:: std :: boxed :: Box :: new (v))".replace(' ', ""),
+        );
+        // The dual, on the same type: reading takes them off outermost-first.
+        let read = read_through_erased_wrappers(&ty, quote!(v)).expect("Box reads");
+        assert_eq!(read.to_string().replace(' ', ""), "**v");
+
+        // The control: nothing erased, so both are the identity and neither
+        // test above can be passing on an unconditional wrap.
+        let plain = crate::api::test_util::reading(syn::parse_quote!(Option<String>));
+        assert!(plain.erased_wrappers().is_empty());
+        for e in [
+            build_through_erased_wrappers(&plain, quote!(v)),
+            read_through_erased_wrappers(&plain, quote!(v)),
+        ] {
+            assert_eq!(e.expect("identity").to_string(), "v");
+        }
+    }
+
+    /// `Cow` declines a rebuild, and the two directions decline for **different
+    /// reasons** — which is why the row carries two `None`s rather than one
+    /// capability flag.
+    ///
+    /// Reading is impossible (`E0507`: a `Cow` payload cannot be moved through
+    /// `Deref`). Building is *possible* — `Cow::Owned(v)` is well-typed for an
+    /// owned payload — and refused on purpose, because a binding that can only
+    /// ever hand a `Cow` parameter `Owned` pays a copy per call and removes the
+    /// borrow path the source asked for. If that policy is ever revisited, this
+    /// test is the thing that has to change with it.
+    #[test]
+    fn a_cow_declines_a_rebuild_by_policy() {
+        let ty = crate::api::test_util::reading(syn::parse_quote!(Cow<'_, str>));
+        assert_eq!(ty.erased_wrappers(), ["Cow"]);
+        assert!(build_through_erased_wrappers(&ty, quote!(v)).is_none());
+        assert!(read_through_erased_wrappers(&ty, quote!(v)).is_none());
+
+        // A `Cow` under a `Box` declines too: one unbuildable layer refuses the
+        // whole chain, rather than the `Box` half quietly succeeding.
+        let nested = crate::api::test_util::reading(syn::parse_quote!(Box<Cow<'_, str>>));
+        assert_eq!(nested.erased_wrappers(), ["Box", "Cow"]);
+        assert!(build_through_erased_wrappers(&nested, quote!(v)).is_none());
     }
 }

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -114,10 +114,11 @@ mod spelling_census {
     /// `(file, call count)` — every `.rs` under `api/lang/jnigen`, checked
     /// against the directory tree so a new module cannot sit outside the census.
     const CENSUS: &[(&str, usize)] = &[
-        // The L4 "layer questions" remainder — #229. Not migrated here because
-        // it is a separate consumer and bundling it would make one review of
-        // both impossible.
-        ("jni/emit/flat_input.rs", 18),
+        // 18 -> 9 (#289): `build_flat_struct_node` takes `flat::Struct` and
+        // peels its fields off the model. What remains is `struct_input_body` /
+        // `sum_input_body`, the `.jobject_input()` decoders — a separate walk
+        // over `syn::Fields`, and the rest of #289.
+        ("jni/emit/flat_input.rs", 9),
         ("jni/emit/struct_out.rs", 2),
         ("jni/emit/wrapper.rs", 2),
         //

--- a/prebindgen/src/api/test_util.rs
+++ b/prebindgen/src/api/test_util.rs
@@ -32,6 +32,35 @@ pub(crate) fn scanned_with<M>(sources: &[&str]) -> Registry<M> {
     reg_with(sources).scanned().expect("scan")
 }
 
+/// One type as the **model** reads it, for a test that needs a `TypeRef` and has
+/// only a spelling.
+///
+/// Minting is sealed to `api::core` (#280), and rightly — a hand-assembled
+/// reading could pair a `kind` with a disagreeing `syntax`, which is the one
+/// thing holding a `TypeRef` is supposed to rule out. So this does not reach
+/// around the seal: it puts the spelling in a parameter position, runs the real
+/// parse, and hands back the reading the model produced. A spelling the grammar
+/// refuses panics here rather than yielding something weaker.
+pub(crate) fn reading(ty: syn::Type) -> crate::core::flat::TypeRef {
+    let item: syn::Item = syn::parse_quote!(
+        pub fn __probe(v: #ty) {
+            unimplemented!()
+        }
+    );
+    let flat = crate::core::Flat::builder()
+        .items(declare_referenced(vec![(
+            item,
+            crate::SourceLocation::default(),
+        )]))
+        .build()
+        .expect("the probe parses");
+    flat.function("__probe")
+        .expect("the probe is indexed")
+        .params[0]
+        .ty
+        .clone()
+}
+
 /// Build a `Registry` from an item stream, the way `Registry::from_items` used
 /// to before reading captured output became `FlatBuilder`'s job alone.
 ///


### PR DESCRIPTION
Item 3 of #292, and #289 with it. The two travel together because **#289 alone breaks the build**: reading a field's layer off the model is what makes the emitter rebuild an `Option` for a slot ascribed `Box<Option<_>>`. Either both, or neither.

## The rebuild

`build_through_erased_wrappers` is the input dual of #293's `read_through_erased_wrappers` — same `WRAPPER_OPS` rows, applied innermost-out. The three declared sites descend instead of refusing, collecting each layer's wrappers on the way down, because an erasure sits outside the layer it wraps.

**A layer's wrappers are applied only where that layer exists.** Applying them unconditionally double-wraps when two layers are the same reading (`arg == under_borrow` with no borrow; `under_borrow == core` with no `Option`). I got that wrong twice; both times a fixture caught it, and neither was reachable by any text assertion.

**`Cow` keeps `build: None`, and that is policy rather than impossibility.** `Cow::Owned(v)` is well-typed — an input rebuild owns its value. It is refused because always-`Owned` pays a copy per call and removes the borrow path the source asked for, and the callee can see the difference (`matches!(c, Cow::Borrowed(_))`). The row says so, and says it is one line to change on purpose. The read/build asymmetry is now two different reasons, not one flag.

## Two findings the fixtures forced out

Neither was in the plan, and neither is visible to the test suite.

**A wrapper silently cost a parameter its lowering.** The data-class declaration was looked up by `inner.key()` — the *wrapped* spelling — so `Box<Payload>` found no `Payload` declaration and fell to the general converter. No error, no diff, just a lost lowering. A declaration says what a type **is**, so it is keyed by the new `TypeRef::stripped_key()`. `key` stays for conversions, which genuinely differ per spelling.

**A wrapper over a terminal had no converter at all.** The layer arms bridge a wrapper as part of handling their layer; nothing covered `Box<Payload>`, which is `Named`. `input_transparent_bridge` delegates to the stripped spelling's converter and re-wraps — tried **last**, so no existing route changes.

## Refusals, each with a stated reason

Per the reserved-vs-definitive rule these say *why*, not just *no*:

| Shape | Why |
|---|---|
| `Box<&T>` | a converter produces an owned value; there is nothing for the borrow to point at that outlives the call (`E0106`) |
| `&Box<Vec<T>>` | interposing a `Box` between the caller's Vec and the callee needs a per-call `clone()` and an unguaranteed `T: Clone` |
| `Vec<Box<T>>` element | the helper trio is named for the element's Kotlin class, so two spellings of one class collide on `payloadVecNew` |

The first two were checked against `rustc` rather than reasoned about — which is how I learned the borrowed run only compiles *with* a clone.

## #289

`build_flat_struct_node` takes `&flat::Struct` and peels its fields off the model. `flat_probe_inner` is gone — its last caller asks `is_kotlin_enum_reading`, whose `enum_probe` peels the same layers, so `Box<Priority>` probes as `Priority` where it answered about the wrapper.

**Both censuses move down**, which no PR in the #284 chain managed, because this retires callers rather than re-typing signatures — exactly #289's prediction:

- spelling helpers in `flat_input.rs`: **18 → 9**
- boundary ledger: `flat_input.rs` **7 → 6** (127 → **126**)

Still on `syn::Fields`: `struct_input_body` / `sum_input_body`, the `.jobject_input()` decoders — separate walk, same rule, and the remaining 9.

## Evidence

Seven fixtures in `perftest-flat`, whose binding covertest `include!`s and CI builds — the only place an `E0308` is a test failure (#269).

**Every wrap was verified by disabling it** and reading the error naming its shape:

| Disabled | Result |
|---|---|
| `wrap_core` | `expected Box<Payload>, found Payload` |
| `wrap_optional` | `expected Box<Option<Payload>>, found Option<Payload>` |
| option-scalar wrap | `expected Box<Option<Priority>>, found Option<Priority>` |
| vec run wrap | `expected Box<Vec<Payload>>, found Vec<Payload>` |
| field wrap | `expected Box<Option<i64>>, found Option<i64>` |
| `input_transparent_bridge` | resolution fails, naming the three types |
| `stripped_key` | **no error at all** — the lowering just vanishes |
| optional-node gate (review) | `holderTagOr(null, ..)` fails at runtime: "Operation on a closed native handle." |

That last row is the one worth keeping: it is the failure mode a compile check cannot see either, and the reason the fix is a keying change rather than a guard.

`Holder { tag, summary: Summary }` is the first declared data class with a **required handle** field, added for the review fix: taken as `Option<Holder>`, the absent case carries a placeholder that cannot be decoded, so it is the only shape that can tell the two decode orders apart. Every pre-existing fixture decodes its placeholders successfully, which is why CI stayed green over the bug.

JVM round trip in `Test.kt` (`PASS - 49 sections`), asserting the wrapped and unwrapped twins have identical surfaces and identical values. `WrappedFields` pins the #289 change directly: `boxed: Box<Option<i64>>` and `plain: Option<i64>` both cross as `Long?` on the decoupled pair, and only the first gets a `Box::new`.

`cargo test` and `--all --all-features` green; clippy `--deny warnings` clean (`large_enum_variant` fired mid-way — the fix was to carry wrapper *lists* rather than whole readings, which is smaller and says more precisely what a rebuild uses); fmt with the CI config clean.

**Regen after a forced clean**: against the merge base the generated bindings have **zero genuinely-removed lines** — the diff is insertions plus moves from sort-order shifts. `example_flat_aarch64.{rs,h}` did not drift. Per #289, an existing golden that moved would have been a found defect.

> **Correction.** This originally read "303 insertions, 0 deletions". That figure was the diff against the *previous commit on this branch*, not the merge base, so it reported only the second commit's delta. Measured properly the first push had **55 changed lines of existing output**, every one an optional-node gate — the regression the review caught. Fixed in `eb9df58`; the statement above is now true and was not before.

## Remaining

#230 (item 2, cbindgen's wire from `kind`) is now the only open item on #292.
