### PR TITLE
S2: a declaration carries identity, a plan carries a reading

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -64,7 +64,9 @@ pub enum Variant {
 /// of the `variants` vector.
 #[derive(Clone)]
 pub struct ConstructorDecl {
-    pub target: syn::Type,
+    /// The type being built, as an **identity**. Every use keyed it; none
+    /// spelled it.
+    pub target: TypeKey,
     pub variants: Vec<Variant>,
     /// Auto-`construct` every matching param of every declared fn. Always
     /// `true` for type-level default (`expand_param!` `.variant*`) declarations.
@@ -95,7 +97,7 @@ pub struct ExpandDecl {
     /// cross-checked against the named param's peeled type in [`apply`].
     /// `None` for the internal `TopLevel` form (the type comes from the
     /// param itself).
-    pub declared_target: Option<syn::Type>,
+    pub declared_target: Option<TypeKey>,
     pub sel: ExpandSel,
 }
 
@@ -126,7 +128,7 @@ fn validate_declarations(exp: &Expansions) -> Result<(), ExpandError> {
     let mut entries: Vec<ExpandDeclError> = Vec::new();
     let mut ctor_targets: HashSet<String> = HashSet::new();
     for c in &exp.constructors {
-        let target = TypeKey::from_type(&c.target).as_str().to_string();
+        let target = c.target.as_str().to_string();
         if c.variants.is_empty() {
             entries.push(ExpandDeclError::EmptyConstructor {
                 target: target.clone(),
@@ -192,11 +194,11 @@ pub fn apply<M>(
         if let Some(declared) = &ed.declared_target {
             let param_ty = param_reading(registry, &ed.func, &ed.param)?;
             let bare = constructed_value(&param_ty);
-            if TypeKey::from_type(&bare) != TypeKey::from_type(declared) {
+            if TypeKey::from_type(&bare) != *declared {
                 return Err(ExpandError::ParamTypeMismatch {
                     func: ed.func.clone(),
                     param: ed.param.clone(),
-                    declared: TypeKey::from_type(declared).as_str().to_string(),
+                    declared: declared.as_str().to_string(),
                     actual: TypeKey::from_type(&bare).as_str().to_string(),
                 });
             }
@@ -221,7 +223,7 @@ pub fn apply<M>(
         if !c.default {
             continue;
         }
-        let ckey = TypeKey::from_type(&c.target);
+        let ckey = c.target.clone();
         for func in declared_fns {
             // Read accessors are excluded from the composer.
             if accessor_fns.contains(func) {
@@ -336,7 +338,7 @@ fn resolve_constructor<M>(
         ExpandSel::TopLevel => exp
             .constructors
             .iter()
-            .find(|c| TypeKey::from_type(&c.target) == *target_key)
+            .find(|c| c.target == *target_key)
             .map(|c| c.variants.clone())
             .ok_or_else(|| ExpandError::NoConstructor {
                 func: ed.func.clone(),
@@ -429,7 +431,7 @@ fn build_plan<M>(
             )?;
             visited.remove(&target.key());
             return Ok(FoldPlan {
-                target: target.as_syn().clone(),
+                target: target.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -447,7 +449,7 @@ fn build_plan<M>(
                 ty: pty.optional(),
             });
             return Ok(FoldPlan {
-                target: target.as_syn().clone(),
+                target: target.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
@@ -491,7 +493,7 @@ fn build_plan<M>(
             inputs.push(arg);
         }
         return Ok(FoldPlan {
-            target: target.as_syn().clone(),
+            target: target.clone(),
             by_ref,
             shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
             leaves,
@@ -523,7 +525,7 @@ fn build_plan<M>(
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
-        target: target.as_syn().clone(),
+        target: target.clone(),
         by_ref,
         shape: FoldShape::Base,
         leaves,
@@ -656,7 +658,7 @@ fn build_arg<M>(
     let canon = exp
         .constructors
         .iter()
-        .find(|c| TypeKey::from_type(&c.target) == key && !c.variants.is_empty());
+        .find(|c| c.target == key && !c.variants.is_empty());
     if let Some(c) = canon {
         if dispatched {
             return Err(ExpandError::UnsupportedRecursive {
@@ -689,7 +691,7 @@ fn build_arg<M>(
         )?;
         visited.remove(&key);
         Ok(FoldArg::Build(Box::new(FoldBuild {
-            target: bare.as_syn().clone(),
+            target: bare.clone(),
             by_ref: pby_ref,
             selector,
             variants: vars,

--- a/prebindgen/src/api/core/expand/plan.rs
+++ b/prebindgen/src/api/core/expand/plan.rs
@@ -17,8 +17,9 @@ pub use crate::api::core::shape::Shape as FoldShape;
 #[derive(Clone)]
 pub struct FoldPlan {
     /// Owned type the core construct produces — what the underlying call needs
-    /// (before any [`Self::shape`] wrapping).
-    pub target: syn::Type,
+    /// (before any [`Self::shape`] wrapping). A **reading**: `target.spell()`
+    /// for generated Rust, `target.key()` for a lookup.
+    pub target: crate::api::core::flat::TypeRef,
     /// True when the original parameter was `&T` / `Option<&T>`: the call
     /// receives `&folded` (or `folded.as_ref()` when also optional). A
     /// call-site concern (the resolver's `&_` handler shares the inner
@@ -118,7 +119,7 @@ pub enum FoldArg {
 #[derive(Clone)]
 pub struct FoldBuild {
     /// Owned type this nested build produces (the constructor parameter type).
-    pub target: syn::Type,
+    pub target: crate::api::core::flat::TypeRef,
     /// `true` when the consuming parameter is `&T` (the built value is borrowed
     /// at the call site).
     pub by_ref: bool,

--- a/prebindgen/src/api/core/expand/tests.rs
+++ b/prebindgen/src/api/core/expand/tests.rs
@@ -2,6 +2,12 @@ use quote::ToTokens;
 
 use super::*;
 
+/// A fixture declaration's identity. A declaration is a key, not a spelling —
+/// see `ConstructorDecl::target`.
+fn key(s: &str) -> crate::api::core::registry::TypeKey {
+    crate::api::core::registry::TypeKey::parse(s).expect("a fixture type")
+}
+
 /// A reading for a fixture type — see the twin in `core/unfold/tests.rs`.
 /// Plan leaves carry `TypeRef`s, and a fixture naming a type inline needs one.
 fn tref(ty: syn::Type) -> crate::api::core::flat::TypeRef {
@@ -29,7 +35,7 @@ fn single_constructor_plan_and_fold() {
     exp.expands.push(ExpandDecl {
         func: ident("z_keyexpr_intersects"),
         param: ident("a"),
-        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        declared_target: Some(key("ZKeyExpr")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from"))]),
     });
 
@@ -69,7 +75,7 @@ fn constructor_plan_and_fold() {
     exp.expands.push(ExpandDecl {
         func: ident("z_keyexpr_intersects"),
         param: ident("a"),
-        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        declared_target: Some(key("ZKeyExpr")),
         sel: ExpandSel::Subset(vec![
             Variant::Ctor(ident("z_keyexpr_try_from")),
             Variant::Identity,
@@ -132,7 +138,7 @@ fn optional_byvalue_single_ctor() {
     exp.expands.push(ExpandDecl {
         func: ident("z_session_delete"),
         param: ident("attachment"),
-        declared_target: Some(syn::parse_quote!(ZZBytes)),
+        declared_target: Some(key("ZZBytes")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_zbytes_from_vec"))]),
     });
     // nullable leaf wrapping the ctor param
@@ -185,7 +191,7 @@ fn optional_byref_single_ctor() {
     exp.expands.push(ExpandDecl {
         func: ident("z_session_put"),
         param: ident("encoding"),
-        declared_target: Some(syn::parse_quote!(ZEncoding)),
+        declared_target: Some(key("ZEncoding")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_encoding_from_string"))]),
     });
     // `encoding: Option<&ZEncoding>` built from a TWO-arg, infallible
@@ -209,7 +215,7 @@ fn optional_byref_single_ctor() {
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
     assert_eq!(plan.leaves[0].ty.spell().to_string(), "Option < String >");
     assert_eq!(
-        plan.target.to_token_stream().to_string(),
+        plan.target.spell().to_string(),
         "ZEncoding",
         "target peeled through Option<&_>"
     );
@@ -228,7 +234,7 @@ fn optional_byref_multi_arg_ctor() {
     exp.expands.push(ExpandDecl {
         func: ident("z_session_put"),
         param: ident("encoding"),
-        declared_target: Some(syn::parse_quote!(ZEncoding)),
+        declared_target: Some(key("ZEncoding")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_encoding_from_id"))]),
     });
     // leaf 0 = present:bool, leaf 1 = id:i32, leaf 2 = schema:Option<String>
@@ -297,7 +303,7 @@ fn optional_combined_selector_encodes_absence() {
     exp.expands.push(ExpandDecl {
         func: ident("z_session_put"),
         param: ident("encoding"),
-        declared_target: Some(syn::parse_quote!(ZEncoding)),
+        declared_target: Some(key("ZEncoding")),
         sel: ExpandSel::Subset(vec![
             Variant::Ctor(ident("z_encoding_from_id")),
             Variant::Identity,
@@ -379,7 +385,7 @@ fn iterable_emit_shape() {
     // plan must produce the `into_iter().map(...).collect::<Result<Vec<_>,_>>()`
     // form, with the inner single-arg ctor applied per element.
     let plan = FoldPlan {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: tref(syn::parse_quote!(ZKeyExpr)),
         by_ref: false,
         shape: FoldShape::Iterable(Box::new(FoldShape::Base)),
         leaves: vec![FoldLeaf {
@@ -420,7 +426,7 @@ fn default_constructor_auto_applies_and_skips() {
     ]);
     let mut exp = Expansions::default();
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
         default: true,
     });
@@ -473,7 +479,7 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
     // `.default()` skips the accessor's `ke`, constructs the consumer's a/b.
     let mut exp = Expansions::default();
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
         default: true,
     });
@@ -494,7 +500,7 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
     exp2.expands.push(ExpandDecl {
         func: ident("z_keyexpr_clone"),
         param: ident("ke"),
-        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        declared_target: Some(key("ZKeyExpr")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from"))]),
     });
     let err = apply(&mut reg2, &exp2, &declared, &accessor, &Default::default()).unwrap_err();
@@ -517,12 +523,12 @@ fn recursive_input_nests_param_constructors() {
     // Default inputs for ZSample (single), ZKeyExpr (combined: try_from|id),
     // ZZBytes (single).
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         variants: vec![Variant::Ctor(ident("z_sample_new"))],
         default: true,
     });
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         variants: vec![
             Variant::Ctor(ident("z_keyexpr_try_from")),
             Variant::Identity,
@@ -530,7 +536,7 @@ fn recursive_input_nests_param_constructors() {
         default: true,
     });
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZZBytes),
+        target: key("ZZBytes"),
         variants: vec![Variant::Ctor(ident("z_zbytes_from_vec"))],
         default: true,
     });
@@ -604,12 +610,12 @@ fn recursive_input_cycle_errors() {
     ]);
     let mut exp = Expansions::default();
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(A),
+        target: key("A"),
         variants: vec![Variant::Ctor(ident("make_a"))],
         default: true,
     });
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(B),
+        target: key("B"),
         variants: vec![Variant::Ctor(ident("make_b"))],
         default: true,
     });
@@ -641,7 +647,7 @@ fn unknown_constructor_errors() {
     exp.expands.push(ExpandDecl {
         func: ident("z_keyexpr_intersects"),
         param: ident("a"),
-        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        declared_target: Some(key("ZKeyExpr")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_keyexpr_try_from_typo"))]),
     });
     // C5 validation map: a variant ctor that exists but does not produce the
@@ -672,7 +678,7 @@ fn constructor_target_mismatch_errors() {
     exp.expands.push(ExpandDecl {
         func: ident("z_keyexpr_intersects"),
         param: ident("a"),
-        declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+        declared_target: Some(key("ZKeyExpr")),
         sel: ExpandSel::Subset(vec![Variant::Ctor(ident("z_sample_new"))]),
     });
     let err = apply(
@@ -700,14 +706,14 @@ fn invalid_declarations_collected() {
     // Duplicate constructor target (two records, same TypeKey).
     for _ in 0..2 {
         exp.constructors.push(ConstructorDecl {
-            target: syn::parse_quote!(ZKeyExpr),
+            target: key("ZKeyExpr"),
             variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
             default: true,
         });
     }
     // Empty constructor variant list.
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZEmpty),
+        target: key("ZEmpty"),
         variants: vec![],
         default: true,
     });
@@ -719,7 +725,7 @@ fn invalid_declarations_collected() {
         exp.expands.push(ExpandDecl {
             func: ident("z_session_get"),
             param: ident("k"),
-            declared_target: Some(syn::parse_quote!(ZKeyExpr)),
+            declared_target: Some(key("ZKeyExpr")),
             sel,
         });
     }
@@ -777,7 +783,7 @@ fn a_vec_param_does_not_match_its_elements_constructor() {
     // The type-level default: every `ZKeyExpr` parameter may be built from a
     // `String`. `parts` is a `Vec<ZKeyExpr>`, so it is not one of them.
     exp.constructors.push(ConstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         variants: vec![Variant::Ctor(ident("z_keyexpr_try_from"))],
         default: true,
     });

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -71,6 +71,14 @@
 # `syn::Type` field is not classification either. Both are follow-ups the count
 # names rather than hides.
 #
+# A NODE CACHE is why the type count can go UP for a good change. A field typed
+# `syn::Type` holds a node permanently: it costs ONE escape where it is filled
+# and none at all where it is read, so N consumers read a node for free and the
+# census sees 1. Replacing that field with a `TypeRef` removes the one and
+# reveals the N — the reads were always there. A rising count after a field is
+# de-cached is the measure becoming true, not the boundary getting worse; a
+# rising count with no field removed is the thing this ledger exists to catch.
+#
 # KNOWN BLIND SPOTS — classification neither half sees:
 #
 #   * token-string classification, e.g. `core/domain.rs` matching
@@ -121,32 +129,32 @@
 
 ## escapes: types
 1	api/core/diagnostics.rs
-11	api/core/expand.rs
+6	api/core/expand.rs
 1	api/core/registry/declare.rs
 1	api/core/registry/key.rs
 2	api/core/registry/order.rs
 4	api/core/registry/scan.rs
-15	api/core/unfold.rs
+5	api/core/unfold.rs
 3	api/lang/cbindgen/convert.rs
 3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
-6	api/lang/jnigen/jni/builder.rs
+2	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/emit/callback.rs
-5	api/lang/jnigen/jni/emit/delivery.rs
+7	api/lang/jnigen/jni/emit/delivery.rs
 8	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
 1	api/lang/jnigen/jni/emit/sum_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
-3	api/lang/jnigen/jni/fn_plan.rs
-12	api/lang/jnigen/jni/iface.rs
-1	api/lang/jnigen/jni/kotlin_emit.rs
-1	api/lang/jnigen/jni/overloads.rs
-1	api/lang/jnigen/jni/render.rs
+4	api/lang/jnigen/jni/fn_plan.rs
+22	api/lang/jnigen/jni/iface.rs
+8	api/lang/jnigen/jni/kotlin_emit.rs
+2	api/lang/jnigen/jni/overloads.rs
+2	api/lang/jnigen/jni/render.rs
 15	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
-16	api/lang/jnigen/jni/trait_impl.rs
+17	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 122
+# total escapes: types: 126
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -167,6 +167,14 @@ const HEADER: &str = "\
 # `syn::Type` field is not classification either. Both are follow-ups the count
 # names rather than hides.
 #
+# A NODE CACHE is why the type count can go UP for a good change. A field typed
+# `syn::Type` holds a node permanently: it costs ONE escape where it is filled
+# and none at all where it is read, so N consumers read a node for free and the
+# census sees 1. Replacing that field with a `TypeRef` removes the one and
+# reveals the N — the reads were always there. A rising count after a field is
+# de-cached is the measure becoming true, not the boundary getting worse; a
+# rising count with no field removed is the thing this ledger exists to catch.
+#
 # KNOWN BLIND SPOTS — classification neither half sees:
 #
 #   * token-string classification, e.g. `core/domain.rs` matching

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -215,6 +215,24 @@ pub struct Struct {
     pub name: syn::Ident,
     pub fields: Vec<Field>,
     pub origin: Origin<syn::ItemStruct>,
+    /// This struct **as a type**, taken at parse time — the twin of
+    /// [`Variant::reading`], stored and `pub(super)` for the same two reasons.
+    pub(super) reading: TypeRef,
+}
+
+impl Struct {
+    /// This struct as a type reference — what the **declaration** answers when
+    /// something needs a reading naming it.
+    ///
+    /// The alternative is composing one from the name at the call site, which
+    /// an adapter cannot do (minting is sealed to `api::core`) and which would
+    /// be phase-dependent if routed through the registry instead: a
+    /// decomposition is declared before anything is interned. The declaration
+    /// is the one thing that can always say. Same reasoning as
+    /// [`Variant::type_ref`].
+    pub fn type_ref(&self) -> &TypeRef {
+        &self.reading
+    }
 }
 
 /// A `#[prebindgen]` enum whose alternatives carry payloads — a sum type.

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -1362,6 +1362,7 @@ fn lower_struct(
         syn::Fields::Unit => Vec::new(),
     };
     Ok(Type::Struct(Struct {
+        reading: TypeRef::named(&s.ident),
         name: s.ident.clone(),
         fields,
         origin: Origin::new(s.clone(), Rc::clone(at)),

--- a/prebindgen/src/api/core/flat/origin.rs
+++ b/prebindgen/src/api/core/flat/origin.rs
@@ -109,6 +109,20 @@ impl<S> Origin<S> {
     }
 }
 
+impl Origin<syn::Type> {
+    /// This type's identity as a table key — the same answer
+    /// [`TypeRef::key`](super::TypeRef::key) gives for a reading.
+    ///
+    /// Here because a **declaration** is an `Origin<syn::Type>`: the type a
+    /// build script wrote, carried with a placeless location. Asking it for its
+    /// identity is not reaching for the node, and it should not have to be
+    /// spelled as one — every `TypeKey::from_type(decl.as_syn())` was a keying
+    /// operation wearing an escape's clothes.
+    pub fn key(&self) -> crate::api::core::registry::TypeKey {
+        crate::api::core::registry::TypeKey::from_type(&self.syntax)
+    }
+}
+
 impl<S: ToTokens> Origin<S> {
     /// The node's tokens, for generated Rust to spell.
     ///

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -153,7 +153,9 @@ impl DeconRecord {
 /// the leaf order is the declaration order of the `records` vector.
 #[derive(Clone)]
 pub struct DeconstructorDecl {
-    pub target: syn::Type,
+    /// The type being decomposed, as an **identity** — see
+    /// [`ConstructorDecl::target`](crate::api::core::expand::ConstructorDecl::target).
+    pub target: TypeKey,
     pub records: Vec<DeconRecord>,
     /// Auto-apply this deconstructor to every matching declared fn (`Some`
     /// carries the inferred `(target-position, delivery)` to use). Always
@@ -209,7 +211,7 @@ pub struct OutputDecl {
     /// cross-checked against the fn's peeled return type in [`apply`].
     /// `None` for internally-synthesized decls (the type comes from the
     /// return itself).
-    pub declared_source: Option<syn::Type>,
+    pub declared_source: Option<TypeKey>,
 }
 
 /// Deconstructor / output-expansion declarations gathered from a language
@@ -240,7 +242,7 @@ fn validate_declarations(acc: &Deconstructors) -> Result<(), UnfoldError> {
     let mut entries: Vec<UnfoldDeclError> = Vec::new();
     let mut decon_targets: std::collections::HashSet<String> = std::collections::HashSet::new();
     for d in &acc.deconstructors {
-        let target = TypeKey::from_type(&d.target).as_str().to_string();
+        let target = d.target.as_str().to_string();
         if !decon_targets.insert(target.clone()) {
             entries.push(UnfoldDeclError::DuplicateDeconstructor { target });
         }
@@ -307,10 +309,10 @@ pub fn apply<M>(
                 .function(&ed.func)
                 .map(|f| f.ret.clone())
                 .ok_or_else(|| UnfoldError::UnknownFunction(ed.func.clone()))?;
-            if !returns_type(&ret, &TypeKey::from_type(declared)) {
+            if !returns_type(&ret, declared) {
                 return Err(UnfoldError::ReturnTypeMismatch {
                     func: ed.func.clone(),
-                    declared: TypeKey::from_type(declared).as_str().to_string(),
+                    declared: declared.as_str().to_string(),
                     actual: {
                         let s = ret.spell();
                         quote::quote!(#s).to_string()
@@ -341,7 +343,7 @@ pub fn apply<M>(
         if d.default.is_none() {
             continue;
         }
-        let dkey = TypeKey::from_type(&d.target);
+        let dkey = d.target.clone();
         let sel = DeconSel::TopLevel;
         for func in declared_fns {
             // Read accessors are never output-decomposed (they ARE the records).
@@ -434,7 +436,7 @@ pub fn apply<M>(
                 let Some(d) = acc
                     .deconstructors
                     .iter()
-                    .find(|d| d.default.is_some() && TypeKey::from_type(&d.target) == core_key)
+                    .find(|d| d.default.is_some() && d.target == core_key)
                 else {
                     continue;
                 };
@@ -481,7 +483,7 @@ pub struct ValueDecon {
     /// Canonical key of the value struct (the `DeconId::Default` key).
     pub key: TypeKey,
     /// The struct type (owned) the leaves decompose.
-    pub source: syn::Type,
+    pub source: crate::api::core::flat::TypeRef,
     /// Field-access leaves in foreign-signature / `fromParts` order.
     pub leaves: Vec<UnfoldLeaf>,
 }
@@ -537,7 +539,7 @@ pub struct SumDecon {
     /// Canonical key of the sum type (the `DeconId::Default` key).
     pub key: TypeKey,
     /// The enum type (owned) the leaves decompose.
-    pub source: syn::Type,
+    pub source: crate::api::core::flat::TypeRef,
     /// The tag leaf followed by every variant's group, in tag order.
     pub leaves: Vec<UnfoldLeaf>,
 }
@@ -609,7 +611,7 @@ pub fn apply_sum_returns<M>(
 fn wire_fixed_decon<M>(
     registry: &mut Registry<M>,
     key: &TypeKey,
-    source: &syn::Type,
+    source: &crate::api::core::flat::TypeRef,
     leaves: &[UnfoldLeaf],
 ) -> Result<DeconId, UnfoldError> {
     let decon = DeconId::Default(key.to_string());
@@ -857,12 +859,12 @@ fn whole_leaf_fold_plan(
     shape: UnfoldShape,
 ) -> UnfoldPlan {
     UnfoldPlan {
-        source: vec_elem.as_syn().clone(),
+        source: vec_elem.clone(),
         decon: None,
         by_ref: peel_borrow(vec_elem).0,
         shape,
         leaves: vec![],
-        element: Some(vec_elem.as_syn().clone()),
+        element: Some(vec_elem.clone()),
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
@@ -1071,12 +1073,12 @@ fn process_decl<M>(
                 let by_ref = peel_borrow(inner).0;
                 registry.require_output(inner);
                 UnfoldPlan {
-                    source: inner.as_syn().clone(),
+                    source: inner.clone(),
                     decon: None,
                     by_ref,
                     shape,
                     leaves: vec![],
-                    element: Some(inner.as_syn().clone()),
+                    element: Some(inner.clone()),
                     delivery: ed.delivery,
                     convert_out_ty: None,
                     fixed_builder: false,
@@ -1146,7 +1148,7 @@ fn process_decl<M>(
             registry.require_output(&cv);
             UnfoldPlan {
                 delivery: Delivery::Return,
-                convert_out_ty: Some(cv.as_syn().clone()),
+                convert_out_ty: Some(cv.clone()),
                 ..plan
             }
         } else {
@@ -1200,11 +1202,11 @@ fn register_decon_spec<M>(
         // derived from it, never emitted code — so its hoists are discarded.
         &mut Vec::new(),
     )?;
-    require_unique_leaf_names(source.as_syn(), &leaves)?;
+    require_unique_leaf_names(source, &leaves)?;
     registry.decon_plans.insert(
         decon.clone(),
         DeconSpec {
-            source: source.as_syn().clone(),
+            source: source.clone(),
             leaves,
         },
     );
@@ -1239,9 +1241,7 @@ fn find_deconstructor_by_type<'a>(
     acc: &'a Deconstructors,
     type_key: &TypeKey,
 ) -> Option<&'a DeconstructorDecl> {
-    acc.deconstructors
-        .iter()
-        .find(|c| TypeKey::from_type(&c.target) == *type_key)
+    acc.deconstructors.iter().find(|c| c.target == *type_key)
 }
 
 /// Build the [`UnfoldPlan`] for a chosen accessor. `shape` is the outer
@@ -1277,11 +1277,11 @@ fn build_plan<M>(
         &mut leaves,
         &mut hoists,
     )?;
-    require_unique_leaf_names(source.as_syn(), &leaves)?;
-    require_root_identity_last(by_ref, source.as_syn(), &leaves)?;
+    require_unique_leaf_names(source, &leaves)?;
+    require_root_identity_last(by_ref, source, &leaves)?;
 
     Ok(UnfoldPlan {
-        source: source.as_syn().clone(),
+        source: source.clone(),
         decon: Some(decon),
         by_ref,
         shape,
@@ -1303,7 +1303,7 @@ fn build_plan<M>(
 /// decompositions clone the root identity, so any order is fine.)
 fn require_root_identity_last(
     by_ref: bool,
-    source: &syn::Type,
+    source: &crate::api::core::flat::TypeRef,
     leaves: &[UnfoldLeaf],
 ) -> Result<(), UnfoldError> {
     if by_ref {
@@ -1316,7 +1316,7 @@ fn require_root_identity_last(
     if let (Some(root), Some(nested)) = (root_at, last_nested_at) {
         if root < nested {
             return Err(UnfoldError::RootIdentityBeforeNested {
-                target: TypeKey::from_type(source).to_string(),
+                target: source.key().to_string(),
             });
         }
     }
@@ -1702,12 +1702,15 @@ fn flatten<M>(
 /// Error if two leaves of one flattened deconstructor share a name. Author leaf
 /// names are explicit and emitted literally, so a collision is a declaration
 /// bug — never auto-resolved.
-fn require_unique_leaf_names(source: &syn::Type, leaves: &[UnfoldLeaf]) -> Result<(), UnfoldError> {
+fn require_unique_leaf_names(
+    source: &crate::api::core::flat::TypeRef,
+    leaves: &[UnfoldLeaf],
+) -> Result<(), UnfoldError> {
     let mut seen: HashSet<&str> = HashSet::new();
     for l in leaves {
         if !seen.insert(l.name.as_str()) {
             return Err(UnfoldError::DuplicateLeafName {
-                target: TypeKey::from_type(source).to_string(),
+                target: source.key().to_string(),
                 name: l.name.clone(),
             });
         }

--- a/prebindgen/src/api/core/unfold/plan.rs
+++ b/prebindgen/src/api/core/unfold/plan.rs
@@ -49,10 +49,11 @@ pub enum DeconId {
 /// the spec must tolerate whichever form their type tables resolved.
 #[derive(Clone)]
 pub struct DeconSpec {
-    /// The decomposed type as first encountered (path qualification may vary
-    /// by call site; compare via [`TypeKey`](crate::api::core::registry::TypeKey),
-    /// not syntactically).
-    pub source: syn::Type,
+    /// The decomposed type as first encountered. A **reading**, so "compare via
+    /// [`TypeKey`](crate::api::core::registry::TypeKey), not syntactically" is
+    /// the type rather than an instruction: `source.key()` is the identity and
+    /// `source.spell()` is what generated Rust says.
+    pub source: crate::api::core::flat::TypeRef,
     /// Flattened leaves in declared record order — names, types, paths,
     /// nullability all declaration-fixed.
     pub leaves: Vec<UnfoldLeaf>,
@@ -224,7 +225,7 @@ pub enum LeafSource {
 pub struct UnfoldPlan {
     /// Owned core type the records decompose — the function's return after
     /// peeling `&` / `Option` / `Vec`.
-    pub source: syn::Type,
+    pub source: crate::api::core::flat::TypeRef,
     /// Which deconstructor declaration produced [`Self::leaves`] — the
     /// identity adapters key signature artifacts on. `None` only for the
     /// whole-element `Iterable` arm (no declaration involved).
@@ -246,7 +247,7 @@ pub struct UnfoldPlan {
     /// delivered to the fold via its own output converter + projection (not
     /// decomposed). `None` for `Decompose`/`Optional` and for a **decomposed**
     /// `Iterable` fold (which uses [`Self::leaves`]).
-    pub element: Option<syn::Type>,
+    pub element: Option<crate::api::core::flat::TypeRef>,
     /// Callback (`deconstruct_output`) vs return-value (`convert_output`)
     /// delivery.
     pub delivery: Delivery,
@@ -254,7 +255,7 @@ pub struct UnfoldPlan {
     /// shape (`Decompose` ⇒ `out_ty`, `Optional` ⇒ `Option<out_ty>`). The
     /// wrapper returns this value through its ordinary output converter (no
     /// callback). `None` for [`Delivery::Callback`].
-    pub convert_out_ty: Option<syn::Type>,
+    pub convert_out_ty: Option<crate::api::core::flat::TypeRef>,
     /// `true` for a synthesized by-value `data_class` decomposition (see
     /// [`crate::api::core::unfold::apply_value_structs`]): the builder/folder
     /// is a **fixed, hoisted** foreign singleton that reconstructs the concrete

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1,6 +1,12 @@
 use quote::ToTokens;
 
 use super::*;
+
+/// A fixture declaration's identity. A declaration is a key, not a spelling —
+/// see `ConstructorDecl::target`.
+fn key(s: &str) -> crate::api::core::registry::TypeKey {
+    crate::api::core::registry::TypeKey::parse(s).expect("a fixture type")
+}
 use crate::api::{
     core::{registry::Registry, types_util::ident},
     test_util::scanned_with as reg_with,
@@ -77,7 +83,7 @@ fn accessor_optional_primitive() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZTimestamp),
+        target: key("ZTimestamp"),
         records: vec![DeconRecord::Acc {
             func: ident("z_timestamp_ntp64"),
             name: "z_timestamp_ntp64".into(),
@@ -100,7 +106,7 @@ fn accessor_optional_primitive() {
         .get(&ident("z_sample_timestamp"))
         .expect("plan");
     assert!(plan.by_ref, "inner was &ZTimestamp");
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZTimestamp");
+    assert_eq!(plan.source.spell().to_string(), "ZTimestamp");
     assert!(
         matches!(&plan.shape, UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Base)),
         "outer shape is Optional(Decompose)"
@@ -128,7 +134,7 @@ fn accessor_plan_byref() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -159,7 +165,7 @@ fn accessor_plan_byref() {
         .get(&ident("z_sample_key_expr"))
         .expect("plan");
     assert!(plan.by_ref, "return was &ZKeyExpr");
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZKeyExpr");
+    assert_eq!(plan.source.spell().to_string(), "ZKeyExpr");
     assert!(matches!(plan.shape, UnfoldShape::Base));
     assert_eq!(plan.leaves.len(), 2);
 
@@ -194,12 +200,12 @@ fn root_identity_before_nested_identity_errors() {
         ["z_query_key_expr"].iter().map(|s| ident(s)).collect();
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![DeconRecord::Identity],
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZQuery),
+        target: key("ZQuery"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -226,12 +232,12 @@ fn root_identity_before_nested_identity_errors() {
     ]);
     let mut acc2 = Deconstructors::default();
     acc2.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![DeconRecord::Identity],
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc2.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZQuery),
+        target: key("ZQuery"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_query_key_expr"),
@@ -259,7 +265,7 @@ fn accessor_target_mismatch_errors() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![DeconRecord::Acc {
             func: ident("wrong"),
             name: "wrong".into(),
@@ -281,7 +287,7 @@ fn multiple_identity_errors() {
     let mut reg: Registry<()> = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![DeconRecord::Identity, DeconRecord::Identity],
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
@@ -305,7 +311,7 @@ fn record_must_be_fun_accessor() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -345,7 +351,7 @@ fn duplicate_leaf_name_errors() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_sample_key_expr"),
@@ -381,7 +387,7 @@ fn reserved_separator_in_name_errors() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![DeconRecord::Acc {
             func: ident("z_sample_key_expr"),
             name: "key__expr".into(),
@@ -425,7 +431,7 @@ fn nested_accessor_flatten() {
     let mut acc = Deconstructors::default();
     // Child accessors (reused via nesting).
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -436,7 +442,7 @@ fn nested_accessor_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZZBytes),
+        target: key("ZZBytes"),
         records: vec![DeconRecord::Acc {
             func: ident("z_zbytes_to_bytes"),
             name: "z_zbytes_to_bytes".into(),
@@ -444,7 +450,7 @@ fn nested_accessor_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZTimestamp),
+        target: key("ZTimestamp"),
         records: vec![DeconRecord::Acc {
             func: ident("z_timestamp_ntp64"),
             name: "z_timestamp_ntp64".into(),
@@ -454,7 +460,7 @@ fn nested_accessor_flatten() {
     // Parent accessor with nested + direct records.
     // Parent accessor with nested + direct records.
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_sample_key_expr"),
@@ -499,7 +505,7 @@ fn nested_accessor_flatten() {
         .get(&ident("z_reply_sample"))
         .expect("plan");
     assert!(plan.by_ref);
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZSample");
+    assert_eq!(plan.source.spell().to_string(), "ZSample");
     assert!(matches!(&plan.shape, UnfoldShape::Optional((), _)));
 
     let path = |l: &UnfoldLeaf| {
@@ -552,7 +558,7 @@ fn reply_product_double_option_flatten() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -563,7 +569,7 @@ fn reply_product_double_option_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZTimestamp),
+        target: key("ZTimestamp"),
         records: vec![DeconRecord::Acc {
             func: ident("z_timestamp_ntp64"),
             name: "z_timestamp_ntp64".into(),
@@ -571,7 +577,7 @@ fn reply_product_double_option_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZZBytes),
+        target: key("ZZBytes"),
         records: vec![DeconRecord::Acc {
             func: ident("z_zbytes_to_bytes"),
             name: "z_zbytes_to_bytes".into(),
@@ -579,7 +585,7 @@ fn reply_product_double_option_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_sample_key_expr"),
@@ -593,7 +599,7 @@ fn reply_product_double_option_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZReplyError),
+        target: key("ZReplyError"),
         records: vec![DeconRecord::Acc {
             func: ident("z_reply_error_payload"),
             name: "z_reply_error_payload".into(),
@@ -601,7 +607,7 @@ fn reply_product_double_option_flatten() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZReply),
+        target: key("ZReply"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_reply_replier_zid"),
@@ -638,7 +644,7 @@ fn reply_product_double_option_flatten() {
     .expect("apply");
     let plan = reg.unfold_plans.get(&ident("z_recv_reply")).expect("plan");
     assert!(!plan.by_ref, "owned ZReply return");
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZReply");
+    assert_eq!(plan.source.spell().to_string(), "ZReply");
     assert!(matches!(&plan.shape, UnfoldShape::Base));
     assert!(matches!(plan.delivery, Delivery::Callback));
 
@@ -693,7 +699,7 @@ fn nested_cycle_errors() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZA),
+        target: key("ZA"),
         records: vec![DeconRecord::Acc {
             func: ident("a_to_b"),
             name: "a_to_b".into(),
@@ -701,7 +707,7 @@ fn nested_cycle_errors() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZB),
+        target: key("ZB"),
         records: vec![DeconRecord::Acc {
             func: ident("b_to_a"),
             name: "b_to_a".into(),
@@ -736,7 +742,7 @@ fn iterable_whole_element_plan() {
         sel: DeconSel::Inline(vec![]),
         target: DeconTarget::Output,
         delivery: Delivery::Callback,
-        declared_source: Some(syn::parse_quote!(ZZenohId)),
+        declared_source: Some(key("ZZenohId")),
     });
     // M5: `z_session_peers_zid -> Vec<ZZenohId>` with a ZZenohId combined
     // accessor → Iterable with per-element leaves: the string form + the
@@ -764,9 +770,7 @@ fn iterable_whole_element_plan() {
         "whole-element: no decomposed leaves"
     );
     assert_eq!(
-        plan.element
-            .as_ref()
-            .map(|t| t.to_token_stream().to_string()),
+        plan.element.as_ref().map(|t| t.spell().to_string()),
         Some("ZZenohId".to_string())
     );
     assert!(reg.output_types[&TypeKey::from_type(&syn::parse_quote!(ZZenohId))].root);
@@ -784,7 +788,7 @@ fn iterable_decomposed_plan() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZZenohId),
+        target: key("ZZenohId"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_zenoh_id_to_string"),
@@ -837,7 +841,7 @@ fn convert_output_single_value() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZTimestamp),
+        target: key("ZTimestamp"),
         records: vec![DeconRecord::Acc {
             func: ident("z_timestamp_ntp64"),
             name: "z_timestamp_ntp64".into(),
@@ -862,9 +866,7 @@ fn convert_output_single_value() {
     assert!(matches!(&plan.shape, UnfoldShape::Optional((), _)));
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(
-        plan.convert_out_ty
-            .as_ref()
-            .map(|t| t.to_token_stream().to_string()),
+        plan.convert_out_ty.as_ref().map(|t| t.spell().to_string()),
         Some("Option < i64 >".to_string())
     );
     // The shaped convert type is registered as a required output.
@@ -880,7 +882,7 @@ fn multi_leaf_output_is_callback() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -916,7 +918,7 @@ fn vec_output_is_iterable_callback() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZZenohId),
+        target: key("ZZenohId"),
         records: vec![DeconRecord::Acc {
             func: ident("z_zenoh_id_to_string"),
             name: "z_zenoh_id_to_string".into(),
@@ -964,7 +966,7 @@ fn option_vec_output_is_optional_iterable_callback() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZZenohId),
+        target: key("ZZenohId"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_zenoh_id_to_string"),
@@ -1007,7 +1009,7 @@ fn option_vec_single_leaf_stays_callback() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZZenohId),
+        target: key("ZZenohId"),
         records: vec![DeconRecord::Acc {
             func: ident("z_zenoh_id_to_string"),
             name: "z_zenoh_id_to_string".into(),
@@ -1040,7 +1042,7 @@ fn option_vec_whole_element_plan() {
         sel: DeconSel::Inline(vec![]),
         target: DeconTarget::Output,
         delivery: Delivery::Callback,
-        declared_source: Some(syn::parse_quote!(ZZenohId)),
+        declared_source: Some(key("ZZenohId")),
     });
     apply(
         &mut reg,
@@ -1061,9 +1063,7 @@ fn option_vec_whole_element_plan() {
         "whole-element: no decomposed leaves"
     );
     assert_eq!(
-        plan.element
-            .as_ref()
-            .map(|t| t.to_token_stream().to_string()),
+        plan.element.as_ref().map(|t| t.spell().to_string()),
         Some("ZZenohId".to_string())
     );
 }
@@ -1088,7 +1088,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
-        source: syn::parse_quote!(Payload),
+        source: tref(syn::parse_quote!(Payload)),
         leaves: vec![
             leaf("id", syn::parse_quote!(i64)),
             leaf("seq", syn::parse_quote!(i32)),
@@ -1141,7 +1141,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
-        source: syn::parse_quote!(Payload),
+        source: tref(syn::parse_quote!(Payload)),
         leaves: vec![
             leaf("id", syn::parse_quote!(i64)),
             leaf("seq", syn::parse_quote!(i32)),
@@ -1172,7 +1172,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     ]);
     let vd2 = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
-        source: syn::parse_quote!(Payload),
+        source: tref(syn::parse_quote!(Payload)),
         leaves: vec![leaf("id", syn::parse_quote!(i64))],
     };
     let declared2: std::collections::HashSet<syn::Ident> =
@@ -1197,7 +1197,7 @@ fn convert_error_decomposes_result_e() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZError),
+        target: key("ZError"),
         records: vec![DeconRecord::Acc {
             func: ident("z_error_message"),
             name: "z_error_message".into(),
@@ -1225,7 +1225,7 @@ fn convert_error_decomposes_result_e() {
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(plan.leaves[0].out_ty.spell().to_string(), "String");
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZError");
+    assert_eq!(plan.source.spell().to_string(), "ZError");
     // The infallible fn gets no error plan.
     assert!(!reg.error_plans.contains_key(&ident("z_infallible")));
     // No output plans created (no ZKeyExpr return among the declared fns; the
@@ -1245,7 +1245,7 @@ fn default_output_applies_to_owned_and_borrow_returns() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -1291,7 +1291,7 @@ fn callback_arg_plan_derived() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -1302,7 +1302,7 @@ fn callback_arg_plan_derived() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_sample_key_expr"),
@@ -1331,7 +1331,7 @@ fn callback_arg_plan_derived() {
         .get(&TypeKey::from_type(&syn::parse_quote!(ZSample)))
         .expect("callback-arg plan for ZSample");
     assert!(!plan.by_ref, "the trampoline owns the callback arg");
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZSample");
+    assert_eq!(plan.source.spell().to_string(), "ZSample");
     assert!(matches!(plan.shape, UnfoldShape::Base));
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 3);
@@ -1368,7 +1368,7 @@ fn callback_arg_borrowed_decomposed() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![
             DeconRecord::Identity,
             DeconRecord::Acc {
@@ -1379,7 +1379,7 @@ fn callback_arg_borrowed_decomposed() {
         default: Some((DeconTarget::Output, Delivery::Callback)),
     });
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![
             DeconRecord::Acc {
                 func: ident("z_sample_key_expr"),
@@ -1409,7 +1409,7 @@ fn callback_arg_borrowed_decomposed() {
         .get(&TypeKey::from_type(&syn::parse_quote!(&ZSample)))
         .expect("callback-arg plan for &ZSample");
     assert!(plan.by_ref, "the callback only borrows the delivered value");
-    assert_eq!(plan.source.to_token_stream().to_string(), "ZSample");
+    assert_eq!(plan.source.spell().to_string(), "ZSample");
     assert!(matches!(plan.shape, UnfoldShape::Base));
     assert_eq!(plan.delivery, Delivery::Callback);
     assert_eq!(plan.leaves.len(), 3);
@@ -1455,7 +1455,7 @@ fn callback_arg_nonbare_skipped() {
     ]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZSample),
+        target: key("ZSample"),
         records: vec![DeconRecord::Acc {
             func: ident("z_sample_kind"),
             name: "z_sample_kind".into(),
@@ -1512,7 +1512,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
     assert!(p.decon.is_none(), "whole-element fold carries no decon");
     assert!(p.leaves.is_empty(), "no decomposed leaves");
     assert_eq!(
-        p.element.as_ref().map(|t| t.to_token_stream().to_string()),
+        p.element.as_ref().map(|t| t.spell().to_string()),
         Some("String".to_string())
     );
 
@@ -1526,7 +1526,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
             UnfoldShape::Optional((), inner)
                 if matches!(&**inner, UnfoldShape::Iterable(i) if matches!(**i, UnfoldShape::Base))));
     assert_eq!(
-        p2.element.as_ref().map(|t| t.to_token_stream().to_string()),
+        p2.element.as_ref().map(|t| t.spell().to_string()),
         Some("ZenohId".to_string())
     );
 
@@ -1554,7 +1554,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
         ["other", "strings"].iter().map(|s| ident(s)).collect();
     // Pre-seed `strings` with a sentinel plan to prove it is preserved.
     let sentinel = UnfoldPlan {
-        source: syn::parse_quote!(String),
+        source: tref(syn::parse_quote!(String)),
         decon: None,
         by_ref: false,
         shape: UnfoldShape::Base,
@@ -1590,7 +1590,7 @@ fn unknown_accessor_errors() {
     let mut reg: Registry<()> = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
-        target: syn::parse_quote!(ZKeyExpr),
+        target: key("ZKeyExpr"),
         records: vec![DeconRecord::Acc {
             func: ident("z_keyexpr_as_str_typo"),
             name: "as_str".into(),
@@ -1620,7 +1620,7 @@ fn duplicate_declarations_collected() {
     let mut acc = Deconstructors::default();
     for _ in 0..2 {
         acc.deconstructors.push(DeconstructorDecl {
-            target: syn::parse_quote!(ZKeyExpr),
+            target: key("ZKeyExpr"),
             records: vec![DeconRecord::Acc {
                 func: ident("z_keyexpr_as_str"),
                 name: "asStr".into(),
@@ -1632,7 +1632,7 @@ fn duplicate_declarations_collected() {
             sel: DeconSel::Inline(vec![DeconRecord::Identity]),
             target: DeconTarget::Output,
             delivery: Delivery::Callback,
-            declared_source: Some(syn::parse_quote!(ZKeyExpr)),
+            declared_source: Some(key("ZKeyExpr")),
         });
     }
     let err = apply(
@@ -1689,7 +1689,7 @@ fn reading_sum_decon() -> SumDecon {
     };
     SumDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Reading)),
-        source: syn::parse_quote!(Reading),
+        source: tref(syn::parse_quote!(Reading)),
         leaves: vec![
             tag,
             // group 0 (`Missing`) is empty — a unit variant contributes only
@@ -1877,7 +1877,7 @@ fn a_vec_of_optionals_installs_no_fixed_fold() {
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
-        source: syn::parse_quote!(Payload),
+        source: tref(syn::parse_quote!(Payload)),
         leaves: vec![
             leaf("id", syn::parse_quote!(i64)),
             leaf("seq", syn::parse_quote!(i32)),

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -786,7 +786,7 @@ impl Declarations {
             }
             exp.constructors
                 .push(crate::api::core::expand::ConstructorDecl {
-                    target: decl.rust_type.as_syn().clone(),
+                    target: decl.rust_type.key(),
                     variants: decl.variants.iter().map(lower).collect(),
                     default: true,
                 });
@@ -809,7 +809,7 @@ impl Declarations {
             exp.expands.push(ExpandDecl {
                 func: func.clone(),
                 param: syn::Ident::new(param, Span::call_site()),
-                declared_target: Some(decl.rust_type.as_syn().clone()),
+                declared_target: Some(decl.rust_type.key()),
                 sel: ExpandSel::Subset(decl.variants.iter().map(lower).collect()),
             });
         }
@@ -1172,7 +1172,7 @@ impl Declarations {
                 k = decl.key.as_str()
             );
             dec.deconstructors.push(DeconstructorDecl {
-                target: decl.rust_type.as_syn().clone(),
+                target: decl.rust_type.key(),
                 records: self.lower_fields(registry, &decl.key, &decl.fields),
                 default: Some((DeconTarget::Output, Delivery::Callback)),
             });
@@ -1197,7 +1197,7 @@ impl Declarations {
                 sel: DeconSel::Inline(self.lower_fields(registry, &decl.key, &decl.fields)),
                 target: DeconTarget::Output,
                 delivery: Delivery::Callback,
-                declared_source: Some(decl.rust_type.as_syn().clone()),
+                declared_source: Some(decl.rust_type.key()),
             });
         }
         dec

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -143,12 +143,12 @@ pub(crate) fn emit_unfold_delivery(
             // otherwise (mirrors `leaf_is_prim`; the folder interface
             // declares the matching typed param).
             let out_entry = registry
-                .reading_of(element)
+                .reading_of(element.as_syn())
                 .and_then(|tr| registry.output_entry(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "emit_unfold_delivery: Vec element `{}` has no registered output converter",
-                        TypeKey::from_type(element)
+                        TypeKey::from_type(element.as_syn())
                     )
                 });
             // The element's COMPLETE Rust -> wire chain. No `convert!` type is

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -756,10 +756,15 @@ fn build_output(
     let error_plan = registry.error_plans().get(ident);
     let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
     let target_ty = match unfold_plan {
+        // The other arm composes a type this adapter built, so the two meet as
+        // spellings: the plan's reading is unwrapped here rather than the whole
+        // local becoming a reading it cannot be.
         Some(p) => p
             .convert_out_ty
-            .clone()
-            .expect("Return delivery carries convert_out_ty"),
+            .as_ref()
+            .expect("Return delivery carries convert_out_ty")
+            .as_syn()
+            .clone(),
         None => ok_ty.unwrap_or(return_ty),
     };
     // Two failures, told apart. `target_ty` is composed here (`convert_out_ty`,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -976,7 +976,7 @@ pub(crate) fn fixed_leaf_element_keys(
         .chain(registry.callback_arg_plans().values())
         .filter(|p| p.fixed_builder)
         .filter_map(|p| p.element.as_ref())
-        .map(TypeKey::from_type)
+        .map(|el| el.key())
         .collect()
 }
 
@@ -1341,9 +1341,9 @@ pub(crate) fn builder_iface_spec(
     let params = plan_leaf_params(ext, registry, &spec.leaves)?;
     let name = format!(
         "{}Builder",
-        decon_base_name(&subject_short(&spec.source), Some(decon))
+        decon_base_name(&subject_short(spec.source.as_syn()), Some(decon))
     );
-    let package = subject_package(ext, &spec.source);
+    let package = subject_package(ext, spec.source.as_syn());
     Some(IfaceSpec::assemble(
         package,
         name,
@@ -1369,9 +1369,9 @@ pub(crate) fn folder_iface_spec(
     params.extend(plan_leaf_params(ext, registry, &spec.leaves)?);
     let name = format!(
         "{}Folder",
-        decon_base_name(&subject_short(&spec.source), Some(decon))
+        decon_base_name(&subject_short(spec.source.as_syn()), Some(decon))
     );
-    let package = subject_package(ext, &spec.source);
+    let package = subject_package(ext, spec.source.as_syn());
     Some(IfaceSpec::assemble(
         package,
         name,
@@ -1430,7 +1430,7 @@ pub(crate) fn folder_iface_for_plan(
         "folder_iface_for_plan requires an Iterable (or Option<Iterable>) plan"
     );
     match (&plan.element, &plan.decon) {
-        (Some(el), _) => ext.iface_spec(registry, &SpecKey::whole_folder(el)),
+        (Some(el), _) => ext.iface_spec(registry, &SpecKey::whole_folder(el.as_syn())),
         (None, Some(d)) => ext.iface_spec(registry, &SpecKey::Folder(d.clone())),
         (None, None) => None,
     }
@@ -1451,8 +1451,9 @@ pub(crate) fn fixed_folder_typed_groups(
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans().get(decon)?;
-    let fqn = ext.kotlin_fqn(&TypeKey::from_type(&spec.source))?;
-    let (reassemble, imports) = fixed_reassembly(ext, registry, &spec.source, &spec.leaves, &fqn);
+    let fqn = ext.kotlin_fqn(&TypeKey::from_type(spec.source.as_syn()))?;
+    let (reassemble, imports) =
+        fixed_reassembly(ext, registry, spec.source.as_syn(), &spec.leaves, &fqn);
     Some(vec![
         TypedGroup {
             name: "acc".to_string(),
@@ -1488,10 +1489,10 @@ pub(crate) fn error_handler_iface_spec(
     let params: Vec<IfaceParam> = plan_leaf_params(ext, registry, &spec.leaves)?;
     let name = format!(
         "{}Handler",
-        decon_base_name(&subject_short(&spec.source), Some(decon))
+        decon_base_name(&subject_short(spec.source.as_syn()), Some(decon))
     );
-    let package = subject_package(ext, &spec.source);
-    let source_short = subject_short(&spec.source);
+    let package = subject_package(ext, spec.source.as_syn());
+    let source_short = subject_short(spec.source.as_syn());
     let mut iface = IfaceSpec::assemble(
         package,
         name,

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1049,7 +1049,7 @@ impl Declarations {
                     let iterable = is_iterable_fold(&plan.shape);
                     match (iterable, &plan.element, &plan.decon) {
                         (true, Some(el), _) => {
-                            uses.insert(SpecKey::whole_folder(el));
+                            uses.insert(SpecKey::whole_folder(el.as_syn()));
                         }
                         (true, None, Some(d)) => {
                             uses.insert(SpecKey::Folder(d.clone()));
@@ -1202,11 +1202,11 @@ impl Declarations {
     ) -> kt::KtDecl {
         let source = &registry.decon_plans()[decon].source;
         let class_fqn = self
-            .kotlin_fqn(&TypeKey::from_type(source))
+            .kotlin_fqn(&TypeKey::from_type(source.as_syn()))
             .unwrap_or_else(|| {
                 panic!(
                     "value-struct builder: no Kotlin FQN for {}",
-                    TypeKey::from_type(source)
+                    TypeKey::from_type(source.as_syn())
                 )
             });
         let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
@@ -1245,11 +1245,11 @@ impl Declarations {
     ) -> kt::KtDecl {
         let source = &registry.decon_plans()[decon].source;
         let class_fqn = self
-            .kotlin_fqn(&TypeKey::from_type(source))
+            .kotlin_fqn(&TypeKey::from_type(source.as_syn()))
             .unwrap_or_else(|| {
                 panic!(
                     "value-struct folder: no Kotlin FQN for {}",
-                    TypeKey::from_type(source)
+                    TypeKey::from_type(source.as_syn())
                 )
             });
         let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
@@ -1303,7 +1303,7 @@ impl Declarations {
         let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
         let (iface_short, when) = self.sum_reconstruct(
             registry,
-            &plan.source,
+            plan.source.as_syn(),
             &plan.leaves,
             &spec.params,
             &names,
@@ -1342,7 +1342,7 @@ impl Declarations {
         let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
         let (iface_short, when) = self.sum_reconstruct(
             registry,
-            &plan.source,
+            plan.source.as_syn(),
             &plan.leaves,
             &spec.params[1..],
             &names[1..],

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -458,7 +458,7 @@ pub(crate) fn render_param_overloads(
                 .zip(combo)
                 .flat_map(|(s, &ai)| {
                     let ctor = s.plan.variants[s.arms[ai].0].ctor.as_ref();
-                    arm_erased_sig(ext, registry, &s.plan.target, ctor)
+                    arm_erased_sig(ext, registry, s.plan.target.as_syn(), ctor)
                 })
                 .collect()
         })

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1314,7 +1314,7 @@ fn classify_output(
             spec.params[1].typed.clone()
         } else {
             let class_fqn = ext
-                .kotlin_fqn(&TypeKey::from_type(&plan.source))
+                .kotlin_fqn(&TypeKey::from_type(plan.source.as_syn()))
                 .map(|s| s.to_string())?;
             kt::KtType::cls(class_fqn)
         };
@@ -2274,7 +2274,7 @@ fn shape_notes(
         .collect();
     plans.sort_by_key(|(p, _)| p.to_string());
     for (param, plan) in plans {
-        let target = plan.target.to_token_stream().to_string();
+        let target = plan.target.spell().to_string();
         let arms: Vec<String> = plan
             .variants
             .iter()
@@ -2311,7 +2311,7 @@ fn shape_notes(
     }
 
     if let Some(plan) = registry.unfold_plans().get(fn_ident) {
-        let source = plan.source.to_token_stream().to_string();
+        let source = plan.source.spell().to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         match plan.delivery {
             crate::api::core::unfold::Delivery::Callback if !leaves.is_empty() => {
@@ -2331,7 +2331,7 @@ fn shape_notes(
     }
 
     if let Some(plan) = registry.error_plans().get(fn_ident) {
-        let source = plan.source.to_token_stream().to_string();
+        let source = plan.source.spell().to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         notes.push(format!(
             "On a domain error `onError` receives the decomposed Rust `{source}` error \

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -218,7 +218,7 @@ impl super::JniGen {
                 .collect();
             shaped.push(format!(
                 "param `{param}` expanded from `{}` — variants [{}]",
-                plan.target.to_token_stream(),
+                plan.target.spell(),
                 variants.join(", ")
             ));
         }
@@ -226,7 +226,7 @@ impl super::JniGen {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "return `{}` decomposed → [{}] ({:?} delivery)",
-                plan.source.to_token_stream(),
+                plan.source.spell(),
                 leaves.join(", "),
                 plan.delivery
             ));
@@ -235,7 +235,7 @@ impl super::JniGen {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "domain error `{}` decomposed → onError [{}] (binding failures → onBindingError)",
-                plan.source.to_token_stream(),
+                plan.source.spell(),
                 leaves.join(", ")
             ));
         }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1405,16 +1405,18 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
     ) -> Vec<crate::api::core::unfold::ValueDecon> {
         let mut out = Vec::new();
-        for (ident, item_struct) in registry.flat().types().filter_map(|t| match t {
-            crate::api::core::flat::Type::Struct(s) => Some((&s.name, s)),
+        for item_struct in registry.flat().types().filter_map(|t| match t {
+            crate::api::core::flat::Type::Struct(s) => Some(s),
             _ => None,
         }) {
-            let source: syn::Type = syn::parse_quote!(#ident);
-            let key = TypeKey::from_type(&source);
+            // The declaration's own reading, and its key off that — neither
+            // composed from the ident, which an adapter cannot do anyway.
+            let reading = item_struct.type_ref();
+            let key = reading.key();
             // A `data_class` is a registered type that is neither an opaque
             // handle nor an enum.
             let is_data_class = matches!(
-                self.type_kind(registry, &source),
+                self.type_kind(registry, reading.as_syn()),
                 TypeKind::DataStruct { cfg: Some(c), .. } if c.name_spec.is_some()
             );
             if !is_data_class {
@@ -1431,7 +1433,7 @@ impl Declarations {
                 if !leaves.is_empty() {
                     out.push(crate::api::core::unfold::ValueDecon {
                         key,
-                        source,
+                        source: reading.clone(),
                         leaves,
                     });
                 }
@@ -1466,7 +1468,10 @@ impl Declarations {
             };
             out.push(crate::api::core::unfold::SumDecon {
                 key: key.clone(),
-                source,
+                // The sum's own reading, which the declaration answers with —
+                // `Variant::type_ref` exists for exactly this, and it works in
+                // the declare phase where a `reading()` lookup could not.
+                source: sum.type_ref().clone(),
                 leaves: crate::api::lang::jnigen::jni::synth_sum_leaves(self, sum_cfg, sum),
             });
         }


### PR DESCRIPTION
S2 of the syntax→model umbrella. The stage table called it "keying stops
being a spelling operation" — that was 7 sites. Measured, the population
is different, and the lever is what a plan *field* is typed as.

## A declaration is an identity

`ConstructorDecl::target` was a `syn::Type` that `expand.rs` re-keyed at
four separate uses and never once spelled. It is a `TypeKey` now, as are
`declared_target`, `DeconstructorDecl::target` and `declared_source` —
so the key is computed where the declaration is made instead of at every
question asked of it. `Origin<syn::Type>::key()` is what lets an adapter
say that without naming an escape.

## A plan carries a reading

`UnfoldPlan::{source, element, convert_out_ty}`, `DeconSpec::source`,
`FoldPlan::target`, `FoldBuild::target`, `ValueDecon::source` and
`SumDecon::source` hold a `TypeRef`. `UnfoldLeaf::out_ty` already did;
this finishes it. Every construction site already **had** the reading and
was throwing it away — `source: vec_elem.as_syn().clone()` is
`source: vec_elem.clone()`.

Two decompositions are declared before anything is interned, so a
registry lookup could not answer there. The declaration does:
`Variant::type_ref()` existed for exactly that, and `Struct::type_ref()`
is its twin, stored at parse time for the reasons its doc gives.

## The count goes UP, and that is the finding

    # total classification sites: 116   (unchanged — nothing reclassified)
    # total escapes: types: 122 -> 126
    # total escapes: items:  43   (unchanged)

`api/core` drops 15; jnigen gains 24. **A `syn::Type` field is a node
cache the census cannot see**: it costs one escape where it is filled and
nothing where it is read, so N consumers read a node for free and the
ledger counts 1. Removing the field removes the one and reveals the N —
and those reads were always happening.

So this stage does not lower the number; it makes the number true. The
revealed reads are concentrated in `iface.rs` (+10) and `kotlin_emit.rs`
(+7), and they are all the same three name-building classifiers
(`subject_short`, `subject_package`, `whole_value_name`) that peel `&` /
`Option` / slice by matching syn. Those are S4's, and they are now
visible as what they are instead of hiding behind a field.

The ledger header states the rule: a rising count after a field is
de-cached is the measure becoming true; a rising count with no field
removed is the thing the ledger exists to catch.

**Did not move**: every generated artifact byte-identical, classification
counts unchanged, 645 lib + 22 doctests green, clippy + fmt clean on
1.85.0 and stable.