### PR TITLE
jnigen: the two sum-position checks read the return, not the signature

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -102,7 +102,7 @@
 # gaps are listed here rather than implied away.
 
 2	api/core/registry/scan.rs
-9	api/core/types_util.rs
+8	api/core/types_util.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 5	api/lang/cbindgen/emit.rs
@@ -123,7 +123,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total classification sites: 96
+# total classification sites: 95
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -163,6 +163,6 @@
 2	api/lang/jnigen/jni/overloads.rs
 6	api/lang/jnigen/jni/render.rs
 3	api/lang/jnigen/jni/symbols.rs
-6	api/lang/jnigen/jni/trait_impl.rs
+5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 43
+# total escapes: items: 42

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -130,23 +130,6 @@ pub fn bare_path_ident(ty: &syn::Type) -> Option<syn::Ident> {
     Some(seg.ident.clone())
 }
 
-/// Strip any nesting of `&` / `Option<…>` / `Vec<…>` layers down to the core
-/// type (`Option<&Vec<ZThing>>` → `ZThing`).
-pub fn peel_ref_option_vec(ty: &syn::Type) -> syn::Type {
-    let mut t = ty.clone();
-    loop {
-        if let syn::Type::Reference(r) = &t {
-            t = (*r.elem).clone();
-            continue;
-        }
-        if let Some(inner) = option_inner_type(&t).or_else(|| vec_inner_type(&t)) {
-            t = inner;
-            continue;
-        }
-        return t;
-    }
-}
-
 /// Build an identifier at call-site span.
 pub(crate) fn ident(s: &str) -> syn::Ident {
     syn::Ident::new(s, Span::call_site())

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1508,6 +1508,20 @@ impl Declarations {
     }
 }
 
