### PR TITLE
jnigen: a question about the form is a question about the kind

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -110,7 +110,6 @@
 6	api/lang/cbindgen/trait_impl.rs
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
-2	api/lang/jnigen/jni/emit/delivery.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
 16	api/lang/jnigen/jni/emit/names.rs
 11	api/lang/jnigen/jni/emit/wrapper.rs
@@ -120,12 +119,11 @@
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 5	api/lang/jnigen/jni/render.rs
-3	api/lang/jnigen/jni/selector.rs
 11	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total classification sites: 110
+# total classification sites: 105
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -138,7 +136,7 @@
 3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
-7	api/lang/jnigen/jni/emit/delivery.rs
+1	api/lang/jnigen/jni/emit/delivery.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
@@ -147,11 +145,11 @@
 3	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/render.rs
-8	api/lang/jnigen/jni/selector.rs
+6	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
 16	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 82
+# total escapes: types: 74
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -143,12 +143,12 @@ pub(crate) fn emit_unfold_delivery(
             // otherwise (mirrors `leaf_is_prim`; the folder interface
             // declares the matching typed param).
             let out_entry = registry
-                .reading_of(element.as_syn())
+                .reading(&element.key())
                 .and_then(|tr| registry.output_entry(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "emit_unfold_delivery: Vec element `{}` has no registered output converter",
-                        TypeKey::from_type(element.as_syn())
+                        element.key()
                     )
                 });
             // The element's COMPLETE Rust -> wire chain. No `convert!` type is
@@ -493,7 +493,10 @@ pub(crate) fn reach_leaf_flat(
     // disagreement would be a borrow handed to an owning converter; this is the
     // second reading, removed.
     let reached_is_ours = if leaf.identity {
-        !matches!(leaf.out_ty.as_syn(), syn::Type::Reference(_))
+        !matches!(
+            leaf.out_ty.kind(),
+            crate::api::core::flat::TypeKind::Ref { .. }
+        )
     } else {
         consuming
     };
@@ -997,7 +1000,7 @@ pub(crate) fn encode_plan_leaves(
         let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
                 "jnigen unfold: leaf `{}` has no registered output converter",
-                TypeKey::from_type(leaf.out_ty.as_syn())
+                leaf.out_ty.key()
             )
         });
         let conv_fail = fail(quote!(__e.to_string()));
@@ -1060,7 +1063,7 @@ pub(crate) fn encode_plan_leaves(
                 panic!(
                     "jnigen unfold: identity leaf `{}` has no projection — \
                      `.accessor_record_id()` requires a ptr_class type",
-                    TypeKey::from_type(leaf.out_ty.as_syn())
+                    leaf.out_ty.key()
                 )
             });
             // The place this handle lives, when it is OURS to give away — the
