### PR TITLE
core: an accessor's signature is an identity, and so is a peeled core

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -131,7 +131,6 @@
 1	api/core/registry/key.rs
 2	api/core/registry/order.rs
 4	api/core/registry/scan.rs
-5	api/core/unfold.rs
 3	api/lang/cbindgen/convert.rs
 3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
@@ -149,7 +148,7 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 16	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 74
+# total escapes: types: 69
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -933,8 +933,9 @@ struct Layered {
     shape: UnfoldShape,
     /// Every type on the way down, outermost first — what a registration walks.
     layer_types: Vec<crate::api::core::flat::TypeRef>,
-    /// Past the borrow too: what actually crosses.
-    core: syn::Type,
+    /// Past the borrow too: what actually crosses — as an **identity**, which
+    /// is all its one consumer ever asked of it.
+    core: TypeKey,
     /// Whether the core is reached through a borrow.
     by_ref: bool,
 }
@@ -952,7 +953,7 @@ fn peel(ty: &crate::api::core::flat::TypeRef) -> Layered {
     Layered {
         shape,
         layer_types: ty.layer_types().into_iter().cloned().collect(),
-        core: borrowed.unwrap_or(layered).as_syn().clone(),
+        core: borrowed.unwrap_or(layered).key(),
         by_ref: borrowed.is_some(),
     }
 }
@@ -975,7 +976,7 @@ fn peel_borrow(ty: &crate::api::core::flat::TypeRef) -> (bool, &crate::api::core
 /// fallible factory (`-> Result<T, E>`) keeps its handle return; the error
 /// position is matched separately on `E`.
 fn returns_type(ret: &crate::api::core::flat::TypeRef, key: &TypeKey) -> bool {
-    TypeKey::from_type(&peel(ret).core) == *key
+    peel(ret).core == *key
 }
 
 /// Build one output/error plan for `ed` and store it in the right registry map.
@@ -1416,7 +1417,7 @@ fn flatten<M>(
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
                 let (takes, _ret) = accessor_signature(registry, func)?;
-                check_takes(func, &takes, source.as_syn())?;
+                check_takes(func, &takes, &source.key())?;
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
@@ -1603,7 +1604,7 @@ fn flatten<M>(
                     DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
                 let (takes, ret) = accessor_signature(registry, &func)?;
-                check_takes(&func, &takes, source.as_syn())?;
+                check_takes(&func, &takes, &source.key())?;
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
@@ -1740,7 +1741,7 @@ pub fn dedup_names(names: &mut [String]) {
 fn accessor_signature<M>(
     registry: &Registry<M>,
     func: &syn::Ident,
-) -> Result<(syn::Type, crate::api::core::flat::TypeRef), UnfoldError> {
+) -> Result<(TypeKey, crate::api::core::flat::TypeRef), UnfoldError> {
     let f = registry
         .flat()
         .function(&func)
@@ -1753,9 +1754,11 @@ fn accessor_signature<M>(
         .params
         .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
+    // The receiver's identity: `accessor_signature`'s one caller compares it,
+    // and `check_takes` keyed both sides to do so.
     let takes = match first.ty.borrow_target() {
-        Some(inner) => inner.as_syn().clone(),
-        None => first.ty.as_syn().clone(),
+        Some(inner) => inner.key(),
+        None => first.ty.key(),
     };
     Ok((takes, f.ret.clone()))
 }
@@ -1794,18 +1797,14 @@ fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
         .is_some_and(|p| p.ty.borrow_target().is_none())
 }
 
-fn check_takes(
-    func: &syn::Ident,
-    takes: &syn::Type,
-    expected: &syn::Type,
-) -> Result<(), UnfoldError> {
-    if TypeKey::from_type(takes) == TypeKey::from_type(expected) {
+fn check_takes(func: &syn::Ident, takes: &TypeKey, expected: &TypeKey) -> Result<(), UnfoldError> {
+    if takes == expected {
         Ok(())
     } else {
         Err(UnfoldError::AccessorTargetMismatch {
             accessor: func.to_string(),
-            takes: TypeKey::from_type(takes).to_string(),
-            expected: TypeKey::from_type(expected).to_string(),
+            takes: takes.to_string(),
+            expected: expected.to_string(),
         })
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -1160,10 +1160,10 @@ pub(crate) fn callback_iface_spec(
                 any_fixed = true;
                 // Peeled off the reading — `borrow_target` is the model's
                 // answer to "is this a borrow", not a syn match.
-                let core = t.borrow_target().unwrap_or(t).as_syn().clone();
-                let fqn = ext.kotlin_fqn(&TypeKey::from_type(&core))?;
+                let core = t.borrow_target().unwrap_or(t);
+                let fqn = ext.kotlin_fqn(&core.key())?;
                 let (reassemble, imports) =
-                    fixed_reassembly(ext, registry, &core, &plan.leaves, &fqn);
+                    fixed_reassembly(ext, registry, core.as_syn(), &plan.leaves, &fqn);
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),


### PR DESCRIPTION
`api/core` reaches **zero type escapes**. Three carriers left in
`unfold`, and each was the S5 shape one more time — a spelling that
existed only to be keyed.

* **`Layered::core`** had exactly one consumer:
  `TypeKey::from_type(&peel(ret).core) == *key`. It is a `TypeKey`, and
  the comparison is the comparison.
* **`accessor_signature`'s `takes`** fed `check_takes` and nothing else —
  the twin of `check_target`, which S5 already turned into a comparison
  of two keys. Same treatment: the function returns the receiver's
  identity, and the three `TypeKey::from_type` calls inside `check_takes`
  are gone with it.
* **`iface.rs`'s peeled core** was cloned out of a reading so it could be
  keyed for a Kotlin FQN lookup. The reading answers.

    # total escapes: types:       74 -> 69   (unfold.rs 5 -> 0)
    # total classification sites: 105        (unchanged)
    # total escapes: items:        43        (unchanged)

**Every file under `api/core` now holds zero type escapes.** What is left
is entirely in the two adapters, which is where the seam was always going
to end up: `trait_impl.rs` (16), `iface.rs` (7), `selector.rs` (6),
cbindgen's six, and a tail.

`registry/scan.rs`'s four are the exception worth naming: `scan_struct`
and `scan_enum` take a `syn::ItemStruct`/`ItemEnum` and rebuild a type
from the ident. They are the registry's own entry point, and `intern`
takes a `&syn::Type` — a stage of its own, not a line to squeeze in here.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.