### PR TITLE
jnigen: one name, one enum question (#223 cheap wins)

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -35,8 +35,9 @@ pub(crate) fn struct_input_body(
         // field now, because the element models a field list rather than a
         // `syn::Fields` shape.
         let fname_ident = field.name.clone()?;
-        let fname = fname_ident.to_string();
-        let camel = mangle_kotlin_ident(&snake_to_camel(&fname));
+        // The name the property was DECLARED with — `GetFieldID` takes the
+        // slot's exact name, so this cannot be derived a second way.
+        let camel = kotlin_property_name(&fname_ident);
         let err_prefix = format!("{struct_name}.{camel}: {{}}");
         let raw_ident = format_ident!("__{}_raw", fname_ident);
 
@@ -1459,7 +1460,7 @@ fn build_flat_struct_node(
                 "only named-field structs can flatten",
             ));
         };
-        let fcamel = mangle_kotlin_ident(&snake_to_camel(&fident.to_string()));
+        let fcamel = kotlin_property_name(&fident);
         let child_native = format!("{native_prefix}_{}", fident);
         let field_ref = if nullable_context {
             format!("{access_prefix}?.{fcamel}")

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -423,26 +423,6 @@ impl Declarations {
     }
 }
 
-/// Slot name of one variant field in the flattened `fromParts` signature:
-/// `<variantCamel>_<property>` (`periodicQueries_period`, `pair_v0`) — the
-/// existing nested-prefix convention, with `_` marking the variant boundary
-/// exactly as core's `<variant_snake>_<field>` leaf names do.
-///
-/// Keyed on the **Kotlin** variant class name, not the Rust ident, so a
-/// `variant!(V).name(...)` rename carries through to the slots and the
-/// emitted surface stays self-consistent.
-fn sum_slot_name(kotlin_variant: &str, property: &str) -> String {
-    // The variant class name is PascalCase; lower its first character so the
-    // slot reads as an ordinary Kotlin parameter (`PeriodicQueries` →
-    // `periodicQueries_period`).
-    let mut chars = kotlin_variant.chars();
-    let head: String = match chars.next() {
-        Some(c) => c.to_lowercase().collect(),
-        None => String::new(),
-    };
-    format!("{head}{}_{property}", chars.as_str())
-}
-
 /// Owned counterpart of [`TypedHandle`] — used internally so the
 /// `collect_typed_handles` helper doesn't have to hand out borrows of
 /// `self.types`.
@@ -654,7 +634,7 @@ impl Declarations {
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
                 let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
-                factory = factory.param(KtParam::new(sum_slot_name(&vname, &prop), ty));
+                factory = factory.param(KtParam::new(sum_slot_fragment(&vname, &prop), ty));
             }
         }
         let mut body = Code::new();
@@ -664,7 +644,7 @@ impl Declarations {
                 let args: Vec<String> = alt
                     .fields
                     .iter()
-                    .map(|f| sum_slot_name(&vname, &sum_field_prop_name(&f.member())))
+                    .map(|f| sum_slot_fragment(&vname, &sum_field_prop_name(&f.member())))
                     .collect();
                 let ctor = if alt.is_empty() {
                     vname

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -105,7 +105,7 @@ pub(crate) fn build_data_class(
                 item_struct.name
             )
         });
-        let kotlin_field_name = mangle_kotlin_ident(&kt_snake_to_camel(&field_ident.to_string()));
+        let kotlin_field_name = kotlin_property_name(field_ident);
         let owner = format!("{}.{}", item_struct.name, field_ident);
 
         // The declaration reads ONE direction — output — because that is the
