### PR TITLE
jnigen: the plan keeps the reading it was handed

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -111,7 +111,7 @@
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
-14	api/lang/jnigen/jni/emit/names.rs
+13	api/lang/jnigen/jni/emit/names.rs
 7	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/iface.rs
@@ -123,7 +123,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 88
+# total classification sites: 87
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -136,7 +136,6 @@
 5	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
-1	api/lang/jnigen/jni/emit/struct_out.rs
 1	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fn_plan.rs
 3	api/lang/jnigen/jni/iface.rs
@@ -144,10 +143,9 @@
 3	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/render.rs
 6	api/lang/jnigen/jni/selector.rs
-3	api/lang/jnigen/jni/struct_plan.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 56
+# total escapes: types: 52
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -237,17 +237,6 @@ pub(crate) fn annotate_jobject_with_lifetime(ty: &syn::Type, life: &str) -> syn:
 // reconstructed as `Box<_>`, matched nothing, and got no converter at all
 // (#270). Dispatch reads `TypeKind` now; nothing needs it.
 
-/// `true` if `ty` is a path whose final segment is `name` (e.g. `Vec<_>` for
-/// `name = "Vec"`, `Option<&T>` for `name = "Option"`). Ignores generic args.
-pub(crate) fn pat_match_top(ty: &syn::Type, name: &str) -> bool {
-    if let syn::Type::Path(tp) = ty {
-        if let Some(last) = tp.path.segments.last() {
-            return last.ident == name;
-        }
-    }
-    false
-}
-
 /// INPUT: wire → rust. Format `<wire_id>_to_<rust_id>_<hash>` (including
 /// `impl Fn(...)` lambda converters — the legacy
 /// `process_kotlin_<Name>_callback` naming is gone with the fun-interface

