### PR TITLE
jnigen: the leaf-vec element list is a set of identities

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -119,11 +119,11 @@
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 5	api/lang/jnigen/jni/render.rs
-11	api/lang/jnigen/jni/trait_impl.rs
+8	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total classification sites: 105
+# total classification sites: 102
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -146,9 +146,9 @@
 1	api/lang/jnigen/jni/render.rs
 6	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
-16	api/lang/jnigen/jni/trait_impl.rs
+14	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 69
+# total escapes: types: 67
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/registry/mod.rs
+++ b/prebindgen/src/api/core/registry/mod.rs
@@ -361,7 +361,7 @@ pub struct Decompositions {
     /// alternative.
     pub sums: Vec<crate::api::core::unfold::SumDecon>,
     /// Element types of a `Vec<T>`/`&[T]` delivered element-by-element.
-    pub leaf_vec_elements: Vec<syn::Type>,
+    pub leaf_vec_elements: Vec<TypeKey>,
     /// The whole-value crossings these decompositions make unnecessary.
     ///
     /// Stated **with** the decompositions rather than beside them: a type

--- a/prebindgen/src/api/core/unfold.rs
+++ b/prebindgen/src/api/core/unfold.rs
@@ -774,13 +774,13 @@ fn wire_fixed_callbacks<M>(
 /// declared decompositions and value-struct folds win.
 pub fn apply_leaf_vec_folds<M>(
     registry: &mut Registry<M>,
-    elements: Vec<syn::Type>,
+    elements: Vec<TypeKey>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
     if elements.is_empty() {
         return Ok(());
     }
-    let elem_keys: Vec<TypeKey> = elements.iter().map(TypeKey::from_type).collect();
+    let elem_keys = elements;
     // Is the leading-`&`-peeled `bare` one of the nominated single-leaf elements?
     let is_nominated = |bare: &crate::api::core::flat::TypeRef| elem_keys.contains(&bare.key());
     for func in declared_fns {

--- a/prebindgen/src/api/core/unfold/tests.rs
+++ b/prebindgen/src/api/core/unfold/tests.rs
@@ -1498,7 +1498,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
             .iter()
             .map(|s| ident(s))
             .collect();
-    let elements = vec![syn::parse_quote!(String), syn::parse_quote!(ZenohId)];
+    let elements = vec![key("String"), key("ZenohId")];
     apply_leaf_vec_folds(&mut reg, elements, &declared).expect("apply_leaf_vec_folds");
 
     // `Vec<String>` return ⇒ Iterable(Base), whole element.
@@ -1566,8 +1566,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
         hoists: Vec::new(),
     };
     reg.unfold_plans.insert(ident("strings"), sentinel);
-    apply_leaf_vec_folds(&mut reg, vec![syn::parse_quote!(String)], &declared)
-        .expect("apply_leaf_vec_folds");
+    apply_leaf_vec_folds(&mut reg, vec![key("String")], &declared).expect("apply_leaf_vec_folds");
     assert!(
         !reg.unfold_plans.contains_key(&ident("other")),
         "un-nominated `NotNominated` element ⇒ no fold plan"

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -455,22 +455,6 @@ impl Declarations {
 /// `err` is generic over `Display`, so both the framework `__JniErr`
 /// (`JniBindingError`, a `String` wrapper) and a domain `Result<T, E>`'s `E`
 /// funnel through one function with no per-type routing.
-/// Strip a single leading `&` (one level) from a type, leaving non-references
-/// unchanged. Used to reach a `Vec`/slice element's bare type for nomination.
-fn peel_leading_ref(ty: &syn::Type) -> syn::Type {
-    match ty {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other.clone(),
-    }
-}
-
-/// True for the `String` builtin (final path segment `String`) — the one
-/// undeclared type that crosses as a single JObject-shaped leaf (`JString`).
-fn is_string_type(ty: &syn::Type) -> bool {
-    matches!(ty, syn::Type::Path(tp)
-        if tp.path.segments.last().is_some_and(|s| s.ident == "String"))
-}
-
 /// The pending-exception guard shared by both signal helpers: if a JVM
 /// exception is already pending (a Java upcall threw during a converter), let
 /// it propagate untouched — do NOT invoke an error callback over it, and do
@@ -1205,8 +1189,8 @@ impl Declarations {
     /// Classified from the adapter's declared [`TypeConfig`] table (and the
     /// `String` builtin), not the resolver's output converters — this runs
     /// **before** type resolution, exactly like [`Self::value_struct_decons`].
-    fn is_leaf_vec_element(&self, elem: &syn::Type) -> bool {
-        match self.types.get(&TypeKey::from_type(elem)) {
+    fn is_leaf_vec_element(&self, elem: &crate::api::core::flat::TypeRef) -> bool {
+        match self.types.get(&elem.key()) {
             // A declared opaque handle crosses as a single `jlong` (pointer)
             // leaf that the Kotlin folder wraps into its typed handle class.
             // Enums and multi-field data classes are not leaf-folded — data
@@ -1216,7 +1200,10 @@ impl Declarations {
             // scalar projection whose raw jlong leaf the Kotlin folder wraps
             // into `ULong`. Other primitive collections retain their existing
             // unsupported status (`Vec<u8>` is the rank-0 ByteArray special).
-            None => is_string_type(elem) || TypeKey::from_type(elem).as_str() == "u64",
+            None => {
+                matches!(elem.kind(), crate::api::core::flat::TypeKind::String)
+                    || elem.key().as_str() == "u64"
+            }
         }
     }
 }
@@ -1481,23 +1468,24 @@ impl Declarations {
     pub(crate) fn build_leaf_vec_fold_elements(
         &self,
         registry: &impl Conversions<KotlinMeta>,
-    ) -> Vec<syn::Type> {
+    ) -> Vec<TypeKey> {
         let mut seen = std::collections::HashSet::new();
         let mut out = Vec::new();
-        let mut consider = |bare: syn::Type| {
-            if seen.insert(TypeKey::from_type(&bare)) && self.is_leaf_vec_element(&bare) {
-                out.push(bare);
+        let mut consider = |bare: &crate::api::core::flat::TypeRef| {
+            if seen.insert(bare.key()) && self.is_leaf_vec_element(bare) {
+                out.push(bare.key());
             }
         };
         for f in registry.flat().functions() {
             // `Vec<T>` / `Option<Vec<T>>` return. The model's `ret` already
             // normalizes an elided return to `()`, so there is no arm for it.
             {
-                let ret = f.ret.as_syn();
-                let after_opt =
-                    crate::api::core::types_util::option_inner_type(ret).unwrap_or(ret.clone());
-                if let Some(elem) = crate::api::core::types_util::vec_inner_type(&after_opt) {
-                    consider(peel_leading_ref(&elem));
+                let after_opt = match f.ret.kind() {
+                    crate::api::core::flat::TypeKind::Optional(inner) => inner,
+                    _ => &f.ret,
+                };
+                if let crate::api::core::flat::TypeKind::Vec(elem) = after_opt.kind() {
+                    consider(peel_one_borrow(elem));
                 }
             }
             // `impl Fn(&[T])` / `impl Fn([T])` callback arg. Over the model's
@@ -1508,13 +1496,24 @@ impl Declarations {
                     continue;
                 };
                 for arg in args {
-                    if let syn::Type::Slice(s) = &peel_leading_ref(arg.as_syn()) {
-                        consider(peel_leading_ref(&s.elem));
+                    if let crate::api::core::flat::TypeKind::Slice(elem) =
+                        peel_one_borrow(arg).kind()
+                    {
+                        consider(peel_one_borrow(elem));
                     }
                 }
             }
         }
         out
+    }
+}
+
+/// One `&` off, and nothing else — the model's own `borrow_target` would also
+/// see through a `Box`/`Cow`, which `peel_leading_ref` did not.
+fn peel_one_borrow(t: &crate::api::core::flat::TypeRef) -> &crate::api::core::flat::TypeRef {
+    match t.kind() {
+        crate::api::core::flat::TypeKind::Ref { inner, .. } => inner,
+        _ => t,
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -133,7 +133,7 @@ mod spelling_census {
         // spelling was — see `util::head_type`.
         // kotlin_emit.rs is off the census: `sum_ctor_arg`'s enum payload peels
         // its `Option` off the leaf's own reading.
-        ("jni/trait_impl.rs", 4),
+        ("jni/trait_impl.rs", 2),
         // Down from 2: the nullability decisions now ask the model. The one
         // left probes for an enum through its layers.
         ("jni/fn_plan.rs", 1),


### PR DESCRIPTION
`Decompositions::leaf_vec_elements` was a `Vec<syn::Type>` whose consumer
opened by keying every element:

    // unfold::apply_leaf_vec_folds
    let elem_keys: Vec<TypeKey> = elements.iter().map(TypeKey::from_type).collect();

The `subs` shape again (#317), and the same answer: the list is
`Vec<TypeKey>` end to end, and the conversion is deleted rather than
moved.

What produced it moved with it. `build_leaf_vec_fold_elements` nominated
elements by taking the spelling apart twice — `option_inner_type` /
`vec_inner_type` on the return, `syn::Type::Slice` under a peeled `&` on
each callback argument. Both are kind matches now: `Optional`, `Vec`,
`Slice`, `Ref`. `is_leaf_vec_element` asked three questions of a node —
a keyed lookup, `is_string_type`, and a key string compare — and all
three are the reading's own answers, so `is_string_type` is deleted with
its only caller.

`peel_leading_ref` is gone too: `peel_one_borrow` peels one `&` off a
reading, and it is worth having its own name rather than reaching for
`borrow_target`, which also sees through a `Box` or `Cow`.

    # total escapes: types:       69 -> 67
    # total classification sites: 105 -> 102
    # total escapes: items:        43   (unchanged)

and jnigen's spelling census drops `jni/trait_impl.rs` 4 → 2.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.