### PR TITLE
core: the edge walk takes the key it was re-deriving anyway (#291 stage A)

### DIFF
--- a/prebindgen/src/api/core/registry/order.rs
+++ b/prebindgen/src/api/core/registry/order.rs
@@ -60,15 +60,23 @@ impl<M> Registry<M> {
             return;
         }
         let (dir, key) = node.clone();
-        let ty = key.to_type();
+        // Every node this walk reaches has a cell: the roots are the table's own
+        // keys, and each edge below is filtered by `contains_key`. So the
+        // spelling `plan_edges` needs is the reading the registry already
+        // stored — not one re-derived from the key (#291).
+        let plan_edges = self
+            .type_table(dir)
+            .get(&key)
+            .map(|cell| self.plan_edges(dir, cell.subject.syntax()))
+            .unwrap_or_default();
         let mut edges: Vec<Crossing> = self
-            .immediate_edges(dir, &ty)
+            .immediate_edges(dir, &key)
             .into_iter()
             // The structural edges arrive as readings, so the key is the
             // model's own answer rather than one re-derived from a spelling.
             .map(|(d, t)| (d, t.key()))
             .chain(
-                self.plan_edges(dir, &ty)
+                plan_edges
                     .into_iter()
                     .map(|(d, t)| (d, TypeKey::from_type(&t))),
             )

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -233,13 +233,13 @@ impl<M> Registry<M> {
         visited: &mut HashSet<TypeKey>,
     ) {
         let key = reading.key();
-        if !visited.insert(key) {
+        if !visited.insert(key.clone()) {
             return; // cycle guard
         }
 
         self.ensure_entry(dir, reading, is_top);
 
-        for (child_dir, sub) in self.immediate_edges(dir, reading.syntax()) {
+        for (child_dir, sub) in self.immediate_edges(dir, &key) {
             self.register_type_inner(child_dir, &sub, false, visited);
         }
     }
@@ -363,14 +363,20 @@ impl<M> Registry<M> {
         Ok(())
     }
 
-    /// Enumerate the immediate type-graph edges out of `(dir, ty)`: the model's
-    /// own children of this type, plus — if `ty` names a declared struct or sum —
+    /// Enumerate the immediate type-graph edges out of `(dir, key)`: the model's
+    /// own children of this type, plus — if `key` names a declared struct or sum —
     /// the field types of that item.
     ///
     /// A callback's argument types flow with `dir.flip()`, because an argument the
     /// binding *hands to* a callback crosses the other way; everything else
     /// inherits `dir`. Used by both `register_type_inner` (during scan) and the
     /// unresolved-descendants BFS in `resolve` (for diagnostics).
+    ///
+    /// **Takes the key, because a key is all it ever used.** This asked for a
+    /// `&syn::Type` and opened by re-keying it, so every caller spelled a key into
+    /// tokens purely so this could undo that — a normalize pass and a token render
+    /// per call, to arrive back where it started. What the walk needs is a table
+    /// lookup, and a table lookup takes an identity (#291).
     ///
     /// The children come from [`TypeKind`], not from taking the syntax apart, and
     /// the difference is load-bearing rather than cosmetic. `&mut MaybeUninit<T>`
@@ -388,16 +394,12 @@ impl<M> Registry<M> {
     pub(crate) fn immediate_edges(
         &self,
         dir: Direction,
-        ty: &syn::Type,
+        key: &TypeKey,
     ) -> Vec<(Direction, crate::api::core::flat::TypeRef)> {
         use crate::api::core::flat::TypeKind;
 
         let mut out: Vec<(Direction, crate::api::core::flat::TypeRef)> = Vec::new();
-        if let Some(reading) = self
-            .type_table(dir)
-            .get(&TypeKey::from_type(ty))
-            .map(|c| &c.subject)
-        {
+        if let Some(reading) = self.type_table(dir).get(key).map(|c| &c.subject) {
             let (children, child_dir): (Vec<&crate::api::core::flat::TypeRef>, Direction) =
                 match reading.kind() {
                     TypeKind::Optional(t)
@@ -436,7 +438,7 @@ impl<M> Registry<M> {
         // have answered `None` and dead-ended the walk.
         if let Some(name) = self
             .type_table(dir)
-            .get(&TypeKey::from_type(ty))
+            .get(key)
             .and_then(|c| match c.subject.kind() {
                 TypeKind::Named { id } => Some(id.name.clone()),
                 _ => None,

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -42,7 +42,9 @@ impl DeclareAndResolve<()> for RegistryBuilder<()> {
             .stub()
             .declare_into_any(self)?
             .validate_with(&ext)?
-            .convert_with(|crossing, _built| ext.converter(&crossing.1.to_type()))?
+            // The reading, not a spelling re-derived from the key: this is the
+            // route a real generator takes, so the stub takes it too (#291).
+            .convert_with(|crossing, built| ext.converter(built.reading(&crossing.1)?.syntax()))?
             .build()?;
         ext.validate_resolved(&registry)
             .map_err(|message| ScanError::AdapterInvariant { message })?;
@@ -1721,19 +1723,19 @@ fn a_recursive_type_is_handed_out_once_and_terminates() {
     // fixture property this test needs.
     let node = TypeKey::parse("Node").expect("test type");
     let mut seen_keys: Set<TypeKey> = Set::new();
-    let mut frontier = vec![node.to_type()];
+    let mut frontier = vec![node];
     let mut revisited = false;
     for _ in 0..8 {
         let mut next = Vec::new();
-        for t in frontier {
-            if !seen_keys.insert(TypeKey::from_type(&t)) {
+        for k in frontier {
+            if !seen_keys.insert(k.clone()) {
                 revisited = true;
                 break;
             }
             next.extend(
-                reg.immediate_edges(Direction::Output, &t)
+                reg.immediate_edges(Direction::Output, &k)
                     .into_iter()
-                    .map(|(_, sub)| sub.syntax().clone()),
+                    .map(|(_, sub)| sub.key()),
             );
         }
         if revisited {

--- a/prebindgen/src/api/core/resolve.rs
+++ b/prebindgen/src/api/core/resolve.rs
@@ -130,8 +130,7 @@ fn collect_unresolved_descendants<M>(
          key: &TypeKey,
          queue: &mut VecDeque<(Direction, TypeKey)>,
          seen: &mut std::collections::HashSet<(Direction, TypeKey)>| {
-            let ty = key.to_type();
-            for (child_dir, sub) in registry.immediate_edges(dir, &ty) {
+            for (child_dir, sub) in registry.immediate_edges(dir, key) {
                 let dep = (child_dir, sub.key());
                 if seen.insert(dep.clone()) {
                     queue.push_back(dep);

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -29,11 +29,11 @@ impl CbindgenBuilder {
         // A tagged union with a `String` payload hands out a `char*` per active
         // arm — allocated by its output converter, released by its typed drop.
         if self.tagged_unions.keys().any(|key| {
-            let ty = key.to_type();
-            registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.output_entry(&tr))
-                .is_some()
+            let Some(reading) = registry.reading(key) else {
+                return false;
+            };
+            let ty = reading.syntax().clone();
+            registry.output_entry(&reading).is_some()
                 && self
                     .enum_variants(registry, &ty)
                     .map(|vs| {
@@ -46,11 +46,11 @@ impl CbindgenBuilder {
             return true;
         }
         self.data.keys().any(|key| {
-            let ty = key.to_type();
-            registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.output_entry(&tr))
-                .is_some()
+            let Some(reading) = registry.reading(key) else {
+                return false;
+            };
+            let ty = reading.syntax().clone();
+            registry.output_entry(&reading).is_some()
                 && self
                     .struct_fields(registry, &ty)
                     .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -532,18 +532,16 @@ impl CbindgenBuilder {
     fn prereq_opaque_handles(&self, registry: &Registry<()>) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.opaque) {
-            let ty = key.to_type();
-            if registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .is_none()
-                && registry
-                    .reading_of(&ty)
-                    .and_then(|tr| registry.output_entry(&tr))
-                    .is_none()
+            // Keyed directly: this used to spell the key into tokens purely so
+            // `reading_of` could re-key them, twice (#291).
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
             {
                 continue;
             }
+            let ty = reading.syntax().clone();
             let c_struct = self.c_type_ident(&ty);
             // Opaque/incomplete C type: the handle is `#c_struct *`, which IS the
             // `Box::into_raw` pointer to the source value.
@@ -575,18 +573,14 @@ impl CbindgenBuilder {
     fn prereq_data_structs(&self, registry: &Registry<()>) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.data) {
-            let ty = key.to_type();
-            if registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .is_none()
-                && registry
-                    .reading_of(&ty)
-                    .and_then(|tr| registry.output_entry(&tr))
-                    .is_none()
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
             {
                 continue;
             }
+            let ty = reading.syntax().clone();
             let Some(fields) = self.struct_fields(registry, &ty) else {
                 continue;
             };
@@ -625,18 +619,14 @@ impl CbindgenBuilder {
         let mut vo: Vec<(&TypeKey, &ValueOpaqueCfg)> = self.value_opaque.iter().collect();
         vo.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
         for (key, cfg) in vo {
-            let ty = key.to_type();
-            if registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .is_none()
-                && registry
-                    .reading_of(&ty)
-                    .and_then(|tr| registry.output_entry(&tr))
-                    .is_none()
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
             {
                 continue;
             }
+            let ty = reading.syntax().clone();
             let src = self.src_ty(&ty);
             let opaque = &cfg.opaque;
             // `repr_c_struct`: the opaque counterpart is an auto-generated
@@ -830,18 +820,14 @@ impl CbindgenBuilder {
     fn prereq_enums(&self, registry: &Registry<()>) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.enums) {
-            let ty = key.to_type();
-            if registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .is_none()
-                && registry
-                    .reading_of(&ty)
-                    .and_then(|tr| registry.output_entry(&tr))
-                    .is_none()
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
             {
                 continue;
             }
+            let ty = reading.syntax().clone();
             let Some(e) = enum_item(registry, &ty) else {
                 continue;
             };
@@ -880,18 +866,14 @@ impl CbindgenBuilder {
     fn prereq_tagged_unions(&self, registry: &Registry<()>) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.tagged_unions) {
-            let ty = key.to_type();
-            if registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
-                .is_none()
-                && registry
-                    .reading_of(&ty)
-                    .and_then(|tr| registry.output_entry(&tr))
-                    .is_none()
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
             {
                 continue;
             }
+            let ty = reading.syntax().clone();
             let Some(e) = enum_item(registry, &ty) else {
                 continue;
             };
@@ -1620,7 +1602,13 @@ impl CbindgenBuilder {
         built: &Building<'_, ()>,
     ) -> Option<ConverterImpl<()>> {
         let (dir, key) = crossing;
-        let ty = key.to_type();
+        // The reading the scan already took for this crossing, fetched by the
+        // key the crossing IS — the same migration the jnigen twin made in #284,
+        // in place of `key -> to_type() -> spelling` (#291). Every crossing
+        // `convert_with` hands out comes from a type table, so it has a cell.
+        // The selectors still take the spelling: moving cbindgen's selector
+        // chain onto readings is its own change.
+        let ty = built.reading(key)?.syntax().clone();
         match dir {
             Direction::Input => self.select_input_type(&ty, built).or_else(|| {
                 let args = crate::api::core::flat::extract_fn_trait_args(&ty)?;

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -570,19 +570,16 @@ pub(crate) fn build_handle_destructor_items(
             continue;
         }
         // Skip handles the (feature-aware) scan never references — their
-        // type may not be in scope in the generated module.
-        let ty = key.to_type();
-        if registry
-            .reading_of(&ty)
-            .and_then(|tr| registry.input_entry(&tr))
-            .is_none()
-            && registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.output_entry(&tr))
-                .is_none()
-        {
+        // type may not be in scope in the generated module. Keyed directly:
+        // this used to spell the key into tokens purely so `reading_of` could
+        // re-key them, twice (#291).
+        let Some(reading) = registry.reading(key) else {
+            continue;
+        };
+        if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none() {
             continue;
         }
+        let ty = reading.syntax().clone();
         let class_fqn = cfg
             .name_spec
             .as_ref()


### PR DESCRIPTION
First of four steps on #291, following that issue's own sequencing: category A alone, which shrinks code and proves the `reading(key)` route **before** anything is removed.

## What

`Registry::immediate_edges` asked for a `&syn::Type` and opened by re-keying it — twice, once for the structural children and once for the declared fields. Its `&syn::Type` parameter was used for nothing else. So `resolve.rs`, `order.rs` and `register_type_inner` each spelled a key into tokens purely so the callee could undo that.

```rust
pub(crate) fn immediate_edges(
    &self,
    dir: Direction,
    key: &TypeKey,
) -> Vec<(Direction, TypeRef)>
```

The same round trip, one layer out, ran wherever `key.to_type()` was fed straight to `reading_of` — which is literally `reading(&TypeKey::from_type(..))`. Those become `reading(key)`, the route #284 already moved jnigen's `convert_crossing` to; any spelling they still need comes off the reading.

44 `to_type()` call sites → 31. `TypeKey` itself is untouched — nothing is deleted until stage D.

## Two sites deliberately keep a spelling

Both now read it from the cell the registry already holds, so neither re-derives anything from a key:

- `order.rs`'s `plan_edges` needs real tokens for `extract_fn_trait_args`. Every node `visit_crossing` reaches has a cell (roots are the table's own keys; edges are filtered by `contains_key`), so the reading is always there.
- cbindgen's `convert_crossing` selector chain still takes `&syn::Type`. Moving it onto readings the way jnigen's went is its own change.

## Behaviour

`resolve.rs`'s `enqueue_edges_from` is deliberately called on keys with **no** cell. Keying rather than reading preserves that exactly — `immediate_edges` returns `Vec::new()` on a missing cell either way. This is why stage A keys the walk instead of switching those two sites to `reading()`.

## Verified

- `cargo test --all --all-features` — 631 lib tests, all green
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical**, after `cargo clean --release` on every example crate so the rebuild was real
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections

`regen-check.sh --with-zenoh-flat-jni` could not run: that sibling checkout is pinned to an older public API (`JniGen::new` no longer exists, plus argument-count drift) and does not build against `language-integration`. Pre-existing and unrelated — this PR changes no public surface.