--- a/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs
@@ -96,7 +96,6 @@ pub(crate) fn synth_value_struct_leaves(
     let mut leaves: Vec<UnfoldLeaf> = Vec::new();
     for field in &s.fields {
         let fname = field.name.as_ref()?.clone();
-        let effective_ty = field.ty.as_syn().clone();
         let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
         let leaf_name = if name_prefix.is_empty() {
             camel
@@ -114,8 +113,10 @@ pub(crate) fn synth_value_struct_leaves(
         // A nested data-class field (a *declared* plain struct) inlines when
         // non-optional (recurse); `Option`/`Vec`-wrapped nesting is deferred
         // to the whole-value path.
-        let probe = option_inner_type(&effective_ty).unwrap_or_else(|| effective_ty.clone());
-        let nested = match ext.type_kind(registry, &TypeKey::from_type(&probe)) {
+        // Both layer questions off the field's own reading: `Optional` to look
+        // through, `Vec` to defer — the kinds, not a last path segment.
+        let probe = field.ty.optional_inner().unwrap_or(&field.ty);
+        let nested = match ext.type_kind(registry, &probe.key()) {
             // A sum joins the kinds this fixed builder cannot forward: it has
             // no single leaf and no converter of its own — it crosses as a tag
             // plus one group per variant, which only the whole-value
@@ -129,7 +130,9 @@ pub(crate) fn synth_value_struct_leaves(
             _ => None,
         };
         if let Some(child) = nested {
-            if option_inner_type(&effective_ty).is_some() || pat_match_top(&effective_ty, "Vec") {
+            if field.ty.optional_inner().is_some()
+                || matches!(field.ty.kind(), crate::api::core::flat::TypeKind::Vec(_))
+            {
                 return None;
             }
             let child_leaves =

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -225,7 +225,6 @@ pub(crate) fn classify_field(
     // classified this type. Taking a `syn::Type` meant asking the registry per
     // question, and a type it had never seen answered "no layer" rather than
     // saying so — which is the missing `?` of #273 waiting to happen again.
-    let effective_ty = reading.as_syn().clone();
 
     // A sum is classified FIRST, because it is the one kind with no converter
     // of its own: it crosses as a tag plus one leaf group per variant, never
@@ -244,13 +243,9 @@ pub(crate) fn classify_field(
     // other about the same field (#273).
     let optional_inner = reading.optional_inner();
     let bare_ref = optional_inner.unwrap_or(reading);
-    let bare = bare_ref.as_syn().clone();
     let seq_elem = bare_ref.sequence_elem();
-    let core = seq_elem.map_or_else(|| bare.clone(), |e| e.as_syn().clone());
-    if matches!(
-        ext.type_kind(registry, &TypeKey::from_type(&core)),
-        TypeKind::Sum
-    ) {
+    let core = seq_elem.unwrap_or(bare_ref);
+    if matches!(ext.type_kind(registry, &core.key()), TypeKind::Sum) {
         // A `Vec` of tag-gated groups has variable arity, exactly like a `Vec`
         // of nested data classes — the flattened bridge is fixed-layout by
         // construction.
@@ -258,10 +253,17 @@ pub(crate) fn classify_field(
             panic!(
                 "fromParts bridge: `Vec<{}>` sealed-class field (`{owner}`) is not supported \
                  (variable arity)",
-                core.to_token_stream(),
+                core.spell(),
             );
         }
-        return sum_plan_kind(ext, registry, &bare, owner, optional_inner.is_some(), depth);
+        return sum_plan_kind(
+            ext,
+            registry,
+            bare_ref,
+            owner,
+            optional_inner.is_some(),
+            depth,
+        );
     }
 
     let field_entry = registry.output_entry(reading)?;
@@ -307,15 +309,15 @@ pub(crate) fn classify_field(
             };
         }
         // Nested plain data-class (optionally under `Option`).
-        let inner_ty = bare.clone();
-        if let TypeKind::DataStruct { st, cfg } =
-            ext.type_kind(registry, &TypeKey::from_type(&inner_ty))
-        {
-            if pat_match_top(&effective_ty, "Vec") {
+        let inner_ty = bare_ref;
+        if let TypeKind::DataStruct { st, cfg } = ext.type_kind(registry, &inner_ty.key()) {
+            // `Vec` off the kind — the layer the model names, not a last path
+            // segment that spells it.
+            if matches!(reading.kind(), crate::api::core::flat::TypeKind::Vec(_)) {
                 panic!(
                     "fromParts bridge: `Vec<{}>` data-class field (`{owner}`) is not supported \
                      (variable arity)",
-                    inner_ty.to_token_stream(),
+                    inner_ty.spell(),
                 );
             }
             let child_fqn = cfg
@@ -498,7 +500,7 @@ impl PlanFieldKind {
 fn sum_plan_kind(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    ty: &syn::Type,
+    ty: &crate::api::core::flat::TypeRef,
     owner: &str,
     optional: bool,
     depth: usize,
@@ -516,7 +518,9 @@ fn sum_plan_kind(
         depth <= 16,
         "fromParts bridge: sealed-class expansion too deep at `{owner}` (recursive sum?)"
     );
-    let ident = bare_path_ident(ty).unwrap_or_else(|| {
+    // The key's ident: a sum is a declared name, and the key is that name when
+    // the key is one identifier.
+    let ident = ty.key().ident().unwrap_or_else(|| {
         panic!("fromParts bridge: sealed-class field `{owner}` is not a path type")
     });
     // The sum as the MODEL holds it: its alternatives' payloads are `TypeRef`s

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -119,7 +119,9 @@ mod spelling_census {
         // `.jobject_input()` decoders — struct, then sum. Every layer question
         // in that file now asks a `TypeRef`, and its walks take `flat::Struct`
         // and `flat::Variant` rather than the items they were parsed from.
-        ("jni/emit/struct_out.rs", 2),
+        // struct_out.rs is off the census: both layer questions ask the field's
+        // own reading — `optional_inner` to look through, the `Vec` kind to
+        // defer.
         ("jni/emit/wrapper.rs", 2),
         //
         // vec_build.rs is absent, and off the boundary ledger too: its element


### PR DESCRIPTION
`build_plan_field_kind` opens with a comment that says exactly what it
should do:

    // The **reading**, not a spelling. Every layer question below is
    // answered from `kind` and cannot fail: holding a `TypeRef` is proof
    // the model classified this type.

and the next line was `let effective_ty = reading.as_syn().clone();`. The
three locals it derived — `effective_ty`, `bare`, `core` — were spellings
of readings sitting right beside them, and every question asked of them
went back through a key or a path segment to recover what the reading
already said.

They are readings now, and the questions are the model's: `Vec` off the
kind rather than `pat_match_top(.., "Vec")`, `Optional` off
`optional_inner`, the sum lookup off `key()`, the sealed-class ident off
the key. `emit/struct_out.rs` had the same pair of layer questions on a
field's spelling and gets the same treatment.

`pat_match_top` — "last path segment is `name`, ignoring generic args" —
had no callers left and is deleted.

    # total escapes: types:       56 -> 52
      struct_plan.rs 3 -> 0, emit/struct_out.rs 1 -> 0
    # total classification sites: 88 -> 87
    # total escapes: items:       24   (unchanged)

and jnigen's spelling census drops `jni/emit/struct_out.rs` (2 → 0).

Counts are against this branch's base; [#334](https://github.com/milyin/prebindgen/pull/334)
is in flight and touches different files, so the two compose.

**Did not move**: every generated artifact byte-identical, 639 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.