### PR TITLE
jnigen: a plan parameter carries its reading, and the wrapper asks it

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -111,8 +111,8 @@
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
-16	api/lang/jnigen/jni/emit/names.rs
-11	api/lang/jnigen/jni/emit/wrapper.rs
+14	api/lang/jnigen/jni/emit/names.rs
+7	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/iface.rs
 2	api/lang/jnigen/jni/overloads.rs
@@ -123,7 +123,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total classification sites: 102
+# total classification sites: 96
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -139,7 +139,7 @@
 2	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
-4	api/lang/jnigen/jni/fn_plan.rs
+3	api/lang/jnigen/jni/fn_plan.rs
 7	api/lang/jnigen/jni/iface.rs
 3	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
@@ -148,7 +148,7 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 14	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 67
+# total escapes: types: 66
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -248,28 +248,6 @@ pub(crate) fn pat_match_top(ty: &syn::Type, name: &str) -> bool {
     false
 }
 
-/// If `ty` is `Option<&T>` or `Option<&mut T>`, return `Some(is_mut)`.
-/// Returns `None` for any other shape. Used by `emit_jni_function_wrapper`
-/// to decide whether the call site needs `.as_deref()` / `.as_deref_mut()`
-/// when the input converter produced `Option<OwnedObject<T>>`.
-pub(crate) fn option_inner_ref_mutability(ty: &syn::Type) -> Option<bool> {
-    let syn::Type::Path(tp) = ty else { return None };
-    let seg = tp.path.segments.last()?;
-    if seg.ident != "Option" {
-        return None;
-    }
-    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
-        return None;
-    };
-    let syn::GenericArgument::Type(inner) = ab.args.first()? else {
-        return None;
-    };
-    let syn::Type::Reference(r) = inner else {
-        return None;
-    };
-    Some(r.mutability.is_some())
-}
-
 /// INPUT: wire → rust. Format `<wire_id>_to_<rust_id>_<hash>` (including
 /// `impl Fn(...)` lambda converters — the legacy
 /// `process_kotlin_<Name>_callback` naming is gone with the fun-interface

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -638,10 +638,11 @@ fn emit_input_param(
         // bound, so non-Clone handles (e.g. `Publisher<'a>`) work too.
         // A null or tagged (closed) pointer — a close that raced past
         // the pre-lock guard — is rejected before any dereference.
-        InputKind::Handle { direct: true } if !matches!(arg_ty, syn::Type::Reference(_)) => {
+        InputKind::Handle { direct: true }
+            if !matches!(arg_ty.kind(), crate::api::core::flat::TypeKind::Ref { .. }) =>
+        {
             let entry = registry
-                .reading_of(arg_ty)
-                .and_then(|tr| registry.input_entry(&tr))
+                .input_entry(arg_ty)
                 .expect("plan classified Handle ⇒ entry present");
             let wire_ident = if matches!(&entry.destination, syn::Type::Ptr(_)) {
                 format_ident!("{}_ptr", arg_ident)
@@ -649,6 +650,7 @@ fn emit_input_param(
                 arg_ident.clone()
             };
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
+            let arg_ty = arg_ty.spell();
             prelude.push(quote!(
                 if #wire_ident == 0 || (#wire_ident & 1) == 1 {
                     signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
@@ -693,9 +695,27 @@ fn emit_input_param(
 fn emit_plain_decode(
     entry: &crate::api::core::registry::TypeEntry<KotlinMeta>,
     arg_ident: &syn::Ident,
-    arg_ty: &syn::Type,
+    arg_ty: &crate::api::core::flat::TypeRef,
     on_err: &TokenStream,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
+    use crate::api::core::flat::TypeKind;
+    /// `&mut T`, read off the kind — and off `kind()` rather than through
+    /// `is_exclusive_borrow`, which also sees through a `Box` and refuses an
+    /// out-parameter's slot. This is the borrow the source wrote.
+    fn is_mut_ref(t: &crate::api::core::flat::TypeRef) -> bool {
+        matches!(t.kind(), TypeKind::Ref { mutable: true, .. })
+    }
+    /// `Option<&T>` / `Option<&mut T>` → `Some(is_mut)`, the shape
+    /// `option_inner_ref_mutability` used to fish out of a path.
+    fn opt_ref_mut(t: &crate::api::core::flat::TypeRef) -> Option<bool> {
+        let TypeKind::Optional(inner) = t.kind() else {
+            return None;
+        };
+        match inner.kind() {
+            TypeKind::Ref { mutable, .. } => Some(*mutable),
+            _ => None,
+        }
+    }
     let mut wire_params: Vec<TokenStream> = Vec::new();
     let mut prelude: Vec<TokenStream> = Vec::new();
     let wire = &entry.destination;
@@ -721,9 +741,7 @@ fn emit_plain_decode(
     // which requires a mutable binding. Also for `Option<&mut T>`
     // where the call site needs `.as_deref_mut()`. Intermediate stage
     // bindings (`__{ident}_sN`) don't need it.
-    let arg_mut: TokenStream = if matches!(arg_ty, syn::Type::Reference(r) if r.mutability.is_some())
-        || matches!(option_inner_ref_mutability(arg_ty), Some(true))
-    {
+    let arg_mut: TokenStream = if is_mut_ref(arg_ty) || matches!(opt_ref_mut(arg_ty), Some(true)) {
         quote!(mut)
     } else {
         quote!()
@@ -781,18 +799,18 @@ fn emit_plain_decode(
             prev = out_ident;
         }
     }
-    let call_arg = match arg_ty {
-        syn::Type::Reference(r) if r.mutability.is_some() => quote!(&mut #arg_ident),
-        syn::Type::Reference(_) => quote!(&#arg_ident),
+    let call_arg = match arg_ty.kind() {
+        TypeKind::Ref { mutable: true, .. } => quote!(&mut #arg_ident),
+        TypeKind::Ref { .. } => quote!(&#arg_ident),
         // `Option<&T>` / `Option<&mut T>` for opaque inner: the input
         // converter produced `Option<OwnedObject<T>>` (see rank-1
         // handler above). `.as_deref()` / `.as_deref_mut()` coerces
         // back to `Option<&T>` / `Option<&mut T>` via OwnedObject's
         // Deref / DerefMut impls.
-        _ if matches!(option_inner_ref_mutability(arg_ty), Some(false)) => {
+        _ if matches!(opt_ref_mut(arg_ty), Some(false)) => {
             quote!(#arg_ident.as_deref())
         }
-        _ if matches!(option_inner_ref_mutability(arg_ty), Some(true)) => {
+        _ if matches!(opt_ref_mut(arg_ty), Some(true)) => {
             quote!(#arg_ident.as_deref_mut())
         }
         _ => quote!(#arg_ident),

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -44,7 +44,11 @@ pub(crate) struct JniFunctionPlan {
 /// One source parameter: the ident/type as written plus its lowered form.
 pub(crate) struct PlanParam {
     pub ident: syn::Ident,
-    pub ty: syn::Type,
+    /// The parameter's **reading**. For a `ParamForm::Single` it is the very
+    /// reading the leaf carries — `emit/wrapper.rs` says as much where it uses
+    /// the leaf's instead — so carrying the spelling was carrying a copy that
+    /// could not disagree, in a form that could not be asked anything.
+    pub ty: crate::api::core::flat::TypeRef,
     pub form: ParamForm,
 }
 
@@ -491,7 +495,7 @@ impl JniFunctionPlan {
         // fail to yield a type.
         for param in &f.params {
             let ident = param.name.clone();
-            let ty = param.ty.as_syn().clone();
+            let ty = param.ty.clone();
 
             let form = if let Some(plan) = registry
                 .expansion_plans()


### PR DESCRIPTION
`PlanParam::ty` was a `syn::Type` beside a leaf that already held the
reading it was spelled from — `emit/wrapper.rs` says exactly that where
it uses the leaf's instead. So the field was a copy that could not
disagree, in a form that could not be asked anything. It is a `TypeRef`.

What the wrapper asked the copy, it asks the model:

* `matches!(arg_ty, syn::Type::Reference(r) if r.mutability.is_some())`
  → `Ref { mutable: true, .. }`;
* `option_inner_ref_mutability(arg_ty)` — twenty lines fishing
  `Option<&mut T>` out of a path, generic argument by generic argument —
  → `Optional(inner)` over `Ref { mutable }`. Its last caller went with
  it, so the function is deleted.

Both are read off `kind()` rather than through `is_exclusive_borrow` /
`optional_inner`, which see through a `Box` and refuse an out-parameter's
slot. This is the borrow the source wrote, and the accessors answer a
slightly different question.

    # total classification sites: 102 -> 96
      emit/wrapper.rs 11 -> 7, emit/names.rs 16 -> 14
    # total escapes: types:        67 -> 66
    # total escapes: items:        43   (unchanged)

The classification drop is the point here: this is the first stage where
deleting a **helper** paid more than the escape it was reached through.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.