### PR TITLE
cbindgen: a C symbol is built from an identity

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -131,7 +131,7 @@
 1	api/core/registry/key.rs
 2	api/core/registry/order.rs
 4	api/core/registry/scan.rs
-3	api/lang/cbindgen/convert.rs
+2	api/lang/cbindgen/convert.rs
 3	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
@@ -147,7 +147,7 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 58
+# total escapes: types: 57
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -310,7 +310,7 @@ impl CbindgenBuilder {
             "Cbindgen::repr_c_struct cannot declare `{}` because it is already ignored",
             key
         );
-        let mirror = self.c_type_ident(&ty);
+        let mirror = self.c_type_ident(&key);
         self.value_opaque.insert(
             key.clone(),
             ValueOpaqueCfg {
@@ -686,14 +686,13 @@ impl CbindgenBuilder {
     }
 
     /// Config of a declared type (across the opaque/data/enum maps), by key.
-    pub(super) fn type_cfg(&self, ty: &syn::Type) -> Option<&TypeCfg> {
-        let key = TypeKey::from_type(ty);
+    pub(super) fn type_cfg(&self, key: &TypeKey) -> Option<&TypeCfg> {
         self.opaque
-            .get(&key)
-            .or_else(|| self.data.get(&key))
-            .or_else(|| self.value_opaque.get(&key).map(|c| &c.cfg))
-            .or_else(|| self.enums.get(&key))
-            .or_else(|| self.tagged_unions.get(&key))
+            .get(key)
+            .or_else(|| self.data.get(key))
+            .or_else(|| self.value_opaque.get(key).map(|c| &c.cfg))
+            .or_else(|| self.enums.get(key))
+            .or_else(|| self.tagged_unions.get(key))
     }
 
     /// The opaque counterpart type of a declared inline-opaque type, if any.
@@ -721,21 +720,21 @@ impl CbindgenBuilder {
     /// Public "take" (move) symbol for a takeable value_opaque type:
     /// [`Self::mangle_take`] over the base, else `<base>_take` (e.g.
     /// `z_sample_take`). Symmetric with [`Self::destructor_symbol`].
-    pub(super) fn take_symbol(&self, ty: &syn::Type) -> syn::Ident {
+    pub(super) fn take_symbol(&self, key: &TypeKey) -> syn::Ident {
         if let Some(f) = &self.mangle_take {
-            return format_ident!("{}", f(&self.rust_base(ty)));
+            return format_ident!("{}", f(&self.rust_base(key)));
         }
-        format_ident!("{}_take", self.rust_base(ty))
+        format_ident!("{}_take", self.rust_base(key))
     }
 
     /// Base token for a Rust type: [`Self::mangle_rust_type`] applied to the Rust
     /// short name, or the short name verbatim when unset. Feeds the type-name,
     /// destructor and callback manglers.
-    pub(super) fn rust_base(&self, ty: &syn::Type) -> String {
-        if let Some(b) = self.type_cfg(ty).and_then(|c| c.base.clone()) {
+    pub(super) fn rust_base(&self, key: &TypeKey) -> String {
+        if let Some(b) = self.type_cfg(key).and_then(|c| c.base.clone()) {
             return b;
         }
-        let short = type_short(ty);
+        let short = type_short(key);
         match &self.mangle_rust_type {
             Some(f) => f(&short),
             // No mangler: a C-like `snake_case` default (so destructors/take/type
@@ -746,8 +745,8 @@ impl CbindgenBuilder {
 
     /// Emitted C type name of a declared type: [`Self::mangle_type_name`] over the
     /// base, else the base (which is the `mangle_rust_type`/`.base_name` token).
-    pub(super) fn c_type_name(&self, ty: &syn::Type) -> String {
-        let base = self.rust_base(ty);
+    pub(super) fn c_type_name(&self, key: &TypeKey) -> String {
+        let base = self.rust_base(key);
         match &self.mangle_type_name {
             Some(f) => f(&base),
             None => base,
@@ -756,17 +755,17 @@ impl CbindgenBuilder {
 
     /// C type identifier (the `#[repr(C)]` struct/enum name + the wire type used
     /// across converters and wrappers).
-    pub(super) fn c_type_ident(&self, ty: &syn::Type) -> syn::Ident {
-        format_ident!("{}", self.c_type_name(ty))
+    pub(super) fn c_type_ident(&self, key: &TypeKey) -> syn::Ident {
+        format_ident!("{}", self.c_type_name(key))
     }
 
     /// Destructor symbol of an opaque handle: [`Self::mangle_destructor`] over the
     /// base, else `<base>_drop`.
-    pub(super) fn destructor_symbol(&self, ty: &syn::Type) -> syn::Ident {
+    pub(super) fn destructor_symbol(&self, key: &TypeKey) -> syn::Ident {
         if let Some(f) = &self.mangle_destructor {
-            return format_ident!("{}", f(&self.rust_base(ty)));
+            return format_ident!("{}", f(&self.rust_base(key)));
         }
-        format_ident!("{}_drop", self.rust_base(ty))
+        format_ident!("{}_drop", self.rust_base(key))
     }
 
     /// Emitted C type name of a callback's closure struct: [`Self::mangle_callback`]
@@ -781,7 +780,10 @@ impl CbindgenBuilder {
             // The override (when set) is the sole base; otherwise the args' bases.
             let bases: Vec<String> = match &base_override {
                 Some(b) => vec![b.clone()],
-                None => args.iter().map(|a| self.rust_base(a)).collect(),
+                None => args
+                    .iter()
+                    .map(|a| self.rust_base(&TypeKey::from_type(a)))
+                    .collect(),
             };
             return f(&bases);
         }
@@ -793,7 +795,10 @@ impl CbindgenBuilder {
         if args.is_empty() {
             "closure".to_string()
         } else {
-            let parts: Vec<String> = args.iter().map(|a| self.rust_base(a)).collect();
+            let parts: Vec<String> = args
+                .iter()
+                .map(|a| self.rust_base(&TypeKey::from_type(a)))
+                .collect();
             format!("closure_{}", parts.join("_"))
         }
     }

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -18,7 +18,7 @@ impl CbindgenBuilder {
                 .get(&decl.key)
                 .cloned()
                 .unwrap_or_else(|| {
-                    let short = type_short(&decl.rust_type.as_syn().clone());
+                    let short = type_short(&decl.rust_type.key().clone());
                     self.mangle_rust_type
                         .as_ref()
                         .map(|m| m(&short))

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -127,7 +127,7 @@ impl CbindgenBuilder {
             return Ok(syn::parse_quote!(*mut ::core::ffi::c_char));
         }
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(fty);
+            let c = self.c_type_ident(&TypeKey::from_type(fty));
             return Ok(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         // `bool` is the one scalar with a restricted domain: `2` is a byte a C
@@ -179,7 +179,7 @@ impl CbindgenBuilder {
         // differ, which is exactly the split (`kind` decides what C sees, syntax
         // decides how the value is built).
         if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
-            let c = self.c_type_ident(&inner);
+            let c = self.c_type_ident(&TypeKey::from_type(&inner));
             return Ok(syn::parse_quote!(*mut #c));
         }
         // Otherwise the payload's wire is its **resolved converter
@@ -243,7 +243,7 @@ impl CbindgenBuilder {
     /// until its tag has been validated. Invisible in C either way.
     pub(super) fn data_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
         if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(fty);
+            let c = self.c_type_ident(&TypeKey::from_type(fty));
             return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         c_field_wire(fty)
@@ -411,7 +411,7 @@ impl CbindgenBuilder {
             return Some(fty.clone());
         }
         if self.enums.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(fty);
+            let c = self.c_type_ident(&TypeKey::from_type(fty));
             return Some(syn::parse_quote!(#c));
         }
         // Opaque pointer: `Option<Box<T>>` (nullable, null-niche ↔ NULL) or `Box<T>`
@@ -423,7 +423,7 @@ impl CbindgenBuilder {
         };
         if let Some(inner) = boxed {
             if self.opaque.contains_key(&TypeKey::from_type(&inner)) {
-                let c = self.c_type_ident(&inner);
+                let c = self.c_type_ident(&TypeKey::from_type(&inner));
                 return Some(syn::parse_quote!(*mut #c));
             }
         }

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -477,10 +477,14 @@ fn sanitize(key: &TypeKey) -> String {
 }
 
 /// Last path-segment ident of a type as a `String` (e.g. `ZKeyExpr`).
-fn type_short(ty: &syn::Type) -> String {
-    type_path_tail(ty)
-        .map(|i| i.to_string())
-        .unwrap_or_else(|| sanitize(&TypeKey::from_type(ty)))
+/// The short name a C symbol is built from — the key's last path segment, or a
+/// sanitized rendering of the whole key when it is not a path.
+///
+/// Off the **identity**: `type_path_tail` took the last segment of a node, and
+/// `TypeKey::short_name` is the same question asked of the canonical string, so
+/// the name no longer depends on holding the node it was derived from.
+fn type_short(key: &TypeKey) -> String {
+    key.short_name().unwrap_or_else(|| sanitize(key))
 }
 
 /// The indexed `syn::ItemEnum` for a declared enum type, by tail ident.

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -15,9 +15,9 @@ impl CbindgenBuilder {
             return None;
         }
         let name = Self::in_name(ty);
-        let c_struct = self.c_type_ident(ty);
+        let c_struct = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
-        let short = type_short(ty);
+        let short = type_short(&TypeKey::from_type(ty));
         let null_msg = format!("null {short} handle passed by value");
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
@@ -54,7 +54,7 @@ impl CbindgenBuilder {
         }
         let fields = self.struct_fields(r, ty)?;
         let name = Self::in_name(ty);
-        let c_struct = self.c_type_ident(ty);
+        let c_struct = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
         let mut inits: Vec<TokenStream> = Vec::new();
         let mut subs: Vec<TypeKey> = Vec::new();
@@ -219,7 +219,7 @@ impl CbindgenBuilder {
         let opaque = self.value_opaque_ty(ty)?.clone();
         let name = Self::in_name(ty);
         let src = self.src_ty(ty);
-        let short = type_short(ty);
+        let short = type_short(&TypeKey::from_type(ty));
         let null_msg = format!("null {short} value passed by value");
         // Owned-ness (whether to clean up the moved-from slot) is inferred from the
         // mirror's fields for a `repr_c_struct`, or the explicit kind for a non-mirror.
@@ -282,7 +282,7 @@ impl CbindgenBuilder {
         let e = enum_item(r, ty)?;
         assert_unit_enum(e);
         let name = Self::in_name(ty);
-        let cname = self.c_type_ident(ty);
+        let cname = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
         let cname_str = cname.to_string();
         let arms = e.variants.iter().map(|v| {
@@ -542,7 +542,7 @@ impl CbindgenBuilder {
                 continue;
             }
             let ty = reading.as_syn().clone();
-            let c_struct = self.c_type_ident(&ty);
+            let c_struct = self.c_type_ident(&reading.key());
             // Opaque/incomplete C type: the handle is `#c_struct *`, which IS the
             // `Box::into_raw` pointer to the source value.
             items.push(syn::parse_quote!(
@@ -553,7 +553,7 @@ impl CbindgenBuilder {
                 }
             ));
             let src = self.src_ty(&ty);
-            let drop_ident = self.destructor_symbol(&ty);
+            let drop_ident = self.destructor_symbol(&reading.key());
             items.push(syn::parse_quote!(
                 #[no_mangle]
                 #[allow(non_snake_case, unused_variables)]
@@ -584,14 +584,14 @@ impl CbindgenBuilder {
             let Some(fields) = self.struct_fields(registry, &ty) else {
                 continue;
             };
-            let c_struct = self.c_type_ident(&ty);
+            let c_struct = self.c_type_ident(&reading.key());
             let mut field_defs: Vec<TokenStream> = Vec::new();
             for (fname, fty) in &fields {
                 let wire = self.data_field_wire(fty).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
                         fname,
-                        type_short(&ty),
+                        type_short(&reading.key()),
                         fty.to_token_stream()
                     )
                 });
@@ -635,11 +635,11 @@ impl CbindgenBuilder {
             // `mirror_field_wire` (scalar / enum / opaque pointer). The size/align
             // assert below then proves the whole-struct reinterpret sound.
             if cfg.generate_mirror {
-                let mirror_ident = self.c_type_ident(&ty);
+                let mirror_ident = self.c_type_ident(&reading.key());
                 let fields = self.struct_fields(registry, &ty).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen::repr_c_struct: `{}` is not a named struct",
-                        type_short(&ty)
+                        type_short(&reading.key())
                     )
                 });
                 // Restricted-validity audit (#170 instance 3, #158 instance 3):
@@ -670,7 +670,7 @@ impl CbindgenBuilder {
                          a separate parameter, or widen it to an integer. If this binding's C \
                          side is trusted to write only in-domain bytes — or never hands the \
                          mirror back at all — acknowledge it with `.assume_c_field_validity()`.",
-                        type_short(&ty),
+                        type_short(&reading.key()),
                         listed.join("\n"),
                     );
                 }
@@ -683,7 +683,7 @@ impl CbindgenBuilder {
                                  type `{}` (expected a scalar, a declared `enum_type`, or an \
                                  opaque pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
                                 fname,
-                                type_short(&ty),
+                                type_short(&reading.key()),
                                 fty.to_token_stream()
                             )
                         });
@@ -755,7 +755,7 @@ impl CbindgenBuilder {
                     }
                 }
             ));
-            let drop_ident = self.destructor_symbol(&ty);
+            let drop_ident = self.destructor_symbol(&reading.key());
             // Unconditional drop: safe because a moved-from slot holds a
             // gravestone (a valid, safely-droppable empty value), so dropping
             // it is a harmless no-op; a live slot drops normally.
@@ -777,7 +777,7 @@ impl CbindgenBuilder {
             // nothing, so the leftover bitwise copy in `src` drops harmlessly and
             // no write-back is needed. This is the C user's "take" operation.
             if takeable_keys.contains(key) {
-                let take_ident = self.take_symbol(&ty);
+                let take_ident = self.take_symbol(&reading.key());
                 // Same inferred write-back as a consume (field-null for a nullable
                 // mirror, `gravestone()` for a bare-`Box` mirror / non-mirror owned).
                 let writeback = self.value_opaque_writeback(registry, &ty, &format_ident!("src"));
@@ -832,7 +832,7 @@ impl CbindgenBuilder {
                 continue;
             };
             assert_unit_enum(e);
-            let cname = self.c_type_ident(&ty);
+            let cname = self.c_type_ident(&reading.key());
             let variants = e.variants.iter().map(|v| {
                 let id = &v.ident;
                 match &v.discriminant {
@@ -878,7 +878,7 @@ impl CbindgenBuilder {
                 continue;
             };
             assert_payload_enum(e);
-            let cname = self.c_type_ident(&ty);
+            let cname = self.c_type_ident(&reading.key());
 
             let mut variant_defs: Vec<TokenStream> = Vec::new();
             // Per-variant drop arm, collected only for variants that own
@@ -941,7 +941,7 @@ impl CbindgenBuilder {
             // symbol that was not emitted.
             if self.tagged_union_has_drop(&ty, registry) {
                 debug_assert!(!drop_arms.is_empty(), "has_drop implies an owning arm");
-                let drop_ident = self.destructor_symbol(&ty);
+                let drop_ident = self.destructor_symbol(&reading.key());
                 // The drop is a second C entry point into the same bytes, so it
                 // owes the same tag check as the input converter — `&mut *this_`
                 // on an out-of-range tag would be the very UB that check exists
@@ -985,7 +985,7 @@ impl CbindgenBuilder {
             .unwrap_or_else(|reason| {
                 panic!(
                     "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
-                    type_short(ty),
+                    type_short(&TypeKey::from_type(ty)),
                     variant,
                     match &field.ident {
                         Some(n) => format!(".{n}"),
@@ -1035,7 +1035,7 @@ impl CbindgenBuilder {
                     // — and the owning pointer is reached even though it is two
                     // levels down. Nothing else can reach it: a union arm is not
                     // a top-level struct field the C caller releases by hand.
-                    let drop_ident = self.destructor_symbol(fty);
+                    let drop_ident = self.destructor_symbol(&TypeKey::from_type(fty));
                     quote!(#drop_ident(&mut (*#binding).#fname);)
                 } else {
                     // `owning_data_struct_fields` yields exactly the two shapes
@@ -1091,7 +1091,7 @@ impl CbindgenBuilder {
         let e = enum_item(r, ty)?;
         assert_payload_enum(e);
         let name = Self::in_name(ty);
-        let cname = self.c_type_ident(ty);
+        let cname = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
         // A payload that crosses through its own converter needs that converter
         // to exist before this one can call it. `subs` only drives the
@@ -1225,7 +1225,7 @@ impl CbindgenBuilder {
         let e = enum_item(r, ty)?;
         assert_payload_enum(e);
         let name = Self::out_name(ty);
-        let cname = self.c_type_ident(ty);
+        let cname = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
         // Deferral, as in `in_tagged_union` — the output counterpart.
         for v in &e.variants {
@@ -1317,7 +1317,7 @@ impl CbindgenBuilder {
             let null_msg = format!(
                 "null payload for `{}` (a non-optional handle payload cannot be NULL — the \
                  union may already have been dropped)",
-                type_short(&inner)
+                type_short(&TypeKey::from_type(&inner))
             );
             return if is_option(fty) {
                 quote!(if #b.is_null() {
@@ -1354,7 +1354,7 @@ impl CbindgenBuilder {
                 let null_msg = format!(
                     "null payload for `{}` (a non-optional `Box` payload cannot be NULL — the \
                      union may already have been dropped)",
-                    type_short(&inner)
+                    type_short(&TypeKey::from_type(&inner))
                 );
                 quote!({
                     if #b.is_null() {
@@ -1413,7 +1413,7 @@ impl CbindgenBuilder {
         // The peer of the input arm above: an owned value the C side must later
         // release, so it is boxed HERE rather than having arrived boxed.
         if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
-            let c = self.c_type_ident(&inner);
+            let c = self.c_type_ident(&TypeKey::from_type(&inner));
             return if is_option(fty) {
                 quote!(match #b {
                     ::core::option::Option::Some(__v) => {
@@ -1426,7 +1426,7 @@ impl CbindgenBuilder {
             };
         }
         if let Some(inner) = opaque_ptr_payload_inner(fty) {
-            let c = self.c_type_ident(&inner);
+            let c = self.c_type_ident(&TypeKey::from_type(&inner));
             return if is_option(fty) {
                 quote!(match #b {
                     ::core::option::Option::Some(__b) => {
@@ -1926,7 +1926,7 @@ impl CbindgenBuilder {
         // Opaque handle output: `Box::into_raw` → the bare `*mut #c_struct` handle.
         if self.opaque.contains_key(&key) {
             let name = Self::out_name(ty);
-            let c_struct = self.c_type_ident(ty);
+            let c_struct = self.c_type_ident(&TypeKey::from_type(ty));
             let src = self.src_ty(ty);
             let function: syn::ItemFn = syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -1973,7 +1973,7 @@ impl CbindgenBuilder {
         if self.data.contains_key(&key) {
             let fields = self.struct_fields(_r, ty)?;
             let name = Self::out_name(ty);
-            let c_struct = self.c_type_ident(ty);
+            let c_struct = self.c_type_ident(&TypeKey::from_type(ty));
             let src = self.src_ty(ty);
             let mut inits: Vec<TokenStream> = Vec::new();
             let mut subs: Vec<TypeKey> = Vec::new();
@@ -2035,7 +2035,7 @@ impl CbindgenBuilder {
             let e = enum_item(_r, ty)?;
             assert_unit_enum(e);
             let name = Self::out_name(ty);
-            let cname = self.c_type_ident(ty);
+            let cname = self.c_type_ident(&TypeKey::from_type(ty));
             let src = self.src_ty(ty);
             let arms = e.variants.iter().map(|v| {
                 let id = &v.ident;
@@ -2295,7 +2295,7 @@ impl CbindgenBuilder {
                 let op = self.value_opaque_ty(&inner)?.clone();
                 let name = Self::in_name(ty);
                 let src = self.src_ty(&inner);
-                let short = type_short(&inner);
+                let short = type_short(&TypeKey::from_type(&inner));
                 let null_ptr_msg = format!("null {short} pointer");
                 let function: syn::ItemFn = syn::parse_quote!(
                     #[allow(non_snake_case, unused_variables, dead_code)]
@@ -2323,14 +2323,14 @@ impl CbindgenBuilder {
             // pointer as a mutable Rust reference. The wire is the handle's C struct
             // or the value-opaque mirror.
             let wire_ty: syn::Type = if self.opaque.contains_key(&TypeKey::from_type(&elem)) {
-                let c_struct = self.c_type_ident(&elem);
+                let c_struct = self.c_type_ident(&TypeKey::from_type(&elem));
                 syn::parse_quote!(#c_struct)
             } else {
                 self.value_opaque_ty(&elem)?.clone()
             };
             let name = Self::in_name(ty);
             let src = self.src_ty(&elem);
-            let short = type_short(&elem);
+            let short = type_short(&TypeKey::from_type(&elem));
             let null_ptr_msg = format!("null {short} pointer");
             let function: syn::ItemFn = syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -2357,14 +2357,14 @@ impl CbindgenBuilder {
         // `&T` (shared borrow) of an opaque handle or value-opaque type.
         let key1 = TypeKey::from_type(&elem);
         let wire_ty: syn::Type = if self.opaque.contains_key(&key1) {
-            let c_struct = self.c_type_ident(&elem);
+            let c_struct = self.c_type_ident(&TypeKey::from_type(&elem));
             syn::parse_quote!(#c_struct)
         } else {
             self.value_opaque_ty(&elem)?.clone()
         };
         let name = Self::in_name(ty);
         let src = self.src_ty(&elem);
-        let short = type_short(&elem);
+        let short = type_short(&TypeKey::from_type(&elem));
         let null_ptr_msg = format!("null {short} pointer");
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
@@ -2474,7 +2474,7 @@ impl CbindgenBuilder {
                 let elem = (*rf.elem).clone();
                 let key = TypeKey::from_type(&elem);
                 let wire_ty: syn::Type = if self.opaque.contains_key(&key) {
-                    let c_struct = self.c_type_ident(&elem);
+                    let c_struct = self.c_type_ident(&TypeKey::from_type(&elem));
                     syn::parse_quote!(#c_struct)
                 } else {
                     self.value_opaque_ty(&elem)?.clone()


### PR DESCRIPTION
Every C name cbindgen emits — the `#[repr(C)]` struct, the destructor,
the take symbol, the converter idents — comes from `rust_base`, and
`rust_base` asked a node two questions:

    self.type_cfg(ty)   // -> TypeKey::from_type(ty), a keyed lookup
    type_short(ty)      // -> the last path segment, else a sanitized key

Both are the identity, so the family takes a `&TypeKey`: `type_cfg`,
`rust_base`, `c_type_name`, `c_type_ident`, `destructor_symbol`,
`take_symbol`. `type_short` is `TypeKey::short_name`, which core already
had — jnigen's `rust_short_name` has been calling it since #291, and this
is the same question asked by the other adapter.

Roughly 60 call sites move: a caller holding a reading asks it
(`reading.key()`), a caller holding a type it composed keys it at the
call. That the two look different at the call site is the point — the
first is free, the second is the adapter naming its own construction.

    # total escapes: types:       58 -> 57
    # total classification sites: 92   (unchanged)
    # total escapes: items:       42   (unchanged)

The escape count barely moves, and that is honest: cbindgen's five
`let ty = reading.as_syn().clone()` sites still feed `src_ty` and
`struct_fields`, which take nodes. What this removes is the *reason* the
naming chain needed one at all — `type_path_tail` no longer runs on a
captured type to produce a symbol.

**Did not move**: every generated artifact byte-identical — which for a
change to how every C symbol is named is the whole proof — 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.