### PR TITLE
jnigen: the constant refusal reads the element, and one peel serves both

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -112,7 +112,7 @@
 4	api/lang/jnigen/jni/emit/convert.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
 13	api/lang/jnigen/jni/emit/names.rs
-7	api/lang/jnigen/jni/emit/wrapper.rs
+6	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/iface.rs
 1	api/lang/jnigen/jni/overloads.rs
@@ -123,7 +123,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 87
+# total classification sites: 86
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -136,7 +136,6 @@
 5	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
-1	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fn_plan.rs
 3	api/lang/jnigen/jni/iface.rs
 1	api/lang/jnigen/jni/kotlin_emit.rs
@@ -145,7 +144,7 @@
 6	api/lang/jnigen/jni/selector.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 52
+# total escapes: types: 51
 
 ## escapes: items
 1	api/core/prebindgen.rs
@@ -156,8 +155,8 @@
 1	api/lang/cbindgen/mod.rs
 5	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
-3	api/lang/jnigen/jni/kotlin_emit.rs
+2	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/symbols.rs
-3	api/lang/jnigen/jni/trait_impl.rs
+2	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 24
+# total escapes: items: 22

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -35,8 +35,15 @@ pub(crate) fn const_getter_fn(
 /// shared closeable `val` is semantically wrong (whose `close()` is it?).
 /// Expose a factory function instead — the established idiom (e.g. zenoh's
 /// `encoding_const_*` companion factories).
-pub(crate) fn reject_handle_const(ext: &Declarations, c: &syn::ItemConst) {
-    reject_handle_constant_type(ext, &c.ty, "const", &c.ident.to_string());
+pub(crate) fn reject_handle_const(ext: &Declarations, c: &crate::api::core::flat::Constant) {
+    // Off the element: a constant's type is a reading, so the peel is the
+    // model's (`util::head_type`) and no node is fetched to reach it.
+    reject_handle_key(
+        ext,
+        &crate::api::lang::jnigen::util::head_type(&c.ty).key(),
+        "const",
+        &c.name.to_string(),
+    );
 }
 
 /// The constant-value handle check shared by both constant kinds: peel
@@ -65,8 +72,18 @@ pub(crate) fn reject_handle_constant_type(
         }
         break;
     }
-    let key = TypeKey::from_type(&ty);
-    let is_handle = ext.types.get(&key).is_some_and(|cfg| cfg.is_opaque());
+    reject_handle_key(ext, &TypeKey::from_type(&ty), what, name);
+}
+
+/// The refusal itself, once: a declared opaque handle cannot be a shared
+/// closeable Kotlin `val`.
+///
+/// Split from the peel because the two callers peel differently — an element's
+/// type is a reading and peels off the kind, while a **build-script-supplied**
+/// expression type has no reading until something interns it and peels off the
+/// spelling. One assertion, two ways to reach it.
+fn reject_handle_key(ext: &Declarations, key: &TypeKey, what: &str, name: &str) {
+    let is_handle = ext.types.get(key).is_some_and(|cfg| cfg.is_opaque());
     assert!(
         !is_handle,
         "{what} `{name}`: type `{}` is a declared opaque handle — a shared closeable Kotlin `val` is \
@@ -839,7 +856,9 @@ pub(crate) fn emit_expanded_param(
 
     debug_assert_eq!(plan.leaves.len(), leaves.len());
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
-        let leaf_ty = leaf.ty.as_syn();
+        let leaf_ty = &leaf.ty;
+        // The ascription generated Rust writes for this leaf's local.
+        let leaf_ty_tokens = leaf_ty.spell();
         let lookup_entry = || {
             // The leaf's own reading goes straight to the entry: spelling it and
             // looking the same reading back up is the round trip #286 removed.
@@ -910,7 +929,7 @@ pub(crate) fn emit_expanded_param(
             )
             .expect("an option-scalar plan is built only for a buildable spelling");
             prelude.push(quote!(
-                let #local: #leaf_ty = #built;
+                let #local: #leaf_ty_tokens = #built;
             ));
             leaf_locals.push(local);
             continue;
@@ -920,7 +939,7 @@ pub(crate) fn emit_expanded_param(
         // jlong handle inline, mirroring the normal by-value-handle path —
         // including its null/tagged (closed) pointer guard.
         let is_consume = matches!(classified.kind, InputKind::Handle { direct: true })
-            && !matches!(leaf_ty, syn::Type::Reference(_));
+            && !matches!(leaf_ty.kind(), crate::api::core::flat::TypeKind::Ref { .. });
         if is_consume {
             let wire_ident = format_ident!("{}_ptr", leaf.name);
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
@@ -929,8 +948,8 @@ pub(crate) fn emit_expanded_param(
                     signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
                     return #on_err;
                 }
-                let #local: #leaf_ty = unsafe {
-                    *std::boxed::Box::from_raw(#wire_ident as *mut #leaf_ty)
+                let #local: #leaf_ty_tokens = unsafe {
+                    *std::boxed::Box::from_raw(#wire_ident as *mut #leaf_ty_tokens)
                 };
             ));
             leaf_locals.push(local);

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1579,7 +1579,7 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            reject_handle_const(self, item_const.origin.as_syn());
+            reject_handle_const(self, item_const);
             if let Some((helper, prop)) = render_const_val(
                 self,
                 &package,

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1508,20 +1508,6 @@ impl Declarations {
     }
 }
 
-/// `&` / `Option` / `Vec` off, to a fixed point — `peel_ref_option_vec` over a
-/// reading, and off `kind()` for the reason [`peel_one_borrow`] gives.
-fn peel_ref_option_vec_reading(
-    t: &crate::api::core::flat::TypeRef,
-) -> &crate::api::core::flat::TypeRef {
-    use crate::api::core::flat::TypeKind;
-    match t.kind() {
-        TypeKind::Ref { inner, .. } | TypeKind::Optional(inner) | TypeKind::Vec(inner) => {
-            peel_ref_option_vec_reading(inner)
-        }
-        _ => t,
-    }
-}
-
 /// One `&` off, and nothing else — the model's own `borrow_target` would also
 /// see through a `Box`/`Cow`, which `peel_leading_ref` did not.
 fn peel_one_borrow(t: &crate::api::core::flat::TypeRef) -> &crate::api::core::flat::TypeRef {
@@ -1705,7 +1691,7 @@ impl Prebindgen for Declarations {
             // the signature had to find the `Result` in a path first.
             if let Some((ok, _)) = func.ret.fallible_parts() {
                 {
-                    let core = peel_ref_option_vec_reading(ok);
+                    let core = crate::api::lang::jnigen::util::head_type(ok);
                     if matches!(self.type_kind(binding, &core.key()), TypeKind::Sum) {
                         return Err(format!(
                             "fn `{ident}`: `Result<{}, _>` — a sealed_class value is not \
@@ -1739,7 +1725,7 @@ impl Prebindgen for Declarations {
             // check.
             if let Some((_, err_ty)) = func.ret.fallible_parts() {
                 {
-                    let core = peel_ref_option_vec_reading(err_ty);
+                    let core = crate::api::lang::jnigen::util::head_type(err_ty);
                     let declared = self
                         .return_expand_decls
                         .iter()
@@ -1942,7 +1928,7 @@ impl Prebindgen for Declarations {
         c: &crate::api::core::flat::Constant,
         registry: &Registry<KotlinMeta>,
     ) -> TokenStream {
-        reject_handle_const(self, c.origin.as_syn());
+        reject_handle_const(self, c);
         let getter = const_getter_fn(c);
         let const_ident = &c.name;
         let source_module = self.fn_module(registry, const_ident);

--- a/prebindgen/src/api/lang/jnigen/util.rs
+++ b/prebindgen/src/api/lang/jnigen/util.rs
@@ -51,6 +51,9 @@ mod tests;
 /// asking the kind for the head is asking the same question of the same
 /// grammar, with the model answering instead of a `match` on `syn`.
 ///
+/// The same peel the sum-position checks make, which is why they call this
+/// rather than keeping a copy: `&`, `Option`, `Vec` to a fixed point.
+///
 /// Peels exactly what `types_util::peel_ref_option_vec` peeled — `&`, `Option`,
 /// `Vec`, in any order, to a fixed point — and **not** a transparent wrapper:
 /// `Box<Vec<T>>` stops at the `Box`, as it did before. The layer accessors


### PR DESCRIPTION
`reject_handle_const` took a `&syn::ItemConst` — fetched through an item
escape at both call sites — to read two things a `Constant` element
holds: its name, and its type. It takes the element, and the peel is
`util::head_type` off the reading.

The refusal itself splits out as `reject_handle_key`, because the two
callers genuinely peel differently: an element's type is a reading and
peels off the kind, while a **build-script-supplied** expression type has
no reading until something interns it and must peel off the spelling. One
assertion, two ways to reach it — rather than one peel pretending both
inputs are the same thing.

Also: `peel_ref_option_vec_reading`, added in #324, is deleted.
`util::head_type` from #316 is the same three layers to a fixed point,
and having written the second copy myself I would rather the ledger had
caught it than that it stayed.

And the leaf borrow check (`is_consume`) asks `Ref` off the kind instead
of matching `syn::Type::Reference` on a spelling the leaf already carries
as a reading.

    # total escapes: items:       24 -> 22
    # total escapes: types:       52 -> 51
    # total classification sites: 87 -> 86

## What `emit/wrapper.rs` is left holding

Six sites, and five of them are `matches!(wire, syn::Type::Ptr(_))` or
the same question of `entry.destination` — **wire types this adapter
built**. `emit/convert.rs`'s four are all that too. That is the
irreducible shape the classification count is converging on: not a
captured type being classified, and no reading in existence to ask
instead.

**Did not move**: every generated artifact byte-identical, 639 lib + 22
doctests green, clippy + fmt clean on 1.85.0 and stable.