### PR TITLE
core, jnigen: an element answers for its own docs

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -121,9 +121,9 @@
 5	api/lang/jnigen/jni/render.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
-2	api/lang/jnigen/util.rs
+1	api/lang/jnigen/util.rs
 
-# total classification sites: 90
+# total classification sites: 89
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -158,10 +158,9 @@
 1	api/lang/cbindgen/mod.rs
 7	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
-5	api/lang/jnigen/jni/kotlin_emit.rs
+3	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
-7	api/lang/jnigen/jni/render.rs
 3	api/lang/jnigen/jni/symbols.rs
 3	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 37
+# total escapes: items: 28

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -489,3 +489,58 @@ pub struct Unsupported {
     /// The item as written, so a diagnosis can quote the source.
     pub origin: Origin<syn::Item>,
 }
+
+/// An item's `///` documentation, read off the attributes it was captured
+/// with: `#[doc = " …"]` lines in order, one leading space stripped per line,
+/// joined with `\n`; `None` when there are none. `*/` is defanged so the text
+/// is safe inside a `/** … */` block, which is what every destination that
+/// re-emits prose needs.
+///
+/// **Here rather than in an adapter.** A doc comment is something the *source*
+/// said, so it is the model's to report — and reading it was the last common
+/// reason an emitter reached for a captured item's node. Two adapters wanting
+/// the same prose is one function, not a copy each.
+fn docs_from(attrs: &[syn::Attribute]) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        let syn::Meta::NameValue(nv) = &attr.meta else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(s),
+            ..
+        }) = &nv.value
+        else {
+            continue;
+        };
+        let raw = s.value();
+        let line = raw.strip_prefix(' ').unwrap_or(&raw);
+        lines.push(line.replace("*/", "*\u{200B}/"));
+    }
+    (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+macro_rules! docs_accessor {
+    ($($ty:ident),+ $(,)?) => {$(
+        impl $ty {
+            /// This item's `///` documentation — see [`docs_from`].
+            pub fn docs(&self) -> Option<String> {
+                docs_from(&self.origin.syntax.attrs)
+            }
+        }
+    )+};
+}
+
+docs_accessor!(
+    Function,
+    Struct,
+    Enum,
+    Variant,
+    Constant,
+    Field,
+    Alternative,
+    EnumValue
+);

--- a/prebindgen/src/api/core/flat/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/flat/tests/roundtrip.rs
@@ -559,3 +559,26 @@ fn the_two_forms_that_do_not_spell_back_verbatim() {
         "the slice is the inner node's"
     );
 }
