### PR TITLE
core: a `SumTag` selector registers the sum it names (#282)

### DIFF
--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -59,6 +59,15 @@ use crate::SourceLocation;
 /// false by design for stored readings — `unrequire_output` leaves a cell whose
 /// converter genuinely cannot resolve, and a `SumTag` leaf never has one — so
 /// converter existence stays a lookup that answers `Option`.
+///
+/// It does **not** claim a registry cell either, and the two are separate
+/// questions. Holding a `TypeRef` means the model classified the type; whether
+/// it is in a type table is the registry's business, and the registry states it
+/// in three parts — a **cell** (the type entered the pipeline), a **root** (the
+/// binding asked for it directly), an **entry** (a converter resolved). A
+/// `SumTag` leaf's type makes the first and not the second, deliberately
+/// (#282); see
+/// [`Registry::reference_output`](crate::api::core::registry::Registry::reference_output).
 #[derive(Clone, Debug)]
 pub struct TypeRef {
     /// What the type means — the closed, destination-neutral classification.

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -550,6 +550,27 @@ impl<M> Registry<M> {
         self.register_type_recursive(Direction::Output, reading, true);
     }
 
+    /// Register `reading` (and its nested positions) as an **output cell without
+    /// demanding a converter** — a type some plan *names* rather than one that
+    /// crosses.
+    ///
+    /// The third thing a table cell can mean, now said out loud. A cell records
+    /// that a type **entered the pipeline**; `root` records that the binding
+    /// asked for it *directly*; `entry` records that a converter resolved. This
+    /// makes the first without the second, which is exactly what a
+    /// [`SumTag`](crate::api::core::unfold::LeafSource::SumTag) selector needs:
+    /// it names *which* sum it chooses between, and that sum has no whole-value
+    /// output converter at all, so requiring one would fail resolution (#282).
+    ///
+    /// **Not [`require_output`](Self::require_output) with a flag.** That one is
+    /// `root = true` by definition — its whole job is to say a converter must
+    /// exist. Registration and demand are separable facts and this is the door
+    /// for the first alone; `ensure_entry`'s `root |= root` means calling it for
+    /// a type the binding did declare cannot weaken anything.
+    pub(crate) fn reference_output(&mut self, reading: &crate::api::core::flat::TypeRef) {
+        self.register_type_recursive(Direction::Output, reading, false);
+    }
+
     /// Drop `ty` from the required-output scan set. The type's table entry is
     /// left intact (so [`crate::api::core::resolve`]'s PASS A still resolves it
     /// if it can, and emits it when resolved), but a `None` resolution no longer

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -556,6 +556,35 @@ pub struct SumDecon {
 /// including the `Option<E>` / `Vec<E>` layers, which the boundary-only pass
 /// does not reach — is dropped here as the plan takes over.
 ///
+/// Put every leaf's `out_ty` in the table, and demand a converter for the ones
+/// that need one.
+///
+/// **Every leaf is registered; only a converter-bearing leaf is a root** (#282).
+/// The two are separate facts and this is the one place a sum plan states both:
+/// a cell says the type entered the pipeline, a root says the binding needs its
+/// conversion to resolve. The `SumTag` selector is registered and not required —
+/// it names *which* sum it chooses between, and a sum has no whole-value output
+/// converter, so requiring one would fail resolution over a type that never
+/// crosses whole.
+///
+/// This used to `filter` the selector out entirely, which left its `out_ty`
+/// with a cell only when the adapter happened to declare the sum separately —
+/// true for jnigen via `export_type`, and not true at all for a registry
+/// assembled without declarations. The invariant holds by construction now
+/// rather than by declaration order.
+fn register_leaves<M>(
+    registry: &mut crate::api::core::registry::Registry<M>,
+    leaves: &[UnfoldLeaf],
+) {
+    for leaf in leaves {
+        if leaf.has_converter() {
+            registry.require_output(&leaf.out_ty);
+        } else {
+            registry.reference_output(&leaf.out_ty);
+        }
+    }
+}
+
 /// Runs in `write_rust` right after [`apply_value_structs`] and before `resolve`.
 pub fn apply_sum_returns<M>(
     registry: &mut Registry<M>,
@@ -642,9 +671,7 @@ fn wire_fixed_returns<M>(
                 registry.unrequire_output(layer);
             }
         }
-        for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-            registry.require_output(&leaf.out_ty);
-        }
+        register_leaves(registry, &vd.leaves);
         let plan = UnfoldPlan {
             source: vd.source.clone(),
             decon: Some(decon.clone()),
@@ -709,9 +736,7 @@ fn wire_fixed_callbacks<M>(
                 if registry.callback_arg_plans.contains_key(&key) {
                     continue;
                 }
-                for leaf in vd.leaves.iter().filter(|l| l.has_converter()) {
-                    registry.require_output(&leaf.out_ty);
-                }
+                register_leaves(registry, &vd.leaves);
                 let plan = UnfoldPlan {
                     source: vd.source.clone(),
                     decon: Some(decon.clone()),

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -192,6 +192,15 @@ pub enum LeafSource {
     /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
     /// the groups it selects between (see
     /// [`crate::api::core::unfold::apply_sum_returns`]).
+    ///
+    /// Its [`out_ty`](UnfoldLeaf::out_ty) is **the sum**, not the `i32` — it
+    /// carries *which* sum it chooses between, which is how the emitter finds
+    /// the enum to `match`. That type is **registered and not required** (#282):
+    /// it gets a table cell like every other leaf's, but no root, because a sum
+    /// has no whole-value output converter and demanding one would fail
+    /// resolution over a type that never crosses whole. The reading comes from
+    /// the declaration — [`Variant::type_ref`](crate::api::core::flat::Variant::type_ref)
+    /// — never from an adapter composing one out of a name.
     SumTag,
     /// A payload field of ONE alternative of a decomposed sum, reached through
     /// a **variant pattern** rather than an accessor chain or a field chain:
@@ -339,6 +348,14 @@ impl UnfoldLeaf {
     /// selector: it is assigned per `match` arm, never converted, so requiring
     /// a converter for it would make every sum depend on an unrelated `i32`
     /// crossing existing in the binding.
+    ///
+    /// **This is the root question, not the registration question.** Every
+    /// leaf's `out_ty` gets a table cell; this decides which of them the
+    /// binding additionally *demands* a converter for. A cell says the type
+    /// entered the pipeline, a root says the binding asked for it directly, and
+    /// an entry says one resolved — three separate claims, and a `SumTag` leaf
+    /// makes only the first (#282). See
+    /// [`Registry::reference_output`](crate::api::core::registry::Registry::reference_output).
     pub fn has_converter(&self) -> bool {
         self.source != LeafSource::SumTag
     }

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1689,11 +1689,17 @@ fn duplicate_declarations_collected() {
 
 /// The tag + group leaves a sum decomposition is made of. Mirrors what the
 /// JNI adapter synthesizes: a selector followed by one group per alternative.
+///
+/// The selector's `out_ty` is **the sum**, as `synth_sum_leaves` stores it — it
+/// names *which* sum it chooses between, which is how the emitter finds the enum
+/// to `match`. It said `i32` here, the tag's wire type, which made the
+/// registration test prove only that *some* converter-free leaf gets a cell
+/// rather than that the selector registers the sum it names (#282).
 fn reading_sum_decon() -> SumDecon {
     let tag = UnfoldLeaf {
         name: "tag".to_string(),
         path: vec![],
-        out_ty: tref(syn::parse_quote!(i32)),
+        out_ty: tref(syn::parse_quote!(Reading)),
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1756,12 +1756,26 @@ fn sum_return_is_a_fixed_builder_plan() {
     // requirement into a binding that has no `i32` crossing of its own.
     assert!(!plan.leaves[0].has_converter());
     assert!(plan.leaves[1].has_converter());
-    assert!(
-        !reg.output_types
-            .get(&TypeKey::from_type(&syn::parse_quote!(Reading)))
-            .is_some_and(|c| c.root),
-        "a sum has no whole-value converter, so its return must not require one"
-    );
+    // #282's invariant, stated over the plan rather than over one type name:
+    // EVERY leaf's `out_ty` is registered, and only a converter-bearing leaf is
+    // a root. The assertion this replaced could state neither half — it read
+    // `!...is_some_and(|c| c.root)` on `Reading`, which is also true when the
+    // cell is ABSENT, and absent is what it was: this fixture's registry
+    // declares nothing, so it passed for the wrong reason.
+    for leaf in &plan.leaves {
+        let cell = reg
+            .output_types
+            .get(&leaf.out_ty.key())
+            .unwrap_or_else(|| panic!("leaf `{}` registers its out_ty", leaf.name));
+        assert_eq!(
+            cell.root,
+            leaf.has_converter(),
+            "leaf `{}`: a cell says the type entered the pipeline, a root says \
+             the binding demands its converter — the selector makes only the \
+             first, because a sum has no whole-value output converter",
+            leaf.name
+        );
+    }
 }
 
 /// `Option` and `Vec` layers ride the existing shape fold — a sum needs

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -659,6 +659,77 @@ fn sum_is_its_own_type_kind() {
     assert!(cfg.special_decl());
 }
 
+/// What the registry holds for a `sealed_class!` sum, in all three parts (#282).
+///
+/// The `SumTag` selector's `out_ty` is the **sum**, not the `i32` — it names
+/// which sum it chooses between. That type is *registered* and *not required*,
+/// and those are separate claims a single predicate cannot state:
+///
+/// * a **cell** says the type entered the pipeline;
+/// * a **root** says the binding demands its converter — cleared here, because
+///   a sum crosses decomposed and has no whole-value output converter;
+/// * an **entry** says one resolved — present INPUT-side (`sum_input_body`
+///   decodes a whole `JObject`), absent OUTPUT-side, and that asymmetry is the
+///   design, not an accident.
+///
+/// Asserted against a real `Registry` rather than a hand-assembled one, because
+/// the claim is about what a *declaration* produces.
+#[test]
+fn a_sums_registry_cells_are_registered_but_not_required() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one() -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .fun(crate::fun!(read_one)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    let reg = gen.registry();
+    let key = TypeKey::from_type(&syn::parse_quote!(Reading));
+
+    let input = reg.input_types.get(&key).expect("input cell");
+    let output = reg.output_types.get(&key).expect("output cell");
+
+    // Registered both ways — the declaration put them there.
+    // Required neither way — `boundary_only_types` clears the root, because the
+    // sum crosses in pieces.
+    assert!(!input.root, "a declared sum crosses decomposed, not whole");
+    assert!(!output.root, "a declared sum crosses decomposed, not whole");
+
+    // The asymmetry: Kotlin → Rust decodes a whole `JObject`; Rust → Kotlin is
+    // always flattened, so there is nothing to resolve.
+    assert!(
+        input.entry.is_some(),
+        "the input direction has a whole-object decoder"
+    );
+    assert!(
+        output.entry.is_none(),
+        "the output direction has none — a sum crosses flattened, always"
+    );
+}
+
 /// A `Vec` of tag-gated groups has variable arity, so it cannot ride the
 /// fixed-layout `fromParts` bridge — the same reason `Vec<data class>` is
 /// rejected. The guard has to peel `Vec` before asking `type_kind`, which

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -673,7 +673,13 @@ fn sum_is_its_own_type_kind() {
 ///   design, not an accident.
 ///
 /// Asserted against a real `Registry` rather than a hand-assembled one, because
-/// the claim is about what a *declaration* produces.
+/// the claim is about what a *declaration* produces — and that is the limit of
+/// what it can claim. It does **not** pin #282: `sealed_class!(Reading)` creates
+/// the output cell through `export_type` whether or not the selector registers
+/// anything, so this passes against the filtered loop too. The selector's own
+/// half is pinned in `core::unfold`'s `sum_return_is_a_fixed_builder_plan`,
+/// whose fixture carries the sum as the tag's `out_ty` exactly so it can fail
+/// when the leaf stops registering it.
 #[test]
 fn a_sums_registry_cells_are_registered_but_not_required() {
     let loc = myflat_loc();


### PR DESCRIPTION
Closes #282. The issue asked for one decision — is `LeafSource::SumTag` boundary-crossing data (registrable) or adapter-only metadata (intentionally unregistered)? **Decision: it gets a cell.**

## The issue text is stale; only registration was open

`sum_out.rs` stopped composing `TypeRef::named(enum_ident)` when #280 sealed the composers (`named` is `pub(super)` to `core::flat`), and the leaf now carries `Variant::type_ref()` — the reading the **declaration** stored. So "may the adapter compose here" is already closed. Registration was the open half.

## `require_output` could not serve it

It is `register_type_recursive(.., root = true)`, and a root **demands** a converter. A sum has no whole-value *output* converter, so requiring one fails resolution — pulling the tag's `i32` in that way is the original reason `has_converter()` exists at all.

So registration and demand had to separate:

```rust
/// Register `reading` as an output cell WITHOUT demanding a converter.
pub(crate) fn reference_output(&mut self, reading: &TypeRef)
```

named after the existing `RegistryBuilder::reference` vocabulary ("scanned, not required"), and both leaf loops now **split** on `has_converter()` instead of filtering by it. `ensure_entry` does `cell.root |= root`, so referencing a type the binding did declare cannot weaken it.

## The invariant, stated where it is checkable

> Every leaf's `out_ty` has a table cell; only a converter-bearing leaf is a root.

A **cell** says the type entered the pipeline, a **root** says the binding asked for it directly, an **entry** says one resolved — three claims, and a `SumTag` leaf makes only the first. Written on `has_converter`, `LeafSource::SumTag`, and `TypeRef` (whose doc already said a reading claims no converter, and now says it claims no cell either).

## What this buys — the old test proves it

The invariant held before **only because jnigen happens to declare the sum** via `export_type`. `unfold/tests.rs`'s assertion read `!...is_some_and(|c| c.root)`, which is *also true when the cell is absent* — and absent is exactly what it was, since that fixture's registry declares nothing. It passed for the wrong reason and could state neither half.

It now asserts the invariant over every leaf of the plan, and **fails against the old filter** (checked by reverting). Its message was wrong too: "a sum has no whole-value converter" is true only output-side.

Also worth noting: that fixture's tag leaf carries `out_ty: i32`, where the real emitter stores the **sum**. Asserting the invariant per-leaf rather than naming `Reading` sidesteps the divergence.

## The end-to-end claim the acceptance asks for

New test against a real `Registry` via `JniGen::registry()`: for a declared sum, a cell **both** ways, root cleared **both** ways, an input `entry` (the whole-`JObject` decoder) and **no** output entry. That asymmetry is the design — Rust → Kotlin is flattened, always.

**Not doing:** a source-scanning guard that `api::lang` never calls the `TypeRef` composers. They are `pub(super)` / `pub(in crate::api::core)`, so the compiler enforces it every build, and `ty.rs:96-100` says a scan test is the wrong instrument here.

## Verified

- `cargo test --all --all-features` — 634 lib tests
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable, from the repo root
- `cargo fmt --check` with the CI config; `cargo doc` clean
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release`. This was the specific risk: `crossings()` seeds from every table key, so a *newly created* cell would add a crossing — but jnigen's sum already had one from its declaration, so nothing entered the order.
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections

Ledger and census do not move, and were not going to: no `syn::Type` match, no spelling-helper call.