### PR TITLE
A declaration keeps the type it was written with (#291 stage B)

### DIFF
--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -139,8 +139,18 @@ impl<M> RegistryBuilder<M> {
 
     /// A type this binding **exports**: it crosses in both directions, and its
     /// body — a struct's fields, an enum's payloads — is scanned too.
-    pub fn export_type(mut self, key: TypeKey) -> Self {
-        self.registry.declared.types.insert(key);
+    ///
+    /// Takes the **type the declaration was written with**, like its sibling
+    /// [`Self::cross`], and derives the key here. It used to take the key alone,
+    /// which meant the scan had to recover tokens *from* the key to intern the
+    /// type and to diagnose its spelling — reasoning backwards from an identity
+    /// to a thing that already existed. A build script wrote `ptr_class!(Foo)`;
+    /// this is that `Foo` (#291).
+    pub fn export_type(mut self, ty: Origin<syn::Type>) -> Self {
+        self.registry
+            .declared
+            .types
+            .insert(TypeKey::from_type(&ty.syntax), ty);
         self
     }
 

--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -146,11 +146,19 @@ impl<M> RegistryBuilder<M> {
     /// type and to diagnose its spelling — reasoning backwards from an identity
     /// to a thing that already existed. A build script wrote `ptr_class!(Foo)`;
     /// this is that `Foo` (#291).
+    ///
+    /// Declaring the same type twice keeps the **first** spelling. That is what
+    /// the `HashSet` this replaced did with the identity, and what
+    /// `register_class` does with a reopened declarator: the two spellings agree
+    /// on identity by construction, so the tie-break only decides which
+    /// equivalent rendering the scan reads, and it should not depend on
+    /// declaration order.
     pub fn export_type(mut self, ty: Origin<syn::Type>) -> Self {
         self.registry
             .declared
             .types
-            .insert(TypeKey::from_type(&ty.syntax), ty);
+            .entry(TypeKey::from_type(&ty.syntax))
+            .or_insert(ty);
         self
     }
 

--- a/prebindgen/src/api/core/registry/mod.rs
+++ b/prebindgen/src/api/core/registry/mod.rs
@@ -161,6 +161,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     api::core::{
+        flat::Origin,
         niches::Niches,
         prebindgen::{Prebindgen, Stage},
         types_util::bare_path_ident,
@@ -306,7 +307,16 @@ pub(crate) struct Declared {
     pub(crate) helper_functions: HashSet<syn::Ident>,
     pub(crate) accessors: HashSet<syn::Ident>,
     pub(crate) method_receivers: HashMap<syn::Ident, TypeKey>,
-    pub(crate) types: HashSet<TypeKey>,
+    /// Exported types, each **with the spelling its declaration was written
+    /// with**.
+    ///
+    /// Keyed by identity, because that is what a declaration is looked up by —
+    /// and carrying the `syn::Type` anyway, because the scan needs real tokens
+    /// for these: to `intern` a type that is not yet in any table, and to say
+    /// whether the build script path-qualified it. Recovering those *from the
+    /// key* was the wrong direction — a build script wrote a `syn::Type`, and
+    /// the declaration simply discarded it (#291).
+    pub(crate) types: HashMap<TypeKey, Origin<syn::Type>>,
     /// Consts to scan and emit, or `None` when the adapter has no const
     /// declaration mechanism — then every captured const is re-emitted
     /// verbatim (see the const gate in [`crate::api::core::write`]).
@@ -358,7 +368,11 @@ pub struct Decompositions {
     /// crosses only in pieces *because* something decomposes it, and once the
     /// plans are applied its own direct converter is genuinely not needed — for
     /// a type with no destination representation, not even resolvable.
-    pub replaces: HashSet<TypeKey>,
+    ///
+    /// Carries each declaration's own spelling for the same reason
+    /// [`Declared::types`] does — these are build-script-authored types the scan
+    /// diagnoses before anything has classified them.
+    pub replaces: HashMap<TypeKey, Origin<syn::Type>>,
 }
 
 #[cfg(test)]

--- a/prebindgen/src/api/core/registry/run.rs
+++ b/prebindgen/src/api/core/registry/run.rs
@@ -58,7 +58,7 @@ impl<M> Registry<M> {
         // unresolvable, since such a type has no destination representation.
         // Drop it both ways; the cell stays, so a converter is still produced
         // if one happens to resolve.
-        for key in &declared.decompositions.replaces {
+        for key in declared.decompositions.replaces.keys() {
             // The key is what a root flag is stored under, so it goes straight
             // in — no `to_type()` round trip to be re-keyed on the far side.
             self.clear_root(Direction::Input, key);

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -22,16 +22,23 @@ impl<M> Registry<M> {
         // shadows a captured item's name — the likely-mistake heuristic).
         //
         // The two syntax matches below **stay** as this file's boundary-ledger
-        // entries, and the reason is what they look at: `declared.types` are keys a
+        // entries, and the reason is what they look at: `declared.types` are types a
         // *build script author* wrote, and this is a diagnostic about the spelling
         // they wrote — is it path-qualified, and does its tail shadow a captured
         // item? No source type is being classified, so there is no element to read
         // instead; asking the model would answer about a type rather than about the
         // declaration. This is the "legitimately the adapter's business" case the
         // integration map (L2, #229) predicts, not a migration still owed.
+        //
+        // It reads the **declaration's own** spelling, canonicalized here. Both
+        // halves of that matter. Normalizing is what the paragraph above relies
+        // on — `crate::Foo` must not read as a qualified path — and it used to
+        // arrive for free because the tokens came out of the key, which is
+        // normalized by construction. Doing it explicitly costs one call and
+        // stops the key from being the source of tokens at all (#291).
         let mut qualified: Vec<(String, String)> = Vec::new();
         let mut probed: HashSet<&TypeKey> = HashSet::new();
-        for key in declared
+        for (key, declared_ty) in declared
             .types
             .iter()
             .chain(declared.decompositions.replaces.iter())
@@ -39,7 +46,7 @@ impl<M> Registry<M> {
             if !probed.insert(key) {
                 continue;
             }
-            let ty = key.to_type();
+            let ty = crate::api::core::flat::canonical_type(&declared_ty.syntax);
             // Peel one reference level; the qualified head only appears on
             // path types.
             let inner = match &ty {
@@ -119,9 +126,15 @@ impl<M> Registry<M> {
             self.intern(*dir, ty, true)?;
         }
 
-        // Scan declared types.
-        for key in &declared.types {
-            let ty = key.to_type();
+        // Scan declared types. The spelling is the declaration's own — `intern`
+        // needs real tokens for a type that is in no table yet, which is exactly
+        // the case a key cannot answer once it is only an identity (#291).
+        for declared_ty in declared.types.values() {
+            // Canonicalized for the same reason the diagnostic above is: this
+            // is the form the type used to arrive in, and interning the
+            // as-written spelling instead would put a differently-spelled
+            // reading in the cell for the same key.
+            let ty = crate::api::core::flat::canonical_type(&declared_ty.syntax);
             let mut matched = false;
             if let Some(ident) = bare_path_ident(&ty) {
                 if let Some(s) = self
@@ -469,18 +482,24 @@ impl<M> Registry<M> {
     /// key is held to the same grammar. A test that wants the whole scan builds its
     /// registry from items instead; this is for the ones that need a specific table
     /// shape and nothing else.
+    /// Takes the **spelling**, like every other door into the table: interning
+    /// needs real tokens, and a fixture has them — it wrote them (#291).
     #[cfg(test)]
     pub(crate) fn insert_crossing(
         &mut self,
         dir: Direction,
-        key: &TypeKey,
+        ty: &syn::Type,
         root: bool,
         entry: Option<TypeEntry<M>>,
     ) {
-        self.intern(dir, &key.to_type(), root)
-            .unwrap_or_else(|e| panic!("fixture key `{key}` is not expressible: {e}"));
+        self.intern(dir, ty, root).unwrap_or_else(|e| {
+            panic!(
+                "fixture type `{}` is not expressible: {e}",
+                ty.to_token_stream()
+            )
+        });
         self.type_table_mut(dir)
-            .get_mut(key)
+            .get_mut(&TypeKey::from_type(ty))
             .expect("just registered")
             .entry = entry;
     }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -60,7 +60,9 @@ struct StubExt {
     functions: HashSet<syn::Ident>,
     helper_functions: HashSet<syn::Ident>,
     consts: Option<HashSet<syn::Ident>>,
-    types: HashSet<TypeKey>,
+    /// Declared with the spelling a build script would write, which is what
+    /// `export_type` takes (#291).
+    types: Vec<syn::Type>,
     local_fns: Vec<(syn::ItemFn, String)>,
 }
 
@@ -86,8 +88,8 @@ impl StubExt {
                 reg = reg.export_const(i);
             }
         }
-        for k in &self.types {
-            reg = reg.export_type(k.clone());
+        for t in &self.types {
+            reg = reg.export_type(crate::api::test_util::declared_origin(t.clone()));
         }
         Ok(reg)
     }
@@ -507,8 +509,7 @@ fn qualified_signature_matches_bare_declaration() {
     let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("get").unwrap());
-    ext.types
-        .insert(TypeKey::parse("Thing").expect("test type"));
+    ext.types.push(syn::parse_str("Thing").expect("test type"));
     let reg = ext
         .declare_into_any(reg)
         .expect("declare")
@@ -541,10 +542,8 @@ fn multi_source_rename_cross_reference_normalizes() {
     let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("use_a").unwrap());
-    ext.types
-        .insert(TypeKey::parse("TypeA").expect("test type"));
-    ext.types
-        .insert(TypeKey::parse("TypeB").expect("test type"));
+    ext.types.push(syn::parse_str("TypeA").expect("test type"));
+    ext.types.push(syn::parse_str("TypeB").expect("test type"));
     let reg = ext
         .declare_into_any(reg)
         .expect("declare")
@@ -564,7 +563,7 @@ fn qualified_declared_type_is_hard_error() {
     let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.types
-        .insert(TypeKey::parse("myflat::Thing").expect("test type"));
+        .push(syn::parse_str("myflat::Thing").expect("test type"));
     match ext.declare_into_any(reg).expect("declare").scanned() {
         Err(ScanError::QualifiedDeclaredTypes { entries }) => {
             assert_eq!(entries.len(), 1);
@@ -586,8 +585,9 @@ fn foreign_qualified_declared_type_stays_supported() {
     let items = vec![fn_item("fn touch(x: u64) -> u64 { x }")];
     let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
-    let foreign = TypeKey::parse("zenoh::KeyExpr<'static>").expect("test type");
-    ext.types.insert(foreign.clone());
+    let foreign_ty: syn::Type = syn::parse_str("zenoh::KeyExpr<'static>").expect("test type");
+    let foreign = TypeKey::from_type(&foreign_ty);
+    ext.types.push(foreign_ty);
     let reg = ext
         .declare_into_any(reg)
         .expect("declare")
@@ -865,7 +865,7 @@ fn a_composed_reading_reaches_the_cell_unchanged() {
     let reg: RegistryBuilder<()> = crate::api::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
-    ext.types.insert(TypeKey::parse("Thing").unwrap());
+    ext.types.push(syn::parse_str("Thing").unwrap());
     let mut reg = ext
         .declare_into_any(reg)
         .expect("declare")
@@ -959,7 +959,7 @@ fn an_adapter_authored_type_cell_is_classified_but_placeless() {
 
     let mut ext = StubExt::default();
     ext.types
-        .insert(TypeKey::parse("Foreign").expect("test type"));
+        .push(syn::parse_str("Foreign").expect("test type"));
     let reg = ext
         .declare_into_any(reg)
         .expect("declare")
@@ -1408,7 +1408,7 @@ fn a_qualified_alias_warns_rather_than_failing() {
     let mut ext = StubExt::default();
     // Head is NOT a source module, so this is the warn branch.
     ext.types
-        .insert(TypeKey::parse("foreign::Handle").expect("test type"));
+        .push(syn::parse_str("foreign::Handle").expect("test type"));
     ext.declare_into_any(reg)
         .expect("declare")
         .scanned()
@@ -1596,7 +1596,7 @@ fn a_declared_crossing_the_grammar_refuses_is_not_called_a_prebindgen_item() {
 
     let mut ext = StubExt::default();
     ext.types
-        .insert(TypeKey::parse("*const u8").expect("a key can hold it; the language cannot"));
+        .push(syn::parse_str("*const u8").expect("a key can hold it; the language cannot"));
 
     let err = ext
         .declare_into_any(reg)
@@ -1686,7 +1686,7 @@ fn a_recursive_type_is_handed_out_once_and_terminates() {
     ]);
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("walk").unwrap());
-    ext.types.insert(TypeKey::parse("Node").expect("test type"));
+    ext.types.push(syn::parse_str("Node").expect("test type"));
     let reg = ext
         .declare_into_any(reg)
         .expect("declare")

--- a/prebindgen/src/api/core/resolve/tests.rs
+++ b/prebindgen/src/api/core/resolve/tests.rs
@@ -51,7 +51,7 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
 /// that the resolved converter doesn't actually depend on.
 #[test]
 fn final_invariant_stops_at_resolved_nodes() {
-    use crate::api::core::registry::{Direction, Registry, TypeEntry, TypeKey};
+    use crate::api::core::registry::{Direction, Registry, TypeEntry};
 
     // Through the real scan, so the state under test is one the pipeline can
     // actually produce: `Unrelated` is a field type nothing declares.
@@ -62,15 +62,15 @@ fn final_invariant_stops_at_resolved_nodes() {
 
     // `Outer` required & unresolved; `Inner` RESOLVED (with a dummy
     // entry); `Unrelated` unresolved but only reachable through Inner.
-    let outer_key = TypeKey::parse("Outer").expect("test type");
-    let inner_key = TypeKey::parse("Inner").expect("test type");
-    let unrelated_key = TypeKey::parse("Unrelated").expect("test type");
+    let outer_ty: syn::Type = syn::parse_quote!(Outer);
+    let inner_ty: syn::Type = syn::parse_quote!(Inner);
+    let unrelated_ty: syn::Type = syn::parse_quote!(Unrelated);
 
-    reg.insert_crossing(Direction::Input, &outer_key, true, None);
+    reg.insert_crossing(Direction::Input, &outer_ty, true, None);
 
     reg.insert_crossing(
         Direction::Input,
-        &inner_key,
+        &inner_ty,
         false,
         Some(TypeEntry {
             destination: syn::parse_quote!(i64),
@@ -84,7 +84,7 @@ fn final_invariant_stops_at_resolved_nodes() {
         }),
     );
 
-    reg.insert_crossing(Direction::Input, &unrelated_key, false, None);
+    reg.insert_crossing(Direction::Input, &unrelated_ty, false, None);
 
     let err = check_complete(&reg).expect_err("must surface Outer");
     let ResolveError::Unresolved { entries } = err;
@@ -113,8 +113,8 @@ fn a_type_reachable_only_through_subs_must_still_resolve() {
     use crate::api::core::registry::{Registry, TypeKey};
 
     let mut reg: Registry<()> = Registry::empty();
-    let outer = TypeKey::parse("Outer").expect("test type");
-    let mid = TypeKey::parse("Mid").expect("test type");
+    let outer: syn::Type = syn::parse_quote!(Outer);
+    let mid: syn::Type = syn::parse_quote!(Mid);
 
     // `Outer` is a root AND resolved — so it is not itself reportable — but its
     // converter delegates to `Mid`.
@@ -128,7 +128,7 @@ fn a_type_reachable_only_through_subs_must_still_resolve() {
                 fn __outer() {}
             ),
             pre_stages: vec![],
-            subs: vec![mid.clone()],
+            subs: vec![TypeKey::from_type(&mid)],
             niches: crate::api::core::niches::Niches::empty(),
             metadata: (),
         }),

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -97,7 +97,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
             _ => None,
         }))
         .into_iter()
-        .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
+        .filter(|(ident, _)| declared_types.contains_key(&TypeKey::from_ident(ident)))
         .map(|(_, item)| ext.on_struct(item, registry)),
     )?);
     // Both enum shapes emit through `on_enum` and sort together: they were one
@@ -113,7 +113,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
             _ => None,
         }))
         .into_iter()
-        .filter(|(ident, _)| declared_types.contains(&TypeKey::from_ident(ident)))
+        .filter(|(ident, _)| declared_types.contains_key(&TypeKey::from_ident(ident)))
         .map(|(_, t)| match t {
             crate::api::core::flat::Type::Variant(v) => ext.on_variant(v, registry),
             crate::api::core::flat::Type::Enum(e) => ext.on_enum(e, registry),

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -64,14 +64,14 @@ impl Prebindgen for IdentityExt {
 #[test]
 fn dedup_and_sort() {
     let mut reg: Registry<()> = Registry::empty();
-    let key_a: syn::Type = syn::parse_quote!(u64);
-    let key_b: syn::Type = syn::parse_quote!(Sample);
+    let ty_a: syn::Type = syn::parse_quote!(u64);
+    let ty_b: syn::Type = syn::parse_quote!(Sample);
     let wire: syn::Type = syn::parse_quote!(i64);
     let wire2: syn::Type = syn::parse_quote!(*const u8);
 
     reg.insert_crossing(
         Direction::Input,
-        &key_a,
+        &ty_a,
         true,
         Some(TypeEntry {
             destination: wire.clone(),
@@ -88,7 +88,7 @@ fn dedup_and_sort() {
     );
     reg.insert_crossing(
         Direction::Input,
-        &key_b,
+        &ty_b,
         true,
         Some(TypeEntry {
             destination: wire2.clone(),

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -17,7 +17,9 @@ impl IdentityExt {
             reg = reg.export(&f);
         }
         for t in ["AEnum", "AStruct", "BEnum", "BStruct"] {
-            reg = reg.export_type(TypeKey::parse(t).expect("test type"));
+            reg = reg.export_type(crate::api::test_util::declared_origin(
+                syn::parse_str(t).expect("test type"),
+            ));
         }
         reg
     }
@@ -62,8 +64,8 @@ impl Prebindgen for IdentityExt {
 #[test]
 fn dedup_and_sort() {
     let mut reg: Registry<()> = Registry::empty();
-    let key_a = TypeKey::parse("u64").expect("test type");
-    let key_b = TypeKey::parse("Sample").expect("test type");
+    let key_a: syn::Type = syn::parse_quote!(u64);
+    let key_b: syn::Type = syn::parse_quote!(Sample);
     let wire: syn::Type = syn::parse_quote!(i64);
     let wire2: syn::Type = syn::parse_quote!(*const u8);
 

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -203,7 +203,7 @@ impl CbindgenBuilder {
             "Cbindgen::opaque_ptr cannot declare `{}` because it is already ignored",
             key
         );
-        self.opaque.insert(key.clone(), TypeCfg::default());
+        self.opaque.insert(key.clone(), TypeCfg::new(ty));
         self.current = Some(CurrentDecl::Ptr(key));
         self
     }
@@ -216,7 +216,7 @@ impl CbindgenBuilder {
             "Cbindgen::data_struct cannot declare `{}` because it is already ignored",
             key
         );
-        self.data.insert(key.clone(), TypeCfg::default());
+        self.data.insert(key.clone(), TypeCfg::new(ty));
         self.current = Some(CurrentDecl::Data(key));
         self
     }
@@ -271,7 +271,7 @@ impl CbindgenBuilder {
                 kind,
                 generate_mirror: false,
                 assume_c_field_validity: false,
-                cfg: TypeCfg::default(),
+                cfg: TypeCfg::new(rust_ty),
             },
         );
         self.current = Some(CurrentDecl::ValueOpaque(key));
@@ -318,7 +318,7 @@ impl CbindgenBuilder {
                 kind: OpaqueKind::Data,
                 generate_mirror: true,
                 assume_c_field_validity: false,
-                cfg: TypeCfg::default(),
+                cfg: TypeCfg::new(ty),
             },
         );
         self.current = Some(CurrentDecl::ValueOpaque(key));
@@ -485,7 +485,7 @@ impl CbindgenBuilder {
             "Cbindgen::enum_type cannot declare `{}` because it is already ignored",
             key
         );
-        self.enums.insert(key.clone(), TypeCfg::default());
+        self.enums.insert(key.clone(), TypeCfg::new(ty));
         self.current = Some(CurrentDecl::Enum(key));
         self
     }
@@ -522,7 +522,7 @@ impl CbindgenBuilder {
             "Cbindgen::tagged_union cannot declare `{}` because it is already ignored",
             key
         );
-        self.tagged_unions.insert(key.clone(), TypeCfg::default());
+        self.tagged_unions.insert(key.clone(), TypeCfg::new(ty));
         self.current = Some(CurrentDecl::TaggedUnion(key));
         self
     }
@@ -541,7 +541,7 @@ impl CbindgenBuilder {
             )
         });
         let key: CallbackKey = args.iter().map(TypeKey::from_type).collect();
-        self.callbacks.insert(key.clone(), CbCfg::default());
+        self.callbacks.insert(key.clone(), CbCfg::new(args));
         self.current = Some(CurrentDecl::Callback(key));
         self
     }

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -18,7 +18,7 @@ impl CbindgenBuilder {
                 .get(&decl.key)
                 .cloned()
                 .unwrap_or_else(|| {
-                    let short = type_short(&decl.key.to_type());
+                    let short = type_short(&decl.rust_type.syntax.clone());
                     self.mangle_rust_type
                         .as_ref()
                         .map(|m| m(&short))
@@ -190,7 +190,7 @@ impl CbindgenBuilder {
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
     ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty(&decl.key.to_type());
+        let target = self.src_ty(&decl.rust_type.syntax.clone());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
@@ -234,7 +234,7 @@ impl CbindgenBuilder {
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
     ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty(&decl.key.to_type());
+        let target = self.src_ty(&decl.rust_type.syntax.clone());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -108,6 +108,7 @@ pub(crate) use crate::api::core::types_util::{
 };
 use crate::api::{
     core::{
+        flat::Origin,
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen},
         registry::{extract_fn_trait_args, Conversions, Direction, Registry, TypeKey},
@@ -115,19 +116,44 @@ use crate::api::{
     lang::jnigen::{ConvertDecl, ConvertSpec},
 };
 
+/// The origin of a type a **build script** wrote: real tokens, and deliberately
+/// no source position — `SourceLocation::default()` is the sanctioned placeless
+/// location for a type that was never in a captured file.
+fn declared_origin(ty: syn::Type) -> Origin<syn::Type> {
+    Origin::new(ty, std::rc::Rc::new(crate::SourceLocation::default()))
+}
+
 /// Identity of a declared callback signature: its argument-type list (the
 /// dedup key, since two `impl Fn` params with the same args share one closure
 /// struct). The return is always unit for the supported callbacks.
 type CallbackKey = Vec<TypeKey>;
 
 /// Per-opaque-handle / per-data-struct / per-enum configuration.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct TypeCfg {
+    /// The type this declaration was **written with** — the `ty` handed to
+    /// `opaque_ptr` / `data_struct` / `enum_type` / `tagged_union`.
+    ///
+    /// A declarator receives a real `syn::Type` and used to keep only the key
+    /// derived from it, so later sites had to ask the key for the tokens back.
+    /// The declaration is where the type came from, and this is where it stays
+    /// (#291).
+    rust_type: Origin<syn::Type>,
     /// Per-declaration **base** token override, fed to the name manglers
     /// (`mangle_type_name` / `mangle_destructor` / `mangle_take`) in place of the
     /// `mangle_rust_type`-derived base. Set by [`CbindgenBuilder::base_name`]. `None` ⇒
     /// the base comes from `mangle_rust_type(short)` (or the short name).
     base: Option<String>,
+}
+
+impl TypeCfg {
+    /// A freshly declared type, no naming override yet.
+    fn new(rust_type: syn::Type) -> Self {
+        Self {
+            rust_type: declared_origin(rust_type),
+            base: None,
+        }
+    }
 }
 
 /// What an inline-opaque by-value type holds, which decides whether its consume
@@ -176,8 +202,14 @@ struct ValueOpaqueCfg {
 }
 
 /// Per-declared-callback configuration.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct CbCfg {
+    /// The argument types this callback was declared with, in order.
+    ///
+    /// `CallbackKey` is a `Vec<TypeKey>` — a list of identities, which is what
+    /// the map is keyed by. Emission needs the argument *types*, and these are
+    /// the ones `extract_fn_trait_args` produced at declaration time (#291).
+    args: Vec<syn::Type>,
     /// Per-declaration **base** token override fed to `mangle_callback` (as the
     /// sole base, replacing the args' derived bases). Set by
     /// [`CbindgenBuilder::base_name`]. `None` ⇒ bases come from the arguments.
@@ -189,6 +221,17 @@ struct CbCfg {
     /// [`CbindgenBuilder::takeable_param`]; each such arg type must be an inline-opaque
     /// type ([`CbindgenBuilder::opaque_owned_struct`] / [`CbindgenBuilder::opaque_data_struct`]).
     takeable: std::collections::BTreeSet<usize>,
+}
+
+impl CbCfg {
+    /// A freshly declared callback signature, no naming or takeable overrides yet.
+    fn new(args: Vec<syn::Type>) -> Self {
+        Self {
+            args,
+            base: None,
+            takeable: std::collections::BTreeSet::new(),
+        }
+    }
 }
 
 /// Per-declared-function configuration.

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1469,13 +1469,14 @@ impl CbindgenBuilder {
     /// context. Deterministic order by emitted name.
     fn prereq_callback_structs(&self, registry: &Registry<()>) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
-        let mut cb_keys: Vec<&CallbackKey> = self.callbacks.keys().collect();
-        cb_keys.sort_by_key(|k| {
-            let args: Vec<syn::Type> = k.iter().map(|t| t.to_type()).collect();
-            self.callback_c_name(&args)
-        });
-        for key in cb_keys {
-            let args: Vec<syn::Type> = key.iter().map(|t| t.to_type()).collect();
+        // The declaration's own argument types. `CallbackKey` is a list of
+        // identities — what the map is keyed by — and the arguments it was
+        // declared with are beside it, so neither is rebuilt from the other
+        // (#291).
+        let mut cb_keys: Vec<(&CallbackKey, &CbCfg)> = self.callbacks.iter().collect();
+        cb_keys.sort_by_key(|(_, cfg)| self.callback_c_name(&cfg.args));
+        for (key, cfg) in cb_keys {
+            let args: Vec<syn::Type> = cfg.args.clone();
             // Emit only if the callback is required (its input resolved); skip a
             // declared-but-unused signature.
             if registry
@@ -1631,8 +1632,8 @@ impl CbindgenBuilder {
         for ident in self.helper_functions() {
             registry = registry.reference(&ident);
         }
-        for key in self.declared_types() {
-            registry = registry.export_type(key);
+        for ty in self.declared_types().into_values() {
+            registry = registry.export_type(ty);
         }
         Ok(registry)
     }
@@ -1768,7 +1769,10 @@ impl Prebindgen for CbindgenBuilder {
             binding.flat(),
             &crate::core::Claimed {
                 functions,
-                types: self.declared_types(),
+                // The report asks what was *claimed*, which is a set of
+                // identities — the declarations' spellings are the scan's
+                // business, not this one's.
+                types: self.declared_types().into_keys().collect(),
                 consts: None,
                 ignored_functions: self.ignored_functions(),
                 ignored_types: self.ignored_types(),
@@ -2539,14 +2543,21 @@ impl CbindgenBuilder {
             .filter(|ident| !self.functions.contains_key(ident))
             .collect()
     }
-    pub(crate) fn declared_types(&self) -> HashSet<TypeKey> {
+    /// Each with the spelling its declarator was written with — the scan needs
+    /// real tokens to intern a type that is in no table yet (#291).
+    pub(crate) fn declared_types(&self) -> HashMap<TypeKey, Origin<syn::Type>> {
         self.opaque
-            .keys()
-            .chain(self.data.keys())
-            .chain(self.value_opaque.keys())
-            .chain(self.enums.keys())
-            .chain(self.tagged_unions.keys())
-            .cloned()
+            .iter()
+            .chain(self.data.iter())
+            .map(|(k, c)| (k, &c.rust_type))
+            .chain(self.value_opaque.iter().map(|(k, c)| (k, &c.cfg.rust_type)))
+            .chain(
+                self.enums
+                    .iter()
+                    .chain(self.tagged_unions.iter())
+                    .map(|(k, c)| (k, &c.rust_type)),
+            )
+            .map(|(k, t)| (k.clone(), t.clone()))
             .collect()
     }
     pub(crate) fn ignored_types(&self) -> HashSet<TypeKey> {

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -412,9 +412,14 @@ impl JniGenBuilder {
     ///
     /// Returns the stored config so the caller can fold in its cross-kind
     /// options (`jobject_input`, interfaces).
+    ///
+    /// `rust_type` is the declaration's own spelling; `key` is the identity
+    /// derived from it. They cannot disagree — every `*ClassDecl::new` builds
+    /// both from the one `syn::Type` it was handed.
     fn register_class(
         &mut self,
         key: &TypeKey,
+        rust_type: Origin<syn::Type>,
         kind: DeclaredKind,
         spec: NameSpec,
     ) -> &mut TypeConfig {
@@ -437,12 +442,17 @@ impl JniGenBuilder {
         let short = rust_short_name(key);
         match self.decls.types.entry(key.clone()) {
             std::collections::hash_map::Entry::Occupied(e) => {
+                // A reopened declarator keeps the first spelling: the two agree
+                // on identity by construction, and the model indexes types
+                // first-mention-wins for the same reason.
                 let cfg = e.into_mut();
                 cfg.kind.merge(kind, &short);
                 cfg.name_spec = Some(spec);
                 cfg
             }
-            std::collections::hash_map::Entry::Vacant(e) => e.insert(TypeConfig::new(kind, spec)),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(TypeConfig::new(kind, spec, rust_type))
+            }
         }
     }
 
@@ -472,6 +482,7 @@ impl JniGenBuilder {
         let key = decl.key;
         self.register_class(
             &key,
+            decl.rust_type,
             DeclaredKind::Ptr(OpaqueConfig {
                 gc_managed: decl.gc_managed,
             }),
@@ -491,6 +502,7 @@ impl JniGenBuilder {
         let key = decl.key;
         self.register_class(
             &key,
+            decl.rust_type,
             DeclaredKind::Enum(EnumConfig::default()),
             NameSpec {
                 subpackage: subpackage.to_string(),
@@ -509,6 +521,7 @@ impl JniGenBuilder {
     fn accept_sealed_class(&mut self, subpackage: &str, decl: SealedClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
+        let rust_type = decl.rust_type;
         // Reopened decls merge — `DeclaredKind::merge` owns that rule for
         // every kind, so this acceptor only builds its own payload.
         let mut sum = SumConfig::default();
@@ -519,6 +532,7 @@ impl JniGenBuilder {
         }
         self.register_class(
             &key,
+            rust_type,
             DeclaredKind::Sealed(sum),
             NameSpec {
                 subpackage: subpackage.to_string(),
@@ -547,7 +561,7 @@ impl JniGenBuilder {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
         let spec = Self::data_value_name_spec(subpackage, short, decl.name_override);
-        self.register_class(&key, DeclaredKind::Data, spec)
+        self.register_class(&key, decl.rust_type, DeclaredKind::Data, spec)
             .jobject_input |= decl.jobject_input;
         self.store_iface_opts(&key, decl.iface);
         self.accept_members(&key, decl.members);
@@ -772,7 +786,7 @@ impl Declarations {
             }
             exp.constructors
                 .push(crate::api::core::expand::ConstructorDecl {
-                    target: decl.key.to_type(),
+                    target: decl.rust_type.syntax.clone(),
                     variants: decl.variants.iter().map(lower).collect(),
                     default: true,
                 });
@@ -795,7 +809,7 @@ impl Declarations {
             exp.expands.push(ExpandDecl {
                 func: func.clone(),
                 param: syn::Ident::new(param, Span::call_site()),
-                declared_target: Some(decl.key.to_type()),
+                declared_target: Some(decl.rust_type.syntax.clone()),
                 sel: ExpandSel::Subset(decl.variants.iter().map(lower).collect()),
             });
         }
@@ -1158,7 +1172,7 @@ impl Declarations {
                 k = decl.key.as_str()
             );
             dec.deconstructors.push(DeconstructorDecl {
-                target: decl.key.to_type(),
+                target: decl.rust_type.syntax.clone(),
                 records: self.lower_fields(registry, &decl.key, &decl.fields),
                 default: Some((DeconTarget::Output, Delivery::Callback)),
             });
@@ -1183,7 +1197,7 @@ impl Declarations {
                 sel: DeconSel::Inline(self.lower_fields(registry, &decl.key, &decl.fields)),
                 target: DeconTarget::Output,
                 delivery: Delivery::Callback,
-                declared_source: Some(decl.key.to_type()),
+                declared_source: Some(decl.rust_type.syntax.clone()),
             });
         }
         dec
@@ -1315,15 +1329,33 @@ impl Declarations {
     /// **rust-side-only** types. Unioned into [`Prebindgen::ignored_types`]
     /// so the registry treats them as acknowledged (no "skipping undeclared"
     /// warning, no direct converter requirement, no Kotlin emission).
-    pub(crate) fn rust_side_only_types(&self) -> impl Iterator<Item = TypeKey> + '_ {
+    ///
+    /// Yields each decl's own `syn::Type` beside its key: these are types a
+    /// build script wrote, and the scan diagnoses their spelling before
+    /// anything has classified them (#291).
+    pub(crate) fn rust_side_only_types(
+        &self,
+    ) -> impl Iterator<Item = (TypeKey, Origin<syn::Type>)> + '_ {
         self.param_expand_decls
             .iter()
-            .map(|d| &d.key)
-            .chain(self.return_expand_decls.iter().map(|d| &d.key))
-            .chain(self.fn_param_expands.iter().map(|(_, _, d)| &d.key))
-            .chain(self.fn_return_expands.iter().map(|(_, d)| &d.key))
-            .filter(|k| !self.is_class_declared(k))
-            .cloned()
+            .map(|d| (&d.key, &d.rust_type))
+            .chain(
+                self.return_expand_decls
+                    .iter()
+                    .map(|d| (&d.key, &d.rust_type)),
+            )
+            .chain(
+                self.fn_param_expands
+                    .iter()
+                    .map(|(_, _, d)| (&d.key, &d.rust_type)),
+            )
+            .chain(
+                self.fn_return_expands
+                    .iter()
+                    .map(|(_, d)| (&d.key, &d.rust_type)),
+            )
+            .filter(|(k, _)| !self.is_class_declared(k))
+            .map(|(k, t)| (k.clone(), t.clone()))
     }
 
     /// Function idents referenced only inside boundary decls (type-level and
@@ -1454,7 +1486,9 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
-        let target = key.to_type();
+        // The `convert!` declaration's own spelling — the key is how the decl
+        // was found, not a second source for what it says (#291).
+        let target = decl.rust_type.syntax.clone();
         let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
                 let item_fn = registry
@@ -1530,7 +1564,9 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
-        let target = key.to_type();
+        // The `convert!` declaration's own spelling — the key is how the decl
+        // was found, not a second source for what it says (#291).
+        let target = decl.rust_type.syntax.clone();
         let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
                 let item_fn = registry

--- a/prebindgen/src/api/lang/jnigen/jni/decl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl.rs
@@ -12,6 +12,16 @@
 
 use super::*;
 
+/// The origin of a type a **build script** wrote.
+///
+/// Real tokens, and deliberately no source position: `SourceLocation::default()`
+/// is the sanctioned placeless location for exactly this — a signature or type a
+/// build script authored was never in a captured file, and `has_position` already
+/// gates what a diagnostic prints for one.
+pub(crate) fn declared_origin(ty: syn::Type) -> Origin<syn::Type> {
+    Origin::new(ty, std::rc::Rc::new(crate::SourceLocation::default()))
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Shared local accumulators (replayed into `Expansions`/`Deconstructors`
 // by the accept logic in `builder.rs` once a decl is handed to `Declarations`)
@@ -349,6 +359,10 @@ macro_rules! fields {
 /// [`implements`](Self::implements).
 pub struct PtrClassDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) name_override: Option<String>,
     pub(crate) members: Vec<(FunctionDecl, MemberKind)>,
     pub(crate) iface: IfaceOpts,
@@ -443,6 +457,7 @@ impl PtrClassDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             name_override: None,
             members: Vec::new(),
             iface: IfaceOpts::default(),
@@ -562,6 +577,10 @@ impl From<syn::Type> for PtrClassDecl {
 #[derive(Clone)]
 pub struct ExpandParamDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) variants: Vec<LocalVariant>,
     /// `.no_split()` — suppress the proactive splittability check for this
     /// variant set (it will only ever be used as the selector form). See
@@ -573,6 +592,7 @@ impl ExpandParamDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             variants: Vec::new(),
             no_split: false,
         }
@@ -664,6 +684,10 @@ impl ExpandParamDecl {
 #[derive(Clone)]
 pub struct ExpandReturnDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) fields: Vec<LocalField>,
 }
 
@@ -671,6 +695,7 @@ impl ExpandReturnDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             fields: Vec::new(),
         }
     }
@@ -993,6 +1018,10 @@ impl From<ExpandReturnDecl> for ExpandDecl {
 /// identity — a "method" on it is just a free function taking the enum.
 pub struct EnumClassDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) name_override: Option<String>,
     pub(crate) iface: IfaceOpts,
 }
@@ -1001,6 +1030,7 @@ impl EnumClassDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             name_override: None,
             iface: IfaceOpts::default(),
         }
@@ -1053,6 +1083,10 @@ impl From<syn::Type> for EnumClassDecl {
 /// taking it.
 pub struct SealedClassDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) name_override: Option<String>,
     pub(crate) variants: Vec<VariantDecl>,
     pub(crate) iface: IfaceOpts,
@@ -1062,6 +1096,7 @@ impl SealedClassDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             name_override: None,
             variants: Vec::new(),
             iface: IfaceOpts::default(),
@@ -1124,6 +1159,10 @@ impl VariantDecl {
 /// destructuring a data-class parameter gets), just rebased to `this`.
 pub struct DataClassDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) name_override: Option<String>,
     pub(crate) jobject_input: bool,
     pub(crate) iface: IfaceOpts,
@@ -1134,6 +1173,7 @@ impl DataClassDecl {
     pub fn new(rust_type: syn::Type) -> Self {
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             name_override: None,
             jobject_input: false,
             iface: IfaceOpts::default(),
@@ -1880,6 +1920,10 @@ impl From<FunctionDecl> for ConvertSourceDecl {
 #[derive(Clone)]
 pub struct ConvertDecl {
     pub(crate) key: TypeKey,
+    /// The type this declaration was **written with** — the `X` the macro
+    /// received. Kept because the declaration is where it came from: recovering
+    /// it later *from* the key was reasoning backwards from an identity (#291).
+    pub(crate) rust_type: Origin<syn::Type>,
     pub(crate) input: Option<ConvertSpec>,
     pub(crate) output: Option<ConvertSpec>,
     pub(crate) domain: Option<crate::core::RepresentationDomain>,
@@ -1910,6 +1954,7 @@ impl ConvertDecl {
         reject_builtin_convert_type(&TypeKey::from_type(&rust_type));
         Self {
             key: TypeKey::from_type(&rust_type),
+            rust_type: declared_origin(rust_type),
             input: None,
             output: None,
             domain: None,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -981,10 +981,11 @@ pub(crate) fn fixed_leaf_element_keys(
 }
 
 /// Derive the spec for one identity — the SINGLE construction point behind
-/// [`Declarations::iface_spec`]. Any `syn` context comes from the key's stored
-/// normalized type ([`TypeKey::to_type`] — a clone, not a reparse). A
-/// `Folder` derivation folds the fixed-builder typed-group view in per
-/// `DeconId` (see [`fixed_decon_ids`]).
+/// [`Declarations::iface_spec`]. Any `syn` context is **looked up**, never
+/// rebuilt from the key: `Registry::reading` answers from the type table, and a
+/// key it cannot answer for defers rather than producing tokens nothing
+/// classified (#291). A `Folder` derivation folds the fixed-builder
+/// typed-group view in per `DeconId` (see [`fixed_decon_ids`]).
 fn derive_iface_spec(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
@@ -1019,7 +1020,12 @@ fn derive_iface_spec(
             }
             Some(spec)
         }
-        SpecKey::WholeFolder(el_key) => whole_folder_iface_spec(ext, registry, &el_key.to_type()),
+        // Same round trip, same reason, same answer as the `Callback` arm
+        // above: the memo key holds an identity, and the reading behind it is a
+        // lookup. `None` defers, exactly as it does there (#291).
+        SpecKey::WholeFolder(el_key) => {
+            whole_folder_iface_spec(ext, registry, registry.reading(el_key)?.syntax())
+        }
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
     }

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -50,6 +50,7 @@ pub(crate) use crate::api::gen::kotlin as kt;
 pub(crate) use crate::api::{
     core::{
         domain::ScalarValue,
+        flat::Origin,
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen, Stage},
         registry::{Direction, Registry, TypeKey},
@@ -186,6 +187,14 @@ pub(crate) struct TypeConfig {
     /// unlike a wrapper registration, which is required per **usage**
     /// direction.
     pub kind: DeclaredKind,
+    /// The type this declaration was **written with**, e.g. the `Foo` in
+    /// `ptr_class!(Foo)`.
+    ///
+    /// A class declarator receives a real `syn::Type` and used to keep only the
+    /// key derived from it, so every later site that needed the tokens back had
+    /// to ask the key for them. That is the wrong direction: the declaration is
+    /// where the type came from, and this is where it stays (#291).
+    pub rust_type: Origin<syn::Type>,
     /// Raw naming spec of the type as declared — verbatim Kotlin type or
     /// settings-derived class name. Required for any type emitted in
     /// Kotlin; the concrete FQN (`Sample` → `"io.zenoh.jni.Sample"`,
@@ -215,9 +224,14 @@ impl TypeConfig {
     /// A freshly declared type: the declarator's kind and naming spec, every
     /// cross-kind option unset. Reopening the same declarator goes through
     /// [`DeclaredKind::merge`] instead.
-    pub(crate) fn new(kind: DeclaredKind, name_spec: NameSpec) -> Self {
+    pub(crate) fn new(
+        kind: DeclaredKind,
+        name_spec: NameSpec,
+        rust_type: Origin<syn::Type>,
+    ) -> Self {
         Self {
             kind,
+            rust_type,
             name_spec: Some(name_spec),
             jobject_input: false,
             interface_enabled: false,

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -62,7 +62,7 @@ impl Declarations {
             if decl.no_split || decl.variants.len() < 2 {
                 continue;
             }
-            let target = decl.key.to_type();
+            let target = decl.rust_type.syntax.clone();
             let sigs: Vec<(String, Vec<ErasedJvmType>)> = decl
                 .variants
                 .iter()

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -167,7 +167,7 @@ impl super::JniGen {
         // listed above with the other declared classes, not here.
         let mut boundary: Vec<String> = ext
             .rust_side_only_types()
-            .map(|k| format!("- `{}` (never materializes in Kotlin)\n", k.as_str()))
+            .map(|(k, _)| format!("- `{}` (never materializes in Kotlin)\n", k.as_str()))
             .collect();
         boundary.sort();
         if !boundary.is_empty() {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/mod.rs
@@ -67,8 +67,8 @@ fn install_input(
     _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
-    let key = TypeKey::parse(ty_str).expect("test type");
-    reg.insert_crossing(Direction::Input, &key, true, Some(e));
+    let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
+    reg.insert_crossing(Direction::Input, &ty, true, Some(e));
 }
 
 fn install_output(
@@ -77,6 +77,6 @@ fn install_output(
     _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
-    let key = TypeKey::parse(ty_str).expect("test type");
-    reg.insert_crossing(Direction::Output, &key, true, Some(e));
+    let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
+    reg.insert_crossing(Direction::Output, &ty, true, Some(e));
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -367,7 +367,7 @@ impl Declarations {
         // Rust-side-only boundary types are absent from the type table but
         // still appear in emitted signatures (e.g. the `E` of a peeled
         // `Result<T, E>`), so they need the same qualification.
-        for key in self.rust_side_only_types().collect::<Vec<_>>() {
+        for (key, _) in self.rust_side_only_types().collect::<Vec<_>>() {
             add(&key);
         }
         // `convert!`-declared types likewise have no type-table entry but
@@ -1341,8 +1341,8 @@ impl Declarations {
         for ident in self.declared_consts().into_iter().flatten() {
             registry = registry.export_const(&ident);
         }
-        for key in self.declared_types() {
-            registry = registry.export_type(key);
+        for ty in self.declared_types().into_values() {
+            registry = registry.export_type(ty);
         }
         for ident in self.accessor_functions() {
             registry = registry.accessor(&ident);
@@ -1449,7 +1449,11 @@ impl Declarations {
             let Some(sum_cfg) = self.types[key].sum() else {
                 continue;
             };
-            let source = key.to_type();
+            // The `sealed_class!` declaration's own spelling. This runs during
+            // the declare phase, where a `reading()` would legitimately answer
+            // `None` for a type nothing has interned yet — the declaration is
+            // the only thing that can say (#291).
+            let source = self.types[key].rust_type.syntax.clone();
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
@@ -2737,8 +2741,14 @@ impl Declarations {
     /// registrations live in their own tables and are deliberately excluded: a
     /// wrapper type is required per **usage** direction, so an output-only
     /// wrapper needs no input twin.
-    pub(crate) fn declared_types(&self) -> std::collections::HashSet<TypeKey> {
-        self.types.keys().cloned().collect()
+    ///
+    /// Each with the spelling its declarator was written with — the scan needs
+    /// real tokens to intern a type that is in no table yet (#291).
+    pub(crate) fn declared_types(&self) -> std::collections::HashMap<TypeKey, Origin<syn::Type>> {
+        self.types
+            .iter()
+            .map(|(k, c)| (k.clone(), c.rust_type.clone()))
+            .collect()
     }
     /// Types acknowledged-but-undeclared via [`JniGenBuilder::ignore`].
     pub(crate) fn ignored_types(&self) -> std::collections::HashSet<TypeKey> {
@@ -2751,8 +2761,11 @@ impl Declarations {
     pub(crate) fn claimed(&self) -> crate::core::Claimed {
         let mut functions = self.declared_functions();
         functions.extend(self.helper_functions());
-        let mut types = self.declared_types();
-        types.extend(self.boundary_only_types());
+        // The report asks what was *claimed*, which is a set of identities —
+        // the declarations' spellings are the scan's business, not this one's.
+        let mut types: std::collections::HashSet<TypeKey> =
+            self.declared_types().into_keys().collect();
+        types.extend(self.boundary_only_types().into_keys());
         crate::core::Claimed {
             functions,
             types,
@@ -2769,7 +2782,9 @@ impl Declarations {
     /// (unfold / error channel) cross the boundary — so the registry
     /// acknowledges them and drops their direct converter requirements once
     /// the plans are in place.
-    pub(crate) fn boundary_only_types(&self) -> std::collections::HashSet<TypeKey> {
+    pub(crate) fn boundary_only_types(
+        &self,
+    ) -> std::collections::HashMap<TypeKey, Origin<syn::Type>> {
         // A `sealed_class!`-declared sum has no single wire: it crosses as a
         // tag plus one leaf group per variant, so a direct converter for the
         // value itself is genuinely not needed. Declaring it boundary-only
@@ -2781,7 +2796,7 @@ impl Declarations {
                 self.types
                     .iter()
                     .filter(|(_, c)| c.sum().is_some())
-                    .map(|(k, _)| k.clone()),
+                    .map(|(k, c)| (k.clone(), c.rust_type.clone())),
             )
             .collect()
     }

--- a/prebindgen/src/api/test_util.rs
+++ b/prebindgen/src/api/test_util.rs
@@ -33,7 +33,8 @@ pub(crate) fn scanned_with<M>(sources: &[&str]) -> Registry<M> {
 }
 
 /// A type as a **build script** would declare it: real tokens, no source
-/// position. What [`RegistryBuilder::export_type`](crate::core::RegistryBuilder::export_type)
+/// position. What
+/// [`RegistryBuilder::export_type`](crate::api::core::registry::RegistryBuilder::export_type)
 /// takes.
 pub(crate) fn declared_origin(ty: syn::Type) -> crate::core::flat::Origin<syn::Type> {
     crate::core::flat::Origin::new(ty, std::rc::Rc::new(crate::SourceLocation::default()))

--- a/prebindgen/src/api/test_util.rs
+++ b/prebindgen/src/api/test_util.rs
@@ -32,6 +32,13 @@ pub(crate) fn scanned_with<M>(sources: &[&str]) -> Registry<M> {
     reg_with(sources).scanned().expect("scan")
 }
 
+/// A type as a **build script** would declare it: real tokens, no source
+/// position. What [`RegistryBuilder::export_type`](crate::core::RegistryBuilder::export_type)
+/// takes.
+pub(crate) fn declared_origin(ty: syn::Type) -> crate::core::flat::Origin<syn::Type> {
+    crate::core::flat::Origin::new(ty, std::rc::Rc::new(crate::SourceLocation::default()))
+}
+
 /// One type as the **model** reads it, for a test that needs a `TypeRef` and has
 /// only a spelling.
 ///


### PR DESCRIPTION
Second of four on #291. **Stacked on #298** — review that one first; this PR's base will be retargeted to `language-integration` once it merges.

## What

`ptr_class!(Foo)` receives a real `syn::Type`, reduces it to a `TypeKey`, and throws it away. Everything that later needed those tokens back asked the **key** to reproduce them. That is backwards — the declaration is where the type came from.

Declarations now carry `Origin<syn::Type>` (the model's own convention for a node's tokens) at `SourceLocation::default()`, the sanctioned placeless location for something a build script authored rather than a captured file.

```rust
pub fn export_type(mut self, ty: Origin<syn::Type>) -> Self   // was: (key: TypeKey)
pub(crate) types:    HashMap<TypeKey, Origin<syn::Type>>      // Declared
pub replaces:        HashMap<TypeKey, Origin<syn::Type>>      // Decompositions
```

`export_type` now matches its sibling `cross`, which already took the spelling.

## The two sites a key genuinely could not serve

Both in `registry/scan.rs`, and both are why the core boundary had to move:

- the **qualified-declared-types diagnostic** needs multi-segment path *structure* for a type with no cell, so neither `reading()` nor a name accessor could serve it;
- the **declared-type scan** needs real tokens for `intern` — of a type that is in no table yet, so `reading()` has nothing to answer with. `intern` is `pub(in crate::api::core)` and deliberately takes tokens; that stays.

Both **canonicalize explicitly** at the point of use. That is not incidental: it is what the key was silently providing (`crate::Foo` must not read as a qualified path), and doing it in the open is the difference between preserving behaviour and hoping. The comments say so.

## Declare-phase consumers read their decl, not the registry

`build_expansions`, `build_deconstructors`, `convert_input_body`/`convert_output_body`, `build_sum_decons` and `validate_split_declarations` all run while only a `RegistryBuilder` exists, where `reading()` legitimately answers `None` for a not-yet-interned type. Swapping those to `reading()` would have been a **silent semantic change**, not a refactor.

## Two sites go the other way

Past the declare phase, where the sibling arm beside each already used `reading()`:

- `SpecKey::WholeFolder` in `derive_iface_spec` — contractually a pure function of its key, so a side channel was not open to it; it now defers on `None` exactly as the `Callback` arm above it does.
- cbindgen's callback structs read the argument types their declaration recorded, instead of rebuilding them from a `Vec<TypeKey>`. `CallbackKey` stays a list of identities — that is what the map is keyed by.

28 `to_type()` call sites → 9. Every one that remains is a name lookup (stage C1) or the idempotence test (stage D).

## Verified

- `cargo test --all --all-features` — 631 lib tests, all green
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release` on every example crate. This was the real question of this PR — whether a declaration's as-written spelling matches what the key was reproducing — and it does.
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections