### PR TITLE
core, jnigen: a key is asked for, not built from a spelling

### DIFF
--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -367,8 +367,8 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
     // The model already read this return; `fallible_parts` is that reading, not a
     // second look at the spelling.
     let (target, fallible) = match f.ret.fallible_parts() {
-        Some((ok, _)) => (ok.as_syn().clone(), true),
-        None => (f.ret.as_syn().clone(), false),
+        Some((ok, _)) => (ok.key(), true),
+        None => (f.ret.key(), false),
     };
     Ok(CtorSig {
         params,
@@ -381,7 +381,9 @@ struct CtorSig {
     /// Readings, not spellings: they come off `Function::params`, and a consumer
     /// that needs the spelling takes it at the point it stores one.
     params: Vec<(syn::Ident, crate::api::core::flat::TypeRef)>,
-    target: syn::Type,
+    /// The type the constructor produces, as an **identity**: every use of it
+    /// is `check_target`, which keyed both sides.
+    target: TypeKey,
     fallible: bool,
 }
 
@@ -441,7 +443,7 @@ fn build_plan<M>(
             });
         };
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, target.as_syn())?;
+        check_target(func, &sig.target, &target.key())?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
             leaves.push(FoldLeaf {
@@ -555,7 +557,7 @@ fn build_core<M>(
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
         let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, target.as_syn())?;
+        check_target(func, &sig.target, &target.key())?;
         let np = sig.params.len();
         let mut args = Vec::new();
         for (pname, pty) in &sig.params {
@@ -590,7 +592,7 @@ fn build_core<M>(
             match v {
                 Variant::Ctor(func) => {
                     let sig = ctor_signature(registry, func)?;
-                    check_target(func, &sig.target, target.as_syn())?;
+                    check_target(func, &sig.target, &target.key())?;
                     let np = sig.params.len();
                     let mut args = Vec::new();
                     for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
@@ -718,16 +720,16 @@ fn build_arg<M>(
 
 fn check_target(
     func: &syn::Ident,
-    produces: &syn::Type,
-    expected: &syn::Type,
+    produces: &TypeKey,
+    expected: &TypeKey,
 ) -> Result<(), ExpandError> {
-    if TypeKey::from_type(produces) == TypeKey::from_type(expected) {
+    if produces == expected {
         Ok(())
     } else {
         Err(ExpandError::TargetMismatch {
             ctor: func.to_string(),
-            produces: TypeKey::from_type(produces).to_string(),
-            expected: TypeKey::from_type(expected).to_string(),
+            produces: produces.to_string(),
+            expected: expected.to_string(),
         })
     }
 }

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -129,8 +129,7 @@
 
 ## escapes: types
 1	api/core/diagnostics.rs
-6	api/core/expand.rs
-1	api/core/registry/declare.rs
+1	api/core/expand.rs
 1	api/core/registry/key.rs
 2	api/core/registry/order.rs
 4	api/core/registry/scan.rs
@@ -143,18 +142,17 @@
 7	api/lang/jnigen/jni/emit/delivery.rs
 8	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
-1	api/lang/jnigen/jni/emit/sum_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
 4	api/lang/jnigen/jni/fn_plan.rs
-10	api/lang/jnigen/jni/iface.rs
-8	api/lang/jnigen/jni/kotlin_emit.rs
+7	api/lang/jnigen/jni/iface.rs
+3	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
-2	api/lang/jnigen/jni/render.rs
+1	api/lang/jnigen/jni/render.rs
 8	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
 17	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 107
+# total escapes: types: 91
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -154,11 +154,7 @@ impl<M> RegistryBuilder<M> {
     /// equivalent rendering the scan reads, and it should not depend on
     /// declaration order.
     pub fn export_type(mut self, ty: Origin<syn::Type>) -> Self {
-        self.registry
-            .declared
-            .types
-            .entry(TypeKey::from_type(ty.as_syn()))
-            .or_insert(ty);
+        self.registry.declared.types.entry(ty.key()).or_insert(ty);
         self
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -347,7 +347,7 @@ fn encode_group_leaf(
         panic!(
             "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
             leaf.name,
-            TypeKey::from_type(leaf.out_ty.as_syn())
+            leaf.out_ty.key()
         )
     });
     let wire = out_entry.destination.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -912,8 +912,8 @@ impl SpecKey {
     }
 
     /// The whole-element fold identity for an element type.
-    pub fn whole_folder(element: &syn::Type) -> Self {
-        SpecKey::WholeFolder(TypeKey::from_type(element))
+    pub fn whole_folder(element: &crate::api::core::flat::TypeRef) -> Self {
+        SpecKey::WholeFolder(element.key())
     }
 }
 
@@ -1191,7 +1191,7 @@ pub(crate) fn callback_iface_spec(
                     };
                     if leaf.source == LeafSource::SumTag {
                         any_fixed = true;
-                        let fqn = ext.kotlin_fqn(&TypeKey::from_type(leaf.out_ty.as_syn()))?;
+                        let fqn = ext.kotlin_fqn(&leaf.out_ty.key())?;
                         let (reassemble, imports) = fixed_reassembly(
                             ext,
                             registry,
@@ -1426,7 +1426,7 @@ pub(crate) fn folder_iface_for_plan(
         "folder_iface_for_plan requires an Iterable (or Option<Iterable>) plan"
     );
     match (&plan.element, &plan.decon) {
-        (Some(el), _) => ext.iface_spec(registry, &SpecKey::whole_folder(el.as_syn())),
+        (Some(el), _) => ext.iface_spec(registry, &SpecKey::whole_folder(el)),
         (None, Some(d)) => ext.iface_spec(registry, &SpecKey::Folder(d.clone())),
         (None, None) => None,
     }
@@ -1447,7 +1447,7 @@ pub(crate) fn fixed_folder_typed_groups(
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans().get(decon)?;
-    let fqn = ext.kotlin_fqn(&TypeKey::from_type(spec.source.as_syn()))?;
+    let fqn = ext.kotlin_fqn(&spec.source.key())?;
     let (reassemble, imports) =
         fixed_reassembly(ext, registry, spec.source.as_syn(), &spec.leaves, &fqn);
     Some(vec![

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1049,7 +1049,7 @@ impl Declarations {
                     let iterable = is_iterable_fold(&plan.shape);
                     match (iterable, &plan.element, &plan.decon) {
                         (true, Some(el), _) => {
-                            uses.insert(SpecKey::whole_folder(el.as_syn()));
+                            uses.insert(SpecKey::whole_folder(el));
                         }
                         (true, None, Some(d)) => {
                             uses.insert(SpecKey::Folder(d.clone()));
@@ -1202,13 +1202,8 @@ impl Declarations {
     ) -> kt::KtDecl {
         let source = &registry.decon_plans()[decon].source;
         let class_fqn = self
-            .kotlin_fqn(&TypeKey::from_type(source.as_syn()))
-            .unwrap_or_else(|| {
-                panic!(
-                    "value-struct builder: no Kotlin FQN for {}",
-                    TypeKey::from_type(source.as_syn())
-                )
-            });
+            .kotlin_fqn(&source.key())
+            .unwrap_or_else(|| panic!("value-struct builder: no Kotlin FQN for {}", source.key()));
         let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
         // The native side calls the raw twin's `run` (== the typed interface
         // when the builder needs no twin — synthesized data classes are
@@ -1245,13 +1240,8 @@ impl Declarations {
     ) -> kt::KtDecl {
         let source = &registry.decon_plans()[decon].source;
         let class_fqn = self
-            .kotlin_fqn(&TypeKey::from_type(source.as_syn()))
-            .unwrap_or_else(|| {
-                panic!(
-                    "value-struct folder: no Kotlin FQN for {}",
-                    TypeKey::from_type(source.as_syn())
-                )
-            });
+            .kotlin_fqn(&source.key())
+            .unwrap_or_else(|| panic!("value-struct folder: no Kotlin FQN for {}", source.key()));
         let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
         // The native side calls the raw twin's `run(acc, leaves…)`; `acc` is the
         // accumulator list and the remaining params are the element leaves.

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -1313,9 +1313,7 @@ fn classify_output(
             let spec = u.iface.as_deref()?;
             spec.params[1].typed.clone()
         } else {
-            let class_fqn = ext
-                .kotlin_fqn(&TypeKey::from_type(plan.source.as_syn()))
-                .map(|s| s.to_string())?;
+            let class_fqn = ext.kotlin_fqn(&plan.source.key()).map(|s| s.to_string())?;
             kt::KtType::cls(class_fqn)
         };
         let class_short = kt_type_short(&class_ty);


### PR DESCRIPTION
The umbrella's original S2 — "keying stops being a spelling operation" —
which was 7 sites when it was written and is 16 now: every stage since
made a spelling into a reading, and a reading can answer for its own
identity.

Three shapes, all of them a key taking the long way round:

    TypeKey::from_type(x.as_syn())   ->  x.key()          9 sites
    CtorSig::target: syn::Type       ->  TypeKey          5 sites
    SpecKey::whole_folder(&syn::Type) -> takes a reading   2 sites

`CtorSig::target` is the S2 pattern one level down: its only consumer is
`check_target`, which keyed **both** sides and formatted both keys into
the error. It is a `TypeKey` now, `check_target` compares two of them, and
the three `TypeKey::from_type` calls inside it are gone with it.

    # total escapes: types:       107 -> 91
    # total classification sites: 110    (unchanged)
    # total escapes: items:        43    (unchanged)

`api/core/expand.rs` goes 6 → 1 and `registry/declare.rs` and
`emit/sum_out.rs` reach **zero** — the first files to.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.