+
+/// An element answers for the prose the source wrote, sanitized for a block
+/// comment — the fact every destination that emits documentation needs, and the
+/// last common reason an emitter reached for a captured item's node.
+#[test]
+fn an_element_answers_for_its_docs() {
+    let element = parse_one(syn::parse_quote!(
+        /// Puts a payload.
+        ///
+        /// Second paragraph with */ inside.
+        pub fn put(payload: u8) {}
+    ));
+    assert_eq!(
+        as_fn(&element).docs().expect("docs present"),
+        "Puts a payload.\n\nSecond paragraph with *\u{200B}/ inside.",
+        "one leading space off each line, joined, and `*/` defanged"
+    );
+
+    let bare = parse_one(syn::parse_quote!(
+        pub fn g() {}
+    ));
+    assert_eq!(as_fn(&bare).docs(), None);
+}

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -579,14 +579,14 @@ impl Declarations {
         sum_cfg: &SumConfig,
     ) -> KtClass {
         // Everything below comes off the element: `alternatives` for the
-        // classes, `Field::member()` for the property names. The docs and the
-        // framework line are spelling, so they read `spell()`.
-        let item_enum = sum.origin.as_syn();
+        // classes, `Field::member()` for the property names, `docs()` for the
+        // prose the source wrote.
         let framework_line = format!(
             "JVM-side surface for the native Rust `{}` sum: exactly one alternative is live.",
-            item_enum.ident
+            sum.name
         );
-        let kdoc = crate::api::lang::jnigen::util::doc_string(&item_enum.attrs)
+        let kdoc = sum
+            .docs()
             .map(|d| format!("{d}\n\n{framework_line}"))
             .unwrap_or(framework_line);
 
@@ -604,9 +604,7 @@ impl Declarations {
             }
             .vis(Vis::Public)
             .supertype(KtType::cls(class_name), None);
-            if let Some(doc) =
-                crate::api::lang::jnigen::util::doc_string(&alt.origin.as_syn().attrs)
-            {
+            if let Some(doc) = alt.docs() {
                 vclass = vclass.kdoc(doc);
             }
             let mut vprops: Vec<(String, KtType)> = Vec::new();
@@ -670,7 +668,7 @@ impl Declarations {
         // The companion is named only when it has to be (a variant took
         // `Companion`), so ordinary emission keeps the anonymous form.
         let mut companion = KtClass::companion_object().vis(Vis::Public).member(factory);
-        let companion_name = self.sum_companion_name(sum_cfg, item_enum);
+        let companion_name = self.sum_companion_name(sum_cfg, sum);
         if companion_name != "Companion" {
             companion.name = companion_name;
         }
@@ -694,12 +692,14 @@ impl Declarations {
     pub(crate) fn sum_companion_name(
         &self,
         sum_cfg: &SumConfig,
-        item_enum: &syn::ItemEnum,
+        sum: &crate::api::core::flat::Variant,
     ) -> String {
-        let taken: std::collections::HashSet<String> = item_enum
-            .variants
+        // The alternatives, not the item's `variants`: the same list, already
+        // classified, and named the way the model names them.
+        let taken: std::collections::HashSet<String> = sum
+            .alternatives
             .iter()
-            .map(|v| self.sum_variant_class_name(sum_cfg, &v.ident))
+            .map(|a| self.sum_variant_class_name(sum_cfg, &a.name))
             .collect();
         let mut name = "Companion".to_string();
         while taken.contains(&name) {

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -45,7 +45,8 @@ pub(crate) fn build_enum_class(
         "JVM-side surface for the native Rust `{}` enum.",
         item_enum.name
     );
-    let enum_kdoc = crate::api::lang::jnigen::util::doc_string(&item_enum.origin.as_syn().attrs)
+    let enum_kdoc = item_enum
+        .docs()
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     kt::KtClass::new(kt::ClassKind::Enum(entries), class_name)
@@ -177,9 +178,7 @@ pub(crate) fn build_data_class(
     });
 
     let mut class = kt::KtClass::new(kt::ClassKind::Data, class_name).vis(kt::Vis::Public);
-    if let Some(doc) =
-        crate::api::lang::jnigen::util::doc_string(&item_struct.origin.as_syn().attrs)
-    {
+    if let Some(doc) = item_struct.docs() {
         class = class.kdoc(doc);
     }
     for p in ctor_params {
@@ -906,7 +905,8 @@ pub(crate) fn render_const_val(
          the generated JNI getter on first use).",
         c.name
     );
-    let kdoc = crate::api::lang::jnigen::util::doc_string(&c.origin.as_syn().attrs)
+    let kdoc = c
+        .docs()
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
@@ -936,7 +936,8 @@ pub(crate) fn render_constant_fn_val(
          through the generated JNI wrapper on first use).",
         f.name
     );
-    let kdoc = crate::api::lang::jnigen::util::doc_string(&f.origin.as_syn().attrs)
+    let kdoc = f
+        .docs()
         .map(|d| format!("{d}\n\n{framework_line}"))
         .unwrap_or(framework_line);
     render_val_over_helper(ext, registry, helper, val_name, kdoc, imports)
@@ -2245,7 +2246,7 @@ fn wrapper_kdoc(
     f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
 ) -> Option<String> {
-    let prose = crate::api::lang::jnigen::util::doc_string(&f.origin.as_syn().attrs);
+    let prose = f.docs();
     let notes = shape_notes(f, registry);
     match (prose, notes) {
         (Some(p), Some(n)) => Some(format!("{p}\n\n{n}")),
@@ -2351,11 +2352,12 @@ fn shape_notes(
 /// The `///` doc of the `#[prebindgen]` struct/enum behind a declared type
 /// key, when the item is indexed (a re-exported foreign type has none).
 pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Option<String> {
-    let name = key.ident()?.to_string();
-    let attrs = registry
-        .flat()
-        .struct_type(&name)
-        .map(|s| s.origin.as_syn().attrs.as_slice())
-        .or_else(|| registry.flat().enum_item(&name).map(|e| e.attrs.as_slice()))?;
-    crate::api::lang::jnigen::util::doc_string(attrs)
+    // Whichever of the three shapes the name declares — the docs are the
+    // element's answer, so there is no `attrs` slice to unify across them.
+    match registry.flat().declared_type(&key.ident()?)? {
+        crate::api::core::flat::Type::Struct(s) => s.docs(),
+        crate::api::core::flat::Type::Enum(e) => e.docs(),
+        crate::api::core::flat::Type::Variant(v) => v.docs(),
+        crate::api::core::flat::Type::Extern(_) => None,
+    }
 }

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -19,37 +19,6 @@ pub(crate) fn snake_to_camel(s: &str) -> String {
     out
 }
 
-/// Extract an item's `///` documentation from its captured attributes
-/// (`#[doc = " …"]` lines, in order): one leading space stripped per line,
-/// joined with `\n`; `None` when the item carries no docs. `*/` is
-/// defanged so the text is always safe inside a `/** … */` KDoc block.
-pub(crate) fn doc_string(attrs: &[syn::Attribute]) -> Option<String> {
-    let mut lines: Vec<String> = Vec::new();
-    for attr in attrs {
-        if !attr.path().is_ident("doc") {
-            continue;
-        }
-        let syn::Meta::NameValue(nv) = &attr.meta else {
-            continue;
-        };
-        let syn::Expr::Lit(syn::ExprLit {
-            lit: syn::Lit::Str(s),
-            ..
-        }) = &nv.value
-        else {
-            continue;
-        };
-        let raw = s.value();
-        let line = raw.strip_prefix(' ').unwrap_or(&raw);
-        lines.push(line.replace("*/", "*\u{200B}/"));
-    }
-    if lines.is_empty() {
-        None
-    } else {
-        Some(lines.join("\n"))
-    }
-}
-
 /// Convert a `CamelCase` Rust identifier to `SCREAMING_SNAKE_CASE`. Used to
 /// project Rust enum variant idents into Kotlin enum constant names.
 pub(crate) fn camel_to_screaming_snake(s: &str) -> String {

--- a/prebindgen/src/api/lang/jnigen/util/tests.rs
+++ b/prebindgen/src/api/lang/jnigen/util/tests.rs
@@ -10,23 +10,3 @@ fn camel_to_screaming_snake_basics() {
     assert_eq!(camel_to_screaming_snake("Data"), "DATA");
     assert_eq!(camel_to_screaming_snake("Background"), "BACKGROUND");
 }
-
-#[test]
-fn doc_string_extracts_and_sanitizes() {
-    use super::doc_string;
-    let f: syn::ItemFn = syn::parse_quote! {
-        /// Puts a payload.
-        ///
-        /// Second paragraph with */ inside.
-        fn f() {}
-    };
-    let doc = doc_string(&f.attrs).expect("docs present");
-    assert_eq!(
-        doc,
-        "Puts a payload.\n\nSecond paragraph with *\u{200B}/ inside."
-    );
-    let bare: syn::ItemFn = syn::parse_quote!(
-        fn g() {}
-    );
-    assert_eq!(doc_string(&bare.attrs), None);
-}


### PR DESCRIPTION
A doc comment is something the **source** said, so it is the model's to
report — and reading it was the single most common reason an emitter
still reached for a captured item's node. Nine sites did
`doc_string(&x.origin.as_syn().attrs)`.

`Element::docs()` is that answer, on every element that carries
attributes (`Function`, `Struct`, `Enum`, `Variant`, `Constant`, `Field`,
`Alternative`, `EnumValue`), and the extraction itself moves out of
jnigen: one leading space per line, joined, `*/` defanged so the prose is
safe inside a `/** … */` block. Two adapters wanting the same prose is
one function, not a copy each — the shape #330 found the hard way with
discriminant numbering.

Two neighbours came along, because they were reading the same item:

* `source_item_doc` unified a `struct_type`/`enum_item` pair into an
  `attrs` slice. It matches the declared type and asks each element, so
  the three shapes need no common slice.
* `sum_companion_name` walked `item_enum.variants` for the names already
  in use. `Variant::alternatives` is the same list, classified, named the
  way the model names them.

    # total escapes: items:       37 -> 28
      render.rs 7 -> 0, kotlin_emit.rs 5 -> 3
    # total classification sites: 90 -> 89
    # total escapes: types:       56   (unchanged)

**The item bucket falls by a quarter, and `render.rs` reaches zero.** It
was the bucket "expected to persist until items grow modelled accessors";
this is that accessor.

**Did not move**: every generated artifact byte-identical — every KDoc
block in the generated Kotlin, which is what this rewrote — 640 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.