### PR TITLE
cbindgen: the lookup for a unit enum is the check for one

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -133,7 +133,7 @@
 2	api/core/registry/scan.rs
 2	api/lang/cbindgen/convert.rs
 4	api/lang/cbindgen/emit.rs
-6	api/lang/cbindgen/trait_impl.rs
+5	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
 1	api/lang/jnigen/jni/emit/struct_out.rs
@@ -147,7 +147,7 @@
 3	api/lang/jnigen/jni/struct_plan.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 56
+# total escapes: types: 55
 
 ## escapes: items
 1	api/core/prebindgen.rs
@@ -156,11 +156,11 @@
 2	api/lang/cbindgen/convert.rs
 1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/mod.rs
-7	api/lang/cbindgen/trait_impl.rs
+5	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
 3	api/lang/jnigen/jni/kotlin_emit.rs
 2	api/lang/jnigen/jni/overloads.rs
 3	api/lang/jnigen/jni/symbols.rs
 3	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 28
+# total escapes: items: 26

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -187,14 +187,5 @@ pub fn enum_shape(e: &syn::ItemEnum) -> EnumShape {
     }
 }
 
-/// The first payload-carrying variant of an enum, if any — the offender an
-/// adapter names when rejecting a [`Sum`](EnumShape::Sum) where only a
-/// [`Unit`](EnumShape::Unit) enum is accepted.
-pub fn first_payload_variant(e: &syn::ItemEnum) -> Option<&syn::Variant> {
-    e.variants
-        .iter()
-        .find(|v| !matches!(v.fields, syn::Fields::Unit))
-}
-
 #[cfg(test)]
 mod tests;

--- a/prebindgen/src/api/core/types_util/tests.rs
+++ b/prebindgen/src/api/core/types_util/tests.rs
@@ -9,7 +9,6 @@ use super::*;
 fn enum_shape_classifies_unit_and_payload() {
     let unit: syn::ItemEnum = syn::parse_quote! { enum E { A, B = 7, C } };
     assert_eq!(enum_shape(&unit), EnumShape::Unit);
-    assert!(first_payload_variant(&unit).is_none());
     // An empty enum has no payload variant, so it is the degenerate unit
     // case — not a sum.
     let empty: syn::ItemEnum = syn::parse_quote! { enum E {} };
@@ -26,19 +25,7 @@ fn enum_shape_classifies_unit_and_payload() {
     ] {
         let e: syn::ItemEnum = syn::parse_quote!(#src);
         assert_eq!(enum_shape(&e), EnumShape::Sum, "for `{src}`");
-        assert!(first_payload_variant(&e).is_some(), "for `{src}`");
     }
-}
-
-/// The offending variant an adapter names in its rejection message is the
-/// **first** payload one, in declaration order.
-#[test]
-fn first_payload_variant_is_the_first_in_declaration_order() {
-    let e: syn::ItemEnum = syn::parse_quote! { enum E { A, B(u32), C { x: u8 } } };
-    assert_eq!(
-        first_payload_variant(&e).expect("payload variant").ident,
-        "B"
-    );
 }
 
 #[test]

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -494,7 +494,7 @@ fn enum_item<'r>(registry: &'r impl Conversions<()>, ty: &syn::Type) -> Option<&
 }
 
 /// Hard error when a `.tagged_union()`-declared enum is unit-only. The
-/// counterpart of [`assert_unit_enum`]: a fieldless enum is exactly a
+/// counterpart of [`unit_enum`]: a fieldless enum is exactly a
 /// discriminant, so it belongs to `.enum_type()` — declaring it here would
 /// emit a `union` with no bodies and a needlessly indirect C surface. Neither
 /// declarator silently accepts the other's shape.
@@ -577,18 +577,34 @@ fn variant_ctor(
 /// is [`EnumShape::Unit`]; a data-carrying enum crosses as a tag plus a
 /// `union` and is reached through a different declarator, so this names
 /// that declarator rather than asserting on `syn::Fields`.
-fn assert_unit_enum(e: &syn::ItemEnum) {
-    use crate::api::core::types_util::{enum_shape, first_payload_variant, EnumShape};
-    if enum_shape(e) == EnumShape::Sum {
-        let offender = first_payload_variant(e)
-            .map(|v| v.ident.to_string())
-            .unwrap_or_default();
-        panic!(
-            "Cbindgen: `{}` is a data-carrying enum (variant `{}` has fields): \
-             declare it with `.tagged_union()`, not `.enum_type()` — a C `enum` \
-             is a bare discriminant and has no room for a payload",
-            e.ident, offender
-        );
+/// The declared **fieldless** enum under `ty`'s name, or a panic naming the
+/// right declarator when it is a sum.
+///
+/// The lookup and the check are the same act: the model decided which of the
+/// two shapes an item is at parse time, and expresses it as two elements. This
+/// was `enum_item` + `assert_unit_enum`, the second running `enum_shape` over a
+/// `syn::ItemEnum` to re-derive what the first had already thrown away.
+fn unit_enum<'r>(
+    registry: &'r impl Conversions<()>,
+    key: &TypeKey,
+) -> Option<&'r crate::api::core::flat::Enum> {
+    match registry.flat().declared_type(&key.ident()?)? {
+        crate::api::core::flat::Type::Enum(e) => Some(e),
+        crate::api::core::flat::Type::Variant(v) => {
+            let offender = v
+                .alternatives
+                .iter()
+                .find(|a| !a.is_empty())
+                .map(|a| a.name.to_string())
+                .unwrap_or_default();
+            panic!(
+                "Cbindgen: `{}` is a data-carrying enum (variant `{offender}` has fields): \
+                 declare it with `.tagged_union()`, not `.enum_type()` — a C `enum` is a bare \
+                 discriminant and has no room for a payload",
+                v.name
+            )
+        }
+        _ => None,
     }
 }
 

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -279,14 +279,13 @@ impl CbindgenBuilder {
         if !self.enums.contains_key(&key) {
             return None;
         }
-        let e = enum_item(r, ty)?;
-        assert_unit_enum(e);
+        let e = unit_enum(r, &TypeKey::from_type(ty))?;
         let name = Self::in_name(ty);
         let cname = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
         let cname_str = cname.to_string();
-        let arms = e.variants.iter().map(|v| {
-            let id = &v.ident;
+        let arms = e.values.iter().map(|v| {
+            let id = &v.name;
             quote!(
                 if __raw == #cname::#id as ::core::ffi::c_int {
                     return ::core::result::Result::Ok(#src::#id);
@@ -829,15 +828,16 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.as_syn().clone();
-            let Some(e) = enum_item(registry, &ty) else {
+            let Some(e) = unit_enum(registry, &reading.key()) else {
                 continue;
             };
-            assert_unit_enum(e);
             let cname = self.c_type_ident(&reading.key());
-            let variants = e.variants.iter().map(|v| {
-                let id = &v.ident;
-                match &v.discriminant {
+            // The C mirror re-states the discriminant **as written** — `= 0x07`
+            // stays `0x07` — which is the one consumer `EnumValue`'s retained
+            // syntax exists for, and the model's own docs name it.
+            let variants = e.values.iter().map(|v| {
+                let id = &v.name;
+                match &v.origin.as_syn().discriminant {
                     Some((_, expr)) => quote!(#id = #expr),
                     None => quote!(#id),
                 }
@@ -2034,13 +2034,12 @@ impl CbindgenBuilder {
 
         // Enum output: `match` the source enum to the C enum.
         if self.enums.contains_key(&key) {
-            let e = enum_item(_r, ty)?;
-            assert_unit_enum(e);
+            let e = unit_enum(_r, &TypeKey::from_type(ty))?;
             let name = Self::out_name(ty);
             let cname = self.c_type_ident(&TypeKey::from_type(ty));
             let src = self.src_ty(ty);
-            let arms = e.variants.iter().map(|v| {
-                let id = &v.ident;
+            let arms = e.values.iter().map(|v| {
+                let id = &v.name;
                 quote!(#src::#id => #cname::#id,)
             });
             let function: syn::ItemFn = syn::parse_quote!(


### PR DESCRIPTION
`enum_item(r, ty)` + `assert_unit_enum(e)` — fetch a `syn::ItemEnum`,
then run `enum_shape` over it to work out whether it carries payloads.
The model decided that at parse time and says it with two different
elements, so `unit_enum` is both acts at once: it returns a
`flat::Enum`, and a `Variant` under an `.enum_type()` panics pointing at
`.tagged_union()`.

`assert_unit_enum` and `types_util::first_payload_variant` are deleted;
the C mirror walks `Enum::values`, and re-states the discriminant **as
written** off `EnumValue`'s retained syntax — `= 0x07` stays `0x07`,
which is the one consumer that slice exists for, and the model's own
docs name it.

    # total escapes: items:       28 -> 26
    # total escapes: types:       56 -> 55
    # total classification sites: 89   (unchanged)

## What I did not ship, and why

The same move for the **tagged-union** sites was written and reverted. It
takes `Variant::alternatives` — which is right, and it lets
`Alternative::spell` replace cbindgen's own `variant_pattern` /
`variant_ctor` copies of the delimiter rule — but every payload field
then meets `payload_needs_converter` / `payload_in_expr` /
`payload_out_expr`, which take nodes. Measured: **items −4, types +6.**

That trade is worth making *after* the payload-wire chain takes readings,
not before, and it is the same lesson as #328 read at a bigger scale: the
count follows the last consumer out of a file. Shipping it would have
raised the total to buy a shape I like.

**Did not move**: every generated artifact byte-identical, 639 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.