@@ -2192,6 +2192,23 @@ pub(crate) fn render_return_surface(
 /// the file renderer produces for the same type.
 pub(crate) fn kt_type_short(ty: &kt::KtType) -> String {
     ty.render(&mut kt::ImportSet::new(""))
+}
+
+/// The Kotlin property name of one struct field — the single derivation, so the
+/// site that DECLARES a property and the sites that ACCESS it cannot disagree.
+///
+/// They did. `render_data_class_source` declared it through `kt_snake_to_camel`,
+/// while `flat_input`'s access expression and JVM-slot name went through
+/// `util::snake_to_camel`, which additionally lower-cases the first character.
+/// The two agree for a conventional lower-snake field and only for that: a field
+/// spelled `Xyz` was declared `Xyz` and read as `xyz`, and a JNI `GetFieldID`
+/// for a name that is not the declared one fails at runtime.
+///
+/// `kt_snake_to_camel` is the behaviour kept, because the declaration is what a
+/// Kotlin property actually gets called; `snake_to_camel` stays where it names
+/// PARAMETERS, which is a different namespace with no declaration to match.
+pub(crate) fn kotlin_property_name(field: &syn::Ident) -> String {
+    mangle_kotlin_ident(&kt_snake_to_camel(&field.to_string()))
 }
 
 pub(crate) fn kt_snake_to_camel(s: &str) -> String {

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -276,17 +276,32 @@ pub(crate) fn classify_field(
             let fqn = projection_leaf_kt(ext, &proj)?.to_string();
             return Some(PlanFieldKind::Projection { conv, proj, fqn });
         }
-        // Bare enum leaf.
-        if ext.is_kotlin_enum(&effective_ty) {
-            let kotlin = field_entry.metadata.kotlin_name.clone()?;
-            return Some(PlanFieldKind::Enum { conv, kotlin });
-        }
-        // `Option<enum>` leaf.
-        if let Some(inner) = optional_inner {
-            if ext.is_kotlin_enum(inner.syntax()) {
-                let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
-                return Some(PlanFieldKind::OptionEnum { conv, kotlin });
-            }
+        // Enum leaf, bare or under `Option` — asked ONCE, of the model, and of
+        // the already-peeled reading beside us.
+        //
+        // It used to ask `is_kotlin_enum` twice, of two spellings. That answers
+        // about the WRAPPER: `builder.rs` documents `Box<Priority>` as `false`
+        // for it and `true` for the reading form, so a wrapped enum field fell
+        // through to the plain-leaf arm and rendered as its wire instead of the
+        // Kotlin enum class — the #273 family, output-side. `flat_input.rs` had
+        // already moved to the reading; this is the other half of the same
+        // question finally giving the same answer.
+        //
+        // Optionality stays the CALLER's fact rather than the probe's:
+        // `enum_probe` peels `Option` as well as borrows, so asking it about
+        // the unpeeled reading would make `Priority` and `Option<Priority>`
+        // indistinguishable and collapse the two arms into one.
+        if ext.is_kotlin_enum_reading(bare_ref) {
+            return match optional_inner {
+                None => {
+                    let kotlin = field_entry.metadata.kotlin_name.clone()?;
+                    Some(PlanFieldKind::Enum { conv, kotlin })
+                }
+                Some(inner) => {
+                    let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
+                    Some(PlanFieldKind::OptionEnum { conv, kotlin })
+                }
+            };
         }
         // Nested plain data-class (optionally under `Option`).
         let inner_ty = bare.clone();


### PR DESCRIPTION
The follow-up to #307. **Stacked on it** — base retargets to `language-integration` once that merges.

Three places where one question had two implementations — #223's own thesis, in the naming/classification layer it does not list. All found while checking whether item 2 ("one struct-field walk") was still tractable; it is **not**, because `classify_field` is output-only and needs *resolved* converters while `synth_value_struct_leaves` runs pre-resolve and `build_flat_struct_node` is input-side. These are the value that was left in that area.

## 1. `sum_slot_name` was a byte-for-byte copy

Of `sum_slot_fragment` — same lower-first-char plus `_` join. `kotlin_emit` called the copy at one site and the shared `sum_field_prop_name` at two others, so a slot name and the property inside it came from different files. Deleted.

## 2. `classify_field` asked the spelling where the model has the answer

It called `is_kotlin_enum` twice, on two spellings, where `flat_input` asks `is_kotlin_enum_reading`. `builder.rs:109-111` documents the difference: a `Box<Priority>` field is **false** for the first and **true** for the second, so a wrapped enum field classifies as a plain leaf and renders as its wire instead of the Kotlin enum class — the #273 family, output-side.

It asks **once** now, of `bare_ref` — the already-peeled reading sitting beside it. Optionality stays the caller's fact: `enum_probe` peels `Option` as well as borrows, so probing the unpeeled reading would make `Priority` and `Option<Priority>` indistinguishable and collapse two arms into one.

### ⚠️ A pre-existing gap found while trying to prove this

I added a `Box<Priority>` field to `WrappedFields` — the fixture #294 added for exactly this bare/wrapped pairing — to demonstrate the fix. **It does not resolve:**

```
Unresolved { key: TypeKey("Box < Priority >"), direction: Output }
```

Reverting the classification change leaves it failing identically, so this is a **pre-existing capability gap**, not this PR's to fix: a `Box<enum>` data-class field cannot be built at all today, in either classification. The fixture is therefore **not** in this PR, and the change stands on the question being the right one to ask rather than on a demonstration it cannot yet have.

It is also a clean instance of #223's own thesis — capability depending on *where the type appears* — and probably wants its own issue.

## 3. Two camel-casers named one Kotlin property

`render_data_class_source` **declared** the property with `kt_snake_to_camel`; `flat_input`'s access expression and its `GetFieldID` slot name used `util::snake_to_camel`, which additionally lower-cases the first character.

They agree for a conventional lower-snake field and only for that — a field spelled `Xyz` is declared `Xyz` and read as `xyz`, and `GetFieldID` for a name that is not the declared one **fails at runtime**. One `kotlin_property_name` now serves the declaration and both readers.

`snake_to_camel` stays where it names *parameters* — a different namespace with no declaration to match. `symbols.rs`'s mangling warning already used the kept caser and deliberately passes pre- and post-mangle names separately, so it needed no change.

## Verified

- `cargo test --all --all-features` — 637 lib tests
- clippy `--all-targets --no-default-features --all-features -- -D warnings` on **both** 1.85.0 and stable, from the repo root
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` **byte-identical** after `cargo clean --release` — expected for all three: the two functions were textually identical, no in-tree field name is unconventional, and the enum divergence needs a shape that does not currently resolve
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections

Ledger and census unmoved. #2 removes a spelling-keyed question but `is_kotlin_enum` keeps other callers, so the census row does not drop.