@@ -1075,15 +1078,16 @@ pub(crate) fn encode_plan_leaves(
             // how to project it — a plain-field run directly, a trailing
             // `Option` through the nullable branch's `match`, which moves the
             // whole `Option` in rather than borrowing it.
-            let owned_place: Option<TokenStream> =
-                if !matches!(leaf.out_ty.as_syn(), syn::Type::Reference(_))
-                    && steps_are_movable(&path)
-                {
-                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                    Some(quote!(#value #(.#segs)*))
-                } else {
-                    None
-                };
+            let owned_place: Option<TokenStream> = if !matches!(
+                leaf.out_ty.kind(),
+                crate::api::core::flat::TypeKind::Ref { .. }
+            ) && steps_are_movable(&path)
+            {
+                let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+                Some(quote!(#value #(.#segs)*))
+            } else {
+                None
+            };
             match proj.kind {
                 ProjectionKind::Handle => {
                     let handle_ident = format_ident!("__h{}", idx);

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -5,35 +5,36 @@ use crate::api::core::registry::Conversions;
 
 /// Whether a decoded `Vec<T>` local can be borrowed where `referent` is expected.
 ///
-/// A **spelling** question, deliberately: it decides what the generated Rust must
-/// be able to say, and Rust distinguishes forms the boundary classification does
-/// not. `[T]` is reached by deref coercion from `&Vec<T>` and `Vec<T>` is the
-/// thing itself; a transparent wrapper such as `Box<Vec<T>>` or `Cow<'_, [T]>`
-/// classifies identically and cannot be reconstructed from the decoded local.
-fn decoded_vec_satisfies(referent: &syn::Type) -> bool {
-    match referent {
-        syn::Type::Slice(_) => true,
-        syn::Type::Path(tp) => tp
-            .path
-            .segments
-            .last()
-            .is_some_and(|s| s.ident == "Vec" && tp.path.segments.len() == 1),
-        _ => false,
-    }
+/// A question about the **form**, and it always was: `[T]` is reached by deref
+/// coercion from `&Vec<T>` and `Vec<T>` is the thing itself, while a transparent
+/// wrapper — `Box<Vec<T>>`, `Cow<'_, [T]>` — cannot be rebuilt from the decoded
+/// local.
+///
+/// It asked the spelling because it had to. This doc used to say so: *"Rust
+/// distinguishes forms the boundary classification does not"*, and that was true
+/// when `Vec<T>` and `[T]` were one `Sequence` and a `Box` was erased. `TypeKind`
+/// **is** the accepted syntax now, so the kind draws every distinction this needs
+/// — `Vec`, `Slice`, `Boxed` and `Cow` are four kinds — and the question is
+/// answered by the model instead of by a `match` on `syn`.
+fn decoded_vec_satisfies(referent: &crate::api::core::flat::TypeRef) -> bool {
+    matches!(
+        referent.kind(),
+        crate::api::core::flat::TypeKind::Slice(_) | crate::api::core::flat::TypeKind::Vec(_)
+    )
 }
 
-/// Whether a spelling has no size, so no by-value converter can name it.
+/// Whether a type has no size, so no by-value converter can name it.
 ///
-/// A **spelling** question, like [`decoded_vec_satisfies`]: `[T]` and `Vec<T>`
-/// are one concept to the model — both `Sequence` — and Rust can return only
-/// one of them. A bare slice is reached exclusively through a borrow, whose own
-/// arm handles it; claiming it here would generate `fn f(..) -> [T]`.
+/// The peer of [`decoded_vec_satisfies`], and it stopped being a *spelling*
+/// question for the same reason: `[T]` and `Vec<T>` were one concept once and
+/// are two kinds now. A bare slice is reached exclusively through a borrow,
+/// whose own arm handles it; claiming it here would generate `fn f(..) -> [T]`.
 ///
 /// `str` is the same shape of fact and is handled the same way, one layer up:
 /// its terminal arm resolves it to the borrowed `&str` converter rather than
-/// pretending an owned `str` exists.
-fn is_unsized_spelling(ty: &syn::Type) -> bool {
-    matches!(ty, syn::Type::Slice(_))
+/// pretending an owned `str` exists — which is why `Str` is not an arm here.
+fn is_unsized_spelling(ty: &crate::api::core::flat::TypeRef) -> bool {
+    matches!(ty.kind(), crate::api::core::flat::TypeKind::Slice(_))
 }
 
 impl Declarations {
@@ -97,7 +98,7 @@ impl Declarations {
             }
             return None;
         }
-        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(syntax)) {
+        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
             if let Some(mut c) =
                 self.input_wrapper_shape(WrapperShape::Sequence, syntax, elem, registry)
             {
@@ -130,7 +131,7 @@ impl Declarations {
             // NOT: passing `&Vec<T>` there does not compile. Those fall through to
             // the plain borrow arm below, which hands the whole spelling on as the
             // sub, exactly as the old syntactic slice check did.
-            if !*mutable && decoded_vec_satisfies(inner.as_syn()) {
+            if !*mutable && decoded_vec_satisfies(inner) {
                 if let Some(elem) = inner.sequence_elem() {
                     let elem_ty = elem.as_syn().clone();
                     // The one place `produced` is NOT the crossing's spelling:
@@ -210,7 +211,7 @@ impl Declarations {
             }
             return None;
         }
-        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(syntax)) {
+        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
             if let Some(mut c) =
                 self.output_wrapper_shape(WrapperShape::Sequence, syntax, elem, registry)
             {
@@ -227,7 +228,7 @@ impl Declarations {
             // input branch, and the same split: `kind` says it is a borrow of a
             // run of values; whether the generated Rust can iterate the borrow
             // directly is a question about the SPELLING.
-            if !*mutable && decoded_vec_satisfies(inner.as_syn()) {
+            if !*mutable && decoded_vec_satisfies(inner) {
                 if let Some(elem) = inner.sequence_elem() {
                     return self.output_slice(elem.as_syn(), registry);
                 }


### PR DESCRIPTION
Three predicates in the converter selector and the delivery emitter asked
`syn` what shape a type was. Their own docs said why, and the reason has
expired.

    /// A **spelling** question, deliberately: ... Rust distinguishes
    /// forms the boundary classification does not. `[T]` and `Vec<T>`
    /// are one concept to the model — both `Sequence` —

That was true when `TypeKind` was a destination-neutral classification.
It is the accepted syntax now: `Vec`, `Slice`, `Boxed` and `Cow` are four
kinds, and `Ref` is its own. So `decoded_vec_satisfies`,
`is_unsized_spelling` and delivery's two `syn::Type::Reference` matches
draw exactly the distinctions they need by asking the model — the same
question, answered by the thing that already knows.

The docs are rewritten rather than deleted: what they explained is *why
the code had to ask the spelling*, and that is now the record of what the
pivot bought.

Also here, because they were in the same two files and are the shape the
last stage established: four `TypeKey::from_type(x.as_syn())` → `x.key()`,
and one `reading_of(x.as_syn())` → `reading(&x.key())`.

    # total escapes: types:       82 -> 74
    # total classification sites: 110 -> 105
    # total escapes: items:        43   (unchanged)

`emit/delivery.rs` goes 7 → 1, and both files reach **zero classification
sites** — the first adapter files to hold neither.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.