### PR TITLE
core: a type is its syntax — `TypeKind` stops classifying

### DIFF
--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -20,9 +20,10 @@ Source(s) ──items──> Flat ──Elements──> Registry ──> adapter
 
 An `Element` is two things at once, and the pairing is the whole point:
 
-* a **closed classification** — `TypeKind`, the field list, which of the two enum
-  shapes an item is — that says what the source *means*, in terms every
-  destination language shares;
+* a **closed model** — `TypeKind`, the field list, which of the two enum shapes
+  an item is. For a **type** that model is the accepted subset of `syn::Type`
+  and nothing more (see *A type is its syntax* below); above the type level it
+  is the concept — a field list, a sum's alternatives;
 * one `Origin`, carrying the **exact syntax** the node was built from and the
   source it arrived in. Every node has one, at every level — item, parameter,
   field, alternative, type, array extent.
@@ -40,6 +41,52 @@ and consumed as different constructs:
 pub struct Variant { pub name: syn::Ident, pub alternatives: Vec<Alternative>, .. }  // a sum
 pub struct Enum    { pub name: syn::Ident, pub values: Vec<EnumValue>, .. }          // C-style
 ```
+
+### A type is its syntax
+
+`TypeKind` began as a **destination-neutral classification**: one variant per
+concept a target language would act on, several Rust spellings folding into
+each. `String` and `str` were one `Str`; `Vec<T>` and `[T]` one `Sequence`;
+`Box<T>` and `Cow<'_, T>` disappeared into whatever they wrapped.
+
+It leaked, and the leak was not at the edges:
+
+* `&T` earned a layer of its own while `Box<T>` was declared transparent — two
+  wrappers, opposite treatments, on no principle either adapter shared;
+* `Cbindgen` picked its C type off the Rust spelling regardless, so the
+  neutrality the kind claimed was not what any adapter used;
+* every fold had to be *undone* somewhere. `erased_wrappers()` and
+  `stripped_syntax()` exist because the model dropped something a consumer
+  needed back.
+
+So `TypeKind` is now the **subset of `syn::Type` the flat API accepts**, and
+nothing else. One variant per accepted form: `Str` and `String`, `Vec` and
+`Slice`, `Boxed`, `Cow`, `Uninit`, `Ref { lifetime, mutable }`, `Named { id,
+args }`. A lifetime and a generic argument are kept, because they are what the
+source wrote.
+
+**The folds did not disappear — they moved to where they are decided**, and are
+one shared reading each rather than a property of the classification:
+
+| The reading | Answers | Replaces |
+|---|---|---|
+| `TypeRef::unwrapped()` | `Box`/`Cow` peeled to the value | the erasure in `lower_path` |
+| `TypeRef::sequence_elem()` | the element of `Vec<T>`, `[T]`, or either behind a wrapper | `TypeKind::Sequence` |
+| `TypeRef::borrow_target()` | what a borrow points at, past an out-parameter's slot | `RefMode::Out`'s absorption |
+| `TypeRef::is_exclusive_borrow()` | `&mut T`, and not `&mut MaybeUninit<T>` | `RefMode::Exclusive` |
+
+What this buys is one property, and it is the point:
+
+> **The syntax is recoverable from the kind.** `TypeKind::to_syn()`, checked
+> against `TypeRef::origin.syntax` over the whole acceptance corpus
+> (`syntax_is_recoverable_from_kind`), with two named exemptions: a callback's
+> bound *order*, and a `Group`/`Paren` the lowering sees through.
+
+The slice still rides along and generated Rust still spells it — it is exact and
+free. It is no longer *load-bearing*, and that is the difference: a fact missing
+from `kind` used to be invisible, because the syntax was there to cover for it.
+
+**Did not move**: every generated artifact byte-identical.
 
 ### Why the syntax rides along
 
@@ -65,7 +112,7 @@ classification stays small and genuinely neutral:
 | `Foo<'a, T>` | `TypeRef::origin.syntax` | generated Rust only |
 | "it is a `Foo`" | `TypeKind::Named` | every adapter |
 | `[u8; TAG_LEN]` — spelling / number / const identity | `TypeRef::origin.syntax` / `ArrayExtent::value` / `ExtentSource::Const` | C header / Kotlin / both |
-| the `Box` in `Box<Option<T>>`, and the `Option<T>` under it | `TypeRef::erased_wrappers()` / `stripped_syntax()` — derived from the syntax, not stored | an emitter that **rebuilds or destructures** a Rust value |
+| the `Box` in `Box<Option<T>>`, and the `Option<T>` under it | `TypeKind::Boxed` — kept, and read through by `TypeRef::unwrapped()` / `erased_wrappers()` | everyone: a classifier unwraps, an emitter that **rebuilds or destructures** puts it back |
 | where an item came from | `Origin::location` — **absent for a synthesized one** | diagnostics |
 
 ### The rule
@@ -91,13 +138,13 @@ The weaker-sounding half is the important one. It is tempting to write "same
 
 | Rust | `kind` | Kotlin type | wire |
 |---|---|---|---|
-| `&[Payload]` | `Sequence` | `List<Payload>` | `Long` — a jlong handle to a Rust-side `Vec` |
-| `Vec<Box<Payload>>` | `Sequence` | `List<Payload>` | `List<Payload>` — a `JObject` |
+| `&[Payload]` | `Ref(Slice)` | `List<Payload>` | `Long` — a jlong handle to a Rust-side `Vec` |
+| `Vec<Box<Payload>>` | `Vec(Boxed)` | `List<Payload>` | `List<Payload>` — a `JObject` |
 
 Two wires, one surface. Choosing a wire is exactly the generator's job, and the
 destination-language wrapper absorbs the difference; a caller cannot tell. What
-a caller *can* tell — and what the model's erasure promises will not happen — is
-the **type** changing because the source spelled a `Box`.
+a caller *can* tell — and what the shared `unwrapped()` reading is there to
+prevent — is the **type** changing because the source spelled a `Box`.
 
 The rule scopes to **converted** positions, which is where a converter stands
 between the Rust value and the destination and is free to bridge. It cannot apply
@@ -208,18 +255,19 @@ a model, and takes two bullets off L1 in the process.
       `Element::Unsupported` with `ItemError::UnresolvedType` — so a dangling name
       is reported here, by name, instead of surfacing downstream as an unresolved
       *converter* from whichever adapter looked first
