### PR TITLE
jnigen: a sum's match pattern keeps its own delimiters

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -239,20 +239,23 @@ pub(crate) fn encode_sum_group(
         .expect("a sum plan carries its selector leaf");
     let tag_id = &obj_idents[tag_idx];
     // A unit variant contributes no leaf, so the arm list is driven by the
-    // enum's own variants, not by the grouped leaves.
-    let item_enum = registry.flat().enum_item(&ident).unwrap_or_else(|| {
-        panic!("jnigen sum unfold: no indexed enum `{ident}` for the decomposed sum")
-    });
-    let spec = crate::api::core::types_util::SumSpec::from_item_enum(item_enum);
+    // enum's own alternatives, not by the grouped leaves. `enum_item` hands
+    // back only the `syn::ItemEnum`, deliberately — a consumer that acts on the
+    // Variant/Enum distinction asks `declared_type` (#289).
+    let Some(crate::api::core::flat::Type::Variant(sum)) = registry.flat().declared_type(&ident)
+    else {
+        panic!("jnigen sum unfold: no indexed sum `{ident}` for the decomposed sum")
+    };
 
-    let arms: Vec<TokenStream> = spec
-        .variants
+    let arms: Vec<TokenStream> = sum
+        .alternatives
         .iter()
-        .map(|variant| {
+        .map(|alt| {
+            let tag = alt.index as i32;
             let group: Vec<usize> = leaves
                 .iter()
                 .enumerate()
-                .filter(|(_, l)| l.group == Some(variant.tag))
+                .filter(|(_, l)| l.group == Some(tag))
                 .map(|(i, _)| i)
                 .collect();
             let binds: Vec<syn::Ident> = group
@@ -260,20 +263,21 @@ pub(crate) fn encode_sum_group(
                 .enumerate()
                 .map(|(k, _)| format_ident!("__sv{}", k))
                 .collect();
-            let vident = &variant.ident;
-            let pattern = match variant.fields.first().map(|f| &f.member) {
-                None => quote!(#source::#vident),
-                Some(syn::Member::Named(_)) => {
-                    let pairs = variant.fields.iter().zip(&binds).map(|(f, b)| {
-                        let syn::Member::Named(n) = &f.member else {
-                            unreachable!("variant field shapes are uniform")
-                        };
-                        quote!(#n: #b)
-                    });
-                    quote!(#source::#vident { #(#pairs),* })
-                }
-                Some(syn::Member::Unnamed(_)) => quote!(#source::#vident(#(#binds),*)),
-            };
+            let vident = &alt.name;
+            // The alternative's OWN delimiters, from the one place that chooses
+            // them — for match patterns and constructors alike. Branching on
+            // `fields.first()` could not answer this: an empty alternative has
+            // no first field, so `enum E { B() }` and `enum E { B {} }` both
+            // matched the `None` arm and emitted the bare `E::B`, which is
+            // E0533 in pattern position. Same shape as the empty struct that
+            // emitted `Unit {}` in #302.
+            let parts: Vec<TokenStream> = alt
+                .fields
+                .iter()
+                .zip(&binds)
+                .map(|(f, b)| f.bind(b))
+                .collect();
+            let pattern = alt.spell(quote!(#source::#vident), &parts);
             // The live group: convert each payload through its own output
             // converter, exactly as a struct field of the same type would be.
             let live: TokenStream = group
@@ -299,7 +303,7 @@ pub(crate) fn encode_sum_group(
                     quote! { #id = #d; }
                 })
                 .collect();
-            let tag_lit = proc_macro2::Literal::i32_unsuffixed(variant.tag);
+            let tag_lit = proc_macro2::Literal::i32_unsuffixed(tag);
             // A nullable selector rides an OBJECT slot (its absent case is JVM
             // null, which a raw `jint` has no room for), so the live tag boxes
             // like any other nullable primitive leaf.

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -1702,3 +1702,77 @@ fn a_raw_named_sum_generates() {
         "the sum encoder matches the raw-named enum by its real path:\n{rust}"
     );
 }
+
+/// A payload-less alternative keeps its own delimiters in the output match.
+///
+/// The arm builder branched on `variant.fields.first()`, so an alternative with
+/// no fields took the `None` arm and was spelled bare — `myflat::Shape::Parens`
+/// for `Parens()`, which is **E0533**: a zero-field tuple or struct variant
+/// still needs its delimiters in pattern position. An empty alternative has no
+/// first field to branch on, exactly as the empty struct in #302 had no field to
+/// refuse.
+///
+/// `Alternative::spell` is the one place those delimiters are chosen — its own
+/// doc says "for match patterns and constructors alike, in either direction" —
+/// and this is the pattern half of that sentence.
+#[test]
+fn empty_sum_alternatives_keep_their_own_pattern_delimiters() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Shape {
+                    Bare,
+                    Parens(),
+                    Braces {},
+                    Full(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn make_shape() -> Shape {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Shape))
+                .fun(crate::fun!(make_shape)),
+        );
+
+    let dir = unique_test_dir("jnigen_empty_sum_alternatives");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = jni.build_with(registry).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+        .expect("read rust");
+    let rc: String = rust.split_whitespace().collect();
+
+    // Each alternative is matched with the delimiters Rust demands for it.
+    assert!(
+        rc.contains("myflat::Shape::Bare=>"),
+        "a unit alternative is matched bare:\n{rust}"
+    );
+    assert!(
+        rc.contains("myflat::Shape::Parens()=>"),
+        "an empty TUPLE alternative keeps its parens:\n{rust}"
+    );
+    assert!(
+        rc.contains("myflat::Shape::Braces{}=>"),
+        "an empty STRUCT alternative keeps its braces:\n{rust}"
+    );
+    // And the bare spelling must not appear for the two that cannot take it.
+    assert!(
+        !rc.contains("myflat::Shape::Parens=>") && !rc.contains("myflat::Shape::Braces=>"),
+        "neither empty alternative may be matched bare:\n{rust}"
+    );
+}


### PR DESCRIPTION
Found while scoping the `SumSpec` retirement (#289 follow-up). Standalone because it is a **bug fix**, not a refactor — it should not wait on the larger change.

## The defect

`encode_sum_group` built each arm's pattern by branching on the first field:

```rust
let pattern = match variant.fields.first().map(|f| &f.member) {
    None                     => quote!(#source::#vident),   // ← empty ⇒ bare
    Some(Member::Named(_))   => quote!(#source::#vident { … }),
    Some(Member::Unnamed(_)) => quote!(#source::#vident(…)),
};
```

For `enum E { B() }` and `enum E { B {} }` that emits `myflat::E::B`, which is **E0533** in pattern position: a zero-field tuple or struct variant still needs its delimiters.

Branching on the first field is structurally unable to answer it — an **empty** alternative has no first field to branch on. That is the same shape as the empty struct that had no field to refuse, which is how #302 came to emit `myflat::Unit {}`.

**Three instances of one defect class in this area now:**

1. #302 — a constructor, `struct Unit;` → `Unit {}`. Caught in review.
2. #303 — a constructor, `enum E { B() }` → avoided by using `Alternative::spell`.
3. **this** — a *pattern*, `enum E { B() }` → `E::B`. Nothing had found it.

## The fix

`Alternative::spell`, whose doc names the case exactly: *"the one place those delimiters are chosen — for match patterns and constructors alike, in either direction."* #303 used the constructor half; this is the pattern half. `Field::bind` shapes each binding.

Getting there needs the element rather than the item, so the arm list comes off `Flat::declared_type` → `Type::Variant` and walks `alternatives`. `enum_item` returns only the `syn::ItemEnum`, deliberately — its own doc says a consumer acting on the Variant/Enum distinction should ask `declared_type`. The tag becomes `alt.index`, which is what `SumVariant::tag` was a copy of.

This removes one of the five `SumSpec` call sites as a side effect; the other four are the follow-up PR.

## Verified

- `empty_sum_alternatives_keep_their_own_pattern_delimiters` covers unit / empty-tuple / empty-struct alternatives, and **fails against the old branch** (checked by reverting).
- `cargo test --all --all-features` — 638 lib tests
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable, from the repo root
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release` — no in-tree fixture declares an empty non-unit alternative, which is exactly why this had no signal
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections