### PR TITLE
jnigen: the adapter's own carriers, and a classifier that only ever keyed

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -137,10 +137,9 @@
 3	api/lang/cbindgen/convert.rs
 3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
-2	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 7	api/lang/jnigen/jni/emit/delivery.rs
-8	api/lang/jnigen/jni/emit/flat_input.rs
+2	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
 4	api/lang/jnigen/jni/fn_plan.rs
@@ -150,9 +149,9 @@
 1	api/lang/jnigen/jni/render.rs
 8	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
-17	api/lang/jnigen/jni/trait_impl.rs
+16	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 91
+# total escapes: types: 82
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -904,7 +904,7 @@ impl Declarations {
              value form returns the struct holding this type's fields",
             key.as_str(),
         );
-        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, ret.as_syn()) else {
+        let TypeKind::DataStruct { st, .. } = self.type_kind(registry, &ret.key()) else {
             panic!(
                 "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
                  not a struct — a value form returns a struct whose fields become the leaves",
@@ -1048,7 +1048,7 @@ impl Declarations {
             // must decompose into its selector and groups wherever it appears.
             let bare = field.ty.optional_inner().unwrap_or(&field.ty);
             let probe = bare.sequence_elem().unwrap_or(bare);
-            match self.type_kind(registry, probe.as_syn()) {
+            match self.type_kind(registry, &probe.key()) {
                 TypeKind::DataStruct { st, cfg: Some(_) }
                     if field.ty.optional_inner().is_none()
                         && field.ty.sequence_elem().is_none() =>

--- a/prebindgen/src/api/lang/jnigen/jni/classify.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/classify.rs
@@ -54,9 +54,9 @@ impl Declarations {
     pub(crate) fn type_kind<'r, 'c>(
         &'c self,
         registry: &'r impl Conversions<KotlinMeta>,
-        bare: &syn::Type,
+        bare: &TypeKey,
     ) -> TypeKind<'r, 'c> {
-        let cfg = self.types.get(&TypeKey::from_type(bare));
+        let cfg = self.types.get(bare);
         if let Some(c) = cfg {
             match c.kind {
                 DeclaredKind::Ptr(_) => return TypeKind::Handle,
@@ -68,7 +68,10 @@ impl Declarations {
                 DeclaredKind::Data => {}
             }
         }
-        if let Some(name) = bare_path_ident(bare) {
+        // The key IS the canonical spelling, so a key that is one identifier is
+        // exactly what `bare_path_ident` used to fish out of the node — and this
+        // function never wanted anything else from it.
+        if let Some(name) = bare.ident() {
             if let Some(st) = registry.flat().struct_type(&name) {
                 return TypeKind::DataStruct { st, cfg };
             }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -757,7 +757,7 @@ pub(crate) enum FlatFieldNode {
         /// from where the reading was (#289).
         direct_handle: Option<Box<syn::Type>>,
         optional_handle: bool,
-        rust_ty: Box<syn::Type>,
+        rust_ty: Box<crate::api::core::flat::TypeRef>,
         /// The transparent wrappers this field's spelling adds over its
         /// classification, outermost first — put back wherever the decode
         /// **rebuilds** the value (an `Option::Some`/`None` literal) rather than
@@ -783,7 +783,7 @@ pub(crate) enum FlatFieldNode {
         source: syn::Path,
         /// Variants in declaration order; index == tag.
         variants: Vec<FlatSumVariant>,
-        rust_ty: Box<syn::Type>,
+        rust_ty: Box<crate::api::core::flat::TypeRef>,
         /// The transparent wrappers this field's spelling adds over its
         /// classification, outermost first — put back wherever the decode
         /// **rebuilds** the value (an `Option::Some`/`None` literal) rather than
@@ -1058,7 +1058,7 @@ fn build_flat_sum_field(
     field_reading: &TypeRef,
     leaves: &mut Vec<FlatLeaf>,
 ) -> Option<FlatFieldNode> {
-    let rust_ty = field_reading.as_syn();
+    let rust_ty = field_reading;
 
     // The NAME off the classification, and then the ELEMENT — `enum_item`
     // hands back only the `syn::ItemEnum`, deliberately, so a consumer that
@@ -1477,7 +1477,10 @@ fn build_flat_struct_node(
         // A data-carrying enum flattens into a tag plus one group per variant.
         // `None` means some payload is not leaf-shaped — fall through and let
         // it cross as one object through its own converter.
-        if matches!(ext.type_kind(registry, &nested_ty), TypeKind::Sum) {
+        if matches!(
+            ext.type_kind(registry, &TypeKey::from_type(&nested_ty)),
+            TypeKind::Sum
+        ) {
             if let Some(node) = build_flat_sum_field(
                 ext,
                 registry,
@@ -1497,7 +1500,7 @@ fn build_flat_struct_node(
         if let TypeKind::DataStruct {
             st: child,
             cfg: Some(cfg),
-        } = ext.type_kind(registry, &nested_ty)
+        } = ext.type_kind(registry, &TypeKey::from_type(&nested_ty))
         {
             if cfg.name_spec.is_some() && !cfg.special_decl() && !cfg.jobject_input {
                 let child_optional = field_optional;
@@ -1567,7 +1570,7 @@ fn build_flat_struct_node(
                                 present_leaf: Some(present_index),
                                 direct_handle: None,
                                 optional_handle: false,
-                                rust_ty: Box::new(field.ty.as_syn().clone()),
+                                rust_ty: Box::new(field.ty.clone()),
                                 wrappers: field.ty.erased_wrappers(),
                             });
                             continue;
@@ -1617,7 +1620,7 @@ fn build_flat_struct_node(
                             present_leaf: Some(present_index),
                             direct_handle: None,
                             optional_handle: false,
-                            rust_ty: Box::new(field.ty.as_syn().clone()),
+                            rust_ty: Box::new(field.ty.clone()),
                             wrappers: field.ty.erased_wrappers(),
                         });
                         continue;
@@ -1647,7 +1650,7 @@ fn build_flat_struct_node(
                         present_leaf: None,
                         direct_handle: Some(Box::new(nested.as_syn().clone())),
                         optional_handle,
-                        rust_ty: Box::new(field.ty.as_syn().clone()),
+                        rust_ty: Box::new(field.ty.clone()),
                         wrappers: field.ty.erased_wrappers(),
                     });
                     continue;
@@ -1678,7 +1681,7 @@ fn build_flat_struct_node(
                         present_leaf: None,
                         direct_handle: None,
                         optional_handle: false,
-                        rust_ty: Box::new(field.ty.as_syn().clone()),
+                        rust_ty: Box::new(field.ty.clone()),
                         wrappers: field.ty.erased_wrappers(),
                     });
                     continue;
@@ -1725,7 +1728,7 @@ fn build_flat_struct_node(
             present_leaf: None,
             direct_handle: None,
             optional_handle: false,
-            rust_ty: Box::new(field.ty.as_syn().clone()),
+            rust_ty: Box::new(field.ty.clone()),
             wrappers: field.ty.erased_wrappers(),
         });
     }
@@ -1846,6 +1849,9 @@ fn render_flat_struct_node(
                 rust_ty,
             } => {
                 let tmp = format_ident!("{}_{}", node.binding, field);
+                // The slot's ascription, spelled from the reading the node
+                // carries — see the comment below on why the type is written.
+                let rust_ty = rust_ty.spell();
                 let tag = &plan.leaves[*tag_leaf].native_ident;
                 let arms = variants.iter().enumerate().map(|(t, v)| {
                     let vident = &v.rust_ident;
@@ -1928,6 +1934,7 @@ fn render_flat_struct_node(
                 let leaf = &plan.leaves[*value_leaf];
                 let wire = &leaf.native_ident;
                 let tmp = format_ident!("{}_{}", node.binding, field);
+                let rust_ty = rust_ty.spell();
                 let wrap = |e: TokenStream| {
                     build_through_wrappers(wrappers, e)
                         .expect("a field spelling the plan accepted is buildable")

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -115,7 +115,7 @@ pub(crate) fn synth_value_struct_leaves(
         // non-optional (recurse); `Option`/`Vec`-wrapped nesting is deferred
         // to the whole-value path.
         let probe = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
-        let nested = match ext.type_kind(registry, &probe) {
+        let nested = match ext.type_kind(registry, &TypeKey::from_type(&probe)) {
             // A sum joins the kinds this fixed builder cannot forward: it has
             // no single leaf and no converter of its own — it crosses as a tag
             // plus one group per variant, which only the whole-value

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -247,7 +247,10 @@ pub(crate) fn classify_field(
     let bare = bare_ref.as_syn().clone();
     let seq_elem = bare_ref.sequence_elem();
     let core = seq_elem.map_or_else(|| bare.clone(), |e| e.as_syn().clone());
-    if matches!(ext.type_kind(registry, &core), TypeKind::Sum) {
+    if matches!(
+        ext.type_kind(registry, &TypeKey::from_type(&core)),
+        TypeKind::Sum
+    ) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by
         // construction.
@@ -305,7 +308,9 @@ pub(crate) fn classify_field(
         }
         // Nested plain data-class (optionally under `Option`).
         let inner_ty = bare.clone();
-        if let TypeKind::DataStruct { st, cfg } = ext.type_kind(registry, &inner_ty) {
+        if let TypeKind::DataStruct { st, cfg } =
+            ext.type_kind(registry, &TypeKey::from_type(&inner_ty))
+        {
             if pat_match_top(&effective_ty, "Vec") {
                 panic!(
                     "fromParts bridge: `Vec<{}>` data-class field (`{owner}`) is not supported \

--- a/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/sealed.rs
@@ -648,7 +648,7 @@ fn sum_is_its_own_type_kind() {
         .package(crate::package!().class(crate::sealed_class!(Reading)));
     let ty: syn::Type = syn::parse_quote!(Reading);
     assert!(matches!(
-        jni.decls.type_kind(&registry, &ty),
+        jni.decls.type_kind(&registry, &TypeKey::from_type(&ty)),
         crate::api::lang::jnigen::jni::classify::TypeKind::Sum
     ));
     let cfg = jni

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1416,7 +1416,7 @@ impl Declarations {
             // A `data_class` is a registered type that is neither an opaque
             // handle nor an enum.
             let is_data_class = matches!(
-                self.type_kind(registry, reading.as_syn()),
+                self.type_kind(registry, &reading.key()),
                 TypeKind::DataStruct { cfg: Some(c), .. } if c.name_spec.is_some()
             );
             if !is_data_class {
@@ -1657,7 +1657,10 @@ impl Prebindgen for Declarations {
             if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
                 if let Some(ok) = crate::api::core::types_util::result_ok_type(ret) {
                     let core = crate::api::core::types_util::peel_ref_option_vec(&ok);
-                    if matches!(self.type_kind(binding, &core), TypeKind::Sum) {
+                    if matches!(
+                        self.type_kind(binding, &TypeKey::from_type(&core)),
+                        TypeKind::Sum
+                    ) {
                         return Err(format!(
                             "fn `{ident}`: `Result<{}, _>` — a sealed_class value is not \
                              supported in the success position of a fallible return. A sum \
@@ -1695,7 +1698,12 @@ impl Prebindgen for Declarations {
                         .return_expand_decls
                         .iter()
                         .any(|d| d.key == TypeKey::from_type(&err_ty));
-                    if !declared && matches!(self.type_kind(binding, &core), TypeKind::Sum) {
+                    if !declared
+                        && matches!(
+                            self.type_kind(binding, &TypeKey::from_type(&core)),
+                            TypeKind::Sum
+                        )
+                    {
                         return Err(format!(
                             "fn `{ident}`: `Result<_, {}>` — `{}` is declared `sealed_class!`, \
                              but nothing decomposes it in the error position, so it would be \
@@ -1742,7 +1750,10 @@ impl Prebindgen for Declarations {
                         syn::Type::Reference(r) => (*r.elem).clone(),
                         other => other.clone(),
                     };
-                    if matches!(self.type_kind(binding, &elem), TypeKind::Sum) {
+                    if matches!(
+                        self.type_kind(binding, &TypeKey::from_type(&elem)),
+                        TypeKind::Sum
+                    ) {
                         return Err(format!(
                             "fn `{ident}`: `impl Fn(&[{}])` — a slice of a sealed_class value \
                              is not supported as a callback argument. A sum crosses as a tag \


### PR DESCRIPTION
Two shapes inside jnigen, both the pattern the earlier stages found in
`api/core`.

## A node cache, adapter-side

`FlatFieldNode::{Sum, Value}::rust_ty` was a `Box<syn::Type>` filled from
`field.ty.as_syn().clone()` at six sites. It is the ascription generated
Rust writes for the decoded slot (`let #tmp: #rust_ty = …`), so it is a
spelling — and a reading spells itself, one `let` before the `quote!`.

## `type_kind` never wanted a node

    let cfg = self.types.get(&TypeKey::from_type(bare));
    ...
    if let Some(name) = bare_path_ident(bare) { … }

Both halves are the identity: a keyed lookup, and the bare ident — which
**is** the key when the key is one identifier. It takes a `&TypeKey` now
and asks `TypeKey::ident()`, so jnigen's classifier — the one the ledger
header calls out as "a whole classifier with zero watched sites" — no
longer takes captured syntax at all. Callers that hold a reading pass
`x.key()`; callers that composed the type key it at the call.

    # total escapes: types:       91 -> 82
    # total classification sites: 110   (unchanged — `bare_path_ident` is
                                         a helper, not a watched variant)
    # total escapes: items:        43   (unchanged)

`emit/flat_input.rs` goes 8 → 2 and `builder.rs` reaches **zero**.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.