### PR TITLE
jnigen: a Kotlin name is read off the kind, not off the spelling

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -115,17 +115,17 @@
 16	api/lang/jnigen/jni/emit/names.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
-4	api/lang/jnigen/jni/iface.rs
+1	api/lang/jnigen/jni/iface.rs
 2	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
-8	api/lang/jnigen/jni/render.rs
+5	api/lang/jnigen/jni/render.rs
 3	api/lang/jnigen/jni/selector.rs
 11	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total classification sites: 116
+# total classification sites: 110
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -146,7 +146,7 @@
 1	api/lang/jnigen/jni/emit/sum_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
 4	api/lang/jnigen/jni/fn_plan.rs
-22	api/lang/jnigen/jni/iface.rs
+10	api/lang/jnigen/jni/iface.rs
 8	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 2	api/lang/jnigen/jni/render.rs
@@ -154,7 +154,7 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 17	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 126
+# total escapes: types: 114
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -647,29 +647,23 @@ fn decon_base_name(short: &str, decon: Option<&DeconId>) -> String {
 /// surfaces as `List<E>`) gets a `List` suffix — `<E>List` — so it yields a valid,
 /// distinct interface name (`<E>ListCallback`) instead of the bracketed `[E]` and
 /// without colliding with the scalar `&E` callback (`<E>Callback`).
-fn subject_short(ty: &syn::Type) -> String {
-    let no_ref = match ty {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other.clone(),
-    };
-    if let syn::Type::Slice(s) = &no_ref {
-        return format!("{}List", subject_short(&s.elem));
+fn subject_short(ty: &crate::api::core::flat::TypeRef) -> String {
+    use crate::api::lang::jnigen::util::{head_name, head_type};
+    // One `&` off, then a slice — the `List` suffix is decided before the
+    // general peel, exactly as it was, because `&[E]` and `Vec<E>` must not
+    // collapse to the same interface name.
+    let no_ref = ty.borrow_target().unwrap_or(ty);
+    if let crate::api::core::flat::TypeKind::Slice(elem) = no_ref.kind() {
+        return format!("{}List", subject_short(elem));
     }
-    let peeled = crate::api::core::types_util::peel_ref_option_vec(ty);
-    if let syn::Type::Path(tp) = &peeled {
-        if let Some(seg) = tp.path.segments.last() {
-            return seg.ident.to_string();
-        }
-    }
-    TypeKey::from_type(&peeled)
-        .to_string()
-        .replace([' ', ':', '<', '>'], "")
+    let peeled = head_type(ty);
+    head_name(peeled).unwrap_or_else(|| peeled.key().to_string().replace([' ', ':', '<', '>'], ""))
 }
 
 /// Package a subject type's interface lives in: the package of the type's
 /// registered Kotlin FQN, the root `ext.package` otherwise.
-fn subject_package(ext: &Declarations, subject: &syn::Type) -> String {
-    let key = TypeKey::from_type(&crate::api::core::types_util::peel_ref_option_vec(subject));
+fn subject_package(ext: &Declarations, subject: &crate::api::core::flat::TypeRef) -> String {
+    let key = crate::api::lang::jnigen::util::head_type(subject).key();
     ext.kotlin_fqn(&key)
         .and_then(|fqn| fqn.rsplit_once('.').map(|(p, _)| p.to_string()))
         .unwrap_or_else(|| ext.package.clone())
@@ -1024,7 +1018,7 @@ fn derive_iface_spec(
         // above: the memo key holds an identity, and the reading behind it is a
         // lookup. `None` defers, exactly as it does there (#291).
         SpecKey::WholeFolder(el_key) => {
-            whole_folder_iface_spec(ext, registry, registry.reading(el_key)?.as_syn())
+            whole_folder_iface_spec(ext, registry, &registry.reading(el_key)?)
         }
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
@@ -1171,7 +1165,7 @@ pub(crate) fn callback_iface_spec(
                 let (reassemble, imports) =
                     fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
                 groups.push(GroupDesc {
-                    name: whole_value_name(t.as_syn(), i),
+                    name: whole_value_name(t, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
                     reassemble: Some(reassemble),
                     imports,
@@ -1248,13 +1242,13 @@ pub(crate) fn callback_iface_spec(
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
-                name: whole_value_name(t.as_syn(), i),
+                name: whole_value_name(t, i),
                 ty: t.as_syn().clone(),
                 nullable: t.optional_inner().is_some(),
                 owned_handle,
             });
             groups.push(GroupDesc {
-                name: whole_value_name(t.as_syn(), i),
+                name: whole_value_name(t, i),
                 typed: None,
                 reassemble: None,
                 imports: Vec::new(),
@@ -1311,14 +1305,14 @@ pub(crate) fn callback_iface_spec(
             "{}Callback",
             cb_args
                 .iter()
-                .map(|t| subject_short(t.as_syn()))
+                .map(subject_short)
                 .collect::<Vec<_>>()
                 .join("")
         )
     };
     let package = cb_args
         .first()
-        .map(|t| subject_package(ext, t.as_syn()))
+        .map(|t| subject_package(ext, t))
         .unwrap_or_else(|| ext.package.clone());
     Some(IfaceSpec {
         typed_groups,
@@ -1341,9 +1335,9 @@ pub(crate) fn builder_iface_spec(
     let params = plan_leaf_params(ext, registry, &spec.leaves)?;
     let name = format!(
         "{}Builder",
-        decon_base_name(&subject_short(spec.source.as_syn()), Some(decon))
+        decon_base_name(&subject_short(&spec.source), Some(decon))
     );
-    let package = subject_package(ext, spec.source.as_syn());
+    let package = subject_package(ext, &spec.source);
     Some(IfaceSpec::assemble(
         package,
         name,
@@ -1369,9 +1363,9 @@ pub(crate) fn folder_iface_spec(
     params.extend(plan_leaf_params(ext, registry, &spec.leaves)?);
     let name = format!(
         "{}Folder",
-        decon_base_name(&subject_short(spec.source.as_syn()), Some(decon))
+        decon_base_name(&subject_short(&spec.source), Some(decon))
     );
-    let package = subject_package(ext, spec.source.as_syn());
+    let package = subject_package(ext, &spec.source);
     Some(IfaceSpec::assemble(
         package,
         name,
@@ -1387,7 +1381,7 @@ pub(crate) fn folder_iface_spec(
 pub(crate) fn whole_folder_iface_spec(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    element: &syn::Type,
+    element: &crate::api::core::flat::TypeRef,
 ) -> Option<IfaceSpec> {
     let mut params: Vec<IfaceParam> =
         vec![IfaceParam::same("acc".to_string(), kt::KtType::var_("A"))];
@@ -1400,7 +1394,9 @@ pub(crate) fn whole_folder_iface_spec(
         ext,
         registry,
         "element".to_string(),
-        element,
+        // `leaf_iface_param` still takes a node, and it is also handed
+        // adapter-composed types — migrating it is its own step.
+        element.as_syn(),
         false,
         true,
     )?);
@@ -1489,10 +1485,10 @@ pub(crate) fn error_handler_iface_spec(
     let params: Vec<IfaceParam> = plan_leaf_params(ext, registry, &spec.leaves)?;
     let name = format!(
         "{}Handler",
-        decon_base_name(&subject_short(spec.source.as_syn()), Some(decon))
+        decon_base_name(&subject_short(&spec.source), Some(decon))
     );
-    let package = subject_package(ext, spec.source.as_syn());
-    let source_short = subject_short(spec.source.as_syn());
+    let package = subject_package(ext, &spec.source);
+    let source_short = subject_short(&spec.source);
     let mut iface = IfaceSpec::assemble(
         package,
         name,

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -2080,32 +2080,24 @@ pub(crate) fn plan_leaf_names(leaves: &[crate::api::core::unfold::UnfoldLeaf]) -
 /// Lambda parameter name for a whole-value (plan-less) callback arg: the
 /// decapitalized bare type short (`ZQuery` → `zQuery`), peeling a `&` /
 /// `Option<…>` layer; `arg{i}` for non-path shapes.
-pub(crate) fn whole_value_name(ty: &syn::Type, i: usize) -> String {
-    let mut t = ty.clone();
-    if let syn::Type::Reference(r) = &t {
-        t = (*r.elem).clone();
-    }
-    if let syn::Type::Path(tp) = &t {
-        if let Some(last) = tp.path.segments.last() {
-            if last.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(ab) = &last.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = ab.args.first() {
-                        t = inner.clone();
-                    }
-                }
-            }
-        }
-    }
-    if let syn::Type::Path(tp) = &t {
-        if let Some(last) = tp.path.segments.last() {
-            let s = last.ident.to_string();
+pub(crate) fn whole_value_name(ty: &crate::api::core::flat::TypeRef, i: usize) -> String {
+    use crate::api::core::flat::TypeKind;
+    // One borrow, then one `Option` — a fixed depth, not the general peel, and
+    // read off `kind()` rather than through `optional_inner` so a `Box` stops
+    // it here as it stopped the `syn::Type::Path` match before.
+    let t = ty.borrow_target().unwrap_or(ty);
+    let t = match t.kind() {
+        TypeKind::Optional(inner) => inner,
+        _ => t,
+    };
+    match crate::api::lang::jnigen::util::head_name(t) {
+        Some(s) => {
             let mut cs = s.chars();
-            if let Some(f) = cs.next() {
-                return kt_param_name(&format!("{}{}", f.to_lowercase(), cs.as_str()));
-            }
+            let f = cs.next().expect("a name is not empty");
+            kt_param_name(&format!("{}{}", f.to_lowercase(), cs.as_str()))
         }
+        None => format!("arg{i}"),
     }
-    format!("arg{i}")
 }
 
 /// Fall-back Kotlin type derived directly from the JNI wire type.

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -128,7 +128,9 @@ mod spelling_census {
         // fold.rs's one call is inside `enum_probe_type`, the spelling twin of
         // `enum_probe` kept for `unfold_leaf_kt`'s `syn::Type` callers.
         ("jni/fold.rs", 1),
-        ("jni/iface.rs", 2),
+        // iface.rs is off the census: `subject_short` / `subject_package` peel
+        // `&`/`Option`/`Vec` off the KIND now, which is the same grammar the
+        // spelling was — see `util::head_type`.
         // kotlin_emit.rs is off the census: `sum_ctor_arg`'s enum payload peels
         // its `Option` off the leaf's own reading.
         ("jni/trait_impl.rs", 4),

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -70,3 +70,63 @@ pub(crate) fn is_unit(ty: &syn::Type) -> bool {
 
 #[cfg(test)]
 mod tests;
+
+/// A type's **head**: what the source spelled outermost, once `&`, `Option` and
+/// `Vec` are peeled off.
+///
+/// The two naming helpers below are what jnigen calls a type in Kotlin — an
+/// interface name, a lambda parameter — and both used to peel by matching
+/// `syn::Type` and then read the last path segment. That was a classifier
+/// outside the model, and it is only writable now because
+/// [`TypeKind`](crate::api::core::flat::TypeKind) **is** the accepted syntax:
+/// asking the kind for the head is asking the same question of the same
+/// grammar, with the model answering instead of a `match` on `syn`.
+///
+/// Peels exactly what `types_util::peel_ref_option_vec` peeled — `&`, `Option`,
+/// `Vec`, in any order, to a fixed point — and **not** a transparent wrapper:
+/// `Box<Vec<T>>` stops at the `Box`, as it did before. The layer accessors
+/// (`borrow_target`, `optional_inner`, `sequence_elem`) see through `Box`/`Cow`
+/// by design, so this reads `kind()` directly rather than through them.
+pub(crate) fn head_type(t: &crate::api::core::flat::TypeRef) -> &crate::api::core::flat::TypeRef {
+    use crate::api::core::flat::TypeKind;
+    match t.kind() {
+        TypeKind::Ref { inner, .. } | TypeKind::Optional(inner) | TypeKind::Vec(inner) => {
+            head_type(inner)
+        }
+        _ => t,
+    }
+}
+
+/// The head's name as the source spelled it — the last path segment of what a
+/// `syn::Type::Path` match would have found, and `None` for a form that is not
+/// a path at all (a slice, an array, a borrow, a callback, the unit).
+///
+/// One arm per accepted form, and that is the point: a kind that is a path in
+/// Rust has a name here, and one that is not, has none. The builtins answer
+/// with the name Rust writes, because that is what the last segment of their
+/// spelling was.
+pub(crate) fn head_name(t: &crate::api::core::flat::TypeRef) -> Option<String> {
+    use crate::api::core::flat::TypeKind;
+    Some(match t.kind() {
+        TypeKind::Named { id, .. } => id
+            .name
+            .rsplit("::")
+            .next()
+            .expect("a name has a last segment")
+            .to_string(),
+        TypeKind::Scalar(s) => s.as_str().to_string(),
+        TypeKind::Str => "str".to_string(),
+        TypeKind::String => "String".to_string(),
+        TypeKind::Optional(_) => "Option".to_string(),
+        TypeKind::Vec(_) => "Vec".to_string(),
+        TypeKind::Boxed(_) => "Box".to_string(),
+        TypeKind::Cow { .. } => "Cow".to_string(),
+        TypeKind::Uninit(_) => "MaybeUninit".to_string(),
+        TypeKind::Fallible { .. } => "Result".to_string(),
+        TypeKind::Ref { .. }
+        | TypeKind::Slice(_)
+        | TypeKind::Array { .. }
+        | TypeKind::Callback { .. }
+        | TypeKind::Unit => return None,
+    })
+}


### PR DESCRIPTION
The stage after S2, and the one S2 made possible. S2 removed the
`syn::Type` fields from `api/core`'s plans and revealed 24 adapter reads
that a field had been caching; 12 of them were the same three functions.

`subject_short`, `subject_package` and `whole_value_name` decide what a
type is called in Kotlin — an interface name, a lambda parameter. All
three peeled `&` / `Option` / `Vec` by matching `syn::Type` and then read
the last path segment. They take a `TypeRef` now and ask the kind.

**This is only writable because of the S0 pivot.** When `TypeKind` was a
destination-neutral classification it could not answer "what did the
source spell outermost" — `Vec<T>` and `[T]` were one `Sequence`, and the
head of a spelling was a fact the model had folded away. `TypeKind` is
the accepted syntax now, so `util::head_type` peels exactly what
`peel_ref_option_vec` peeled, and `util::head_name` answers with the same
last segment, one arm per accepted form.

Two details carried over deliberately, because a name is an artifact:

* the peel reads `kind()` directly rather than through `borrow_target` /
  `optional_inner` / `sequence_elem`. Those see through `Box`/`Cow` by
  design, and the syntactic peel did not — `Box<Vec<T>>` stops at the
  `Box`, as before;
* `subject_short` decides its `List` suffix before the general peel, so
  `&[E]` and `Vec<E>` keep their distinct interface names.

## Both censuses moved down

    # total classification sites: 116 -> 110   (iface -3, render -3)
    # total escapes: types:       126 -> 114   (iface -12)
    # total escapes: items:        43           (unchanged)

and jnigen's own spelling census drops `jni/iface.rs` (2 → 0) — the row
is gone, not lowered.

## Why not S3 as the umbrella wrote it

`ConverterImpl::subs` becoming `Vec<TypeKey>` is right — `TypeEntry::subs`
already is one, and `cell.rs` keys the adapter's spellings the moment
they arrive — but it is 7 escapes across 77 assignment sites. It stays on
the list at a better moment; this stage took the 12 that S2 had just put
on the table.

**Did not move**: every generated artifact byte-identical, which is the
whole proof for a change that rewrites how names are computed — every
interface name, every lambda parameter, over the covertest corpus.
645 lib + 22 doctests green, clippy + fmt clean on 1.85.0 and stable.