### PR TITLE
jnigen: one reading of the movability rule (#223 item 1)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -456,8 +456,16 @@ pub(crate) fn reach_leaf_flat(
     // somewhere to go. This derivation has none — it yields a plain Rust value,
     // not a `JObject` that could be null — so the shape is refused here rather
     // than composed into code that cannot type-check in the consumer's crate.
+    //
+    // Asked of the leaf's OWN path, not of `path`. The caller may hand a
+    // suffix: `wrapper.rs` rebases onto a hoisted local, and `Hoisted::innermost`
+    // strips the prefix that bound it — including any optional step inside it.
+    // Checking the parameter would therefore pass exactly when the hoist is the
+    // conditional one, which is the case that cannot compose (an `Option<T>`
+    // local with a field read hung off it). The full path is what the shape
+    // question is about.
     assert!(
-        !path.iter().rev().skip(1).any(PathStep::is_optional),
+        !leaf.path.iter().rev().skip(1).any(PathStep::is_optional),
         "jnigen unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
@@ -475,17 +483,21 @@ pub(crate) fn reach_leaf_flat(
     //   so ownership is the enclosing form's: only a consuming one gives its
     //   fields away.
     //
-    // A trailing `Option` step cannot arrive here at all: return delivery has
-    // no `None` arm for the absent case, so a nullable leaf is routed to
-    // callback delivery when the plan picks its `Delivery` — see
-    // `single_return` in `core/unfold.rs`. `is_plain_field` is what that rules
-    // out, and it stays as the local statement of the same fact.
+    // How to project that place is `steps_are_movable`'s question, and it is
+    // asked there rather than restated here. This used to spell it
+    // `all(is_plain_field)`, defending the restatement on the grounds that a
+    // trailing `Option` cannot reach return delivery anyway — true, and enforced
+    // in `single_return` (`core/unfold.rs`), which is precisely why a local
+    // restatement could disagree with the rule for as long as the invariant held
+    // somewhere else. `plan.rs` says two readings would drift and the
+    // disagreement would be a borrow handed to an owning converter; this is the
+    // second reading, removed.
     let reached_is_ours = if leaf.identity {
         !matches!(leaf.out_ty.syntax(), syn::Type::Reference(_))
     } else {
         consuming
     };
-    if reached_is_ours && path.iter().all(PathStep::is_plain_field) {
+    if reached_is_ours && steps_are_movable(path) {
         let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
         return quote!(#base #(.#segs)*);
     }
@@ -1401,4 +1413,96 @@ pub(crate) fn leaf_ty_is_prim(registry: &impl Conversions<KotlinMeta>, out_ty: &
         Some(p) => matches!(p.kind, ProjectionKind::Handle | ProjectionKind::Unsigned64),
     };
     proj_ok && matches!(jni_field_access(&entry.destination), Some((_, _, false)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::core::unfold::{LeafSource, UnfoldLeaf};
+    /// A `TypeRef` through the model. `Flat::classify` is sealed to `api::core`
+    /// (#280), so a test under `api::lang` asks the sanctioned probe helper
+    /// rather than reaching around the seal — which is the seal working.
+    use crate::api::test_util::reading as tref;
+
+    fn leaf(out_ty: syn::Type, path: Vec<PathStep>, identity: bool) -> UnfoldLeaf {
+        UnfoldLeaf {
+            name: "probe".to_string(),
+            path,
+            out_ty: tref(out_ty),
+            identity,
+            nullable: false,
+            source: LeafSource::Field,
+            group: None,
+        }
+    }
+
+    fn qualify(id: &syn::Ident) -> syn::Path {
+        syn::parse_quote!(myflat::#id)
+    }
+
+    /// `reach_leaf_flat` projects the place `steps_are_movable` says is movable
+    /// — the two are one rule, not two readings of one.
+    ///
+    /// The trailing-optional path is the case that discriminates: it IS movable
+    /// (a `None` arm still hands the whole `Option` over by value), and the
+    /// `all(is_plain_field)` restatement this replaced called it not-movable.
+    /// Where the plan had already granted an owned `out_ty` on the strength of
+    /// `steps_are_movable`, that disagreement is a borrow reaching an owning
+    /// converter — `plan.rs`'s stated hazard, and PR#221's P1.
+    #[test]
+    fn a_movable_place_is_projected_as_a_move() {
+        for path in [
+            vec![PathStep::field(syn::parse_quote!(a), false)],
+            vec![
+                PathStep::field(syn::parse_quote!(a), false),
+                PathStep::field(syn::parse_quote!(b), false),
+            ],
+            // Movable by `steps_are_movable`; NOT by `all(is_plain_field)`.
+            vec![
+                PathStep::field(syn::parse_quote!(a), false),
+                PathStep::field(syn::parse_quote!(b), true),
+            ],
+        ] {
+            assert!(steps_are_movable(&path), "fixture must be movable");
+            let l = leaf(syn::parse_quote!(Owned), path.clone(), true);
+            let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+            assert!(
+                !got.contains('&') && !got.contains("clone"),
+                "a movable place is moved, not borrowed or cloned — got `{got}`"
+            );
+        }
+    }
+
+    /// A borrow stays a borrow: an identity leaf whose `out_ty` is a reference
+    /// did not own what it reached, whatever the path shape says.
+    #[test]
+    fn a_borrowed_out_ty_is_never_moved() {
+        let path = vec![PathStep::field(syn::parse_quote!(a), false)];
+        let l = leaf(syn::parse_quote!(&Owned), path.clone(), true);
+        let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+        assert!(
+            got.contains('&'),
+            "a borrowed out_ty keeps its borrow — got `{got}`"
+        );
+    }
+
+    /// The optional-step guard asks the LEAF's path, not the caller's slice.
+    ///
+    /// `wrapper.rs` rebases onto a hoisted local and hands over the remaining
+    /// suffix, so checking the parameter would pass exactly when the hoist is
+    /// the conditional one — an `Option<T>` local with a field read hung off it,
+    /// which cannot compose. Passing the suffix here mimics that rebase.
+    #[test]
+    #[should_panic(expected = "which has no `None` arm")]
+    fn an_optional_step_in_a_stripped_prefix_is_still_refused() {
+        let full = vec![
+            PathStep::call(syn::parse_quote!(get_it), true, false),
+            PathStep::field(syn::parse_quote!(a), false),
+        ];
+        let l = leaf(syn::parse_quote!(Owned), full, false);
+        // The suffix a rebase would hand over — the optional call is gone from
+        // it, and used to take the guard with it.
+        let rest = vec![PathStep::field(syn::parse_quote!(a), false)];
+        let _ = reach_leaf_flat(&qualify, &l, &rest, quote!(__vf0), false, false);
+    }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -1424,14 +1424,27 @@ mod tests {
     /// rather than reaching around the seal — which is the seal working.
     use crate::api::test_util::reading as tref;
 
-    fn leaf(out_ty: syn::Type, path: Vec<PathStep>, identity: bool) -> UnfoldLeaf {
+    /// A leaf as the resolver builds one. `source` is not decoration: it
+    /// decides the terminal treatment (a `Field` leaf is CLONED out of the
+    /// place it reached), and production pairs it with the path shape —
+    /// `Accessor` for identity leaves and accessor chains (`unfold.rs`'s
+    /// `DeconRecord::Identity` arm), `Field` only for the synthesized
+    /// by-value `data_class` decomposition, whose paths are field idents and
+    /// never calls. A fixture that mixed them would exercise a leaf the
+    /// resolver cannot produce.
+    fn leaf(
+        out_ty: syn::Type,
+        path: Vec<PathStep>,
+        identity: bool,
+        source: LeafSource,
+    ) -> UnfoldLeaf {
         UnfoldLeaf {
             name: "probe".to_string(),
             path,
             out_ty: tref(out_ty),
             identity,
             nullable: false,
-            source: LeafSource::Field,
+            source,
             group: None,
         }
     }
@@ -1464,7 +1477,12 @@ mod tests {
             ],
         ] {
             assert!(steps_are_movable(&path), "fixture must be movable");
-            let l = leaf(syn::parse_quote!(Owned), path.clone(), true);
+            let l = leaf(
+                syn::parse_quote!(Owned),
+                path.clone(),
+                true,
+                LeafSource::Accessor,
+            );
             let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
             assert!(
                 !got.contains('&') && !got.contains("clone"),
@@ -1478,11 +1496,40 @@ mod tests {
     #[test]
     fn a_borrowed_out_ty_is_never_moved() {
         let path = vec![PathStep::field(syn::parse_quote!(a), false)];
-        let l = leaf(syn::parse_quote!(&Owned), path.clone(), true);
+        let l = leaf(
+            syn::parse_quote!(&Owned),
+            path.clone(),
+            true,
+            LeafSource::Accessor,
+        );
         let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
         assert!(
             got.contains('&'),
             "a borrowed out_ty keeps its borrow — got `{got}`"
+        );
+    }
+
+    /// A `Field` leaf is cloned out of the place it reached, whatever the path
+    /// shape says — its converter takes the field type as written.
+    ///
+    /// The counterpart of the move above, and what keeps `source` load-bearing
+    /// in these fixtures rather than a value they all happen to share.
+    #[test]
+    fn a_field_leaf_is_cloned_out_of_its_place() {
+        let path = vec![
+            PathStep::field(syn::parse_quote!(a), false),
+            PathStep::field(syn::parse_quote!(b), false),
+        ];
+        let l = leaf(
+            syn::parse_quote!(Owned),
+            path.clone(),
+            false,
+            LeafSource::Field,
+        );
+        let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+        assert!(
+            got.contains("clone"),
+            "a non-consuming field leaf clones rather than moves — got `{got}`"
         );
     }
 
@@ -1499,7 +1546,7 @@ mod tests {
             PathStep::call(syn::parse_quote!(get_it), true, false),
             PathStep::field(syn::parse_quote!(a), false),
         ];
-        let l = leaf(syn::parse_quote!(Owned), full, false);
+        let l = leaf(syn::parse_quote!(Owned), full, false, LeafSource::Accessor);
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -35,8 +35,9 @@ pub(crate) fn struct_input_body(
         // field now, because the element models a field list rather than a
         // `syn::Fields` shape.
         let fname_ident = field.name.clone()?;
-        let fname = fname_ident.to_string();
-        let camel = mangle_kotlin_ident(&snake_to_camel(&fname));
+        // The name the property was DECLARED with — `GetFieldID` takes the
+        // slot's exact name, so this cannot be derived a second way.
+        let camel = kotlin_property_name(&fname_ident);
         let err_prefix = format!("{struct_name}.{camel}: {{}}");
         let raw_ident = format_ident!("__{}_raw", fname_ident);
 
@@ -1459,7 +1460,7 @@ fn build_flat_struct_node(
                 "only named-field structs can flatten",
             ));
         };
-        let fcamel = mangle_kotlin_ident(&snake_to_camel(&fident.to_string()));
+        let fcamel = kotlin_property_name(&fident);
         let child_native = format!("{native_prefix}_{}", fident);
         let field_ref = if nullable_context {
             format!("{access_prefix}?.{fcamel}")

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -423,26 +423,6 @@ impl Declarations {
     }
 }
 
-/// Slot name of one variant field in the flattened `fromParts` signature:
-/// `<variantCamel>_<property>` (`periodicQueries_period`, `pair_v0`) — the
-/// existing nested-prefix convention, with `_` marking the variant boundary
-/// exactly as core's `<variant_snake>_<field>` leaf names do.
-///
-/// Keyed on the **Kotlin** variant class name, not the Rust ident, so a
-/// `variant!(V).name(...)` rename carries through to the slots and the
-/// emitted surface stays self-consistent.
-fn sum_slot_name(kotlin_variant: &str, property: &str) -> String {
-    // The variant class name is PascalCase; lower its first character so the
-    // slot reads as an ordinary Kotlin parameter (`PeriodicQueries` →
-    // `periodicQueries_period`).
-    let mut chars = kotlin_variant.chars();
-    let head: String = match chars.next() {
-        Some(c) => c.to_lowercase().collect(),
-        None => String::new(),
-    };
-    format!("{head}{}_{property}", chars.as_str())
-}
-
 /// Owned counterpart of [`TypedHandle`] — used internally so the
 /// `collect_typed_handles` helper doesn't have to hand out borrows of
 /// `self.types`.
@@ -654,7 +634,7 @@ impl Declarations {
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
                 let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
-                factory = factory.param(KtParam::new(sum_slot_name(&vname, &prop), ty));
+                factory = factory.param(KtParam::new(sum_slot_fragment(&vname, &prop), ty));
             }
         }
         let mut body = Code::new();
@@ -664,7 +644,7 @@ impl Declarations {
                 let args: Vec<String> = alt
                     .fields
                     .iter()
-                    .map(|f| sum_slot_name(&vname, &sum_field_prop_name(&f.member())))
+                    .map(|f| sum_slot_fragment(&vname, &sum_field_prop_name(&f.member())))
                     .collect();
                 let ctor = if alt.is_empty() {
                     vname

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -105,7 +105,7 @@ pub(crate) fn build_data_class(
                 item_struct.name
             )
         });
-        let kotlin_field_name = mangle_kotlin_ident(&kt_snake_to_camel(&field_ident.to_string()));
+        let kotlin_field_name = kotlin_property_name(field_ident);
         let owner = format!("{}.{}", item_struct.name, field_ident);
 
         // The declaration reads ONE direction — output — because that is the
@@ -2192,6 +2192,23 @@ pub(crate) fn render_return_surface(
 /// the file renderer produces for the same type.
 pub(crate) fn kt_type_short(ty: &kt::KtType) -> String {
     ty.render(&mut kt::ImportSet::new(""))
+}
+
+/// The Kotlin property name of one struct field — the single derivation, so the
+/// site that DECLARES a property and the sites that ACCESS it cannot disagree.
+///
+/// They did. `render_data_class_source` declared it through `kt_snake_to_camel`,
+/// while `flat_input`'s access expression and JVM-slot name went through
+/// `util::snake_to_camel`, which additionally lower-cases the first character.
+/// The two agree for a conventional lower-snake field and only for that: a field
+/// spelled `Xyz` was declared `Xyz` and read as `xyz`, and a JNI `GetFieldID`
+/// for a name that is not the declared one fails at runtime.
+///
+/// `kt_snake_to_camel` is the behaviour kept, because the declaration is what a
+/// Kotlin property actually gets called; `snake_to_camel` stays where it names
+/// PARAMETERS, which is a different namespace with no declaration to match.
+pub(crate) fn kotlin_property_name(field: &syn::Ident) -> String {
+    mangle_kotlin_ident(&kt_snake_to_camel(&field.to_string()))
 }
 
 pub(crate) fn kt_snake_to_camel(s: &str) -> String {

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -276,17 +276,32 @@ pub(crate) fn classify_field(
             let fqn = projection_leaf_kt(ext, &proj)?.to_string();
             return Some(PlanFieldKind::Projection { conv, proj, fqn });
         }
-        // Bare enum leaf.
-        if ext.is_kotlin_enum(&effective_ty) {
-            let kotlin = field_entry.metadata.kotlin_name.clone()?;
-            return Some(PlanFieldKind::Enum { conv, kotlin });
-        }
-        // `Option<enum>` leaf.
-        if let Some(inner) = optional_inner {
-            if ext.is_kotlin_enum(inner.syntax()) {
-                let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
-                return Some(PlanFieldKind::OptionEnum { conv, kotlin });
-            }
+        // Enum leaf, bare or under `Option` — asked ONCE, of the model, and of
+        // the already-peeled reading beside us.
+        //
+        // It used to ask `is_kotlin_enum` twice, of two spellings. That answers
+        // about the WRAPPER: `builder.rs` documents `Box<Priority>` as `false`
+        // for it and `true` for the reading form, so a wrapped enum field fell
+        // through to the plain-leaf arm and rendered as its wire instead of the
+        // Kotlin enum class — the #273 family, output-side. `flat_input.rs` had
+        // already moved to the reading; this is the other half of the same
+        // question finally giving the same answer.
+        //
+        // Optionality stays the CALLER's fact rather than the probe's:
+        // `enum_probe` peels `Option` as well as borrows, so asking it about
+        // the unpeeled reading would make `Priority` and `Option<Priority>`
+        // indistinguishable and collapse the two arms into one.
+        if ext.is_kotlin_enum_reading(bare_ref) {
+            return match optional_inner {
+                None => {
+                    let kotlin = field_entry.metadata.kotlin_name.clone()?;
+                    Some(PlanFieldKind::Enum { conv, kotlin })
+                }
+                Some(inner) => {
+                    let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
+                    Some(PlanFieldKind::OptionEnum { conv, kotlin })
+                }
+            };
         }
         // Nested plain data-class (optionally under `Option`).
         let inner_ty = bare.clone();


### PR DESCRIPTION
#223 item 1 — the one it calls *"worth doing regardless"*. Two divergences in the reach family, both latent, and neither unreachable for a reason the emitter states.

Note two of the issue's premises are **stale**: `wrapper.rs` no longer hand-rolls a reach (it calls `bind_hoists` + `reach_leaf_flat`, shared with `encode_plan_leaves`), and all four struct-field walks moved to `flat::Struct::fields`. What survives is smaller and sharper.

## (a) A second reading of `steps_are_movable`

`plan.rs:163-166` says of it:

> This is the one place the rule is written… **Two readings of it would drift, and the disagreement would be a borrow handed to an owning converter.**

`reach_leaf_flat` was the second reading, spelled `path.iter().all(PathStep::is_plain_field)`. **They already disagreed**: the rule permits a *trailing* optional field — a `None` arm still hands the whole `Option` over by value — and the restatement did not. So where `place_is_owned` granted an owned `out_ty` *on the strength of the rule*, the emitter projected a borrow into the owning converter that `out_ty` had selected. PR#221's P1, one path shape away.

Its comment **defended** the restatement: a trailing optional can't reach return delivery, since `single_return` routes a nullable leaf to callback delivery. That's true, and it is the shape of the hazard rather than a defence against it — a local restatement can disagree with the rule for as long as an invariant *somewhere else* keeps the disagreement unreachable.

## (b) A guard that inspected the wrong path

The optional-step assert asked its `path` **parameter**. `wrapper.rs` rebases onto a hoisted local and hands over the remaining suffix, `Hoisted::innermost` having stripped the prefix that bound it — optional step and all. So the guard passed **exactly when the hoist was the conditional one**, which is the case that cannot compose: an `Option<T>` local with a field read hung off it. It asks `leaf.path` now.

## (c) The missing test level

**No test called a reach function directly.** Every pin was an end-to-end string match on generated Rust — which is why a latent divergence had no failing test. Three unit tests now do, and each fails against the code it replaced. The movability one reports the defect verbatim:

```
a movable place is moved, not borrowed or cloned — got `(& (& __src . a) . b) . clone ()`
```

They ask `test_util::reading` rather than `Flat::classify`, which #280 sealed to `api::core` — a test under `api::lang` meeting that boundary is the boundary working.

## Verified

- `cargo test --all --all-features` — 637 lib tests
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable, from the repo root
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release` — expected, since neither divergence is reachable today
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections

Ledger and census unmoved: no `syn::Type` match added, no spelling-helper call.

Follow-up PR covers the three duplicates exploration turned up (`sum_slot_name` being a byte-for-byte copy of `sum_slot_fragment`; `classify_field` asking the spelling where `flat_input` asks the model; two camel-casers for one Kotlin property name). Item 3 — `UnfoldPlan` keeping its tree — stays deferred until #220 forces it, as the issue advises.