+/// `&` / `Option` / `Vec` off, to a fixed point — `peel_ref_option_vec` over a
+/// reading, and off `kind()` for the reason [`peel_one_borrow`] gives.
+fn peel_ref_option_vec_reading(
+    t: &crate::api::core::flat::TypeRef,
+) -> &crate::api::core::flat::TypeRef {
+    use crate::api::core::flat::TypeKind;
+    match t.kind() {
+        TypeKind::Ref { inner, .. } | TypeKind::Optional(inner) | TypeKind::Vec(inner) => {
+            peel_ref_option_vec_reading(inner)
+        }
+        _ => t,
+    }
+}
+
 /// One `&` off, and nothing else — the model's own `borrow_target` would also
 /// see through a `Box`/`Cow`, which `peel_leading_ref` did not.
 fn peel_one_borrow(t: &crate::api::core::flat::TypeRef) -> &crate::api::core::flat::TypeRef {
@@ -1647,19 +1661,18 @@ impl Prebindgen for Declarations {
             let Some(func) = binding.flat().function(&ident) else {
                 continue;
             };
-            let item_fn = func.origin.as_syn();
             // (1) A sum in the `Ok` position of a fallible return. A sum is
             // delivered DECOMPOSED through a builder callback, and the
             // `Result` lane has no builder: a `Result` return deliberately
             // keeps its whole-value converter so a fallible factory still
             // yields a handle (see `unfold::returns_type`).
-            if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
-                if let Some(ok) = crate::api::core::types_util::result_ok_type(ret) {
-                    let core = crate::api::core::types_util::peel_ref_option_vec(&ok);
-                    if matches!(
-                        self.type_kind(binding, &TypeKey::from_type(&core)),
-                        TypeKind::Sum
-                    ) {
+            // Off the model's return, not the item's `sig.output`: the reading
+            // says it is fallible and hands over both sides, where re-reading
+            // the signature had to find the `Result` in a path first.
+            if let Some((ok, _)) = func.ret.fallible_parts() {
+                {
+                    let core = peel_ref_option_vec_reading(ok);
+                    if matches!(self.type_kind(binding, &core.key()), TypeKind::Sum) {
                         return Err(format!(
                             "fn `{ident}`: `Result<{}, _>` — a sealed_class value is not \
                              supported in the success position of a fallible return. A sum \
@@ -1669,8 +1682,8 @@ impl Prebindgen for Declarations {
                              factory can still hand back a handle. Return `{}` directly and \
                              report failure through the error channel, or model the failure \
                              as one of the sum's own variants",
-                            ok.to_token_stream(),
-                            ok.to_token_stream(),
+                            ok.spell(),
+                            ok.spell(),
                         ));
                     }
                 }
@@ -1690,19 +1703,14 @@ impl Prebindgen for Declarations {
             // `.expand_return(...)` always targets the Output position. So the
             // declaration set is the whole story, and this stays a pre-resolve
             // check.
-            if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
-                if let Some(err_ty) = crate::api::core::types_util::result_err_type(ret) {
-                    let core = crate::api::core::types_util::peel_ref_option_vec(&err_ty);
+            if let Some((_, err_ty)) = func.ret.fallible_parts() {
+                {
+                    let core = peel_ref_option_vec_reading(err_ty);
                     let declared = self
                         .return_expand_decls
                         .iter()
-                        .any(|d| d.key == TypeKey::from_type(&err_ty));
-                    if !declared
-                        && matches!(
-                            self.type_kind(binding, &TypeKey::from_type(&core)),
-                            TypeKind::Sum
-                        )
-                    {
+                        .any(|d| d.key == err_ty.key());
+                    if !declared && matches!(self.type_kind(binding, &core.key()), TypeKind::Sum) {
                         return Err(format!(
                             "fn `{ident}`: `Result<_, {}>` — `{}` is declared `sealed_class!`, \
                              but nothing decomposes it in the error position, so it would be \
@@ -1721,10 +1729,10 @@ impl Prebindgen for Declarations {
                             // peeled sum, since that is what carries the
                             // declaration. Identical for a bare `E`; they
                             // diverge once it is wrapped.
-                            err_ty.to_token_stream(),
-                            core.to_token_stream(),
-                            err_ty.to_token_stream(),
-                            err_ty.to_token_stream(),
+                            err_ty.spell(),
+                            core.spell(),
+                            err_ty.spell(),
+                            err_ty.spell(),
                         ));
                     }
                 }

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -133,7 +133,9 @@ mod spelling_census {
         // spelling was — see `util::head_type`.
         // kotlin_emit.rs is off the census: `sum_ctor_arg`'s enum payload peels
         // its `Option` off the leaf's own reading.
-        ("jni/trait_impl.rs", 2),
+        // trait_impl.rs is off the census: the two sum-position checks read the
+        // model's `fallible_parts` and peel the reading, so no helper of this
+        // kind is left in the file.
         // Down from 2: the nullability decisions now ask the model. The one
         // left probes for an enum through its layers.
         ("jni/fn_plan.rs", 1),


### PR DESCRIPTION
Both refusals — a sum in a `Result`'s `Ok`, a sum in its `Err` with no
deconstructor — opened by re-reading the item:

    if let syn::ReturnType::Type(_, ret) = &item_fn.sig.output {
        if let Some(ok) = result_ok_type(ret) {
            let core = peel_ref_option_vec(&ok);

The model's `ret` already says it is fallible and hands over both sides:
`func.ret.fallible_parts()`. So the `sig.output` match, `result_ok_type`,
`result_err_type` and the spelling peel all go, and the item escape that
reached the signature goes with them.

`peel_ref_option_vec` had exactly these two callers left and is deleted;
`peel_ref_option_vec_reading` peels the same three layers off a reading,
off `kind()` rather than through the layer accessors, which also see
through a `Box`.

    # total classification sites: 96 -> 95   (types_util 9 -> 8)
    # total escapes: items:       43 -> 42
    # total escapes: types:       66         (unchanged)

and jnigen's spelling census drops `jni/trait_impl.rs` (2 → 0) — the row
is gone.

**The item bucket moved for the first time.** It was expected to persist
until items grow modelled accessors, and this is the other way it can
fall: an item read that existed only because the *type* question was
being asked of the signature.

## A near miss worth recording

`is_option_type` / `is_vec_type` / `is_result_type` looked callerless and
were deleted — then the compiler produced three errors from
`cbindgen/mod.rs`, which re-exports them as `is_option` / `is_vec` /
`is_result`. Restored. It is the same alias blind spot the ledger's own
scanner handles for `use syn::Type as T`, arriving from the other
direction: a grep for the definition's name does not see the callers.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.