### PR TITLE
jnigen: the slice-of-sums refusal reads the model

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -119,11 +119,11 @@
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 5	api/lang/jnigen/jni/render.rs
-8	api/lang/jnigen/jni/trait_impl.rs
+5	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 2	api/lang/jnigen/util.rs
 
-# total classification sites: 95
+# total classification sites: 92
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -146,9 +146,9 @@
 1	api/lang/jnigen/jni/render.rs
 6	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
-14	api/lang/jnigen/jni/trait_impl.rs
+13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 66
+# total escapes: types: 65
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1746,21 +1746,15 @@ impl Prebindgen for Declarations {
                     continue;
                 };
                 for arg in args {
-                    let after_ref = match arg.as_syn() {
-                        syn::Type::Reference(r) => (*r.elem).clone(),
-                        other => other.clone(),
-                    };
-                    let syn::Type::Slice(s) = &after_ref else {
+                    // The same walk `build_leaf_vec_fold_elements` makes over a
+                    // callback argument, off the same helper: one borrow, a
+                    // slice, one borrow off its element.
+                    let crate::api::core::flat::TypeKind::Slice(elem) = peel_one_borrow(arg).kind()
+                    else {
                         continue;
                     };
-                    let elem = match &*s.elem {
-                        syn::Type::Reference(r) => (*r.elem).clone(),
-                        other => other.clone(),
-                    };
-                    if matches!(
-                        self.type_kind(binding, &TypeKey::from_type(&elem)),
-                        TypeKind::Sum
-                    ) {
+                    let elem = peel_one_borrow(elem);
+                    if matches!(self.type_kind(binding, &elem.key()), TypeKind::Sum) {
                         return Err(format!(
                             "fn `{ident}`: `impl Fn(&[{}])` — a slice of a sealed_class value \
                              is not supported as a callback argument. A sum crosses as a tag \
@@ -1768,10 +1762,10 @@ impl Prebindgen for Declarations {
                              those into the foreign list needs the element folder a `Vec<{}>` \
                              RETURN provides; declare the callback over one value \
                              (`impl Fn({})`) or return `Vec<{}>` instead",
-                            elem.to_token_stream(),
-                            elem.to_token_stream(),
-                            elem.to_token_stream(),
-                            elem.to_token_stream(),
+                            elem.spell(),
+                            elem.spell(),
+                            elem.spell(),
+                            elem.spell(),
                         ));
                     }
                 }


### PR DESCRIPTION
The twin of the walk #322 migrated, left behind because it lives in a
different function. Same shape, three `syn::Type` matches deep:

    let after_ref = match arg.as_syn() {
        syn::Type::Reference(r) => (*r.elem).clone(),
        other => other.clone(),
    };
    let syn::Type::Slice(s) = &after_ref else { continue };
    let elem = match &*s.elem { syn::Type::Reference(r) => …, … };

One borrow, a slice, one borrow off its element — which is exactly what
`peel_one_borrow` and a `Slice` kind say, and #322 already added the
helper for the other copy.

    # total classification sites: 95 -> 92   (trait_impl.rs 8 -> 5)
    # total escapes: types:       66 -> 65
    # total escapes: items:        42        (unchanged)

`trait_impl.rs`'s five remaining classification sites are on **produced**
— the spelling the converter selector composes and hands in, not
captured source. That is the ledger's "adapter-synthesized" case, and it
is what the file is left holding.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.