### PR TITLE
jnigen: the transparent bridge gets its outbound half (closes #309)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -577,6 +577,7 @@ fn main() {
                 .fun(fun!(blob_value_echo))
                 .fun(fun!(arrays_echo))
                 .fun(fun!(duration_optional))
+                .fun(fun!(boxed_duration_echo))
                 .fun(fun!(duration_boundary_echo))
                 // The converted analogue of `unsigned_emit`: a whole-value
                 // callback argument, which encodes on its own path rather than

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -63,6 +63,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
 - `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue>): BlobValue`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
+- `boxed_duration_echo` — `fun boxedDurationEcho(value: ULong, onError: JniErrorHandler<ULong>): ULong`
 - `boxed_elem_id_sum` — `fun boxedElemIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `boxed_latest` — `fun <R> boxedLatest(a: SummaryVault, onError: JniErrorHandler<R?>, build: SummaryBuilder<R>): R?`
   - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -940,6 +940,8 @@ internal object CovNative {
         errorSink: Any,
     ): Any?
 
+    external fun boxedDurationEcho(value: Long, errorSink: Any): Long
+
     external fun boxedElemIdSum(ps: List<Payload>, errorSink: Any): Long
 
     external fun boxedLatest(a: Long, build: Any, errorSink: Any): Any?

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -11,6 +11,7 @@ import io.prebindgen.covertest.model.Lookup
 import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.Observation
+import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Tagged
 import java.lang.ref.Cleaner
@@ -248,10 +249,16 @@ public data class Payload(override val id: Long, override val seq: Int, override
  * `plain` is the control: the two fields must produce the same wire, since the
  * model says they are the same type.
  */
-public data class WrappedFields(val id: Long, val boxed: Long?, val plain: Long?) {
+public data class WrappedFields(val id: Long, val boxed: Long?, val plain: Long?, val boxedEnum: Priority, val plainEnum: Priority) {
     public companion object {
         @JvmStatic
-        public fun fromParts(id: Long, boxed: Long?, plain: Long?): WrappedFields = WrappedFields(id, boxed, plain)
+        public fun fromParts(
+            id: Long,
+            boxed: Long?,
+            plain: Long?,
+            boxedEnum: Int,
+            plainEnum: Int,
+        ): WrappedFields = WrappedFields(id, boxed, plain, Priority.fromInt(boxedEnum), Priority.fromInt(plainEnum))
     }
 }
 
@@ -1336,6 +1343,8 @@ internal object CovNative {
         wBoxedValue: Long,
         wPlainPresent: Boolean,
         wPlainValue: Long,
+        wBoxedEnum: Int,
+        wPlainEnum: Int,
         errorSink: Any,
     ): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1635,6 +1635,8 @@ public fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): L
         w.boxed ?: 0L,
         w.plain != null,
         w.plain ?: 0L,
+        w.boxedEnum.value,
+        w.plainEnum.value,
         __bcap,
     )
     if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -2058,6 +2058,22 @@ public fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): UL
 }
 
 /**
+ * A transparent wrapper over a **`convert!`-declared** type, both directions.
+ *
+ * `Duration` reaches its Rust value through a staged chain
+ * (`jlong -> u64 -> Duration`), and the transparent bridge used to call the
+ * inner converter's function directly and leave `pre_stages` empty — so the
+ * stages were skipped and the rebuild put `Box::new` around a `u64`. Not a
+ * silent wrong value: `E0308` in the generated crate (#309).
+ */
+public fun boxedDurationEcho(value: ULong, onError: JniErrorHandler<ULong>): ULong {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.boxedDurationEcho(value.toLong(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret.toULong()
+}
+
+/**
  * Round-trip [`DurationBoundary`] through the explicit object-input bridge.
  *
  * The Rust `DurationBoundary` result is delivered decomposed: the builder callback receives (`required`, `delay`).

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -1485,10 +1485,18 @@ fun main() {
         // are one type to the model, so both cross as `Long?` on the decoupled
         // `(present, value)` pair — the boxed one used to be read by path
         // segment as "not optional" and crossed as one boxed object.
-        check(wrappedFieldsSum(WrappedFields(1L, 2L, 4L), boom) == 7L)
-        check(wrappedFieldsSum(WrappedFields(1L, null, 4L), boom) == 5L)
-        check(wrappedFieldsSum(WrappedFields(1L, 2L, null), boom) == 3L)
-        check(wrappedFieldsSum(WrappedFields(1L, null, null), boom) == 1L)
+        // `Priority.LOW` weighs 1, `HIGH` weighs 10 — see `priority_weight`.
+        check(wrappedFieldsSum(WrappedFields(1L, 2L, 4L, Priority.LOW, Priority.LOW), boom) == 9L)
+        check(wrappedFieldsSum(WrappedFields(1L, null, 4L, Priority.LOW, Priority.LOW), boom) == 7L)
+        check(wrappedFieldsSum(WrappedFields(1L, 2L, null, Priority.LOW, Priority.LOW), boom) == 5L)
+        check(wrappedFieldsSum(WrappedFields(1L, null, null, Priority.LOW, Priority.LOW), boom) == 3L)
+
+        // And over a TERMINAL (#309): `Box<Priority>` had no outbound route at
+        // all, where `Box<Option<Long>>` above rode the `Optional` layer arm.
+        // Both enum fields are declared `Priority` in Kotlin — the wrapper is
+        // invisible — and the pair differing only in spelling must weigh alike.
+        check(wrappedFieldsSum(WrappedFields(0L, null, null, Priority.HIGH, Priority.LOW), boom) == 11L)
+        check(wrappedFieldsSum(WrappedFields(0L, null, null, Priority.LOW, Priority.HIGH), boom) == 11L)
 
         // An absent `Option<data class>` must deliver `None`, not an error. Its
         // leaves are inert placeholders when the object is null, and a required

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -59,6 +59,7 @@ import io.prebindgen.covertest.model.plainNoteEcho
 import io.prebindgen.covertest.model.blobValueNew
 import io.prebindgen.covertest.model.annotatedAlternateValue
 import io.prebindgen.covertest.model.celsiusDouble
+import io.prebindgen.covertest.model.boxedDurationEcho
 import io.prebindgen.covertest.model.durationOptional
 import io.prebindgen.covertest.model.durationBoundaryEcho
 import io.prebindgen.covertest.model.durationEmit
@@ -251,6 +252,13 @@ fun main() {
         check(durationOptional(null, boom) == null)
         check(durationOptional(0uL, boom) == 0uL)
         check(durationOptional(86_400_000uL, boom) == 86_400_000uL)
+
+        // A `Box<Duration>` crosses as a bare `Duration` does — the wrapper is
+        // invisible to Kotlin, which is why the model erases it. Both
+        // directions run the full staged chain; skipping it put `Box::new`
+        // around a `u64` and did not compile (#309).
+        check(boxedDurationEcho(86_400_000uL, boom) == 86_400_000uL)
+        check(boxedDurationEcho(0uL, boom) == 0uL)
 
         // The data-class properties are semantic `ULong` / `ULong?`, while the
         // native output factory receives primitive Longs (the optional one

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -772,6 +772,28 @@ pub(crate) unsafe fn Box_Option_i64_to_JObject_cf5a3724<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Box_Priority_to_jint_a16653ae<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<perftest_flat::Priority>,
+) -> ::core::result::Result<jni::sys::jint, __JniErr> {
+    Ok({
+        let __inner = *v;
+        Priority_to_jint_447102d2(env, __inner)?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Box<String>,
@@ -3611,10 +3633,38 @@ pub(crate) unsafe fn JObject_to_WrappedFields_f14f08c1<'env, 'v>(
                 String,
             >>::from(format!("WrappedFields.plain: {}", e)))?;
         let plain = JObject_to_Option_i64_2ba9a5ed(env, &__plain_raw)?;
+        let __boxed_enum_jobj: jni::objects::JObject = env
+            .get_field(v, "boxedEnum", "Lio/prebindgen/covertest/model/Priority;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.boxedEnum: {}", e)))?;
+        let __boxed_enum_raw: jni::sys::jint = env
+            .call_method(&__boxed_enum_jobj, "getValue", "()I", &[])
+            .and_then(|val| val.i())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.boxedEnum: {}", e)))?;
+        let boxed_enum = jint_to_Box_Priority_a16653ae(env, &__boxed_enum_raw)?;
+        let __plain_enum_jobj: jni::objects::JObject = env
+            .get_field(v, "plainEnum", "Lio/prebindgen/covertest/model/Priority;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.plainEnum: {}", e)))?;
+        let __plain_enum_raw: jni::sys::jint = env
+            .call_method(&__plain_enum_jobj, "getValue", "()I", &[])
+            .and_then(|val| val.i())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("WrappedFields.plainEnum: {}", e)))?;
+        let plain_enum = jint_to_Priority_447102d2(env, &__plain_enum_raw)?;
         perftest_flat::WrappedFields {
             id,
             boxed,
             plain,
+            boxed_enum,
+            plain_enum,
         }
     })
 }
@@ -9499,15 +9549,25 @@ pub(crate) unsafe fn WrappedFields_to_JObject_f14f08c1<'a>(
             env,
             v.plain.clone(),
         )?;
+        let ___boxed_enum: jni::sys::jint = Box_Priority_to_jint_a16653ae(
+            env,
+            v.boxed_enum.clone(),
+        )?;
+        let ___plain_enum: jni::sys::jint = Priority_to_jint_447102d2(
+            env,
+            v.plain_enum.clone(),
+        )?;
         let __obj = env
             .call_static_method(
                 "io/prebindgen/covertest/WrappedFields",
                 "fromParts",
-                "(JLjava/lang/Long;Ljava/lang/Long;)Lio/prebindgen/covertest/WrappedFields;",
+                "(JLjava/lang/Long;Ljava/lang/Long;II)Lio/prebindgen/covertest/WrappedFields;",
                 &[
                     jni::objects::JValue::from(___id),
                     jni::objects::JValue::Object(&___boxed),
                     jni::objects::JValue::Object(&___plain),
+                    jni::objects::JValue::from(___boxed_enum),
+                    jni::objects::JValue::from(___plain_enum),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -9880,6 +9940,28 @@ pub(crate) unsafe fn jdouble_to_f64_9e4a8f70<'env, 'v>(
     v: &jni::sys::jdouble,
 ) -> ::core::result::Result<f64, __JniErr> {
     Ok(*v)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jint_to_Box_Priority_a16653ae<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jint,
+) -> ::core::result::Result<Box<perftest_flat::Priority>, __JniErr> {
+    Ok({
+        let __inner = jint_to_Priority_447102d2(env, v)?;
+        ::std::boxed::Box::new(__inner)
+    })
 }
 #[allow(
     non_snake_case,
@@ -22917,6 +22999,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_wrappedFieldsSum
     w_boxed_value: jni::sys::jlong,
     w_plain_present: jni::sys::jboolean,
     w_plain_value: jni::sys::jlong,
+    w_boxed_enum: jni::sys::jint,
+    w_plain_enum: jni::sys::jint,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
     #[allow(non_upper_case_globals)]
@@ -22983,10 +23067,43 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_wrappedFieldsSum
     } else {
         ::core::option::Option::None
     };
+    let __flat_w_boxed_enum = match jint_to_Box_Priority_a16653ae(
+        &mut env,
+        &w_boxed_enum,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __flat_w_plain_enum = match jint_to_Priority_447102d2(&mut env, &w_plain_enum) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
     let __flat_w = perftest_flat::WrappedFields {
         id: __flat_w_id,
         boxed: __flat_w_boxed,
         plain: __flat_w_plain,
+        boxed_enum: __flat_w_boxed_enum,
+        plain_enum: __flat_w_plain_enum,
     };
     let w = __flat_w;
     let __out = perftest_flat::wrapped_fields_sum(w);

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -684,6 +684,34 @@ pub(crate) unsafe fn Box_Box_Option_String_to_JString_299999e0<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Box_Duration_to_jlong_0776c1ca<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<perftest_flat::Duration>,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok({
+        let __inner = *v;
+        {
+            let __inner_s0 = Duration_to_u64_e3980876(env, __inner)
+                .map_err(|__e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string()))?;
+            u64_to_jlong_4384a5d6(env, __inner_s0)?
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Box_Option_Summary_to_jlong_75560ba9<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Box<Option<perftest_flat::Summary>>,
@@ -9995,6 +10023,35 @@ pub(crate) unsafe fn jlong_to_Archive_cd73502c<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn jlong_to_Box_Duration_0776c1ca<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<Box<perftest_flat::Duration>, __JniErr> {
+    Ok({
+        let __inner = {
+            let __inner_s0 = jlong_to_u64_4384a5d6(env, v)?;
+            let __inner_s1 = u64_to_Duration_7c0845f9(env, __inner_s0)
+                .map_err(|__e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string()))?;
+            __inner_s1
+        };
+        ::std::boxed::Box::new(__inner)
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn jlong_to_EscapeProbe_416aab42<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -13178,6 +13235,48 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
                 &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedDurationEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen::lang::CachedIfaceMethod = ::prebindgen::lang::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match jlong_to_Box_Duration_0776c1ca(&mut env, &value) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::boxed_duration_echo(value);
+    match Box_Duration_to_jlong_0776c1ca(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -732,6 +732,18 @@ pub fn duration_optional(value: Option<Duration>) -> Option<Duration> {
     value
 }
 
+/// A transparent wrapper over a **`convert!`-declared** type, both directions.
+///
+/// `Duration` reaches its Rust value through a staged chain
+/// (`jlong -> u64 -> Duration`), and the transparent bridge used to call the
+/// inner converter's function directly and leave `pre_stages` empty — so the
+/// stages were skipped and the rebuild put `Box::new` around a `u64`. Not a
+/// silent wrong value: `E0308` in the generated crate (#309).
+#[prebindgen]
+pub fn boxed_duration_echo(value: Box<Duration>) -> Box<Duration> {
+    value
+}
+
 /// Deliberately violate the binding's declared output domain so the Kotlin
 /// covertest can verify outbound validation and error routing.
 #[prebindgen]

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1693,12 +1693,22 @@ pub struct WrappedFields {
     pub id: i64,
     pub boxed: Box<Option<i64>>,
     pub plain: Option<i64>,
+    /// The same pairing over a **terminal**, which is the shape that had no
+    /// outbound route at all: `Box<Option<_>>` above rides the `Optional` layer
+    /// arm, while `Box<Priority>` classifies as `Named` and no arm claims it
+    /// (#309). Both must present as `Priority` in Kotlin — the wrapper is
+    /// invisible there, which is why the model erases it.
+    pub boxed_enum: Box<Priority>,
+    pub plain_enum: Priority,
 }
 
 /// Round-trip a [`WrappedFields`] so both field spellings cross in one call.
 #[prebindgen]
 pub fn wrapped_fields_sum(w: WrappedFields) -> i64 {
-    w.id + w.boxed.unwrap_or(0) + w.plain.unwrap_or(0)
+    w.id + w.boxed.unwrap_or(0)
+        + w.plain.unwrap_or(0)
+        + i64::from(priority_weight(*w.boxed_enum))
+        + i64::from(priority_weight(w.plain_enum))
 }
 
 /// Transparent wrappers on the **input** side, one per specialized lowering.

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -438,6 +438,29 @@ impl<M> Registry<M> {
                 out.push((child_dir, child.clone()));
             }
         }
+        // A spelling the model **erased wrappers from** depends on the stripped
+        // spelling: whoever converts `Box<T>` does it by delegating to `T`'s own
+        // converter and putting the wrapper back. That is a real edge and the
+        // `kind` walk above cannot see it — `Box<T>` classifies as whatever `T`
+        // is, so the two share a classification and differ only in spelling.
+        //
+        // Without it the dependency existed but the ORDER did not: a converter
+        // that delegates is built in one pass, so it needs its inner already
+        // built, and `subs` says "this is required" rather than "this comes
+        // first". `Box<Payload>` resolved only because some other root's fields
+        // happened to pull `Payload` in earlier — alphabetical luck, which
+        // `Box<ZSample>` did not have.
+        if let Some(cell) = self.type_table(dir).get(key) {
+            let reading = &cell.subject;
+            if !reading.erased_wrappers().is_empty() {
+                let stripped = reading.stripped_key();
+                if stripped != *key {
+                    if let Some(inner) = self.type_table(dir).get(&stripped) {
+                        out.push((dir, (*inner.subject).clone()));
+                    }
+                }
+            }
+        }
         // A declared type's own fields, read off the element rather than off its
         // `syn::Fields`: a positional field is an ordinary `Field` there, so the
         // named-only asymmetry the syntax walk had does not arise. An `Enum` has

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -245,7 +245,11 @@ impl Declarations {
                 return Some(c);
             }
         }
-        None
+        // 4. Last resort: the spelling differs from something convertible only
+        //    by the wrappers the model erased. Dual of the input side's step 4,
+        //    and reached the same way — after every layer arm, so nothing that
+        //    resolves today changes route (#309).
+        self.output_transparent_bridge(ty, registry)
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2603,8 +2603,11 @@ fn a_transparent_wrapper_is_bridged_only_where_it_can_be() {
 #[test]
 fn an_erased_wrapper_over_a_terminal_crosses_both_ways() {
     let loc = myflat_loc();
-    // Each field type is wrapped and unwrapped in one struct, so the test says
-    // "these present alike", not merely "the wrapped one compiles".
+    // The enum is carried wrapped AND bare, so the Kotlin assertion below can
+    // say "these present alike" rather than merely "the wrapped one compiles".
+    // The handle and the data class are wrapped only: what they are here to
+    // show is that ONE arm serves every terminal kind, and a bare twin of each
+    // would test the terminal lookup rather than the bridge.
     let items: Vec<(syn::Item, SourceLocation)> = vec![
         (
             syn::Item::Enum(syn::parse_quote!(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2586,6 +2586,124 @@ fn a_transparent_wrapper_is_bridged_only_where_it_can_be() {
     );
 }
 
+/// An erased wrapper over a **terminal** crosses in BOTH directions, and one
+/// selector arm serves every terminal kind (#309).
+///
+/// The layer arms bridge a wrapper as part of handling their own layer, so
+/// `Box<Option<T>>` and `Box<Vec<T>>` resolved all along — which is what made
+/// the gap hard to see. A wrapper over a plain `TypeKind::Named` has no arm, and
+/// the terminal lookup keys on the SPELLING: no config sits under
+/// `Box < Priority >`. Inbound that was a last resort added by #294; outbound it
+/// was nothing at all, so the same field was a parameter this binding could take
+/// and a return it could not give.
+///
+/// The three terminal kinds are asserted together because they miss the terminal
+/// lookup the same way, and one arm therefore covers them all — a claim worth
+/// showing rather than arguing.
+#[test]
+fn an_erased_wrapper_over_a_terminal_crosses_both_ways() {
+    let loc = myflat_loc();
+    // Each field type is wrapped and unwrapped in one struct, so the test says
+    // "these present alike", not merely "the wrapped one compiles".
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Leaf {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Wrapped {
+                    pub boxed_enum: Box<Priority>,
+                    pub plain_enum: Priority,
+                    pub boxed_handle: Box<ZSample>,
+                    pub boxed_data: Box<Leaf>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_sample_to_wrapped(s: &ZSample) -> Wrapped {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_wrapped_take(w: Wrapped) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::api::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZSample))
+                .class(crate::enum_class!(Priority))
+                .class(crate::data_class!(Leaf))
+                .class(crate::data_class!(Wrapped))
+                .fun(crate::fun!(z_wrapped_take)),
+        )
+        .expand(crate::expand_return!(ZSample).fields(crate::fields!(z_sample_to_wrapped)));
+    let dir = unique_test_dir("jnigen_terminal_bridge");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    // Resolving at all is the claim: every one of these reached `None` outbound
+    // before, and the build failed naming the wrapped spelling.
+    let gen = jni
+        .build_with(registry)
+        .expect("an erased wrapper over a terminal resolves in both directions");
+    let rust =
+        std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust")).unwrap();
+    let rc: String = rust.split_whitespace().collect();
+
+    // Outbound: the wrapper comes off, then the inner converter runs. Inbound
+    // is the mirror — the inner converter runs, then the wrapper goes back on.
+    for kind in ["Priority", "ZSample", "Leaf"] {
+        assert!(
+            rc.contains(&format!("Box_{kind}_to_")),
+            "`Box<{kind}>` needs an OUTBOUND converter:\n{rust}"
+        );
+        assert!(
+            rc.contains(&format!("_to_Box_{kind}_")),
+            "`Box<{kind}>` needs an inbound converter:\n{rust}"
+        );
+    }
+    // The wrapper is invisible to Kotlin, so the bare and wrapped enum fields
+    // present as the same type — the point of the model erasing it.
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+    assert!(
+        kc.contains("valboxedEnum:Priority") && kc.contains("valplainEnum:Priority"),
+        "a wrapped enum presents as the enum class, exactly as the bare one does:\n{kotlin}"
+    );
+}
+
 /// A wrapper cannot be bridged where the converter does not produce the spelled
 /// type at all — the **borrow** shapes — so those refuse rather than resolve.
 ///

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -2240,13 +2240,20 @@ impl Declarations {
         let inner = registry.reading_of(&stripped)?;
         let entry = registry.input_entry(&inner)?;
         let wire = entry.destination.clone();
-        let inner_fn = &entry.function.sig.ident;
         // Wrap what the inner converter produced. `None` here is `Cow`'s policy
         // refusal — the crossing then stays unresolved and names the type,
         // rather than resolving and emitting Rust the consumer cannot build.
         let built = build_through_erased_wrappers(reading, quote!(__inner))?;
+        // The inner's COMPLETE chain, stages included. This called
+        // `entry.function` directly and left `pre_stages` empty, which SKIPPED
+        // them: a `convert!`-declared type reaches its Rust value through those
+        // stages (`jlong -> u64 -> Duration`), so a `Box` over one arrived
+        // un-staged. Every other composing arm goes through this helper for
+        // exactly that reason (#309).
+        let inner_call =
+            crate::api::lang::jnigen::jni::emit::composed_inner_input(entry, quote!(v));
         let body: syn::Expr = syn::parse_quote!({
-            let __inner = #inner_fn(env, v)?;
+            let __inner = #inner_call;
             #built
         });
         Some(ConverterImpl {

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -2116,6 +2116,80 @@ impl Declarations {
     /// **Input** wrapper shape (`pat` = the reconstructed canonical pattern,
     /// `t1` = its captured inner): the built-in `&`/`Option<&>`/`Vec`/`Option`
     /// handlers.
+    /// The **outbound** half of [`Self::input_transparent_bridge`], and the same
+    /// last resort: a spelling whose only difference from something this adapter
+    /// can already convert is the transparent wrappers over it.
+    ///
+    /// It had no twin, so an erased wrapper resolved inbound and not outbound —
+    /// `Box<Priority>` was a parameter this binding could take and a return it
+    /// could not give, for a wrapper the model exists to make invisible (#309).
+    /// The one arm covers `Box<Handle>`, `Box<enum>` and `Box<DataClass>` alike,
+    /// because [`Self::output_terminal`] misses all three the same way: it keys
+    /// on the SPELLING, and no config sits under `Box < Priority >`.
+    ///
+    /// The wrappers come **off** here rather than going on, which is the whole
+    /// difference:
+    ///
+    /// ```text
+    /// input : let __inner = <inner>(env, v)?;      build_through_erased_wrappers(__inner)
+    /// output: let __inner = read_through(v);       <inner>(env, __inner)
+    /// ```
+    ///
+    /// Everything else is direction-independent — `subs`, `destination`,
+    /// `niches`, `metadata` all mean the same thing either way, and inheriting
+    /// the inner's metadata is what keeps `Box<Priority>` presenting as the
+    /// Kotlin enum class instead of losing it behind the wrapper.
+    pub(crate) fn output_transparent_bridge(
+        &self,
+        reading: &crate::api::core::flat::TypeRef,
+        registry: &impl Conversions<KotlinMeta>,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        if reading.erased_wrappers().is_empty() {
+            return None;
+        }
+        let produced = reading.syntax();
+        let stripped = reading.stripped_syntax();
+        // A wrapper over a **borrow** is refused here too, and outbound the
+        // reason is its own: a borrow's output route is the clone-into-a-fresh-
+        // handle arm, which hands back a wire built from a reference — there is
+        // no owned value to read the wrapper off. Inbound the same guard is
+        // about `E0106`; the shapes coincide, the reasons do not.
+        //
+        // Asked of the MODEL: an erasure is transparent, so `Box<&T>` already
+        // classifies as `Ref` and nothing here matches a `syn` variant.
+        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Ref { .. }) {
+            return None;
+        }
+        // It has to be a type this binding already crosses; if it is not, the
+        // ordinary "unresolved" diagnostic names it, which is the better error.
+        let inner = registry.reading_of(&stripped)?;
+        let entry = registry.output_entry(&inner)?;
+        let wire = entry.destination.clone();
+        // Take the wrappers off what the caller handed us. `None` is `Cow`'s
+        // policy refusal — the crossing then stays unresolved and names the
+        // type, rather than resolving and emitting Rust the consumer cannot
+        // build.
+        let read = read_through_erased_wrappers(reading, quote!(v))?;
+        // The inner's COMPLETE chain, stages included: a `convert!` type reaches
+        // its wire through them.
+        let inner_call =
+            crate::api::lang::jnigen::jni::emit::composed_inner_output(entry, quote!(__inner));
+        let body: syn::Expr = syn::parse_quote!({
+            let __inner = #read;
+            #inner_call
+        });
+        Some(ConverterImpl {
+            subs: vec![stripped],
+            pre_stages: vec![],
+            function: self.build_output_fn(produced, &wire, &body, None),
+            destination: wire,
+            niches: entry.niches.clone(),
+            // The surface is the inner type's — a wrapper is invisible to the
+            // destination language, which is why the model erases it.
+            metadata: entry.metadata.clone(),
+        })
+    }
+
     /// **Last resort**: a spelling whose only difference from something this
     /// adapter can already convert is the transparent wrappers over it.
     ///

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -2113,9 +2113,6 @@ impl Declarations {
         None
     }
 
