### PR TITLE
jnigen: a lookup takes the reading, a reconstruction takes the identity

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -135,20 +135,19 @@
 3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
-1	api/lang/jnigen/jni/emit/delivery.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fn_plan.rs
-7	api/lang/jnigen/jni/iface.rs
-3	api/lang/jnigen/jni/kotlin_emit.rs
+3	api/lang/jnigen/jni/iface.rs
+1	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/render.rs
 6	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 65
+# total escapes: types: 58
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -1393,18 +1393,18 @@ pub(crate) fn leaf_is_prim(
     if leaf.nullable {
         return false;
     }
-    leaf_ty_is_prim(registry, leaf.out_ty.as_syn())
+    leaf_ty_is_prim(registry, &leaf.out_ty)
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw
 /// primitive** slot? Split out so the interface derivation can ask the question
 /// about a leaf whose own `nullable` flag it is in the middle of computing (an
 /// inert sum group slot).
-pub(crate) fn leaf_ty_is_prim(registry: &impl Conversions<KotlinMeta>, out_ty: &syn::Type) -> bool {
-    let Some(entry) = registry
-        .reading_of(out_ty)
-        .and_then(|tr| registry.output_entry(&tr))
-    else {
+pub(crate) fn leaf_ty_is_prim(
+    registry: &impl Conversions<KotlinMeta>,
+    out_ty: &crate::api::core::flat::TypeRef,
+) -> bool {
+    let Some(entry) = registry.output_entry(out_ty) else {
         return false;
     };
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -714,7 +714,7 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, leaf.out_ty.as_syn());
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
     leaf_iface_param(
         ext,
         registry,
@@ -1073,7 +1073,7 @@ impl Declarations {
 fn fixed_reassembly(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    source: &syn::Type,
+    source: &TypeKey,
     leaves: &[crate::api::core::unfold::UnfoldLeaf],
     class_fqn: &str,
 ) -> (String, Vec<String>) {
@@ -1163,7 +1163,7 @@ pub(crate) fn callback_iface_spec(
                 let core = t.borrow_target().unwrap_or(t);
                 let fqn = ext.kotlin_fqn(&core.key())?;
                 let (reassemble, imports) =
-                    fixed_reassembly(ext, registry, core.as_syn(), &plan.leaves, &fqn);
+                    fixed_reassembly(ext, registry, &core.key(), &plan.leaves, &fqn);
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(kt::KtType::cls(fqn.to_string())),
@@ -1195,7 +1195,7 @@ pub(crate) fn callback_iface_spec(
                         let (reassemble, imports) = fixed_reassembly(
                             ext,
                             registry,
-                            leaf.out_ty.as_syn(),
+                            &leaf.out_ty.key(),
                             &plan.leaves[k..seg],
                             &fqn,
                         );
@@ -1449,7 +1449,7 @@ pub(crate) fn fixed_folder_typed_groups(
     let spec = registry.decon_plans().get(decon)?;
     let fqn = ext.kotlin_fqn(&spec.source.key())?;
     let (reassemble, imports) =
-        fixed_reassembly(ext, registry, spec.source.as_syn(), &spec.leaves, &fqn);
+        fixed_reassembly(ext, registry, &spec.source.key(), &spec.leaves, &fqn);
     Some(vec![
         TypedGroup {
             name: "acc".to_string(),

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1293,7 +1293,7 @@ impl Declarations {
         let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
         let (iface_short, when) = self.sum_reconstruct(
             registry,
-            plan.source.as_syn(),
+            &plan.source.key(),
             &plan.leaves,
             &spec.params,
             &names,
@@ -1332,7 +1332,7 @@ impl Declarations {
         let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
         let (iface_short, when) = self.sum_reconstruct(
             registry,
-            plan.source.as_syn(),
+            &plan.source.key(),
             &plan.leaves,
             &spec.params[1..],
             &names[1..],
@@ -1371,25 +1371,28 @@ impl Declarations {
     pub(crate) fn sum_reconstruct(
         &self,
         registry: &impl Conversions<KotlinMeta>,
-        source: &syn::Type,
+        // The sum's **identity**: every use of `source` here was
+        // `TypeKey::from_type` or `bare_path_ident`, and a key that is one
+        // identifier IS the ident — the same reduction `type_kind` made.
+        key: &TypeKey,
         leaves: &[crate::api::core::unfold::UnfoldLeaf],
         params: &[crate::api::lang::jnigen::jni::IfaceParam],
         names: &[String],
         imports: &mut BTreeSet<String>,
     ) -> (String, String) {
-        let key = TypeKey::from_type(source);
         let iface_fqn = self
-            .kotlin_fqn(&key)
+            .kotlin_fqn(key)
             .unwrap_or_else(|| panic!("sum builder: no Kotlin FQN for {key}"));
         let iface_short = register_fqn(&iface_fqn, imports);
-        let ident = bare_path_ident(source)
+        let ident = key
+            .ident()
             .unwrap_or_else(|| panic!("sum builder: `{key}` is not a path type"));
         let Some(crate::api::core::flat::Type::Variant(sum)) =
             registry.flat().declared_type(&ident)
         else {
             panic!("sum builder: `{ident}` is not an indexed sum")
         };
-        let sum_cfg = self.types[&key]
+        let sum_cfg = self.types[key]
             .sum()
             .unwrap_or_else(|| panic!("sum builder: `{ident}` is not a sealed class"));
         let tag = &names[0];


### PR DESCRIPTION
Two helpers in the Kotlin-surface chain took a node and immediately
un-took it.

* **`leaf_ty_is_prim`** opened with `reading_of(out_ty)` — a keyed lookup
  of a reading both its callers already held. It takes the `&TypeRef` and
  asks `output_entry` directly.
* **`sum_reconstruct`** used `source` for exactly two things:
  `TypeKey::from_type(source)` and `bare_path_ident(source)`. Both are the
  identity, and a key that is one identifier IS the ident — the reduction
  #319 already made for `type_kind`. It takes a `&TypeKey`, and
  `fixed_reassembly` hands one on rather than a spelling.

    # total escapes: types:       65 -> 58
      iface.rs 7 -> 3, kotlin_emit.rs 3 -> 1, emit/delivery.rs 1 -> 0
    # total classification sites: 92   (unchanged)
    # total escapes: items:       42   (unchanged)

`emit/delivery.rs` reaches **zero** on both counts — the first adapter
file to hold neither an escape nor a classification site.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.