-- [x] `&mut MaybeUninit<T>` becomes `RefMode::Out` — an out-parameter is a
-      property of the **borrow**, not a wrapper type, and it is a boundary concept
-      every destination language has (C's `T *out`)
+- [x] `&mut MaybeUninit<T>` is modelled — first as `RefMode::Out`, then (see
+      *A type is its syntax*) as the two forms the source wrote, with
+      `borrow_target()` as the reading that sees past the slot
 - [x] The example flat APIs are closed, and covertest-kotlin's build script
       asserts they stay closed across both its sources
 - [x] **Did not move**: every generated artifact byte-identical
 
-`Cow<'_, T>` needed neither an alias nor a grammar addition in the end: it is
-transparent, exactly like `Box<T>`, so it lowers to whatever `T` is
-([#236](https://github.com/milyin/prebindgen/pull/236)). Both adapters already
-treated it as `Vec<T>`, which is what made the transparency the honest reading
-rather than a convenience.
+`Cow<'_, T>` needed neither an alias nor a grammar addition in the end: both
+adapters already treat it as the `Vec<T>` it borrows
+([#236](https://github.com/milyin/prebindgen/pull/236)). It first landed *as*
+that reading — lowered to whatever `T` is — and is now a `TypeKind::Cow` that
+`unwrapped()` reads through, which is the same behaviour with the fold moved to
+where it is decided.
 
 **Still open**: `zenoh-flat` and its two consumers are separate repos. Their
 unmarked types — the 26 zenoh aliases, plus `Duration`, which is not in the
@@ -494,22 +542,26 @@ The long pole — 97 sites, down from 106 because #248 took `jni/builder` from 1
 
 #### What L4 taught: an erasure sits outside the layer it wraps
 
-The model erases `Box` and `Cow`, and that erasure is right — `Box<Option<T>>`
-is one optional to every destination. But **conversion follows the syntax**, and
-the two facts a rebuild needs were not on the model: what was taken off, and what
-is left under it. #292 added them as derived readings, `TypeRef::erased_wrappers()`
+Reading through `Box` and `Cow` is right — `Box<Option<T>>` is one optional to
+every destination. But **conversion follows the syntax**, and the two facts a
+rebuild needs were not on the model at the time: what was taken off, and what is
+left under it. #292 added them as derived readings, `TypeRef::erased_wrappers()`
 and `stripped_syntax()`, defined by an invariant rather than by a loop — the
-stripped spelling is *the one whose own lowering yields exactly this `kind`*, so
-the peel runs to a fixed point (`Box<Box<T>>` classifies as `T`, and one strip
-leaves a `Box<T>` that does not match).
+stripped spelling is *the one whose own lowering yields the kind `unwrapped()`
+reaches*, so the peel runs to a fixed point (`Box<Box<T>>` unwraps to `T`, and
+one strip leaves a `Box<T>` that does not match).
+
+Both readings survived *A type is its syntax* unchanged, computed off the kind
+rather than off the spelling. The lesson below is the reason the fold had to
+become a reading in the first place.
 
 The rule, which outlives the stage:
 
-> **`kind` is precisely the thing the wrapper is missing from, so interpreting
-> `kind` before checking for a wrapper always discards one.**
+> **The unwrapped reading is precisely the thing the wrapper is missing from, so
+> taking it before checking for a wrapper always discards one.**
 
-`Box<&Vec<T>>` classifies as `Ref`; peel that first and the wrapper is gone from
-everywhere a consumer will look. `&Box<Vec<T>>` hides it on the referent, where a
+`Box<&Vec<T>>` *reads* as a `Ref`; take that reading first and the wrapper is
+gone from everywhere a consumer will look. `&Box<Vec<T>>` hides it on the referent, where a
 question asked of the outer `syn::Type::Reference` cannot see it. Neither check
 subsumes the other, so a walk must ask at **every layer, on the way down** —
 which is also why the wrapper is a *list*, gathered as the walk descends.

--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -86,6 +86,19 @@ The slice still rides along and generated Rust still spells it — it is exact a
 free. It is no longer *load-bearing*, and that is the difference: a fact missing
 from `kind` used to be invisible, because the syntax was there to cover for it.
 
+**Recoverability is an acceptance rule, not just a property.** A spelling the
+model could not give back is refused where it is read, rather than accepted and
+reconstructed as something else:
+
+* a generic argument on any but the last path segment (`a::B<T>::C`) —
+  `Named` holds the last segment's arguments;
+* a `Cow` whose argument list is not `['a, T]` — `Cow<u8>` (not Rust at all),
+  `Cow<u8, 'a>`, `Cow<'a, 'b, u8>`. Checking the *type-argument count* alone
+  accepted all three, and each then spelled back as `Cow<'a, u8>`. `Cow` is the
+  one builtin with a lifetime in its own signature, so it is the one whose whole
+  list has to be checked — which is also what lets its `lifetime` be a
+  `syn::Lifetime` and not an `Option`.
+
 **Did not move**: every generated artifact byte-identical.
 
 ### Why the syntax rides along

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -19,9 +19,9 @@
 //!
 //! Two things at once, and that pairing is the whole design:
 //!
-//! * a **closed classification** — [`TypeKind`], the field list, which of the two
-//!   enum shapes an item is — that says what the source *means*, in terms every
-//!   destination language shares;
+//! * a **closed model** — [`TypeKind`], the field list, which of the two enum
+//!   shapes an item is — where the type grammar is the accepted Rust syntax and
+//!   the element structure is the concept above it;
 //! * one [`Origin`], carrying the **exact syntax** the node was built from and
 //!   the source it arrived in.
 //!
@@ -44,22 +44,34 @@
 //!
 //! # What earns a variant
 //!
-//! A concept, not a Rust spelling. The test is whether a *destination* language
-//! would act on the distinction; if only Rust can see it, it is spelling, and
-//! the slice already carries it:
+//! For a **type**, a Rust form — and nothing else. [`TypeKind`] is the accepted
+//! subset of `syn::Type`, so two spellings are two variants even when every
+//! destination language would treat them alike. Deciding that `&str` and
+//! `String` are both "a string" is a destination's decision, taken in an
+//! adapter, on a reading the model provides:
+//!
+//! | Rust writes | The model says | The reading, where a consumer wants one |
+//! |---|---|---|
+//! | `String`, `str` | [`String`](TypeKind::String), [`Str`](TypeKind::Str) | the adapter's, at its own site |
+//! | `Vec<T>`, `[T]` | [`Vec`](TypeKind::Vec), [`Slice`](TypeKind::Slice) | [`TypeRef::sequence_elem`] — one run of `T` |
+//! | `Box<T>`, `Cow<'_, T>` | [`Boxed`](TypeKind::Boxed), [`Cow`](TypeKind::Cow) | [`TypeRef::unwrapped`] — a `T` either way |
+//! | `&mut MaybeUninit<T>` | `Ref` over [`Uninit`](TypeKind::Uninit) | [`TypeRef::borrow_target`] — the value, not its slot |
+//! | no `->`, `-> ()` | [`TypeKind::Unit`] | the same function |
+//! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
+//!
+//! It buys one property: the syntax is **recoverable from the kind**
+//! ([`TypeKind::to_syn`], checked over the whole acceptance corpus). Which is
+//! the difference between a slice that rides along because it is exact, and one
+//! the model cannot do without.
+//!
+//! An **element** is not a type, and there the rule is still the concept:
 //!
 //! | Rust writes | The model says | Because |
 //! |---|---|---|
-//! | `String`, `str` | [`TypeKind::Str`] | one concept, two Rust types |
-//! | `Vec<T>`, `[T]` | [`TypeKind::Sequence`] | a run of `T`; owned vs borrowed is the [`Ref`](TypeKind::Ref) layer's fact |
-//! | `Box<T>` | whatever `T` is | an owned `T` either way |
 //! | `struct S;`, `struct S {}` | zero fields | the delimiters are spelling |
 //! | `enum E { A(u8) }` | [`Variant`] | a sum, identified by position |
 //! | `enum E { A = 7 }` | [`Enum`] | a named integer, identified by its value |
 //! | `type X = ..`, `struct X(..)` | [`Extern`] | named here; contents not modelled |
-//! | `&mut MaybeUninit<T>` | [`RefMode::Out`] | an out-param slot the caller supplies |
-//! | no `->`, `-> ()` | [`TypeKind::Unit`] | the same function |
-//! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
 //!
 //! The two enum shapes are the clearest case of a *concept* splitting where Rust
 //! has one spelling. Both are `enum` and both keep a `syn::ItemEnum`, but a sum's
@@ -84,17 +96,24 @@
 //!
 //! The generated Rust glue is itself a destination artifact, and the only one
 //! that needs syntax fidelity: `B()` must not be re-spelled `B`, `= 0x07` must
-//! not become `= 7`, `Foo<'a>` is not `Foo`. A model that carries no syntax has
-//! to become *lossless* to serve it — which is how a language-neutral IR turns
-//! back into a second `syn`. Carrying the original slice costs nothing and lets
-//! the classification stay small: a lifetime, a delimiter and a literal's base
-//! are simply not modelled facts.
+//! not become `= 7`. Carrying the source's own slice is how it gets that —
+//! exactly, and at no modelling cost, so a delimiter and a literal's base need
+//! never become fields.
+//!
+//! For a **type** the slice is no longer where facts go to survive:
+//! [`TypeKind`] keeps the lifetime, the wrapper and the argument it once
+//! dropped, and [`TypeKind::to_syn`] is the round-trip that says so. What is
+//! left is the reason a slice beats a reconstruction anywhere — it is what the
+//! source wrote, and it is already there.
 //!
 //! # Where acceptance is enforced
 //!
 //! Lowering is **total over the accepted grammar**: a form with no variant in
 //! [`TypeKind`] is a form the language does not accept, so there is no second
-//! acceptance list to drift from it.
+//! acceptance list to drift from it. One rule cannot be stated that way and is
+//! stated in the lowering instead: [`Uninit`](TypeKind::Uninit) is accepted only
+//! directly under a `&mut`, which is a fact about a **position** and not about a
+//! form.
 //!
 //! **Parsing diagnoses; ingestion raises.** Those are two different points, and
 //! the split is what lets one model serve both.
@@ -182,7 +201,7 @@ pub use self::{
     origin::Origin,
     spelling::{canonical_spelling, canonical_type, type_from_ident},
     ty::{
-        peel_transparent, RefMode, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType,
+        peel_transparent, GenericArg, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType,
         UnsupportedTypeReason, TRANSPARENT_WRAPPERS,
     },
 };

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -5,32 +5,6 @@
 
 use super::*;
 
-/// Lower one type by putting it in a struct field, and report what the language
-/// made of it. The field path is used because a field is the position every
-/// consumer already agrees is a boundary surface.
-fn lower(ty: proc_macro2::TokenStream) -> Result<TypeRef, UnsupportedType> {
-    let item: syn::Item = syn::parse_quote!(
-        pub struct S {
-            pub f: #ty,
-        }
-    );
-    // The fixture types stand in for a declared type wherever the grammar needs
-    // a nominal one, so references resolve and the test is about the grammar.
-    let mut items = fixture_types();
-    items.push(tag_len_const());
-    items.push(opaque("Sample"));
-    let n = items.len();
-    items.push(item);
-    match parse(items).remove(n) {
-        Element::Type(Type::Struct(s)) => Ok(s.fields[0].ty.clone()),
-        Element::Unsupported(u) => match *u.error {
-            ItemError::FieldType { source, .. } => Err(source),
-            other => panic!("expected a field-type diagnosis, got {other}"),
-        },
-        other => panic!("expected a struct, got {}", describe(&other)),
-    }
-}
-
 fn kind(ty: proc_macro2::TokenStream) -> TypeKind {
     lower(ty).expect("in the language").kind
 }
@@ -55,23 +29,27 @@ fn scalars_and_strings() {
         kind(quote::quote!(f64)),
         TypeKind::Scalar(ScalarKind::F64)
     ));
-    assert!(matches!(kind(quote::quote!(String)), TypeKind::Str));
+    assert!(matches!(kind(quote::quote!(String)), TypeKind::String));
     assert!(matches!(kind(quote::quote!(())), TypeKind::Unit));
 }
 
-/// `String` and `str` are one concept, and the borrow is the `Ref` layer's
-/// fact. Every adapter already treats `&str` as a borrowed string by hand;
-/// classifying `str` as a nominal type would send them all looking for an item
-/// named `str` to resolve.
+/// `str` and `String` are two Rust types, so they are two kinds. That they are
+/// one *string* to every destination language is a destination's reading, and
+/// the adapters make it — the model reports what the source wrote.
+///
+/// Neither is a nominal type: both are in the grammar, so no adapter goes
+/// looking for a declared item named `str` to resolve.
 #[test]
-fn a_string_is_a_string_however_it_is_spelled() {
+fn the_two_string_types_stay_two() {
     assert!(matches!(kind(quote::quote!(str)), TypeKind::Str));
-    for spelling in [quote::quote!(&str), quote::quote!(&String)] {
-        let TypeKind::Ref { mode, inner } = kind(spelling) else {
+    assert!(matches!(kind(quote::quote!(String)), TypeKind::String));
+    for (spelling, owned) in [(quote::quote!(&str), false), (quote::quote!(&String), true)] {
+        let TypeKind::Ref { mutable, inner, .. } = kind(spelling) else {
             panic!("a borrow");
         };
-        assert_eq!(mode, RefMode::Shared);
-        assert!(matches!(inner.kind, TypeKind::Str));
+        assert!(!mutable);
+        assert_eq!(matches!(inner.kind, TypeKind::String), owned);
+        assert_eq!(matches!(inner.kind, TypeKind::Str), !owned);
     }
 }
 
@@ -81,32 +59,34 @@ fn the_builtin_generics() {
         kind(quote::quote!(Option<u8>)),
         TypeKind::Optional(_)
     ));
-    assert!(matches!(
-        kind(quote::quote!(Vec<u8>)),
-        TypeKind::Sequence(_)
-    ));
+    assert!(matches!(kind(quote::quote!(Vec<u8>)), TypeKind::Vec(_)));
     assert!(matches!(
         kind(quote::quote!(Result<u8, Error>)),
         TypeKind::Fallible { .. }
     ));
 }
 
-/// `Box<T>` **is** `T` — an owned value either way, and no destination language
-/// can tell them apart, so it carries no kind of its own. The `Box` survives
-/// where it matters: in the syntax generated Rust spells.
+/// A `Box<T>` **is a `Box<T>`** in the model. That no destination language can
+/// tell it from `T` is true and is the adapters' to act on: `unwrapped` is where
+/// that reading is taken, and it is taken on purpose, at a call site.
 #[test]
-fn a_box_classifies_as_what_it_wraps() {
+fn a_box_is_a_box_until_a_consumer_unwraps_it() {
     let ty = lower(quote::quote!(Box<String>)).expect("in the language");
-    assert!(matches!(ty.kind, TypeKind::Str));
+    let TypeKind::Boxed(inner) = &ty.kind else {
+        panic!("a box");
+    };
+    assert!(matches!(inner.kind, TypeKind::String));
     assert_eq!(tokens(&ty.origin.syntax), "Box < String >");
+    // The reading a destination takes.
+    assert!(matches!(ty.unwrapped().kind(), TypeKind::String));
 
     // And it composes: the nullable heap string of a `#[repr(C)]` struct field
-    // is an optional string, spelled with its `Box`.
+    // is an optional string, spelled with its `Box`. `optional_inner` reads
+    // through the wrapper, so the layer accessors answer as they always did.
     let ty = lower(quote::quote!(Option<Box<String>>)).expect("in the language");
-    let TypeKind::Optional(inner) = &ty.kind else {
-        panic!("an option");
-    };
-    assert!(matches!(inner.kind, TypeKind::Str));
+    let inner = ty.optional_inner().expect("an option");
+    assert!(matches!(inner.kind, TypeKind::Boxed(_)));
+    assert!(matches!(inner.unwrapped().kind(), TypeKind::String));
     assert_eq!(tokens(&inner.origin.syntax), "Box < String >");
 }
 
@@ -114,11 +94,11 @@ fn a_box_classifies_as_what_it_wraps() {
 /// off, and what is left under it.
 ///
 /// The invariant is not "the loop peels until it stops" — it is that
-/// [`TypeRef::stripped_syntax`] is *the spelling whose own lowering yields
-/// exactly this type's `kind`*. That is what makes it a safe base for a
+/// [`TypeRef::stripped_syntax`] is *the spelling whose own lowering yields the
+/// kind [`TypeRef::unwrapped`] reaches*. That is what makes it a safe base for a
 /// reconstruction, and it is why the peel must run to a **fixed point**:
-/// `Box<Box<T>>` classifies as `T`, so one strip leaves a `Box<T>` that does
-/// not match.
+/// `Box<Box<T>>` unwraps to `T`, so one strip leaves a `Box<T>` that does not
+/// match.
 #[test]
 fn the_stripped_spelling_is_the_one_that_lowers_to_this_kind() {
     // The property, asserted as a property: strip, lower again, get the same
@@ -137,7 +117,7 @@ fn the_stripped_spelling_is_the_one_that_lowers_to_this_kind() {
         let stripped = ty.stripped_syntax();
         assert_eq!(
             format!("{:?}", kind(quote::quote!(#stripped))),
-            format!("{:?}", ty.kind),
+            format!("{:?}", ty.unwrapped().kind()),
             "`{}` strips to `{}`, which must classify identically",
             tokens(&ty.origin.syntax),
             tokens(&stripped),
@@ -206,11 +186,11 @@ fn a_wrapper_is_found_only_at_the_layer_that_spells_it() {
     // alone is enough: the difference between them lives in a spelling, and the
     // classification is exactly the thing it is missing from.
     for ty in [&outside, &inside] {
-        let TypeKind::Ref { mode, inner } = &ty.kind else {
+        let TypeKind::Ref { mutable, inner, .. } = ty.unwrapped().kind() else {
             panic!("a borrow");
         };
-        assert_eq!(*mode, RefMode::Shared);
-        let TypeKind::Sequence(elem) = &inner.kind else {
+        assert!(!mutable);
+        let TypeKind::Vec(elem) = inner.unwrapped().kind() else {
             panic!("a run");
         };
         assert!(matches!(elem.kind, TypeKind::Named { .. }));
@@ -268,15 +248,18 @@ fn the_prelude_reaches_every_builtin_by_either_spelling() {
     ));
     assert!(matches!(
         kind(quote::quote!(alloc::string::String)),
-        TypeKind::Str
+        TypeKind::String
     ));
 
     // The bug: qualified `MaybeUninit` used to fall through to an unresolvable
     // nominal type, so an out-parameter worked only if the source `use`d it.
-    let TypeKind::Ref { mode, .. } = kind(quote::quote!(&mut std::mem::MaybeUninit<Sample>)) else {
+    let TypeKind::Ref { mutable, inner, .. } =
+        kind(quote::quote!(&mut std::mem::MaybeUninit<Sample>))
+    else {
         panic!("a borrow");
     };
-    assert_eq!(mode, RefMode::Out);
+    assert!(mutable);
+    assert!(matches!(inner.kind, TypeKind::Uninit(_)));
 }
 
 /// A `#[prebindgen] pub type` is a **one-way road**: it brings a foreign type into
@@ -307,10 +290,8 @@ fn an_alias_is_a_declaration_not_an_equivalence() {
 
     // The declared name works.
     let f = flat.function("by_name").expect("declared");
-    let TypeKind::Ref { inner, .. } = &f.params[0].ty.kind else {
-        panic!("a borrow");
-    };
-    let TypeKind::Named { id } = &inner.kind else {
+    let inner = f.params[0].ty.borrow_target().expect("a borrow");
+    let TypeKind::Named { id, .. } = &inner.kind else {
         panic!("a nominal type");
     };
     assert_eq!(id.name, "Session");
@@ -391,7 +372,7 @@ fn an_alias_never_retypes_a_spelling() {
     // unrelated alias happens to target.
     for f in ["strings", "bytes"] {
         assert!(
-            matches!(param(f), TypeKind::Sequence(_)),
+            matches!(param(f), TypeKind::Vec(_)),
             "`{f}`: the grammar's spelling stays canonical"
         );
     }
@@ -399,7 +380,7 @@ fn an_alias_never_retypes_a_spelling() {
     // Each alias is usable by its own name, and they cannot collide: a bare path is
     // never reduced, so the name IS the identity.
     for (f, expected) in [("by_name", "Bytes"), ("small", "Small"), ("big", "Big")] {
-        let TypeKind::Named { id } = param(f) else {
+        let TypeKind::Named { id, .. } = param(f) else {
             panic!("{f}: a nominal type");
         };
         assert_eq!(id.name, expected, "{f}");
@@ -439,66 +420,94 @@ fn a_qualified_builtin_is_a_named_type() {
 fn references() {
     assert!(matches!(
         kind(quote::quote!(&Sample)),
-        TypeKind::Ref {
-            mode: RefMode::Shared,
-            ..
-        }
+        TypeKind::Ref { mutable: false, .. }
     ));
     assert!(matches!(
         kind(quote::quote!(&mut Sample)),
-        TypeKind::Ref {
-            mode: RefMode::Exclusive,
-            ..
-        }
+        TypeKind::Ref { mutable: true, .. }
     ));
+    // The lifetime is part of the type, so the model keeps it.
+    let TypeKind::Ref { lifetime, .. } = kind(quote::quote!(&'a Sample)) else {
+        panic!("a borrow");
+    };
+    assert_eq!(lifetime.expect("a lifetime").ident, "a");
 }
 
-/// `Vec<T>` and `[T]` are one concept — a run of `T` — and ownership is the
-/// `Ref` layer's fact, not a second variant. That is already how the pipeline
-/// behaves: one `Shape::Iterable` covers both, and jnigen rewrites a `&[T]`
-/// input into the `Vec<_>` pattern outright.
+/// `Vec<T>` and `[T]` are two Rust forms, so two kinds — and one *run of values*
+/// to a consumer, which is what [`TypeRef::sequence_elem`] answers. That reading
+/// is what the pipeline is built on (one `Shape::Iterable` covers both, and
+/// jnigen rewrites a `&[T]` input into the `Vec<_>` pattern outright); the model
+/// no longer has to lose the difference to provide it.
 #[test]
-fn a_sequence_is_a_sequence_borrowed_or_owned() {
-    assert!(matches!(
-        kind(quote::quote!(Vec<u8>)),
-        TypeKind::Sequence(_)
-    ));
+fn a_run_of_values_is_read_through_either_spelling() {
+    assert!(matches!(kind(quote::quote!(Vec<u8>)), TypeKind::Vec(_)));
     // Bare, as a callback argument is written: `impl Fn([T])`.
-    assert!(matches!(kind(quote::quote!([u8])), TypeKind::Sequence(_)));
+    assert!(matches!(kind(quote::quote!([u8])), TypeKind::Slice(_)));
     let TypeKind::Ref { inner, .. } = kind(quote::quote!(&[u8])) else {
         panic!("a reference");
     };
-    assert!(matches!(inner.kind, TypeKind::Sequence(_)));
+    assert!(matches!(inner.kind, TypeKind::Slice(_)));
+
+    // One reading over both, plus a wrapper over either.
+    for spelling in [
+        quote::quote!(Vec<u8>),
+        quote::quote!([u8]),
+        quote::quote!(Box<Vec<u8>>),
+        quote::quote!(Cow<'_, [u8]>),
+    ] {
+        let ty = lower(spelling).expect("in the language");
+        assert!(
+            matches!(
+                ty.sequence_elem().expect("a run").kind(),
+                TypeKind::Scalar(ScalarKind::U8)
+            ),
+            "`{}` is a run of `u8`",
+            tokens(&ty.origin.syntax)
+        );
+    }
 }
 
-/// `Cow<'_, T>` **is** `T`, the same treatment `Box<T>` gets: borrowed or owned, and
-/// no destination language can tell.
+/// A `Cow<'_, T>` keeps its own kind, its lifetime included, and reads as the
+/// `T` it borrows — the same treatment `Box<T>` gets, taken at the consumer
+/// rather than during lowering.
 ///
-/// Both adapters already behave that way — cbindgen lowers `Cow<'_, [T]>` "just like
+/// Both adapters act on that reading — cbindgen lowers `Cow<'_, [T]>` "just like
 /// `Vec<T>` outputs", and jnigen's converter is `byte_array_from_slice(&v)`, which
-/// works by deref and is identical to the `Vec<u8>` one — so this classification
-/// predicts their behaviour rather than leaving it a special case.
+/// works by deref and is identical to the `Vec<u8>` one — and now both can also
+/// see the `Cow` they are seeing through.
 #[test]
-fn a_cow_is_what_it_borrows() {
-    // The property the whole treatment rests on: indistinguishable from the owned
-    // spelling of the same thing.
+fn a_cow_reads_as_what_it_borrows() {
+    // The reading the whole treatment rests on: indistinguishable from the owned
+    // spelling of the same thing, once a consumer says it does not care.
+    let cow = lower(quote::quote!(Cow<'_, [u8]>)).expect("in the language");
     assert_eq!(
-        format!("{:?}", kind(quote::quote!(Cow<'_, [u8]>))),
-        format!("{:?}", kind(quote::quote!(Vec<u8>))),
-        "a byte Cow classifies exactly as a byte Vec"
+        format!("{:?}", cow.unwrapped().kind()),
+        format!("{:?}", kind(quote::quote!([u8]))),
+        "a byte Cow reads exactly as the byte slice it borrows"
     );
-    assert!(matches!(kind(quote::quote!(Cow<'_, str>)), TypeKind::Str));
+    let TypeKind::Cow { lifetime, .. } = &cow.kind else {
+        panic!("a cow");
+    };
+    assert_eq!(lifetime.as_ref().expect("a lifetime").ident, "_");
+    assert!(matches!(
+        lower(quote::quote!(Cow<'_, str>))
+            .expect("in the language")
+            .unwrapped()
+            .kind(),
+        TypeKind::Str
+    ));
 
     // The `Cow` survives where codegen reads it: a generated signature must spell
     // `Cow<'_, [u8]>`, which is not interchangeable with `Vec<u8>` in Rust.
-    let ty = lower(quote::quote!(Cow<'_, [u8]>)).expect("in the language");
-    assert_eq!(tokens(&ty.origin.syntax), "Cow < '_ , [u8] >");
+    assert_eq!(tokens(&cow.origin.syntax), "Cow < '_ , [u8] >");
 
     // Transparent for any target, as `Box` is: whether it can actually cross is the
     // adapter's call, and both already restrict which elements they accept.
-    let TypeKind::Sequence(elem) = kind(quote::quote!(Cow<'_, [Sample]>)) else {
-        panic!("a sequence");
-    };
+    let elem = lower(quote::quote!(Cow<'_, [Sample]>))
+        .expect("in the language")
+        .sequence_elem()
+        .expect("a run")
+        .clone();
     assert!(matches!(elem.kind, TypeKind::Named { .. }));
 
     // A lifetime argument is expected on `Cow` alone. On any other builtin it is
@@ -543,7 +552,8 @@ fn a_cow_returning_accessor_resolves() {
 
     assert_eq!(flat.unsupported().count(), 0, "no longer refused");
     let f = flat.function("zbytes_to_bytes").expect("survives");
-    assert!(matches!(f.ret.kind, TypeKind::Sequence(_)));
+    assert!(matches!(f.ret.kind, TypeKind::Cow { .. }));
+    assert!(f.ret.sequence_elem().is_some(), "and it reads as a run");
     // And the return still spells its `Cow`, so an adapter can emit the signature.
     assert_eq!(tokens(&f.ret.origin.syntax), "Cow < '_ , [u8] >");
 }
@@ -573,7 +583,7 @@ fn a_raw_pointer_is_not_in_the_language() {
 #[test]
 fn generic_arguments_are_spelling_only() {
     let ty = lower(quote::quote!(Foo<'a, u8>)).expect("in the language");
-    let TypeKind::Named { id } = &ty.kind else {
+    let TypeKind::Named { id, .. } = &ty.kind else {
         panic!("a named type");
     };
     assert_eq!(id.name, "Foo");
@@ -1472,37 +1482,47 @@ fn an_undeclared_reference_refuses_the_referencing_item() {
     }
 }
 
-/// An out-parameter is a **mode of borrowing**, not a type. `&mut MaybeUninit<T>`
-/// says the caller supplies the slot and the callee fills it; the `MaybeUninit` is
-/// absorbed into the mode, so `inner` is the value's own type.
+/// An out-parameter is `&mut MaybeUninit<T>` — the two forms the source wrote,
+/// each with its own kind. What it *means* (the caller supplies the slot, the
+/// callee fills it) is a reading, and the model provides the two that consumers
+/// need: [`TypeRef::borrow_target`] sees past the slot to the `T` that actually
+/// crosses, and [`TypeRef::is_exclusive_borrow`] is false for it, because a
+/// callee may not read the slot first.
 ///
-/// Uninitialized storage anywhere else promises nothing a destination language can
-/// use, so the combinations that mean nothing cannot be written down.
+/// Uninitialized storage anywhere else promises nothing a destination language
+/// can use, so it is refused — an acceptance rule about a **position**, which is
+/// the one thing a variant set cannot state.
 #[test]
-fn an_out_parameter_is_a_borrow_mode() {
-    let TypeKind::Ref { mode, inner } = kind(quote::quote!(&mut MaybeUninit<Sample>)) else {
+fn an_out_parameter_is_a_mutable_borrow_of_a_slot() {
+    let out = lower(quote::quote!(&mut MaybeUninit<Sample>)).expect("in the language");
+    let TypeKind::Ref { mutable, inner, .. } = &out.kind else {
         panic!("a borrow");
     };
-    assert_eq!(mode, RefMode::Out);
-    // The `MaybeUninit` is gone from the type: it described the borrow.
-    let TypeKind::Named { id, .. } = &inner.kind else {
+    assert!(mutable);
+    let TypeKind::Uninit(slot) = &inner.kind else {
+        panic!("the slot the source wrote");
+    };
+    let TypeKind::Named { id, .. } = &slot.kind else {
         panic!("the value's own type");
     };
     assert_eq!(id.name, "Sample");
 
-    // The three modes are one axis.
-    assert_eq!(
-        [
-            quote::quote!(&Sample),
-            quote::quote!(&mut Sample),
-            quote::quote!(&mut MaybeUninit<Sample>),
-        ]
-        .map(|t| match kind(t) {
-            TypeKind::Ref { mode, .. } => mode,
-            other => panic!("a borrow, got {other:?}"),
-        }),
-        [RefMode::Shared, RefMode::Exclusive, RefMode::Out]
-    );
+    // The readings: the target is the value, and it is not an exclusive borrow.
+    let target = out.borrow_target().expect("a borrow");
+    assert!(matches!(&target.kind, TypeKind::Named { id, .. } if id.name == "Sample"));
+    assert!(!out.is_exclusive_borrow());
+
+    // Against the other two borrows, which differ only where they should.
+    for (spelling, exclusive) in [
+        (quote::quote!(&Sample), false),
+        (quote::quote!(&mut Sample), true),
+    ] {
+        let ty = lower(spelling).expect("in the language");
+        assert_eq!(ty.is_exclusive_borrow(), exclusive);
+        assert!(
+            matches!(&ty.borrow_target().expect("a borrow").kind, TypeKind::Named { id, .. } if id.name == "Sample")
+        );
+    }
 
     // Owned, or shared-borrowed, it means nothing.
     assert_eq!(
@@ -1956,7 +1976,7 @@ fn a_raw_identifier_survives_typeid() {
     assert_eq!(raw.to_string(), "r#type", "the hash is part of the name");
 
     let t = TypeRef::named(&raw);
-    let TypeKind::Named { id } = &t.kind else {
+    let TypeKind::Named { id, .. } = &t.kind else {
         panic!("named")
     };
     // Recovered, and it spells itself back the way it was written.

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -488,7 +488,7 @@ fn a_cow_reads_as_what_it_borrows() {
     let TypeKind::Cow { lifetime, .. } = &cow.kind else {
         panic!("a cow");
     };
-    assert_eq!(lifetime.as_ref().expect("a lifetime").ident, "_");
+    assert_eq!(lifetime.ident, "_");
     assert!(matches!(
         lower(quote::quote!(Cow<'_, str>))
             .expect("in the language")
@@ -527,6 +527,48 @@ fn a_cow_reads_as_what_it_borrows() {
         as_unsupported(&element),
         ItemError::UnresolvedType { name } if name == "Vec"
     ));
+}
+
+/// `Cow` is the one builtin whose signature carries a lifetime, so it is the one
+/// whose **whole argument list** is checked rather than its type-argument count.
+///
+/// Counting types alone accepts three spellings that are not `Cow`s: the review
+/// case `Cow<u8, 'a>`, a second lifetime, and no lifetime at all. Each has
+/// exactly one type argument, so each passed — and then reconstructed as
+/// `Cow<'a, u8>`, quietly breaking the property
+/// [`syntax_is_recoverable_from_kind`] asserts. A model that keeps only the
+/// first lifetime cannot spell any of them back, which is the reason to refuse
+/// them rather than the consequence of doing so.
+#[test]
+fn a_cow_takes_a_lifetime_and_a_type_in_that_order() {
+    // The accepted shape, either way the lifetime is written.
+    for spelling in [quote::quote!(Cow<'_, [u8]>), quote::quote!(Cow<'a, str>)] {
+        let ty = lower(spelling).expect("in the language");
+        assert!(matches!(ty.kind, TypeKind::Cow { .. }));
+        // And it spells back, which is what the refusals below protect.
+        assert_eq!(tokens(&ty.kind().to_syn()), tokens(ty.syntax()));
+    }
+
+    // Everything else is refused by shape, and named as such.
+    for spelling in [
+        // No lifetime: `Cow<T>` is not Rust, so no source crate compiles it.
+        quote::quote!(Cow<u8>),
+        // The review case: the arguments are there, in the wrong order.
+        quote::quote!(Cow<u8, 'a>),
+        // Two lifetimes, where `Cow` takes one.
+        quote::quote!(Cow<'a, 'b, u8>),
+        // Two types.
+        quote::quote!(Cow<'a, u8, u8>),
+    ] {
+        let rendered = spelling.to_string();
+        assert_eq!(
+            reason(spelling),
+            UnsupportedTypeReason::WrongGenericArguments {
+                expected: "Cow<'a, T>"
+            },
+            "`{rendered}` is not a `Cow`"
+        );
+    }
 }
 
 /// The signature that motivated this: zenoh-flat's `zbytes_to_bytes`. It was refused

--- a/prebindgen/src/api/core/flat/tests/mod.rs
+++ b/prebindgen/src/api/core/flat/tests/mod.rs
@@ -16,6 +16,32 @@ use super::*;
 mod acceptance;
 mod roundtrip;
 
+/// Lower one type by putting it in a struct field, and report what the language
+/// made of it. The field path is used because a field is the position every
+/// consumer already agrees is a boundary surface.
+fn lower(ty: proc_macro2::TokenStream) -> Result<TypeRef, UnsupportedType> {
+    let item: syn::Item = syn::parse_quote!(
+        pub struct S {
+            pub f: #ty,
+        }
+    );
+    // The fixture types stand in for a declared type wherever the grammar needs
+    // a nominal one, so references resolve and the test is about the grammar.
+    let mut items = fixture_types();
+    items.push(tag_len_const());
+    items.push(opaque("Sample"));
+    let n = items.len();
+    items.push(item);
+    match parse(items).remove(n) {
+        Element::Type(Type::Struct(s)) => Ok(s.fields[0].ty.clone()),
+        Element::Unsupported(u) => match *u.error {
+            ItemError::FieldType { source, .. } => Err(source),
+            other => panic!("expected a field-type diagnosis, got {other}"),
+        },
+        other => panic!("expected a struct, got {}", describe(&other)),
+    }
+}
+
 /// Parse one item, stamped with an origin crate so array extents can name
 /// `#[prebindgen]` consts from "their own" crate.
 ///

--- a/prebindgen/src/api/core/flat/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/flat/tests/roundtrip.rs
@@ -1,11 +1,16 @@
-//! The round-trip property: an element's syntax slices are the source's own
-//! tokens, sliced — never a reconstruction.
+//! The round-trip property, in both directions:
 //!
-//! Every test here would also pass against a model that rebuilt syntax from its
-//! classification *for the easy cases*. The ones that matter are the cases where
-//! a reconstruction loses: an empty tuple variant, a hex discriminant, a
-//! lifetime, an aliased path, a doc comment. Those are the reason the slices
-//! ride along at all.
+//! * an element's syntax slices are the source's own tokens, sliced — never a
+//!   reconstruction. A delimiter, a hex discriminant, a doc comment survive
+//!   because the slice was kept, and that is what generated Rust re-emits;
+//! * and the type grammar can spell them back. [`TypeKind`] is the accepted
+//!   subset of `syn::Type` and nothing less, so a kind that could not reproduce
+//!   the tokens it was lowered from would have dropped something —
+//!   `syntax_is_recoverable_from_kind` is where that is checked.
+//!
+//! The second is what keeps the first honest. Slices ride along because they
+//! are exact and free, not because the classification needs them to be
+//! complete.
 
 use super::*;
 
@@ -113,7 +118,7 @@ fn an_item_and_its_components_share_one_location() {
         assert!(Rc::ptr_eq(item, &field.ty.origin.location), "field type");
     }
     // And down through a nested type's arguments.
-    let TypeKind::Sequence(elem) = &s.fields[1].ty.kind else {
+    let TypeKind::Vec(elem) = &s.fields[1].ty.kind else {
         panic!("a sequence");
     };
     assert!(Rc::ptr_eq(item, &elem.origin.location), "element type");
@@ -463,4 +468,94 @@ fn an_unsupported_item_keeps_its_tokens() {
     let element = parse_one(source.clone());
     assert!(matches!(element, Element::Unsupported(_)));
     assert_eq!(tokens(&element.syntax()), tokens(&source));
+}
+
+/// **Every accepted form spells back exactly what was written.**
+///
+/// The property the pivot rests on: [`TypeKind`] is the accepted subset of
+/// `syn::Type`, so the tokens are recoverable from the kind alone. It is checked
+/// rather than relied on — generated Rust still emits the slice — because a kind
+/// that has quietly stopped carrying a lifetime, a wrapper or a path prefix is
+/// exactly the drift the old design shipped, and it was invisible while the
+/// slice was there to cover for it.
+///
+/// One row per accepted form, plus the compositions where a lost fact would hide
+/// under an outer layer.
+#[test]
+fn syntax_is_recoverable_from_kind() {
+    for spelling in [
+        // Scalars, the unit, the two string types.
+        quote::quote!(u8),
+        quote::quote!(bool),
+        quote::quote!(f64),
+        quote::quote!(()),
+        quote::quote!(String),
+        quote::quote!(&str),
+        // The builtin generics.
+        quote::quote!(Option<u8>),
+        quote::quote!(Vec<u8>),
+        quote::quote!(Result<u8, Error>),
+        quote::quote!(Box<String>),
+        quote::quote!(Cow<'_, [u8]>),
+        quote::quote!(Cow<'a, str>),
+        // Runs and borrows, with the lifetime and the mutability the source wrote.
+        quote::quote!(&[u8]),
+        quote::quote!(&'a Sample),
+        quote::quote!(&mut Sample),
+        quote::quote!(&mut MaybeUninit<Sample>),
+        // Arrays, by literal and by named const — the extent keeps its own
+        // spelling, so `TAG_LEN` does not come back as `4`.
+        quote::quote!([u8; 4]),
+        quote::quote!([u8; TAG_LEN]),
+        quote::quote!([[u8; 4]; TAG_LEN]),
+        // Nominal types, carrying arguments a classification has no other place
+        // to put. Bare only: a path-qualified name cannot name a flat-API item,
+        // so no surviving element ever holds one.
+        quote::quote!(Sample),
+        quote::quote!(Sample<'a>),
+        quote::quote!(Sample<'a, u8, Vec<u8>>),
+        // Compositions, where a lost inner fact hides under an outer layer.
+        quote::quote!(Option<Box<String>>),
+        quote::quote!(Box<Cow<'_, [u8]>>),
+        quote::quote!(Result<Option<Vec<Sample>>, Error>),
+        quote::quote!(Vec<&'a Sample>),
+    ] {
+        let ty = lower(spelling).expect("in the language");
+        assert_eq!(
+            tokens(&ty.kind().to_syn()),
+            tokens(ty.syntax()),
+            "`{}` must spell back as itself",
+            tokens(ty.syntax()),
+        );
+    }
+}
+
+/// The two forms that reconstruct up to their own freedom rather than token for
+/// token, each because the model deliberately keeps *what* was written and not
+/// *how*.
+///
+/// Stated as a test so the exemptions are a short, named list rather than a
+/// silent gap in the one above.
+#[test]
+fn the_two_forms_that_do_not_spell_back_verbatim() {
+    // A callback's bounds are a set. `Send + Sync` and `Sync + Send` are one
+    // accepted form and nothing reads the order, so `to_syn` emits the canonical
+    // one — but the arguments, which everything reads, must survive exactly.
+    let cb = lower(quote::quote!(impl Fn(&Sample, u8) + Sync + Send + 'static))
+        .expect("in the language");
+    assert_eq!(
+        tokens(&cb.kind().to_syn()),
+        "impl Fn (& Sample , u8) + Send + Sync + 'static"
+    );
+
+    // A `Paren` (or an invisible `Group` from macro capture) wraps the same
+    // type, and the lowering sees through it: the node classifies as the inner
+    // type and reconstructs the inner spelling.
+    let parens = lower(quote::quote!((u8))).expect("in the language");
+    assert_eq!(tokens(&parens.kind().to_syn()), "u8");
+    assert_eq!(
+        tokens(parens.syntax()),
+        "u8",
+        "the slice is the inner node's"
+    );
 }

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -1,14 +1,25 @@
-//! Types: a closed classification paired with the syntax it was read from.
+//! Types: the accepted syntax, paired with the tokens it was read from.
 //!
-//! [`TypeRef`] is the pattern the whole element model follows — `kind` says what
-//! the type *means*, `syntax` is the tokens the source wrote. Consumers
-//! **classify off `kind` and spell off `syntax`**; see the [module docs](super)
-//! for why that split is the point.
+//! [`TypeKind`] is the subset of [`syn::Type`] a `#[prebindgen]` crate may
+//! write — one variant per accepted **form**, nothing folded together, nothing
+//! interpreted. What `&str` and `String` have in common is a *destination*
+//! language's business, and the adapters are where that decision belongs.
+//!
+//! [`TypeRef`] pairs that kind with the tokens the source wrote. The pairing
+//! survives the pivot because the two answer different questions — the kind is
+//! the grammar an adapter may rely on, the syntax is what generated Rust must
+//! spell — but the syntax is no longer *load-bearing*: nothing is recoverable
+//! only from it. [`TypeKind::to_syn`] is what checks that, and
+//! `syntax_is_recoverable_from_kind` is what runs it over the whole acceptance
+//! corpus.
 //!
 //! [`TypeKind`] is total over the accepted grammar: a form with no variant here
-//! is a form the language does not accept, so acceptance is a consequence of
-//! lowering rather than a second list that can drift from it. Same contract, and
-//! for the same reason, as [`lower_array_len`].
+//! is a form the language does not accept, so acceptance is mostly a
+//! consequence of lowering rather than a second list that can drift from it.
+//! Mostly: [`Uninit`](TypeKind::Uninit) is accepted in one **position** only,
+//! which no variant set can express — see
+//! [`OwnedUninit`](UnsupportedTypeReason::OwnedUninit). Same contract otherwise,
+//! and for the same reason, as [`lower_array_len`].
 
 use std::{fmt, rc::Rc};
 
@@ -20,12 +31,14 @@ use super::{
 };
 use crate::SourceLocation;
 
-/// A type as the language decided it, plus the exact syntax it came from.
+/// A type as the language accepted it, plus the exact syntax it came from.
 ///
-/// The [`Origin::syntax`] slice is what removes the pressure to make `kind`
-/// lossless: a lifetime, an elided argument, a `Box` that changes nothing
-/// outside Rust all survive there at zero modelling cost, so `kind` can stay
-/// language-neutral and small.
+/// The [`Origin::syntax`] slice is what generated Rust spells. It is **not**
+/// where facts go to survive a lossy classification any more — `kind` keeps the
+/// lifetime, the wrapper and the argument it used to drop, and
+/// [`TypeKind::to_syn`] proves it. Keeping the slice anyway is cheap, exact
+/// (nothing has to reconstruct token for token what the source already wrote),
+/// and it is what makes the proof possible at all.
 ///
 /// # The invariant
 ///
@@ -70,16 +83,17 @@ use crate::SourceLocation;
 /// [`Registry::reference_output`](crate::api::core::registry::Registry::reference_output).
 #[derive(Clone, Debug)]
 pub struct TypeRef {
-    /// What the type means — the closed, destination-neutral classification.
+    /// The accepted syntax this type is — the closed grammar, not an
+    /// interpretation of it.
     pub(super) kind: TypeKind,
     /// The type as generated Rust must spell it — the source's own tokens,
     /// normalized to the flat namespace the generated crate can name (see
     /// [`Flat::parse`](super::Flat::parse)) — plus the source they came
     /// from.
     ///
-    /// The syntax can say strictly more than `kind` does — `Box<String>` is a
-    /// `Str` here — which is the point: what Rust needs and no destination
-    /// language can see lives in the tokens, not in the classification.
+    /// It says exactly what `kind` says — that is the invariant
+    /// [`TypeKind::to_syn`] checks — and it says it in the source's own tokens,
+    /// which is why generated Rust re-emits this rather than a reconstruction.
     pub(super) origin: Origin<syn::Type>,
 }
 
@@ -165,13 +179,16 @@ impl TypeRef {
         // which reads the inner optional as a boundary layer when it is part of
         // the element, and `Option<Option<T>>` as two nullable layers when the
         // boundary has one way to say absent.
+        // Through the transparent wrappers, never past the node: a layer is read
+        // off `unwrapped`, while the type this returns is the one the source
+        // spelled — `Box<Foo>` is a `Base` whose core still spells the `Box`.
         let mut core = self;
-        let optional = matches!(core.kind, TypeKind::Optional(_));
-        if let TypeKind::Optional(inner) = &core.kind {
+        let optional = matches!(core.unwrapped().kind, TypeKind::Optional(_));
+        if let TypeKind::Optional(inner) = &core.unwrapped().kind {
             core = inner;
         }
-        let iterable = matches!(core.kind, TypeKind::Sequence(_));
-        if let TypeKind::Sequence(inner) = &core.kind {
+        let iterable = matches!(core.unwrapped().kind, TypeKind::Vec(_) | TypeKind::Slice(_));
+        if let TypeKind::Vec(inner) | TypeKind::Slice(inner) = &core.unwrapped().kind {
             core = inner;
         }
 
@@ -196,14 +213,33 @@ impl TypeRef {
         // un-require types the shape says are part of the element.
         let mut out = vec![self];
         let mut cur = self;
-        if let TypeKind::Optional(inner) = &cur.kind {
+        if let TypeKind::Optional(inner) = &cur.unwrapped().kind {
             out.push(inner);
             cur = inner;
         }
-        if let TypeKind::Sequence(inner) = &cur.kind {
+        if let TypeKind::Vec(inner) | TypeKind::Slice(inner) = &cur.unwrapped().kind {
             out.push(inner);
         }
         out
+    }
+
+    /// This type with every [transparent wrapper](TRANSPARENT_WRAPPERS) peeled
+    /// off — `Box<Cow<'_, [T]>>` → the `[T]` node, an unwrapped type → itself.
+    ///
+    /// **The fold, made explicit.** [`kind`](Self::kind) is the syntax the source
+    /// wrote, wrappers and all; a consumer that does not care which of them stand
+    /// over a type says so here, at its own call site, and the ones that must put
+    /// them back in generated Rust ask [`erased_wrappers`](Self::erased_wrappers)
+    /// instead. That split is why the wrapper is no longer erased during
+    /// lowering: the model reports, the consumer decides.
+    ///
+    /// Per layer, and only this one: a wrapper under a borrow or inside an
+    /// `Option` belongs to that inner node, which answers for itself.
+    pub fn unwrapped(&self) -> &TypeRef {
+        match &self.kind {
+            TypeKind::Boxed(inner) | TypeKind::Cow { inner, .. } => inner.unwrapped(),
+            _ => self,
+        }
     }
 
     /// What an `Option<T>` wraps, else `None`.
@@ -211,8 +247,12 @@ impl TypeRef {
     /// One layer, named. [`layer_stack`](Self::layer_stack) reads the whole
     /// arity stack; these three read exactly the layer a caller asks for, which
     /// is what a consumer wants when it can only *represent* some of them.
+    ///
+    /// Read through [`unwrapped`](Self::unwrapped), like every layer accessor
+    /// here: `Box<Option<T>>` is an optional to a destination language, and the
+    /// `Box` is still on the node for whoever has to spell it.
     pub fn optional_inner(&self) -> Option<&TypeRef> {
-        match &self.kind {
+        match &self.unwrapped().kind {
             TypeKind::Optional(inner) => Some(inner),
             _ => None,
         }
@@ -220,18 +260,28 @@ impl TypeRef {
 
     /// The element of a run of values (`Vec<T>`, `[T]`), else `None`.
     pub fn sequence_elem(&self) -> Option<&TypeRef> {
-        match &self.kind {
-            TypeKind::Sequence(elem) => Some(elem),
+        match &self.unwrapped().kind {
+            TypeKind::Vec(elem) | TypeKind::Slice(elem) => Some(elem),
             _ => None,
         }
     }
 
     /// What a borrow points at, else `None`.
+    ///
+    /// Through an out-parameter's [`Uninit`](TypeKind::Uninit): `&mut
+    /// MaybeUninit<T>` points at a `T`'s storage, and the slot is not a type
+    /// anything converts, registers or crosses with. A consumer that needs to
+    /// tell the two borrows apart reads the [`kind`](Self::kind), where the
+    /// `MaybeUninit` the source wrote is still standing.
     pub fn borrow_target(&self) -> Option<&TypeRef> {
-        match &self.kind {
-            TypeKind::Ref { inner, .. } => Some(inner),
-            _ => None,
-        }
+        let inner = match &self.unwrapped().kind {
+            TypeKind::Ref { inner, .. } => inner,
+            _ => return None,
+        };
+        Some(match &inner.kind {
+            TypeKind::Uninit(slot) => slot,
+            _ => inner,
+        })
     }
 
     // ── Composition ───────────────────────────────────────────────
@@ -258,7 +308,8 @@ impl TypeRef {
         let inner = &self.origin.syntax;
         TypeRef {
             kind: TypeKind::Ref {
-                mode: RefMode::Shared,
+                lifetime: None,
+                mutable: false,
                 inner: Box::new(self.clone()),
             },
             origin: self.origin.with(syn::parse_quote!(&#inner)),
@@ -303,6 +354,7 @@ impl TypeRef {
                 id: TypeId {
                     name: ident.to_string(),
                 },
+                args: Vec::new(),
             },
             origin: Origin::new(
                 syn::parse_quote!(#ident),
@@ -383,12 +435,21 @@ impl TypeRef {
     /// they are missing from.
     pub fn erased_wrappers(&self) -> Vec<&'static str> {
         let mut names = Vec::new();
-        let mut ty = std::borrow::Cow::Borrowed(&self.origin.syntax);
-        while let Some((name, inner)) = peel_transparent(&ty) {
+        let mut ty = self;
+        loop {
+            let name = match &ty.kind {
+                TypeKind::Boxed(inner) => {
+                    ty = inner;
+                    "Box"
+                }
+                TypeKind::Cow { inner, .. } => {
+                    ty = inner;
+                    "Cow"
+                }
+                _ => return names,
+            };
             names.push(name);
-            ty = std::borrow::Cow::Owned(inner);
         }
-        names
     }
 
     /// This type's identity as a table key with every transparent wrapper
@@ -434,16 +495,26 @@ impl TypeRef {
     /// a wrapper under a borrow or inside an `Option` belongs to that inner
     /// node's own spelling.
     pub fn stripped_syntax(&self) -> syn::Type {
-        let mut ty = self.origin.syntax.clone();
-        while let Some((_, inner)) = peel_transparent(&ty) {
-            ty = inner;
-        }
-        ty
+        self.unwrapped().origin.syntax.clone()
+    }
+
+    /// True when this is `&mut T` over a **value** — not `&mut MaybeUninit<T>`.
+    ///
+    /// The one distinction an out-parameter's form makes to a converter: an
+    /// exclusive borrow may be read before it is written and an out-parameter
+    /// may not, so the two cannot share a conversion. Everything else about the
+    /// slot — that it points at a `T`, that the `T` is what crosses — is
+    /// [`borrow_target`](Self::borrow_target)'s answer.
+    pub fn is_exclusive_borrow(&self) -> bool {
+        matches!(
+            &self.unwrapped().kind,
+            TypeKind::Ref { mutable: true, inner, .. } if !matches!(inner.kind, TypeKind::Uninit(_))
+        )
     }
 
     /// The `Ok` and `Err` sides when this is a `Result`, else `None`.
     pub fn fallible_parts(&self) -> Option<(&TypeRef, &TypeRef)> {
-        match &self.kind {
+        match &self.unwrapped().kind {
             TypeKind::Fallible { ok, err } => Some((ok, err)),
             _ => None,
         }
@@ -468,7 +539,7 @@ impl TypeRef {
     /// callback but was refused (a missing `Send`, an `impl Fn() -> u8`): the
     /// acceptance already happened, and asking again is how the two drift.
     pub fn callback_args(&self) -> Option<&[TypeRef]> {
-        match &self.kind {
+        match &self.unwrapped().kind {
             TypeKind::Callback { args } => Some(args),
             _ => None,
         }
@@ -476,7 +547,7 @@ impl TypeRef {
 
     /// The extent of this type when it is an array, else `None`.
     pub fn array_extent(&self) -> Option<&ArrayExtent> {
-        match &self.kind {
+        match &self.unwrapped().kind {
             TypeKind::Array { extent, .. } => Some(extent),
             _ => None,
         }
@@ -503,16 +574,24 @@ impl TypeRef {
         declared: &std::collections::HashSet<String>,
     ) -> Option<String> {
         match &self.kind {
-            TypeKind::Named { id } => (!declared.contains(&id.name)).then(|| id.name.clone()),
-            TypeKind::Optional(t) | TypeKind::Sequence(t) | TypeKind::Ref { inner: t, .. } => {
-                t.first_unresolved(declared)
-            }
+            // The name resolves; the arguments do not. No declaration takes type
+            // parameters, so `Foo<Bar>` is one reference to `Foo` — requiring
+            // `Bar` to be declared as well would refuse a reference the source
+            // crate compiles.
+            TypeKind::Named { id, .. } => (!declared.contains(&id.name)).then(|| id.name.clone()),
+            TypeKind::Optional(t)
+            | TypeKind::Vec(t)
+            | TypeKind::Slice(t)
+            | TypeKind::Boxed(t)
+            | TypeKind::Uninit(t)
+            | TypeKind::Cow { inner: t, .. }
+            | TypeKind::Ref { inner: t, .. } => t.first_unresolved(declared),
             TypeKind::Array { elem, .. } => elem.first_unresolved(declared),
             TypeKind::Fallible { ok, err } => ok
                 .first_unresolved(declared)
                 .or_else(|| err.first_unresolved(declared)),
             TypeKind::Callback { args } => args.iter().find_map(|a| a.first_unresolved(declared)),
-            TypeKind::Scalar(_) | TypeKind::Str | TypeKind::Unit => None,
+            TypeKind::Scalar(_) | TypeKind::Str | TypeKind::String | TypeKind::Unit => None,
         }
     }
 
@@ -531,10 +610,20 @@ impl TypeRef {
         out
     }
 
+    // Both walks descend through [`unwrapped`](Self::unwrapped): a transparent
+    // wrapper is not a type of its own to a consumer that indexes or converts,
+    // so `Box<Vec<Foo>>` reaches `Foo` and yields no node in between.
     fn collect_refs<'a>(&'a self, out: &mut Vec<&'a TypeRef>) {
         out.push(self);
-        match &self.kind {
-            TypeKind::Optional(t) | TypeKind::Sequence(t) | TypeKind::Ref { inner: t, .. } => {
+        match &self.unwrapped().kind {
+            // Through [`borrow_target`](Self::borrow_target), so an
+            // out-parameter reaches the value and not its slot.
+            TypeKind::Ref { .. } => {
+                if let Some(t) = self.borrow_target() {
+                    t.collect_refs(out)
+                }
+            }
+            TypeKind::Optional(t) | TypeKind::Vec(t) | TypeKind::Slice(t) | TypeKind::Uninit(t) => {
                 t.collect_refs(out)
             }
             TypeKind::Array { elem, .. } => elem.collect_refs(out),
@@ -543,79 +632,98 @@ impl TypeRef {
                 err.collect_refs(out);
             }
             TypeKind::Callback { args } => args.iter().for_each(|t| t.collect_refs(out)),
-            TypeKind::Named { .. } | TypeKind::Scalar(_) | TypeKind::Str | TypeKind::Unit => {}
+            TypeKind::Named { .. }
+            | TypeKind::Scalar(_)
+            | TypeKind::Str
+            | TypeKind::String
+            | TypeKind::Unit => {}
+            // `unwrapped` peeled these off, so reaching one is impossible.
+            TypeKind::Boxed(_) | TypeKind::Cow { .. } => unreachable!(),
         }
     }
 
     fn collect_extents<'a>(&'a self, out: &mut Vec<&'a ArrayExtent>) {
-        match &self.kind {
+        match &self.unwrapped().kind {
             TypeKind::Array { elem, extent } => {
                 out.push(extent);
                 elem.collect_extents(out);
             }
-            TypeKind::Optional(t) | TypeKind::Sequence(t) | TypeKind::Ref { inner: t, .. } => {
-                t.collect_extents(out)
-            }
+            TypeKind::Optional(t)
+            | TypeKind::Vec(t)
+            | TypeKind::Slice(t)
+            | TypeKind::Uninit(t)
+            | TypeKind::Ref { inner: t, .. } => t.collect_extents(out),
             TypeKind::Fallible { ok, err } => {
                 ok.collect_extents(out);
                 err.collect_extents(out);
             }
             TypeKind::Callback { args } => args.iter().for_each(|t| t.collect_extents(out)),
-            TypeKind::Named { .. } => {}
-            TypeKind::Scalar(_) | TypeKind::Str | TypeKind::Unit => {}
+            TypeKind::Named { .. }
+            | TypeKind::Scalar(_)
+            | TypeKind::Str
+            | TypeKind::String
+            | TypeKind::Unit => {}
+            TypeKind::Boxed(_) | TypeKind::Cow { .. } => unreachable!(),
         }
     }
 }
 
-/// What a [`TypeRef`] means. The variants are the accepted type grammar.
+/// The **accepted syntax** of a [`TypeRef`]: the subset of [`syn::Type`] a
+/// `#[prebindgen]` crate may write, and nothing more.
 ///
-/// One Rust spelling per concept is **not** the rule here — several are. A
-/// concept earns a variant when a destination language would act on it; a
-/// spelling that changes nothing outside Rust folds into the concept it carries
-/// and survives in [`TypeRef::syntax`]:
+/// One variant per accepted Rust **form**, not per destination concept. `str`
+/// and `String` are two forms and get two variants; `Box<T>` is a form of its
+/// own and does not disappear into `T`. Nothing here folds two spellings
+/// together, which is what makes [`TypeRef::syntax`] recoverable from this —
+/// see [`TypeKind::to_syn`], the round-trip that checks it.
 ///
-/// | Spelling | Kind | Why |
-/// |---|---|---|
-/// | `String`, `str` | [`Str`](TypeKind::Str) | one concept, two Rust types |
-/// | `Vec<T>`, `[T]` | [`Sequence`](TypeKind::Sequence) | a run of `T`; owned vs borrowed is the [`Ref`](TypeKind::Ref) layer's fact, not a second variant |
-/// | `Box<T>` | *whatever `T` is* | an owned `T` either way; nothing outside Rust can tell |
+/// # Why it is only syntax
+///
+/// It was a *destination-neutral classification* once, and that leaked: `&T`
+/// earned a layer while `Box<T>` was declared transparent, on no principle
+/// either adapter shared, and `Cbindgen` went on picking its C type from the
+/// Rust spelling anyway. Deciding that `&str` and `String` are both "a string"
+/// is a **destination** decision, so it belongs to the destination — the model
+/// hands over what the source wrote and stays out of it.
+///
+/// Where two adapters want the same fold, it is a *reading*, not a variant:
+/// [`TypeRef::unwrapped`] peels `Box`/`Cow` for the consumers that want them
+/// gone, and the ones that must rebuild the Rust value ask
+/// [`TypeRef::erased_wrappers`] instead. One helper, visible at the call site,
+/// rather than a fold baked into every classification.
 #[derive(Clone, Debug)]
 pub enum TypeKind {
-    /// A primitive with a fixed C/JVM counterpart.
-    Scalar(ScalarKind),
-    /// A UTF-8 string — `String` owned, `str` behind a [`Ref`](TypeKind::Ref).
+    /// A primitive with a fixed C/JVM counterpart — `u8`, `bool`, `f64`.
     ///
-    /// Both spellings are one concept: `&str` and `&String` are each a borrowed
-    /// string and classify identically, which is what every adapter already
-    /// does by hand.
+    /// A closed set of bare idents, so recognising one is reading the syntax
+    /// rather than interpreting it — and it keeps every adapter off a name
+    /// table of its own.
+    Scalar(ScalarKind),
+    /// `str` — unsized, so it is only ever reached through a
+    /// [`Ref`](TypeKind::Ref) or a wrapper.
     Str,
+    /// `String`.
+    String,
     /// `Option<T>`.
     Optional(Box<TypeRef>),
-    /// A run of `T` — `Vec<T>` owned, `[T]` behind a [`Ref`](TypeKind::Ref).
-    ///
-    /// One variant, because ownership is already the [`Ref`](TypeKind::Ref)
-    /// layer's fact: `&[T]` is `Ref(Sequence)`, `Vec<T>` is `Sequence`. A
-    /// second variant would encode ownership twice and let the two copies
-    /// disagree. `[T; N]` is *not* this — a fixed extent is a different
-    /// concept, see [`Array`](TypeKind::Array).
-    Sequence(Box<TypeRef>),
+    /// `Vec<T>`.
+    Vec(Box<TypeRef>),
+    /// `[T]` — the unsized run, reached through a [`Ref`](TypeKind::Ref) or a
+    /// wrapper. Not the same form as [`Vec`](TypeKind::Vec), so not the same
+    /// variant.
+    Slice(Box<TypeRef>),
     /// `Result<T, E>`.
     Fallible { ok: Box<TypeRef>, err: Box<TypeRef> },
     /// Any other named type: a `#[prebindgen]` struct or enum, or a foreign
     /// path.
     ///
-    /// `id` is the type's **identity** — a name, not syntax, so nothing outside
-    /// this module has to take a path apart to learn what a type is. The last
-    /// segment's generic arguments live in `args`, and only the *type*
-    /// arguments: a lifetime argument says nothing a destination language can
-    /// act on. The full spelling is in [`TypeRef::syntax`] for whoever re-emits it.
-    Named { id: TypeId },
+    /// `id` is the type's **identity** — a name, not a `syn::Path`, so nothing
+    /// downstream has to take a path apart to learn what a type is. `args` is
+    /// the last segment's generic arguments, in the order they were written and
+    /// including lifetimes, because dropping either would make the spelling
+    /// unrecoverable.
+    Named { id: TypeId, args: Vec<GenericArg> },
     /// `[T; N]` — a run of `T` whose length is known at compile time.
-    ///
-    /// Deliberately not a [`Sequence`](TypeKind::Sequence) with an optional
-    /// extent: a fixed array crosses by value as a primitive array, a `Vec`
-    /// crosses as a heap collection, and every adapter branches between the two
-    /// at every site.
     Array {
         elem: Box<TypeRef>,
         /// Boxed: an extent carries an [`Origin`] over the length expression, which
@@ -623,43 +731,157 @@ pub enum TypeKind {
         /// The same trade-off [`Unsupported::error`](super::Unsupported) makes.
         extent: Box<ArrayExtent>,
     },
-    /// A borrow — `&T`, `&mut T`, or `&mut MaybeUninit<T>`. The lifetime is
-    /// spelling, so it lives in [`TypeRef::syntax`] rather than here.
+    /// A borrow — `&T` or `&mut T`, with the lifetime the source wrote.
     ///
-    /// This is the ownership layer for every concept underneath it: `&str` is
-    /// `Ref(Str)`, `&[T]` is `Ref(Sequence)`. A shared-ownership handle
-    /// (`Arc<T>`, `Rc<T>`) belongs here too when the language accepts one.
+    /// An out-parameter is `&mut` over [`Uninit`](TypeKind::Uninit), which is
+    /// what the source spells. What that *means* at a boundary — the caller
+    /// supplies the slot, the callee fills it — is the adapter's reading of the
+    /// form, not a third value of a mode enum.
+    Ref {
+        lifetime: Option<syn::Lifetime>,
+        mutable: bool,
+        inner: Box<TypeRef>,
+    },
+    /// `Box<T>`.
     ///
-    /// `inner` is always the borrowed *value's* type, so an out-parameter's
-    /// `MaybeUninit` is absorbed into [`RefMode::Out`] rather than wrapping it:
-    /// uninitialized-ness is a property of the **borrow**, not of the type, and
-    /// it is meaningless anywhere else.
-    Ref { mode: RefMode, inner: Box<TypeRef> },
+    /// A form of its own. It was erased once, on the grounds that no
+    /// destination language can tell `Box<T>` from `T` — true, and still the
+    /// adapter's call to make: [`TypeRef::unwrapped`] makes it, on demand.
+    Boxed(Box<TypeRef>),
+    /// `Cow<'a, T>`.
+    Cow {
+        lifetime: Option<syn::Lifetime>,
+        inner: Box<TypeRef>,
+    },
+    /// `MaybeUninit<T>`.
+    ///
+    /// Accepted **only** directly under a `&mut` — see
+    /// [`UnsupportedTypeReason::OwnedUninit`]. It has a variant because the
+    /// source writes it; that it is refused elsewhere is an acceptance rule,
+    /// which is a separate question from how the form is represented.
+    Uninit(Box<TypeRef>),
     /// `impl Fn(A, B, …) + Send + Sync + 'static` — the callback form.
     Callback { args: Vec<TypeRef> },
     /// `()`.
     Unit,
 }
 
-/// What a borrow permits, and what the callee owes.
+/// One generic argument of a [`Named`](TypeKind::Named) type, as written.
 ///
-/// One axis with three values rather than a `mutable` flag plus a wrapper, so the
-/// combinations that mean nothing at a boundary — a shared borrow of
-/// uninitialized storage, an owned `MaybeUninit` — cannot be written down.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RefMode {
-    /// `&T` — the callee may read it and must not write it.
-    Shared,
-    /// `&mut T` — the callee may read and write an already-valid `T`.
-    Exclusive,
-    /// `&mut MaybeUninit<T>` — an **out-parameter**: the caller supplies storage
-    /// only, and the callee's job is to make it a valid `T`. The callee may not
-    /// read it first.
+/// A lifetime is kept rather than dropped: no destination language acts on it,
+/// but `Foo<'a>` is not `Foo`, and a model that cannot say which one the source
+/// wrote cannot claim to have lost nothing.
+#[derive(Clone, Debug)]
+pub enum GenericArg {
+    Lifetime(syn::Lifetime),
+    /// Boxed so a lifetime argument — the common one, and a fraction of the
+    /// size — does not pay for a type it is not. The same trade-off
+    /// [`Array`](TypeKind::Array)'s extent makes.
+    Type(Box<TypeRef>),
+}
+
+impl TypeKind {
+    /// This kind spelled back as Rust — the inverse of the lowering.
     ///
-    /// This is a boundary concept every destination language has (C's `T *out`),
-    /// which is why it is modelled here rather than left as a nominal
-    /// `MaybeUninit` for each adapter to recognise.
-    Out,
+    /// # What it is for
+    ///
+    /// **Not** for generating code: generated Rust spells
+    /// [`TypeRef::syntax`], the source's own tokens, and always will. This
+    /// exists so that claim can be *checked* — a kind that cannot reproduce the
+    /// syntax it was lowered from has dropped something, and the round-trip test
+    /// is what says so before a consumer has to discover it.
+    ///
+    /// Two forms reconstruct up to their own freedom rather than token for
+    /// token, because the model keeps what was written and not how it was
+    /// written:
+    ///
+    /// * a `Group` or `Paren` around a type, which the lowering sees through;
+    /// * a [`Callback`](TypeKind::Callback)'s bound *order* — `Send + Sync` and
+    ///   `Sync + Send` are one accepted form, and nothing reads the order.
+    pub fn to_syn(&self) -> syn::Type {
+        let opt_lifetime =
+            |l: &Option<syn::Lifetime>| l.as_ref().map(|l| quote::quote!(#l)).unwrap_or_default();
+        match self {
+            Self::Scalar(k) => {
+                let ident = syn::Ident::new(k.as_str(), proc_macro2::Span::call_site());
+                syn::parse_quote!(#ident)
+            }
+            Self::Str => syn::parse_quote!(str),
+            Self::String => syn::parse_quote!(String),
+            Self::Optional(t) => {
+                let inner = t.kind.to_syn();
+                syn::parse_quote!(Option<#inner>)
+            }
+            Self::Vec(t) => {
+                let inner = t.kind.to_syn();
+                syn::parse_quote!(Vec<#inner>)
+            }
+            Self::Slice(t) => {
+                let inner = t.kind.to_syn();
+                syn::parse_quote!([#inner])
+            }
+            Self::Boxed(t) => {
+                let inner = t.kind.to_syn();
+                syn::parse_quote!(Box<#inner>)
+            }
+            Self::Uninit(t) => {
+                let inner = t.kind.to_syn();
+                syn::parse_quote!(MaybeUninit<#inner>)
+            }
+            Self::Cow { lifetime, inner } => {
+                let lt = opt_lifetime(lifetime);
+                let inner = inner.kind.to_syn();
+                if lt.is_empty() {
+                    syn::parse_quote!(Cow<#inner>)
+                } else {
+                    syn::parse_quote!(Cow<#lt, #inner>)
+                }
+            }
+            Self::Fallible { ok, err } => {
+                let (ok, err) = (ok.kind.to_syn(), err.kind.to_syn());
+                syn::parse_quote!(Result<#ok, #err>)
+            }
+            Self::Ref {
+                lifetime,
+                mutable,
+                inner,
+            } => {
+                let lt = opt_lifetime(lifetime);
+                let mutability = mutable.then(|| quote::quote!(mut)).unwrap_or_default();
+                let inner = inner.kind.to_syn();
+                syn::parse_quote!(& #lt #mutability #inner)
+            }
+            Self::Array { elem, extent } => {
+                let elem = elem.kind.to_syn();
+                let len = &extent.origin.syntax;
+                syn::parse_quote!([#elem; #len])
+            }
+            Self::Named { id, args } => {
+                // The name is a spelling, so it parses back as one — including
+                // the leading `::` and any path segments before the last.
+                let mut path: syn::Path =
+                    syn::parse_str(&id.name).expect("a name this model built from a path");
+                if !args.is_empty() {
+                    let args = args.iter().map(|a| match a {
+                        GenericArg::Lifetime(l) => quote::quote!(#l),
+                        GenericArg::Type(t) => {
+                            let t = t.kind.to_syn();
+                            quote::quote!(#t)
+                        }
+                    });
+                    let last = path.segments.last_mut().expect("a non-empty path");
+                    last.arguments =
+                        syn::PathArguments::AngleBracketed(syn::parse_quote!(<#(#args),*>));
+                }
+                syn::parse_quote!(#path)
+            }
+            Self::Callback { args } => {
+                let args = args.iter().map(|a| a.kind.to_syn());
+                syn::parse_quote!(impl Fn(#(#args),*) + Send + Sync + 'static)
+            }
+            Self::Unit => syn::parse_quote!(()),
+        }
+    }
 }
 
 /// A nominal type's identity: a name, and nothing else.
@@ -793,17 +1015,18 @@ pub enum UnsupportedTypeReason {
     /// lowered a tuple, so accepting one would defer the failure to a late
     /// "unresolved type" instead of naming it here.
     UnsupportedTuple,
-    /// `MaybeUninit<T>` somewhere other than behind a `&mut`.
+    /// `MaybeUninit<T>` somewhere other than directly under a `&mut`.
     ///
-    /// Uninitialized storage is a property of a *borrow*, not of a type — see
-    /// [`RefMode::Out`]. Owned, returned or stored in a field it promises nothing
-    /// a destination language can use, and reading it would be undefined.
+    /// The one acceptance rule about a **position** rather than a form:
+    /// [`Uninit`](TypeKind::Uninit) exists, and only an out-parameter can hold
+    /// one. Owned, returned or stored in a field it promises nothing a
+    /// destination language can use, and reading it would be undefined.
     OwnedUninit,
     /// `&MaybeUninit<T>` — a shared borrow of uninitialized storage.
     ///
     /// A shared borrow promises a readable `T`, and this supplies storage that may
-    /// not be one. Only `&mut MaybeUninit<T>` means anything: see
-    /// [`RefMode::Out`].
+    /// not be one. Only `&mut MaybeUninit<T>` means anything — see
+    /// [`Uninit`](TypeKind::Uninit).
     SharedUninit,
     /// A path with a qualified self — `<T as Trait>::Assoc`.
     ///
@@ -885,25 +1108,30 @@ impl std::error::Error for UnsupportedType {}
 /// `at` is the origin of the item this type was written in — the location every
 /// node lowered from that item shares, and the crate an array extent's const
 /// must come from.
-/// The wrappers this language **erases**: `W<T>` classifies as whatever `T`
-/// classifies as, because no destination language can tell them apart.
+/// The wrappers a destination language **cannot see**: `W<T>` crosses as
+/// whatever `T` crosses as, because nothing outside Rust can tell them apart.
 ///
-/// The single source of truth for that set. [`lower_type`] erases exactly these,
-/// and an adapter that has to *undo* one in generated Rust reads the same list —
-/// so the question "which wrappers are transparent?" has one answer instead of a
-/// copy per consumer that can drift out of step.
+/// The single source of truth for that set. [`TypeRef::unwrapped`] peels exactly
+/// these, and an adapter that has to *put one back* in generated Rust reads the
+/// same list — so the question "which wrappers are transparent?" has one answer
+/// instead of a copy per consumer that can drift out of step.
 ///
-/// Adding one is adding a row here. What it means for a given destination is
-/// that adapter's business: erasing a wrapper says nothing about whether Rust
-/// can move a value out of it, which is why `Cow` is on this list and is still
+/// It is a **reading**, not a classification: [`TypeKind`] keeps every wrapper
+/// the source wrote, and a consumer says here, at its own call site, that it
+/// does not care. What that means for a given destination is still that
+/// adapter's business — erasing a wrapper says nothing about whether Rust can
+/// move a value out of it, which is why `Cow` is on this list and is still
 /// refused where a converter would have to move its payload.
 pub const TRANSPARENT_WRAPPERS: &[&str] = &["Box", "Cow"];
 
 /// Strip one [transparent wrapper](TRANSPARENT_WRAPPERS) from a **spelling**,
 /// naming the one removed — `Box<Option<T>>` → `("Box", Option<T>)`.
 ///
-/// Spelling in, spelling out: this is the inverse of the erasure, for a consumer
-/// that must reconstruct in Rust what the classification dropped.
+/// Spelling in, spelling out — the syntax-side peer of
+/// [`TypeRef::unwrapped`], for an adapter comparing a spelling it composed
+/// against one it has a converter for. Here rather than in the adapter because
+/// taking a `syn::Type` apart is this module's job, and doing it next door would
+/// put a classifier back outside the model.
 pub fn peel_transparent(ty: &syn::Type) -> Option<(&'static str, syn::Type)> {
     let syn::Type::Path(tp) = ty else { return None };
     let seg = tp.path.segments.last()?;
@@ -933,25 +1161,27 @@ pub(crate) fn lower_type(
         // spelling, which is the one a consumer wants to emit.
         syn::Type::Group(g) => return lower_type(&g.elem, consts, at),
         syn::Type::Paren(p) => return lower_type(&p.elem, consts, at),
-        // The mode is read off the borrow AND its target together, because
-        // `&mut MaybeUninit<T>` is one concept — an out-parameter — rather than a
-        // mutable borrow of a distinct `MaybeUninit` type.
+        // The borrow and its target are read together for one reason only: a
+        // `MaybeUninit` is accepted **here** and refused everywhere else, so the
+        // position is what decides, and only this arm knows it.
         syn::Type::Reference(r) => {
-            let (mode, target) = match maybe_uninit_inner(&r.elem) {
-                Some(inner) if r.mutability.is_some() => (RefMode::Out, inner),
+            let inner = match maybe_uninit_inner(&r.elem) {
+                Some(uninit) if r.mutability.is_some() => TypeRef {
+                    kind: TypeKind::Uninit(Box::new(lower_type(&uninit, consts, at)?)),
+                    origin: Origin::new((*r.elem).clone(), Rc::clone(at)),
+                },
                 // `&MaybeUninit<T>` promises a readable `T` and supplies storage
                 // that may not be one. Nothing at a boundary can use it.
                 Some(_) => return Err(fail(UnsupportedTypeReason::SharedUninit)),
-                None if r.mutability.is_some() => (RefMode::Exclusive, (*r.elem).clone()),
-                None => (RefMode::Shared, (*r.elem).clone()),
+                None => lower_type(&r.elem, consts, at)?,
             };
             TypeKind::Ref {
-                mode,
-                inner: Box::new(lower_type(&target, consts, at)?),
+                lifetime: r.lifetime.clone(),
+                mutable: r.mutability.is_some(),
+                inner: Box::new(inner),
             }
         }
-        // `[T]` is the borrowed spelling of the same concept `Vec<T>` owns.
-        syn::Type::Slice(s) => TypeKind::Sequence(Box::new(lower_type(&s.elem, consts, at)?)),
+        syn::Type::Slice(s) => TypeKind::Slice(Box::new(lower_type(&s.elem, consts, at)?)),
         _ if is_unit_type(ty) => TypeKind::Unit,
         // Only the unit is in the language. Refusing here names the type;
         // accepting would defer the failure to an "unresolved type" much later.
@@ -1007,20 +1237,23 @@ fn lower_path(
     };
     let name = last.ident.to_string();
 
-    // Type arguments only. A lifetime argument is accepted and dropped: it is
-    // part of the spelling (`Foo<'a>` is not `Foo`), and the spelling is in
-    // `TypeRef::origin`, so modelling it would be a second copy of one fact.
+    // Every argument is kept, in the order it was written — a lifetime among
+    // them. `Foo<'a>` is not `Foo`, and a model that drops the difference cannot
+    // spell the type back.
     let mut has_lifetime_arg = false;
-    let args: Vec<TypeRef> = match &last.arguments {
+    let args: Vec<GenericArg> = match &last.arguments {
         syn::PathArguments::None => Vec::new(),
         syn::PathArguments::AngleBracketed(ab) => {
             let mut out = Vec::new();
             for a in &ab.args {
                 match a {
                     syn::GenericArgument::Type(t) => {
-                        out.push(lower_type(t, consts, at)?);
+                        out.push(GenericArg::Type(Box::new(lower_type(t, consts, at)?)));
                     }
-                    syn::GenericArgument::Lifetime(_) => has_lifetime_arg = true,
+                    syn::GenericArgument::Lifetime(l) => {
+                        has_lifetime_arg = true;
+                        out.push(GenericArg::Lifetime(l.clone()));
+                    }
                     _ => return Err(fail(UnsupportedTypeReason::UnsupportedGenericArgument)),
                 }
             }
@@ -1030,6 +1263,19 @@ fn lower_path(
             return Err(fail(UnsupportedTypeReason::UnsupportedForm))
         }
     };
+    // `Named` holds the last segment's arguments, so a generic anywhere else is
+    // a spelling this model cannot give back. Refused rather than dropped: no
+    // flat API writes `a::B<T>::C`.
+    if tp
+        .path
+        .segments
+        .iter()
+        .rev()
+        .skip(1)
+        .any(|s| !matches!(s.arguments, syn::PathArguments::None))
+    {
+        return Err(fail(UnsupportedTypeReason::UnsupportedForm));
+    }
 
     // A builtin must be spelled BARE. `normalize_type` has already reduced the
     // real std paths (`std::option::Option` → `Option`) at ingest and
@@ -1038,16 +1284,14 @@ fn lower_path(
     // is not `Option`, and collapsing it would silently retype the field.
     let is_bare = tp.path.leading_colon.is_none() && tp.path.segments.len() == 1;
     if is_bare {
-        if args.is_empty() && !has_lifetime_arg {
+        if args.is_empty() {
             if let Some(kind) = ScalarKind::from_name(&name) {
                 return Ok(TypeKind::Scalar(kind));
             }
-            // `String` and `str` are one concept. `str` is unsized and so only
-            // ever appears behind a `&`, which the `Ref` layer already records
-            // — classifying it as a nominal type instead would send every
-            // adapter looking for an item named `str` to resolve.
-            if name == "String" || name == "str" {
-                return Ok(TypeKind::Str);
+            match name.as_str() {
+                "String" => return Ok(TypeKind::String),
+                "str" => return Ok(TypeKind::Str),
+                _ => {}
             }
         }
         // A builtin generic takes TYPE arguments only — a lifetime on one is not a
@@ -1055,9 +1299,15 @@ fn lower_path(
         // lifetime, so it is the one builtin where a lifetime argument is expected
         // rather than refused.
         if !has_lifetime_arg || name == "Cow" {
-            let mut args = args;
+            let mut types: Vec<TypeRef> = args
+                .iter()
+                .filter_map(|a| match a {
+                    GenericArg::Type(t) => Some((**t).clone()),
+                    GenericArg::Lifetime(_) => None,
+                })
+                .collect();
             let arity = |n: usize| {
-                if args.len() == n {
+                if types.len() == n {
                     Ok(())
                 } else {
                     Err(fail(UnsupportedTypeReason::WrongGenericArity {
@@ -1068,40 +1318,41 @@ fn lower_path(
             match name.as_str() {
                 "Option" => {
                     arity(1)?;
-                    return Ok(TypeKind::Optional(Box::new(args.remove(0))));
+                    return Ok(TypeKind::Optional(Box::new(types.remove(0))));
                 }
                 "Vec" => {
                     arity(1)?;
-                    return Ok(TypeKind::Sequence(Box::new(args.remove(0))));
+                    return Ok(TypeKind::Vec(Box::new(types.remove(0))));
                 }
-                // Reached here, it is not behind a `&mut`, so it is not an
-                // out-parameter — see `RefMode::Out`, which is the only place
-                // uninitialized storage means anything.
-                "MaybeUninit" => return Err(fail(UnsupportedTypeReason::OwnedUninit)),
-                // `Box<T>` **is** `T`: an owned value either way, and no
-                // destination language can tell the two apart. So it carries no
-                // kind of its own and classifies as whatever it wraps — the
-                // `Box` survives in `TypeRef::origin`, which is what generated
-                // Rust spells. (A shared-ownership handle would classify as a
-                // `Ref` for the same reason, when the language accepts one.)
-                // `Box` and `Cow` are erased — see `TRANSPARENT_WRAPPERS`,
-                // which is the list this arm consults so the set cannot drift
-                // from the one adapters undo.
-                w if TRANSPARENT_WRAPPERS.contains(&w) => {
+                "Box" => {
                     arity(1)?;
-                    return Ok(args.remove(0).kind);
+                    return Ok(TypeKind::Boxed(Box::new(types.remove(0))));
                 }
+                "Cow" => {
+                    arity(1)?;
+                    return Ok(TypeKind::Cow {
+                        lifetime: args.iter().find_map(|a| match a {
+                            GenericArg::Lifetime(l) => Some(l.clone()),
+                            _ => None,
+                        }),
+                        inner: Box::new(types.remove(0)),
+                    });
+                }
+                // Reached here it is not directly under a `&mut`, and that is the
+                // one position where uninitialized storage means anything —
+                // `TypeKind::Uninit` is built by the reference arm alone.
+                "MaybeUninit" => return Err(fail(UnsupportedTypeReason::OwnedUninit)),
                 "Result" => {
                     arity(2)?;
-                    let err = Box::new(args.remove(1));
-                    let ok = Box::new(args.remove(0));
+                    let err = Box::new(types.remove(1));
+                    let ok = Box::new(types.remove(0));
                     return Ok(TypeKind::Fallible { ok, err });
                 }
-                _ => return Ok(named(tp)),
+                _ => return Ok(named(tp, args)),
             }
         }
     }
-    Ok(named(tp))
+    Ok(named(tp, args))
 }
 
 /// If `ty` is a bare `MaybeUninit<T>`, the `T` it holds storage for.
@@ -1144,24 +1395,25 @@ pub(crate) fn is_unit_type(ty: &syn::Type) -> bool {
 
 /// `Named` with the identity read off the path: every segment joined, minus the
 /// generic arguments, which are already in `args`.
-/// `Named` with the identity read off the path: every segment joined, minus the
-/// generic arguments.
 ///
-/// The arguments are **lowered but not retained** — a bad type inside one is still
-/// diagnosed, it just leaves no trace. Nothing could read them: a surviving
-/// reference resolves to a declared type, and no declaration takes type parameters,
-/// so `Foo<u8>` against a declared `Foo` would not compile in the source crate.
-/// Accepting *instantiated* generics — `Wrapper<u8>` as its own declared type — is
-/// what would bring the field back.
-fn named(tp: &syn::TypePath) -> TypeKind {
-    let name = tp
-        .path
-        .segments
-        .iter()
-        .map(|s| s.ident.to_string())
-        .collect::<Vec<_>>()
-        .join("::");
+/// The leading `::` rides along in the name when the source wrote one. It is
+/// nothing a destination language acts on — but the name is what
+/// [`TypeKind::to_syn`] spells the path back from, and `::a::B` is not `a::B`.
+fn named(tp: &syn::TypePath, args: Vec<GenericArg>) -> TypeKind {
+    let mut name = String::new();
+    if tp.path.leading_colon.is_some() {
+        name.push_str("::");
+    }
+    name.push_str(
+        &tp.path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::"),
+    );
     TypeKind::Named {
         id: TypeId { name },
+        args,
     }
 }

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -749,8 +749,14 @@ pub enum TypeKind {
     /// adapter's call to make: [`TypeRef::unwrapped`] makes it, on demand.
     Boxed(Box<TypeRef>),
     /// `Cow<'a, T>`.
+    ///
+    /// The lifetime is **not** optional: `Cow` has one in its own signature, so
+    /// a `Cow<T>` is not Rust and no source crate can compile it. Lowering
+    /// refuses the shape ([`WrongGenericArguments`](UnsupportedTypeReason::WrongGenericArguments))
+    /// rather than modelling an absence that would then have to be spelled back
+    /// as something the source did not write.
     Cow {
-        lifetime: Option<syn::Lifetime>,
+        lifetime: syn::Lifetime,
         inner: Box<TypeRef>,
     },
     /// `MaybeUninit<T>`.
@@ -829,13 +835,8 @@ impl TypeKind {
                 syn::parse_quote!(MaybeUninit<#inner>)
             }
             Self::Cow { lifetime, inner } => {
-                let lt = opt_lifetime(lifetime);
                 let inner = inner.kind.to_syn();
-                if lt.is_empty() {
-                    syn::parse_quote!(Cow<#inner>)
-                } else {
-                    syn::parse_quote!(Cow<#lt, #inner>)
-                }
+                syn::parse_quote!(Cow<#lifetime, #inner>)
             }
             Self::Fallible { ok, err } => {
                 let (ok, err) = (ok.kind.to_syn(), err.kind.to_syn());
@@ -1010,7 +1011,22 @@ pub enum UnsupportedTypeReason {
     DisallowedImplTrait,
     /// A generic that takes a fixed arity and did not get it — `Option` with no
     /// argument, `Result` with one.
+    ///
+    /// Counts **type** arguments, which is the whole question for every builtin
+    /// but one: a lifetime on `Option`, `Vec`, `Box` or `Result` is not a shape
+    /// this language has, and such a spelling is a nominal type nobody declared
+    /// rather than a builtin with a bad argument. `Cow` is the exception and has
+    /// its own reason, [`WrongGenericArguments`](Self::WrongGenericArguments).
     WrongGenericArity { expected: usize },
+    /// A builtin whose whole argument list is not the shape it takes —
+    /// `Cow<u8>` (no lifetime), `Cow<u8, 'a>` (wrong order), `Cow<'a, 'b, u8>`
+    /// (two lifetimes).
+    ///
+    /// Separate from [`WrongGenericArity`](Self::WrongGenericArity) because it
+    /// is about the list and not its type-argument count: each of those three
+    /// has exactly one type argument, and refusing them is what keeps
+    /// [`TypeKind::to_syn`] able to spell every accepted form back.
+    WrongGenericArguments { expected: &'static str },
     /// A non-empty tuple. Only `()` is in the language: no adapter has ever
     /// lowered a tuple, so accepting one would defer the failure to a late
     /// "unresolved type" instead of naming it here.
@@ -1059,6 +1075,12 @@ impl fmt::Display for UnsupportedType {
             UnsupportedTypeReason::WrongGenericArity { expected } => write!(
                 f,
                 "type `{}` needs exactly {expected} type argument(s)",
+                self.offending
+            ),
+            UnsupportedTypeReason::WrongGenericArguments { expected } => write!(
+                f,
+                "type `{}` is not the shape `{expected}` \u{2014} its arguments are the ones \
+                 that type takes, in the order it takes them",
                 self.offending
             ),
             UnsupportedTypeReason::UnsupportedTuple => write!(
@@ -1328,14 +1350,21 @@ fn lower_path(
                     arity(1)?;
                     return Ok(TypeKind::Boxed(Box::new(types.remove(0))));
                 }
+                // The one builtin whose signature has a lifetime, so it is the
+                // one whose WHOLE argument list has to be checked: counting type
+                // arguments alone accepts `Cow<u8, 'a>` and `Cow<'a, 'b, u8>`,
+                // which are not `Cow`s at all, and a model that then kept only
+                // the first lifetime could not spell either one back.
                 "Cow" => {
-                    arity(1)?;
+                    let [GenericArg::Lifetime(lifetime), GenericArg::Type(inner)] = &args[..]
+                    else {
+                        return Err(fail(UnsupportedTypeReason::WrongGenericArguments {
+                            expected: "Cow<'a, T>",
+                        }));
+                    };
                     return Ok(TypeKind::Cow {
-                        lifetime: args.iter().find_map(|a| match a {
-                            GenericArg::Lifetime(l) => Some(l.clone()),
-                            _ => None,
-                        }),
-                        inner: Box::new(types.remove(0)),
+                        lifetime: lifetime.clone(),
+                        inner: inner.clone(),
                     });
                 }
                 // Reached here it is not directly under a `&mut`, and that is the

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -393,11 +393,10 @@ impl<M> Registry<M> {
     ///
     /// The children come from [`TypeKind`], not from taking the syntax apart, and
     /// the difference is load-bearing rather than cosmetic. `&mut MaybeUninit<T>`
-    /// is `Ref { mode: Out, inner: T }` — the model absorbed the `MaybeUninit`, so
-    /// the edge lands on `T` directly instead of on an intermediate
-    /// `MaybeUninit<T>` that no source ever wrote and no adapter can convert.
-    /// Each edge is still *spelled* from the child's own `origin.syntax`, which is
-    /// what the caller keys the table by.
+    /// yields `T` — [`borrow_target`](crate::api::core::flat::TypeRef::borrow_target)
+    /// sees past the slot — instead of an intermediate `MaybeUninit<T>` that no
+    /// adapter can convert and no table holds. Each edge is still *spelled* from
+    /// the child's own `origin.syntax`, which is what the caller keys the table by.
     ///
     /// The reading comes from **this registry's own table**, where `ensure_entry`
     /// put it before the walk reached this type — so a spelling the binding composed
@@ -414,21 +413,29 @@ impl<M> Registry<M> {
         let mut out: Vec<(Direction, crate::api::core::flat::TypeRef)> = Vec::new();
         if let Some(reading) = self.type_table(dir).get(key).map(|c| &c.subject) {
             let (children, child_dir): (Vec<&crate::api::core::flat::TypeRef>, Direction) =
-                match reading.kind() {
+                match reading.unwrapped().kind() {
+                    // Through the accessor, not the field: it sees past an
+                    // out-parameter's `MaybeUninit` slot, which is storage rather
+                    // than a type any converter is keyed by.
+                    TypeKind::Ref { .. } => (reading.borrow_target().into_iter().collect(), dir),
                     TypeKind::Optional(t)
-                    | TypeKind::Sequence(t)
-                    | TypeKind::Ref { inner: t, .. } => (vec![t], dir),
+                    | TypeKind::Vec(t)
+                    | TypeKind::Slice(t)
+                    | TypeKind::Uninit(t) => (vec![t], dir),
                     TypeKind::Array { elem, .. } => (vec![elem], dir),
                     TypeKind::Fallible { ok, err } => (vec![ok, err], dir),
                     TypeKind::Callback { args } => (args.iter().collect(), dir.flip()),
-                    // A name is a leaf in the type graph: its generic arguments are
-                    // lowered but not retained, because no declaration takes type
-                    // parameters. Its *fields* are the edges, and they come off the
-                    // element below.
+                    // A name is a leaf in the type graph: its generic arguments
+                    // belong to the reference, not to a declaration, because no
+                    // declaration takes type parameters. Its *fields* are the
+                    // edges, and they come off the element below.
                     TypeKind::Named { .. }
                     | TypeKind::Scalar(_)
                     | TypeKind::Str
+                    | TypeKind::String
                     | TypeKind::Unit => (Vec::new(), dir),
+                    // `unwrapped` peeled these off.
+                    TypeKind::Boxed(_) | TypeKind::Cow { .. } => (Vec::new(), dir),
                 };
             // The child reading itself, not its spelling: it has already been
             // classified — by the model, or by whoever composed the parent — so
@@ -472,13 +479,13 @@ impl<M> Registry<M> {
         // `Named { id: Node }` — `Box<T>` **is** `T` in this language — so it
         // reaches `Node`'s fields, where asking the syntax for a bare ident would
         // have answered `None` and dead-ended the walk.
-        if let Some(name) = self
-            .type_table(dir)
-            .get(key)
-            .and_then(|c| match c.subject.kind() {
-                TypeKind::Named { id } => Some(id.name.clone()),
-                _ => None,
-            })
+        if let Some(name) =
+            self.type_table(dir)
+                .get(key)
+                .and_then(|c| match c.subject.unwrapped().kind() {
+                    TypeKind::Named { id, .. } => Some(id.name.clone()),
+                    _ => None,
+                })
         {
             use crate::api::core::flat::{Field, Type};
             let fields: Vec<&Field> = match self.flat.declared_type(name.as_str()) {

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -417,7 +417,16 @@ impl<M> Registry<M> {
                     // Through the accessor, not the field: it sees past an
                     // out-parameter's `MaybeUninit` slot, which is storage rather
                     // than a type any converter is keyed by.
-                    TypeKind::Ref { .. } => (reading.borrow_target().into_iter().collect(), dir),
+                    // `expect`, not a fallible collect: a `Ref` kind always has a
+                    // target, so an empty child list here would mean the accessor
+                    // and the kind disagree — and it would silently truncate the
+                    // graph walk instead of saying so.
+                    TypeKind::Ref { .. } => (
+                        vec![reading
+                            .borrow_target()
+                            .expect("a `Ref` kind has a borrow target")],
+                        dir,
+                    ),
                     TypeKind::Optional(t)
                     | TypeKind::Vec(t)
                     | TypeKind::Slice(t)

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -971,7 +971,7 @@ fn an_adapter_authored_type_cell_is_classified_but_placeless() {
     let cell = &reg.input_types[&TypeKey::parse("Foreign").expect("test type")];
     assert!(cell.root, "the binding asked for it directly");
     assert!(
-        matches!(cell.subject.kind(), TypeKind::Named { id } if id.name == "Foreign"),
+        matches!(cell.subject.kind(), TypeKind::Named { id, .. } if id.name == "Foreign"),
         "a declared name is a name, and the grammar can say so"
     );
     assert!(

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -418,10 +418,10 @@ pub fn apply<M>(
                 let (by_ref, core_ty) = peel_borrow(arg_ty);
                 // Only a NAMED core can match a deconstructor target: an
                 // `Option<T>` / `Vec<T>` / tuple arg is delivered whole. The model
-                // says which, so a wrapper the language sees through — `Box<T>` —
-                // no longer reads as un-nameable.
+                // says which, and `unwrapped` is where a wrapper the destination
+                // cannot see — `Box<T>` — stops reading as un-nameable.
                 if !matches!(
-                    core_ty.kind(),
+                    core_ty.unwrapped().kind(),
                     crate::api::core::flat::TypeKind::Named { .. }
                 ) {
                     continue;
@@ -1743,16 +1743,16 @@ fn accessor_signature<M>(
         .function(&func)
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
 
-    // First parameter is the receiver `&T`; peel the borrow to get `T`. The
-    // borrow is `TypeKind::Ref`, so the peel reads the classification instead of
-    // re-deciding it from `syn::Type::Reference`.
+    // First parameter is the receiver `&T`; peel the borrow to get `T`.
+    // `borrow_target` is the model's own answer, so the peel reads a
+    // classification instead of re-deciding it from `syn::Type::Reference`.
     let first = f
         .params
         .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
-    let takes = match first.ty.kind() {
-        crate::api::core::flat::TypeKind::Ref { inner, .. } => inner.syntax().clone(),
-        _ => first.ty.syntax().clone(),
+    let takes = match first.ty.borrow_target() {
+        Some(inner) => inner.syntax().clone(),
+        None => first.ty.syntax().clone(),
     };
     Ok((takes, f.ret.clone()))
 }
@@ -1788,7 +1788,7 @@ fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
         .flat()
         .function(&func)
         .and_then(|f| f.params.first())
-        .is_some_and(|p| !matches!(p.ty.kind(), crate::api::core::flat::TypeKind::Ref { .. }))
+        .is_some_and(|p| p.ty.borrow_target().is_none())
 }
 
 fn check_takes(

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -351,9 +351,11 @@ impl CbindgenBuilder {
     /// Whether any declared function returns a `Vec<_>` (possibly nested under
     /// `Result`/`Option`), so the array builder/freer prelude must be emitted.
     ///
-    /// `TypeKind::Sequence` is the whole question: it is what `Vec<T>` lowers to,
-    /// and — since `Cow<'_, T>` **is** `T` — what `Cow<'_, [T]>` lowers to as well,
-    /// so the two spellings this used to test separately are one classification.
+    /// A run of values is the whole question — `Vec<T>` and `[T]` alike, and
+    /// through a transparent wrapper, so `Cow<'_, [T]>` counts as the `Vec<T>`
+    /// it crosses as. [`sequence_elem`](crate::api::core::flat::TypeRef::sequence_elem)
+    /// answers all three, which is why the two spellings this used to test
+    /// separately need no arms of their own.
     pub(super) fn produces_array(&self, registry: &Registry<()>) -> bool {
         self.functions.keys().any(|orig| {
             registry
@@ -361,12 +363,7 @@ impl CbindgenBuilder {
                 .function(&orig)
                 // The model already decided that an elided return and `-> ()`
                 // are one thing, so there is no second arm to write here.
-                .map(|f| {
-                    f.ret
-                        .walk()
-                        .iter()
-                        .any(|t| matches!(t.kind(), crate::api::core::flat::TypeKind::Sequence(_)))
-                })
+                .map(|f| f.ret.walk().iter().any(|t| t.sequence_elem().is_some()))
                 .unwrap_or(false)
         })
     }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -127,7 +127,7 @@ impl Declarations {
     /// `Box<Option<&Priority>>` reaches the same declaration `Priority` does,
     /// where taking the spelling apart finds `Box` and answers about it.
     pub(crate) fn is_kotlin_enum_reading(&self, reading: &TypeRef) -> bool {
-        let flat::TypeKind::Named { id } = enum_probe(reading).kind() else {
+        let flat::TypeKind::Named { id, .. } = enum_probe(reading).unwrapped().kind() else {
             return false;
         };
         id.ident()
@@ -899,7 +899,7 @@ impl Declarations {
         // model already normalized them.
         let ret = accessor.ret.borrow_target().unwrap_or(&accessor.ret);
         assert!(
-            !matches!(ret.kind(), flat::TypeKind::Unit),
+            !matches!(ret.unwrapped().kind(), flat::TypeKind::Unit),
             "expand_return!({}).fields(fields!({func})): `{func}` returns nothing — a \
              value form returns the struct holding this type's fields",
             key.as_str(),
@@ -1100,7 +1100,7 @@ impl Declarations {
                     );
                     // The name is the reading's, not a path taken apart to
                     // re-derive one.
-                    let flat::TypeKind::Named { id } = probe.kind() else {
+                    let flat::TypeKind::Named { id, .. } = probe.unwrapped().kind() else {
                         panic!("a sum type is a named type")
                     };
                     let flat::Type::Variant(sum) = registry

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -173,8 +173,8 @@ pub(crate) fn struct_input_body(
             // The NAME off the classification, not off the last path segment:
             // `Box<T>` IS `T` here, and taking the spelling apart would answer
             // about the wrapper.
-            if let Some(fqn) = match inner.kind() {
-                flat::TypeKind::Named { id } => id.ident(),
+            if let Some(fqn) = match inner.unwrapped().kind() {
+                flat::TypeKind::Named { id, .. } => id.ident(),
                 _ => None,
             }
             .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
@@ -253,8 +253,8 @@ pub(crate) fn struct_input_body(
                     .or_else(|| {
                         // The NAME off the classification, not off the last
                         // path segment.
-                        match inner.kind() {
-                            flat::TypeKind::Named { id } => id.ident(),
+                        match inner.unwrapped().kind() {
+                            flat::TypeKind::Named { id, .. } => id.ident(),
                             _ => None,
                         }
                         .and_then(|name| {
@@ -494,8 +494,8 @@ fn read_kotlin_property(
     // distinction for data-class fields; this is that logic for a property.
     if ext.is_kotlin_enum_reading(inner) {
         // The NAME off the classification, not off the last path segment.
-        let fqn = match inner.kind() {
-            flat::TypeKind::Named { id } => id.ident(),
+        let fqn = match inner.unwrapped().kind() {
+            flat::TypeKind::Named { id, .. } => id.ident(),
             _ => None,
         }
         .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
@@ -562,10 +562,10 @@ fn read_kotlin_property(
             // class, another sum, a `List`): the slot's descriptor is the
             // registered Kotlin class and the value decodes through its own
             // converter — the same delegation the data-class path uses.
-            let sig = match inner.kind() {
+            let sig = match inner.unwrapped().kind() {
                 // The NAME off the classification, not off the last path
                 // segment: `Box<T>` IS `T` here.
-                flat::TypeKind::Named { id } => id.ident(),
+                flat::TypeKind::Named { id, .. } => id.ident(),
                 _ => None,
             }
             .and_then(|name| ext.kotlin_fqn(&TypeKey::from_ident(&name)))
@@ -1063,8 +1063,8 @@ fn build_flat_sum_field(
     // The NAME off the classification, and then the ELEMENT — `enum_item`
     // hands back only the `syn::ItemEnum`, deliberately, so a consumer that
     // acts on the Variant/Enum distinction asks `declared_type` (#289).
-    let ident = match sum_reading.kind() {
-        flat::TypeKind::Named { id } => id.ident(),
+    let ident = match sum_reading.unwrapped().kind() {
+        flat::TypeKind::Named { id, .. } => id.ident(),
         _ => None,
     }?;
     let flat::Type::Variant(sum) = registry.flat().declared_type(&ident)? else {
@@ -1322,7 +1322,7 @@ pub(crate) fn build_flat_input_plan(
     // every caller — see the sibling helper's doc.
     // The name off the classification, not off the last path segment: `Box<S>`
     // IS `S` here, and taking the spelling apart would answer about the wrapper.
-    let flat::TypeKind::Named { id } = inner.kind() else {
+    let flat::TypeKind::Named { id, .. } = inner.unwrapped().kind() else {
         return Ok(None);
     };
     let Some(name) = id.ident() else {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -180,7 +180,8 @@ pub(crate) fn encode_sum_group(
         .expect("a sum segment carries its selector leaf");
     // The name off the reading — `TypeId` IS the name, so nothing takes a path
     // apart to re-derive one.
-    let crate::api::core::flat::TypeKind::Named { id } = tag_leaf.out_ty.kind() else {
+    let crate::api::core::flat::TypeKind::Named { id, .. } = tag_leaf.out_ty.unwrapped().kind()
+    else {
         panic!(
             "jnigen sum unfold: selector type `{}` is not a named type",
             tag_leaf.out_ty.key()

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -6,7 +6,7 @@ use super::*;
 // classifier (reached through `use super::*`), and an explicit import would win
 // over the glob and silently retarget it.
 use crate::api::{
-    core::flat::{self, RefMode, TypeRef},
+    core::flat::{self, TypeRef},
     lang::jnigen::jni::trait_impl::build_through_erased_wrappers,
 };
 
@@ -16,7 +16,7 @@ use crate::api::{
 // where a `Box<Vec<T>>` answers as `Vec<T>` does instead of failing a
 // last-path-segment test. Its one non-structural rule — `&mut [T]` is refused,
 // because mutate-back semantics keep the `input_vec` path — survives as the
-// `RefMode::Shared` guard on that match.
+// `mutable: false` guard on that match.
 
 /// `Some((element_type, by_ref))` when `arg_ty` is a slice/`Vec` input whose
 /// element is a **flattenable `data_class`** — i.e. it decomposes into the
@@ -35,7 +35,8 @@ pub(crate) fn vec_build_elem(
 ) -> Option<(TypeRef, bool)> {
     // The run and its element off the MODEL. `&mut [T]` is still refused —
     // mutate-back semantics keep the `input_vec` path — and that is the one
-    // fact the layer accessors do not carry, so `RefMode` is read directly.
+    // fact the layer accessors do not carry, so the borrow's mutability is read
+    // off the kind directly.
     //
     // The conversion follows the SYNTAX, and must: this path builds a Rust-side
     // `Vec<T>` and hands the source fn a borrow of it (or `mem::take`s it), so
@@ -51,8 +52,12 @@ pub(crate) fn vec_build_elem(
     // sequence — whose spelling is a clean `Vec<T>` — and let the outer `Box`
     // through unseen. Every layer is checked on the way down, the way
     // `rebuildable_target` does it.
-    let (run, by_ref) = match arg.kind() {
-        flat::TypeKind::Ref { mode, inner } if *mode == RefMode::Shared => (&**inner, true),
+    let (run, by_ref) = match arg.unwrapped().kind() {
+        flat::TypeKind::Ref {
+            mutable: false,
+            inner,
+            ..
+        } => (&**inner, true),
         _ => (arg, false),
     };
     // A wrapper over the RUN is buildable only on the by-value path, and the

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -44,8 +44,6 @@ impl Declarations {
         ty: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        use crate::api::core::flat::RefMode;
-
         // What the type IS comes from `kind`; what generated Rust must SPELL it
         // comes from here. The converter yields this spelling, so a
         // `Box<Option<T>>` crossing produces a `Box<Option<T>>` — the shape it
@@ -65,13 +63,7 @@ impl Declarations {
             // `Option<OwnedObject<T>>`) before the shallow `Optional`; the shape
             // that resolves correctly wins.
             if let Some(target) = inner.borrow_target() {
-                let mutable = matches!(
-                    inner.kind(),
-                    crate::api::core::flat::TypeKind::Ref {
-                        mode: RefMode::Exclusive,
-                        ..
-                    }
-                );
+                let mutable = inner.is_exclusive_borrow();
                 if let Some(mut c) = self.input_wrapper_shape(
                     WrapperShape::OptionRef { mutable },
                     syntax,
@@ -114,7 +106,10 @@ impl Declarations {
             }
             return None;
         }
-        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = ty.kind() {
+        if let crate::api::core::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() {
+            // The target through the accessor: an out-parameter's `MaybeUninit`
+            // is the slot a `T` goes in, and it is the `T` that converts.
+            let inner = ty.borrow_target().expect("a borrow");
             // `&[T]` shared slice borrow: there is no owned `[T]` to decode, so
             // reuse the `Vec<_>` shape — decode the Java `List<T>` into an owned
             // `Vec<T>`; the call site borrows it (`&Vec<T>` deref-coerces to
@@ -135,7 +130,7 @@ impl Declarations {
             // NOT: passing `&Vec<T>` there does not compile. Those fall through to
             // the plain borrow arm below, which hands the whole spelling on as the
             // sub, exactly as the old syntactic slice check did.
-            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(inner.syntax()) {
+            if !*mutable && decoded_vec_satisfies(inner.syntax()) {
                 if let Some(elem) = inner.sequence_elem() {
                     let elem_ty = elem.syntax().clone();
                     // The one place `produced` is NOT the crossing's spelling:
@@ -160,7 +155,7 @@ impl Declarations {
                     return None;
                 }
             }
-            let mutable = matches!(mode, RefMode::Exclusive);
+            let mutable = ty.is_exclusive_borrow();
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, inner, registry)
             {
@@ -181,8 +176,6 @@ impl Declarations {
         ty: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        use crate::api::core::flat::RefMode;
-
         // What the type IS comes from `kind`; the spelling is what generated
         // Rust must say. This direction used to be handed only the spelling —
         // `convert_crossing` fetched the reading and threw it away — so it
@@ -226,18 +219,20 @@ impl Declarations {
             }
             return None;
         }
-        if let crate::api::core::flat::TypeKind::Ref { mode, inner } = ty.kind() {
+        if let crate::api::core::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() {
+            // The target through the accessor, as on the input side.
+            let inner = ty.borrow_target().expect("a borrow");
             // `&[T]` shared slice (a callback argument crossing native→JVM):
             // build a `List<T>` from the borrowed slice. Dual of the `&[T]`
             // input branch, and the same split: `kind` says it is a borrow of a
             // run of values; whether the generated Rust can iterate the borrow
             // directly is a question about the SPELLING.
-            if matches!(mode, RefMode::Shared) && decoded_vec_satisfies(inner.syntax()) {
+            if !*mutable && decoded_vec_satisfies(inner.syntax()) {
                 if let Some(elem) = inner.sequence_elem() {
                     return self.output_slice(elem.syntax(), registry);
                 }
             }
-            let mutable = matches!(mode, RefMode::Exclusive);
+            let mutable = ty.is_exclusive_borrow();
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, inner, registry)
             {
@@ -269,8 +264,11 @@ fn fallible_parts(
     ty: &syn::Type,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Type)> {
-    use crate::api::core::flat::TypeKind;
-    if let Some(TypeKind::Fallible { ok, err }) = registry.flat().type_ref(ty).map(|t| t.kind()) {
+    if let Some((ok, err)) = registry
+        .flat()
+        .type_ref(ty)
+        .and_then(|t| t.fallible_parts())
+    {
         return Some((ok.syntax().clone(), err.syntax().clone()));
     }
     crate::api::core::types_util::result_parts(ty)

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -355,8 +355,8 @@ pub(crate) fn classify_field(
                         // The NAME off the classification, not off the last
                         // path segment: `Box<T>` IS `T` here, and taking the
                         // spelling apart would answer about the wrapper.
-                        match slot.kind() {
-                            crate::api::core::flat::TypeKind::Named { id } => id.ident(),
+                        match slot.unwrapped().kind() {
+                            crate::api::core::flat::TypeKind::Named { id, .. } => id.ident(),
                             _ => None,
                         }
                         .and_then(|name| {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1638,11 +1638,12 @@ fn check_array_length_qualification(loc: SourceLocation, module: &str) {
 /// A borrowed **transparent wrapper** around a sequence is refused, not decoded as
 /// a bare `Vec`.
 ///
-/// `Box<Vec<T>>` and `Cow<'_, [T]>` classify as `TypeKind::Sequence` — correctly:
-/// no destination language can tell them from `Vec<T>`, which is exactly why the
-/// model folds them together. But the generated glue **is** a destination
-/// artifact, and it is the one consumer that can tell: `&Vec<i32>` is not
-/// `&Box<Vec<i32>>`, and `TypeRef::origin` exists to carry precisely that.
+/// `Box<Vec<T>>` and `Cow<'_, [T]>` read as a run of values — correctly: no
+/// destination language can tell them from `Vec<T>`, which is why
+/// `sequence_elem` answers through the wrapper. But the generated glue **is** a
+/// destination artifact, and it is the one consumer that can tell: `&Vec<i32>`
+/// is not `&Box<Vec<i32>>`, which is why the wrapper is still standing in
+/// `kind` and in `TypeRef::origin` alike.
 ///
 /// So the selector asks two questions, and only the first is `kind`'s: that this
 /// is a run of values makes the `Vec` shortcut a *candidate*, and the **spelling**
@@ -1907,9 +1908,10 @@ fn a_transparently_wrapped_option_takes_the_present_value_pair_and_is_rebuilt() 
 /// The transparent-wrapper guard runs **before** the model's layers are
 /// interpreted, not after.
 ///
-/// An erasure sits *outside* the layer it wraps, so `Box<&Vec<Foo>>` classifies
-/// as `TypeKind::Ref` — the `Box` is gone from `kind` and survives only in the
-/// spelling. A guard that reads `kind` first replaces the argument with the
+/// A wrapper sits *outside* the layer it wraps, so `Box<&Vec<Foo>>` **reads** as
+/// a borrow — `unwrapped` peels the `Box` to answer, and it is the reading, not
+/// the kind, that the layers come off. A guard that takes that reading first
+/// and forgets the wrapper replaces the argument with the
 /// inner sequence reading, whose own spelling is a clean `Vec<Foo>`, and the
 /// outer wrapper is never seen: the Vec-build plan is selected, its emitter
 /// hands the source fn a `&[Foo]` built from the transient Rust-side `Vec`, and

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1310,7 +1310,9 @@ impl Declarations {
                 // rides `immediate_edges` rather than this converter's `subs`.
                 // The arguments are `TypeRef`s on the classification, so nothing
                 // is re-extracted from the signature's syntax.
-                let crate::api::core::flat::TypeKind::Callback { args } = reading.kind() else {
+                let crate::api::core::flat::TypeKind::Callback { args } =
+                    reading.unwrapped().kind()
+                else {
                     return None;
                 };
                 self.dispatch_fn_input(args, built)
@@ -2013,7 +2015,10 @@ impl Declarations {
         // `str` is handled above, separately and deliberately: it is unsized,
         // so its converter yields an owned `String` the call site borrows —
         // a different contract, not a different spelling.
-        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Str) {
+        if matches!(
+            reading.unwrapped().kind(),
+            crate::api::core::flat::TypeKind::Str | crate::api::core::flat::TypeKind::String
+        ) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 let s = env.get_string(v).map_err(|e| {
@@ -2154,7 +2159,7 @@ impl Declarations {
         //
         // Asked of the MODEL: an erasure is transparent, so `Box<&T>` already
         // classifies as `Ref` and nothing here matches a `syn` variant.
-        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Ref { .. }) {
+        if reading.borrow_target().is_some() {
             return None;
         }
         // It has to be a type this binding already crosses; if it is not, the
@@ -2229,7 +2234,7 @@ impl Declarations {
         // Asked of the MODEL, not of `stripped`: an erasure is transparent, so
         // `Box<&T>` already classifies as `Ref` and `kind` answers this without
         // anything here matching a `syn` variant.
-        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Ref { .. }) {
+        if reading.borrow_target().is_some() {
             return None;
         }
         // It has to be a type this binding already crosses; if it is not, the
@@ -2371,7 +2376,10 @@ impl Declarations {
         // Plain `String` keeps its own earlier arm in `primitive_output`, whose
         // body this matches exactly; this one is reached for the wrapped
         // spellings that arm's key cannot name.
-        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Str) {
+        if matches!(
+            reading.unwrapped().kind(),
+            crate::api::core::flat::TypeKind::Str | crate::api::core::flat::TypeKind::String
+        ) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 env.new_string(v.as_str()).map_err(|e| {
@@ -2403,7 +2411,10 @@ impl Declarations {
         // Wire is `()`. Body just returns `v`. No Kotlin name — Unit
         // returns are dropped from emitted signatures, so metadata stays
         // empty.
-        if matches!(reading.kind(), crate::api::core::flat::TypeKind::Unit) {
+        if matches!(
+            reading.unwrapped().kind(),
+            crate::api::core::flat::TypeKind::Unit
+        ) {
             let wire: syn::Type = syn::parse_quote!(());
             let body: syn::Expr = syn::parse_quote!(v);
             return Some(ConverterImpl {


### PR DESCRIPTION
`TypeKind` was a **destination-neutral classification**: one variant per
concept a target language would act on, several Rust spellings folding
into each. `String` and `str` were one `Str`; `Vec<T>` and `[T]` one
`Sequence`; `Box<T>` and `Cow<'_, T>` disappeared into what they wrapped.

It leaked, and not at the edges:

* `&T` earned a layer of its own while `Box<T>` was declared transparent
  — two wrappers, opposite treatments, on no principle either adapter
  shared;
* `Cbindgen` picked its C type off the Rust spelling regardless, so the
  neutrality the kind claimed was not what any adapter used;
* every fold had to be **undone** somewhere. `erased_wrappers()` and
  `stripped_syntax()` exist because lowering dropped something a consumer
  needed back.

So `TypeKind` is now the subset of `syn::Type` the flat API accepts, and
nothing else. One variant per accepted form:

    Scalar Str String Unit
    Optional Vec Slice Fallible
    Boxed Cow Uninit
    Array Ref { lifetime, mutable } Named { id, args } Callback

`RefMode` is gone: `&mut MaybeUninit<T>` is `Ref { mutable: true }` over
`Uninit`, the two forms the source wrote. A lifetime and a generic
argument are kept, because they are what the source wrote.

## The folds did not disappear — they moved to where they are decided

Each is one shared reading, taken on purpose at a call site rather than
baked into every classification:

    TypeRef::unwrapped()           Box/Cow peeled       <- the erasure in lower_path
    TypeRef::sequence_elem()       Vec<T>, [T], either  <- TypeKind::Sequence
                                   behind a wrapper
    TypeRef::borrow_target()       past an out-param    <- RefMode::Out's absorption
                                   slot
    TypeRef::is_exclusive_borrow() &mut T, not          <- RefMode::Exclusive
                                   &mut MaybeUninit<T>

Old `x.kind()` is exactly new `x.unwrapped().kind()`, which is what made
the ~30 consumer sites in `registry/scan`, `unfold`, `cbindgen` and
`jnigen` a mechanical rewrite rather than a re-reading of each one.

## What it buys

> **The syntax is recoverable from the kind.**

`TypeKind::to_syn()`, checked against `TypeRef::origin.syntax` over the
acceptance corpus by `syntax_is_recoverable_from_kind` — 27 spellings,
token-exact, including `[u8; TAG_LEN]`, `&'a T`, `Cow<'_, [u8]>` and
`Sample<'a, u8, Vec<u8>>`. Two exemptions, each named in a test of its
own: a callback's bound *order*, and a `Group`/`Paren` the lowering sees
through.

The slice still rides along and generated Rust still spells it — it is
exact and free. It is no longer **load-bearing**, and that is the whole
difference: a fact missing from `kind` used to be invisible, because the
syntax was there to cover for it.

## Also

One new refusal falls out: mid-path generic arguments (`a::B<T>::C`) are
`UnsupportedForm`, since `Named` holds the last segment's arguments and a
spelling this model cannot give back must not be accepted. No flat API
writes that shape.

`peel_transparent` stays — the syntax-side peer of `unwrapped`, for an
adapter comparing a spelling it composed against one it has a converter
for. It lives in `flat` so taking a `syn::Type` apart stays inside the
model.

**Did not move**: every generated artifact byte-identical
(`examples/regen-check.sh`), boundary ledger unchanged, 641 lib tests and
22 doctests green, clippy + fmt clean on 1.85.0 and stable.