### PR TITLE
cbindgen: a struct's fields come from the element

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -132,7 +132,7 @@
 2	api/core/registry/order.rs
 4	api/core/registry/scan.rs
 2	api/lang/cbindgen/convert.rs
-3	api/lang/cbindgen/emit.rs
+4	api/lang/cbindgen/emit.rs
 6	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
@@ -147,14 +147,14 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 57
+# total escapes: types: 58
 
 ## escapes: items
 1	api/core/prebindgen.rs
 4	api/core/registry/scan.rs
 1	api/core/write.rs
 2	api/lang/cbindgen/convert.rs
-2	api/lang/cbindgen/emit.rs
+1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/mod.rs
 7	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
@@ -164,4 +164,4 @@
 3	api/lang/jnigen/jni/symbols.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 42
+# total escapes: items: 41

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -52,7 +52,7 @@ impl CbindgenBuilder {
             let ty = reading.as_syn().clone();
             registry.output_entry(&reading).is_some()
                 && self
-                    .struct_fields(registry, &ty)
+                    .struct_fields(registry, &TypeKey::from_type(&ty))
                     .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))
                     .unwrap_or(false)
         })
@@ -301,7 +301,7 @@ impl CbindgenBuilder {
         if !self.data.contains_key(&TypeKey::from_type(fty)) {
             return Vec::new();
         }
-        self.struct_fields(registry, fty)
+        self.struct_fields(registry, &TypeKey::from_type(fty))
             .unwrap_or_default()
             .into_iter()
             .filter(|(_, fty)| self.data_field_owns(fty, registry))
@@ -374,24 +374,18 @@ impl CbindgenBuilder {
     pub(super) fn struct_fields(
         &self,
         registry: &impl Conversions<()>,
-        ty: &syn::Type,
+        key: &TypeKey,
     ) -> Option<Vec<(syn::Ident, syn::Type)>> {
-        let ident = type_path_tail(ty)?;
-        let item = registry
-            .flat()
-            .struct_type(&ident)
-            .map(|st| st.origin.as_syn())?;
-        if let syn::Fields::Named(named) = &item.fields {
-            Some(
-                named
-                    .named
-                    .iter()
-                    .map(|f| (f.ident.clone().unwrap(), f.ty.clone()))
-                    .collect(),
-            )
-        } else {
-            None
-        }
+        // The element, not its item. A `Struct` holds the field list the
+        // `syn::Fields::Named` match used to dig out, each field's name beside
+        // the reading of its type — so the name lookup is the key's own ident
+        // and the positional case is `f.name` being `None` rather than a
+        // `Fields` variant.
+        let st = registry.flat().struct_type(&key.ident()?)?;
+        st.fields
+            .iter()
+            .map(|f| Some((f.name.clone()?, f.ty.as_syn().clone())))
+            .collect()
     }
 
     /// Wire type of a `repr_c_struct` field in the generated **visible** mirror: a
@@ -467,7 +461,7 @@ impl CbindgenBuilder {
         registry: &Registry<()>,
         ty: &syn::Type,
     ) -> Vec<(syn::Ident, &'static str)> {
-        self.struct_fields(registry, ty)
+        self.struct_fields(registry, &TypeKey::from_type(ty))
             .unwrap_or_default()
             .into_iter()
             .filter_map(|(fname, fty)| {

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -52,7 +52,7 @@ impl CbindgenBuilder {
         if !self.data.contains_key(&key) {
             return None;
         }
-        let fields = self.struct_fields(r, ty)?;
+        let fields = self.struct_fields(r, &TypeKey::from_type(ty))?;
         let name = Self::in_name(ty);
         let c_struct = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
@@ -129,7 +129,7 @@ impl CbindgenBuilder {
             return None;
         }
         let mut idents = Vec::new();
-        for (fname, fty) in self.struct_fields(registry, ty)? {
+        for (fname, fty) in self.struct_fields(registry, &TypeKey::from_type(ty))? {
             // An owned-pointer field is one whose mirror wire is a raw pointer
             // (`Option<Box<T>>` / `Box<T>` → `*mut t_t`); scalars/enums are not.
             if matches!(self.mirror_field_wire(&fty), Some(syn::Type::Ptr(_))) {
@@ -581,7 +581,7 @@ impl CbindgenBuilder {
                 continue;
             }
             let ty = reading.as_syn().clone();
-            let Some(fields) = self.struct_fields(registry, &ty) else {
+            let Some(fields) = self.struct_fields(registry, &TypeKey::from_type(&ty)) else {
                 continue;
             };
             let c_struct = self.c_type_ident(&reading.key());
@@ -636,12 +636,14 @@ impl CbindgenBuilder {
             // assert below then proves the whole-struct reinterpret sound.
             if cfg.generate_mirror {
                 let mirror_ident = self.c_type_ident(&reading.key());
-                let fields = self.struct_fields(registry, &ty).unwrap_or_else(|| {
-                    panic!(
-                        "Cbindgen::repr_c_struct: `{}` is not a named struct",
-                        type_short(&reading.key())
-                    )
-                });
+                let fields = self
+                    .struct_fields(registry, &TypeKey::from_type(&ty))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Cbindgen::repr_c_struct: `{}` is not a named struct",
+                            type_short(&reading.key())
+                        )
+                    });
                 // Restricted-validity audit (#170 instance 3, #158 instance 3):
                 // a mirror is reinterpreted whole, so a field whose Rust type
                 // rejects some bit patterns is UB the moment C writes one and
@@ -1971,7 +1973,7 @@ impl CbindgenBuilder {
         // Data struct output: encode each field into its C wire (`String` →
         // malloc'd `char*` raw block, freed by the `free_memory_function`).
         if self.data.contains_key(&key) {
-            let fields = self.struct_fields(_r, ty)?;
+            let fields = self.struct_fields(_r, &TypeKey::from_type(ty))?;
             let name = Self::out_name(ty);
             let c_struct = self.c_type_ident(&TypeKey::from_type(ty));
             let src = self.src_ty(ty);


### PR DESCRIPTION
`struct_fields` reached the field list the long way: take the last path
segment of a node, look the struct up by that ident, then take its
**item** apart —

    let item = registry.flat().struct_type(&ident).map(|st| st.origin.as_syn())?;
    if let syn::Fields::Named(named) = &item.fields { … }

A `Struct` element holds the field list already: each `Field` carries its
name beside the reading of its type. So the lookup is the key's own
ident, the positional case is `f.name` being `None` rather than a
`Fields` variant, and the item is not read at all.

    # total escapes: items:       42 -> 41
    # total escapes: types:       57 -> 58
    # total classification sites: 92   (unchanged)

**The type count goes up by one, and it is the same one.** The consumers
take `(Ident, syn::Type)` pairs — `is_string`, `data_field_wire`,
`payload_field_wire` all take nodes — so the field readings are spelled
once, at this function's boundary, instead of being read off an item that
had to be fetched first. One counted conversion in the place that
produces the spelling, rather than an item escape plus a path match.

That boundary is where the next cbindgen stage starts: when the field
consumers take readings, the conversion goes with them and this returns
`(Ident, TypeRef)`.

**Did not move**: every generated artifact byte-identical, 645 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.