### PR TITLE
cbindgen: one kind presents one C type, however it is spelled (#292 item 2)

### DIFF
--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -77,6 +77,46 @@ classification stays small and genuinely neutral:
 > `Origin`'s syntax into `quote!` is spelling, and spelling the source is exactly
 > what generated Rust must do.
 
+#### What the split does *not* say: who decides the destination type
+
+"Classify off `kind`, spell off `syntax`" tells an adapter where to get each
+fact. It is silent on the question adapters actually face, which is what the
+**destination language** ends up seeing. The companion rule:
+
+> **Same `kind` ⇒ same destination-language type.** The *wire* is the
+> generator's to choose, and may differ per spelling.
+
+The weaker-sounding half is the important one. It is tempting to write "same
+`kind` ⇒ same wire", and that is **false** — prebindgen violates it deliberately:
+
+| Rust | `kind` | Kotlin type | wire |
+|---|---|---|---|
+| `&[Payload]` | `Sequence` | `List<Payload>` | `Long` — a jlong handle to a Rust-side `Vec` |
+| `Vec<Box<Payload>>` | `Sequence` | `List<Payload>` | `List<Payload>` — a `JObject` |
+
+Two wires, one surface. Choosing a wire is exactly the generator's job, and the
+destination-language wrapper absorbs the difference; a caller cannot tell. What
+a caller *can* tell — and what the model's erasure promises will not happen — is
+the **type** changing because the source spelled a `Box`.
+
+The rule scopes to **converted** positions, which is where a converter stands
+between the Rust value and the destination and is free to bridge. It cannot apply
+to a **layout mirror**: `Cbindgen`'s `repr_c_struct` crosses a struct zero-copy,
+so the C struct is reinterpreted from the source struct's bytes and its field
+types are a *layout* fact. There `Box<T>` (a pointer) genuinely is a different C
+type from `T` (inline), the spelling is load-bearing by construction, and no
+erasure can apply. A mirror reads `syntax` for the destination type on purpose —
+the one place the usual split inverts, and it inverts because the contract is
+layout rather than surface.
+
+Reusing a mirror's spelling test in a converted position is how the rule gets
+broken. A tagged-union payload is converted, and it used to take its
+opaque-pointer arm from the `Box` in the spelling: `Option<Box<Handle>>` crossed
+as `handle_t *` while `Option<Handle>` — the same optional handle to every
+destination — was **refused outright**. An erased wrapper decided whether the
+shape was expressible. It asks the declaration now, and the two spellings share
+one C type with different converter bodies.
+
 This is mechanically measured, and needed no new mechanism:
 `core::flat::boundary` (ported from
 [#224](https://github.com/milyin/prebindgen/pull/224)) counts *variant mentions*

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -70,6 +70,30 @@ impl CbindgenBuilder {
         Some(item.variants.iter().cloned().collect())
     }
 
+    /// The declared `opaque_ptr` under a union payload's spelling, when there is
+    /// one and the spelling does **not** already carry a `Box` —
+    /// `Option<Handle>` / `Handle` → `Some(Handle)`, `Option<Box<Handle>>` →
+    /// `None` (that shape keeps its own arm, so its emitted Rust does not move).
+    ///
+    /// Keyed on `stripped_key`, because a **declaration** is about the type: a
+    /// wrapper the model erases cannot change which declaration a payload
+    /// matches. See [`Self::payload_field_wire`] for why a union payload asks
+    /// this at all where a `repr_c_struct` mirror must not.
+    pub(super) fn declared_opaque_payload_inner(
+        &self,
+        fty: &syn::Type,
+        registry: &impl Conversions<()>,
+    ) -> Option<syn::Type> {
+        if opaque_ptr_payload_inner(fty).is_some() {
+            return None;
+        }
+        let reading = registry.reading_of(fty)?;
+        let core = reading.optional_inner().unwrap_or(&reading);
+        self.opaque
+            .contains_key(&core.stripped_key())
+            .then(|| core.stripped_syntax())
+    }
+
     /// Wire type of one **tagged-union payload field**: the
     /// [`Self::mirror_field_wire`] policy (scalar / declared `enum_type` /
     /// opaque pointer `Option<Box<T>>` / `Box<T>`) extended with `String` →
@@ -129,6 +153,34 @@ impl CbindgenBuilder {
         // opaque pointer), so what already worked keeps its exact wire.
         if let Some(w) = self.mirror_field_wire(fty) {
             return Ok(w);
+        }
+        // The opaque-pointer arm again, keyed on the **declaration** instead of
+        // on the spelling — which is what a *converted* position must do.
+        //
+        // `mirror_field_wire` above answers for a `repr_c_struct`, where the C
+        // type is a **layout** fact: the mirror is reinterpreted from the source
+        // struct's bytes, so `Box<T>` (a pointer) and `T` (inline) genuinely are
+        // different C types and the spelling is load-bearing. A union payload is
+        // not mirrored — it is rebuilt arm by arm through real conversions — so
+        // that reasoning does not carry over, and reusing the same
+        // `Box`-in-the-spelling test made an erased wrapper decide what C sees.
+        //
+        // Concretely: `Option<Box<Handle>>` crossed as `*mut handle_t` while
+        // `Option<Handle>` — the same optional handle to every destination
+        // language — was REFUSED, because it fell through to the
+        // converter-destination rule below where its output side is a structural
+        // marker (`()`) that cannot agree with the input's pointer. A wrapper the
+        // model erases decided whether the shape was expressible at all.
+        //
+        // So: peel the optional off the model and ask whether what is under it is
+        // a declared `opaque_ptr`. `stripped_key` rather than `key`, because a
+        // declaration is about the TYPE — see the same rule on the jnigen side
+        // (#292). The two spellings now share this C type; their converter bodies
+        // differ, which is exactly the split (`kind` decides what C sees, syntax
+        // decides how the value is built).
+        if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
+            let c = self.c_type_ident(&inner);
+            return Ok(syn::parse_quote!(*mut #c));
         }
         // Otherwise the payload's wire is its **resolved converter
         // destination** — the same source a `data_struct` field effectively

--- a/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
+++ b/prebindgen/src/api/lang/cbindgen/tests/tagged_unions.rs
@@ -758,3 +758,91 @@ fn bool_payload_is_normalised_not_materialised() {
     // A bool owns nothing, so the union still gets no typed drop.
     assert!(!compact.contains("flagged_drop"), "{src}");
 }
+
+/// **Same `kind` ⇒ same destination-language type.** Three spellings of one
+/// optional handle present one C type.
+///
+/// The rule the wire question actually obeys, and a correction to how #292
+/// stated it: "same `kind` ⇒ same wire" is false — a generator owns wire
+/// selection and may legitimately vary it per spelling, absorbing the
+/// difference in the destination-language wrapper (jnigen crosses `&[Payload]`
+/// as a `Long` Vec handle and `Vec<Box<Payload>>` as a `JObject`, both surfacing
+/// as `List<Payload>`). What must not vary is **what the destination sees**.
+///
+/// A union payload is the position where that bites in C, because it is
+/// *converted* — rebuilt arm by arm — so nothing about the Rust layout is
+/// forced on the C type. `Option<Box<Handle>>` took an opaque-pointer arm keyed
+/// on the `Box` in the spelling, while `Option<Handle>` fell through to the
+/// converter-destination rule and was **refused outright** (its output side is a
+/// structural marker whose `()` cannot agree with the input's pointer). So an
+/// erased wrapper decided whether the shape was expressible at all — the same
+/// defect shape as jnigen's declaration lookup in #292.
+///
+/// The exemption this does *not* touch is [`CbindgenBuilder::repr_c_struct`]: a
+/// zero-copy mirror is reinterpreted from the source struct's bytes, so its C
+/// type is a **layout** fact and `Box<T>` (a pointer) really is a different C
+/// type from `T` (inline). There the spelling is load-bearing by construction.
+#[test]
+fn one_kind_presents_one_c_type_however_it_is_spelled() {
+    let loc = SourceLocation::default();
+    let e: syn::ItemEnum = syn::parse_quote!(
+        pub enum Pick {
+            Boxed(Option<Box<Handle>>),
+            Bare(Option<Handle>),
+            Owned(Handle),
+        }
+    );
+    let h: syn::Item = syn::parse_quote!(
+        pub type Handle = __x::Handle;
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn pick_new() -> Pick {
+            unimplemented!()
+        }
+    );
+    let take: syn::ItemFn = syn::parse_quote!(
+        pub fn pick_take(p: Pick) {
+            unimplemented!()
+        }
+    );
+    let registry = crate::api::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Enum(e), loc.clone()),
+        (h, loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+        (syn::Item::Fn(take), loc.clone()),
+    ]))
+    .expect("index items");
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(example_flat))
+        .free_memory_function("example_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .tagged_union(syn::parse_quote!(Pick))
+        .function(syn::parse_quote!(pick_new))
+        .function(syn::parse_quote!(pick_take))
+        .panic();
+    let src = write(cbindgen, registry, "one_kind_one_c_type");
+    let compact: String = src.split_whitespace().collect();
+
+    // The claim: one C type for all three. Asserted on the whole mirror rather
+    // than per arm, so a change that made them agree on the WRONG type by
+    // collapsing the arms would still have to say so here.
+    assert!(
+        compact
+            .contains("pubenumpick_t{Boxed(*muthandle_t),Bare(*muthandle_t),Owned(*muthandle_t),}"),
+        "three spellings of one optional handle, one C type:\n{src}"
+    );
+
+    // …and the converter BODIES differ, which is the other half of the split:
+    // the C type follows `kind`, the conversion follows the syntax. The `Box`
+    // spelling hands its box over; the bare ones are boxed here.
+    assert!(
+        compact.contains("::std::boxed::Box::into_raw(__b)as*muthandle_t"),
+        "the `Box` spelling hands over the box it already has:\n{src}"
+    );
+    assert!(
+        compact.contains("::std::boxed::Box::into_raw(::std::boxed::Box::new(__v))as*muthandle_t"),
+        "a bare optional handle is boxed by the converter:\n{src}"
+    );
+}

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1324,6 +1324,36 @@ impl CbindgenBuilder {
             let conv = Self::in_name(fty);
             return quote!(#conv(#b)?);
         }
+        // The same opaque-pointer arm the wire took, for a spelling with no
+        // `Box` in it: the C caller still hands over a `*mut handle_t` it gave
+        // up ownership of, so the pointer is reclaimed the same way — the value
+        // is just moved out of the box instead of kept in one. Conversion
+        // follows the SYNTAX; the C type followed `kind` + the declaration.
+        if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
+            let src_inner = self.src_ty(&inner);
+            let owned = quote!(*::std::boxed::Box::from_raw(#b as *mut #src_inner));
+            let null_msg = format!(
+                "null payload for `{}` (a non-optional handle payload cannot be NULL — the \
+                 union may already have been dropped)",
+                type_short(&inner)
+            );
+            return if is_option(fty) {
+                quote!(if #b.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    ::core::option::Option::Some(#owned)
+                })
+            } else {
+                quote!({
+                    if #b.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_msg),
+                        );
+                    }
+                    #owned
+                })
+            };
+        }
         if let Some(inner) = opaque_ptr_payload_inner(fty) {
             let src_inner = self.src_ty(&inner);
             let boxed = quote!(::std::boxed::Box::from_raw(#b as *mut #src_inner));
@@ -1397,6 +1427,21 @@ impl CbindgenBuilder {
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
             let conv = Self::out_name(fty);
             return quote!(::core::mem::MaybeUninit::new(#conv(#b)));
+        }
+        // The peer of the input arm above: an owned value the C side must later
+        // release, so it is boxed HERE rather than having arrived boxed.
+        if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
+            let c = self.c_type_ident(&inner);
+            return if is_option(fty) {
+                quote!(match #b {
+                    ::core::option::Option::Some(__v) => {
+                        ::std::boxed::Box::into_raw(::std::boxed::Box::new(__v)) as *mut #c
+                    }
+                    ::core::option::Option::None => ::core::ptr::null_mut(),
+                })
+            } else {
+                quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(#b)) as *mut #c)
+            };
         }
         if let Some(inner) = opaque_ptr_payload_inner(fty) {
             let c = self.c_type_ident(&inner);


### PR DESCRIPTION
Item 2 of #292 — with the rule restated, because as written it was wrong.

## "same `kind` ⇒ same wire" is false

The wire is the generator's to choose. prebindgen already varies it deliberately:

| Rust | `kind` | Kotlin type | wire |
|---|---|---|---|
| `&[Payload]` | `Sequence` | `List<Payload>` | `Long` — a jlong handle to a Rust-side `Vec` |
| `Vec<Box<Payload>>` | `Sequence` | `List<Payload>` | `List<Payload>` — a `JObject` |

Two wires, one surface, on purpose: the vec-build path is a performance specialization the adapter declines for a wrapped element, and the Kotlin wrapper absorbs the difference. A caller cannot tell.

What a caller *can* tell — and what the erasure promises will not happen — is the **type** changing because the source spelled a `Box`. So:

> **Same `kind` ⇒ same destination-language type.** The wire is the generator's, and may differ per spelling.

## The scope qualifier, which is where #230 goes

The rule holds for **converted** positions. It cannot hold for a **layout mirror**: `repr_c_struct` crosses a struct zero-copy, so the C struct is reinterpreted from the source struct's bytes and its field types are a *layout* fact. `Box<T>` (a pointer) genuinely is a different C type from `T` (inline). The spelling is load-bearing by construction — the one place the usual split inverts, and it inverts because the contract is layout rather than surface.

**That is #230's headline example.** `Payload` is declared `.repr_c_struct(Payload)`, so `label: Option<Box<String>>` → `string_t *` because a nullable `Box` *is* a nullable pointer. Not a defect. #230's cited evidence is entirely the mirror path.

## What was actually broken

One position, found by taking the corrected rule seriously: a **tagged-union payload** is converted, not mirrored, but reused the mirror's `Box`-in-the-spelling test.

- `Option<Box<Handle>>` → `handle_t *`
- `Option<Handle>` → **refused outright**, falling through to a converter-agreement check whose structural output marker (`()`) can never match the input's pointer

So an erased wrapper decided whether the shape was **expressible at all** — the same defect shape #292's jnigen half found in the declaration lookup, in the opposite direction.

The arm asks the declaration now, off the model. All three spellings present one C type:

```rust
pub enum pick_t { Boxed(*mut handle_t), Bare(*mut handle_t), Owned(*mut handle_t), }
```

…and their converter **bodies** differ — the boxed one hands over the box it already has, the others are boxed by the converter. The C type follows `kind`; the conversion follows the syntax. Both halves are asserted, so a change that made them agree by collapsing the arms would still have to say so.

## Verification

- `one_kind_presents_one_c_type_however_it_is_spelled` (`cbindgen/tests/tagged_unions.rs`) — the three-spelling mirror plus both converter bodies.
- `cargo test --all --all-features` green; clippy `--deny warnings` clean; fmt clean.
- **Regen after a forced clean: byte-identical against the merge base.** This is a pure addition — previously-refused shapes now resolve, and nothing that worked changes route, because `mirror_field_wire` is still consulted first.

## Docs

`docs/language-integration.md` gains *"What the split does not say: who decides the destination type"* under **The rule**. "Classify off `kind`, spell off `syntax`" tells an adapter where to get each fact and is silent on what the destination ends up seeing, which is the question adapters actually face.

## #230

Should be closed as largely miscategorised — its example is a layout mirror behaving correctly. The one real instance it pointed at is fixed here. Its other question, "should `Box` stay in the source language at all?", answers itself: yes, for `repr_c_struct`, where it is how a source crate states a field is a nullable pointer. That is a layout statement a zero-copy mirror is entitled to read, not the source naming a C type.