### PR TITLE
jnigen: the wrapped-Vec-element refusal is reserved, not definitive

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -84,11 +84,18 @@ pub(crate) fn vec_build_elem(
     // **Kotlin class** (`Payload` → `payloadVec`), which the two share, so both
     // would emit `payloadVecNew`/`Push`/`Free` and collide.
     //
-    // Definitive as long as the name comes from the Kotlin class: the
-    // alternative is spelling a Rust wrapper into a JNI symbol, which is the
-    // representation leak this whole layer exists to prevent. The general
-    // converter serves the shape correctly (see `input_transparent_bridge`),
-    // just without the per-element push loop.
+    // **Reserved, not definitive** (#296). The collision is real; the choice it
+    // seems to force is not. Keying the trio on the CANONICAL element gives one
+    // trio per Kotlin class — storage `Vec<Payload>` — with the element's
+    // wrapper applied where the Vec is consumed
+    // (`.into_iter().map(Box::new).collect()`), so no Rust wrapper reaches a JNI
+    // symbol and nothing collides.
+    //
+    // The cost of not doing it is not correctness: the general converter serves
+    // the shape (see `input_transparent_bridge`). It is that a `Box` the model
+    // erases silently downgrades the crossing from raw scalar leaves to a
+    // per-element `JObject` plus a field read per field — which is exactly what
+    // this path exists to remove.
     if !elem.erased_wrappers().is_empty() {
         return None;
     }


### PR DESCRIPTION
Comment-only. #294 justified declining a wrapped `Vec` element as definitive, on the grounds that the only alternative was spelling a Rust wrapper into a JNI symbol. That is a false dichotomy — keying the helper trio on the canonical element removes the collision without any wrapper reaching a symbol, and #296 has the sketch.

Per the reserved-vs-definitive rule, a refusal has to say which it is and name the issue. This corrects it and states the real cost: not incorrectness, but a silent downgrade from raw scalar leaves to a per-element `JObject` plus a field read per field.

No code change.