### PR TITLE
jnigen: a declaration is looked up by the reading, not by a key you built

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -113,7 +113,9 @@ impl Declarations {
     /// should use.
     pub(crate) fn is_kotlin_enum(&self, ty: &syn::Type) -> bool {
         let key = TypeKey::from_type(ty);
-        self.types.get(&key).is_some_and(|c| c.is_enum_class())
+        self.types
+            .by_declared_key(&key)
+            .is_some_and(|c| c.is_enum_class())
     }
 
     /// Whether this value's core is a type registered via an `EnumClassDecl`,
@@ -131,7 +133,7 @@ impl Declarations {
             return false;
         };
         id.ident()
-            .and_then(|i| self.types.get(&TypeKey::from_ident(&i)))
+            .and_then(|i| self.types.declaration_of_name(&i))
             .is_some_and(|c| c.is_enum_class())
     }
 }
@@ -147,7 +149,7 @@ impl Default for Declarations {
             method_name_mangle: None,
             harness_name_mangle: None,
             interface_name_mangle: None,
-            types: HashMap::new(),
+            types: Default::default(),
             packages: BTreeMap::new(),
             emit_handle_locks: true,
             jni_native_init: None,
@@ -464,7 +466,7 @@ impl JniGenBuilder {
         let cfg = self
             .decls
             .types
-            .get_mut(key)
+            .declared_mut(key)
             .expect("register_class created the entry");
         cfg.interface_enabled |= iface.enabled;
         if iface.name_override.is_some() {
@@ -716,7 +718,7 @@ impl Declarations {
         }
         let spec = self
             .types
-            .get(key)
+            .by_declared_key(key)
             .and_then(|cfg| cfg.name_spec.as_ref())
             .unwrap_or_else(|| panic!("class member `{}` has no class name", m.rust_ident));
         let fqn = self.fqn_of(spec);
@@ -748,7 +750,7 @@ impl Declarations {
     /// boundary and never materializes in Kotlin — so the `_self` arms are
     /// structurally impossible for it.
     fn is_class_declared(&self, key: &TypeKey) -> bool {
-        self.types.contains_key(key)
+        self.types.contains_declared_key(key)
     }
 
     /// Lower the raw [`ExpandParamDecl`]s into the core's immutable
@@ -1110,7 +1112,10 @@ impl Declarations {
                     else {
                         panic!("TypeKind::Sum implies a payload-carrying enum")
                     };
-                    let sum_cfg = self.types[&probe.key()]
+                    let sum_cfg = self
+                        .types
+                        .by_declared_key(&probe.key())
+                        .expect("TypeKind::Sum implies a declared sum")
                         .sum()
                         .expect("TypeKind::Sum implies a sealed-class config");
                     out.push(FieldRecord {
@@ -1314,7 +1319,9 @@ impl Declarations {
         };
         let inner_key = TypeKey::from_type(&r.elem);
         assert!(
-            self.types.get(&inner_key).is_some_and(|c| c.is_opaque()),
+            self.types
+                .by_declared_key(&inner_key)
+                .is_some_and(|c| c.is_opaque()),
             "expand_return!({}).field(… .name(\"{name}\")): an `Option<&T>` binding-local field \
              delivers a nullable typed HANDLE, so `T` must be a declared ptr_class — `{}` is \
              not; return an owned `Option<{}>` instead",
@@ -1918,7 +1925,7 @@ impl Declarations {
                 // Terminal: `ty` is the wire; the body produces `outer`.
                 let kotlin_name = self
                     .types
-                    .get(&key)
+                    .by_declared_key(&key)
                     .and_then(|c| c.name_spec.as_ref())
                     .map(|s| kt::KtType::cls(self.fqn_of(s)))
                     .or_else(|| kotlin_for_wire(&ty));
@@ -2068,7 +2075,7 @@ impl Declarations {
                 } else {
                     let kn = self
                         .types
-                        .get(&key)
+                        .by_declared_key(&key)
                         .and_then(|c| c.name_spec.as_ref())
                         .map(|s| kt::KtType::cls(self.fqn_of(s)))
                         .or_else(|| kotlin_for_wire(&ty));

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -56,7 +56,7 @@ impl Declarations {
         registry: &'r impl Conversions<KotlinMeta>,
         bare: &syn::Type,
     ) -> TypeKind<'r, 'c> {
-        let cfg = self.types.get(&TypeKey::from_type(bare));
+        let cfg = self.types.declaration_of_spelling(bare);
         if let Some(c) = cfg {
             match c.kind {
                 DeclaredKind::Ptr(_) => return TypeKind::Handle,

--- a/prebindgen/src/api/lang/jnigen/jni/config.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/config.rs
@@ -239,7 +239,7 @@ impl Declarations {
     /// the former linear string scan is gone (issue #95).
     pub(crate) fn kotlin_fqn(&self, key: &TypeKey) -> Option<String> {
         self.types
-            .get(key)
+            .by_declared_key(key)
             .and_then(|cfg| cfg.name_spec.as_ref())
             .map(|spec| self.fqn_of(spec))
     }

--- a/prebindgen/src/api/lang/jnigen/jni/decl_table.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/decl_table.rs
@@ -1,0 +1,149 @@
+//! The declared-class table, and the one door into it.
+//!
+//! # Why this is a module
+//!
+//! The table used to be a `pub(crate) HashMap<TypeKey, TypeConfig>` field on
+//! [`Declarations`](super::Declarations), and every reader built its own key.
+//! Building it from a **spelling** is wrong for a declaration and right for a
+//! conversion, the difference is invisible at the call site, and the resulting
+//! defects do not announce themselves: a `Box<Payload>` parameter found no
+//! `Payload` declaration and silently lost its data-class lowering (#294), a
+//! `Box<Priority>` field rendered as its `Int` wire instead of the Kotlin enum
+//! class (#308), and `is_kotlin_enum` answered about the wrapper (#290).
+//!
+//! Making the field private would have enforced nothing: `Declarations` is
+//! declared in `jni`, every consumer is a **descendant** module of `jni`, and
+//! Rust makes a private item visible to descendants. Measured — the whole crate
+//! still compiled. The boundary has to be a module the consumers are *outside*
+//! of, which is what this file is. `map` is private to `decl_table`, so
+//! `jni::trait_impl` and its siblings can reach the table only through the
+//! accessors below.
+//!
+//! # The rule the accessors encode
+//!
+//! A **declaration** says what a type IS to Kotlin, and a wrapper the model
+//! erases cannot change that: `Box<Payload>` is a `Payload` over there. So the
+//! lookup strips, and it takes a [`TypeRef`] — the reading only the model can
+//! mint (#280) — rather than a key the caller assembled. There is no key to
+//! build, and therefore none to build wrongly.
+//!
+//! A **conversion** is the other question and keeps its wrappers, because
+//! `Box<Option<T>>` and `Option<T>` genuinely need different converter bodies.
+//! That lives in the registry's type tables, keyed by `TypeKey`, and is
+//! deliberately untouched by this module.
+
+use std::collections::HashMap;
+
+use super::TypeConfig;
+use crate::api::core::{flat::TypeRef, registry::TypeKey};
+
+/// Every type declared to this adapter by a class declarator, keyed by the
+/// **stripped** spelling.
+///
+/// Presence *is* "declared as a class" — the single writer is
+/// `JniGenBuilder::register_class`, through [`Self::entry`].
+#[derive(Clone, Default)]
+pub(crate) struct DeclTable {
+    /// Private to this module on purpose — see the module docs. Keyed by
+    /// `TypeRef::stripped_key`, so a wrapped and a bare spelling of one type
+    /// land on one entry.
+    map: HashMap<TypeKey, TypeConfig>,
+}
+
+impl DeclTable {
+    /// The declaration this type carries, **wrappers ignored**.
+    ///
+    /// The door for every property question — what kind is it, what is it
+    /// called in Kotlin, is it a sum. Takes the reading, so the identity is
+    /// derived here rather than asserted by the caller.
+    ///
+    /// A caller that needs a wrapped spelling to *decline* — converter
+    /// selection, where finding `Priority` for `Box<Priority>` would emit a body
+    /// that takes a bare `Priority` and not compile — says so in the open, with
+    /// the same `erased_wrappers()` predicate the transparent bridges use:
+    ///
+    /// ```ignore
+    /// if !ty.erased_wrappers().is_empty() {
+    ///     return None; // the bridge serves this, and puts the wrapper back
+    /// }
+    /// let cfg = ext.declarations().declaration(ty)?;
+    /// ```
+    ///
+    /// That is a routing decision and reads as one, rather than a second
+    /// accessor whose name has to be remembered — which is how `key` and
+    /// `stripped_key` came to disagree in the first place.
+    pub(crate) fn declaration(&self, ty: &TypeRef) -> Option<&TypeConfig> {
+        self.map.get(&ty.stripped_key())
+    }
+
+    /// [`Self::declaration`] for a caller that holds only a **spelling**.
+    ///
+    /// The visible "I only had tokens" step, exactly as
+    /// [`Conversions::reading_of`](crate::api::core::registry::Conversions::reading_of)
+    /// is for readings. It gives the SAME answer — it strips to a fixed point
+    /// before looking up — so it is not a second policy; it is the same policy
+    /// with weaker provenance, because a bare `syn::Type` is not proof the model
+    /// classified anything.
+    ///
+    /// Every caller of this is migration debt: the reading was available further
+    /// up and was discarded on the way here. The count going to zero is the
+    /// measure, the way `flat_input.rs` went 18 → 0 on the spelling census.
+    pub(crate) fn declaration_of_spelling(&self, ty: &syn::Type) -> Option<&TypeConfig> {
+        let mut stripped = ty.clone();
+        while let Some((_, inner)) = crate::api::core::flat::peel_transparent(&stripped) {
+            stripped = inner;
+        }
+        self.map.get(&TypeKey::from_type(&stripped))
+    }
+
+    /// The declaration under a declared **name**.
+    ///
+    /// Safe by construction and not confusable with [`Self::declaration`]: an
+    /// ident cannot carry a wrapper, and the compiler will not let one stand in
+    /// for the other.
+    pub(crate) fn declaration_of_name(&self, ident: &syn::Ident) -> Option<&TypeConfig> {
+        self.map.get(&TypeKey::from_ident(ident))
+    }
+
+    /// Every declaration, for the emitters that walk the whole table rather
+    /// than asking about one type. Order is the caller's business — the
+    /// emitters sort by key for determinism.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&TypeKey, &TypeConfig)> {
+        self.map.iter()
+    }
+
+    /// The keys alone, for a walk that only needs identities.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &TypeKey> {
+        self.map.keys()
+    }
+
+    /// The declaration stored under an identity this table already handed out.
+    ///
+    /// For a caller that took a key from [`Self::keys`] or [`Self::iter`] and is
+    /// looking the entry back up — the key came from here, so it is already
+    /// stripped. **Not** a door for a key built from a spelling: there is no
+    /// spelling to strip at this point, which is what makes it safe.
+    pub(crate) fn by_declared_key(&self, key: &TypeKey) -> Option<&TypeConfig> {
+        self.map.get(key)
+    }
+
+    /// Whether this identity is declared. Takes a key the table already handed
+    /// out, for the same reason [`Self::by_declared_key`] does.
+    pub(crate) fn contains_declared_key(&self, key: &TypeKey) -> bool {
+        self.map.contains_key(key)
+    }
+
+    /// Mutable access to an entry this table already holds, for the acceptors
+    /// that fold cross-kind options in after `register_class` created it.
+    pub(crate) fn declared_mut(&mut self, key: &TypeKey) -> Option<&mut TypeConfig> {
+        self.map.get_mut(key)
+    }
+
+    /// The writer's door — `register_class` only.
+    pub(crate) fn entry(
+        &mut self,
+        key: TypeKey,
+    ) -> std::collections::hash_map::Entry<'_, TypeKey, TypeConfig> {
+        self.map.entry(key)
+    }
+}

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -327,7 +327,7 @@ pub(crate) fn sum_input_body(
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr)> {
     let key = TypeKey::from_ident(&v.name);
-    let cfg = ext.types.get(&key)?;
+    let cfg = ext.types.by_declared_key(&key)?;
     let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
     let iface_path = iface_fqn.replace('.', "/");
@@ -1070,7 +1070,7 @@ fn build_flat_sum_field(
     let flat::Type::Variant(sum) = registry.flat().declared_type(&ident)? else {
         return None;
     };
-    let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
+    let cfg = ext.types.declaration_of_name(&ident)?;
     let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
 
@@ -1340,7 +1340,7 @@ pub(crate) fn build_flat_input_plan(
     // the general converter — the flatten lowering was unreachable for every
     // wrapped core.
     let key = inner.stripped_key();
-    let Some(cfg) = ext.types.get(&key) else {
+    let Some(cfg) = ext.types.by_declared_key(&key) else {
         return Ok(None);
     };
     if cfg.special_decl() || cfg.name_spec.is_none() || cfg.jobject_input {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -598,7 +598,7 @@ pub(crate) fn struct_output_body(
     let struct_ty: syn::Type = syn::parse_quote!(#struct_ident);
     let registered_fqn = ext
         .types
-        .get(&TypeKey::from_type(&struct_ty))
+        .declaration_of_spelling(&struct_ty)
         .and_then(|cfg| cfg.name_spec.as_ref())
         .map(|s| ext.fqn_of(s));
     let java_class_prefix = ext.java_class_prefix();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -178,7 +178,7 @@ pub(crate) fn vec_build_helpers(
     let key = elem.key();
     let kt_fqn = ext
         .types
-        .get(&key)
+        .by_declared_key(&key)
         .and_then(|c| c.name_spec.as_ref())
         .map(|s| ext.fqn_of(s))?;
     let short = kt_fqn.rsplit('.').next().unwrap_or(&kt_fqn);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -66,7 +66,10 @@ pub(crate) fn reject_handle_constant_type(
         break;
     }
     let key = TypeKey::from_type(&ty);
-    let is_handle = ext.types.get(&key).is_some_and(|cfg| cfg.is_opaque());
+    let is_handle = ext
+        .types
+        .by_declared_key(&key)
+        .is_some_and(|cfg| cfg.is_opaque());
     assert!(
         !is_handle,
         "{what} `{name}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -398,7 +398,10 @@ impl Declarations {
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
-            let cfg = &self.types[key];
+            let cfg = &self
+                .types
+                .by_declared_key(key)
+                .expect("a key this table handed out");
             if !cfg.is_opaque() {
                 continue;
             }
@@ -449,7 +452,10 @@ impl Declarations {
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
-            let cfg = &self.types[key];
+            let cfg = &self
+                .types
+                .by_declared_key(key)
+                .expect("a key this table handed out");
             if !cfg.is_enum_class() {
                 continue;
             }
@@ -503,7 +509,10 @@ impl Declarations {
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in keys {
-            let cfg = &self.types[key];
+            let cfg = &self
+                .types
+                .by_declared_key(key)
+                .expect("a key this table handed out");
             let Some(sum_cfg) = cfg.sum() else {
                 continue;
             };
@@ -840,7 +849,10 @@ impl Declarations {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
         for key in keys {
-            let cfg = &self.types[key];
+            let cfg = &self
+                .types
+                .by_declared_key(key)
+                .expect("a key this table handed out");
             // Opaque handles, enums and sealed classes each have their own
             // emitter; only plain structs become data classes here.
             if cfg.special_decl() {
@@ -1398,7 +1410,10 @@ impl Declarations {
         else {
             panic!("sum builder: `{ident}` is not an indexed sum")
         };
-        let sum_cfg = self.types[&key]
+        let sum_cfg = self
+            .types
+            .by_declared_key(&key)
+            .expect("a key this table handed out")
             .sum()
             .unwrap_or_else(|| panic!("sum builder: `{ident}` is not a sealed class"));
         let tag = &names[0];
@@ -1897,7 +1912,7 @@ impl Declarations {
         base_abstracts: Vec<kt::KtFun>,
         include_ctor_props: bool,
     ) -> Option<kt::KtClass> {
-        let cfg = self.types.get(key)?;
+        let cfg = self.types.by_declared_key(key)?;
         let interfaces = cfg.interfaces.clone();
         let enabled = cfg.interface_enabled;
         let name_override = cfg.interface_name_override.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -496,7 +496,7 @@ pub struct Declarations {
     /// [`JniGenBuilder::fqn_of`]). Terminal dispatch order is opaque → enum →
     /// `convert!` → primitive → struct; see
     /// [`JniGenBuilder::select_input_type`](crate::lang::JniGenBuilder)'s selector.
-    pub(crate) types: HashMap<TypeKey, TypeConfig>,
+    pub(crate) types: decl_table::DeclTable,
 
     /// Free-standing package-level wrappers, keyed by subpackage path
     /// (relative to [`Self::package`], dot-separated; the empty key is the
@@ -639,6 +639,7 @@ mod builder;
 mod classify;
 mod config;
 mod decl;
+mod decl_table;
 mod emit;
 mod equality;
 mod iface;

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -150,7 +150,11 @@ fn rust_type_erased(
         other => other,
     };
     let key = TypeKey::from_type(peeled);
-    if ext.types.get(&key).is_some_and(|c| c.name_spec.is_some()) {
+    if ext
+        .types
+        .by_declared_key(&key)
+        .is_some_and(|c| c.name_spec.is_some())
+    {
         if let Some(fqn) = ext.kotlin_fqn(&key) {
             return erase_kt_type(&[], &kt::KtType::cls(fqn));
         }

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -267,7 +267,7 @@ pub(crate) fn build_typed_handle(
     // its own type-specific `close()`/`take()`/`freePtr`.
     let class_fqn = ext
         .types
-        .get(key)
+        .by_declared_key(key)
         .and_then(|cfg| cfg.name_spec.as_ref())
         .map(|spec| ext.fqn_of(spec))
         .unwrap_or_else(|| class_name.to_string());
@@ -277,7 +277,7 @@ pub(crate) fn build_typed_handle(
     let free_extern = ext.mangle_method(class_package, final_class_name, "freePtr");
     let gc_managed = ext
         .types
-        .get(key)
+        .by_declared_key(key)
         .and_then(|cfg| cfg.opaque())
         .is_some_and(|o| o.gc_managed);
     let base_short = if gc_managed {

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -124,7 +124,10 @@ impl super::JniGen {
         let mut type_keys: Vec<&TypeKey> = ext.types.keys().collect();
         type_keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         for key in type_keys {
-            let cfg = &ext.types[key];
+            let cfg = &ext
+                .types
+                .by_declared_key(key)
+                .expect("a key this table handed out");
             if cfg.name_spec.is_none() {
                 continue;
             }
@@ -248,7 +251,7 @@ impl super::JniGen {
 impl Declarations {
     /// Human-readable class-kind name of a declared type (report use).
     pub(crate) fn class_kind_name(&self, key: &TypeKey) -> &'static str {
-        let Some(cfg) = self.types.get(key) else {
+        let Some(cfg) = self.types.by_declared_key(key) else {
             return "undeclared";
         };
         cfg.kind.macro_name()

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -525,7 +525,7 @@ fn sum_plan_kind(
     let key = TypeKey::from_ident(&ident);
     let cfg = ext
         .types
-        .get(&key)
+        .by_declared_key(&key)
         .unwrap_or_else(|| panic!("fromParts bridge: `{ident}` is not declared"));
     let sum_cfg = cfg
         .sum()

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -82,7 +82,10 @@ pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMet
         .collect();
     class_keys.sort_by_key(|k| k.as_str().to_string());
     for key in class_keys {
-        let cfg = &ext.types[key];
+        let cfg = &ext
+            .types
+            .by_declared_key(key)
+            .expect("a key this table handed out");
         let spec = cfg.name_spec.as_ref().expect("filtered to Some");
         let fqn = ext.fqn_of(spec);
         let (package, short) = fqn.rsplit_once('.').unwrap_or(("", fqn.as_str()));

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -300,7 +300,7 @@ fn reopened_ptr_class_keeps_gc_managed() {
         let key = TypeKey::from_type(&syn::parse_quote!(Session));
         jni.decls
             .types
-            .get(&key)
+            .by_declared_key(&key)
             .expect("declared")
             .opaque()
             .expect("ptr_class")
@@ -654,7 +654,7 @@ fn sum_is_its_own_type_kind() {
     let cfg = jni
         .decls
         .types
-        .get(&TypeKey::from_type(&ty))
+        .declaration_of_spelling(&ty)
         .expect("declared");
     assert!(cfg.special_decl());
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -2690,6 +2690,17 @@ fn an_erased_wrapper_over_a_terminal_crosses_both_ways() {
             rc.contains(&format!("_to_Box_{kind}_")),
             "`Box<{kind}>` needs an inbound converter:\n{rust}"
         );
+        // And it must be the BRIDGE's converter, not the terminal's. The
+        // declaration lookup strips, so a terminal arm that did not decline a
+        // wrapped spelling would find `{kind}`'s own config here and emit a body
+        // taking a bare `{kind}` — `E0308`. Today several arms decline only
+        // because `bare_path_ident` answers `None` for a generic spelling; this
+        // asserts the routing itself, so the incidental protection is not what
+        // the correctness rests on.
+        assert!(
+            rc.contains(&format!("let__inner=*v;{kind}_to_")),
+            "`Box<{kind}>` must delegate through the bridge, unwrapping first:\n{rust}"
+        );
     }
     // The wrapper is invisible to Kotlin, so the bare and wrapped enum fields
     // present as the same type — the point of the model erasing it.

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -309,7 +309,7 @@ impl Declarations {
         inherited: Option<kt::KtType>,
     ) -> Option<kt::KtType> {
         let key = TypeKey::from_type(outer_ty);
-        if let Some(cfg) = self.types.get(&key) {
+        if let Some(cfg) = self.types.by_declared_key(&key) {
             // Opaque-handle entries keep their typed FQN in
             // `name_spec` for FQN-consumers, but the value-context
             // name is `"Long"` (set on the rank-0 handler's metadata).
@@ -565,7 +565,7 @@ pub(crate) fn build_handle_destructor_items(
     registry: &Registry<KotlinMeta>,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
-    for (key, cfg) in &ext.types {
+    for (key, cfg) in ext.types.iter() {
         if !cfg.is_opaque() {
             continue;
         }
@@ -1206,7 +1206,7 @@ impl Declarations {
     /// `String` builtin), not the resolver's output converters — this runs
     /// **before** type resolution, exactly like [`Self::value_struct_decons`].
     fn is_leaf_vec_element(&self, elem: &syn::Type) -> bool {
-        match self.types.get(&TypeKey::from_type(elem)) {
+        match self.types.declaration_of_spelling(elem) {
             // A declared opaque handle crosses as a single `jlong` (pointer)
             // leaf that the Kotlin folder wraps into its typed handle class.
             // Enums and multi-field data classes are not leaf-folded — data
@@ -1446,14 +1446,17 @@ impl Declarations {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         let mut out = Vec::new();
         for key in keys {
-            let Some(sum_cfg) = self.types[key].sum() else {
+            let Some(sum_cfg) = self.types.by_declared_key(key).and_then(|c| c.sum()) else {
                 continue;
             };
             // The `sealed_class!` declaration's own spelling. This runs during
             // the declare phase, where a `reading()` would legitimately answer
             // `None` for a type nothing has interned yet — the declaration is
             // the only thing that can say (#291).
-            let source = self.types[key].rust_type.syntax.clone();
+            let Some(cfg) = self.types.by_declared_key(key) else {
+                continue;
+            };
+            let source = cfg.rust_type.syntax.clone();
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
@@ -1923,8 +1926,25 @@ impl Declarations {
         let ty = reading.syntax();
         // Structured-config overrides first (opaque handles, then user-
         // registered rank-0 wrappers, then built-ins).
-        let key = TypeKey::from_type(ty);
-        if let Some(cfg) = self.types.get(&key) {
+        // The declaration-keyed arms, and ONLY those, decline a wrapped
+        // spelling: `declaration` strips, so `Box<Priority>` would otherwise
+        // find `Priority`'s enum config here and emit a body taking a bare
+        // `Priority` — `E0308`. The transparent bridge serves it instead, by
+        // delegating to the stripped spelling's converter and putting the
+        // wrapper back, and it uses this same predicate in the opposite sense.
+        //
+        // Scoped to these arms rather than to the whole function, because the
+        // arms below that dispatch on `kind()` handle a wrapper correctly by
+        // re-spelling — `Box<String>` is `Str`, and its terminal encoder is
+        // right. A blanket guard sent that one to the bridge too; measured, it
+        // moved goldens. Today those arms decline a wrapped spelling only
+        // because `bare_path_ident` answers `None` for a generic spelling —
+        // true, incidental, and stated here so it stops being either.
+        let declared = self
+            .types
+            .declaration(reading)
+            .filter(|_| reading.erased_wrappers().is_empty());
+        if let Some(cfg) = declared {
             if cfg.is_opaque() {
                 return Some(self.opaque_handle_input(ty));
             }
@@ -1951,7 +1971,25 @@ impl Declarations {
         // `input_wrapper` registration on the same key would have to be
         // intentional. The rank-0 enum arm produces a terminal converter
         // (jint → Rust enum) with the configured Kotlin FQN in metadata.
-        if let Some(cfg) = self.types.get(&key) {
+        // The declaration-keyed arms, and ONLY those, decline a wrapped
+        // spelling: `declaration` strips, so `Box<Priority>` would otherwise
+        // find `Priority`'s enum config here and emit a body taking a bare
+        // `Priority` — `E0308`. The transparent bridge serves it instead, by
+        // delegating to the stripped spelling's converter and putting the
+        // wrapper back, and it uses this same predicate in the opposite sense.
+        //
+        // Scoped to these arms rather than to the whole function, because the
+        // arms below that dispatch on `kind()` handle a wrapper correctly by
+        // re-spelling — `Box<String>` is `Str`, and its terminal encoder is
+        // right. A blanket guard sent that one to the bridge too; measured, it
+        // moved goldens. Today those arms decline a wrapped spelling only
+        // because `bare_path_ident` answers `None` for a generic spelling —
+        // true, incidental, and stated here so it stops being either.
+        let declared = self
+            .types
+            .declaration(reading)
+            .filter(|_| reading.erased_wrappers().is_empty());
+        if let Some(cfg) = declared {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
                     if let Some(e) = registry.flat().enum_item(&name) {
@@ -2061,7 +2099,7 @@ impl Declarations {
             // delegates exactly as it does for a nested data class. (The
             // OUTPUT direction has no counterpart: a sum crosses Rust →
             // Kotlin flattened, always.)
-            if self.types.get(&key).is_some_and(|c| c.sum().is_some()) {
+            if declared.is_some_and(|c| c.sum().is_some()) {
                 if let Some(crate::api::core::flat::Type::Variant(v)) =
                     registry.flat().declared_type(&name)
                 {
@@ -2072,7 +2110,7 @@ impl Declarations {
                     let niches = default_niches_for_wire(&wire);
                     let kotlin_name = self
                         .types
-                        .get(&key)
+                        .declaration(reading)
                         .and_then(|c| c.name_spec.as_ref())
                         .map(|s| kt::KtType::cls(self.fqn_of(s)));
                     return Some(ConverterImpl {
@@ -2094,7 +2132,7 @@ impl Declarations {
                 // surfaces this as a build-time hard error.
                 let kotlin_name = self
                     .types
-                    .get(&key)
+                    .declaration(reading)
                     .and_then(|c| c.name_spec.as_ref())
                     .map(|s| kt::KtType::cls(self.fqn_of(s)));
                 return Some(ConverterImpl {
@@ -2303,8 +2341,25 @@ impl Declarations {
         // Classify off `kind`, spell off `syntax` — see `input_terminal`.
         let ty = reading.syntax();
         // Structured-config overrides first (opaque handles, then built-ins).
-        let key = TypeKey::from_type(ty);
-        if let Some(cfg) = self.types.get(&key) {
+        // The declaration-keyed arms, and ONLY those, decline a wrapped
+        // spelling: `declaration` strips, so `Box<Priority>` would otherwise
+        // find `Priority`'s enum config here and emit a body taking a bare
+        // `Priority` — `E0308`. The transparent bridge serves it instead, by
+        // delegating to the stripped spelling's converter and putting the
+        // wrapper back, and it uses this same predicate in the opposite sense.
+        //
+        // Scoped to these arms rather than to the whole function, because the
+        // arms below that dispatch on `kind()` handle a wrapper correctly by
+        // re-spelling — `Box<String>` is `Str`, and its terminal encoder is
+        // right. A blanket guard sent that one to the bridge too; measured, it
+        // moved goldens. Today those arms decline a wrapped spelling only
+        // because `bare_path_ident` answers `None` for a generic spelling —
+        // true, incidental, and stated here so it stops being either.
+        let declared = self
+            .types
+            .declaration(reading)
+            .filter(|_| reading.erased_wrappers().is_empty());
+        if let Some(cfg) = declared {
             if cfg.is_opaque() {
                 return Some(self.opaque_handle_output(ty));
             }
@@ -2330,7 +2385,25 @@ impl Declarations {
         // encode. Symmetric to the input arm above; relies on
         // `#[repr(i32)]` (or any repr that supports the cast) on the
         // declared enum so the discriminant value round-trips identically.
-        if let Some(cfg) = self.types.get(&key) {
+        // The declaration-keyed arms, and ONLY those, decline a wrapped
+        // spelling: `declaration` strips, so `Box<Priority>` would otherwise
+        // find `Priority`'s enum config here and emit a body taking a bare
+        // `Priority` — `E0308`. The transparent bridge serves it instead, by
+        // delegating to the stripped spelling's converter and putting the
+        // wrapper back, and it uses this same predicate in the opposite sense.
+        //
+        // Scoped to these arms rather than to the whole function, because the
+        // arms below that dispatch on `kind()` handle a wrapper correctly by
+        // re-spelling — `Box<String>` is `Str`, and its terminal encoder is
+        // right. A blanket guard sent that one to the bridge too; measured, it
+        // moved goldens. Today those arms decline a wrapped spelling only
+        // because `bare_path_ident` answers `None` for a generic spelling —
+        // true, incidental, and stated here so it stops being either.
+        let declared = self
+            .types
+            .declaration(reading)
+            .filter(|_| reading.erased_wrappers().is_empty());
+        if let Some(cfg) = declared {
             if cfg.is_enum_class() {
                 if let Some(name) = bare_path_ident(ty) {
                     if let Some(e) = registry.flat().enum_item(&name) {
@@ -2438,7 +2511,7 @@ impl Declarations {
                 let niches = default_niches_for_wire(&wire);
                 let kotlin_name = self
                     .types
-                    .get(&key)
+                    .declaration(reading)
                     .and_then(|c| c.name_spec.as_ref())
                     .map(|s| kt::KtType::cls(self.fqn_of(s)));
                 return Some(ConverterImpl {
@@ -2480,7 +2553,7 @@ impl Declarations {
             if r.mutability.is_none()
                 && self
                     .types
-                    .get(&TypeKey::from_type(t1_ty))
+                    .declaration_of_spelling(t1_ty)
                     .is_some_and(|c| c.is_opaque())
             {
                 let mut ref_ty = r.clone();


### PR DESCRIPTION
Answers "why was that mistake so easy to make?" — the hypothesis being that nothing in the model reminds a caller to ask about wrappers.

Measured: **118 production `.syntax()` sites**, in three groups — ~56 emit (wrapper must be present, correct by construction), ~17 conversion-keyed (wrapper must be present, also correct), **~36 declaration-keyed (wrapper must be absent — the entire defect population)**. `stripped_key()`, whose doc states that rule precisely, had **3** callers. `erased_wrapper()` had **0**.

## The change

The declared-class table moves behind `DeclTable`, and the door takes the **reading**:

```rust
pub(crate) fn declaration(&self, ty: &TypeRef) -> Option<&TypeConfig> {
    self.map.get(&ty.stripped_key())
}
```

There is no key to build and therefore none to build wrongly. Holding a `TypeRef` is proof the model classified the type (#280), so the identity is derived at the door rather than asserted by the caller.

This kills the three defects that had **no compile signature**: #290, #294 (*"no error at all — the lowering just vanishes"*), #308. Every other defect in this family announced itself as `E0308` and a fixture caught it.

## ⚠️ Two things I measured rather than assumed

**1. Privacy alone enforces nothing here.** The plan said "make the field private". `Declarations` is declared in `jni`, every consumer is a *descendant* module, and Rust makes private items visible to descendants — I made the field private and the crate compiled with **zero errors**. The boundary has to be a module the consumers sit *outside* of, which is what `decl_table` is. With it, the compiler named all 48 sites at once.

**2. A blanket terminal guard moves goldens.** `declaration` strips, so `Box<Priority>` would find `Priority`'s enum config in `input_terminal`/`output_terminal` and emit a body taking a bare `Priority` — `E0308`. So the terminals must decline a wrapped spelling. But guarding the *whole function* also sent `Box<String>` to the bridge, because the `Str` arm dispatches on `kind()` and already handles wrappers correctly by re-spelling. Scoped to the declaration-keyed arms only, goldens are byte-identical.

Worth noting what that guard replaces: those arms declined a wrapped spelling before only because `bare_path_ident` answers `None` for a generic spelling. True, incidental, and now stated.

## Scope note

The plan's 3-PR split assumed privacy-based forcing, which works incrementally. A real boundary does not — the compiler demands every site at once. So PR1 and PR2 collapsed into this one; cbindgen (PR3) is still separate.

`declaration_of_spelling` is the visible "I only had tokens" step, the peer of `Conversions::reading_of`. It gives the **same** answer (it strips first), so it is not a second policy — just weaker provenance. **5 callers remain**, and that count is the migration's measure.

## Verified

- `cargo test --all --all-features` — 639 lib tests
- clippy `-D warnings` on **both** 1.85.0 and stable, from the repo root
- `cargo fmt --check`; `examples/regen-check.sh` **byte-identical** after `cargo clean --release`
- `examples/covertest-kotlin$ ./gradlew run` — PASS, 49 sections
- `an_erased_wrapper_over_a_terminal_crosses_both_ways` now asserts the **route** (a wrapped terminal delegates through the bridge, unwrapping first) rather than merely that a converter exists — and **fails with the guard removed**