### PR TITLE
core: a converter's `subs` are identities, and always were

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -150,11 +150,11 @@
 8	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 2	api/lang/jnigen/jni/render.rs
-15	api/lang/jnigen/jni/selector.rs
+8	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
 17	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 114
+# total escapes: types: 107
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -106,7 +106,14 @@ pub struct ConverterImpl<M = ()> {
     /// required-ness flows through the registry's type-graph edges, not here). The
     /// resolver copies these into `TypeEntry::subs`, which `propagate_required`
     /// walks to mark reachable types required.
-    pub subs: Vec<syn::Type>,
+    ///
+    /// **Identities, not spellings.** They are looked up and walked, never
+    /// emitted — [`TypeEntry::subs`](crate::api::core::registry::TypeEntry::subs)
+    /// was already `Vec<TypeKey>` and the resolver keyed these on arrival, so
+    /// the spelling existed only to be converted. An adapter that composed the
+    /// inner type keys it (`TypeKey::from_type`); one that read it off the model
+    /// asks the reading (`TypeRef::key`), and names no escape to do it.
+    pub subs: Vec<crate::api::core::registry::TypeKey>,
 }
 
 /// Re-emit a captured `#[prebindgen]` const as a **path-alias** to its

--- a/prebindgen/src/api/core/registry/cell.rs
+++ b/prebindgen/src/api/core/registry/cell.rs
@@ -77,7 +77,7 @@ impl<M> TypeEntry<M> {
             destination: c.destination,
             function: c.function,
             pre_stages: c.pre_stages,
-            subs: c.subs.iter().map(TypeKey::from_type).collect(),
+            subs: c.subs.clone(),
             niches: c.niches,
             metadata: c.metadata,
         }

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -107,7 +107,7 @@ impl CbindgenBuilder {
         };
         let niches = self.c_domain_niches(decl, registry, Direction::Input);
         Some(ConverterImpl {
-            subs: vec![repr],
+            subs: vec![TypeKey::from_type(&repr)],
             destination: wire,
             function,
             pre_stages: vec![],
@@ -175,7 +175,7 @@ impl CbindgenBuilder {
         };
         let niches = self.c_domain_niches(decl, registry, Direction::Output);
         Some(ConverterImpl {
-            subs: vec![repr],
+            subs: vec![TypeKey::from_type(&repr)],
             destination: wire,
             function,
             pre_stages: vec![],

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -57,7 +57,7 @@ impl CbindgenBuilder {
         let c_struct = self.c_type_ident(ty);
         let src = self.src_ty(ty);
         let mut inits: Vec<TokenStream> = Vec::new();
-        let mut subs: Vec<syn::Type> = Vec::new();
+        let mut subs: Vec<TypeKey> = Vec::new();
         let mut fallible = false;
         for (fname, fty) in &fields {
             if is_string(fty) {
@@ -71,7 +71,7 @@ impl CbindgenBuilder {
                 // validates the tag and rebuilds the live arm, which is what
                 // makes this whole decode fallible.
                 let conv = Self::in_name(fty);
-                subs.push(fty.clone());
+                subs.push(TypeKey::from_type(fty));
                 fallible = true;
                 inits.push(quote!(#fname: #conv(v.#fname)?));
             } else if is_bool(fty) {
@@ -1110,7 +1110,7 @@ impl CbindgenBuilder {
                 }
             }
         }
-        let mut subs: Vec<syn::Type> = Vec::new();
+        let mut subs: Vec<TypeKey> = Vec::new();
         let arms: Vec<TokenStream> = e
             .variants
             .iter()
@@ -1132,7 +1132,7 @@ impl CbindgenBuilder {
                         // emitted. Without it the payload silently falls back to
                         // a passthrough and the generated code does not compile.
                         if self.payload_needs_converter(&f.ty) {
-                            subs.push(f.ty.clone());
+                            subs.push(TypeKey::from_type(&f.ty));
                         }
                         self.payload_in_expr(&f.ty, b, r)
                     })
@@ -1239,7 +1239,7 @@ impl CbindgenBuilder {
                 }
             }
         }
-        let mut subs: Vec<syn::Type> = Vec::new();
+        let mut subs: Vec<TypeKey> = Vec::new();
         let arms: Vec<TokenStream> = e
             .variants
             .iter()
@@ -1255,7 +1255,7 @@ impl CbindgenBuilder {
                     .zip(&binds)
                     .map(|(f, b)| {
                         if self.payload_needs_converter(&f.ty) {
-                            subs.push(f.ty.clone());
+                            subs.push(TypeKey::from_type(&f.ty));
                         }
                         self.payload_out_expr(&f.ty, b, r)
                     })
@@ -1976,13 +1976,13 @@ impl CbindgenBuilder {
             let c_struct = self.c_type_ident(ty);
             let src = self.src_ty(ty);
             let mut inits: Vec<TokenStream> = Vec::new();
-            let mut subs: Vec<syn::Type> = Vec::new();
+            let mut subs: Vec<TypeKey> = Vec::new();
             for (fname, fty) in &fields {
                 if is_string(fty) {
                     inits.push(quote!(#fname: __cbg_alloc_cstr(v.#fname)));
                 } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
                     let conv = Self::out_name(fty);
-                    subs.push(fty.clone());
+                    subs.push(TypeKey::from_type(fty));
                     inits.push(quote!(#fname: #conv(v.#fname)));
                 } else if is_bool(fty) {
                     let wrap = bool_out_expr(quote!(v.#fname));
@@ -2129,7 +2129,7 @@ impl CbindgenBuilder {
                     )
                 };
                 return Some(ConverterImpl {
-                    subs: vec![inner],
+                    subs: vec![TypeKey::from_type(&inner)],
                     destination: inner_wire,
                     function,
                     pre_stages: vec![],
@@ -2182,7 +2182,7 @@ impl CbindgenBuilder {
                 )
             };
             return Some(ConverterImpl {
-                subs: vec![inner],
+                subs: vec![TypeKey::from_type(&inner)],
                 destination: wire,
                 function,
                 pre_stages: vec![],
@@ -2228,7 +2228,7 @@ impl CbindgenBuilder {
                         pub(crate) fn #name() {}
                     );
                     return Some(ConverterImpl {
-                        subs: vec![e.clone()],
+                        subs: vec![TypeKey::from_type(&e)],
                         destination: syn::parse_quote!(*const #e),
                         function,
                         pre_stages: vec![],
@@ -2245,7 +2245,7 @@ impl CbindgenBuilder {
                         pub(crate) fn #name() {}
                     );
                     return Some(ConverterImpl {
-                        subs: vec![e],
+                        subs: vec![TypeKey::from_type(&e)],
                         destination: syn::parse_quote!(*const #counterpart),
                         function,
                         pre_stages: vec![],
@@ -2277,7 +2277,7 @@ impl CbindgenBuilder {
                 }
             );
             return Some(ConverterImpl {
-                subs: vec![elem],
+                subs: vec![TypeKey::from_type(&elem)],
                 destination: syn::parse_quote!(*const ::core::ffi::c_char),
                 function,
                 pre_stages: vec![],
@@ -2311,7 +2311,7 @@ impl CbindgenBuilder {
                     }
                 );
                 return Some(ConverterImpl {
-                    subs: vec![inner],
+                    subs: vec![TypeKey::from_type(&inner)],
                     destination: syn::parse_quote!(*mut #op),
                     function,
                     pre_stages: vec![],
@@ -2346,7 +2346,7 @@ impl CbindgenBuilder {
                 }
             );
             return Some(ConverterImpl {
-                subs: vec![elem],
+                subs: vec![TypeKey::from_type(&elem)],
                 destination: syn::parse_quote!(*mut #wire_ty),
                 function,
                 pre_stages: vec![],
@@ -2378,7 +2378,7 @@ impl CbindgenBuilder {
             }
         );
         Some(ConverterImpl {
-            subs: vec![elem],
+            subs: vec![TypeKey::from_type(&elem)],
             destination: syn::parse_quote!(*const #wire_ty),
             function,
             pre_stages: vec![],
@@ -2411,7 +2411,7 @@ impl CbindgenBuilder {
                 pub(crate) fn #name() {}
             );
             return Some(ConverterImpl {
-                subs: vec![inner],
+                subs: vec![TypeKey::from_type(&inner)],
                 destination: syn::parse_quote!(()),
                 function,
                 pre_stages: vec![],
@@ -2432,7 +2432,7 @@ impl CbindgenBuilder {
                 pub(crate) fn #name() {}
             );
             return Some(ConverterImpl {
-                subs: vec![inner],
+                subs: vec![TypeKey::from_type(&inner)],
                 destination: syn::parse_quote!(()),
                 function,
                 pre_stages: vec![],
@@ -2460,7 +2460,7 @@ impl CbindgenBuilder {
                 pub(crate) fn #name() {}
             );
             return Some(ConverterImpl {
-                subs: vec![elem],
+                subs: vec![TypeKey::from_type(&elem)],
                 destination: syn::parse_quote!(()),
                 function,
                 pre_stages: vec![],
@@ -2488,7 +2488,7 @@ impl CbindgenBuilder {
                     }
                 );
                 return Some(ConverterImpl {
-                    subs: vec![elem],
+                    subs: vec![TypeKey::from_type(&elem)],
                     destination: syn::parse_quote!(*const #wire_ty),
                     function,
                     pre_stages: vec![],
@@ -2508,7 +2508,7 @@ impl CbindgenBuilder {
                 pub(crate) fn #name() {}
             );
             return Some(ConverterImpl {
-                subs: vec![ok, err],
+                subs: vec![TypeKey::from_type(&ok), TypeKey::from_type(&err)],
                 destination: syn::parse_quote!(()),
                 function,
                 pre_stages: vec![],

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -70,7 +70,7 @@ impl Declarations {
                     target,
                     registry,
                 ) {
-                    c.subs = vec![target.as_syn().clone()];
+                    c.subs = vec![target.key()];
                     return Some(c);
                 }
             }
@@ -92,7 +92,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Optional, syntax, inner, registry)
             {
-                c.subs = vec![inner.as_syn().clone()];
+                c.subs = vec![inner.key()];
                 return Some(c);
             }
             return None;
@@ -101,7 +101,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Sequence, syntax, elem, registry)
             {
-                c.subs = vec![elem.as_syn().clone()];
+                c.subs = vec![elem.key()];
                 return Some(c);
             }
             return None;
@@ -149,7 +149,7 @@ impl Declarations {
                     if let Some(mut c) =
                         self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry)
                     {
-                        c.subs = vec![elem_ty];
+                        c.subs = vec![TypeKey::from_type(&elem_ty)];
                         return Some(c);
                     }
                     return None;
@@ -159,7 +159,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, inner, registry)
             {
-                c.subs = vec![inner.as_syn().clone()];
+                c.subs = vec![inner.key()];
                 return Some(c);
             }
         }
@@ -205,7 +205,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Optional, syntax, inner, registry)
             {
-                c.subs = vec![inner.as_syn().clone()];
+                c.subs = vec![inner.key()];
                 return Some(c);
             }
             return None;
@@ -214,7 +214,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Sequence, syntax, elem, registry)
             {
-                c.subs = vec![elem.as_syn().clone()];
+                c.subs = vec![elem.key()];
                 return Some(c);
             }
             return None;
@@ -236,7 +236,7 @@ impl Declarations {
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Borrow { mutable }, syntax, inner, registry)
             {
-                c.subs = vec![inner.as_syn().clone()];
+                c.subs = vec![inner.key()];
                 return Some(c);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -2186,7 +2186,7 @@ impl Declarations {
             #inner_call
         });
         Some(ConverterImpl {
-            subs: vec![stripped],
+            subs: vec![TypeKey::from_type(&stripped)],
             pre_stages: vec![],
             function: self.build_output_fn(produced, &wire, &body, None),
             destination: wire,
@@ -2264,7 +2264,7 @@ impl Declarations {
             #built
         });
         Some(ConverterImpl {
-            subs: vec![stripped],
+            subs: vec![TypeKey::from_type(&stripped)],
             pre_stages: vec![],
             function: self.build_input_fn(produced, &wire, &body, None),
             destination: wire,
@@ -2706,7 +2706,7 @@ impl Declarations {
         });
         let niches = default_niches_for_wire(&wire);
         Some(ConverterImpl {
-            subs: vec![elem.clone()],
+            subs: vec![TypeKey::from_type(elem)],
             pre_stages: vec![],
             function: self.build_output_fn(&outer_ty, &wire, &body, None),
             destination: wire,


### PR DESCRIPTION
`ConverterImpl::subs` was `Vec<syn::Type>`, and the resolver's very first
act was to key every one of them:

    // registry/cell.rs
    subs: c.subs.iter().map(TypeKey::from_type).collect(),

`TypeEntry::subs` has been `Vec<TypeKey>` all along, and the field's own
doc says what they are for — looked up to mark reachable types required,
by `propagate_required`. Never spelled. So the spelling existed only to
be converted one line later, and the conversion is deleted along with it.

An adapter that **composed** the inner type keys it
(`TypeKey::from_type`); one that read it **off the model** asks the
reading (`inner.key()`), and names no escape to do it. That second shape
is where the escapes were:

    # total escapes: types: 114 -> 107   (selector.rs 15 -> 8)
    # total classification sites: 110    (unchanged)
    # total escapes: items:        43    (unchanged)

Seven of `selector.rs`'s fifteen escapes were `c.subs = vec![x.as_syn()
.clone()]` — the converter selector naming its inner types by spelling so
that the registry could immediately un-spell them.

Fifty of the seventy assignment sites are `subs: vec![]` and did not
change at all. The four accumulators in `cbindgen/trait_impl.rs` collect
keys now, one per pushed field.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.