-    /// **Input** wrapper shape (`pat` = the reconstructed canonical pattern,
-    /// `t1` = its captured inner): the built-in `&`/`Option<&>`/`Vec`/`Option`
-    /// handlers.
     /// The **outbound** half of [`Self::input_transparent_bridge`], and the same
     /// last resort: a spelling whose only difference from something this adapter
     /// can already convert is the transparent wrappers over it.
@@ -2270,6 +2267,13 @@ impl Declarations {
         })
     }
 
+    /// **Input** wrapper shape (`pat` = the reconstructed canonical pattern,
+    /// `t1` = its captured inner): the built-in `&`/`Option<&>`/`Vec`/`Option`
+    /// handlers. The dual of [`Self::output_wrapper_shape`], whose own doc has
+    /// said so all along — this had been stranded above a different function
+    /// since the transparent bridge was inserted between them (#294), and
+    /// adding the outbound bridge moved it onto an OUTPUT converter, where it
+    /// read as an outright contradiction.
     pub(crate) fn input_wrapper_shape(
         &self,
         shape: WrapperShape,


### PR DESCRIPTION
Closes #309. Four commits: the missing capability, two defects found while building it, and the fixture that started it.

The model erases `Box` and `Cow` deliberately — `Box<Priority>` **is** `Priority` to every destination language. #294 gave the *input* selector a last resort for the case no layer arm claims (a wrapper over a **terminal**). `select_output_type` never got the twin.

## 1. The outbound arm

The dual inverts two lines, because the wrappers come **off** rather than going on:

```
input : let __inner = <inner>(env, v)?;   build_through_erased_wrappers(__inner)
output: let __inner = read_through(v);    <inner>(env, __inner)
```

`read_through_erased_wrappers` was already the operation. Everything else is direction-independent — inheriting the inner's `metadata` is what keeps `Box<Priority>` presenting as the Kotlin enum class rather than losing it behind the wrapper.

**One arm covers `Box<Handle>`, `Box<enum>` and `Box<DataClass>`** — `output_terminal` misses all three the same way, by keying on the *spelling*. The acceptance item answered, and asserted rather than argued.

## 2. ⚠️ The bridge skipped the inner's stages — and did not compile

`input_transparent_bridge` called the inner converter's function directly and left `pre_stages` empty, where every other composing arm uses `composed_inner_*`. A `convert!`-declared type reaches its Rust value *through* those stages, so a `Box` over one skipped them:

```rust
let __inner = jlong_to_u64_4384a5d6(env, v)?;
::std::boxed::Box::new(__inner)
//                     ^^^^^^^ expected `Duration`, found `u64`   [E0308]
```

Not a subtly wrong value — **the generated crate does not compile**. `boxed_duration_echo` is the fixture and it is load-bearing: revert this commit with it in place and the build fails with that error.

## 3. ⚠️ The inbound bridge has been resolving by alphabetical luck since #294

The deeper find. Whoever converts `Box<T>` delegates to `T`'s converter — a real dependency the `kind` walk cannot see, since `Box<T>` *classifies as* `T` and differs only in spelling. `subs` said "required"; nothing said "first". And `convert_with` is a **single pass in dependency order**.

So `Box<Payload>` resolved only because some other root's fields happened to pull `Payload` in earlier. Measured: rename `Priority` → `APriority` and `Box<APriority>` resolves while `Box<ZSample>` still does not, purely because `"ZSample"` sorts after `"Box < ZSample >"`. **A capability that depends on the alphabet is not one.**

`immediate_edges` now yields the stripped spelling as an edge. Goldens byte-identical — it replaces luck with an edge rather than changing output.

## 4. The fixture that could not be built

`WrappedFields` gains `Box<Priority>` beside `Priority`, matching the `Box<Option<i64>>` / `Option<i64>` pair it already carries. It now builds:

```kotlin
public data class WrappedFields(
    val id: Long, val boxed: Long?, val plain: Long?,
    val boxedEnum: Priority, val plainEnum: Priority,
)
```

`boxedEnum` presenting as `Priority` rather than its `Int` wire is **#308's** fix — which landed correct and undemonstrable, because no `Box<enum>` field could be built to show it. This is its first end-to-end evidence. The Kotlin exercise weighs the two enum fields against each other, so the claim is that wrapped and bare behave alike, not merely that the wrapped one compiles.

## Verified

Per commit, with each claim proven to bite (revert → fail → restore):

- `cargo test --all --all-features` — 639 lib tests
- clippy `-D warnings` on **both** 1.85.0 and stable, from the repo root
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` after `cargo clean --release` — **byte-identical for commits 1 and 3**; commits 2 and 4 move goldens deliberately, by their fixtures alone
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections, including both new exercises

Ledger and census unmoved: nothing here adds a `syn::Type` match or a spelling-helper call.

## Correction to the issue text

#309 says `every_erased_wrapper_has_ops` "already pins that each erased wrapper has both operations". It does not — its doc pins **membership, not capability**, and `Cow` deliberately carries `read: None`. The outbound bridge refuses `Cow` through `read` exactly as the inbound one refuses it through `build`.