### PR TITLE
jnigen: a signature is a parameter list

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -115,7 +115,7 @@
 7	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/iface.rs
-2	api/lang/jnigen/jni/overloads.rs
+1	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
 3	api/lang/jnigen/jni/prim_array.rs
 5	api/lang/jnigen/jni/render.rs
@@ -123,7 +123,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 89
+# total classification sites: 88
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -141,13 +141,13 @@
 3	api/lang/jnigen/jni/fn_plan.rs
 3	api/lang/jnigen/jni/iface.rs
 1	api/lang/jnigen/jni/kotlin_emit.rs
-2	api/lang/jnigen/jni/overloads.rs
+3	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/render.rs
 6	api/lang/jnigen/jni/selector.rs
 3	api/lang/jnigen/jni/struct_plan.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 55
+# total escapes: types: 56
 
 ## escapes: items
 1	api/core/prebindgen.rs
@@ -159,8 +159,7 @@
 5	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
 3	api/lang/jnigen/jni/kotlin_emit.rs
-2	api/lang/jnigen/jni/overloads.rs
 3	api/lang/jnigen/jni/symbols.rs
 3	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 26
+# total escapes: items: 24

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -114,19 +114,11 @@ fn arm_erased_sig(
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
     match ctor {
-        Some(cf) => match registry
-            .flat()
-            .function(&cf)
-            .map(|func| func.origin.as_syn())
-        {
-            Some(item_fn) => item_fn
-                .sig
-                .inputs
+        Some(cf) => match registry.flat().function(&cf) {
+            Some(f) => f
+                .params
                 .iter()
-                .filter_map(|a| match a {
-                    syn::FnArg::Typed(pt) => Some(rust_type_erased(ext, registry, &pt.ty)),
-                    _ => None,
-                })
+                .map(|p| rust_type_erased(ext, registry, p.ty.as_syn()))
                 .collect(),
             None => Vec::new(),
         },
@@ -199,17 +191,16 @@ struct Split<'a> {
 }
 
 /// Camel-cased Kotlin names of a `#[prebindgen]` constructor's parameters.
-fn ctor_param_names(f: &syn::ItemFn) -> Vec<String> {
-    f.sig
-        .inputs
+/// The Kotlin names of a constructor's parameters.
+///
+/// Off `Function::params`, where a parameter **is** a name and a reading. The
+/// `sig.inputs` walk this replaced had to skip a receiver it could not have
+/// (the frontend refuses one) and match `Pat::Ident` for a pattern the frontend
+/// already required.
+fn ctor_param_names(f: &crate::api::core::flat::Function) -> Vec<String> {
+    f.params
         .iter()
-        .filter_map(|a| match a {
-            syn::FnArg::Typed(pt) => match &*pt.pat {
-                syn::Pat::Ident(pid) => Some(kt_param_name(&pid.ident.to_string())),
-                _ => None,
-            },
-            _ => None,
-        })
+        .map(|p| kt_param_name(&p.name.to_string()))
         .collect()
 }
 
@@ -233,15 +224,6 @@ fn non_null(mut ty: kt::KtType) -> kt::KtType {
     ty
 }
 
-fn is_option(ty: &syn::Type) -> bool {
-    matches!(
-        ty,
-        syn::Type::Path(p)
-            if p.qself.is_none()
-                && p.path.segments.last().is_some_and(|s| s.ident == "Option")
-    )
-}
-
 /// The typed overload params of one variant arm, paired with the leaf index
 /// each fills. `origin`/`multi` drive name disambiguation (build-arm params are
 /// prefixed with the origin parameter name when the function splits more than
@@ -259,20 +241,15 @@ fn variant_typed_params(
     let origin_kt = kt_param_name(&origin.to_string());
     let (names, optional): (Vec<String>, Vec<bool>) = match &variant.ctor {
         Some(cf) => {
-            let item_fn = registry
-                .flat()
-                .function(&cf)
-                .map(|func| func.origin.as_syn())?;
-            let optional = item_fn
-                .sig
-                .inputs
+            let f = registry.flat().function(&cf)?;
+            // `Optional` off the kind, not `is_option` off a path: the same
+            // question, asked of the grammar the source wrote.
+            let optional = f
+                .params
                 .iter()
-                .filter_map(|a| match a {
-                    syn::FnArg::Typed(pt) => Some(is_option(&pt.ty)),
-                    _ => None,
-                })
+                .map(|p| matches!(p.ty.kind(), crate::api::core::flat::TypeKind::Optional(_)))
                 .collect();
-            (ctor_param_names(item_fn), optional)
+            (ctor_param_names(f), optional)
         }
         // Identity arm: one parameter, the value itself, named after the origin
         // parameter (already unique across split params — never prefixed).


### PR DESCRIPTION
`overloads.rs` walked `item_fn.sig.inputs` three times — once for the
types, once for which parameters are optional, once for their names —
each walk skipping a receiver the frontend refuses and matching
`Pat::Ident` for a pattern the frontend already required.

`Function::params` is that list, already classified: a `Param` **is** a
name and a reading. So the three walks are three field accesses, and
`is_option` off a path segment becomes `Optional` off the kind — the same
question, asked of the grammar the source wrote. Its last caller went
with it.

    # total escapes: items:       26 -> 24   (overloads.rs 2 -> 0)
    # total classification sites: 89 -> 88
    # total escapes: types:       55 -> 56

The one type escape added is `rust_type_erased`, which still takes a node
— it peels a borrow, keys it, and falls back to a token string. Its other
caller is handed a **declaration's** type, which has no reading until the
scan interns one, so the two callers cannot agree on a parameter type
yet. That is the same ordering constraint #332 stopped on.

**Did not move**: every generated artifact byte-identical, 639 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.