### PR TITLE
S24: the string audit reads alternatives, not an ItemEnum

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -150,7 +150,6 @@
 2	api/core/registry/scan.rs
 1	api/core/write.rs
 2	api/lang/cbindgen/convert.rs
-1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/mod.rs
 5	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
@@ -158,4 +157,4 @@
 3	api/lang/jnigen/jni/symbols.rs
 2	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 22
+# total escapes: items: 21

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -32,14 +32,13 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            let ty = reading.as_syn().clone();
             registry.output_entry(&reading).is_some()
                 && self
-                    .enum_variants(registry, &ty)
-                    .map(|vs| {
-                        vs.iter()
-                            .flat_map(|v| v.fields.iter())
-                            .any(|f| is_string(&f.ty))
+                    .enum_alternatives(registry, key)
+                    .map(|alts| {
+                        alts.iter().flat_map(|a| a.fields.iter()).any(|f| {
+                            matches!(f.ty.kind(), crate::api::core::flat::TypeKind::String)
+                        })
                     })
                     .unwrap_or(false)
         }) {
@@ -49,25 +48,29 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            let ty = reading.as_syn().clone();
             registry.output_entry(&reading).is_some()
                 && self
-                    .struct_fields(registry, &TypeKey::from_type(&ty))
+                    .struct_fields(registry, key)
                     .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))
                     .unwrap_or(false)
         })
     }
 
-    /// Variants of a declared enum, looked up from the registry's indexed
-    /// enums. `None` if the type isn't an indexed enum.
-    pub(super) fn enum_variants(
+    /// The alternatives of a declared sum, by **identity**.
+    ///
+    /// Off the element: an `Alternative` holds its fields already classified,
+    /// so the callers that ask "does any payload own memory" read a `TypeRef`
+    /// per field instead of a `syn::Field`. This took a node, took its last
+    /// path segment, and fetched the `syn::ItemEnum` to reach the same list.
+    pub(super) fn enum_alternatives<'r>(
         &self,
-        registry: &Registry<()>,
-        ty: &syn::Type,
-    ) -> Option<Vec<syn::Variant>> {
-        let ident = type_path_tail(ty)?;
-        let item = registry.flat().enum_item(&ident)?;
-        Some(item.variants.iter().cloned().collect())
+        registry: &'r Registry<()>,
+        key: &TypeKey,
+    ) -> Option<&'r [crate::api::core::flat::Alternative]> {
+        match registry.flat().declared_type(&key.ident()?)? {
+            crate::api::core::flat::Type::Variant(v) => Some(&v.alternatives),
+            _ => None,
+        }
     }
 
     /// The declared `opaque_ptr` under a union payload's spelling, when there is
@@ -336,15 +339,15 @@ impl CbindgenBuilder {
         {
             return false;
         }
-        self.enum_variants(registry, fty)
+        self.enum_alternatives(registry, &TypeKey::from_type(fty))
             .unwrap_or_default()
             .iter()
-            .flat_map(|v| v.fields.iter())
-            .any(|f| match self.payload_field_wire(&f.ty, registry) {
+            .flat_map(|a| a.fields.iter())
+            .any(|f| match self.payload_field_wire(f.ty.as_syn(), registry) {
                 // A rejected payload is reported from the emission site, which
                 // panics before any of this matters.
                 Err(_) => false,
-                Ok(wire) => self.payload_wire_owns(&f.ty, &wire, registry),
+                Ok(wire) => self.payload_wire_owns(f.ty.as_syn(), &wire, registry),
             })
     }
 


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

## What moved

`CbindgenBuilder::enum_variants(registry, &syn::Type) -> Option<Vec<syn::Variant>>` took a node, took its last path segment, and fetched the whole `syn::ItemEnum` — an **item escape** — to reach one list of variants. Both of its callers then walked `syn::Field`s to ask a single question the model already answers per field.

It becomes:

```rust
fn enum_alternatives<'r>(&self, registry: &'r Registry<()>, key: &TypeKey)
    -> Option<&'r [Alternative]>
```

Identity in, the element's own `alternatives` out. Each `Alternative` holds its fields already classified, so:

| caller | was | is |
|---|---|---|
| `needs_free_memory`, union arm | `is_string(&f.ty)` over a `syn::Field` | `matches!(f.ty.kind(), TypeKind::String)` |
| `needs_free_memory`, data arm | `let ty = reading.as_syn().clone(); struct_fields(r, &TypeKey::from_type(&ty))` | `struct_fields(r, key)` |
| `union_payload_owns` | `v.fields` off the item | `a.fields` off the element |

The data-arm line is an S5-style miss: the reading was in hand and got round-tripped through a spelling to produce a key it could have answered itself.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 83 | 83 |
| escapes: types | 51 | 51 |
| escapes: items | 22 | **21** |

`escapes: items` for `api/lang/cbindgen/emit.rs` goes `1 → 0`: the `enum_item` door and the `type_path_tail` identity walk both leave the file.

**Types is flat, honestly.** Two `as_syn().clone()` locals are gone; two `f.ty.as_syn()` appear where `payload_field_wire` / `payload_wire_owns` still take a `&syn::Type`. That is the escape *moving inward* to the helper boundary, which is where it can be removed in one place instead of at each call.

## Why this is the wedge

Three `enum_item` uses remain in `cbindgen/trait_impl.rs` (the tagged-union mirror, the in-converter, and the out-converter). They cannot follow until the payload-wire chain — `payload_field_wire`, `payload_wire_owns`, `payload_needs_converter`, `mirror_field_wire`, `data_field_wire`, `struct_fields` — takes a `TypeRef` rather than a node. Moving the walk first without that chain measures as a rise (the S19 lesson: −4 items / +6 types), so the chain is the next stage and the walk follows it.

## Gate

- `cargo test -p prebindgen --all-features` — 639 lib, 22 doctests
- `boundary_ledger` regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — **every generated artifact byte-identical**