### PR TITLE
jnigen: a fixed-size array is read off the extent, not re-matched

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -117,13 +117,12 @@
 1	api/lang/jnigen/jni/iface.rs
 1	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
-3	api/lang/jnigen/jni/prim_array.rs
 5	api/lang/jnigen/jni/render.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 86
+# total classification sites: 83
 
 ## escapes: types
 1	api/core/diagnostics.rs

--- a/prebindgen/src/api/lang/jnigen/jni/prim_array.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/prim_array.rs
@@ -50,16 +50,18 @@ pub(crate) struct PrimArray {
 /// `None` for everything else, including `[T; N]` of a declared class or enum —
 /// those keep resolving as unsupported, so an unhandled shape is a clear
 /// resolve error rather than silently wrong code.
-pub(crate) fn prim_array_of(ty: &syn::Type) -> Option<PrimArray> {
-    let syn::Type::Array(arr) = ty else {
+pub(crate) fn prim_array_of(ty: &crate::api::core::flat::TypeRef) -> Option<PrimArray> {
+    use crate::api::core::flat::{ScalarKind, TypeKind};
+    let TypeKind::Array { elem, .. } = ty.kind() else {
         return None;
     };
-    let syn::Type::Path(tp) = &*arr.elem else {
+    let &TypeKind::Scalar(elem) = elem.kind() else {
         return None;
     };
-    let elem = tp.path.segments.last()?.ident.to_string();
     // `usize`/`isize` are deliberately absent: their width is platform
-    // dependent, so there is no stable JNI element type to pick.
+    // dependent, so there is no stable JNI element type to pick. Reaching them
+    // by name is the ScalarKind's own spelling, so the set below is still the
+    // set Rust writes — a kind that is not on it falls through as before.
     let (letter, jni_elem) = match elem.as_str() {
         "u8" | "i8" => ("byte", "jbyte"),
         "u16" | "i16" => ("short", "jshort"),
@@ -80,8 +82,8 @@ pub(crate) fn prim_array_of(ty: &syn::Type) -> Option<PrimArray> {
         new_fn: format_ident!("new_{}_array", letter),
         set_region: format_ident!("set_{}_array_region", letter),
         get_region: format_ident!("get_{}_array_region", letter),
-        is_bool: elem == "bool",
-        is_u8: elem == "u8",
+        is_bool: elem == ScalarKind::Bool,
+        is_u8: elem == ScalarKind::U8,
     })
 }
 
@@ -128,8 +130,17 @@ pub(crate) fn output_body(spec: &PrimArray) -> syn::Expr {
 ///
 /// The length check is the `try_into`: a JVM array of the wrong size becomes a
 /// binding error naming the type, never a panic or a partially-filled array.
-pub(crate) fn input_body(ty: &syn::Type, spec: &PrimArray) -> syn::Expr {
-    let key = TypeKey::from_type(ty);
+pub(crate) fn input_body(ty: &crate::api::core::flat::TypeRef, spec: &PrimArray) -> syn::Expr {
+    let key = ty.key();
+    // The element spelled from the model's own `Array`, so the local's type
+    // ascription cannot disagree with what `prim_array_of` matched.
+    let elem_ty = match ty.kind() {
+        crate::api::core::flat::TypeKind::Array { elem, .. } => elem.spell(),
+        _ => unreachable!("prim_array_of matched a non-array"),
+    };
+    // The ascription the decoded array is checked against — spelled from the
+    // reading, as generated Rust always spells.
+    let ty = ty.spell();
     let len_err = format!("fixed-size array decode: `{key}` expects a different length");
     if spec.is_u8 {
         return syn::parse_quote!({
@@ -147,10 +158,6 @@ pub(crate) fn input_body(ty: &syn::Type, spec: &PrimArray) -> syn::Expr {
     }
     let elem_wire = &spec.elem_wire;
     let get_region = &spec.get_region;
-    let elem_ty = match ty {
-        syn::Type::Array(a) => (*a.elem).clone(),
-        _ => unreachable!("prim_array_of matched a non-array"),
-    };
     // A `jboolean` is a `u8`: normalize it, never reinterpret it — an out-of-
     // range byte read back as a Rust `bool` would be undefined behavior.
     let from_wire: syn::Expr = if spec.is_bool {

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1971,8 +1971,8 @@ impl Declarations {
         // Fixed-size array of JNI primitives — dual of the output branch.
         // The `try_into` IS the length check: a JVM array of the wrong size
         // becomes a binding error naming the type, never a panic.
-        if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(ty) {
-            let body = crate::api::lang::jnigen::jni::prim_array::input_body(ty, &spec);
+        if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(reading) {
+            let body = crate::api::lang::jnigen::jni::prim_array::input_body(reading, &spec);
             let wire = spec.wire.clone();
             let kotlin_name = self.override_kotlin_name(ty, Some(spec.kotlin.clone()));
             let niches = default_niches_for_wire(&wire);
@@ -2358,7 +2358,7 @@ impl Declarations {
         // Fixed-size array of JNI primitives: `[u8; N]` -> `ByteArray`,
         // `[i64; N]` -> `LongArray`, ... Bulk-copied, nothing boxed. See
         // [`prim_array`]; this replaced the raw-memory value blob.
-        if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(ty) {
+        if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(reading) {
             let body = crate::api::lang::jnigen::jni::prim_array::output_body(&spec);
             let wire = spec.wire.clone();
             let kotlin_name = self.override_kotlin_name(ty, Some(spec.kotlin.clone()));


### PR DESCRIPTION
The original integration map listed this under L4 and it outlived the
program that named it:

    - [ ] `prim_array_of` reads `ArrayExtent` instead of re-matching
          `Type::Array`

`prim_array_of` matched `syn::Type::Array`, then `syn::Type::Path` on the
element, then compared the last path segment against a table of primitive
names. All three are the model: `TypeKind::Array { elem, .. }` and
`TypeKind::Scalar(ScalarKind)`, and the JNI table keys on the
`ScalarKind` itself rather than on a string that happened to spell it.

`input_body` follows, because it re-matched the same array to recover the
element for a local's ascription. Both come off the same reading now, so
the shape `prim_array_of` accepted and the element `input_body` spells
cannot disagree.

    # total classification sites: 86 -> 83   (prim_array.rs 3 -> 0)
    # total escapes: types:       51         (unchanged)
    # total escapes: items:       22         (unchanged)

Rebased onto the umbrella head after #335 and #336 landed, so the counts
are against that base rather than the one this branch was cut from.

`prim_array.rs` holds neither count now. The `usize`/`isize` exclusion is
unchanged and still deliberate: their width is platform dependent, so
there is no stable JNI element type to pick, and a `ScalarKind` that is
not in the table falls through exactly as an unmatched name did.

**Did not move**: every generated artifact byte-identical — including
every fixed-size-array converter, which is what this rewrote — 639 lib +
22 doctests green, clippy + fmt clean on 1.85.0 and stable.