### PR TITLE
A key answers what it is called (#291 stage C1)

### DIFF
--- a/prebindgen/src/api/core/diagnostics.rs
+++ b/prebindgen/src/api/core/diagnostics.rs
@@ -15,7 +15,6 @@ use crate::api::core::{
     flat::{type_from_ident, Flat},
     prebindgen::NamePredicate,
     registry::TypeKey,
-    types_util::bare_path_ident,
 };
 
 /// What a binding claimed, so everything else can be reported.
@@ -79,7 +78,7 @@ pub(crate) fn unclaimed_report(flat: &Flat, claimed: &Claimed) -> Vec<String> {
     for key in sorted(claimed.ignored_types.iter().map(|k| k.as_str().to_owned())) {
         let named = TypeKey::parse(&key)
             .ok()
-            .and_then(|k| bare_path_ident(&k.to_type()))
+            .and_then(|k| k.ident())
             .is_some_and(|ident| flat.declared_type(&ident).is_some());
         if !named {
             out.push(format!(

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -55,11 +55,10 @@
 4	api/lang/jnigen/jni/emit/convert.rs
 2	api/lang/jnigen/jni/emit/delivery.rs
 5	api/lang/jnigen/jni/emit/flat_input.rs
-17	api/lang/jnigen/jni/emit/names.rs
+16	api/lang/jnigen/jni/emit/names.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 4	api/lang/jnigen/jni/iface.rs
-2	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
@@ -69,4 +68,4 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 120
+# total: 117

--- a/prebindgen/src/api/core/registry/key.rs
+++ b/prebindgen/src/api/core/registry/key.rs
@@ -102,10 +102,144 @@ impl TypeKey {
     pub fn to_type(&self) -> syn::Type {
         (*self.ty).clone()
     }
+
+    /// The bare item ident this key names — `Foo`, `a::Foo` → `Foo`; `None`
+    /// when the type carries generic arguments or is not a path.
+    ///
+    /// Matches [`bare_path_ident`](crate::api::core::types_util::bare_path_ident)
+    /// on the same type, which is the property
+    /// `key_name_accessors_match_the_syn_walks` pins.
+    ///
+    /// **A name is not syntax**, which is why this is the key's business and
+    /// producing a `syn::Type` is not. A caller that wants to look a declared
+    /// item up by name was never asking for tokens; it was asking the key what
+    /// it is called (#291).
+    pub fn ident(&self) -> Option<syn::Ident> {
+        let short = self.short_name()?;
+        // The generic-argument rule the syn walk has: `Vec<u8>` names no bare
+        // item, so it answers `None` where `short_name` still says "Vec".
+        if self.canon.contains('<') {
+            return None;
+        }
+        syn::parse_str::<syn::Ident>(&short).ok()
+    }
+
+    /// The last path segment's ident, **ignoring** generic arguments —
+    /// `Publisher<'static>` → `"Publisher"`, `a::Foo` → `"Foo"`. `None` for
+    /// anything that is not a path.
+    ///
+    /// The looser sibling of [`Self::ident`], for the callers that derive a
+    /// destination-language class name from a Rust type: a declaration writes
+    /// `ptr_class!(Publisher<'static>)` and means the class `Publisher`.
+    ///
+    /// # Read off the canonical string
+    ///
+    /// Deliberately, and not as a shortcut. `canon` is a token-stream
+    /// rendering, so its tokens are space-separated — `Vec < u8 >`, `& Foo`,
+    /// `a :: Foo`, `[u8 ; 4]` — which makes a path's head everything before the
+    /// first `<`, and its last segment everything after the last `::`.
+    /// `syn::parse_str::<syn::Ident>` is the total validator on the far end:
+    /// every non-path shape fails it. Reparsing the whole type instead would
+    /// make a name depend on a serialize-then-reparse round trip, which is the
+    /// dependency #95 removed.
+    ///
+    /// One deliberate limit: a qualified-self path (`<T as Tr>::Item`) answers
+    /// `None` rather than `Item`. It cannot reach here — `scan_declared_items`
+    /// refuses a `qself` declaration — and refusing is the safe direction for a
+    /// shape this cannot read.
+    pub fn short_name(&self) -> Option<String> {
+        // Strip generic arguments FIRST: in `Vec < a :: B >` the `::` belongs to
+        // the argument, and the segment being named is still `Vec`.
+        let head = self.canon.split('<').next()?;
+        let tail = head.rsplit("::").next()?.trim();
+        syn::parse_str::<syn::Ident>(tail)
+            .ok()
+            .map(|i| i.to_string())
+    }
 }
 
 impl fmt::Display for TypeKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.canon)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::core::types_util::bare_path_ident;
+
+    /// Every shape a key can hold, as a build script or a source could spell it.
+    ///
+    /// A `qself` path is absent on purpose: `scan_declared_items` refuses one,
+    /// and `short_name` documents answering `None` for it rather than reading
+    /// through the qualification.
+    const SHAPES: &[&str] = &[
+        "Foo",
+        "a::Foo",
+        "std::string::String",
+        "Vec<u8>",
+        "Vec<a::B>",
+        "Publisher<'static>",
+        "Option<Box<Node>>",
+        "&Foo",
+        "&mut Foo",
+        "&[u8]",
+        "[u8; 4]",
+        "()",
+        "(u8, u8)",
+        "*const u8",
+        "dyn Error",
+        "fn() -> u8",
+    ];
+
+    /// The accessors and the `syn` walks they replace answer identically.
+    ///
+    /// This is the whole warrant for reading names off the canonical string
+    /// instead of off a parsed type. Both walks are the incumbent definition —
+    /// `bare_path_ident` for [`TypeKey::ident`], and `rust_short_name_opt`'s
+    /// last-segment rule (spelled out here rather than imported, since it lives
+    /// under a language adapter) for [`TypeKey::short_name`].
+    #[test]
+    fn key_name_accessors_match_the_syn_walks() {
+        for spec in SHAPES {
+            let ty: syn::Type = syn::parse_str(spec).expect("test shape parses");
+            let key = TypeKey::from_type(&ty);
+
+            assert_eq!(
+                key.ident(),
+                bare_path_ident(&crate::api::core::flat::canonical_type(&ty)),
+                "ident() disagrees with bare_path_ident on `{spec}` (canon `{key}`)"
+            );
+
+            // `rust_short_name_opt`: the last path segment's ident, generic
+            // arguments and all.
+            let expected_short = match &crate::api::core::flat::canonical_type(&ty) {
+                syn::Type::Path(tp) => tp.path.segments.last().map(|s| s.ident.to_string()),
+                _ => None,
+            };
+            assert_eq!(
+                key.short_name(),
+                expected_short,
+                "short_name() disagrees with the last-segment rule on `{spec}` (canon `{key}`)"
+            );
+        }
+    }
+
+    /// `short_name` is looser than `ident` in exactly one way: generic arguments.
+    #[test]
+    fn short_name_reads_through_generics_and_ident_does_not() {
+        let key = TypeKey::from_type(&syn::parse_quote!(Publisher<'static>));
+        assert_eq!(key.short_name().as_deref(), Some("Publisher"));
+        assert_eq!(key.ident(), None);
+    }
+
+    /// A name comes back out as the ident it names — `from_ident` is the inverse.
+    #[test]
+    fn ident_round_trips_through_from_ident() {
+        let ident = syn::Ident::new("ZKeyExpr", proc_macro2::Span::call_site());
+        let key = TypeKey::from_ident(&ident);
+        assert_eq!(key.ident().as_ref(), Some(&ident));
+        assert_eq!(key.short_name().as_deref(), Some("ZKeyExpr"));
     }
 }

--- a/prebindgen/src/api/core/registry/key.rs
+++ b/prebindgen/src/api/core/registry/key.rs
@@ -103,11 +103,13 @@ impl TypeKey {
         (*self.ty).clone()
     }
 
-    /// The bare item ident this key names — `Foo`, `a::Foo` → `Foo`; `None`
-    /// when the type carries generic arguments or is not a path.
+    /// The bare item ident this key names — `Foo`, `a::Foo` → `Foo`,
+    /// `a::Foo<u8>::Bar` → `Bar`; `None` when the **last** segment carries
+    /// generic arguments (`Vec<u8>` names no bare item) or the key is not a
+    /// path.
     ///
     /// Matches [`bare_path_ident`](crate::api::core::types_util::bare_path_ident)
-    /// on the same type, which is the property
+    /// on the same type, which is what
     /// `key_name_accessors_match_the_syn_walks` pins.
     ///
     /// **A name is not syntax**, which is why this is the key's business and
@@ -115,47 +117,128 @@ impl TypeKey {
     /// item up by name was never asking for tokens; it was asking the key what
     /// it is called (#291).
     pub fn ident(&self) -> Option<syn::Ident> {
-        let short = self.short_name()?;
-        // The generic-argument rule the syn walk has: `Vec<u8>` names no bare
-        // item, so it answers `None` where `short_name` still says "Vec".
-        if self.canon.contains('<') {
+        let (ident, generic) = self.path_segments()?.pop()?;
+        // `bare_path_ident` reads `PathArguments` on the LAST segment only, so
+        // arguments earlier in the path do not disqualify the name.
+        if generic {
             return None;
         }
-        syn::parse_str::<syn::Ident>(&short).ok()
+        Some(ident)
     }
 
-    /// The last path segment's ident, **ignoring** generic arguments —
-    /// `Publisher<'static>` → `"Publisher"`, `a::Foo` → `"Foo"`. `None` for
-    /// anything that is not a path.
+    /// The last path segment's ident, **ignoring** its generic arguments —
+    /// `Publisher<'static>` → `"Publisher"`, `a::Foo<u8>::Bar` → `"Bar"`.
+    /// `None` for anything that is not a path.
     ///
     /// The looser sibling of [`Self::ident`], for the callers that derive a
     /// destination-language class name from a Rust type: a declaration writes
     /// `ptr_class!(Publisher<'static>)` and means the class `Publisher`.
+    pub fn short_name(&self) -> Option<String> {
+        Some(self.path_segments()?.pop()?.0.to_string())
+    }
+
+    /// The **top-level** path segments of the canonical string: each segment's
+    /// ident, and whether that segment carried generic arguments. `None` if the
+    /// canon is not a path at all.
     ///
     /// # Read off the canonical string
     ///
     /// Deliberately, and not as a shortcut. `canon` is a token-stream
     /// rendering, so its tokens are space-separated — `Vec < u8 >`, `& Foo`,
-    /// `a :: Foo`, `[u8 ; 4]` — which makes a path's head everything before the
-    /// first `<`, and its last segment everything after the last `::`.
-    /// `syn::parse_str::<syn::Ident>` is the total validator on the far end:
-    /// every non-path shape fails it. Reparsing the whole type instead would
-    /// make a name depend on a serialize-then-reparse round trip, which is the
-    /// dependency #95 removed.
+    /// `a :: Foo` — and the structure is recoverable by tracking angle depth.
+    /// Reparsing the whole type instead would make a NAME depend on a
+    /// serialize-then-reparse round trip, which is the dependency #95 removed;
+    /// storing the derived names on the key would put derived state back on a
+    /// value whose whole point is that it carries none.
     ///
-    /// One deliberate limit: a qualified-self path (`<T as Tr>::Item`) answers
-    /// `None` rather than `Item`. It cannot reach here — `scan_declared_items`
-    /// refuses a `qself` declaration — and refusing is the safe direction for a
-    /// shape this cannot read.
-    pub fn short_name(&self) -> Option<String> {
-        // Strip generic arguments FIRST: in `Vec < a :: B >` the `::` belongs to
-        // the argument, and the segment being named is still `Vec`.
-        let head = self.canon.split('<').next()?;
-        let tail = head.rsplit("::").next()?.trim();
-        syn::parse_str::<syn::Ident>(tail)
-            .ok()
-            .map(|i| i.to_string())
+    /// **Nesting-aware, because a path segment is not the last thing before a
+    /// `<`.** `a::Foo<u8>::Bar` names `Bar`, and `Vec<a::B>` names `Vec` — the
+    /// `::` in the second belongs to the argument. Splitting at the first `<`
+    /// got the second right and the first wrong.
+    ///
+    /// `syn::parse_str::<syn::Ident>` on every segment is the totality check:
+    /// each non-path shape puts something in a segment that is not an ident —
+    /// `& Foo`, `[u8 ; 4]`, `( )`, `* const u8`, `dyn Error`, `fn () -> u8`.
+    fn path_segments(&self) -> Option<Vec<(syn::Ident, bool)>> {
+        let mut rest: &str = &self.canon;
+        // A qualified-self path renders its qualification first
+        // (`< T as Tr > :: Item`) and syn keeps only the tail in
+        // `path.segments` — so drop the group and read the rest as a plain path.
+        if rest.starts_with('<') {
+            rest = rest[close_angle(rest)? + 1..]
+                .trim_start()
+                .strip_prefix("::")?;
+        }
+
+        let bytes = rest.as_bytes();
+        let mut out = Vec::new();
+        let mut depth = 0usize;
+        let mut start = 0usize;
+        let mut ident_end: Option<usize> = None;
+        let mut i = 0usize;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'<' => {
+                    if depth == 0 && ident_end.is_none() {
+                        ident_end = Some(i);
+                    }
+                    depth += 1;
+                }
+                // The `>` of a bare fn's `->` is an arrow, not a bracket, and
+                // miscounting it would let a `::` inside `Vec<fn() -> a::B>`
+                // read as a top-level separator.
+                b'>' if i > 0 && bytes[i - 1] == b'-' => {}
+                b'>' => depth = depth.saturating_sub(1),
+                b':' if depth == 0 && bytes.get(i + 1) == Some(&b':') => {
+                    out.push(segment(rest, start, ident_end, i)?);
+                    i += 2;
+                    start = i;
+                    ident_end = None;
+                    continue;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        out.push(segment(rest, start, ident_end, bytes.len())?);
+        Some(out)
     }
+}
+
+/// One path segment's ident (up to its own generic arguments, if any) and
+/// whether it had them. `None` when the text is not an ident, which is how a
+/// non-path canon is refused.
+fn segment(
+    s: &str,
+    start: usize,
+    ident_end: Option<usize>,
+    end: usize,
+) -> Option<(syn::Ident, bool)> {
+    let text = s[start..ident_end.unwrap_or(end)].trim();
+    Some((
+        syn::parse_str::<syn::Ident>(text).ok()?,
+        ident_end.is_some(),
+    ))
+}
+
+/// Byte index of the `>` closing the angle group `s` opens with.
+fn close_angle(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0usize;
+    for (i, b) in bytes.iter().enumerate() {
+        match b {
+            b'<' => depth += 1,
+            b'>' if i > 0 && bytes[i - 1] == b'-' => {}
+            b'>' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 impl fmt::Display for TypeKey {
@@ -171,15 +254,22 @@ mod tests {
 
     /// Every shape a key can hold, as a build script or a source could spell it.
     ///
-    /// A `qself` path is absent on purpose: `scan_declared_items` refuses one,
-    /// and `short_name` documents answering `None` for it rather than reading
-    /// through the qualification.
+    /// Generics on a **non-final** segment (`a::Foo<u8>::Bar`) and a `::` inside
+    /// an argument (`Vec<a::B>`) pull in opposite directions, and a `->` inside
+    /// an argument (`Vec<fn() -> a::B>`) breaks naive angle counting — each is a
+    /// way the string walk can be wrong while the easy cases still pass.
     const SHAPES: &[&str] = &[
         "Foo",
         "a::Foo",
+        "a::b::Foo",
         "std::string::String",
         "Vec<u8>",
         "Vec<a::B>",
+        "Vec<Vec<u8>>",
+        "a::Foo<u8>::Bar",
+        "Foo<u8>::Assoc",
+        "<T as Tr>::Item",
+        "Vec<fn() -> a::B>",
         "Publisher<'static>",
         "Option<Box<Node>>",
         "&Foo",
@@ -188,9 +278,11 @@ mod tests {
         "[u8; 4]",
         "()",
         "(u8, u8)",
+        "(a::B, c::D)",
         "*const u8",
         "dyn Error",
         "fn() -> u8",
+        "fn(u8) -> a::B",
     ];
 
     /// The accessors and the `syn` walks they replace answer identically.
@@ -226,12 +318,46 @@ mod tests {
         }
     }
 
-    /// `short_name` is looser than `ident` in exactly one way: generic arguments.
+    /// `short_name` is looser than `ident` in exactly one way: generic arguments
+    /// **on the last segment**.
     #[test]
-    fn short_name_reads_through_generics_and_ident_does_not() {
+    fn short_name_reads_through_last_segment_generics_and_ident_does_not() {
         let key = TypeKey::from_type(&syn::parse_quote!(Publisher<'static>));
         assert_eq!(key.short_name().as_deref(), Some("Publisher"));
         assert_eq!(key.ident(), None);
+
+        // Arguments EARLIER in the path disqualify nothing: the segment being
+        // named is `Bar`, and it has none.
+        let nested = TypeKey::from_type(&syn::parse_quote!(a::Foo<u8>::Bar));
+        assert_eq!(nested.short_name().as_deref(), Some("Bar"));
+        assert_eq!(
+            nested.ident().map(|i| i.to_string()).as_deref(),
+            Some("Bar")
+        );
+    }
+
+    /// A qualified-self path names its tail, like `bare_path_ident` does —
+    /// syn keeps only `Item` in `path.segments`, and so does the string walk.
+    #[test]
+    fn qualified_self_paths_name_their_tail() {
+        let key = TypeKey::from_type(&syn::parse_quote!(<T as Tr>::Item));
+        assert_eq!(key.short_name().as_deref(), Some("Item"));
+        assert_eq!(key.ident().map(|i| i.to_string()).as_deref(), Some("Item"));
+    }
+
+    /// A `::` inside a generic argument is not a path separator, and neither
+    /// angle counting nor the `->` in a bare-fn argument may make it look like
+    /// one.
+    #[test]
+    fn separators_inside_generic_arguments_are_not_path_separators() {
+        for (spec, expected) in [
+            ("Vec<a::B>", Some("Vec")),
+            ("Vec<fn() -> a::B>", Some("Vec")),
+            ("Vec<Vec<a::B>>", Some("Vec")),
+        ] {
+            let key = TypeKey::from_type(&syn::parse_str(spec).expect("test shape"));
+            assert_eq!(key.short_name().as_deref(), expected, "on `{spec}`");
+        }
     }
 
     /// A name comes back out as the ident it names — `from_ident` is the inverse.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -27,13 +27,7 @@ pub(crate) fn rust_short_name(key: &TypeKey) -> String {
 /// wrapper patterns including non-path shapes like `()` where there
 /// is no Kotlin short name to derive.
 pub(crate) fn rust_short_name_opt(key: &TypeKey) -> Option<String> {
-    let ty = key.to_type();
-    if let syn::Type::Path(tp) = &ty {
-        if let Some(last) = tp.path.segments.last() {
-            return Some(last.ident.to_string());
-        }
-    }
-    None
+    key.short_name()
 }
 
 /// `VisitMut` that prefixes every bare single-segment `Type::Path` whose

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -487,16 +487,11 @@ impl Declarations {
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
-            // Look up the syn::ItemEnum by the type-key's bare ident.
-            let ty = key.to_type();
-            let Some(ident) = (if let syn::Type::Path(tp) = &ty {
-                tp.path.segments.last().map(|s| s.ident.clone())
-            } else {
-                None
-            }) else {
+            // Look up the syn::ItemEnum by the type-key's own short name.
+            let Some(name) = key.short_name() else {
                 continue;
             };
-            let Some(item_enum) = registry.flat().enum_item(&ident) else {
+            let Some(item_enum) = registry.flat().enum_item(&name) else {
                 continue;
             };
             let (package, class_name) = match kotlin_fqn.rsplit_once('.') {
@@ -548,8 +543,7 @@ impl Declarations {
             let Some(kotlin_fqn) = cfg.name_spec.as_ref().map(|s| self.fqn_of(s)) else {
                 continue;
             };
-            let ty = key.to_type();
-            let Some(ident) = bare_path_ident(&ty) else {
+            let Some(ident) = key.ident() else {
                 continue;
             };
             // The sum as the MODEL holds it: its alternatives' payloads are
@@ -891,15 +885,10 @@ impl Declarations {
                 continue;
             };
 
-            let ty = key.to_type();
-            let Some(ident) = (if let syn::Type::Path(tp) = &ty {
-                tp.path.segments.last().map(|s| s.ident.clone())
-            } else {
-                None
-            }) else {
+            let Some(name) = key.short_name() else {
                 continue;
             };
-            let Some(item_struct) = registry.flat().struct_type(&ident) else {
+            let Some(item_struct) = registry.flat().struct_type(&name) else {
                 continue;
             };
 

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -2332,8 +2332,7 @@ fn shape_notes(
 /// The `///` doc of the `#[prebindgen]` struct/enum behind a declared type
 /// key, when the item is indexed (a re-exported foreign type has none).
 pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Option<String> {
-    let ident = bare_path_ident(&key.to_type())?;
-    let name = ident.to_string();
+    let name = key.ident()?.to_string();
     let attrs = registry
         .flat()
         .struct_type(&name)

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -127,9 +127,7 @@ pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMet
                 short.to_string(),
                 format!("sealed class `{key}` itself (its variants' supertype)"),
             )]);
-            if let Some(item_enum) =
-                bare_path_ident(&key.to_type()).and_then(|i| registry.flat().enum_item(&i))
-            {
+            if let Some(item_enum) = key.ident().and_then(|i| registry.flat().enum_item(&i)) {
                 for v in &item_enum.variants {
                     let name = ext.sum_variant_class_name(sum_cfg, &v.ident);
                     let vorigin = format!("variant `{}` of sealed class `{key}`", v.ident);
@@ -268,9 +266,8 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
         .collect();
     class_keys.sort_by_key(|k| k.as_str().to_string());
     for key in class_keys {
-        let ident = match bare_path_ident(&key.to_type()) {
-            Some(i) => i,
-            None => continue,
+        let Some(ident) = key.ident() else {
+            continue;
         };
         if let Some(s) = registry
             .flat()


### PR DESCRIPTION
Third of four on #291. **Stacked on #299 → #298** — both green; bases get retargeted as each merges.

## What

Eight sites asked `to_type()` for a whole `syn::Type` and then threw all of it away but one ident. They were not asking for syntax; they were asking the key what it is *called*.

```rust
TypeKey::ident()      -> Option<syn::Ident>   // bare_path_ident's rule
TypeKey::short_name() -> Option<String>       // last segment, generics and all
```

**Two accessors, because the incumbent walks genuinely differ.** `bare_path_ident` refuses a type carrying generic arguments; the Kotlin class-name derivation reads `Publisher<'static>` as `Publisher` — a declaration writes the latter and means the class. One accessor would have had to pick a winner and silently change one set of call sites.

## Read off the canonical string, deliberately

`canon` is a token-stream rendering, so its tokens are space-separated — `Vec < u8 >`, `& Foo`, `a :: Foo`, `[u8 ; 4]` — which puts a path's head before the first `<` and its last segment after the last `::`, with `syn::parse_str::<syn::Ident>` as the total validator on the far end.

Reparsing the whole type instead would make a **name** depend on a serialize-then-reparse round trip, which is precisely the dependency #95 removed. Generic arguments are stripped *first*, because in `Vec<a::B>` the `::` belongs to the argument and the segment being named is still `Vec`.

## The warrant

`key_name_accessors_match_the_syn_walks` asserts both accessors equal to the walk each replaces across sixteen shapes: bare and qualified paths, generics, lifetime generics, references, mutable references, slices, arrays, tuples, unit, raw pointers, trait objects, fn pointers.

It also pins the one documented limit: a qualified-self path (`<T as Tr>::Item`) answers `None` rather than `Item`. It cannot reach here — `scan_declared_items` refuses a `qself` declaration — and refusing beats guessing for a shape this cannot read.

## Independent signal

The boundary ledger moved **120 → 117**, and `api/lang/jnigen/jni/kotlin_emit.rs` left it entirely. These were real source-syntax classification sites (`if let syn::Type::Path(tp) = &ty { … segments.last() … }`), not just call-site noise — which is the ledger's whole job to notice.

Three `to_type()` sites remain, all stage D: `option_depth`, `KotlinMeta::value_rust_key`, and the idempotence assertion that dies with the method.

## Verified

- `cargo test --all --all-features` — 634 lib tests, all green
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release` on every example crate
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections