### PR TITLE
A key is only an identity (#291 stage D, closes #291)

### DIFF
--- a/prebindgen/src/api/core/registry/key.rs
+++ b/prebindgen/src/api/core/registry/key.rs
@@ -7,16 +7,32 @@ use quote::ToTokens;
 /// Canonical type-shape key: identity is the token string of the
 /// **normalized** type ([`crate::api::core::flat::spelling::normalize_type`] —
 /// group/paren unwrap, `crate::`/`self::` and std-prelude path reduction;
-/// the complete equivalence rule set is documented there). The normalized
-/// parsed form is kept alongside the string, so [`Self::to_type`] is an
-/// infallible clone — no core invariant depends on serialize-then-reparse
-/// round trips (issue #95).
+/// the complete equivalence rule set is documented there).
+///
+/// # A key is an identity, and nothing else
+///
+/// It is what a table is indexed by. It is **not** a route to `syn::Type`: the
+/// only way to reach a type's syntax is
+/// [`Conversions::reading`](super::Conversions::reading) followed by
+/// [`TypeRef::syntax`](crate::api::core::flat::TypeRef::syntax), because a
+/// reading is what pairs a spelling with the classification that vouches for
+/// it.
+///
+/// This used to keep the parsed form beside the string and hand it out through
+/// `to_type()`, which let any holder of a key produce tokens for a type the
+/// model never classified — the same capability #280 sealed `TypeRef` against,
+/// granted by the key itself. A caller that wants tokens now has to have gotten
+/// them from somewhere that knows what they mean: the registry's reading, or
+/// the declaration that wrote them (#291).
+///
+/// What a key can still answer about itself is what it is **called** —
+/// [`Self::as_str`], [`Self::ident`], [`Self::short_name`] — because a name is
+/// not syntax.
 #[derive(Clone)]
 pub struct TypeKey {
-    /// Canonical token string — the identity `Eq`/`Hash` compare.
+    /// Canonical token string — the identity `Eq`/`Hash` compare, and the whole
+    /// of what a key is.
     canon: std::rc::Rc<str>,
-    /// The normalized parsed form the string was rendered from.
-    ty: std::rc::Rc<syn::Type>,
 }
 
 impl PartialEq for TypeKey {
@@ -66,6 +82,10 @@ impl std::error::Error for TypeKeyParseError {}
 
 impl TypeKey {
     /// Build a key by parsing the input as a type and normalizing.
+    ///
+    /// The parse is kept for **validation** and then discarded: a key that
+    /// cannot be a type is a mistake worth reporting at the declaration, and a
+    /// key that can is still only its canonical string.
     pub fn parse(s: &str) -> Result<Self, TypeKeyParseError> {
         let ty: syn::Type = syn::parse_str(s).map_err(|error| TypeKeyParseError {
             input: s.to_string(),
@@ -79,10 +99,11 @@ impl TypeKey {
     pub fn from_type(ty: &syn::Type) -> Self {
         // Off the shared reduction, so this key and the model's type index
         // cannot drift apart about what a type is called.
-        let t = crate::api::core::flat::canonical_type(ty);
         Self {
-            canon: t.to_token_stream().to_string().into(),
-            ty: std::rc::Rc::new(t),
+            canon: crate::api::core::flat::canonical_type(ty)
+                .to_token_stream()
+                .to_string()
+                .into(),
         }
     }
 
@@ -97,17 +118,10 @@ impl TypeKey {
         &self.canon
     }
 
-    /// The normalized parsed form. Infallible — a clone of the stored type,
-    /// never a reparse.
-    pub fn to_type(&self) -> syn::Type {
-        (*self.ty).clone()
-    }
-
     /// The bare item ident this key names — `Foo`, `a::Foo` → `Foo`,
     /// `a::Foo<u8>::Bar` → `Bar`; `None` when the **last** segment carries
     /// generic arguments (`Vec<u8>` names no bare item) or the key is not a
     /// path.
-    ///
     /// Matches [`bare_path_ident`](crate::api::core::types_util::bare_path_ident)
     /// on the same type, which is what
     /// `key_name_accessors_match_the_syn_walks` pins.

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -479,9 +479,11 @@ fn typekey_equivalence_rules() {
     assert_ne!(k("std::ffi::CString"), k("CString"));
     assert_ne!(k("&Foo"), k("&'a Foo"));
     assert_ne!(k("Foo<'static>"), k("Foo"));
-    // Idempotence: re-keying a key's own type or string is the identity.
+    // Idempotence: re-keying a key's own string is the identity. The key IS the
+    // canonical string now, so that is the whole claim — there used to be a
+    // second assertion re-keying `to_type()`, which was really about the parsed
+    // form a key kept beside the string, and a key keeps no such thing (#291).
     let once = k("std::vec::Vec<crate::m::Foo>");
-    assert_eq!(once, TypeKey::from_type(&once.to_type()));
     assert_eq!(once, k(once.as_str()));
     assert_eq!(once.as_str(), "Vec < Foo >");
 }

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -8,8 +8,8 @@ impl CbindgenBuilder {
             let Some(domain) = &decl.domain else { continue };
             let demand = [Direction::Input, Direction::Output]
                 .into_iter()
-                .flat_map(|direction| registry.type_table(direction).keys())
-                .map(|candidate| option_depth(candidate, &decl.key))
+                .flat_map(|direction| registry.type_table(direction).values())
+                .map(|cell| option_depth(&cell.subject, &decl.key))
                 .max()
                 .unwrap_or(0);
             let ty = domain.ty();
@@ -281,10 +281,13 @@ impl CbindgenBuilder {
         let Some(domain) = &decl.domain else {
             return Niches::empty();
         };
+        // Every crossing key has a cell — that is where `crossing_keys` got it
+        // — so the reading is always there to count layers off.
         let demand = registry
             .crossing_keys(direction)
             .iter()
-            .map(|candidate| option_depth(candidate, &decl.key))
+            .filter_map(|candidate| registry.reading(candidate))
+            .map(|candidate| option_depth(&candidate, &decl.key))
             .max()
             .unwrap_or(0);
         Niches::from_slots(
@@ -351,17 +354,21 @@ fn fn_ret(item: &syn::ItemFn) -> syn::Type {
     }
 }
 
-fn option_depth(candidate: &TypeKey, target: &TypeKey) -> usize {
-    let mut ty = candidate.to_type();
+/// How many `Option<…>` layers `candidate` puts over `target`, or 0 if it is
+/// not that type under any number of them.
+///
+/// Counted off the **reading**. The optional layers are already what the model
+/// says this type is — `TypeKind::Optional` is produced for exactly `Option<T>`
+/// — so peeling tokens to rediscover them was re-deriving the classification
+/// the registry stored (#291).
+fn option_depth(candidate: &crate::api::core::flat::TypeRef, target: &TypeKey) -> usize {
+    let mut reading = candidate;
     let mut depth = 0;
-    while is_option(&ty) {
-        let Some(inner) = first_type_arg(&ty) else {
-            return 0;
-        };
-        ty = inner;
+    while let Some(inner) = reading.optional_inner() {
+        reading = inner;
         depth += 1;
     }
-    if TypeKey::from_type(&ty) == *target {
+    if reading.key() == *target {
         depth
     } else {
         0

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -281,13 +281,21 @@ impl CbindgenBuilder {
         let Some(domain) = &decl.domain else {
             return Niches::empty();
         };
-        // Every crossing key has a cell — that is where `crossing_keys` got it
-        // — so the reading is always there to count layers off.
+        // A crossing with no reading contributes no demand, and that is an
+        // answer rather than a gap being swallowed: the niche allocator is
+        // reserving values no SIBLING CONVERSION can produce, and a crossing
+        // the registry never entered has no conversion to produce one. Spelled
+        // as an explicit `0` — the same answer jnigen's twin gives — so the
+        // reasoning is in the code instead of in a claim that a `filter_map`
+        // silently relied on.
         let demand = registry
             .crossing_keys(direction)
             .iter()
-            .filter_map(|candidate| registry.reading(candidate))
-            .map(|candidate| option_depth(&candidate, &decl.key))
+            .map(|candidate| {
+                registry
+                    .reading(candidate)
+                    .map_or(0, |reading| option_depth(&reading, &decl.key))
+            })
             .max()
             .unwrap_or(0);
         Niches::from_slots(

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1790,7 +1790,7 @@ impl Declarations {
     pub(crate) fn framework_meta(&self, kotlin_name: Option<kt::KtType>) -> KotlinMeta {
         KotlinMeta {
             kotlin_name,
-            value_rust_key: None,
+            value_rust_type: None,
             projection: None,
         }
     }
@@ -1931,7 +1931,7 @@ impl Declarations {
                     niches,
                     metadata: KotlinMeta {
                         kotlin_name,
-                        value_rust_key: None,
+                        value_rust_type: None,
                         // Terminal: body produces the wire directly, no inner
                         // converter composed, so no handle to carry.
                         projection: None,
@@ -1954,7 +1954,7 @@ impl Declarations {
                 let mut pre_stages = vec![stage];
                 pre_stages.extend(inner.pre_stages.iter().cloned());
                 let kotlin_name = inner.metadata.kotlin_name.clone();
-                let value_rust_key = None;
+                let value_rust_type = None;
                 let (niches, sentinels) = self.conversion_domain_niches(
                     &key,
                     registry,
@@ -1963,7 +1963,7 @@ impl Declarations {
                 );
                 let mut metadata = KotlinMeta {
                     kotlin_name,
-                    value_rust_key,
+                    value_rust_type,
                     projection: inner.metadata.projection.clone(),
                 };
                 Self::attach_domain_sentinels(&mut metadata, sentinels);
@@ -2054,11 +2054,16 @@ impl Declarations {
         match inner {
             None if is_self || is_wire_type(&ty) => {
                 // Terminal: `ty` is the wire; the body produces it from `outer`.
-                let (kotlin_name, value_rust_key) = if let Some(a0) = arg0 {
+                let (kotlin_name, value_rust_type) = if let Some(a0) = arg0 {
                     registry
                         .reading_of(a0)
                         .and_then(|tr| registry.output_entry(&tr))
-                        .map(|e| (e.metadata.kotlin_name.clone(), Some(TypeKey::from_type(a0))))
+                        .map(|e| {
+                            (
+                                e.metadata.kotlin_name.clone(),
+                                Some(crate::api::core::flat::canonical_type(a0)),
+                            )
+                        })
                         .unwrap_or((None, None))
                 } else {
                     let kn = self
@@ -2081,7 +2086,7 @@ impl Declarations {
                     niches,
                     metadata: KotlinMeta {
                         kotlin_name,
-                        value_rust_key,
+                        value_rust_type,
                         // Terminal: body produces the wire directly, no inner
                         // converter composed, so no handle to carry.
                         projection: None,
@@ -2099,7 +2104,7 @@ impl Declarations {
                 let mut pre_stages = vec![stage];
                 pre_stages.extend(inner.pre_stages.iter().cloned());
                 let kotlin_name = inner.metadata.kotlin_name.clone();
-                let value_rust_key = arg0.map(TypeKey::from_type);
+                let value_rust_type = arg0.map(crate::api::core::flat::canonical_type);
                 let (niches, sentinels) = match arg0 {
                     None => self.conversion_domain_niches(
                         &key,
@@ -2111,7 +2116,7 @@ impl Declarations {
                 };
                 let mut metadata = KotlinMeta {
                     kotlin_name,
-                    value_rust_key,
+                    value_rust_type,
                     projection: inner.metadata.projection.clone(),
                 };
                 Self::attach_domain_sentinels(&mut metadata, sentinels);

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -824,9 +824,11 @@ impl ReturnSurface {
             .and_then(|tr| registry.output_entry(&tr))
             .map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
-        // `value_rust_type`) declare no Kotlin return type. The peeled type
-        // comes straight off the stored key — no reparse, no silent
-        // fallback.
+        // `value_rust_type`) declare no Kotlin return type. The peeled type is
+        // the one the converter's metadata stored — a canonical `syn::Type`,
+        // so nothing is rebuilt here. Falling back to the declared return is
+        // not a miss: `value_rust_type` is `None` exactly for plain values and
+        // arity-0 converters, which have no inner identity to peel to.
         let canonical: syn::Type = outer_meta
             .as_ref()
             .and_then(|m| m.value_rust_type.as_ref())

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -185,10 +185,10 @@ pub(crate) struct ValueOutputPlan {
     pub wire_ty: syn::Type,
     /// Kotlin surface classification over the **declared** return
     /// (`convert_out_ty` for a convert, else `f.sig.output` — not
-    /// `target_ty`: the Kotlin error peel rides `value_rust_key`).
+    /// `target_ty`: the Kotlin error peel rides `value_rust_type`).
     pub surface: ReturnSurface,
     /// `enum_class` / `Option<enum>` probes over the canonical
-    /// (`value_rust_key`-peeled) declared return. The extern decl uses them
+    /// (`value_rust_type`-peeled) declared return. The extern decl uses them
     /// raw; the wrapper surface masks them with `!is_convert` (the historical
     /// `unfold.is_none()` gate).
     pub is_enum: bool,
@@ -781,7 +781,7 @@ fn build_output(
 
     // The Kotlin surface classifies the DECLARED return — `convert_out_ty`
     // for a convert, else the signature's own output. (Not `target_ty`: the
-    // Kotlin error peel rides the entry's `value_rust_key`, so the full
+    // Kotlin error peel rides the entry's `value_rust_type`, so the full
     // `Result<T, E>` type is looked up as written.)
     let ret_decl: syn::ReturnType = if is_convert {
         syn::parse_quote!(-> #target_ty)
@@ -807,7 +807,7 @@ fn build_output(
 
 impl ReturnSurface {
     /// Classify a declared return type. Returns the surface plus the
-    /// canonical (`value_rust_key`-peeled) type the enum probes run over —
+    /// canonical (`value_rust_type`-peeled) type the enum probes run over —
     /// the single peel that subsumed both `classify_return`'s inline peel
     /// and the former `canonical_return_ty`.
     pub fn classify(
@@ -824,13 +824,13 @@ impl ReturnSurface {
             .and_then(|tr| registry.output_entry(&tr))
             .map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
-        // `value_rust_key`) declare no Kotlin return type. The peeled type
+        // `value_rust_type`) declare no Kotlin return type. The peeled type
         // comes straight off the stored key — no reparse, no silent
         // fallback.
         let canonical: syn::Type = outer_meta
             .as_ref()
-            .and_then(|m| m.value_rust_key.as_ref())
-            .map(TypeKey::to_type)
+            .and_then(|m| m.value_rust_type.as_ref())
+            .cloned()
             .unwrap_or_else(|| ty.clone());
         if crate::api::lang::jnigen::util::is_unit(&canonical) {
             return (Self::Unit, canonical);

--- a/prebindgen/src/api/lang/jnigen/jni/metadata.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/metadata.rs
@@ -99,15 +99,19 @@ pub struct KotlinMeta {
     pub kotlin_name: Option<kt::KtType>,
     /// For wrapper converters whose Kotlin projection is the *inner*
     /// type's projection (e.g. `ZResult<Publisher>` → `Publisher`),
-    /// this carries the inner Rust type's canonical key so downstream
+    /// this carries the inner Rust type — canonicalized — so downstream
     /// emitters (typed-handle constructor lookup in `classify_return`) can find
     /// the wrapped value's identity without baking in any specific shape.
-    /// Populated with `args[0]`'s canonical key for arity-1 wrappers, and
+    /// Populated with `args[0]`'s canonical type for arity-1 wrappers, and
     /// inherited by the built-in `Option<_>` / `Vec<_>` / `&_` wrappers from
     /// their inner type's metadata. `None` for plain values and arity-0
-    /// converters. A typed key — readers get the type via `to_type()`, no
-    /// reparse.
-    pub value_rust_key: Option<crate::api::core::registry::TypeKey>,
+    /// converters.
+    ///
+    /// **A type, because that is the only thing anyone reads it as.** It held a
+    /// `TypeKey` and had exactly one reader, which immediately spent it on
+    /// `to_type()` — so the key was never an identity here, only a detour
+    /// through one. The producers have the `syn::Type` in hand (#291).
+    pub value_rust_type: Option<syn::Type>,
     /// Present iff this (possibly wrapped) value is an opaque native handle. Set
     /// at the opaque-handle leaf and folded outward by the `&_` / `Option<_>`
     /// wrappers and the `lookup_*` composed branches. The single source of truth
@@ -119,7 +123,7 @@ impl KotlinMeta {
     pub fn from_name(name: impl Into<String>) -> Self {
         Self {
             kotlin_name: Some(kt::KtType::cls(name)),
-            value_rust_key: None,
+            value_rust_type: None,
             projection: None,
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -929,7 +929,7 @@ impl Declarations {
             niches: inner.niches.clone(),
             metadata: KotlinMeta {
                 kotlin_name,
-                value_rust_key: None,
+                value_rust_type: None,
                 projection,
             },
         })
@@ -1001,7 +1001,7 @@ impl Declarations {
             niches: Niches::empty(),
             metadata: KotlinMeta {
                 kotlin_name,
-                value_rust_key: None,
+                value_rust_type: None,
                 projection,
             },
         })
@@ -1070,7 +1070,7 @@ impl Declarations {
             niches: Niches::empty(),
             metadata: KotlinMeta {
                 kotlin_name,
-                value_rust_key: None,
+                value_rust_type: None,
                 projection: None,
             },
         })
@@ -1142,7 +1142,7 @@ impl Declarations {
                     niches: Niches::empty(),
                     metadata: KotlinMeta {
                         kotlin_name,
-                        value_rust_key: None,
+                        value_rust_type: None,
                         projection,
                     },
                 });
@@ -2543,7 +2543,7 @@ impl Declarations {
                 niches,
                 metadata: KotlinMeta {
                     kotlin_name,
-                    value_rust_key: None,
+                    value_rust_type: None,
                     projection,
                 },
             });
@@ -2610,7 +2610,7 @@ impl Declarations {
             niches,
             metadata: KotlinMeta {
                 kotlin_name,
-                value_rust_key: None,
+                value_rust_type: None,
                 projection,
             },
         })


### PR DESCRIPTION
Last of four on #291. **Stacked on #300 → #299 → #298** — all green; bases get retargeted as each merges.

## The last three readers

- **`option_depth`** peeled `Option<…>` tokens to count layers the model had already counted. `TypeKind::Optional` is produced for exactly `Option<T>` at arity 1, and `optional_inner()` names the layer. It takes the reading now, and both callers hand over readings they were already sitting next to (one iterated `type_table(dir).keys()` when `.values()` had the answer).
- **`KotlinMeta::value_rust_key`** held a `TypeKey` and had exactly **one** reader, which immediately spent it on `to_type()`. It was never an identity here — only a detour through one — and both producers have the `syn::Type` in hand. Now `value_rust_type: Option<syn::Type>`, carrying the same canonical form it always yielded.
- **The idempotence assertion** re-keyed `to_type()`, which was really a claim about the parsed form a key kept beside its string. A key keeps no such thing; the next line's string round trip is the whole claim and it stays.

## Then the field

```rust
#[derive(Clone)]
pub struct TypeKey {
    canon: std::rc::Rc<str>,
}
```

`from_type` stops allocating the second `Rc`. `parse` still parses — to **validate** — and discards it. `Eq`/`Hash`/`Ord`/`Debug`/`Display` never read anything else, so nothing about identity, ordering, or error text moves.

## What this closes

Not a miscompilation — none was known. It is that the type system permitted a category of mistake: *spell a type nobody classified*. #280 sealed `TypeRef` so only the model may mint a reading, and a key that handed out tokens walked straight around that seal. The route from a key to syntax is `Conversions::reading` + `TypeRef::syntax`, and now it is the only one.

**44 call sites → 0**, across four PRs, with generated output byte-identical at every step.

## On the issue's "one genuine loss"

#291 predicted ~5 production sites turning infallible into `Option`. In the end **none did**. Stage B gave the declare-phase sites their own `syn::Type` (where `reading()` would have answered `None` and silently changed behaviour), stage C1 answered the name sites from the key itself, and the three here needed no new failure mode. The two sites that did move to `reading()` — `SpecKey::WholeFolder` and `crossing_keys` — each sit beside a sibling that already did, and defer on `None` exactly as it does.

## Verified

- `cargo test --all --all-features` — 634 lib tests, all green
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release` on every example crate
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections