### PR TITLE
core: a spelling is for spelling — seal the model's syntax

### DIFF
--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -635,7 +635,12 @@ growing back.
       to approximate. The ledger grew two sections: **escapes: types** (115,
       must reach zero) and **escapes: items** (28, expected until items grow
       modelled accessors). `ToTokens` is gone from `Origin` on purpose — it would
-      have handed every consumer `to_token_stream().to_string()` back
+      have handed every consumer `to_token_stream().to_string()` back.
+      The census counts **four doors** (`as_syn`, `stripped_syntax`, `to_syn`,
+      `enum_item`) by NAME rather than by call shape, so UFCS and a function item
+      count like a method call — and `escape_surface_is_closed` reads the model's
+      own surface so a fifth cannot appear quietly, which is how three of the
+      four were found
 - [ ] Drive **escapes: types** to zero. The population is three kinds, and only
       the first is classification: taking a node apart (what the ledger's first
       section already sees), keying by spelling (`TypeKey::from_type` where

--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -627,11 +627,27 @@ growing back.
       `prerequisites` / `local_functions` returning raw items
 - [ ] `Niches { value: syn::Expr, matches: syn::Expr }` — a semantic fact carried
       as raw expression syntax
+- [x] **The syntax is sealed, and the door is counted** — the last two bullets
+      below, answered structurally instead of by widening a grep. `Origin`'s
+      syntax is private; `spell()` yields tokens, `as_syn()` yields the node and
+      is the only route to one. So a file with no escapes cannot classify source
+      syntax *however it is written*, which is what widening `WATCHED` was trying
+      to approximate. The ledger grew two sections: **escapes: types** (115,
+      must reach zero) and **escapes: items** (28, expected until items grow
+      modelled accessors). `ToTokens` is gone from `Origin` on purpose — it would
+      have handed every consumer `to_token_stream().to_string()` back
+- [ ] Drive **escapes: types** to zero. The population is three kinds, and only
+      the first is classification: taking a node apart (what the ledger's first
+      section already sees), keying by spelling (`TypeKey::from_type` where
+      `TypeRef::key()` is the answer), and carrying a spelling into an
+      adapter-owned `syn::Type` field (`ConverterImpl::subs` / `produced`, above)
 - [ ] Extend the ledger's `WATCHED` beyond `Type` / `Expr` — `Item`, `Fields`,
-      `FnArg`, `ReturnType`, `GenericArgument`, `Pat` — one enum at a time, each
-      addition a regenerated ledger whose diff *is* the decision
-- [ ] Close or accept the blind spots the ledger header lists (token-string
-      classification, ident-name classification, helper delegation)
+      `FnArg`, `ReturnType`, `GenericArgument`, `Pat`. Still worth doing, now as
+      a *sharper* reading of what escapes are used for rather than the only one
+- [ ] The blind spots the ledger header lists: ident-name classification and
+      helper delegation are gated (each needs an escape first); token-string
+      classification is **not**, and cannot be — `core/domain.rs` reads a
+      `syn::Type` a build script supplied, which was never the model's
 
 ## Completion criteria
 

--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -636,11 +636,14 @@ growing back.
       must reach zero) and **escapes: items** (28, expected until items grow
       modelled accessors). `ToTokens` is gone from `Origin` on purpose — it would
       have handed every consumer `to_token_stream().to_string()` back.
-      The census counts **four doors** (`as_syn`, `stripped_syntax`, `to_syn`,
-      `enum_item`) by NAME rather than by call shape, so UFCS and a function item
-      count like a method call — and `escape_surface_is_closed` reads the model's
-      own surface so a fifth cannot appear quietly, which is how three of the
-      four were found
+      The census counts **five doors** (`as_syn`, `stripped_syntax`, `to_syn`,
+      `enum_item`, `type_from_ident`) by NAME rather than by call shape, so UFCS
+      and a function item count like a method call — and
+      `escape_surface_is_closed` reads the model's own surface so a sixth cannot
+      appear quietly, which is how four of the five were found. It asks the
+      question the safe way round: every `syn` return is a door unless its type
+      is a leaf (`Ident`, `Lifetime`, `Member`, `Index`) and unless the function
+      was already handed a node to transform
 - [ ] Drive **escapes: types** to zero. The population is three kinds, and only
       the first is classification: taking a node apart (what the ledger's first
       section already sees), keying by spelling (`TypeKey::from_type` where

--- a/docs/language-integration.md
+++ b/docs/language-integration.md
@@ -641,9 +641,11 @@ growing back.
       and a function item count like a method call — and
       `escape_surface_is_closed` reads the model's own surface so a sixth cannot
       appear quietly, which is how four of the five were found. It asks the
-      question the safe way round: every `syn` return is a door unless its type
+      question the safe way round — every `syn` return is a door unless its type
       is a leaf (`Ident`, `Lifetime`, `Member`, `Index`) and unless the function
-      was already handed a node to transform
+      is one of three named transformers — and it reads more than functions,
+      because more than a function can hand out a node: a public field, a trait
+      method and its impl, and an alias that hides the name
 - [ ] Drive **escapes: types** to zero. The population is three kinds, and only
       the first is classification: taking a node apart (what the ledger's first
       section already sees), keying by spelling (`TypeKey::from_type` where

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -267,7 +267,7 @@ pub fn apply<M>(
 /// The **reading** of a declared function's parameter.
 ///
 /// `Param::ty` is a `TypeRef` computed at parse time. Reaching into the item's
-/// `origin.syntax` and digging the parameter out of `sig.inputs` — what these
+/// `spell()` and digging the parameter out of `sig.inputs` — what these
 /// three sites used to do — re-derives a fact the model was already handing over,
 /// which is `origin` used for reasoning rather than for emission.
 fn param_reading<M>(
@@ -365,8 +365,8 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
     // The model already read this return; `fallible_parts` is that reading, not a
     // second look at the spelling.
     let (target, fallible) = match f.ret.fallible_parts() {
-        Some((ok, _)) => (ok.syntax().clone(), true),
-        None => (f.ret.syntax().clone(), false),
+        Some((ok, _)) => (ok.as_syn().clone(), true),
+        None => (f.ret.as_syn().clone(), false),
     };
     Ok(CtorSig {
         params,
@@ -429,7 +429,7 @@ fn build_plan<M>(
             )?;
             visited.remove(&target.key());
             return Ok(FoldPlan {
-                target: target.syntax().clone(),
+                target: target.as_syn().clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -439,7 +439,7 @@ fn build_plan<M>(
             });
         };
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, target.syntax())?;
+        check_target(func, &sig.target, target.as_syn())?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
             leaves.push(FoldLeaf {
@@ -447,7 +447,7 @@ fn build_plan<M>(
                 ty: pty.optional(),
             });
             return Ok(FoldPlan {
-                target: target.syntax().clone(),
+                target: target.as_syn().clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -491,7 +491,7 @@ fn build_plan<M>(
             inputs.push(arg);
         }
         return Ok(FoldPlan {
-            target: target.syntax().clone(),
+            target: target.as_syn().clone(),
             by_ref,
             shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
             leaves,
@@ -523,7 +523,7 @@ fn build_plan<M>(
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
-        target: target.syntax().clone(),
+        target: target.as_syn().clone(),
         by_ref,
         shape: FoldShape::Base,
         leaves,
@@ -553,7 +553,7 @@ fn build_core<M>(
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, target.syntax())?;
+        check_target(func, &sig.target, target.as_syn())?;
         let np = sig.params.len();
         let mut args = Vec::new();
         for (pname, pty) in &sig.params {
@@ -588,7 +588,7 @@ fn build_core<M>(
             match v {
                 Variant::Ctor(func) => {
                     let sig = ctor_signature(registry, func)?;
-                    check_target(func, &sig.target, target.syntax())?;
+                    check_target(func, &sig.target, target.as_syn())?;
                     let np = sig.params.len();
                     let mut args = Vec::new();
                     for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
@@ -689,7 +689,7 @@ fn build_arg<M>(
         )?;
         visited.remove(&key);
         Ok(FoldArg::Build(Box::new(FoldBuild {
-            target: bare.syntax().clone(),
+            target: bare.as_syn().clone(),
             by_ref: pby_ref,
             selector,
             variants: vars,
@@ -1085,7 +1085,7 @@ fn constructed_value(reading: &crate::api::core::flat::TypeRef) -> syn::Type {
     after_opt
         .borrow_target()
         .unwrap_or(after_opt)
-        .syntax()
+        .as_syn()
         .clone()
 }
 

--- a/prebindgen/src/api/core/expand/plan.rs
+++ b/prebindgen/src/api/core/expand/plan.rs
@@ -63,7 +63,7 @@ pub struct FoldLeaf {
     /// The **reading** of the type whose resolved input converter decodes this
     /// leaf. For a single constructor these are the raw constructor parameter
     /// types; for a combined one the selector (`i32`) and `Option`-wrapped
-    /// variant inputs. Spell it with `ty.origin.syntax`.
+    /// variant inputs. Spell it with `ty.spell()`.
     ///
     /// A reading rather than a spelling for the reason [`UnfoldLeaf::out_ty`]
     /// gives: a consumer asking what this leaf's type MEANS had to hand the

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -51,7 +51,7 @@ fn single_constructor_plan_and_fold() {
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(plan.leaves[0].name.to_string(), "a");
     assert_eq!(
-        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_token_stream().to_string(),
         "String"
     );
 
@@ -101,16 +101,16 @@ fn constructor_plan_and_fold() {
     // selector + try_from(String) + identity(ZKeyExpr) = 3 leaves
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(
-        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_token_stream().to_string(),
         "i32"
     );
     assert_eq!(
-        plan.leaves[1].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[1].ty.spell().to_token_stream().to_string(),
         "Option < String >"
     );
     // `&ZKeyExpr` consumer ⇒ borrowed identity leaf (clone-preserving).
     assert_eq!(
-        plan.leaves[2].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[2].ty.spell().to_token_stream().to_string(),
         "Option < & ZKeyExpr >"
     );
     assert_eq!(plan.variants.len(), 2);
@@ -166,7 +166,7 @@ fn optional_byvalue_single_ctor() {
     assert_eq!(plan.leaves.len(), 1);
     // nullable leaf wrapping the ctor param
     assert_eq!(
-        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_token_stream().to_string(),
         "Option < Vec < u8 > >"
     );
 
@@ -217,7 +217,7 @@ fn optional_byref_single_ctor() {
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
     assert_eq!(
-        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_token_stream().to_string(),
         "Option < String >"
     );
     assert_eq!(
@@ -271,17 +271,17 @@ fn optional_byref_multi_arg_ctor() {
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_present");
     assert_eq!(
-        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_token_stream().to_string(),
         "bool"
     );
     assert_eq!(plan.leaves[1].name.to_string(), "encoding_id");
     assert_eq!(
-        plan.leaves[1].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[1].ty.spell().to_token_stream().to_string(),
         "i32"
     );
     assert_eq!(plan.leaves[2].name.to_string(), "encoding_schema");
     assert_eq!(
-        plan.leaves[2].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[2].ty.spell().to_token_stream().to_string(),
         "Option < String >"
     );
 
@@ -355,20 +355,20 @@ fn optional_combined_selector_encodes_absence() {
     assert_eq!(plan.leaves.len(), 4);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_sel");
     assert_eq!(
-        plan.leaves[0].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_token_stream().to_string(),
         "i32"
     );
     assert_eq!(
-        plan.leaves[1].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[1].ty.spell().to_token_stream().to_string(),
         "Option < i32 >"
     );
     assert_eq!(
-        plan.leaves[2].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[2].ty.spell().to_token_stream().to_string(),
         "Option < String >",
         "already-Option ctor arg is NOT double-wrapped"
     );
     assert_eq!(
-        plan.leaves[3].ty.syntax().to_token_stream().to_string(),
+        plan.leaves[3].ty.spell().to_token_stream().to_string(),
         "Option < & ZEncoding >"
     );
     assert!(
@@ -609,7 +609,7 @@ fn recursive_input_nests_param_constructors() {
     let leaf_tys: Vec<String> = plan
         .leaves
         .iter()
-        .map(|l| l.ty.syntax().to_token_stream().to_string())
+        .map(|l| l.ty.spell().to_token_stream().to_string())
         .collect();
     assert!(
         leaf_tys.iter().any(|t| t.contains("i32")),

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -50,10 +50,7 @@ fn single_constructor_plan_and_fold() {
     assert_eq!(plan.selector, None);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(plan.leaves[0].name.to_string(), "a");
-    assert_eq!(
-        plan.leaves[0].ty.spell().to_token_stream().to_string(),
-        "String"
-    );
+    assert_eq!(plan.leaves[0].ty.spell().to_string(), "String");
 
     let locals = vec![ident("a")];
     let folded = emit_fold(plan, &locals, &src_qualify);
@@ -100,17 +97,11 @@ fn constructor_plan_and_fold() {
     assert_eq!(plan.selector, Some(0));
     // selector + try_from(String) + identity(ZKeyExpr) = 3 leaves
     assert_eq!(plan.leaves.len(), 3);
-    assert_eq!(
-        plan.leaves[0].ty.spell().to_token_stream().to_string(),
-        "i32"
-    );
-    assert_eq!(
-        plan.leaves[1].ty.spell().to_token_stream().to_string(),
-        "Option < String >"
-    );
+    assert_eq!(plan.leaves[0].ty.spell().to_string(), "i32");
+    assert_eq!(plan.leaves[1].ty.spell().to_string(), "Option < String >");
     // `&ZKeyExpr` consumer ⇒ borrowed identity leaf (clone-preserving).
     assert_eq!(
-        plan.leaves[2].ty.spell().to_token_stream().to_string(),
+        plan.leaves[2].ty.spell().to_string(),
         "Option < & ZKeyExpr >"
     );
     assert_eq!(plan.variants.len(), 2);
@@ -166,7 +157,7 @@ fn optional_byvalue_single_ctor() {
     assert_eq!(plan.leaves.len(), 1);
     // nullable leaf wrapping the ctor param
     assert_eq!(
-        plan.leaves[0].ty.spell().to_token_stream().to_string(),
+        plan.leaves[0].ty.spell().to_string(),
         "Option < Vec < u8 > >"
     );
 
@@ -216,10 +207,7 @@ fn optional_byref_single_ctor() {
     assert!(matches!(plan.shape, FoldShape::Optional((), _)));
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
-    assert_eq!(
-        plan.leaves[0].ty.spell().to_token_stream().to_string(),
-        "Option < String >"
-    );
+    assert_eq!(plan.leaves[0].ty.spell().to_string(), "Option < String >");
     assert_eq!(
         plan.target.to_token_stream().to_string(),
         "ZEncoding",
@@ -270,20 +258,11 @@ fn optional_byref_multi_arg_ctor() {
     // leaf 0 = present:bool, leaf 1 = id:i32, leaf 2 = schema:Option<String>
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_present");
-    assert_eq!(
-        plan.leaves[0].ty.spell().to_token_stream().to_string(),
-        "bool"
-    );
+    assert_eq!(plan.leaves[0].ty.spell().to_string(), "bool");
     assert_eq!(plan.leaves[1].name.to_string(), "encoding_id");
-    assert_eq!(
-        plan.leaves[1].ty.spell().to_token_stream().to_string(),
-        "i32"
-    );
+    assert_eq!(plan.leaves[1].ty.spell().to_string(), "i32");
     assert_eq!(plan.leaves[2].name.to_string(), "encoding_schema");
-    assert_eq!(
-        plan.leaves[2].ty.spell().to_token_stream().to_string(),
-        "Option < String >"
-    );
+    assert_eq!(plan.leaves[2].ty.spell().to_string(), "Option < String >");
 
     let locals = vec![ident("pres"), ident("id"), ident("schema")];
     let s = emit_fold(plan, &locals, &src_qualify)
@@ -354,21 +333,15 @@ fn optional_combined_selector_encodes_absence() {
     // (passthrough), identity:Option<&ZEncoding>.
     assert_eq!(plan.leaves.len(), 4);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_sel");
+    assert_eq!(plan.leaves[0].ty.spell().to_string(), "i32");
+    assert_eq!(plan.leaves[1].ty.spell().to_string(), "Option < i32 >");
     assert_eq!(
-        plan.leaves[0].ty.spell().to_token_stream().to_string(),
-        "i32"
-    );
-    assert_eq!(
-        plan.leaves[1].ty.spell().to_token_stream().to_string(),
-        "Option < i32 >"
-    );
-    assert_eq!(
-        plan.leaves[2].ty.spell().to_token_stream().to_string(),
+        plan.leaves[2].ty.spell().to_string(),
         "Option < String >",
         "already-Option ctor arg is NOT double-wrapped"
     );
     assert_eq!(
-        plan.leaves[3].ty.spell().to_token_stream().to_string(),
+        plan.leaves[3].ty.spell().to_string(),
         "Option < & ZEncoding >"
     );
     assert!(
@@ -609,7 +582,7 @@ fn recursive_input_nests_param_constructors() {
     let leaf_tys: Vec<String> = plan
         .leaves
         .iter()
-        .map(|l| l.ty.spell().to_token_stream().to_string())
+        .map(|l| l.ty.spell().to_string())
         .collect();
     assert!(
         leaf_tys.iter().any(|t| t.contains("i32")),

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -53,8 +53,12 @@
 # every syn return is a door unless the type is on a small LEAF allowlist, and
 # unless the function is one of three NAMED transformers that take a node and
 # nothing else. Both allowlists are the exception side, where being wrong is a
-# false alarm rather than a silent hole, and an import alias (`use syn::Type as
-# SynType`) is read as the syn type it binds.
+# false alarm rather than a silent hole.
+#
+# It reads more than functions, because more than a function can hand out a
+# node: a public field, a trait method and its impl, and an alias that hides the
+# name (`use syn::Type as SynType` is resolved; `use syn as syntax` and
+# `type Node = syn::Type` are reported, since flat names syn types in full).
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -32,16 +32,28 @@
 # below count what the first section can only measure — every place that still
 # has a node to take apart.
 #
-#   ## escapes: types   `ty.as_syn()`         — MUST reach zero
-#   ## escapes: items   `f.origin.as_syn()`   — expected to persist
+#   ## escapes: types   `ty.as_syn()`, `stripped_syntax()`, `to_syn()`
+#                                             — MUST reach zero
+#   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
+#                                             — expected to persist
 #
 # A type escape is a source type the model should have been able to answer for;
 # the classification sites above are the subset that visibly does classify. An
 # item escape is a captured item's own node, which an emitter re-stating a whole
 # item legitimately needs until items grow modelled accessors.
 #
-# The bucket is read off the RECEIVER: `origin` means the item's node, anything
-# else means a type. Two over-counts land in the type bucket on purpose, both in
+# The scan counts FOUR doors — `as_syn`, `stripped_syntax`, `to_syn`,
+# `enum_item` — and counts each by NAME rather than by call shape, so UFCS
+# (`TypeRef::as_syn(&ty)`) and a function item (`let read = TypeRef::as_syn;`)
+# are counted like a method call. A shape-matched rule missed both, which is a
+# ratchet that can be stepped around. `escape_surface_is_closed` keeps the list
+# honest: it reads the model's own surface and fails if a public method hands
+# out a structural syn node under a name the scan does not count — which is how
+# three of the four doors were found.
+#
+# The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
+# item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
+# the item's node, anything else means a type. Two over-counts land in the type bucket on purpose, both in
 # the safe direction — adapter declarations reuse `Origin` for a placeless
 # location (`decl.rust_type`), and carrying a spelling into an adapter-owned
 # `syn::Type` field is not classification either. Both are follow-ups the count
@@ -102,7 +114,7 @@
 2	api/core/registry/scan.rs
 15	api/core/unfold.rs
 3	api/lang/cbindgen/convert.rs
-2	api/lang/cbindgen/emit.rs
+3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
 6	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/emit/callback.rs
@@ -118,22 +130,23 @@
 1	api/lang/jnigen/jni/render.rs
 15	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
-14	api/lang/jnigen/jni/trait_impl.rs
+16	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 115
+# total escapes: types: 118
 
 ## escapes: items
 1	api/core/prebindgen.rs
-3	api/core/registry/scan.rs
+4	api/core/registry/scan.rs
 1	api/core/write.rs
 2	api/lang/cbindgen/convert.rs
-1	api/lang/cbindgen/emit.rs
-1	api/lang/cbindgen/trait_impl.rs
+2	api/lang/cbindgen/emit.rs
+1	api/lang/cbindgen/mod.rs
+7	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
-5	api/lang/jnigen/jni/kotlin_emit.rs
+6	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
-5	api/lang/jnigen/jni/render.rs
-1	api/lang/jnigen/jni/symbols.rs
-4	api/lang/jnigen/jni/trait_impl.rs
+6	api/lang/jnigen/jni/render.rs
+3	api/lang/jnigen/jni/symbols.rs
+6	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 28
+# total escapes: items: 43

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -57,8 +57,11 @@
 #
 # It reads more than functions, because more than a function can hand out a
 # node: a public field, a trait method and its impl, and an alias that hides the
-# name (`use syn::Type as SynType` is resolved; `use syn as syntax` and
-# `type Node = syn::Type` are reported, since flat names syn types in full).
+# name (`use syn::Type as SynType` is resolved; a crate rename, a local
+# `type Node = syn::Type` and an associated `type Target = syn::Type` are
+# reported, since flat names syn types in full). An alias is reported whatever
+# its own visibility is: an alias is transparent, so a private one still lets a
+# public signature hand out the node.
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -25,16 +25,41 @@
 # A count going DOWN is the goal (a classifier reads elements instead) and is
 # still a ledger edit, so the win shows up in the diff.
 #
-# KNOWN BLIND SPOTS — classification this check cannot see, because it never
-# writes a `syn::` path. Each is a candidate addition to WATCHED:
+# ── THE ESCAPES ───────────────────────────────────────────────────────────
+#
+# The model's syntax is sealed: `Origin::syntax` is private, `spell()` hands out
+# tokens, and `as_syn()` is the ONE way to a `syn` node. So the two sections
+# below count what the first section can only measure — every place that still
+# has a node to take apart.
+#
+#   ## escapes: types   `ty.as_syn()`         — MUST reach zero
+#   ## escapes: items   `f.origin.as_syn()`   — expected to persist
+#
+# A type escape is a source type the model should have been able to answer for;
+# the classification sites above are the subset that visibly does classify. An
+# item escape is a captured item's own node, which an emitter re-stating a whole
+# item legitimately needs until items grow modelled accessors.
+#
+# The bucket is read off the RECEIVER: `origin` means the item's node, anything
+# else means a type. Two over-counts land in the type bucket on purpose, both in
+# the safe direction — adapter declarations reuse `Origin` for a placeless
+# location (`decl.rust_type`), and carrying a spelling into an adapter-owned
+# `syn::Type` field is not classification either. Both are follow-ups the count
+# names rather than hides.
+#
+# KNOWN BLIND SPOTS — classification neither half sees:
 #
 #   * token-string classification, e.g. `core/domain.rs` matching
-#     `ty.to_token_stream().to_string()` against "i8" / "f32";
-#   * ident-name classification, e.g. `seg.ident == "Option"`;
+#     `ty.to_token_stream().to_string()` against "i8" / "f32". The seal does
+#     NOT close this and cannot: what `domain.rs` reads is a `syn::Type` a build
+#     script supplied, which never was the model's. `spell().to_string()` reaches
+#     a string too — one call further, and greppable, which is the whole gain;
+#   * ident-name classification, e.g. `seg.ident == "Option"` — now gated, in
+#     that a path has to come from an escape first;
 #   * helper delegation — `jnigen/jni/classify.rs` is a whole classifier with
-#     zero watched sites;
+#     zero watched sites; gated the same way;
 #   * syn enums outside WATCHED: Item, Fields, FnArg, ReturnType,
-#     GenericArgument, Pat, ...
+#     GenericArgument, Pat, ... — likewise reachable only through an escape.
 #
 # One listed gap is closed rather than still open: `types_util::match_pattern`
 # unified against `parse_quote!(_)` patterns, adding shape rules with no watched
@@ -68,4 +93,47 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total: 116
+# total classification sites: 116
+
+## escapes: types
+11	api/core/expand.rs
+1	api/core/registry/declare.rs
+2	api/core/registry/order.rs
+2	api/core/registry/scan.rs
+15	api/core/unfold.rs
+3	api/lang/cbindgen/convert.rs
+2	api/lang/cbindgen/emit.rs
+6	api/lang/cbindgen/trait_impl.rs
+6	api/lang/jnigen/jni/builder.rs
+1	api/lang/jnigen/jni/emit/callback.rs
+5	api/lang/jnigen/jni/emit/delivery.rs
+8	api/lang/jnigen/jni/emit/flat_input.rs
+1	api/lang/jnigen/jni/emit/struct_out.rs
+1	api/lang/jnigen/jni/emit/sum_out.rs
+1	api/lang/jnigen/jni/emit/wrapper.rs
+3	api/lang/jnigen/jni/fn_plan.rs
+12	api/lang/jnigen/jni/iface.rs
+1	api/lang/jnigen/jni/kotlin_emit.rs
+1	api/lang/jnigen/jni/overloads.rs
+1	api/lang/jnigen/jni/render.rs
+15	api/lang/jnigen/jni/selector.rs
+3	api/lang/jnigen/jni/struct_plan.rs
+14	api/lang/jnigen/jni/trait_impl.rs
+
+# total escapes: types: 115
+
+## escapes: items
+1	api/core/prebindgen.rs
+3	api/core/registry/scan.rs
+1	api/core/write.rs
+2	api/lang/cbindgen/convert.rs
+1	api/lang/cbindgen/emit.rs
+1	api/lang/cbindgen/trait_impl.rs
+2	api/lang/jnigen/jni/builder.rs
+5	api/lang/jnigen/jni/kotlin_emit.rs
+2	api/lang/jnigen/jni/overloads.rs
+5	api/lang/jnigen/jni/render.rs
+1	api/lang/jnigen/jni/symbols.rs
+4	api/lang/jnigen/jni/trait_impl.rs
+
+# total escapes: items: 28

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -51,7 +51,10 @@
 # out a non-leaf syn node under a name the scan does not count — which is how
 # four of the five doors were found. It asks the question the safe way round:
 # every syn return is a door unless the type is on a small LEAF allowlist, and
-# unless the function was already handed a node to transform.
+# unless the function is one of three NAMED transformers that take a node and
+# nothing else. Both allowlists are the exception side, where being wrong is a
+# false alarm rather than a silent hole, and an import alias (`use syn::Type as
+# SynType`) is read as the syn type it binds.
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -32,8 +32,8 @@
 # below count what the first section can only measure — every place that still
 # has a node to take apart.
 #
-#   ## escapes: types   `ty.as_syn()`, `stripped_syntax()`, `to_syn()`
-#                                             — MUST reach zero
+#   ## escapes: types   `as_syn()`, `stripped_syntax()`, `to_syn()`,
+#                       `type_from_ident()`   — MUST reach zero
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
 #                                             — expected to persist
 #
@@ -42,14 +42,16 @@
 # item escape is a captured item's own node, which an emitter re-stating a whole
 # item legitimately needs until items grow modelled accessors.
 #
-# The scan counts FOUR doors — `as_syn`, `stripped_syntax`, `to_syn`,
-# `enum_item` — and counts each by NAME rather than by call shape, so UFCS
+# The scan counts FIVE doors — `as_syn`, `stripped_syntax`, `to_syn`,
+# `enum_item`, `type_from_ident` — each by NAME rather than by call shape, so UFCS
 # (`TypeRef::as_syn(&ty)`) and a function item (`let read = TypeRef::as_syn;`)
 # are counted like a method call. A shape-matched rule missed both, which is a
 # ratchet that can be stepped around. `escape_surface_is_closed` keeps the list
 # honest: it reads the model's own surface and fails if a public method hands
-# out a structural syn node under a name the scan does not count — which is how
-# three of the four doors were found.
+# out a non-leaf syn node under a name the scan does not count — which is how
+# four of the five doors were found. It asks the question the safe way round:
+# every syn return is a door unless the type is on a small LEAF allowlist, and
+# unless the function was already handed a node to transform.
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
@@ -108,10 +110,12 @@
 # total classification sites: 116
 
 ## escapes: types
+1	api/core/diagnostics.rs
 11	api/core/expand.rs
 1	api/core/registry/declare.rs
+1	api/core/registry/key.rs
 2	api/core/registry/order.rs
-2	api/core/registry/scan.rs
+4	api/core/registry/scan.rs
 15	api/core/unfold.rs
 3	api/lang/cbindgen/convert.rs
 3	api/lang/cbindgen/emit.rs
@@ -132,7 +136,7 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 16	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 118
+# total escapes: types: 122
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -128,16 +128,28 @@ const HEADER: &str = "\
 # below count what the first section can only measure — every place that still
 # has a node to take apart.
 #
-#   ## escapes: types   `ty.as_syn()`         — MUST reach zero
-#   ## escapes: items   `f.origin.as_syn()`   — expected to persist
+#   ## escapes: types   `ty.as_syn()`, `stripped_syntax()`, `to_syn()`
+#                                             — MUST reach zero
+#   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
+#                                             — expected to persist
 #
 # A type escape is a source type the model should have been able to answer for;
 # the classification sites above are the subset that visibly does classify. An
 # item escape is a captured item's own node, which an emitter re-stating a whole
 # item legitimately needs until items grow modelled accessors.
 #
-# The bucket is read off the RECEIVER: `origin` means the item's node, anything
-# else means a type. Two over-counts land in the type bucket on purpose, both in
+# The scan counts FOUR doors — `as_syn`, `stripped_syntax`, `to_syn`,
+# `enum_item` — and counts each by NAME rather than by call shape, so UFCS
+# (`TypeRef::as_syn(&ty)`) and a function item (`let read = TypeRef::as_syn;`)
+# are counted like a method call. A shape-matched rule missed both, which is a
+# ratchet that can be stepped around. `escape_surface_is_closed` keeps the list
+# honest: it reads the model's own surface and fails if a public method hands
+# out a structural syn node under a name the scan does not count — which is how
+# three of the four doors were found.
+#
+# The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
+# item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
+# the item's node, anything else means a type. Two over-counts land in the type bucket on purpose, both in
 # the safe direction — adapter declarations reuse `Origin` for a placeless
 # location (`decl.rust_type`), and carrying a spelling into an adapter-owned
 # `syn::Type` field is not classification either. Both are follow-ups the count
@@ -312,7 +324,43 @@ impl Counts {
     }
 }
 
-/// Which bucket an `as_syn()` call belongs to, read off the **receiver**.
+/// Every route from the model to a structural `syn` node.
+///
+/// `as_syn` is the door the seal opened deliberately; the other three predate it
+/// and hand out a node just as completely, so the census covers them or it is
+/// not a census. [`escape_surface_is_closed`] is what stops a fifth from
+/// appearing quietly.
+///
+/// | | hands out | why it exists |
+/// |---|---|---|
+/// | `as_syn` | the node itself | the escape |
+/// | `stripped_syntax` | `syn::Type` | the spelling under a transparent wrapper |
+/// | `to_syn` | `syn::Type` | the round-trip that checks the lowering |
+/// | `enum_item` | `&syn::ItemEnum` | a declared enum's own item |
+const ESCAPES: &[&str] = &["as_syn", "stripped_syntax", "to_syn", "enum_item"];
+
+/// The syn types a consumer can **take apart**. An ident, a lifetime or a member
+/// is a leaf: there is no shape to match on, so handing one out is not a door.
+const STRUCTURAL: &[&str] = &[
+    "Type",
+    "Expr",
+    "Item",
+    "ItemEnum",
+    "ItemStruct",
+    "ItemFn",
+    "ItemConst",
+    "Fields",
+    "Variant",
+    "Field",
+    "Path",
+    "Signature",
+    "FnArg",
+    "ReturnType",
+    "Pat",
+    "GenericArgument",
+];
+
+/// Which bucket an escape belongs to — by name, then by **receiver**.
 ///
 /// Outside `flat/`, a receiver named `origin` is always a captured item's node —
 /// an `ItemFn`, an `ItemStruct`, a `Field`, a `Variant` — because `TypeRef`'s own
@@ -325,11 +373,35 @@ impl Counts {
 /// wrote rather than what a source crate did. The bucket that must reach zero is
 /// the one that over-counts; the real fix is that a declaration is not an
 /// `Origin`, which is a refactor and not a rule.
-fn escape_bucket(receiver: Option<&str>) -> fn(&mut Counts) -> &mut usize {
-    match receiver {
-        Some("origin") => |c: &mut Counts| &mut c.escape_item,
-        _ => |c: &mut Counts| &mut c.escape_type,
+fn escape_bucket(name: &str, qualifier: Option<&str>) -> fn(&mut Counts) -> &mut usize {
+    let item: fn(&mut Counts) -> &mut usize = |c| &mut c.escape_item;
+    let ty: fn(&mut Counts) -> &mut usize = |c| &mut c.escape_type;
+    match (name, qualifier) {
+        // Hands out a whole captured item, whatever the receiver is called.
+        ("enum_item", _) => item,
+        // `f.origin.as_syn()` — a method call on an item's origin — and
+        // `Origin::as_syn(&f.origin)`, the same thing spelled through UFCS.
+        ("as_syn", Some("origin" | "Origin")) => item,
+        _ => ty,
     }
+}
+
+/// What stands before the escape's name: the receiver of `recv.as_syn()`, or the
+/// path qualifier of `TypeRef::as_syn(..)`. `None` for a bare mention.
+fn escape_qualifier(toks: &[TokenTree], i: usize) -> Option<String> {
+    // `recv . as_syn`
+    if i >= 2 && is_punct(&toks[i - 1], '.') {
+        if let Some(TokenTree::Ident(id)) = toks.get(i - 2) {
+            return Some(id.to_string());
+        }
+    }
+    // `Qualifier :: as_syn` — a `::` is two `Punct` tokens.
+    if i >= 3 && is_sep(toks, i - 2) {
+        if let Some(TokenTree::Ident(id)) = toks.get(i - 3) {
+            return Some(id.to_string());
+        }
+    }
+    None
 }
 
 fn count(stream: TokenStream, aliases: &[String], n: &mut Counts) {
@@ -379,20 +451,25 @@ fn count(stream: TokenStream, aliases: &[String], n: &mut Counts) {
             i += 4;
             continue;
         }
-        // `<receiver> . as_syn ( )` — the escape, bucketed by receiver.
-        if matches!(&toks[i], TokenTree::Ident(id) if *id == "as_syn")
-            && i > 0
-            && is_punct(&toks[i - 1], '.')
-            && matches!(toks.get(i + 1), Some(TokenTree::Group(g))
-                if g.delimiter() == Delimiter::Parenthesis && g.stream().is_empty())
-        {
-            let receiver = match toks.get(i.wrapping_sub(2)) {
-                Some(TokenTree::Ident(id)) if i >= 2 => Some(id.to_string()),
-                _ => None,
-            };
-            *escape_bucket(receiver.as_deref())(n) += 1;
-            i += 2;
-            continue;
+        // The escape — **every mention of the name**, not every call.
+        //
+        // A shape-matched rule (`<recv> . as_syn ( )`) is the census that gets
+        // bypassed: `TypeRef::as_syn(&ty)` reaches the same node through UFCS,
+        // and `let read = TypeRef::as_syn;` reaches it through a function item
+        // that is never *called* at the escape's own name at all. Both would
+        // have added a source-syntax escape with no ledger drift. Counting the
+        // ident covers call, UFCS and reference alike, because none of them can
+        // reach the node without writing the name.
+        if let TokenTree::Ident(id) = &toks[i] {
+            let name = id.to_string();
+            // ...except a definition, which is what is being counted.
+            let is_def =
+                i > 0 && matches!(toks.get(i - 1), Some(TokenTree::Ident(kw)) if *kw == "fn");
+            if ESCAPES.contains(&name.as_str()) && !is_def {
+                *escape_bucket(&name, escape_qualifier(&toks, i).as_deref())(n) += 1;
+                i += 1;
+                continue;
+            }
         }
         if let TokenTree::Group(g) = &toks[i] {
             count(g.stream(), aliases, n);
@@ -636,6 +713,119 @@ fn scanner_recognizes_the_shapes_that_matter() {
     );
 }
 
+/// **The census is only a census if it covers every door.**
+///
+/// The escape scan counts [`ESCAPES`] by name. That is a list, and a list is a
+/// thing someone forgets to add to — so this reads the model's own surface and
+/// fails if a public function in `core/flat` hands out a [`STRUCTURAL`] `syn`
+/// node under a name the scan does not count.
+///
+/// Three of the four entries were found this way rather than by design:
+/// `stripped_syntax`, `to_syn` and `enum_item` predate the seal and hand out a
+/// node just as completely as `as_syn` does. The review that asked for UFCS
+/// coverage is the same question one level up — a spelling the check does not
+/// know about is not counted, whether it is a call syntax or a whole method.
+#[test]
+fn escape_surface_is_closed() {
+    let mut doors = Vec::new();
+    let mut stack = vec![src_root().join("api/core/flat")];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("flat/ is readable") {
+            let path = entry.expect("readable dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let text = fs::read_to_string(&path).expect("source file is UTF-8");
+            let file: syn::File = syn::parse_str(&text).expect("flat source parses");
+            collect_doors(&file.items, &rel_key(&src_root(), &path), &mut doors);
+        }
+    }
+    let uncounted: Vec<_> = doors
+        .iter()
+        .filter(|(name, _)| !ESCAPES.contains(&name.as_str()))
+        .collect();
+    assert!(
+        uncounted.is_empty(),
+        "these hand a structural syn node out of the model under a name the \
+         escape scan does not count, so a consumer can take the source apart \
+         with no ledger drift:\n{}\n\nEither add the name to ESCAPES (and \
+         regenerate the ledger, so the doors it opens are counted), or return \
+         tokens instead.",
+        uncounted
+            .iter()
+            .map(|(name, at)| format!("  {at}: {name}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Public **methods** whose return type names a [`STRUCTURAL`] `syn` type.
+///
+/// Two conditions, and each rules out a whole class of false positive:
+///
+/// * **a `self` receiver.** A door hands out a node the *model holds*; a free
+///   function has no model state, so whatever it returns it built from what the
+///   caller passed in. `canonical_type(&syn::Type) -> syn::Type` cannot give a
+///   consumer a node it could not already reach, and neither can
+///   `extract_fn_trait_args` or `type_from_ident`.
+/// * **visibility past `flat`.** A `pub(super)` method cannot be called from
+///   outside the model, so it is the model reading itself. Everything wider is a
+///   door.
+fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>) {
+    fn escapes_flat(vis: &syn::Visibility) -> bool {
+        match vis {
+            syn::Visibility::Public(_) => true,
+            syn::Visibility::Restricted(r) => !r.path.is_ident("super") && !r.path.is_ident("self"),
+            syn::Visibility::Inherited => false,
+        }
+    }
+    fn hands_out_a_node(ret: &syn::ReturnType) -> bool {
+        let syn::ReturnType::Type(_, ty) = ret else {
+            return false;
+        };
+        // `syn :: <structural>` anywhere in the return type. Qualified because
+        // `-> Option<&Type>` is *flat's own* `Type`, which is the model, not a node.
+        names_a_node(quote::ToTokens::to_token_stream(ty))
+    }
+    // Through groups: `Option<(&'static str, syn::Type)>` nests the mention
+    // inside a parenthesised token group.
+    fn names_a_node(stream: TokenStream) -> bool {
+        let toks: Vec<TokenTree> = stream.into_iter().collect();
+        (0..toks.len()).any(|i| {
+            (matches!(&toks[i], TokenTree::Ident(id) if id == "syn")
+                && is_sep(&toks, i + 1)
+                && matches!(toks.get(i + 3), Some(TokenTree::Ident(id))
+                    if STRUCTURAL.contains(&id.to_string().as_str())))
+                || matches!(&toks[i], TokenTree::Group(g) if names_a_node(g.stream()))
+        })
+    }
+    for item in items {
+        match item {
+            syn::Item::Impl(im) => {
+                for it in &im.items {
+                    if let syn::ImplItem::Fn(f) = it {
+                        let is_method =
+                            matches!(f.sig.inputs.first(), Some(syn::FnArg::Receiver(_)));
+                        if is_method && escapes_flat(&f.vis) && hands_out_a_node(&f.sig.output) {
+                            out.push((f.sig.ident.to_string(), at.to_string()));
+                        }
+                    }
+                }
+            }
+            syn::Item::Mod(m) => {
+                if let Some((_, items)) = &m.content {
+                    collect_doors(items, at, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 /// The escape scan: what it counts, which bucket it lands in, and what it must
 /// not count.
 #[test]
@@ -668,8 +858,51 @@ fn escapes_are_counted_by_their_receiver() {
 
     // A method that merely *starts* with the name is not the escape.
     assert_eq!(c("fn f() { let t = ty.as_syntax(); }").escape_type, 0);
-    // Nor is a call that takes arguments — the escape is nullary.
-    assert_eq!(c("fn f() { let t = ty.as_syn(x); }").escape_type, 0);
+
+    // ── The bypasses (#313 review) ────────────────────────────────────────
+    //
+    // The same node, reached without ever writing `.as_syn()`. A rule matched on
+    // the CALL SHAPE counted none of these, so a new escape could land with no
+    // ledger drift — which is the one thing a ratchet must not allow.
+    assert_eq!(
+        c("fn f() { let t = TypeRef::as_syn(&ty); }").escape_type,
+        1,
+        "UFCS reaches the node"
+    );
+    assert_eq!(
+        c("fn f() { let i = Origin::as_syn(&func.origin); }").escape_item,
+        1,
+        "UFCS on an origin is an item escape, read off the qualifier"
+    );
+    assert_eq!(
+        c("fn f() { let read = TypeRef::as_syn; read(&ty); }").escape_type,
+        1,
+        "a function item is an escape at the point it is NAMED, and the call \
+         site does not name it at all"
+    );
+    assert_eq!(
+        c("fn f() { let t = <TypeRef>::as_syn(&ty); }").escape_type,
+        1,
+        "a qualified path still writes the name"
+    );
+    // The definition is not a use of itself — the model may reach its own field.
+    assert_eq!(
+        c("impl T { pub fn as_syn(&self) -> &S { &self.syntax } }").escape_type,
+        0
+    );
+
+    // The other three doors, which predate the seal and hand out a node just as
+    // completely. `escape_surface_is_closed` is what found them.
+    assert_eq!(
+        c("fn f() { let t = reading.stripped_syntax(); }").escape_type,
+        1
+    );
+    assert_eq!(c("fn f() { let t = ty.kind().to_syn(); }").escape_type, 1);
+    assert_eq!(
+        c("fn f() { let e = registry.flat().enum_item(&n); }").escape_item,
+        1,
+        "an item, whatever the receiver is called"
+    );
 
     // The two populations are independent: classifying through an escape counts
     // in both, which is the intended double entry — one says a node was taken,

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -147,7 +147,10 @@ const HEADER: &str = "\
 # out a non-leaf syn node under a name the scan does not count — which is how
 # four of the five doors were found. It asks the question the safe way round:
 # every syn return is a door unless the type is on a small LEAF allowlist, and
-# unless the function was already handed a node to transform.
+# unless the function is one of three NAMED transformers that take a node and
+# nothing else. Both allowlists are the exception side, where being wrong is a
+# false alarm rather than a silent hole, and an import alias (`use syn::Type as
+# SynType`) is read as the syn type it binds.
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
@@ -244,6 +247,27 @@ fn scan_file(text: &str) -> Counts {
 /// `imports_granularity=Crate` makes such an import more likely over time, not
 /// less. No file does this today; the point is that none can start.
 fn collect_aliases(stream: TokenStream) -> Vec<String> {
+    syn_imports(stream)
+        .into_iter()
+        .filter(|(_, original)| WATCHED.contains(&original.as_str()))
+        .map(|(bound, _)| bound)
+        .collect()
+}
+
+/// Every syn **type** a file imports, as `(bound name, original name)` —
+/// `use syn::{Expr, Type as T}` yields `[("Expr", "Expr"), ("T", "Type")]`.
+///
+/// One walk for both halves of the check. The classification scan wants the
+/// names bound to a [`WATCHED`] enum; the surface guard wants the names bound to
+/// anything that is not a [`LEAF`], because `use syn::Type as SynType` makes
+/// `-> &SynType` a door that a literal `syn::` match cannot see (#313 review).
+///
+/// A run is flattened, so `use syn::{punctuated::Punctuated, Type}` reads as
+/// `["syn", "punctuated", "Punctuated", "Type"]` and a module segment is
+/// indistinguishable from an item — except by case, which in Rust is not a
+/// coincidence: modules are `snake_case`, types are `CamelCase`. An import that
+/// defeats that convention defeats this, and would be the only one in the tree.
+fn syn_imports(stream: TokenStream) -> Vec<(String, String)> {
     let mut out = Vec::new();
     for run in use_runs(stream) {
         // `use syn::...` only; `use crate::Type` binds something else entirely.
@@ -252,15 +276,16 @@ fn collect_aliases(stream: TokenStream) -> Vec<String> {
         }
         let mut i = 1;
         while i < run.len() {
-            if WATCHED.contains(&run[i].as_str()) {
+            let is_type = run[i].starts_with(char::is_uppercase);
+            if is_type {
                 let renamed = run.get(i + 1).map(String::as_str) == Some("as");
                 match (renamed, run.get(i + 2)) {
                     (true, Some(alias)) => {
-                        out.push(alias.clone());
+                        out.push((alias.clone(), run[i].clone()));
                         i += 3;
                         continue;
                     }
-                    _ => out.push(run[i].clone()),
+                    _ => out.push((run[i].clone(), run[i].clone())),
                 }
             }
             i += 1;
@@ -358,6 +383,19 @@ const ESCAPES: &[&str] = &[
 /// syn type nobody considered is a door until someone argues it is a leaf, and
 /// that argument is a diff on this line.
 const LEAF: &[&str] = &["Ident", "Lifetime", "Member", "Index"];
+
+/// The functions that hand back a node they were **given**, so the caller could
+/// have reached it without them.
+///
+/// An allowlist because a structural test cannot prove provenance: a function
+/// can take a node *and* the model, and return the model's. Three names, each
+/// still checked for the shape that makes the claim true — see
+/// [`collect_doors`]. Adding a fourth is a deliberate line in this file.
+const TRANSFORMERS: &[&str] = &[
+    "canonical_type",
+    "extract_fn_trait_args",
+    "peel_transparent",
+];
 
 /// Which bucket an escape belongs to — by name, then by **receiver**.
 ///
@@ -740,7 +778,17 @@ fn escape_surface_is_closed() {
             }
             let text = fs::read_to_string(&path).expect("source file is UTF-8");
             let file: syn::File = syn::parse_str(&text).expect("flat source parses");
-            collect_doors(&file.items, &rel_key(&src_root(), &path), &mut doors);
+            let aliases: Vec<String> = syn_imports(TokenStream::from_str(&text).expect("tokens"))
+                .into_iter()
+                .filter(|(_, original)| !LEAF.contains(&original.as_str()))
+                .map(|(bound, _)| bound)
+                .collect();
+            collect_doors(
+                &file.items,
+                &rel_key(&src_root(), &path),
+                &aliases,
+                &mut doors,
+            );
         }
     }
     let uncounted: Vec<_> = doors
@@ -784,7 +832,12 @@ fn escape_surface_is_closed() {
 ///
 /// Visibility still applies: `pub(super)` cannot be called from outside the
 /// model, so it is the model reading itself.
-fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>) {
+fn collect_doors(
+    items: &[syn::Item],
+    at: &str,
+    aliases: &[String],
+    out: &mut Vec<(String, String)>,
+) {
     fn escapes_flat(vis: &syn::Visibility) -> bool {
         match vis {
             syn::Visibility::Public(_) => true,
@@ -792,39 +845,59 @@ fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>)
             syn::Visibility::Inherited => false,
         }
     }
-    fn hands_out_a_node(ret: &syn::ReturnType) -> bool {
+    fn hands_out_a_node(ret: &syn::ReturnType, aliases: &[String]) -> bool {
         let syn::ReturnType::Type(_, ty) = ret else {
             return false;
         };
-        names_a_node(quote::ToTokens::to_token_stream(ty))
+        names_a_node(quote::ToTokens::to_token_stream(ty), aliases)
     }
     /// A non-[`LEAF`] `syn::` type named anywhere in a signature position.
     ///
     /// Qualified, because `-> Option<&Type>` is *flat's own* `Type` — the model,
     /// not a node. Through groups, because `Option<(&'static str, syn::Type)>`
     /// nests the mention inside a parenthesised token group.
-    fn names_a_node(stream: TokenStream) -> bool {
+    fn names_a_node(stream: TokenStream, aliases: &[String]) -> bool {
         let toks: Vec<TokenTree> = stream.into_iter().collect();
         (0..toks.len()).any(|i| {
             (matches!(&toks[i], TokenTree::Ident(id) if id == "syn")
                 && is_sep(&toks, i + 1)
                 && matches!(toks.get(i + 3), Some(TokenTree::Ident(id))
                     if !LEAF.contains(&id.to_string().as_str())))
-                || matches!(&toks[i], TokenTree::Group(g) if names_a_node(g.stream()))
+                // A name the file imported from syn — `use syn::Type as SynType`
+                // makes `-> &SynType` the same door under another spelling.
+                || matches!(&toks[i], TokenTree::Ident(id) if aliases.contains(&id.to_string()))
+                || matches!(&toks[i], TokenTree::Group(g) if names_a_node(g.stream(), aliases))
         })
     }
-    /// A function the caller could have written itself: no receiver, and a
-    /// non-leaf node already among its inputs.
-    fn is_transformer(sig: &syn::Signature) -> bool {
-        let has_receiver = matches!(sig.inputs.first(), Some(syn::FnArg::Receiver(_)));
-        let takes_a_node = sig.inputs.iter().any(|arg| match arg {
-            syn::FnArg::Typed(pt) => names_a_node(quote::ToTokens::to_token_stream(&pt.ty)),
-            syn::FnArg::Receiver(_) => false,
-        });
-        !has_receiver && takes_a_node
+    /// A function the caller could have written itself. **Named**, and then
+    /// checked, because the structural test alone does not establish where the
+    /// return came from (#313 review):
+    ///
+    /// ```ignore
+    /// pub fn leak<'a>(model: &'a TypeRef, _decoy: &syn::Type) -> &'a syn::Type {
+    ///     model.as_syn()
+    /// }
+    /// ```
+    ///
+    /// A node among the inputs says only that *a* node was passed, not that the
+    /// returned one came from it — and any other parameter may carry the model.
+    /// So the exemption is an allowlist of three, each of which must still take
+    /// **exactly one** parameter, and that parameter must be the node. The decoy
+    /// above cannot be exempted even by name.
+    fn is_transformer(name: &str, sig: &syn::Signature, aliases: &[String]) -> bool {
+        TRANSFORMERS.contains(&name)
+            && sig.inputs.len() == 1
+            && match sig.inputs.first() {
+                Some(syn::FnArg::Typed(pt)) => {
+                    names_a_node(quote::ToTokens::to_token_stream(&pt.ty), aliases)
+                }
+                _ => false,
+            }
     }
     let is_door = |vis: &syn::Visibility, sig: &syn::Signature| {
-        escapes_flat(vis) && hands_out_a_node(&sig.output) && !is_transformer(sig)
+        escapes_flat(vis)
+            && hands_out_a_node(&sig.output, aliases)
+            && !is_transformer(&sig.ident.to_string(), sig, aliases)
     };
     for item in items {
         match item {
@@ -842,7 +915,7 @@ fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>)
             }
             syn::Item::Mod(m) => {
                 if let Some((_, items)) = &m.content {
-                    collect_doors(items, at, out);
+                    collect_doors(items, at, aliases, out);
                 }
             }
             _ => {}
@@ -856,8 +929,13 @@ fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>)
 fn a_door_is_the_default_and_a_transformer_is_the_exception() {
     let doors = |src: &str| {
         let file: syn::File = syn::parse_str(src).expect("test source parses");
+        let aliases: Vec<String> = syn_imports(TokenStream::from_str(src).expect("tokens"))
+            .into_iter()
+            .filter(|(_, original)| !LEAF.contains(&original.as_str()))
+            .map(|(bound, _)| bound)
+            .collect();
         let mut out = Vec::new();
-        collect_doors(&file.items, "test", &mut out);
+        collect_doors(&file.items, "test", &aliases, &mut out);
         out.into_iter().map(|(name, _)| name).collect::<Vec<_>>()
     };
 
@@ -880,13 +958,39 @@ fn a_door_is_the_default_and_a_transformer_is_the_exception() {
         ["attrs"]
     );
 
-    // A transformer is exempt: it was handed a node, so it can give back only
-    // what the caller could already reach.
+    // A decoy input defeats an existential test: this takes a node AND the
+    // model, and returns the model's. Only the allowlist keeps it out.
+    assert_eq!(
+        doors(
+            "pub fn leak<'a>(model: &'a TypeRef, _decoy: &syn::Type) -> &'a syn::Type { \
+             model.as_syn() }"
+        ),
+        ["leak"]
+    );
+    // An alias is the same door under another spelling.
+    assert_eq!(
+        doors(
+            "use syn::Type as SynType;\n\
+             impl S { pub fn leak(&self) -> &SynType { self.as_syn() } }"
+        ),
+        ["leak"]
+    );
+
+    // A named transformer is exempt: it was handed a node and nothing else, so
+    // it can give back only what the caller could already reach.
     assert!(doors("pub fn canonical_type(ty: &syn::Type) -> syn::Type { ty.clone() }").is_empty());
     assert!(
-        doors("pub fn peel(ty: &syn::Type) -> Option<(&'static str, syn::Type)> { None }")
-            .is_empty(),
+        doors(
+            "pub fn peel_transparent(ty: &syn::Type) -> Option<(&'static str, syn::Type)> { None }"
+        )
+        .is_empty(),
         "the mention nests inside a token group, and must still be seen"
+    );
+    // The allowlist is not a password: the shape still has to hold.
+    assert_eq!(
+        doors("pub fn canonical_type(t: &TypeRef, ty: &syn::Type) -> syn::Type { t.as_syn() }"),
+        ["canonical_type"],
+        "a second parameter can carry the model, so one input or nothing"
     );
     // A leaf is not a node: there is no shape to match on.
     assert!(doors("impl S { pub fn name(&self) -> &syn::Ident { &self.name } }").is_empty());

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -153,8 +153,11 @@ const HEADER: &str = "\
 #
 # It reads more than functions, because more than a function can hand out a
 # node: a public field, a trait method and its impl, and an alias that hides the
-# name (`use syn::Type as SynType` is resolved; `use syn as syntax` and
-# `type Node = syn::Type` are reported, since flat names syn types in full).
+# name (`use syn::Type as SynType` is resolved; a crate rename, a local
+# `type Node = syn::Type` and an associated `type Target = syn::Type` are
+# reported, since flat names syn types in full). An alias is reported whatever
+# its own visibility is: an alias is transparent, so a private one still lets a
+# public signature hand out the node.
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
@@ -783,11 +786,16 @@ fn scanner_recognizes_the_shapes_that_matter() {
 /// **Externally visible is not just a function** (#313 review). A public field
 /// reopens exactly the capability an accessor closes; a trait method is as
 /// visible as its trait, and its impl carries no visibility of its own; and an
-/// alias — `use syn as syntax`, `type Node = syn::Type` — puts a node behind a
-/// name no check of `syn::` paths can follow. All four are doors here, and the
-/// alias forms are reported rather than resolved: `flat` names `syn::` types in
-/// full, everywhere, so following aliases to a fixed point would be machinery
-/// for a spelling the model does not use.
+/// alias — `use syn as syntax`, `type Node = syn::Type`, or an associated
+/// `type Target = syn::Type` reached through `Self::` — puts a node behind a
+/// name no check of `syn::` paths can follow. All are doors here.
+///
+/// The alias forms are **reported rather than resolved**: `flat` names `syn::`
+/// types in full, everywhere, so following aliases to a fixed point would be
+/// machinery for a spelling the model does not use. And an alias is reported
+/// whatever its own visibility is, because an alias is transparent — a private
+/// `type Node = syn::Type` still lets a public signature hand out the node, and
+/// the caller never has to name `Node` to use it.
 ///
 /// Three of the four entries were found this way rather than by design:
 /// `stripped_syntax`, `to_syn` and `enum_item` predate the seal and hand out a
@@ -976,14 +984,27 @@ fn collect_doors(
             }
             // A crate rename or a local alias puts a node behind a name this
             // check cannot follow, so the name itself is reported.
+            //
+            // **Whatever the alias's own visibility is.** An alias is
+            // transparent: a private `type Node = syn::Type` still makes
+            // `pub fn leak(&self) -> &Node` hand out a `syn::Type`, and the
+            // caller never has to name `Node` to use it (#313 review).
             syn::Item::Type(t)
-                if escapes_flat(&t.vis)
-                    && names_a_node(quote::ToTokens::to_token_stream(&t.ty), aliases) =>
+                if names_a_node(quote::ToTokens::to_token_stream(&t.ty), aliases) =>
             {
                 out.push((format!("type {}", t.ident), at.to_string()));
             }
             syn::Item::Impl(im) => {
                 for it in &im.items {
+                    // An associated type is an alias reached through `Self::`,
+                    // so a signature that names it names no node — which is how
+                    // `impl Deref for TypeRef { type Target = syn::Type; }`
+                    // hands the node to `&*ty` with nothing to count.
+                    if let syn::ImplItem::Type(t) = it {
+                        if names_a_node(quote::ToTokens::to_token_stream(&t.ty), aliases) {
+                            out.push((format!("type {}", t.ident), at.to_string()));
+                        }
+                    }
                     if let syn::ImplItem::Fn(f) = it {
                         // A trait impl's method carries no visibility of its
                         // own: it is reachable wherever the trait is, so the
@@ -1003,6 +1024,15 @@ fn collect_doors(
             }
             syn::Item::Trait(tr) if escapes_flat(&tr.vis) => {
                 for it in &tr.items {
+                    // An associated type's default is the same alias, declared
+                    // one level up.
+                    if let syn::TraitItem::Type(t) = it {
+                        if t.default.as_ref().is_some_and(|(_, ty)| {
+                            names_a_node(quote::ToTokens::to_token_stream(ty), aliases)
+                        }) {
+                            out.push((format!("{}::{}", tr.ident, t.ident), at.to_string()));
+                        }
+                    }
                     if let syn::TraitItem::Fn(f) = it {
                         // A trait method is as visible as its trait.
                         if is_door(&tr.vis, &f.sig) {
@@ -1164,6 +1194,35 @@ fn a_door_is_the_default_and_a_transformer_is_the_exception() {
     );
     // A leaf alias is not a door: there is still no shape to match on.
     assert!(doors("pub type Name = syn::Ident;").is_empty());
+    // An alias is TRANSPARENT, so its own visibility says nothing: a private
+    // one still makes `pub fn leak(&self) -> &Node` hand out a `syn::Type`,
+    // and the caller never has to name `Node` to use it.
+    assert_eq!(
+        doors("type Node = syn::Type;\nimpl S { pub fn leak(&self) -> &Node { self.as_syn() } }"),
+        ["type Node"]
+    );
+
+    // An associated type is an alias reached through `Self::`, so the signature
+    // that returns it names no node at all. `&*ty` then hands out the node with
+    // nothing to count.
+    assert_eq!(
+        doors(
+            "impl std::ops::Deref for TypeRef {\n\
+             type Target = syn::Type;\n\
+             fn deref(&self) -> &Self::Target { self.as_syn() }\n\
+             }"
+        ),
+        ["type Target"]
+    );
+    assert_eq!(
+        doors("pub trait Leak { type Node = syn::Type; }"),
+        ["Leak::Node"],
+        "an associated type's default is the same alias, one level up"
+    );
+    assert!(
+        doors("impl Deref for S { type Target = syn::Ident; }").is_empty(),
+        "a leaf is a leaf however it is reached"
+    );
 
     // Test code is not the model's surface.
     assert!(doors("#[cfg(test)]\nmod t { pub struct S { pub node: syn::Type } }").is_empty());

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -149,8 +149,12 @@ const HEADER: &str = "\
 # every syn return is a door unless the type is on a small LEAF allowlist, and
 # unless the function is one of three NAMED transformers that take a node and
 # nothing else. Both allowlists are the exception side, where being wrong is a
-# false alarm rather than a silent hole, and an import alias (`use syn::Type as
-# SynType`) is read as the syn type it binds.
+# false alarm rather than a silent hole.
+#
+# It reads more than functions, because more than a function can hand out a
+# node: a public field, a trait method and its impl, and an alias that hides the
+# name (`use syn::Type as SynType` is resolved; `use syn as syntax` and
+# `type Node = syn::Type` are reported, since flat names syn types in full).
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
@@ -276,6 +280,16 @@ fn syn_imports(stream: TokenStream) -> Vec<(String, String)> {
         }
         let mut i = 1;
         while i < run.len() {
+            // `use syn as syntax;` renames the crate, so `syntax::Type` is a
+            // node under a name no uppercase check finds. Reported rather than
+            // resolved — see `RENAMED_SYN`.
+            if run[i] == "as" {
+                if let Some(alias) = run.get(i + 1) {
+                    out.push((alias.clone(), RENAMED_SYN.to_string()));
+                }
+                i += 2;
+                continue;
+            }
             let is_type = run[i].starts_with(char::is_uppercase);
             if is_type {
                 let renamed = run.get(i + 1).map(String::as_str) == Some("as");
@@ -396,6 +410,15 @@ const TRANSFORMERS: &[&str] = &[
     "extract_fn_trait_args",
     "peel_transparent",
 ];
+
+/// The "original" recorded for `use syn as <name>` — a rename of the crate
+/// itself, which puts every node behind a path no uppercase check finds.
+///
+/// **Rejected rather than resolved**, and so is a local `type Node = syn::Type`.
+/// Resolving either means following aliases to a fixed point, for a spelling
+/// `flat` has no reason to write: the model names `syn::` types in full,
+/// everywhere, today. If that ever has to change, this is the line that says so.
+const RENAMED_SYN: &str = "<syn itself>";
 
 /// Which bucket an escape belongs to — by name, then by **receiver**.
 ///
@@ -754,8 +777,17 @@ fn scanner_recognizes_the_shapes_that_matter() {
 ///
 /// The escape scan counts [`ESCAPES`] by name. That is a list, and a list is a
 /// thing someone forgets to add to — so this reads the model's own surface and
-/// fails if a public function in `core/flat` hands out a non-[`LEAF`] `syn`
-/// node under a name the scan does not count.
+/// fails if anything externally visible in `core/flat` hands out a non-[`LEAF`]
+/// `syn` node under a name the scan does not count.
+///
+/// **Externally visible is not just a function** (#313 review). A public field
+/// reopens exactly the capability an accessor closes; a trait method is as
+/// visible as its trait, and its impl carries no visibility of its own; and an
+/// alias — `use syn as syntax`, `type Node = syn::Type` — puts a node behind a
+/// name no check of `syn::` paths can follow. All four are doors here, and the
+/// alias forms are reported rather than resolved: `flat` names `syn::` types in
+/// full, everywhere, so following aliases to a fixed point would be machinery
+/// for a spelling the model does not use.
 ///
 /// Three of the four entries were found this way rather than by design:
 /// `stripped_syntax`, `to_syn` and `enum_item` predate the seal and hand out a
@@ -770,10 +802,18 @@ fn escape_surface_is_closed() {
         for entry in fs::read_dir(&dir).expect("flat/ is readable") {
             let path = entry.expect("readable dir entry").path();
             if path.is_dir() {
+                // Test code is not the model's surface, and the same exclusion
+                // the ledger scan makes: a `pub type` inside a `parse_quote!`
+                // fixture is test *data*, not a declaration.
+                if path.file_name().is_some_and(|n| n == "tests") {
+                    continue;
+                }
                 stack.push(path);
                 continue;
             }
-            if path.extension().is_none_or(|e| e != "rs") {
+            if path.extension().is_none_or(|e| e != "rs")
+                || path.file_name().is_some_and(|n| n == "tests.rs")
+            {
                 continue;
             }
             let text = fs::read_to_string(&path).expect("source file is UTF-8");
@@ -899,18 +939,85 @@ fn collect_doors(
             && hands_out_a_node(&sig.output, aliases)
             && !is_transformer(&sig.ident.to_string(), sig, aliases)
     };
+    // A field is sealed when its type IS an `Origin`, whatever that origin holds:
+    // `pub origin: Origin<syn::ItemFn>` names a node and hands out none.
+    // `always_public` is what an enum variant's fields are: they carry no
+    // visibility of their own and are reachable wherever the enum is.
+    let field_is_door = |f: &syn::Field, always_public: bool| {
+        let toks: Vec<TokenTree> = quote::ToTokens::to_token_stream(&f.ty)
+            .into_iter()
+            .collect();
+        let sealed = matches!(toks.first(), Some(TokenTree::Ident(id)) if id == "Origin");
+        (always_public || escapes_flat(&f.vis))
+            && !sealed
+            && names_a_node(quote::ToTokens::to_token_stream(&f.ty), aliases)
+    };
+    let fields_of = |fields: &syn::Fields,
+                     ty_name: &syn::Ident,
+                     always_public: bool,
+                     out: &mut Vec<(String, String)>| {
+        for f in fields {
+            if field_is_door(f, always_public) {
+                let field = f
+                    .ident
+                    .as_ref()
+                    .map_or_else(|| "0".to_string(), ToString::to_string);
+                out.push((format!("{ty_name}::{field}"), at.to_string()));
+            }
+        }
+    };
     for item in items {
+        if is_cfg_test_item(&item_attrs(item)) {
+            continue;
+        }
         match item {
             syn::Item::Fn(f) if is_door(&f.vis, &f.sig) => {
                 out.push((f.sig.ident.to_string(), at.to_string()));
             }
+            // A crate rename or a local alias puts a node behind a name this
+            // check cannot follow, so the name itself is reported.
+            syn::Item::Type(t)
+                if escapes_flat(&t.vis)
+                    && names_a_node(quote::ToTokens::to_token_stream(&t.ty), aliases) =>
+            {
+                out.push((format!("type {}", t.ident), at.to_string()));
+            }
             syn::Item::Impl(im) => {
                 for it in &im.items {
                     if let syn::ImplItem::Fn(f) = it {
-                        if is_door(&f.vis, &f.sig) {
+                        // A trait impl's method carries no visibility of its
+                        // own: it is reachable wherever the trait is, so the
+                        // trait's own declaration cannot be the only thing
+                        // checked. Treated as public here, and again on the
+                        // trait below — the same door twice is fine, a door
+                        // missed is not.
+                        let vis = match im.trait_ {
+                            Some(_) => &syn::Visibility::Public(syn::token::Pub::default()),
+                            None => &f.vis,
+                        };
+                        if is_door(vis, &f.sig) {
                             out.push((f.sig.ident.to_string(), at.to_string()));
                         }
                     }
+                }
+            }
+            syn::Item::Trait(tr) if escapes_flat(&tr.vis) => {
+                for it in &tr.items {
+                    if let syn::TraitItem::Fn(f) = it {
+                        // A trait method is as visible as its trait.
+                        if is_door(&tr.vis, &f.sig) {
+                            out.push((format!("{}::{}", tr.ident, f.sig.ident), at.to_string()));
+                        }
+                    }
+                }
+            }
+            // A public field reopens exactly the capability an accessor closes.
+            syn::Item::Struct(st) if escapes_flat(&st.vis) => {
+                fields_of(&st.fields, &st.ident, false, out);
+            }
+            syn::Item::Enum(en) if escapes_flat(&en.vis) => {
+                for v in &en.variants {
+                    fields_of(&v.fields, &en.ident, true, out);
                 }
             }
             syn::Item::Mod(m) => {
@@ -921,6 +1028,31 @@ fn collect_doors(
             _ => {}
         }
     }
+}
+
+/// An item's attributes, for the `#[cfg(test)]` skip the ledger scan also makes.
+fn item_attrs(item: &syn::Item) -> Vec<syn::Attribute> {
+    match item {
+        syn::Item::Fn(i) => i.attrs.clone(),
+        syn::Item::Impl(i) => i.attrs.clone(),
+        syn::Item::Trait(i) => i.attrs.clone(),
+        syn::Item::Struct(i) => i.attrs.clone(),
+        syn::Item::Enum(i) => i.attrs.clone(),
+        syn::Item::Type(i) => i.attrs.clone(),
+        syn::Item::Mod(i) => i.attrs.clone(),
+        _ => Vec::new(),
+    }
+}
+
+fn is_cfg_test_item(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        a.path().is_ident("cfg")
+            && is_cfg_test(
+                quote::ToTokens::to_token_stream(&a.meta)
+                    .into_iter()
+                    .collect(),
+            )
+    })
 }
 
 /// The **guard's own** rules, on shapes the tree does not currently contain —
@@ -998,6 +1130,43 @@ fn a_door_is_the_default_and_a_transformer_is_the_exception() {
     assert!(doors("impl S { pub(super) fn syntax(&self) -> &syn::Type { &self.ty } }").is_empty());
     // Nor is flat's OWN `Type`, which is the model and not a node.
     assert!(doors("impl F { pub fn declared_type(&self) -> Option<&Type> { None } }").is_empty());
+
+    // ── Shapes that are not a function at all (#313 review) ───────────────
+
+    // A public field reopens exactly the capability an accessor closes.
+    assert_eq!(doors("pub struct S { pub node: syn::Type }"), ["S::node"]);
+    // ...but a field whose type IS an `Origin` is sealed by the origin itself,
+    // whatever it holds. Most of the model's public fields are this shape.
+    assert!(doors("pub struct S { pub origin: Origin<syn::ItemFn> }").is_empty());
+    assert!(doors("pub struct S { pub name: syn::Ident }").is_empty());
+    // An enum's payload is a field too.
+    assert_eq!(doors("pub enum E { A(syn::Type) }"), ["E::0"]);
+
+    // A trait method is as visible as its trait, and its impl carries no
+    // visibility of its own — so both halves are counted.
+    assert_eq!(
+        doors("pub trait Leak { fn leak(&self) -> &syn::Type; }"),
+        ["Leak::leak"]
+    );
+    assert_eq!(
+        doors("impl Leak for TypeRef { fn leak(&self) -> &syn::Type { self.as_syn() } }"),
+        ["leak"],
+        "an impl of a trait declared elsewhere is still reachable"
+    );
+
+    // An alias hides the node behind a name this check cannot follow, so the
+    // ALIAS is reported — fix that, and the door it hid becomes visible.
+    assert_eq!(doors("pub type Node = syn::Type;"), ["type Node"]);
+    assert_eq!(
+        doors("use syn as syntax;\npub type Node = syntax::Type;"),
+        ["type Node"],
+        "a renamed crate is followed as far as the alias that uses it"
+    );
+    // A leaf alias is not a door: there is still no shape to match on.
+    assert!(doors("pub type Name = syn::Ident;").is_empty());
+
+    // Test code is not the model's surface.
+    assert!(doors("#[cfg(test)]\nmod t { pub struct S { pub node: syn::Type } }").is_empty());
 }
 
 /// The escape scan: what it counts, which bucket it lands in, and what it must

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -128,8 +128,8 @@ const HEADER: &str = "\
 # below count what the first section can only measure — every place that still
 # has a node to take apart.
 #
-#   ## escapes: types   `ty.as_syn()`, `stripped_syntax()`, `to_syn()`
-#                                             — MUST reach zero
+#   ## escapes: types   `as_syn()`, `stripped_syntax()`, `to_syn()`,
+#                       `type_from_ident()`   — MUST reach zero
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
 #                                             — expected to persist
 #
@@ -138,14 +138,16 @@ const HEADER: &str = "\
 # item escape is a captured item's own node, which an emitter re-stating a whole
 # item legitimately needs until items grow modelled accessors.
 #
-# The scan counts FOUR doors — `as_syn`, `stripped_syntax`, `to_syn`,
-# `enum_item` — and counts each by NAME rather than by call shape, so UFCS
+# The scan counts FIVE doors — `as_syn`, `stripped_syntax`, `to_syn`,
+# `enum_item`, `type_from_ident` — each by NAME rather than by call shape, so UFCS
 # (`TypeRef::as_syn(&ty)`) and a function item (`let read = TypeRef::as_syn;`)
 # are counted like a method call. A shape-matched rule missed both, which is a
 # ratchet that can be stepped around. `escape_surface_is_closed` keeps the list
 # honest: it reads the model's own surface and fails if a public method hands
-# out a structural syn node under a name the scan does not count — which is how
-# three of the four doors were found.
+# out a non-leaf syn node under a name the scan does not count — which is how
+# four of the five doors were found. It asks the question the safe way round:
+# every syn return is a door unless the type is on a small LEAF allowlist, and
+# unless the function was already handed a node to transform.
 #
 # The bucket is read off the NAME, then the RECEIVER: `enum_item` hands out an
 # item; for `as_syn`, a receiver of `origin` (or an `Origin::` qualifier) means
@@ -337,28 +339,25 @@ impl Counts {
 /// | `stripped_syntax` | `syn::Type` | the spelling under a transparent wrapper |
 /// | `to_syn` | `syn::Type` | the round-trip that checks the lowering |
 /// | `enum_item` | `&syn::ItemEnum` | a declared enum's own item |
-const ESCAPES: &[&str] = &["as_syn", "stripped_syntax", "to_syn", "enum_item"];
-
-/// The syn types a consumer can **take apart**. An ident, a lifetime or a member
-/// is a leaf: there is no shape to match on, so handing one out is not a door.
-const STRUCTURAL: &[&str] = &[
-    "Type",
-    "Expr",
-    "Item",
-    "ItemEnum",
-    "ItemStruct",
-    "ItemFn",
-    "ItemConst",
-    "Fields",
-    "Variant",
-    "Field",
-    "Path",
-    "Signature",
-    "FnArg",
-    "ReturnType",
-    "Pat",
-    "GenericArgument",
+/// | `type_from_ident` | `syn::Type` | a spelling built from a name |
+const ESCAPES: &[&str] = &[
+    "as_syn",
+    "stripped_syntax",
+    "to_syn",
+    "enum_item",
+    "type_from_ident",
 ];
+
+/// The syn types that are **leaves**: a name, a lifetime, a field address.
+/// There is no shape to match on, so handing one out is not a door.
+///
+/// An allowlist, and deliberately the small side of the question. It began as
+/// the opposite — a list of the structural types that *are* doors — and that is
+/// a list of what someone thought of: a method returning `&[syn::Attribute]`
+/// was invisible because `Attribute` was not on it (#313 review). Inverted, a
+/// syn type nobody considered is a door until someone argues it is a leaf, and
+/// that argument is a diff on this line.
+const LEAF: &[&str] = &["Ident", "Lifetime", "Member", "Index"];
 
 /// Which bucket an escape belongs to — by name, then by **receiver**.
 ///
@@ -717,7 +716,7 @@ fn scanner_recognizes_the_shapes_that_matter() {
 ///
 /// The escape scan counts [`ESCAPES`] by name. That is a list, and a list is a
 /// thing someone forgets to add to — so this reads the model's own surface and
-/// fails if a public function in `core/flat` hands out a [`STRUCTURAL`] `syn`
+/// fails if a public function in `core/flat` hands out a non-[`LEAF`] `syn`
 /// node under a name the scan does not count.
 ///
 /// Three of the four entries were found this way rather than by design:
@@ -763,18 +762,28 @@ fn escape_surface_is_closed() {
     );
 }
 
-/// Public **methods** whose return type names a [`STRUCTURAL`] `syn` type.
+/// Public functions that hand out a non-[`LEAF`] `syn` node.
 ///
-/// Two conditions, and each rules out a whole class of false positive:
+/// **A door is the default; being a transformer is what earns the exemption.**
+/// The rule was a `self` receiver once, on the reasoning that a function without
+/// one holds no model state — and an associated function does not need a
+/// receiver to be handed the model (#313 review):
 ///
-/// * **a `self` receiver.** A door hands out a node the *model holds*; a free
-///   function has no model state, so whatever it returns it built from what the
-///   caller passed in. `canonical_type(&syn::Type) -> syn::Type` cannot give a
-///   consumer a node it could not already reach, and neither can
-///   `extract_fn_trait_args` or `type_from_ident`.
-/// * **visibility past `flat`.** A `pub(super)` method cannot be called from
-///   outside the model, so it is the model reading itself. Everything wider is a
-///   door.
+/// ```ignore
+/// impl TypeRef {
+///     pub fn leak(this: &Self) -> &syn::Type { this.as_syn() }
+/// }
+/// ```
+///
+/// `TypeRef::leak(&ty)` hands out the held node, and a rule keyed on the
+/// receiver waves it through. So the exemption is stated as what it actually
+/// is: a function is exempt only when it **already receives** a non-leaf syn
+/// node and takes no receiver — then everything it hands back, the caller could
+/// reach without it. That is `canonical_type`, `extract_fn_trait_args` and
+/// `peel_transparent`, and nothing else.
+///
+/// Visibility still applies: `pub(super)` cannot be called from outside the
+/// model, so it is the model reading itself.
 fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>) {
     fn escapes_flat(vis: &syn::Visibility) -> bool {
         match vis {
@@ -787,30 +796,45 @@ fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>)
         let syn::ReturnType::Type(_, ty) = ret else {
             return false;
         };
-        // `syn :: <structural>` anywhere in the return type. Qualified because
-        // `-> Option<&Type>` is *flat's own* `Type`, which is the model, not a node.
         names_a_node(quote::ToTokens::to_token_stream(ty))
     }
-    // Through groups: `Option<(&'static str, syn::Type)>` nests the mention
-    // inside a parenthesised token group.
+    /// A non-[`LEAF`] `syn::` type named anywhere in a signature position.
+    ///
+    /// Qualified, because `-> Option<&Type>` is *flat's own* `Type` — the model,
+    /// not a node. Through groups, because `Option<(&'static str, syn::Type)>`
+    /// nests the mention inside a parenthesised token group.
     fn names_a_node(stream: TokenStream) -> bool {
         let toks: Vec<TokenTree> = stream.into_iter().collect();
         (0..toks.len()).any(|i| {
             (matches!(&toks[i], TokenTree::Ident(id) if id == "syn")
                 && is_sep(&toks, i + 1)
                 && matches!(toks.get(i + 3), Some(TokenTree::Ident(id))
-                    if STRUCTURAL.contains(&id.to_string().as_str())))
+                    if !LEAF.contains(&id.to_string().as_str())))
                 || matches!(&toks[i], TokenTree::Group(g) if names_a_node(g.stream()))
         })
     }
+    /// A function the caller could have written itself: no receiver, and a
+    /// non-leaf node already among its inputs.
+    fn is_transformer(sig: &syn::Signature) -> bool {
+        let has_receiver = matches!(sig.inputs.first(), Some(syn::FnArg::Receiver(_)));
+        let takes_a_node = sig.inputs.iter().any(|arg| match arg {
+            syn::FnArg::Typed(pt) => names_a_node(quote::ToTokens::to_token_stream(&pt.ty)),
+            syn::FnArg::Receiver(_) => false,
+        });
+        !has_receiver && takes_a_node
+    }
+    let is_door = |vis: &syn::Visibility, sig: &syn::Signature| {
+        escapes_flat(vis) && hands_out_a_node(&sig.output) && !is_transformer(sig)
+    };
     for item in items {
         match item {
+            syn::Item::Fn(f) if is_door(&f.vis, &f.sig) => {
+                out.push((f.sig.ident.to_string(), at.to_string()));
+            }
             syn::Item::Impl(im) => {
                 for it in &im.items {
                     if let syn::ImplItem::Fn(f) = it {
-                        let is_method =
-                            matches!(f.sig.inputs.first(), Some(syn::FnArg::Receiver(_)));
-                        if is_method && escapes_flat(&f.vis) && hands_out_a_node(&f.sig.output) {
+                        if is_door(&f.vis, &f.sig) {
                             out.push((f.sig.ident.to_string(), at.to_string()));
                         }
                     }
@@ -824,6 +848,52 @@ fn collect_doors(items: &[syn::Item], at: &str, out: &mut Vec<(String, String)>)
             _ => {}
         }
     }
+}
+
+/// The **guard's own** rules, on shapes the tree does not currently contain —
+/// which is the point: it is what stops one from being added quietly.
+#[test]
+fn a_door_is_the_default_and_a_transformer_is_the_exception() {
+    let doors = |src: &str| {
+        let file: syn::File = syn::parse_str(src).expect("test source parses");
+        let mut out = Vec::new();
+        collect_doors(&file.items, "test", &mut out);
+        out.into_iter().map(|(name, _)| name).collect::<Vec<_>>()
+    };
+
+    // The #313 review's case: an associated function needs no receiver to be
+    // handed the model, so a rule keyed on the receiver waved this through.
+    assert_eq!(
+        doors("impl TypeRef { pub fn leak(this: &Self) -> &syn::Type { this.as_syn() } }"),
+        ["leak"]
+    );
+    // Neither does a free function, given the model by value.
+    assert_eq!(
+        doors("pub fn leak(t: &TypeRef) -> &syn::Type { t.as_syn() }"),
+        ["leak"]
+    );
+    // And a syn type nobody put on a list is a door, not an oversight.
+    assert_eq!(
+        doors(
+            "impl S { pub fn attrs(&self) -> &[syn::Attribute] { &self.origin.as_syn().attrs } }"
+        ),
+        ["attrs"]
+    );
+
+    // A transformer is exempt: it was handed a node, so it can give back only
+    // what the caller could already reach.
+    assert!(doors("pub fn canonical_type(ty: &syn::Type) -> syn::Type { ty.clone() }").is_empty());
+    assert!(
+        doors("pub fn peel(ty: &syn::Type) -> Option<(&'static str, syn::Type)> { None }")
+            .is_empty(),
+        "the mention nests inside a token group, and must still be seen"
+    );
+    // A leaf is not a node: there is no shape to match on.
+    assert!(doors("impl S { pub fn name(&self) -> &syn::Ident { &self.name } }").is_empty());
+    // The model reading itself is not a door.
+    assert!(doors("impl S { pub(super) fn syntax(&self) -> &syn::Type { &self.ty } }").is_empty());
+    // Nor is flat's OWN `Type`, which is the model and not a node.
+    assert!(doors("impl F { pub fn declared_type(&self) -> Option<&Type> { None } }").is_empty());
 }
 
 /// The escape scan: what it counts, which bucket it lands in, and what it must
@@ -903,6 +973,7 @@ fn escapes_are_counted_by_their_receiver() {
         1,
         "an item, whatever the receiver is called"
     );
+    assert_eq!(c("fn f() { let t = type_from_ident(&n); }").escape_type, 1);
 
     // The two populations are independent: classifying through an escape counts
     // in both, which is the intended double entry — one says a node was taken,

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -1,16 +1,25 @@
 //! The mechanical boundary check: a committed ledger of every place outside
-//! this module that classifies captured Rust syntax.
+//! this module that can still take captured Rust syntax apart.
 //!
 //! Issue #211's sixth completion criterion is that a mechanical check must
 //! prevent new source-syntax classifiers from appearing outside the frontend.
-//! This is that check. It is test-only; it ships no production code.
+//! This is that check, and it counts **two populations**:
 //!
-//! It measures exactly the rule the [element model](super) states — **classify
-//! off `kind`, spell off `syntax`** — and it can, because it counts *variant
-//! mentions* of a syn syntax enum rather than uses of syn values. Handing a
-//! `syntax` slice to `quote!` names no variant and is invisible here; asking
-//! `matches!(ty, syn::Type::Reference(_))` names one and is counted. So the
-//! check needed no adaptation to the design: spelling was never what it saw.
+//! * **classification sites** — variant mentions of a [`WATCHED`] syn enum. What
+//!   a consumer visibly *does* with a node.
+//! * **escapes** — calls to [`Origin::as_syn`](super::Origin::as_syn), the one
+//!   route from the model to a `syn` node at all. What a consumer *can* do.
+//!
+//! The second exists because the first can only measure. Since the model's
+//! syntax is sealed — `spell()` yields tokens, `as_syn()` yields the node — a
+//! file with no escapes cannot classify source syntax however it is written, and
+//! the ledger's own blind spots (an ident compared by name, a helper handed the
+//! node, a syn enum outside `WATCHED`) are gated behind the same call. Counting
+//! them turns "we grep for what we thought of" into "we count the door".
+//!
+//! Both are read the same way and fail the same way: a count that moved is a
+//! ledger edit, and the diff is the decision. It is test-only; it ships no
+//! production code.
 //!
 //! ## What a site is
 //!
@@ -112,16 +121,41 @@ const HEADER: &str = "\
 # A count going DOWN is the goal (a classifier reads elements instead) and is
 # still a ledger edit, so the win shows up in the diff.
 #
-# KNOWN BLIND SPOTS — classification this check cannot see, because it never
-# writes a `syn::` path. Each is a candidate addition to WATCHED:
+# ── THE ESCAPES ───────────────────────────────────────────────────────────
+#
+# The model's syntax is sealed: `Origin::syntax` is private, `spell()` hands out
+# tokens, and `as_syn()` is the ONE way to a `syn` node. So the two sections
+# below count what the first section can only measure — every place that still
+# has a node to take apart.
+#
+#   ## escapes: types   `ty.as_syn()`         — MUST reach zero
+#   ## escapes: items   `f.origin.as_syn()`   — expected to persist
+#
+# A type escape is a source type the model should have been able to answer for;
+# the classification sites above are the subset that visibly does classify. An
+# item escape is a captured item's own node, which an emitter re-stating a whole
+# item legitimately needs until items grow modelled accessors.
+#
+# The bucket is read off the RECEIVER: `origin` means the item's node, anything
+# else means a type. Two over-counts land in the type bucket on purpose, both in
+# the safe direction — adapter declarations reuse `Origin` for a placeless
+# location (`decl.rust_type`), and carrying a spelling into an adapter-owned
+# `syn::Type` field is not classification either. Both are follow-ups the count
+# names rather than hides.
+#
+# KNOWN BLIND SPOTS — classification neither half sees:
 #
 #   * token-string classification, e.g. `core/domain.rs` matching
-#     `ty.to_token_stream().to_string()` against \"i8\" / \"f32\";
-#   * ident-name classification, e.g. `seg.ident == \"Option\"`;
+#     `ty.to_token_stream().to_string()` against \"i8\" / \"f32\". The seal does
+#     NOT close this and cannot: what `domain.rs` reads is a `syn::Type` a build
+#     script supplied, which never was the model's. `spell().to_string()` reaches
+#     a string too — one call further, and greppable, which is the whole gain;
+#   * ident-name classification, e.g. `seg.ident == \"Option\"` — now gated, in
+#     that a path has to come from an escape first;
 #   * helper delegation — `jnigen/jni/classify.rs` is a whole classifier with
-#     zero watched sites;
+#     zero watched sites; gated the same way;
 #   * syn enums outside WATCHED: Item, Fields, FnArg, ReturnType,
-#     GenericArgument, Pat, ...
+#     GenericArgument, Pat, ... — likewise reachable only through an escape.
 #
 # One listed gap is closed rather than still open: `types_util::match_pattern`
 # unified against `parse_quote!(_)` patterns, adding shape rules with no watched
@@ -138,7 +172,7 @@ const HEADER: &str = "\
 /// Excluded: this module's own directory (the language is where classification
 /// is *supposed* to live), and test code — `tests.rs`, anything under a `tests/`
 /// directory, and any item carrying `#[cfg(test)]`.
-fn scan_tree(src_root: &Path) -> BTreeMap<String, usize> {
+fn scan_tree(src_root: &Path) -> BTreeMap<String, Counts> {
     let mut out = BTreeMap::new();
     let mut stack = vec![src_root.to_path_buf()];
     while let Some(dir) = stack.pop() {
@@ -163,7 +197,7 @@ fn scan_tree(src_root: &Path) -> BTreeMap<String, usize> {
             }
             let text = fs::read_to_string(&path).expect("source file is UTF-8");
             let n = scan_file(&text);
-            if n > 0 {
+            if !n.is_empty() {
                 out.insert(rel, n);
             }
         }
@@ -181,10 +215,10 @@ fn rel_key(root: &Path, path: &Path) -> String {
 }
 
 /// Sites in one file's text.
-fn scan_file(text: &str) -> usize {
+fn scan_file(text: &str) -> Counts {
     let stream = TokenStream::from_str(text).expect("source file parses as tokens");
     let aliases = collect_aliases(stream.clone());
-    let mut n = 0;
+    let mut n = Counts::default();
     count(stream, &aliases, &mut n);
     n
 }
@@ -261,7 +295,44 @@ fn flatten_idents(tt: &TokenTree, out: &mut Vec<String>) {
     }
 }
 
-fn count(stream: TokenStream, aliases: &[String], n: &mut usize) {
+/// What one file owes, in the three populations this ledger tracks.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub(super) struct Counts {
+    /// Variant mentions of a [`WATCHED`] syn enum — the original measure.
+    classify: usize,
+    /// `as_syn()` on a type spelling.
+    escape_type: usize,
+    /// `as_syn()` on a captured item's origin.
+    escape_item: usize,
+}
+
+impl Counts {
+    fn is_empty(self) -> bool {
+        self == Self::default()
+    }
+}
+
+/// Which bucket an `as_syn()` call belongs to, read off the **receiver**.
+///
+/// Outside `flat/`, a receiver named `origin` is always a captured item's node —
+/// an `ItemFn`, an `ItemStruct`, a `Field`, a `Variant` — because `TypeRef`'s own
+/// origin is private and a type spelling is therefore reached as `ty.as_syn()`.
+/// Everything else is a type.
+///
+/// **A known over-count, in the safe direction.** Adapter *declarations* reuse
+/// `Origin` to carry a placeless location (`decl.rust_type`, `declared_ty`), and
+/// those escapes land in the type bucket though they read what a build script
+/// wrote rather than what a source crate did. The bucket that must reach zero is
+/// the one that over-counts; the real fix is that a declaration is not an
+/// `Origin`, which is a refactor and not a rule.
+fn escape_bucket(receiver: Option<&str>) -> fn(&mut Counts) -> &mut usize {
+    match receiver {
+        Some("origin") => |c: &mut Counts| &mut c.escape_item,
+        _ => |c: &mut Counts| &mut c.escape_type,
+    }
+}
+
+fn count(stream: TokenStream, aliases: &[String], n: &mut Counts) {
     let toks: Vec<TokenTree> = stream.into_iter().collect();
     let mut i = 0;
     while i < toks.len() {
@@ -295,7 +366,7 @@ fn count(stream: TokenStream, aliases: &[String], n: &mut usize) {
             && is_sep(&toks, i + 4)
             && matches!(toks.get(i + 6), Some(TokenTree::Ident(_)))
         {
-            *n += 1;
+            n.classify += 1;
             i += 7;
             continue;
         }
@@ -304,8 +375,23 @@ fn count(stream: TokenStream, aliases: &[String], n: &mut usize) {
             && is_sep(&toks, i + 1)
             && matches!(toks.get(i + 3), Some(TokenTree::Ident(_)))
         {
-            *n += 1;
+            n.classify += 1;
             i += 4;
+            continue;
+        }
+        // `<receiver> . as_syn ( )` — the escape, bucketed by receiver.
+        if matches!(&toks[i], TokenTree::Ident(id) if *id == "as_syn")
+            && i > 0
+            && is_punct(&toks[i - 1], '.')
+            && matches!(toks.get(i + 1), Some(TokenTree::Group(g))
+                if g.delimiter() == Delimiter::Parenthesis && g.stream().is_empty())
+        {
+            let receiver = match toks.get(i.wrapping_sub(2)) {
+                Some(TokenTree::Ident(id)) if i >= 2 => Some(id.to_string()),
+                _ => None,
+            };
+            *escape_bucket(receiver.as_deref())(n) += 1;
+            i += 2;
             continue;
         }
         if let TokenTree::Group(g) = &toks[i] {
@@ -361,29 +447,65 @@ fn is_punct(tt: &TokenTree, c: char) -> bool {
     matches!(tt, TokenTree::Punct(p) if p.as_char() == c)
 }
 
-fn render(sites: &BTreeMap<String, usize>) -> String {
+/// The three populations, in the order the ledger writes them. A `##` line
+/// switches section; a `#` line is a comment, as before.
+type Section = (&'static str, fn(&Counts) -> usize);
+
+const SECTIONS: &[Section] = &[
+    ("classification sites", |c| c.classify),
+    ("escapes: types", |c| c.escape_type),
+    ("escapes: items", |c| c.escape_item),
+];
+
+fn render(sites: &BTreeMap<String, Counts>) -> String {
     let mut s = String::from(HEADER);
-    s.push('\n');
-    for (path, n) in sites {
-        s.push_str(&format!("{n}\t{path}\n"));
+    for (i, (name, get)) in SECTIONS.iter().enumerate() {
+        s.push('\n');
+        // The first section is the original ledger, and its lines are written
+        // exactly as before so the two added populations read as an addition
+        // rather than a rewrite.
+        if i > 0 {
+            s.push_str(&format!("## {name}\n"));
+        }
+        let mut total = 0;
+        for (path, counts) in sites {
+            let n = get(counts);
+            if n > 0 {
+                s.push_str(&format!("{n}\t{path}\n"));
+                total += n;
+            }
+        }
+        s.push_str(&format!("\n# total {name}: {total}\n"));
     }
-    s.push_str(&format!("\n# total: {}\n", sites.values().sum::<usize>()));
     s
 }
 
-fn parse(text: &str) -> BTreeMap<String, usize> {
-    text.lines()
-        .filter(|l| !l.starts_with('#') && !l.trim().is_empty())
-        .map(|l| {
-            let (n, path) = l
-                .split_once('\t')
-                .expect("ledger line is `<count>\\t<path>`");
-            (
-                path.to_string(),
-                n.parse().expect("ledger count is a number"),
-            )
-        })
-        .collect()
+fn parse(text: &str) -> BTreeMap<String, Counts> {
+    let mut out: BTreeMap<String, Counts> = BTreeMap::new();
+    let mut section = 0usize;
+    for line in text.lines() {
+        if let Some(name) = line.strip_prefix("## ") {
+            section = SECTIONS
+                .iter()
+                .position(|(n, _)| *n == name.trim())
+                .expect("ledger section is one this scanner writes");
+            continue;
+        }
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+        let (n, path) = line
+            .split_once('\t')
+            .expect("ledger line is `<count>\\t<path>`");
+        let n: usize = n.parse().expect("ledger count is a number");
+        let counts = out.entry(path.to_string()).or_default();
+        match section {
+            0 => counts.classify = n,
+            1 => counts.escape_type = n,
+            _ => counts.escape_item = n,
+        }
+    }
+    out
 }
 
 fn src_root() -> PathBuf {
@@ -410,9 +532,15 @@ fn boundary_ledger() {
     let paths: std::collections::BTreeSet<_> = committed.keys().chain(found.keys()).collect();
     for path in paths {
         let (was, now) = (committed.get(path), found.get(path));
-        if was != now {
-            let fmt = |v: Option<&usize>| v.map_or("-".to_string(), usize::to_string);
-            drift.push_str(&format!("  {path}: {} -> {}\n", fmt(was), fmt(now)));
+        if was == now {
+            continue;
+        }
+        for (name, get) in SECTIONS {
+            let fmt = |v: Option<&Counts>| v.map_or(0, get);
+            let (was, now) = (fmt(was), fmt(now));
+            if was != now {
+                drift.push_str(&format!("  {path} [{name}]: {was} -> {now}\n"));
+            }
         }
     }
     panic!(
@@ -431,40 +559,49 @@ fn scanner_recognizes_the_shapes_that_matter() {
     // A match arm, and a `matches!` body — invisible to an AST visitor, which is
     // why this walks tokens.
     assert_eq!(
-        scan_file("fn f(t: &syn::Type) { match t { syn::Type::Slice(s) => g(s), _ => {} } }"),
+        scan_file("fn f(t: &syn::Type) { match t { syn::Type::Slice(s) => g(s), _ => {} } }")
+            .classify,
         1
     );
     assert_eq!(
-        scan_file("fn f() -> bool { matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty()) }"),
+        scan_file("fn f() -> bool { matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty()) }")
+            .classify,
         1
     );
     assert_eq!(
-        scan_file("fn f() { let syn::Expr::Lit(l) = e else { return; }; }"),
+        scan_file("fn f() { let syn::Expr::Lit(l) = e else { return; }; }").classify,
         1
     );
     // Two on one line: a line count would report one.
     assert_eq!(
-        scan_file("fn f() { if let (syn::Type::Path(a), syn::Type::Path(b)) = p {} }"),
+        scan_file("fn f() { if let (syn::Type::Path(a), syn::Type::Path(b)) = p {} }").classify,
         2
     );
 
     // The one-line defeat the alias handling closes.
     assert_eq!(
-        scan_file("use syn::Type;\nfn f() { if let Type::Reference(r) = t {} }"),
+        scan_file("use syn::Type;\nfn f() { if let Type::Reference(r) = t {} }").classify,
         1
     );
     assert_eq!(
         scan_file(
             "use syn::{Expr, Type as T};\nfn f() { if let T::Ptr(p) = t { h(Expr::Lit(l)) } }"
-        ),
+        )
+        .classify,
         2
     );
     // An import is not a site, and neither is a non-syn `Type`.
-    assert_eq!(scan_file("use syn::Type;\nfn f() {}"), 0);
-    assert_eq!(scan_file("fn f() { if let Type::Reference(r) = t {} }"), 0);
+    assert_eq!(scan_file("use syn::Type;\nfn f() {}").classify, 0);
+    assert_eq!(
+        scan_file("fn f() { if let Type::Reference(r) = t {} }").classify,
+        0
+    );
 
     // Outside WATCHED — emitters construct these constantly.
-    assert_eq!(scan_file("fn f() { let i = syn::Item::Fn(f); }"), 0);
+    assert_eq!(
+        scan_file("fn f() { let i = syn::Item::Fn(f); }").classify,
+        0
+    );
 
     // Test code does not count, whatever the module is called.
     assert_eq!(
@@ -472,27 +609,71 @@ fn scanner_recognizes_the_shapes_that_matter() {
             "fn f() { match t { syn::Type::Slice(s) => (), _ => () } }\n\
              #[cfg(test)]\n\
              mod replace_ident_tests { fn g() { let _ = syn::Type::Ptr(p); } }"
-        ),
+        )
+        .classify,
         1
     );
-    assert_eq!(scan_file("#[cfg(test)]\nmod tests;"), 0);
+    assert_eq!(scan_file("#[cfg(test)]\nmod tests;").classify, 0);
 
     // But ONLY code proven test-only. Both of these compile in a production
     // build, and a rule that looked for the ident `test` anywhere let a
     // classifier under either evade the count.
     assert_eq!(
-        scan_file("#[cfg(not(test))]\nfn g() { let _ = syn::Type::Ptr(p); }"),
+        scan_file("#[cfg(not(test))]\nfn g() { let _ = syn::Type::Ptr(p); }").classify,
         1,
         "cfg(not(test)) is production code"
     );
     assert_eq!(
-        scan_file("#[cfg(any(test, feature = \"x\"))]\nfn g() { let _ = syn::Type::Ptr(p); }"),
+        scan_file("#[cfg(any(test, feature = \"x\"))]\nfn g() { let _ = syn::Type::Ptr(p); }")
+            .classify,
         1,
         "cfg(any(test, ..)) compiles whenever the other arm holds"
     );
     // A feature literally named "test" is not the test predicate either.
     assert_eq!(
-        scan_file("#[cfg(feature = \"test\")]\nfn g() { let _ = syn::Type::Ptr(p); }"),
+        scan_file("#[cfg(feature = \"test\")]\nfn g() { let _ = syn::Type::Ptr(p); }").classify,
         1
     );
+}
+
+/// The escape scan: what it counts, which bucket it lands in, and what it must
+/// not count.
+#[test]
+fn escapes_are_counted_by_their_receiver() {
+    let c = |src: &str| scan_file(src);
+
+    // A type escape, and an item escape, told apart by the receiver alone.
+    assert_eq!(c("fn f() { let t = ty.as_syn(); }").escape_type, 1);
+    assert_eq!(c("fn f() { let t = ty.as_syn(); }").escape_item, 0);
+    assert_eq!(c("fn f() { let i = func.origin.as_syn(); }").escape_item, 1);
+    assert_eq!(c("fn f() { let i = func.origin.as_syn(); }").escape_type, 0);
+
+    // Spelling is free — the whole point of the split.
+    assert_eq!(c("fn f() { quote!(fn g(x: #ty)) }").escape_type, 0);
+    assert_eq!(c("fn f() { let t = ty.spell(); }").escape_type, 0);
+
+    // Inside a macro body, where an AST visit would miss it.
+    assert_eq!(
+        c("fn f() { assert_eq!(k, TypeKey::from_type(ty.as_syn())); }").escape_type,
+        1
+    );
+    // Two on one line: a line count would report one.
+    assert_eq!(c("fn f() { g(a.as_syn(), b.as_syn()); }").escape_type, 2);
+
+    // Test code does not count here either.
+    assert_eq!(
+        c("#[cfg(test)]\nmod t { fn g() { let _ = ty.as_syn(); } }").escape_type,
+        0
+    );
+
+    // A method that merely *starts* with the name is not the escape.
+    assert_eq!(c("fn f() { let t = ty.as_syntax(); }").escape_type, 0);
+    // Nor is a call that takes arguments — the escape is nullary.
+    assert_eq!(c("fn f() { let t = ty.as_syn(x); }").escape_type, 0);
+
+    // The two populations are independent: classifying through an escape counts
+    // in both, which is the intended double entry — one says a node was taken,
+    // the other says what was done with it.
+    let both = c("fn f() { matches!(ty.as_syn(), syn::Type::Slice(_)) }");
+    assert_eq!((both.escape_type, both.classify), (1, 1));
 }

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -72,14 +72,20 @@ impl Element {
         }
     }
 
-    /// The whole item as the source wrote it.
-    pub fn syntax(&self) -> syn::Item {
+    /// The whole item as `syn` — **the escape**, at the item level. See
+    /// [`Origin::as_syn`](super::Origin::as_syn).
+    ///
+    /// It builds a `syn::Item` rather than borrowing one, because each variant
+    /// keeps the item kind it was parsed as. That makes it the natural route for
+    /// an emitter re-stating a whole item, and the ledger's **item** bucket is
+    /// where those land.
+    pub fn as_syn(&self) -> syn::Item {
         match self {
-            Element::Function(f) => syn::Item::Fn(f.origin.syntax.clone()),
-            Element::Type(t) => t.syntax(),
-            Element::Constant(c) => syn::Item::Const(c.origin.syntax.clone()),
-            Element::Guard(g) => syn::Item::Const(g.origin.syntax.clone()),
-            Element::Unsupported(u) => u.origin.syntax.clone(),
+            Element::Function(f) => syn::Item::Fn(f.origin.as_syn().clone()),
+            Element::Type(t) => t.as_syn(),
+            Element::Constant(c) => syn::Item::Const(c.origin.as_syn().clone()),
+            Element::Guard(g) => syn::Item::Const(g.origin.as_syn().clone()),
+            Element::Unsupported(u) => u.origin.as_syn().clone(),
         }
     }
 }
@@ -123,13 +129,13 @@ impl Type {
         }
     }
 
-    /// The whole item as the source wrote it.
-    pub fn syntax(&self) -> syn::Item {
+    /// The whole item as `syn` — **the escape**. See [`Element::as_syn`].
+    pub fn as_syn(&self) -> syn::Item {
         match self {
-            Type::Struct(s) => syn::Item::Struct(s.origin.syntax.clone()),
-            Type::Variant(v) => syn::Item::Enum(v.origin.syntax.clone()),
-            Type::Enum(e) => syn::Item::Enum(e.origin.syntax.clone()),
-            Type::Extern(e) => e.origin.syntax.clone(),
+            Type::Struct(s) => syn::Item::Struct(s.origin.as_syn().clone()),
+            Type::Variant(v) => syn::Item::Enum(v.origin.as_syn().clone()),
+            Type::Enum(e) => syn::Item::Enum(e.origin.as_syn().clone()),
+            Type::Extern(e) => e.origin.as_syn().clone(),
         }
     }
 }

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -8,7 +8,7 @@
 //! ```text
 //! Source(s) ──items──> Flat ──Elements──> Registry ──> adapters
 //!   raw records          parse +               indexes       classify off `kind`
-//!   (syn::Item)          validate              elements      spell off `origin`
+//!   (syn::Item)          validate              elements      spell with `spell()`
 //! ```
 //!
 //! [`Flat::source`] folds the first arrow in for the common case, so a build
@@ -34,13 +34,16 @@
 //!
 //! So the rule for every consumer is:
 //!
-//! > **Classify off `kind`, spell off `origin.syntax`.**
+//! > **Classify off `kind`, spell with [`spell()`](Origin::spell).**
 //!
-//! Matching a `syn::Type` or `syn::Expr` variant outside this module is a
-//! classifier, and issue #211 says classification lives here alone. Passing a
-//! node's [`Origin`] into `quote!` is spelling, and spelling the source is
-//! exactly what generated Rust must do — see [`spell`] for the helpers that do
-//! it.
+//! And the model enforces it rather than asking. [`Origin`]'s syntax is
+//! private: `spell()` hands out tokens, which is all generated Rust ever needed,
+//! and [`as_syn`](Origin::as_syn) hands out the node and is the one way to get
+//! one. Matching a `syn::Type` or `syn::Expr` variant outside this module is a
+//! classifier — issue #211 says classification lives here alone — and it now
+//! takes a named escape to reach the node to match on. See [`spell`] for the
+//! helpers that turn an element back into Rust, and `boundary.rs` for the
+//! ledger that counts the escapes still owed.
 //!
 //! # What earns a variant
 //!
@@ -635,8 +638,8 @@ impl Flat {
     /// reaches for [`Self::declared_type`].
     pub fn enum_item<N: Name + ?Sized>(&self, name: &N) -> Option<&syn::ItemEnum> {
         match self.declared_type(name)? {
-            Type::Variant(v) => Some(&v.origin.syntax),
-            Type::Enum(e) => Some(&e.origin.syntax),
+            Type::Variant(v) => Some(v.origin.as_syn()),
+            Type::Enum(e) => Some(e.origin.as_syn()),
             _ => None,
         }
     }
@@ -692,7 +695,7 @@ impl Flat {
     /// **The scan's entry point, and nowhere else's.** A caller holding an element
     /// already has the reading — `Function::ret`, `Param::ty`, `Field::ty` are
     /// `TypeRef`s computed at parse time — and re-deriving one from
-    /// `origin.syntax` is reasoning from the spelling, which is what `origin` is
+    /// `spell()` is reasoning from the spelling, which is what `origin` is
     /// not for. This exists for the one case with no element behind it: a type a
     /// build script declared, or one expansion composed. `ensure_entry` is its
     /// only caller — the single call in the whole crate — and
@@ -718,7 +721,7 @@ impl Flat {
         let consts = ConstIndex::new(self.constants().map(|c| {
             (
                 c.name.to_string(),
-                (*c.origin.syntax.expr).clone(),
+                (*c.origin.as_syn().expr).clone(),
                 c.origin.crate_name().map(str::to_owned),
             )
         }));
@@ -739,7 +742,7 @@ impl Flat {
         for ty in refs {
             self.by_type
                 .entry(crate::api::core::flat::canonical_spelling(
-                    &ty.origin.syntax,
+                    ty.origin.as_syn(),
                 ))
                 .or_insert(ty);
         }
@@ -777,7 +780,7 @@ impl Flat {
         let consts = ConstIndex::new(self.constants().map(|c| {
             (
                 c.name.to_string(),
-                (*c.origin.syntax.expr).clone(),
+                (*c.origin.as_syn().expr).clone(),
                 c.origin.crate_name().map(str::to_owned),
             )
         }));
@@ -866,7 +869,7 @@ fn resolve_references(elements: &mut [Element]) {
             let element = &mut elements[i];
             let name = element.name().cloned();
             let origin = Origin::new(
-                element.syntax(),
+                element.as_syn(),
                 Rc::clone(match element {
                     Element::Function(f) => &f.origin.location,
                     Element::Type(t) => t.location_rc(),

--- a/prebindgen/src/api/core/flat/origin.rs
+++ b/prebindgen/src/api/core/flat/origin.rs
@@ -19,7 +19,7 @@ use crate::SourceLocation;
 /// `syn` tokens normally carry spans, so in principle the syntax alone could
 /// answer "where was this written". Not here: the proc-macro serializes each
 /// marked item as a **string** into JSONL, and `build.rs` re-parses it, so every
-/// span in [`Self::syntax`] points into an anonymous buffer.
+/// span in [`spell()`](Self::spell) points into an anonymous buffer.
 /// [`SourceLocation::from_span`] captures file, line and column at
 /// macro-expansion time — while real rustc spans still exist — precisely because
 /// they cannot survive that trip.
@@ -47,12 +47,27 @@ use crate::SourceLocation;
 /// in one flat namespace. [`ConstId`](super::ConstId) is not an exception — the
 /// crate it records is the const's *declaring* crate, obtained by lookup, and
 /// that is exactly what lets an array extent refuse a const from another source.
+/// # The syntax is sealed
+///
+/// > **You may output the source. You may not read it.**
+///
+/// [`spell`](Self::spell) hands out tokens and nothing else, which is all
+/// generated Rust ever needed; [`as_syn`](Self::as_syn) hands out the node and
+/// is the **one** way to get one. The field itself is `pub(super)`, so the model
+/// still reads it freely and everything downstream has to say which of the two
+/// it meant.
+///
+/// It was a public field returning a `syn` node to anyone who asked, and the
+/// boundary ledger counted the consequences — measurement, not prevention. Now
+/// the type system asks the question and the ledger counts the answer.
 #[derive(Clone, Debug)]
 pub struct Origin<S> {
-    /// The exact tokens this node was built from. Feed it to `quote!` when
-    /// generated Rust has to spell the node; never `match` on it to decide what
-    /// the node is — see the [module docs](super) on classifying off `kind`.
-    pub syntax: S,
+    /// The exact tokens this node was built from.
+    ///
+    /// `pub(super)` is the seal: inside the model this is the syntax being
+    /// lowered, classified and round-tripped, and reading it is the work. Outside,
+    /// see [`spell`](Self::spell) and [`as_syn`](Self::as_syn).
+    pub(super) syntax: S,
     /// The captured item this node belongs to, shared with every sibling.
     pub location: Rc<SourceLocation>,
 }
@@ -60,6 +75,21 @@ pub struct Origin<S> {
 impl<S> Origin<S> {
     pub fn new(syntax: S, location: Rc<SourceLocation>) -> Self {
         Self { syntax, location }
+    }
+
+    /// The node as `syn` — **the escape**.
+    ///
+    /// Every remaining place that takes the source apart instead of asking the
+    /// model comes through here, which is what makes the population countable:
+    /// `boundary.rs` counts these calls per file, and the count reaching zero is
+    /// what "the model answers every source question" would mean.
+    ///
+    /// Naming it is not an accusation. An emitter assembling a `syn::Item`, or a
+    /// signature the generated crate must restate node for node, legitimately
+    /// needs the node — that is why the ledger keeps item escapes in their own
+    /// bucket. What it stops is reaching for one *by default*.
+    pub fn as_syn(&self) -> &S {
+        &self.syntax
     }
 
     /// The crate this node's source was written in.
@@ -79,10 +109,21 @@ impl<S> Origin<S> {
     }
 }
 
-/// Spelling a node emits its syntax, so a site that re-states a whole node
-/// needs no `.syntax` hop.
-impl<S: ToTokens> ToTokens for Origin<S> {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        self.syntax.to_tokens(tokens)
+impl<S: ToTokens> Origin<S> {
+    /// The node's tokens, for generated Rust to spell.
+    ///
+    /// **The only output route, and deliberately not `ToTokens`.** Implementing
+    /// that trait would make `quote!(#node)` work — and hand every consumer
+    /// `to_token_stream().to_string()` with it, which is a classifier's input in
+    /// a spelling's clothing. A `TokenStream` interpolates just as well one `let`
+    /// earlier, and the string, if a site really wants one, is now a two-call
+    /// pattern that says so.
+    ///
+    /// It does not make a token string *impossible* — `spell().to_string()`
+    /// reaches one, and the ledger still lists that as open. What it makes is
+    /// **visible**: `.to_token_stream().to_string()` was indistinguishable from
+    /// the same call on a type an adapter built itself.
+    pub fn spell(&self) -> proc_macro2::TokenStream {
+        self.syntax.to_token_stream()
     }
 }

--- a/prebindgen/src/api/core/flat/spell.rs
+++ b/prebindgen/src/api/core/flat/spell.rs
@@ -1,6 +1,6 @@
 //! Spelling an element back as Rust: the one place the model turns into tokens.
 //!
-//! The other half of **classify off `kind`, spell off `syntax`**. Every helper
+//! The other half of **classify off `kind`, spell with `spell()`**. Every helper
 //! here reads an element's retained syntax and emits Rust; none of them decides
 //! what anything *means*. Keeping them out of [`element`](super::element) is
 //! what lets that module describe structure alone — a `Field` is a name, a
@@ -37,7 +37,7 @@ pub fn fields(shape: &syn::Fields, head: TokenStream, parts: &[TokenStream]) -> 
 impl Alternative {
     /// [`fields`] over this alternative's own delimiters.
     pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.origin.syntax.fields, head, parts)
+        fields(&self.origin.as_syn().fields, head, parts)
     }
 }
 
@@ -49,7 +49,7 @@ impl EnumValue {
     /// named. `parts` is therefore always empty — the signature matches
     /// [`Alternative::spell`] so one caller can spell either.
     pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.origin.syntax.fields, head, parts)
+        fields(&self.origin.as_syn().fields, head, parts)
     }
 }
 
@@ -57,7 +57,7 @@ impl Struct {
     /// [`fields`] over this struct's own delimiters — the dual of
     /// [`Variant::spell`], and the reason neither needs a modelled shape.
     pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.origin.syntax.fields, head, parts)
+        fields(&self.origin.as_syn().fields, head, parts)
     }
 }
 

--- a/prebindgen/src/api/core/flat/tests/acceptance.rs
+++ b/prebindgen/src/api/core/flat/tests/acceptance.rs
@@ -76,7 +76,7 @@ fn a_box_is_a_box_until_a_consumer_unwraps_it() {
         panic!("a box");
     };
     assert!(matches!(inner.kind, TypeKind::String));
-    assert_eq!(tokens(&ty.origin.syntax), "Box < String >");
+    assert_eq!(tokens(ty.origin.as_syn()), "Box < String >");
     // The reading a destination takes.
     assert!(matches!(ty.unwrapped().kind(), TypeKind::String));
 
@@ -87,7 +87,7 @@ fn a_box_is_a_box_until_a_consumer_unwraps_it() {
     let inner = ty.optional_inner().expect("an option");
     assert!(matches!(inner.kind, TypeKind::Boxed(_)));
     assert!(matches!(inner.unwrapped().kind(), TypeKind::String));
-    assert_eq!(tokens(&inner.origin.syntax), "Box < String >");
+    assert_eq!(tokens(inner.origin.as_syn()), "Box < String >");
 }
 
 /// The erasure, stated as something the model can be **asked**: what was taken
@@ -119,7 +119,7 @@ fn the_stripped_spelling_is_the_one_that_lowers_to_this_kind() {
             format!("{:?}", kind(quote::quote!(#stripped))),
             format!("{:?}", ty.unwrapped().kind()),
             "`{}` strips to `{}`, which must classify identically",
-            tokens(&ty.origin.syntax),
+            tokens(ty.origin.as_syn()),
             tokens(&stripped),
         );
     }
@@ -138,7 +138,7 @@ fn the_stripped_spelling_is_the_one_that_lowers_to_this_kind() {
     let plain = lower(quote::quote!(Option<Sample>)).expect("in the language");
     assert_eq!(
         tokens(&plain.stripped_syntax()),
-        tokens(&plain.origin.syntax)
+        tokens(plain.origin.as_syn())
     );
     assert_eq!(
         tokens(
@@ -462,7 +462,7 @@ fn a_run_of_values_is_read_through_either_spelling() {
                 TypeKind::Scalar(ScalarKind::U8)
             ),
             "`{}` is a run of `u8`",
-            tokens(&ty.origin.syntax)
+            tokens(ty.origin.as_syn())
         );
     }
 }
@@ -499,7 +499,7 @@ fn a_cow_reads_as_what_it_borrows() {
 
     // The `Cow` survives where codegen reads it: a generated signature must spell
     // `Cow<'_, [u8]>`, which is not interchangeable with `Vec<u8>` in Rust.
-    assert_eq!(tokens(&cow.origin.syntax), "Cow < '_ , [u8] >");
+    assert_eq!(tokens(cow.origin.as_syn()), "Cow < '_ , [u8] >");
 
     // Transparent for any target, as `Box` is: whether it can actually cross is the
     // adapter's call, and both already restrict which elements they accept.
@@ -546,7 +546,7 @@ fn a_cow_takes_a_lifetime_and_a_type_in_that_order() {
         let ty = lower(spelling).expect("in the language");
         assert!(matches!(ty.kind, TypeKind::Cow { .. }));
         // And it spells back, which is what the refusals below protect.
-        assert_eq!(tokens(&ty.kind().to_syn()), tokens(ty.syntax()));
+        assert_eq!(tokens(&ty.kind().to_syn()), tokens(ty.as_syn()));
     }
 
     // Everything else is refused by shape, and named as such.
@@ -597,7 +597,7 @@ fn a_cow_returning_accessor_resolves() {
     assert!(matches!(f.ret.kind, TypeKind::Cow { .. }));
     assert!(f.ret.sequence_elem().is_some(), "and it reads as a run");
     // And the return still spells its `Cow`, so an adapter can emit the signature.
-    assert_eq!(tokens(&f.ret.origin.syntax), "Cow < '_ , [u8] >");
+    assert_eq!(tokens(f.ret.origin.as_syn()), "Cow < '_ , [u8] >");
 }
 
 /// A raw pointer is not in the language. A `#[prebindgen]` crate is idiomatic
@@ -629,7 +629,7 @@ fn generic_arguments_are_spelling_only() {
         panic!("a named type");
     };
     assert_eq!(id.name, "Foo");
-    assert_eq!(tokens(&ty.origin.syntax), "Foo < 'a , u8 >");
+    assert_eq!(tokens(ty.origin.as_syn()), "Foo < 'a , u8 >");
 
     // Lowered, so still checked: a tuple inside a generic argument is refused.
     assert_eq!(
@@ -825,9 +825,9 @@ fn the_three_extent_projections_are_independent() {
 
     // Declaration spelling is per occurrence, and distinguishes cases the value
     // cannot: `4` is not `0x04`, and neither is `TAG_LEN`.
-    assert_eq!(tokens(&by_literal.origin.syntax), "4");
-    assert_eq!(tokens(&by_hex.origin.syntax), "0x04");
-    assert_eq!(tokens(&by_const.origin.syntax), "TAG_LEN");
+    assert_eq!(tokens(by_literal.origin.as_syn()), "4");
+    assert_eq!(tokens(by_hex.origin.as_syn()), "0x04");
+    assert_eq!(tokens(by_const.origin.as_syn()), "TAG_LEN");
 
     // Header dependency is the named const, and distinguishes cases the
     // spelling groups together and the value does not see at all.
@@ -847,7 +847,7 @@ fn the_three_extent_projections_are_independent() {
     assert!(by_const.value == by_literal.value && by_const.const_id() != by_literal.const_id());
     assert!(
         by_literal.value == by_hex.value
-            && tokens(&by_literal.origin.syntax) != tokens(&by_hex.origin.syntax)
+            && tokens(by_literal.origin.as_syn()) != tokens(by_hex.origin.as_syn())
     );
     assert!(
         by_const.const_id() != by_other_const.const_id() && by_const.value == by_other_const.value
@@ -1022,7 +1022,7 @@ fn consts_carry_their_type_and_value() {
     let c = as_const(&element);
     assert_eq!(c.name, "TAG_LEN");
     assert!(matches!(c.ty.kind, TypeKind::Scalar(ScalarKind::Usize)));
-    assert_eq!(tokens(&c.origin.syntax.expr), "4");
+    assert_eq!(tokens(&c.origin.as_syn().expr), "4");
 }
 
 /// An unnamed const is a `Guard`, not a `Constant`: nothing can name it, so it
@@ -1081,7 +1081,7 @@ fn a_marked_alias_declares_an_extern() {
     assert_eq!(e.target.as_deref(), Some("zenoh :: Session"));
     // The whole item survives, so a consumer can still read what it aliased.
     assert_eq!(
-        tokens(&e.origin.syntax),
+        tokens(e.origin.as_syn()),
         "pub type Session = zenoh :: Session ;"
     );
 
@@ -1250,7 +1250,7 @@ fn a_lifetime_binder_is_accepted() {
     ));
     let s = as_struct(&element);
     assert_eq!(s.fields.len(), 1);
-    assert_eq!(tokens(&s.fields[0].ty.origin.syntax), "& 'a str");
+    assert_eq!(tokens(&s.fields[0].ty.origin.spell()), "& 'a str");
 }
 
 /// `impl Trait` in argument position is an anonymous type parameter in Rust, but
@@ -1902,7 +1902,7 @@ fn the_layer_stack_stops_at_an_out_of_order_layer() {
         };
         (
             rendered,
-            quote::ToTokens::to_token_stream(&core.origin.syntax).to_string(),
+            quote::ToTokens::to_token_stream(core.origin.as_syn()).to_string(),
             reading.layer_types().len(),
         )
     };
@@ -1949,7 +1949,7 @@ fn the_layer_stack_stops_at_an_out_of_order_layer() {
 /// `parse_quote!(&#t)`, it would register a *different cell* and resolution
 /// would silently change. So the identity is pinned, not assumed.
 ///
-/// The pairing is the point: `kind` and `origin.syntax` are built together in
+/// The pairing is the point: `kind` and `spell()` are built together in
 /// one place, so a consumer classifying off one and spelling off the other
 /// cannot be handed a disagreement.
 #[test]
@@ -2024,7 +2024,7 @@ fn a_raw_identifier_survives_typeid() {
     // Recovered, and it spells itself back the way it was written.
     let back = id.ident().expect("a raw ident is still an ident");
     assert_eq!(back, raw);
-    assert_eq!(tokens(&t.origin.syntax), "r#type");
+    assert_eq!(tokens(t.origin.as_syn()), "r#type");
 
     // A path-qualified name is not a single identifier — the same answer the
     // old `bare_path_ident` gave.

--- a/prebindgen/src/api/core/flat/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/flat/tests/roundtrip.rs
@@ -33,7 +33,7 @@ fn function_parts_are_the_source_tokens() {
     assert_eq!(
         func.params
             .iter()
-            .map(|p| tokens(&p.origin.syntax))
+            .map(|p| tokens(p.origin.as_syn()))
             .collect::<Vec<_>>(),
         vec![
             "key : & 'a KeyExpr",
@@ -42,10 +42,10 @@ fn function_parts_are_the_source_tokens() {
         ]
     );
     // The lifetime is nowhere in the classification, and still survives.
-    assert_eq!(tokens(&func.params[0].ty.origin.syntax), "& 'a KeyExpr");
+    assert_eq!(tokens(&func.params[0].ty.origin.spell()), "& 'a KeyExpr");
     assert!(matches!(func.params[0].ty.kind, TypeKind::Ref { .. }));
 
-    assert_eq!(tokens(&func.ret.origin.syntax), "Result < () , Error >");
+    assert_eq!(tokens(func.ret.origin.as_syn()), "Result < () , Error >");
 }
 
 /// A defaulted return and a written `-> ()` are the same function, and both
@@ -65,14 +65,14 @@ fn a_defaulted_return_spells_as_the_unit() {
         let element = parse_one(item);
         let ret = &as_fn(&element).ret;
         assert!(matches!(ret.kind, TypeKind::Unit));
-        assert_eq!(tokens(&ret.origin.syntax), "()");
+        assert_eq!(tokens(ret.origin.as_syn()), "()");
     }
 
     let defaulted = parse_one(syn::parse_quote!(
         pub fn a() {}
     ));
     assert!(matches!(
-        as_fn(&defaulted).origin.syntax.sig.output,
+        as_fn(&defaulted).origin.as_syn().sig.output,
         syn::ReturnType::Default
     ));
 }
@@ -91,9 +91,9 @@ fn struct_field_slices_keep_attributes() {
     ));
     let fields = &as_struct(&element).fields;
     assert_eq!(fields.len(), 2);
-    assert!(tokens(&fields[0].origin.syntax).contains("The key it was published on."));
+    assert!(tokens(&fields[0].origin.spell()).contains("The key it was published on."));
     assert_eq!(
-        tokens(&fields[1].origin.syntax),
+        tokens(&fields[1].origin.spell()),
         "# [allow (dead_code)] pub (crate) seq : u64"
     );
 }
@@ -137,7 +137,7 @@ fn an_item_and_its_components_share_one_location() {
     assert!(Rc::ptr_eq(item, &f.origin.location), "alternative field");
     let extent = f.ty.array_extent().expect("an extent");
     assert!(Rc::ptr_eq(item, &extent.origin.location), "extent");
-    assert_eq!(tokens(&extent.origin.syntax), "4");
+    assert_eq!(tokens(extent.origin.as_syn()), "4");
 
     let element = parse_one(syn::parse_quote!(
         pub fn f(a: u8) {}
@@ -293,7 +293,7 @@ fn struct_delimiters_survive_and_spell() {
     ));
     let o = as_extern(&element);
     assert_eq!(o.name, "D");
-    assert!(tokens(&o.origin.syntax).contains("Whatever"));
+    assert!(tokens(o.origin.as_syn()).contains("Whatever"));
 }
 
 /// A discriminant is two facts with two homes: the number is modelled, the
@@ -320,7 +320,7 @@ fn discriminant_number_and_spelling_both_survive() {
         .as_ref()
         .expect("an explicit discriminant");
     assert_eq!(tokens(expr), "0x07");
-    assert!(e.values[1].origin.syntax.discriminant.is_none());
+    assert!(e.values[1].origin.as_syn().discriminant.is_none());
 }
 
 /// A discriminant the frontend cannot evaluate breaks the *numeric* chain and
@@ -433,7 +433,7 @@ fn array_extent_carries_number_const_and_spelling() {
     let named = fields[0].ty.array_extent().expect("an extent");
     assert_eq!(named.value, 4);
     assert_eq!(named.const_id().expect("a const").name, "TAG_LEN");
-    assert_eq!(tokens(&fields[0].ty.origin.syntax), "[u8 ; TAG_LEN]");
+    assert_eq!(tokens(&fields[0].ty.origin.spell()), "[u8 ; TAG_LEN]");
 
     let literal = fields[1].ty.array_extent().expect("an extent");
     assert_eq!(literal.value, 2);
@@ -452,8 +452,8 @@ fn the_whole_item_survives() {
         }
     );
     let element = parse_one(syn::Item::Fn(source.clone()));
-    assert_eq!(tokens(&as_fn(&element).origin.syntax), tokens(&source));
-    assert_eq!(tokens(&element.syntax()), tokens(&syn::Item::Fn(source)));
+    assert_eq!(tokens(&as_fn(&element).origin.spell()), tokens(&source));
+    assert_eq!(tokens(&element.as_syn()), tokens(&syn::Item::Fn(source)));
 }
 
 /// An item the language cannot express still keeps its tokens, so a diagnosis
@@ -467,7 +467,7 @@ fn an_unsupported_item_keeps_its_tokens() {
     );
     let element = parse_one(source.clone());
     assert!(matches!(element, Element::Unsupported(_)));
-    assert_eq!(tokens(&element.syntax()), tokens(&source));
+    assert_eq!(tokens(&element.as_syn()), tokens(&source));
 }
 
 /// **Every accepted form spells back exactly what was written.**
@@ -523,9 +523,9 @@ fn syntax_is_recoverable_from_kind() {
         let ty = lower(spelling).expect("in the language");
         assert_eq!(
             tokens(&ty.kind().to_syn()),
-            tokens(ty.syntax()),
+            tokens(ty.as_syn()),
             "`{}` must spell back as itself",
-            tokens(ty.syntax()),
+            tokens(ty.as_syn()),
         );
     }
 }
@@ -554,7 +554,7 @@ fn the_two_forms_that_do_not_spell_back_verbatim() {
     let parens = lower(quote::quote!((u8))).expect("in the language");
     assert_eq!(tokens(&parens.kind().to_syn()), "u8");
     assert_eq!(
-        tokens(parens.syntax()),
+        tokens(parens.as_syn()),
         "u8",
         "the slice is the inner node's"
     );

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -33,7 +33,8 @@ use crate::SourceLocation;
 
 /// A type as the language accepted it, plus the exact syntax it came from.
 ///
-/// The [`Origin::syntax`] slice is what generated Rust spells. It is **not**
+/// The retained slice is what generated Rust spells, through
+/// [`spell`](Self::spell). It is **not**
 /// where facts go to survive a lossy classification any more — `kind` keeps the
 /// lifetime, the wrapper and the argument it used to drop, and
 /// [`TypeKind::to_syn`] proves it. Keeping the slice anyway is cheap, exact
@@ -126,10 +127,20 @@ impl TypeRef {
     }
 
     /// The tokens generated Rust must spell. **Spell off this**, never off
-    /// `kind` — the syntax says strictly more, and re-deriving it from the
-    /// classification is how `Box<Option<T>>` becomes an `E0308`.
-    pub fn syntax(&self) -> &syn::Type {
-        &self.origin.syntax
+    /// `kind` — re-deriving a spelling from the classification is how
+    /// `Box<Option<T>>` becomes an `E0308`.
+    ///
+    /// Tokens, not a `syn::Type`: a spelling is for spelling. What the type
+    /// *is* has an answer in [`kind`](Self::kind) and in the readings beside it,
+    /// and a consumer that still has to take the node apart says so with
+    /// [`as_syn`](Self::as_syn).
+    pub fn spell(&self) -> proc_macro2::TokenStream {
+        self.origin.spell()
+    }
+
+    /// The type as `syn` — **the escape**. See [`Origin::as_syn`].
+    pub fn as_syn(&self) -> &syn::Type {
+        self.origin.as_syn()
     }
 
     /// Where the type was written, for diagnostics. A composed type is
@@ -297,7 +308,7 @@ impl TypeRef {
     // what a crate wrote, and `classify_has_no_caller_outside_the_registry`
     // keeps it that way. These compose a type from parts already understood,
     // which needs no lowering at all: each builds `kind` **and** the matching
-    // `origin.syntax` in one place, so the classification and the spelling
+    // `spell()` in one place, so the classification and the spelling
     // cannot disagree — the invariant every consumer of a `TypeRef` relies on.
 
     /// A borrow of this type — `&T` from `T`.
@@ -305,7 +316,7 @@ impl TypeRef {
     /// Keeps this type's location: the borrow exists *because of* this value,
     /// so a diagnostic about it should point where the value came from.
     pub(in crate::api::core) fn borrowed(&self) -> TypeRef {
-        let inner = &self.origin.syntax;
+        let inner = self.origin.spell();
         TypeRef {
             kind: TypeKind::Ref {
                 lifetime: None,
@@ -319,7 +330,7 @@ impl TypeRef {
     /// An optional of this type — `Option<T>` from `T`. Location as
     /// [`Self::borrowed`].
     pub(in crate::api::core) fn optional(&self) -> TypeRef {
-        let inner = &self.origin.syntax;
+        let inner = self.origin.spell();
         TypeRef {
             kind: TypeKind::Optional(Box::new(self.clone())),
             origin: self.origin.with(syn::parse_quote!(Option<#inner>)),
@@ -367,17 +378,17 @@ impl TypeRef {
     ///
     /// The canonical spelling is what a key *is* (#113), and reading it is
     /// legitimate — but it should be the model's answer rather than every caller
-    /// reaching into [`syntax`](Self::syntax) for it, since a caller that reaches
+    /// reaching for the spelling itself, since a caller that reaches
     /// into `origin` to *reason* is the thing this model exists to stop.
     pub fn key(&self) -> crate::api::core::registry::TypeKey {
-        crate::api::core::registry::TypeKey::from_type(&self.origin.syntax)
+        crate::api::core::registry::TypeKey::from_type(self.origin.as_syn())
     }
 
     /// The [transparent wrapper](TRANSPARENT_WRAPPERS) this type's **spelling**
     /// adds over its classification, if any — `Box<Option<T>>` → `Some("Box")`,
     /// `Option<T>` → `None`.
     ///
-    /// This exists because [`kind`](Self::kind) and [`syntax`](Self::syntax)
+    /// This exists because [`kind`](Self::kind) and [`spell`](Self::spell)
     /// answer different questions, and only one of them is about the
     /// destination:
     ///
@@ -495,7 +506,7 @@ impl TypeRef {
     /// a wrapper under a borrow or inside an `Option` belongs to that inner
     /// node's own spelling.
     pub fn stripped_syntax(&self) -> syn::Type {
-        self.unwrapped().origin.syntax.clone()
+        self.unwrapped().origin.as_syn().clone()
     }
 
     /// True when this is `&mut T` over a **value** — not `&mut MaybeUninit<T>`.
@@ -603,7 +614,7 @@ impl TypeRef {
     ///
     /// A [`Named`](TypeKind::Named)'s generic arguments are **not** among them:
     /// [`TypeId`] keeps a name and nothing else, so `MyBox<Foo>` reaches no `Foo`
-    /// here. The full spelling is in [`Self::syntax`] for whoever needs it.
+    /// here. The full spelling is [`Self::spell`]'s answer for whoever needs it.
     pub fn walk(&self) -> Vec<&TypeRef> {
         let mut out = Vec::new();
         self.collect_refs(&mut out);
@@ -854,7 +865,7 @@ impl TypeKind {
             }
             Self::Array { elem, extent } => {
                 let elem = elem.kind.to_syn();
-                let len = &extent.origin.syntax;
+                let len = extent.origin.spell();
                 syn::parse_quote!([#elem; #len])
             }
             Self::Named { id, args } => {

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -287,10 +287,9 @@ pub trait Prebindgen {
         c: &crate::api::core::flat::Constant,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        use quote::ToTokens;
         match self.source_module() {
             Some(m) => const_path_alias(c.origin.as_syn(), m),
-            None => c.origin.spell().to_token_stream(),
+            None => c.origin.spell(),
         }
     }
 }

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -236,7 +236,7 @@ pub trait Prebindgen {
     // and be told "no reading" — the question a `&syn::ItemFn` forced it to ask
     // the registry, and which answered wrongly for a type that never entered
     // the pipeline (#275). What generated Rust must *spell* is still exactly
-    // available, on `origin.syntax`: classify off `kind`, spell off `syntax`.
+    // available, through `spell()`: classify off `kind`, spell with `spell()`.
 
     /// Wrap a `#[prebindgen]` fn into the destination-language wrapper
     /// (e.g. JNI `extern "C"` fn).
@@ -289,8 +289,8 @@ pub trait Prebindgen {
     ) -> TokenStream {
         use quote::ToTokens;
         match self.source_module() {
-            Some(m) => const_path_alias(&c.origin.syntax, m),
-            None => c.origin.syntax.to_token_stream(),
+            Some(m) => const_path_alias(c.origin.as_syn(), m),
+            None => c.origin.spell().to_token_stream(),
         }
     }
 }

--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -157,7 +157,7 @@ impl<M> RegistryBuilder<M> {
         self.registry
             .declared
             .types
-            .entry(TypeKey::from_type(&ty.syntax))
+            .entry(TypeKey::from_type(ty.as_syn()))
             .or_insert(ty);
         self
     }

--- a/prebindgen/src/api/core/registry/order.rs
+++ b/prebindgen/src/api/core/registry/order.rs
@@ -67,7 +67,7 @@ impl<M> Registry<M> {
         let plan_edges = self
             .type_table(dir)
             .get(&key)
-            .map(|cell| self.plan_edges(dir, cell.subject.syntax()))
+            .map(|cell| self.plan_edges(dir, cell.subject.as_syn()))
             .unwrap_or_default();
         let mut edges: Vec<Crossing> = self
             .immediate_edges(dir, &key)
@@ -120,7 +120,7 @@ impl<M> Registry<M> {
         for arg in args {
             if let Some(plan) = self.callback_arg_plans.get(&TypeKey::from_type(&arg)) {
                 for leaf in &plan.leaves {
-                    out.push((Direction::Output, leaf.out_ty.syntax().clone()));
+                    out.push((Direction::Output, leaf.out_ty.as_syn().clone()));
                 }
             }
         }

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -46,7 +46,7 @@ impl<M> Registry<M> {
             if !probed.insert(key) {
                 continue;
             }
-            let ty = crate::api::core::flat::canonical_type(&declared_ty.syntax);
+            let ty = crate::api::core::flat::canonical_type(declared_ty.as_syn());
             // Peel one reference level; the qualified head only appears on
             // path types.
             let inner = match &ty {
@@ -88,7 +88,11 @@ impl<M> Registry<M> {
 
         // Scan declared functions.
         for ident in &declared.functions {
-            if let Some(item_fn) = self.flat.function(&ident).map(|f| f.origin.syntax.clone()) {
+            if let Some(item_fn) = self
+                .flat
+                .function(&ident)
+                .map(|f| f.origin.as_syn().clone())
+            {
                 self.scan_fn_signature(&item_fn)?;
             } else {
                 missing.push(("function", ident.to_string()));
@@ -108,7 +112,11 @@ impl<M> Registry<M> {
         // Scan declared consts: a const is a nullary source of its type, so
         // the type is required in the output direction only.
         for ident in declared.consts.iter().flatten() {
-            if let Some(item_const) = self.flat.constant(&ident).map(|c| c.origin.syntax.clone()) {
+            if let Some(item_const) = self
+                .flat
+                .constant(&ident)
+                .map(|c| c.origin.as_syn().clone())
+            {
                 self.intern(Direction::Output, &item_const.ty, true)?;
             } else {
                 missing.push(("constant", ident.to_string()));
@@ -134,13 +142,13 @@ impl<M> Registry<M> {
             // is the form the type used to arrive in, and interning the
             // as-written spelling instead would put a differently-spelled
             // reading in the cell for the same key.
-            let ty = crate::api::core::flat::canonical_type(&declared_ty.syntax);
+            let ty = crate::api::core::flat::canonical_type(declared_ty.as_syn());
             let mut matched = false;
             if let Some(ident) = bare_path_ident(&ty) {
                 if let Some(s) = self
                     .flat
                     .struct_type(&ident)
-                    .map(|s| s.origin.syntax.clone())
+                    .map(|s| s.origin.as_syn().clone())
                 {
                     self.scan_struct(&s)?;
                     self.intern(Direction::Input, &ty, true)?;
@@ -396,7 +404,7 @@ impl<M> Registry<M> {
     /// yields `T` — [`borrow_target`](crate::api::core::flat::TypeRef::borrow_target)
     /// sees past the slot — instead of an intermediate `MaybeUninit<T>` that no
     /// adapter can convert and no table holds. Each edge is still *spelled* from
-    /// the child's own `origin.syntax`, which is what the caller keys the table by.
+    /// the child's own `spell()`, which is what the caller keys the table by.
     ///
     /// The reading comes from **this registry's own table**, where `ensure_entry`
     /// put it before the walk reached this type — so a spelling the binding composed

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -44,7 +44,7 @@ impl DeclareAndResolve<()> for RegistryBuilder<()> {
             .validate_with(&ext)?
             // The reading, not a spelling re-derived from the key: this is the
             // route a real generator takes, so the stub takes it too (#291).
-            .convert_with(|crossing, built| ext.converter(built.reading(&crossing.1)?.syntax()))?
+            .convert_with(|crossing, built| ext.converter(built.reading(&crossing.1)?.as_syn()))?
             .build()?;
         ext.validate_resolved(&registry)
             .map_err(|message| ScanError::AdapterInvariant { message })?;
@@ -1816,7 +1816,7 @@ fn a_built_registry_exposes_no_mutation() {
 ///
 /// The failure it exists for is specific and was live: a consumer holding an
 /// element — whose `ret` / `ty` is already a `TypeRef` — reaching into
-/// `origin.syntax`, digging the type back out, and re-classifying it. The boundary
+/// `spell()`, digging the type back out, and re-classifying it. The boundary
 /// ledger cannot see that at all: the syn matching happens inside `core::flat`,
 /// which the ledger excludes by design, so the count falls while the round trip
 /// stays. `origin` is for reconstructing Rust, not for reasoning about it.

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -312,7 +312,7 @@ pub fn apply<M>(
                     func: ed.func.clone(),
                     declared: TypeKey::from_type(declared).as_str().to_string(),
                     actual: {
-                        let s = ret.syntax();
+                        let s = ret.spell();
                         quote::quote!(#s).to_string()
                     },
                 });
@@ -857,12 +857,12 @@ fn whole_leaf_fold_plan(
     shape: UnfoldShape,
 ) -> UnfoldPlan {
     UnfoldPlan {
-        source: vec_elem.syntax().clone(),
+        source: vec_elem.as_syn().clone(),
         decon: None,
         by_ref: peel_borrow(vec_elem).0,
         shape,
         leaves: vec![],
-        element: Some(vec_elem.syntax().clone()),
+        element: Some(vec_elem.as_syn().clone()),
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
@@ -942,7 +942,7 @@ struct Layered {
 /// Takes a `&TypeRef`, not a `&syn::Type`, and that is the whole point: a caller
 /// must hold a reading, and the ways to hold one are to take it off an element or
 /// to be the scan admitting a type with no element. Re-deriving a reading from
-/// `origin.syntax` — the round trip this signature makes impossible — is reasoning
+/// `spell()` — the round trip this signature makes impossible — is reasoning
 /// from the spelling, which is what `origin` is not for.
 fn peel(ty: &crate::api::core::flat::TypeRef) -> Layered {
     let (shape, layered) = ty.layer_stack();
@@ -950,7 +950,7 @@ fn peel(ty: &crate::api::core::flat::TypeRef) -> Layered {
     Layered {
         shape,
         layer_types: ty.layer_types().into_iter().cloned().collect(),
-        core: borrowed.unwrap_or(layered).syntax().clone(),
+        core: borrowed.unwrap_or(layered).as_syn().clone(),
         by_ref: borrowed.is_some(),
     }
 }
@@ -1071,12 +1071,12 @@ fn process_decl<M>(
                 let by_ref = peel_borrow(inner).0;
                 registry.require_output(inner);
                 UnfoldPlan {
-                    source: inner.syntax().clone(),
+                    source: inner.as_syn().clone(),
                     decon: None,
                     by_ref,
                     shape,
                     leaves: vec![],
-                    element: Some(inner.syntax().clone()),
+                    element: Some(inner.as_syn().clone()),
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
@@ -1146,7 +1146,7 @@ fn process_decl<M>(
             registry.require_output(&cv);
             UnfoldPlan {
                 delivery: Delivery::Return,
-                convert_out_ty: Some(cv.syntax().clone()),
+                convert_out_ty: Some(cv.as_syn().clone()),
                 ..plan
             }
         } else {
@@ -1200,11 +1200,11 @@ fn register_decon_spec<M>(
         // derived from it, never emitted code — so its hoists are discarded.
         &mut Vec::new(),
     )?;
-    require_unique_leaf_names(source.syntax(), &leaves)?;
+    require_unique_leaf_names(source.as_syn(), &leaves)?;
     registry.decon_plans.insert(
         decon.clone(),
         DeconSpec {
-            source: source.syntax().clone(),
+            source: source.as_syn().clone(),
             leaves,
         },
     );
@@ -1277,11 +1277,11 @@ fn build_plan<M>(
         &mut leaves,
         &mut hoists,
     )?;
-    require_unique_leaf_names(source.syntax(), &leaves)?;
-    require_root_identity_last(by_ref, source.syntax(), &leaves)?;
+    require_unique_leaf_names(source.as_syn(), &leaves)?;
+    require_root_identity_last(by_ref, source.as_syn(), &leaves)?;
 
     Ok(UnfoldPlan {
-        source: source.syntax().clone(),
+        source: source.as_syn().clone(),
         decon: Some(decon),
         by_ref,
         shape,
@@ -1416,7 +1416,7 @@ fn flatten<M>(
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
                 let (takes, _ret) = accessor_signature(registry, func)?;
-                check_takes(func, &takes, source.syntax())?;
+                check_takes(func, &takes, source.as_syn())?;
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
@@ -1603,7 +1603,7 @@ fn flatten<M>(
                     DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
                 let (takes, ret) = accessor_signature(registry, &func)?;
-                check_takes(&func, &takes, source.syntax())?;
+                check_takes(&func, &takes, source.as_syn())?;
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
@@ -1751,8 +1751,8 @@ fn accessor_signature<M>(
         .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
     let takes = match first.ty.borrow_target() {
-        Some(inner) => inner.syntax().clone(),
-        None => first.ty.syntax().clone(),
+        Some(inner) => inner.as_syn().clone(),
+        None => first.ty.as_syn().clone(),
     };
     Ok((takes, f.ret.clone()))
 }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -308,7 +308,7 @@ pub struct UnfoldLeaf {
     /// The **reading** of the type whose resolved output converter encodes this
     /// leaf — a reference type for accessors (`&str`, `&F`), `&Source` for the
     /// identity leaf (so the borrowed-opaque clone converter / projection is
-    /// reused). Spell it with `out_ty.origin.syntax`.
+    /// reused). Spell it with `out_ty.spell()`.
     ///
     /// A reading rather than a spelling because a consumer asking what this
     /// leaf's type *means* had to hand the spelling back to the registry and

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -111,10 +111,7 @@ fn accessor_optional_primitive() {
         plan.leaves[0].path[0].ident().to_string(),
         "z_timestamp_ntp64"
     );
-    assert_eq!(
-        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
-        "i64"
-    );
+    assert_eq!(plan.leaves[0].out_ty.spell().to_string(), "i64");
     assert!(
         reg.output_types[&TypeKey::from_type(&syn::parse_quote!(i64))].root,
         "the leaf type must be a root"
@@ -169,10 +166,7 @@ fn accessor_plan_byref() {
     // Identity leaf: out_ty `&ZKeyExpr`, empty path, emitted last.
     assert!(plan.leaves[0].identity);
     assert!(plan.leaves[0].path.is_empty());
-    assert_eq!(
-        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
-        "& ZKeyExpr"
-    );
+    assert_eq!(plan.leaves[0].out_ty.spell().to_string(), "& ZKeyExpr");
     // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
     assert!(!plan.leaves[1].identity);
     assert_eq!(plan.leaves[1].path.len(), 1);
@@ -180,10 +174,7 @@ fn accessor_plan_byref() {
         plan.leaves[1].path[0].ident().to_string(),
         "z_keyexpr_as_str"
     );
-    assert_eq!(
-        plan.leaves[1].out_ty.spell().to_token_stream().to_string(),
-        "& str"
-    );
+    assert_eq!(plan.leaves[1].out_ty.spell().to_string(), "& str");
 
     // Leaf out_tys registered as required outputs so the resolver builds
     // their converters.
@@ -526,10 +517,7 @@ fn nested_accessor_flatten() {
     assert_eq!(path(&plan.leaves[1]), "z_sample_key_expr.z_keyexpr_as_str");
     assert_eq!(path(&plan.leaves[2]), "z_sample_payload.z_zbytes_to_bytes");
     assert_eq!(path(&plan.leaves[3]), "z_sample_kind");
-    assert_eq!(
-        plan.leaves[3].out_ty.spell().to_token_stream().to_string(),
-        "SampleKind"
-    );
+    assert_eq!(plan.leaves[3].out_ty.spell().to_string(), "SampleKind");
     assert_eq!(
         path(&plan.leaves[4]),
         "z_sample_timestamp.z_timestamp_ntp64"
@@ -665,7 +653,7 @@ fn reply_product_double_option_flatten() {
     // Acc leaf keeping its full `Option<…>` return — not a nesting step.
     assert_eq!(path(&plan.leaves[0]), "z_reply_replier_zid");
     assert_eq!(
-        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_string(),
         "Option < ZZenohId >"
     );
     assert!(!plan.leaves[0].nullable && !plan.leaves[0].identity);
@@ -830,18 +818,12 @@ fn iterable_decomposed_plan() {
         plan.leaves[0].path[0].ident().to_string(),
         "z_zenoh_id_to_string"
     );
-    assert_eq!(
-        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
-        "String"
-    );
+    assert_eq!(plan.leaves[0].out_ty.spell().to_string(), "String");
     // Identity leaf: owned value (`ZZenohId`, not `&ZZenohId`) since the Vec
     // owns its elements (by_ref = false).
     assert!(plan.leaves[1].identity);
     assert!(plan.leaves[1].path.is_empty());
-    assert_eq!(
-        plan.leaves[1].out_ty.spell().to_token_stream().to_string(),
-        "ZZenohId"
-    );
+    assert_eq!(plan.leaves[1].out_ty.spell().to_string(), "ZZenohId");
 }
 
 #[test]
@@ -1242,10 +1224,7 @@ fn convert_error_decomposes_result_e() {
         .expect("error plan for the fallible fn");
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 1);
-    assert_eq!(
-        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
-        "String"
-    );
+    assert_eq!(plan.leaves[0].out_ty.spell().to_string(), "String");
     assert_eq!(plan.source.to_token_stream().to_string(), "ZError");
     // The infallible fn gets no error plan.
     assert!(!reg.error_plans.contains_key(&ident("z_infallible")));
@@ -1362,18 +1341,12 @@ fn callback_arg_plan_derived() {
         plan.leaves[0].path[0].ident().to_string(),
         "z_sample_key_expr"
     );
-    assert_eq!(
-        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
-        "& ZKeyExpr"
-    );
+    assert_eq!(plan.leaves[0].out_ty.spell().to_string(), "& ZKeyExpr");
     assert_eq!(
         plan.leaves[1].path.last().unwrap().ident().to_string(),
         "z_keyexpr_as_str"
     );
-    assert_eq!(
-        plan.leaves[2].out_ty.spell().to_token_stream().to_string(),
-        "SampleKind"
-    );
+    assert_eq!(plan.leaves[2].out_ty.spell().to_string(), "SampleKind");
     // Leaf out_tys registered so the resolver builds their converters.
     assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(&str))].root);
     assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(SampleKind))].root);
@@ -1445,10 +1418,7 @@ fn callback_arg_borrowed_decomposed() {
         plan.leaves[0].path[0].ident().to_string(),
         "z_sample_key_expr"
     );
-    assert_eq!(
-        plan.leaves[2].out_ty.spell().to_token_stream().to_string(),
-        "SampleKind"
-    );
+    assert_eq!(plan.leaves[2].out_ty.spell().to_string(), "SampleKind");
 }
 
 #[test]

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -112,7 +112,7 @@ fn accessor_optional_primitive() {
         "z_timestamp_ntp64"
     );
     assert_eq!(
-        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
         "i64"
     );
     assert!(
@@ -170,7 +170,7 @@ fn accessor_plan_byref() {
     assert!(plan.leaves[0].identity);
     assert!(plan.leaves[0].path.is_empty());
     assert_eq!(
-        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
         "& ZKeyExpr"
     );
     // Accessor leaf: out_ty `&str`, path `[z_keyexpr_as_str]`.
@@ -181,7 +181,7 @@ fn accessor_plan_byref() {
         "z_keyexpr_as_str"
     );
     assert_eq!(
-        plan.leaves[1].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[1].out_ty.spell().to_token_stream().to_string(),
         "& str"
     );
 
@@ -527,7 +527,7 @@ fn nested_accessor_flatten() {
     assert_eq!(path(&plan.leaves[2]), "z_sample_payload.z_zbytes_to_bytes");
     assert_eq!(path(&plan.leaves[3]), "z_sample_kind");
     assert_eq!(
-        plan.leaves[3].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[3].out_ty.spell().to_token_stream().to_string(),
         "SampleKind"
     );
     assert_eq!(
@@ -665,7 +665,7 @@ fn reply_product_double_option_flatten() {
     // Acc leaf keeping its full `Option<…>` return — not a nesting step.
     assert_eq!(path(&plan.leaves[0]), "z_reply_replier_zid");
     assert_eq!(
-        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
         "Option < ZZenohId >"
     );
     assert!(!plan.leaves[0].nullable && !plan.leaves[0].identity);
@@ -831,7 +831,7 @@ fn iterable_decomposed_plan() {
         "z_zenoh_id_to_string"
     );
     assert_eq!(
-        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
         "String"
     );
     // Identity leaf: owned value (`ZZenohId`, not `&ZZenohId`) since the Vec
@@ -839,7 +839,7 @@ fn iterable_decomposed_plan() {
     assert!(plan.leaves[1].identity);
     assert!(plan.leaves[1].path.is_empty());
     assert_eq!(
-        plan.leaves[1].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[1].out_ty.spell().to_token_stream().to_string(),
         "ZZenohId"
     );
 }
@@ -1243,7 +1243,7 @@ fn convert_error_decomposes_result_e() {
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(
-        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
         "String"
     );
     assert_eq!(plan.source.to_token_stream().to_string(), "ZError");
@@ -1363,7 +1363,7 @@ fn callback_arg_plan_derived() {
         "z_sample_key_expr"
     );
     assert_eq!(
-        plan.leaves[0].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[0].out_ty.spell().to_token_stream().to_string(),
         "& ZKeyExpr"
     );
     assert_eq!(
@@ -1371,7 +1371,7 @@ fn callback_arg_plan_derived() {
         "z_keyexpr_as_str"
     );
     assert_eq!(
-        plan.leaves[2].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[2].out_ty.spell().to_token_stream().to_string(),
         "SampleKind"
     );
     // Leaf out_tys registered so the resolver builds their converters.
@@ -1446,7 +1446,7 @@ fn callback_arg_borrowed_decomposed() {
         "z_sample_key_expr"
     );
     assert_eq!(
-        plan.leaves[2].out_ty.syntax().to_token_stream().to_string(),
+        plan.leaves[2].out_ty.spell().to_token_stream().to_string(),
         "SampleKind"
     );
 }

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -142,7 +142,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     //    purpose: with no name there is nothing for an adapter to declare, so
     //    the const gate above cannot apply to them.
     for guard in flat.guards() {
-        items.push(syn::Item::Const(guard.origin.syntax.clone()));
+        items.push(syn::Item::Const(guard.origin.as_syn().clone()));
     }
 
     // 4. Cross-cutting post-process pass. Adapters use this to qualify

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -1,7 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use proc_macro2::TokenStream;
-use quote::ToTokens;
 
 use super::*;
 use crate::{
@@ -33,7 +32,7 @@ impl Prebindgen for IdentityExt {
         f: &crate::api::core::flat::Function,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        f.origin.spell().to_token_stream()
+        f.origin.spell()
     }
 
     fn on_struct(
@@ -41,7 +40,7 @@ impl Prebindgen for IdentityExt {
         s: &crate::api::core::flat::Struct,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        s.origin.spell().to_token_stream()
+        s.origin.spell()
     }
 
     fn on_variant(
@@ -49,7 +48,7 @@ impl Prebindgen for IdentityExt {
         v: &crate::api::core::flat::Variant,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        v.origin.spell().to_token_stream()
+        v.origin.spell()
     }
 
     fn on_enum(
@@ -57,7 +56,7 @@ impl Prebindgen for IdentityExt {
         e: &crate::api::core::flat::Enum,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        e.origin.spell().to_token_stream()
+        e.origin.spell()
     }
 }
 
@@ -244,20 +243,20 @@ fn guards_emit_ungated_and_in_stream_order() {
             f: &crate::api::core::flat::Function,
             _r: &Registry<()>,
         ) -> TokenStream {
-            f.origin.spell().to_token_stream()
+            f.origin.spell()
         }
         fn on_struct(&self, s: &crate::api::core::flat::Struct, _r: &Registry<()>) -> TokenStream {
-            s.origin.spell().to_token_stream()
+            s.origin.spell()
         }
         fn on_variant(
             &self,
             v: &crate::api::core::flat::Variant,
             _r: &Registry<()>,
         ) -> TokenStream {
-            v.origin.spell().to_token_stream()
+            v.origin.spell()
         }
         fn on_enum(&self, e: &crate::api::core::flat::Enum, _r: &Registry<()>) -> TokenStream {
-            e.origin.spell().to_token_stream()
+            e.origin.spell()
         }
     }
 

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -33,7 +33,7 @@ impl Prebindgen for IdentityExt {
         f: &crate::api::core::flat::Function,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        f.origin.syntax.to_token_stream()
+        f.origin.spell().to_token_stream()
     }
 
     fn on_struct(
@@ -41,7 +41,7 @@ impl Prebindgen for IdentityExt {
         s: &crate::api::core::flat::Struct,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        s.origin.syntax.to_token_stream()
+        s.origin.spell().to_token_stream()
     }
 
     fn on_variant(
@@ -49,7 +49,7 @@ impl Prebindgen for IdentityExt {
         v: &crate::api::core::flat::Variant,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        v.origin.syntax.to_token_stream()
+        v.origin.spell().to_token_stream()
     }
 
     fn on_enum(
@@ -57,7 +57,7 @@ impl Prebindgen for IdentityExt {
         e: &crate::api::core::flat::Enum,
         _registry: &Registry<Self::Metadata>,
     ) -> TokenStream {
-        e.origin.syntax.to_token_stream()
+        e.origin.spell().to_token_stream()
     }
 }
 
@@ -244,20 +244,20 @@ fn guards_emit_ungated_and_in_stream_order() {
             f: &crate::api::core::flat::Function,
             _r: &Registry<()>,
         ) -> TokenStream {
-            f.origin.syntax.to_token_stream()
+            f.origin.spell().to_token_stream()
         }
         fn on_struct(&self, s: &crate::api::core::flat::Struct, _r: &Registry<()>) -> TokenStream {
-            s.origin.syntax.to_token_stream()
+            s.origin.spell().to_token_stream()
         }
         fn on_variant(
             &self,
             v: &crate::api::core::flat::Variant,
             _r: &Registry<()>,
         ) -> TokenStream {
-            v.origin.syntax.to_token_stream()
+            v.origin.spell().to_token_stream()
         }
         fn on_enum(&self, e: &crate::api::core::flat::Enum, _r: &Registry<()>) -> TokenStream {
-            e.origin.syntax.to_token_stream()
+            e.origin.spell().to_token_stream()
         }
     }
 

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -18,7 +18,7 @@ impl CbindgenBuilder {
                 .get(&decl.key)
                 .cloned()
                 .unwrap_or_else(|| {
-                    let short = type_short(&decl.rust_type.syntax.clone());
+                    let short = type_short(&decl.rust_type.as_syn().clone());
                     self.mangle_rust_type
                         .as_ref()
                         .map(|m| m(&short))
@@ -190,13 +190,13 @@ impl CbindgenBuilder {
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
     ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty(&decl.rust_type.syntax.clone());
+        let target = self.src_ty(&decl.rust_type.as_syn().clone());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
                     .flat()
                     .function(&f)
-                    .map(|func| &func.origin.syntax)
+                    .map(|func| func.origin.as_syn())
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (repr, by_ref) = one_param(item);
                 let ret = fn_ret(item);
@@ -234,13 +234,13 @@ impl CbindgenBuilder {
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
     ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty(&decl.rust_type.syntax.clone());
+        let target = self.src_ty(&decl.rust_type.as_syn().clone());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
                     .flat()
                     .function(&f)
-                    .map(|func| &func.origin.syntax)
+                    .map(|func| func.origin.as_syn())
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (param, by_ref) = one_param(item);
                 assert_eq!(TypeKey::from_type(&param), decl.key);

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -32,7 +32,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             registry.output_entry(&reading).is_some()
                 && self
                     .enum_variants(registry, &ty)
@@ -49,7 +49,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             registry.output_entry(&reading).is_some()
                 && self
                     .struct_fields(registry, &ty)
@@ -380,7 +380,7 @@ impl CbindgenBuilder {
         let item = registry
             .flat()
             .struct_type(&ident)
-            .map(|st| &st.origin.syntax)?;
+            .map(|st| st.origin.as_syn())?;
         if let syn::Fields::Named(named) = &item.fields {
             Some(
                 named

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -541,7 +541,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             let c_struct = self.c_type_ident(&ty);
             // Opaque/incomplete C type: the handle is `#c_struct *`, which IS the
             // `Box::into_raw` pointer to the source value.
@@ -580,7 +580,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             let Some(fields) = self.struct_fields(registry, &ty) else {
                 continue;
             };
@@ -626,7 +626,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             let src = self.src_ty(&ty);
             let opaque = &cfg.opaque;
             // `repr_c_struct`: the opaque counterpart is an auto-generated
@@ -827,7 +827,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             let Some(e) = enum_item(registry, &ty) else {
                 continue;
             };
@@ -873,7 +873,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.syntax().clone();
+            let ty = reading.as_syn().clone();
             let Some(e) = enum_item(registry, &ty) else {
                 continue;
             };
@@ -1609,7 +1609,7 @@ impl CbindgenBuilder {
         // `convert_with` hands out comes from a type table, so it has a cell.
         // The selectors still take the spelling: moving cbindgen's selector
         // chain onto readings is its own change.
-        let ty = built.reading(key)?.syntax().clone();
+        let ty = built.reading(key)?.as_syn().clone();
         match dir {
             Direction::Input => self.select_input_type(&ty, built).or_else(|| {
                 let args = crate::api::core::flat::extract_fn_trait_args(&ty)?;
@@ -1827,7 +1827,7 @@ impl Prebindgen for CbindgenBuilder {
         f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
     ) -> TokenStream {
-        self.emit_function_wrapper(&f.origin.syntax, registry)
+        self.emit_function_wrapper(f.origin.as_syn(), registry)
     }
 
     fn on_struct(

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -786,7 +786,7 @@ impl Declarations {
             }
             exp.constructors
                 .push(crate::api::core::expand::ConstructorDecl {
-                    target: decl.rust_type.syntax.clone(),
+                    target: decl.rust_type.as_syn().clone(),
                     variants: decl.variants.iter().map(lower).collect(),
                     default: true,
                 });
@@ -809,7 +809,7 @@ impl Declarations {
             exp.expands.push(ExpandDecl {
                 func: func.clone(),
                 param: syn::Ident::new(param, Span::call_site()),
-                declared_target: Some(decl.rust_type.syntax.clone()),
+                declared_target: Some(decl.rust_type.as_syn().clone()),
                 sel: ExpandSel::Subset(decl.variants.iter().map(lower).collect()),
             });
         }
@@ -904,12 +904,12 @@ impl Declarations {
              value form returns the struct holding this type's fields",
             key.as_str(),
         );
-        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, ret.syntax()) else {
+        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, ret.as_syn()) else {
             panic!(
                 "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
                  not a struct — a value form returns a struct whose fields become the leaves",
                 key.as_str(),
-                ret.syntax().to_token_stream(),
+                ret.spell().to_token_stream(),
             )
         };
         let st = st.clone();
@@ -1048,7 +1048,7 @@ impl Declarations {
             // must decompose into its selector and groups wherever it appears.
             let bare = field.ty.optional_inner().unwrap_or(&field.ty);
             let probe = bare.sequence_elem().unwrap_or(bare);
-            match self.type_kind(registry, probe.syntax()) {
+            match self.type_kind(registry, probe.as_syn()) {
                 TypeKind::DataStruct { st, cfg: Some(_) }
                     if field.ty.optional_inner().is_none()
                         && field.ty.sequence_elem().is_none() =>
@@ -1082,7 +1082,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.syntax().to_token_stream(),
+                        probe.spell().to_token_stream(),
                     );
                     assert!(
                         field.ty.optional_inner().is_none(),
@@ -1095,7 +1095,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.syntax().to_token_stream(),
+                        probe.spell().to_token_stream(),
                         dotted,
                     );
                     // The name is the reading's, not a path taken apart to
@@ -1172,7 +1172,7 @@ impl Declarations {
                 k = decl.key.as_str()
             );
             dec.deconstructors.push(DeconstructorDecl {
-                target: decl.rust_type.syntax.clone(),
+                target: decl.rust_type.as_syn().clone(),
                 records: self.lower_fields(registry, &decl.key, &decl.fields),
                 default: Some((DeconTarget::Output, Delivery::Callback)),
             });
@@ -1197,7 +1197,7 @@ impl Declarations {
                 sel: DeconSel::Inline(self.lower_fields(registry, &decl.key, &decl.fields)),
                 target: DeconTarget::Output,
                 delivery: Delivery::Callback,
-                declared_source: Some(decl.rust_type.syntax.clone()),
+                declared_source: Some(decl.rust_type.as_syn().clone()),
             });
         }
         dec
@@ -1488,13 +1488,13 @@ impl Declarations {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
         // was found, not a second source for what it says (#291).
-        let target = decl.rust_type.syntax.clone();
+        let target = decl.rust_type.spell().clone();
         let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
                 let item_fn = registry
                     .flat()
                     .function(&f)
-                    .map(|func| &func.origin.syntax)
+                    .map(|func| func.origin.as_syn())
                     .unwrap_or_else(|| {
                         panic!(
                             "convert!({}).input({f}): function not found among #[prebindgen] items",
@@ -1566,13 +1566,13 @@ impl Declarations {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
         // was found, not a second source for what it says (#291).
-        let target = decl.rust_type.syntax.clone();
+        let target = decl.rust_type.spell().clone();
         let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
                 let item_fn = registry
                     .flat()
                     .function(&g)
-                    .map(|func| &func.origin.syntax)
+                    .map(|func| func.origin.as_syn())
                     .unwrap_or_else(|| {
                         panic!(
                         "convert!({}).output({g}): function not found among #[prebindgen] items",

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -909,7 +909,7 @@ impl Declarations {
                 "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
                  not a struct — a value form returns a struct whose fields become the leaves",
                 key.as_str(),
-                ret.spell().to_token_stream(),
+                ret.spell(),
             )
         };
         let st = st.clone();
@@ -1082,7 +1082,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.spell().to_token_stream(),
+                        probe.spell(),
                     );
                     assert!(
                         field.ty.optional_inner().is_none(),
@@ -1095,7 +1095,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.spell().to_token_stream(),
+                        probe.spell(),
                         dotted,
                     );
                     // The name is the reading's, not a path taken apart to
@@ -1488,7 +1488,7 @@ impl Declarations {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
         // was found, not a second source for what it says (#291).
-        let target = decl.rust_type.spell().clone();
+        let target = decl.rust_type.spell();
         let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
                 let item_fn = registry
@@ -1566,7 +1566,7 @@ impl Declarations {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
         // was found, not a second source for what it says (#291).
-        let target = decl.rust_type.spell().clone();
+        let target = decl.rust_type.spell();
         let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
                 let item_fn = registry

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -29,7 +29,7 @@ pub(crate) enum TypeKind<'r, 'c> {
     /// The **element**, not its `syn::ItemStruct`. A flattening emitter wants
     /// each field's reading, and the model already decided one per field; going
     /// through the syntax means asking some other authority for it again. An
-    /// emitter that only re-emits the struct reads `st.origin.syntax`.
+    /// emitter that only re-emits the struct reads `st.origin.as_syn()`.
     DataStruct {
         st: &'r crate::api::core::flat::Struct,
         cfg: Option<&'c TypeConfig>,

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -49,7 +49,7 @@ pub(crate) fn callback_input(
     let arg_pat_ty: Vec<TokenStream> = args
         .iter()
         .map(|t| {
-            let t = t.syntax();
+            let t = t.spell();
             quote!(#t)
         })
         .collect();
@@ -312,10 +312,10 @@ pub(crate) fn callback_input(
     // memoized spec (`SpecKey::Callback`) the wrapper surface and the
     // interface declaration read, so it cannot drift from the jvalues above.
     // The memo key is spellings — `SpecKey` needs `Ord`, which a `TypeRef`
-    // cannot give. Keyed off each arg's own `origin.syntax`, which
+    // cannot give. Keyed off each arg's own `spell()`, which
     // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax` pins as
     // the SAME identity the signature-derived key produces.
-    let arg_spellings: Vec<syn::Type> = args.iter().map(|a| a.syntax().clone()).collect();
+    let arg_spellings: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
     let spec = ext.iface_spec(registry, &SpecKey::callback(&arg_spellings))?;
     let descr_lit = syn::LitStr::new(&spec.descr, Span::call_site());
     // Local-frame capacity: roughly an encoded wire + a wrapped object per

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -493,7 +493,7 @@ pub(crate) fn reach_leaf_flat(
     // disagreement would be a borrow handed to an owning converter; this is the
     // second reading, removed.
     let reached_is_ours = if leaf.identity {
-        !matches!(leaf.out_ty.syntax(), syn::Type::Reference(_))
+        !matches!(leaf.out_ty.as_syn(), syn::Type::Reference(_))
     } else {
         consuming
     };
@@ -744,7 +744,7 @@ pub(crate) fn bind_hoists(
 /// Rust spells that `Option<T>`, `Box<Option<T>>`, or something else — the flat
 /// model states the destination-language invariant, and the side interpreting
 /// it is the side that must accept any representation. Matching the reached
-/// place directly assumed one, which is `classify off kind, spell off syntax`
+/// place directly assumed one, which is `classify off kind, spell with spell()`
 /// broken in the direction nothing was watching: the classification was right
 /// and the *spelling* came from it too. `Box<Option<T>>` then produced
 /// `match &place { Some(..) => .. }` and `E0308` (#268).
@@ -997,7 +997,7 @@ pub(crate) fn encode_plan_leaves(
         let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
                 "jnigen unfold: leaf `{}` has no registered output converter",
-                TypeKey::from_type(leaf.out_ty.syntax())
+                TypeKey::from_type(leaf.out_ty.as_syn())
             )
         });
         let conv_fail = fail(quote!(__e.to_string()));
@@ -1060,7 +1060,7 @@ pub(crate) fn encode_plan_leaves(
                 panic!(
                     "jnigen unfold: identity leaf `{}` has no projection — \
                      `.accessor_record_id()` requires a ptr_class type",
-                    TypeKey::from_type(leaf.out_ty.syntax())
+                    TypeKey::from_type(leaf.out_ty.as_syn())
                 )
             });
             // The place this handle lives, when it is OURS to give away — the
@@ -1076,7 +1076,7 @@ pub(crate) fn encode_plan_leaves(
             // `Option` through the nullable branch's `match`, which moves the
             // whole `Option` in rather than borrowing it.
             let owned_place: Option<TokenStream> =
-                if !matches!(leaf.out_ty.syntax(), syn::Type::Reference(_))
+                if !matches!(leaf.out_ty.as_syn(), syn::Type::Reference(_))
                     && steps_are_movable(&path)
                 {
                     let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
@@ -1389,7 +1389,7 @@ pub(crate) fn leaf_is_prim(
     if leaf.nullable {
         return false;
     }
-    leaf_ty_is_prim(registry, leaf.out_ty.syntax())
+    leaf_ty_is_prim(registry, leaf.out_ty.as_syn())
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -75,7 +75,7 @@ pub(crate) fn struct_input_body(
                     // converter would yield `OwnedObject<T>`, which can't
                     // populate an owned field. `Option<_>` handle fields keep
                     // the niche-aware converter (jlong 0 ⇒ `None`).
-                    let field_ty = field.ty.syntax();
+                    let field_ty = field.ty.spell();
                     let decode = if field_optional {
                         quote! { let #fname_ident = #field_conv; }
                     } else {
@@ -424,7 +424,7 @@ fn read_kotlin_property(
     // segment, so a payload spelled `Box<Option<T>>` answered "not optional"
     // four separate times here (#289).
     let entry = registry.input_entry(reading)?;
-    let ty = reading.syntax();
+    let ty = reading.spell();
     let optional = reading.optional_inner().is_some();
     let inner = reading.optional_inner().unwrap_or(reading);
     let wire = entry.destination.clone();
@@ -1058,7 +1058,7 @@ fn build_flat_sum_field(
     field_reading: &TypeRef,
     leaves: &mut Vec<FlatLeaf>,
 ) -> Option<FlatFieldNode> {
-    let rust_ty = field_reading.syntax();
+    let rust_ty = field_reading.as_syn();
 
     // The NAME off the classification, and then the ELEMENT — `enum_item`
     // hands back only the `syn::ItemEnum`, deliberately, so a consumer that
@@ -1473,7 +1473,7 @@ fn build_flat_struct_node(
         // could (#273).
         let field_optional = field.ty.optional_inner().is_some();
         let nested = field.ty.optional_inner().unwrap_or(&field.ty);
-        let nested_ty = nested.syntax().clone();
+        let nested_ty = nested.as_syn().clone();
         // A data-carrying enum flattens into a tag plus one group per variant.
         // `None` means some payload is not leaf-shaped — fall through and let
         // it cross as one object through its own converter.
@@ -1567,7 +1567,7 @@ fn build_flat_struct_node(
                                 present_leaf: Some(present_index),
                                 direct_handle: None,
                                 optional_handle: false,
-                                rust_ty: Box::new(field.ty.syntax().clone()),
+                                rust_ty: Box::new(field.ty.as_syn().clone()),
                                 wrappers: field.ty.erased_wrappers(),
                             });
                             continue;
@@ -1617,7 +1617,7 @@ fn build_flat_struct_node(
                             present_leaf: Some(present_index),
                             direct_handle: None,
                             optional_handle: false,
-                            rust_ty: Box::new(field.ty.syntax().clone()),
+                            rust_ty: Box::new(field.ty.as_syn().clone()),
                             wrappers: field.ty.erased_wrappers(),
                         });
                         continue;
@@ -1645,9 +1645,9 @@ fn build_flat_struct_node(
                         field: fident,
                         value_leaf: value_index,
                         present_leaf: None,
-                        direct_handle: Some(Box::new(nested.syntax().clone())),
+                        direct_handle: Some(Box::new(nested.as_syn().clone())),
                         optional_handle,
-                        rust_ty: Box::new(field.ty.syntax().clone()),
+                        rust_ty: Box::new(field.ty.as_syn().clone()),
                         wrappers: field.ty.erased_wrappers(),
                     });
                     continue;
@@ -1678,7 +1678,7 @@ fn build_flat_struct_node(
                         present_leaf: None,
                         direct_handle: None,
                         optional_handle: false,
-                        rust_ty: Box::new(field.ty.syntax().clone()),
+                        rust_ty: Box::new(field.ty.as_syn().clone()),
                         wrappers: field.ty.erased_wrappers(),
                     });
                     continue;
@@ -1725,7 +1725,7 @@ fn build_flat_struct_node(
             present_leaf: None,
             direct_handle: None,
             optional_handle: false,
-            rust_ty: Box::new(field.ty.syntax().clone()),
+            rust_ty: Box::new(field.ty.as_syn().clone()),
             wrappers: field.ty.erased_wrappers(),
         });
     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -96,7 +96,7 @@ pub(crate) fn synth_value_struct_leaves(
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     for field in &s.fields {
         let fname = field.name.as_ref()?.clone();
-        let effective_ty = field.ty.syntax().clone();
+        let effective_ty = field.ty.as_syn().clone();
         let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
         let leaf_name = if name_prefix.is_empty() {
             camel

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -347,7 +347,7 @@ fn encode_group_leaf(
         panic!(
             "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
             leaf.name,
-            TypeKey::from_type(leaf.out_ty.syntax())
+            TypeKey::from_type(leaf.out_ty.as_syn())
         )
     });
     let wire = out_entry.destination.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -234,9 +234,9 @@ pub(crate) fn build_vec_build_helper_items(
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
     for elem_reading in collect_vec_build_elem_types(ext, registry) {
-        // Generated Rust spells `origin.syntax`; the reading is what the plan
+        // Generated Rust spells `spell()`; the reading is what the plan
         // and the key are taken from.
-        let elem = elem_reading.syntax();
+        let elem = elem_reading.spell();
         let Some(h) = vec_build_helpers(ext, registry, &elem_reading) else {
             continue;
         };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -142,7 +142,7 @@ pub(crate) fn synthetic_getter(
     ident: syn::Ident,
     ret: crate::api::core::flat::TypeRef,
 ) -> crate::api::core::flat::Function {
-    let ret_syntax = ret.syntax();
+    let ret_syntax = ret.spell();
     let item: syn::ItemFn = syn::parse_quote! {
         pub fn #ident() -> #ret_syntax {
             unimplemented!()
@@ -381,7 +381,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                      Reserved rather than refused for good: rebuilding through every \
                      transparent wrapper is #292 item 3 — until then, spell the return \
                      without it.",
-                    delivered.syntax().to_token_stream(),
+                    delivered.spell().to_token_stream(),
                     delivered.erased_wrappers().join("<"),
                 )
             });
@@ -598,7 +598,7 @@ fn emit_input_param(
         // by-value-handle consume below.
         InputKind::VecBuild { elem, by_ref } => {
             // Generated Rust spells the reading's own tokens.
-            let elem = elem.syntax();
+            let elem = elem.spell();
             let handle_ident = format_ident!("{}_handle", arg_ident);
             wire_params.push(quote!(#handle_ident: jni::sys::jlong));
             if *by_ref {
@@ -821,7 +821,7 @@ pub(crate) fn emit_expanded_param(
 
     debug_assert_eq!(plan.leaves.len(), leaves.len());
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
-        let leaf_ty = leaf.ty.syntax();
+        let leaf_ty = leaf.ty.as_syn();
         let lookup_entry = || {
             // The leaf's own reading goes straight to the entry: spelling it and
             // looking the same reading back up is the round trip #286 removed.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -381,7 +381,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                      Reserved rather than refused for good: rebuilding through every \
                      transparent wrapper is #292 item 3 — until then, spell the return \
                      without it.",
-                    delivered.spell().to_token_stream(),
+                    delivered.spell(),
                     delivered.erased_wrappers().join("<"),
                 )
             });

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -67,7 +67,7 @@ pub(crate) enum ParamForm {
 pub(crate) struct PlanLeaf {
     /// The leaf's **reading** — classification and spelling in one value, so
     /// the two cannot disagree and no consumer has to look the type up. Spell
-    /// with `reading.origin.syntax`.
+    /// with `reading.spell()`.
     pub reading: TypeRef,
     /// Kotlin parameter name (`kt_param_name(ident)`: camelCase +
     /// hard-keyword escaping) — shared by the wrapper signature and the
@@ -111,7 +111,7 @@ pub(crate) enum InputKind {
     /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
     /// Vec-handle on the wire, built by pushing element leaves.
     /// The element as a **reading**: the vec-helper plan and the element key
-    /// are both taken from it, and generated Rust spells `elem.syntax()`.
+    /// are both taken from it, and generated Rust spells `elem.spell()`.
     VecBuild { elem: TypeRef, by_ref: bool },
     /// Bare `Option<primitive>` / `Option<enum>`: a decoupled
     /// `(present: jboolean, value: <wire>)` pair.
@@ -491,7 +491,7 @@ impl JniFunctionPlan {
         // fail to yield a type.
         for param in &f.params {
             let ident = param.name.clone();
-            let ty = param.ty.syntax().clone();
+            let ty = param.ty.as_syn().clone();
 
             let form = if let Some(plan) = registry
                 .expansion_plans()
@@ -612,7 +612,7 @@ fn classify_leaf(
         // rather than one re-extracted from the parameter's bounds.
         // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax`
         // pins that the two routes are one memo identity.
-        let arg_tys: Vec<syn::Type> = args.iter().map(|a| a.syntax().clone()).collect();
+        let arg_tys: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
         let iface = ext.iface_spec(registry, &SpecKey::callback(&arg_tys));
         return Ok(PlanLeaf {
             reading: reading.clone(),
@@ -752,7 +752,7 @@ fn build_output(
     let is_convert = unfold_plan.is_some();
     // The element normalizes an elided return and a written `-> ()` to one
     // `Unit` reading, so there is no `ReturnType` match here.
-    let return_ty: syn::Type = f.ret.syntax().clone();
+    let return_ty: syn::Type = f.ret.as_syn().clone();
     let error_plan = registry.error_plans().get(ident);
     let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
     let target_ty = match unfold_plan {
@@ -786,7 +786,7 @@ fn build_output(
     let ret_decl: syn::ReturnType = if is_convert {
         syn::parse_quote!(-> #target_ty)
     } else {
-        let ret = f.ret.syntax();
+        let ret = f.ret.spell();
         syn::parse_quote!(-> #ret)
     };
     let (surface, canonical) = ReturnSurface::classify(ext, registry, &ret_decl);

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -21,7 +21,7 @@ use crate::api::core::flat::TypeRef;
 /// Borrowing rather than composing is not a shortcut: every layer of a reading
 /// already holds the next as a `TypeRef` of its own, so there is nothing to
 /// mint — which is also why this needs no registry. What it returns spells
-/// itself (`origin.syntax`) and classifies itself (`kind`), and the two cannot
+/// itself (`spell()`) and classifies itself (`kind`), and the two cannot
 /// disagree.
 pub(crate) fn enum_probe(reading: &TypeRef) -> &TypeRef {
     let mut cur = reading;

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -720,12 +720,12 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, leaf.out_ty.syntax());
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, leaf.out_ty.as_syn());
     leaf_iface_param(
         ext,
         registry,
         name,
-        leaf.out_ty.syntax(),
+        leaf.out_ty.as_syn(),
         leaf.nullable || inert_nullable,
         true,
     )
@@ -1024,7 +1024,7 @@ fn derive_iface_spec(
         // above: the memo key holds an identity, and the reading behind it is a
         // lookup. `None` defers, exactly as it does there (#291).
         SpecKey::WholeFolder(el_key) => {
-            whole_folder_iface_spec(ext, registry, registry.reading(el_key)?.syntax())
+            whole_folder_iface_spec(ext, registry, registry.reading(el_key)?.as_syn())
         }
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
@@ -1166,12 +1166,12 @@ pub(crate) fn callback_iface_spec(
                 any_fixed = true;
                 // Peeled off the reading — `borrow_target` is the model's
                 // answer to "is this a borrow", not a syn match.
-                let core = t.borrow_target().unwrap_or(t).syntax().clone();
+                let core = t.borrow_target().unwrap_or(t).as_syn().clone();
                 let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
                 let (reassemble, imports) =
                     fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
                 groups.push(GroupDesc {
-                    name: whole_value_name(t.syntax(), i),
+                    name: whole_value_name(t.as_syn(), i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
                     reassemble: Some(reassemble),
                     imports,
@@ -1197,11 +1197,11 @@ pub(crate) fn callback_iface_spec(
                     };
                     if leaf.source == LeafSource::SumTag {
                         any_fixed = true;
-                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(leaf.out_ty.syntax()))?;
+                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(leaf.out_ty.as_syn()))?;
                         let (reassemble, imports) = fixed_reassembly(
                             ext,
                             registry,
-                            leaf.out_ty.syntax(),
+                            leaf.out_ty.as_syn(),
                             &plan.leaves[k..seg],
                             &fqn,
                         );
@@ -1248,13 +1248,13 @@ pub(crate) fn callback_iface_spec(
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
-                name: whole_value_name(t.syntax(), i),
-                ty: t.syntax().clone(),
+                name: whole_value_name(t.as_syn(), i),
+                ty: t.as_syn().clone(),
                 nullable: t.optional_inner().is_some(),
                 owned_handle,
             });
             groups.push(GroupDesc {
-                name: whole_value_name(t.syntax(), i),
+                name: whole_value_name(t.as_syn(), i),
                 typed: None,
                 reassemble: None,
                 imports: Vec::new(),
@@ -1311,14 +1311,14 @@ pub(crate) fn callback_iface_spec(
             "{}Callback",
             cb_args
                 .iter()
-                .map(|t| subject_short(t.syntax()))
+                .map(|t| subject_short(t.as_syn()))
                 .collect::<Vec<_>>()
                 .join("")
         )
     };
     let package = cb_args
         .first()
-        .map(|t| subject_package(ext, t.syntax()))
+        .map(|t| subject_package(ext, t.as_syn()))
         .unwrap_or_else(|| ext.package.clone());
     Some(IfaceSpec {
         typed_groups,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -575,8 +575,8 @@ impl Declarations {
     ) -> KtClass {
         // Everything below comes off the element: `alternatives` for the
         // classes, `Field::member()` for the property names. The docs and the
-        // framework line are spelling, so they read `origin.syntax`.
-        let item_enum = &sum.origin.syntax;
+        // framework line are spelling, so they read `spell()`.
+        let item_enum = sum.origin.as_syn();
         let framework_line = format!(
             "JVM-side surface for the native Rust `{}` sum: exactly one alternative is live.",
             item_enum.ident
@@ -599,7 +599,8 @@ impl Declarations {
             }
             .vis(Vis::Public)
             .supertype(KtType::cls(class_name), None);
-            if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&alt.origin.syntax.attrs)
+            if let Some(doc) =
+                crate::api::lang::jnigen::util::doc_string(&alt.origin.as_syn().attrs)
             {
                 vclass = vclass.kdoc(doc);
             }
@@ -750,7 +751,7 @@ impl Declarations {
         // The field's own reading: the nullability question below is answered
         // from `kind`, so a wrapped spelling answers as the bare one does and
         // nothing is looked up (#275).
-        let field_ty = field.ty.syntax();
+        let field_ty = field.ty.spell();
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
         let out = registry.output_entry(&field.ty).unwrap_or_else(|| {
             panic!(
@@ -1032,11 +1033,11 @@ impl Declarations {
                 let Some(func) = registry.flat().function(&ident) else {
                     continue;
                 };
-                let item_fn = &func.origin.syntax;
+                let item_fn = func.origin.as_syn();
                 for p in &func.params {
                     if let Some(cb_args) = p.ty.callback_args() {
                         let arg_tys: Vec<syn::Type> =
-                            cb_args.iter().map(|a| a.syntax().clone()).collect();
+                            cb_args.iter().map(|a| a.as_syn().clone()).collect();
                         uses.insert(SpecKey::callback(&arg_tys));
                     }
                 }
@@ -1580,7 +1581,7 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            reject_handle_const(self, &item_const.origin.syntax);
+            reject_handle_const(self, item_const.origin.as_syn());
             if let Some((helper, prop)) = render_const_val(
                 self,
                 &package,
@@ -1608,7 +1609,7 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            validate_constant_fn(self, &item_fn.origin.syntax);
+            validate_constant_fn(self, item_fn.origin.as_syn());
             if let Some((helper, prop)) = render_constant_fn_val(
                 self,
                 &package,

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -62,7 +62,7 @@ impl Declarations {
             if decl.no_split || decl.variants.len() < 2 {
                 continue;
             }
-            let target = decl.rust_type.syntax.clone();
+            let target = decl.rust_type.as_syn().clone();
             let sigs: Vec<(String, Vec<ErasedJvmType>)> = decl
                 .variants
                 .iter()
@@ -117,7 +117,7 @@ fn arm_erased_sig(
         Some(cf) => match registry
             .flat()
             .function(&cf)
-            .map(|func| &func.origin.syntax)
+            .map(|func| func.origin.as_syn())
         {
             Some(item_fn) => item_fn
                 .sig
@@ -262,7 +262,7 @@ fn variant_typed_params(
             let item_fn = registry
                 .flat()
                 .function(&cf)
-                .map(|func| &func.origin.syntax)?;
+                .map(|func| func.origin.as_syn())?;
             let optional = item_fn
                 .sig
                 .inputs

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -166,7 +166,8 @@ pub(crate) fn build_data_class(
     });
 
     let mut class = kt::KtClass::new(kt::ClassKind::Data, class_name).vis(kt::Vis::Public);
-    if let Some(doc) = crate::api::lang::jnigen::util::doc_string(&item_struct.origin.syntax.attrs)
+    if let Some(doc) =
+        crate::api::lang::jnigen::util::doc_string(&item_struct.origin.as_syn().attrs)
     {
         class = class.kdoc(doc);
     }
@@ -894,7 +895,7 @@ pub(crate) fn render_const_val(
          the generated JNI getter on first use).",
         c.name
     );
-    let kdoc = crate::api::lang::jnigen::util::doc_string(&c.origin.syntax.attrs)
+    let kdoc = crate::api::lang::jnigen::util::doc_string(&c.origin.as_syn().attrs)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
@@ -924,7 +925,7 @@ pub(crate) fn render_constant_fn_val(
          through the generated JNI wrapper on first use).",
         f.name
     );
-    let kdoc = crate::api::lang::jnigen::util::doc_string(&f.origin.syntax.attrs)
+    let kdoc = crate::api::lang::jnigen::util::doc_string(&f.origin.as_syn().attrs)
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
@@ -1069,7 +1070,7 @@ fn classify_params(
     let mut params: Vec<Param> = Vec::new();
     for leaf in fplan.leaves() {
         let mut name = leaf.kt_name.clone();
-        let arg_ty = leaf.reading.syntax();
+        let arg_ty = leaf.reading.as_syn();
 
         // Instance-method receiver: the first parameter whose peeled Rust type
         // is the owning class binds to `this` (so `this_ptr`/`this.ptr`/lock or
@@ -2243,7 +2244,7 @@ fn wrapper_kdoc(
     f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
 ) -> Option<String> {
-    let prose = crate::api::lang::jnigen::util::doc_string(&f.origin.syntax.attrs);
+    let prose = crate::api::lang::jnigen::util::doc_string(&f.origin.as_syn().attrs);
     let notes = shape_notes(f, registry);
     match (prose, notes) {
         (Some(p), Some(n)) => Some(format!("{p}\n\n{n}")),
@@ -2353,7 +2354,7 @@ pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Optio
     let attrs = registry
         .flat()
         .struct_type(&name)
-        .map(|s| s.origin.syntax.attrs.as_slice())
+        .map(|s| s.origin.as_syn().attrs.as_slice())
         .or_else(|| registry.flat().enum_item(&name).map(|e| e.attrs.as_slice()))?;
     crate::api::lang::jnigen::util::doc_string(attrs)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -48,7 +48,7 @@ impl Declarations {
         // comes from here. The converter yields this spelling, so a
         // `Box<Option<T>>` crossing produces a `Box<Option<T>>` — the shape it
         // is dispatched as no longer decides what it is called.
-        let syntax = ty.syntax();
+        let syntax = ty.as_syn();
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
         if let Some(c) = self.input_terminal(ty, registry) {
@@ -70,7 +70,7 @@ impl Declarations {
                     target,
                     registry,
                 ) {
-                    c.subs = vec![target.syntax().clone()];
+                    c.subs = vec![target.as_syn().clone()];
                     return Some(c);
                 }
             }
@@ -82,7 +82,7 @@ impl Declarations {
             // wrapped optional borrow stops here rather than resolving wrong.
             if inner.borrow_target().is_some() {
                 let canonical: syn::Type = {
-                    let b = inner.syntax();
+                    let b = inner.spell();
                     syn::parse_quote!(Option<#b>)
                 };
                 if syntax.to_token_stream().to_string() != canonical.to_token_stream().to_string() {
@@ -92,7 +92,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Optional, syntax, inner, registry)
             {
-                c.subs = vec![inner.syntax().clone()];
+                c.subs = vec![inner.as_syn().clone()];
                 return Some(c);
             }
             return None;
@@ -101,7 +101,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Sequence, syntax, elem, registry)
             {
-                c.subs = vec![elem.syntax().clone()];
+                c.subs = vec![elem.as_syn().clone()];
                 return Some(c);
             }
             return None;
@@ -130,9 +130,9 @@ impl Declarations {
             // NOT: passing `&Vec<T>` there does not compile. Those fall through to
             // the plain borrow arm below, which hands the whole spelling on as the
             // sub, exactly as the old syntactic slice check did.
-            if !*mutable && decoded_vec_satisfies(inner.syntax()) {
+            if !*mutable && decoded_vec_satisfies(inner.as_syn()) {
                 if let Some(elem) = inner.sequence_elem() {
-                    let elem_ty = elem.syntax().clone();
+                    let elem_ty = elem.as_syn().clone();
                     // The one place `produced` is NOT the crossing's spelling:
                     // there is no owned `[T]` to decode into, so the converter
                     // yields an owned `Vec<T>` and the call site borrows it.
@@ -159,7 +159,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, inner, registry)
             {
-                c.subs = vec![inner.syntax().clone()];
+                c.subs = vec![inner.as_syn().clone()];
                 return Some(c);
             }
         }
@@ -182,7 +182,7 @@ impl Declarations {
         // detected its layers with `option_inner_type`/`vec_inner_type`, which
         // read the last path segment's ident. A `Box<Option<T>>` answered
         // "neither", and got no converter at all (#270).
-        let syntax = ty.syntax();
+        let syntax = ty.as_syn();
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
         if let Some(c) = self.output_terminal(ty, registry) {
@@ -205,7 +205,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Optional, syntax, inner, registry)
             {
-                c.subs = vec![inner.syntax().clone()];
+                c.subs = vec![inner.as_syn().clone()];
                 return Some(c);
             }
             return None;
@@ -214,7 +214,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Sequence, syntax, elem, registry)
             {
-                c.subs = vec![elem.syntax().clone()];
+                c.subs = vec![elem.as_syn().clone()];
                 return Some(c);
             }
             return None;
@@ -227,16 +227,16 @@ impl Declarations {
             // input branch, and the same split: `kind` says it is a borrow of a
             // run of values; whether the generated Rust can iterate the borrow
             // directly is a question about the SPELLING.
-            if !*mutable && decoded_vec_satisfies(inner.syntax()) {
+            if !*mutable && decoded_vec_satisfies(inner.as_syn()) {
                 if let Some(elem) = inner.sequence_elem() {
-                    return self.output_slice(elem.syntax(), registry);
+                    return self.output_slice(elem.as_syn(), registry);
                 }
             }
             let mutable = ty.is_exclusive_borrow();
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, inner, registry)
             {
-                c.subs = vec![inner.syntax().clone()];
+                c.subs = vec![inner.as_syn().clone()];
                 return Some(c);
             }
         }
@@ -269,7 +269,7 @@ fn fallible_parts(
         .type_ref(ty)
         .and_then(|t| t.fallible_parts())
     {
-        return Some((ok.syntax().clone(), err.syntax().clone()));
+        return Some((ok.as_syn().clone(), err.as_syn().clone()));
     }
     crate::api::core::types_util::result_parts(ty)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -225,7 +225,7 @@ pub(crate) fn classify_field(
     // classified this type. Taking a `syn::Type` meant asking the registry per
     // question, and a type it had never seen answered "no layer" rather than
     // saying so — which is the missing `?` of #273 waiting to happen again.
-    let effective_ty = reading.syntax().clone();
+    let effective_ty = reading.as_syn().clone();
 
     // A sum is classified FIRST, because it is the one kind with no converter
     // of its own: it crosses as a tag plus one leaf group per variant, never
@@ -244,9 +244,9 @@ pub(crate) fn classify_field(
     // other about the same field (#273).
     let optional_inner = reading.optional_inner();
     let bare_ref = optional_inner.unwrap_or(reading);
-    let bare = bare_ref.syntax().clone();
+    let bare = bare_ref.as_syn().clone();
     let seq_elem = bare_ref.sequence_elem();
-    let core = seq_elem.map_or_else(|| bare.clone(), |e| e.syntax().clone());
+    let core = seq_elem.map_or_else(|| bare.clone(), |e| e.as_syn().clone());
     if matches!(ext.type_kind(registry, &core), TypeKind::Sum) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -272,7 +272,7 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
         if let Some(s) = registry
             .flat()
             .struct_type(&ident)
-            .map(|st| &st.origin.syntax)
+            .map(|st| st.origin.as_syn())
         {
             for f in &s.fields {
                 if let Some(fname) = &f.ident {

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -587,7 +587,7 @@ fn fn_plan_memo_shares_one_derivation() {
 /// `SourceLocation`, so two identical readings from different files would
 /// compare unequal). That means the args reach `SpecKey::callback` as
 /// spellings, and #275's last part changes *which* spelling: from
-/// `extract_fn_trait_args(&pt.ty)` to each arg `TypeRef`'s `origin.syntax`.
+/// `extract_fn_trait_args(&pt.ty)` to each arg `TypeRef`'s `spell()`.
 ///
 /// If those two disagreed, the memo would split one interface identity into
 /// two — an extra generated `fun interface` and a descriptor mismatch. Nothing
@@ -632,11 +632,11 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
     let from_reading = SpecKey::callback(
         &arg_readings
             .iter()
-            .map(|a| a.syntax().clone())
+            .map(|a| a.as_syn().clone())
             .collect::<Vec<_>>(),
     );
     let from_syntax = SpecKey::callback(
-        &crate::api::core::registry::extract_fn_trait_args(param.ty.syntax())
+        &crate::api::core::registry::extract_fn_trait_args(param.ty.as_syn())
             .expect("the param is an impl Fn"),
     );
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -241,7 +241,7 @@ fn deriving_matches_the_equivalent_hand_written_list() {
             .map(|l| {
                 (
                     l.name.clone(),
-                    l.out_ty.syntax().to_token_stream().to_string(),
+                    l.out_ty.spell().to_token_stream().to_string(),
                 )
             })
             .collect()

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -238,12 +238,7 @@ fn deriving_matches_the_equivalent_hand_written_list() {
             .callback_arg_plans
             .values()
             .flat_map(|p| p.leaves.iter())
-            .map(|l| {
-                (
-                    l.name.clone(),
-                    l.out_ty.spell().to_token_stream().to_string(),
-                )
-            })
+            .map(|l| (l.name.clone(), l.out_ty.spell().to_string()))
             .collect()
     };
 

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1778,11 +1778,11 @@ fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
     // The difference from the spelling-keyed probe, pinned: a transparent
     // wrapper is invisible to the model and decisive for a canonical key.
     assert!(
-        !ext.is_kotlin_enum(field("borrowed").syntax()),
+        !ext.is_kotlin_enum(field("borrowed").as_syn()),
         "if the spelling key ever started seeing through `Box`, this test would \
          stop distinguishing the two probes"
     );
-    assert!(ext.is_kotlin_enum(field("plain").syntax()));
+    assert!(ext.is_kotlin_enum(field("plain").as_syn()));
 }
 
 /// A **transparently-wrapped** parameter takes the same specialized lowering as

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -579,7 +579,7 @@ pub(crate) fn build_handle_destructor_items(
         if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none() {
             continue;
         }
-        let ty = reading.syntax().clone();
+        let ty = reading.spell().clone();
         let class_fqn = cfg
             .name_spec
             .as_ref()
@@ -640,8 +640,8 @@ pub(crate) fn build_handle_destructor_items(
 /// (#270) — even though the model classifies it `Optional` and says so.
 ///
 /// So the shape comes from [`TypeKind`](crate::api::core::flat::TypeKind) and
-/// the spelling comes from `origin.syntax`, which is the same split the rest of
-/// the pipeline follows: classify off `kind`, spell off `syntax`.
+/// the spelling comes from `spell()`, which is the same split the rest of
+/// the pipeline follows: classify off `kind`, spell with `spell()`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum WrapperShape {
     /// `Ref` — a borrow of its inner.
@@ -889,7 +889,7 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions; the
         // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.syntax();
+        let t1_ty = t1.as_syn();
         let WrapperShape::Borrow { mutable } = shape else {
             return None;
         };
@@ -948,7 +948,7 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions; the
         // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.syntax();
+        let t1_ty = t1.as_syn();
         let WrapperShape::OptionRef { mutable } = shape else {
             return None;
         };
@@ -1019,7 +1019,7 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions; the
         // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.syntax();
+        let t1_ty = t1.as_syn();
         if shape != WrapperShape::Sequence {
             return None;
         }
@@ -1090,7 +1090,7 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions; the
         // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.syntax();
+        let t1_ty = t1.as_syn();
         if shape == WrapperShape::Optional {
             let inner = registry.input_entry(t1)?;
             if inner.metadata.is_direct_handle() {
@@ -1455,7 +1455,7 @@ impl Declarations {
             // the declare phase, where a `reading()` would legitimately answer
             // `None` for a type nothing has interned yet — the declaration is
             // the only thing that can say (#291).
-            let source = self.types[key].rust_type.syntax.clone();
+            let source = self.types[key].rust_type.as_syn().clone();
             let Some(ident) = bare_path_ident(&source) else {
                 continue;
             };
@@ -1488,7 +1488,7 @@ impl Declarations {
             // `Vec<T>` / `Option<Vec<T>>` return. The model's `ret` already
             // normalizes an elided return to `()`, so there is no arm for it.
             {
-                let ret = f.ret.syntax();
+                let ret = f.ret.as_syn();
                 let after_opt =
                     crate::api::core::types_util::option_inner_type(ret).unwrap_or(ret.clone());
                 if let Some(elem) = crate::api::core::types_util::vec_inner_type(&after_opt) {
@@ -1503,7 +1503,7 @@ impl Declarations {
                     continue;
                 };
                 for arg in args {
-                    if let syn::Type::Slice(s) = &peel_leading_ref(arg.syntax()) {
+                    if let syn::Type::Slice(s) = &peel_leading_ref(arg.as_syn()) {
                         consider(peel_leading_ref(&s.elem));
                     }
                 }
@@ -1519,7 +1519,7 @@ impl Declarations {
         args: &[crate::api::core::flat::TypeRef],
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let spellings: Vec<syn::Type> = args.iter().map(|a| a.syntax().clone()).collect();
+        let spellings: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
         let outer_ty = build_fn_type(&spellings);
         let (wire, body) = callback_input(self, args, registry)?;
         let niches = default_niches_for_wire(&wire);
@@ -1570,7 +1570,7 @@ impl Prebindgen for Declarations {
                 let Some(item_fn) = binding
                     .flat()
                     .function(&m.rust_ident)
-                    .map(|func| &func.origin.syntax)
+                    .map(|func| func.origin.as_syn())
                 else {
                     continue;
                 };
@@ -1643,7 +1643,7 @@ impl Prebindgen for Declarations {
             let Some(func) = binding.flat().function(&ident) else {
                 continue;
             };
-            let item_fn = &func.origin.syntax;
+            let item_fn = func.origin.as_syn();
             // (1) A sum in the `Ok` position of a fallible return. A sum is
             // delivered DECOMPOSED through a builder callback, and the
             // `Result` lane has no builder: a `Result` return deliberately
@@ -1726,7 +1726,7 @@ impl Prebindgen for Declarations {
                     continue;
                 };
                 for arg in args {
-                    let after_ref = match arg.syntax() {
+                    let after_ref = match arg.as_syn() {
                         syn::Type::Reference(r) => (*r.elem).clone(),
                         other => other.clone(),
                     };
@@ -1891,13 +1891,13 @@ impl Prebindgen for Declarations {
         c: &crate::api::core::flat::Constant,
         registry: &Registry<KotlinMeta>,
     ) -> TokenStream {
-        reject_handle_const(self, &c.origin.syntax);
+        reject_handle_const(self, c.origin.as_syn());
         let getter = const_getter_fn(c);
         let const_ident = &c.name;
         let source_module = self.fn_module(registry, const_ident);
         let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
         let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
-        let alias = crate::api::core::const_path_alias(&c.origin.syntax, &source_module);
+        let alias = crate::api::core::const_path_alias(c.origin.as_syn(), &source_module);
         quote! {
             #alias
             #wrapper
@@ -1919,10 +1919,10 @@ impl Declarations {
         reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Classify off `kind`, spell off `syntax`: the arms below that ask what
+        // Classify off `kind`, spell with `spell()`: the arms below that ask what
         // a type IS use `reading`, and everything that has to name it in
         // generated Rust uses this.
-        let ty = reading.syntax();
+        let ty = reading.as_syn();
         // Structured-config overrides first (opaque handles, then user-
         // registered rank-0 wrappers, then built-ins).
         let key = TypeKey::from_type(ty);
@@ -2149,7 +2149,7 @@ impl Declarations {
         if reading.erased_wrappers().is_empty() {
             return None;
         }
-        let produced = reading.syntax();
+        let produced = reading.as_syn();
         let stripped = reading.stripped_syntax();
         // A wrapper over a **borrow** is refused here too, and outbound the
         // reason is its own: a borrow's output route is the clone-into-a-fresh-
@@ -2220,7 +2220,7 @@ impl Declarations {
         if reading.erased_wrappers().is_empty() {
             return None;
         }
-        let produced = reading.syntax();
+        let produced = reading.as_syn();
         // The spelling under every wrapper — by the model's own definition, the
         // one whose lowering yields this `kind`.
         let stripped = reading.stripped_syntax();
@@ -2305,8 +2305,8 @@ impl Declarations {
         reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Classify off `kind`, spell off `syntax` — see `input_terminal`.
-        let ty = reading.syntax();
+        // Classify off `kind`, spell with `spell()` — see `input_terminal`.
+        let ty = reading.as_syn();
         // Structured-config overrides first (opaque handles, then built-ins).
         let key = TypeKey::from_type(ty);
         if let Some(cfg) = self.types.get(&key) {
@@ -2477,7 +2477,7 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions; the
         // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.syntax();
+        let t1_ty = t1.as_syn();
         // Borrowed opaque-handle output (`&T` / `&'static T` where `T` is a
         // declared opaque handle). Canonical zenoh-flat's `z_*` accessors
         // return *borrowed* handles for the C tier's zero-copy borrows, but

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -579,7 +579,7 @@ pub(crate) fn build_handle_destructor_items(
         if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none() {
             continue;
         }
-        let ty = reading.spell().clone();
+        let ty = reading.spell();
         let class_fqn = cfg
             .name_spec
             .as_ref()


### PR DESCRIPTION
The `TypeKind` pivot put every source fact in the model. The door stayed
open: `TypeRef::syntax()` handed out a `&syn::Type`, `Origin::syntax` was
a public field, and any consumer could still take the source apart
instead of asking. The boundary ledger *measured* that — 116 sites — and
its own header listed three kinds of classification it cannot see.

So the model stops handing out nodes:

    Origin::syntax   pub -> pub(super)
    Origin::spell()  -> TokenStream    output — free
    Origin::as_syn() -> &S             THE escape — counted

`TypeRef::syntax()` is **replaced** by `spell()` and `as_syn()`, and
`Element`/`Type::syntax()` become `as_syn()`. Removing the old name is
the point: each of its call sites had to say which of the two it meant,
and the compiler asked one by one — 260 of them.

**No `ToTokens` on `Origin`.** That trait is what made `quote!(#node)`
compile, and it hands `to_token_stream().to_string()` over with it —
a classifier's input in a spelling's clothing. A `TokenStream`
interpolates just as well one `let` earlier. It does not make a token
string impossible (`spell().to_string()` reaches one, and `domain.rs`
classifies a `syn::Type` a *build script* supplied, which the seal never
covers); it makes one **say so**.

## The ledger counts the door, not just the grep

    # total classification sites: 116   (unchanged — nothing reclassified)
    # total escapes: types:       115   MUST reach zero
    # total escapes: items:        28   expected to persist

A file with no escapes cannot classify source syntax *however it is
written*, so the blind spots that had no watched site — an ident compared
by name, a helper handed the node, a syn enum outside `WATCHED` — are
gated behind the same call. That is what widening `WATCHED` was trying to
approximate.

The bucket is read off the receiver: `origin` means a captured item's own
node, anything else means a type. Two over-counts land in the type bucket
deliberately, both in the safe direction — adapter declarations reuse
`Origin` for a placeless location, and carrying a spelling into an
adapter-owned `syn::Type` field is not classification either. The header
says so rather than implying it away.

## What the escape count is made of

Three kinds, and only the first is classification: taking a node apart
(what the first section already sees), keying by spelling
(`TypeKey::from_type` where `TypeRef::key()` is the answer), and carrying
a spelling into a `syn::Type`-typed adapter field (`ConverterImpl::subs`
/ `produced`). Each is a follow-up the count now names. This PR rewrites
no classifier.

**Did not move**: every generated artifact byte-identical, classification
counts unchanged, 643 lib tests + 22 doctests green, clippy + fmt clean
on 1.85.0 and stable.