### PR TITLE
S25: cbindgen's field policies take a reading

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -131,8 +131,8 @@
 2	api/core/registry/order.rs
 2	api/core/registry/scan.rs
 2	api/lang/cbindgen/convert.rs
-4	api/lang/cbindgen/emit.rs
-5	api/lang/cbindgen/trait_impl.rs
+1	api/lang/cbindgen/emit.rs
+4	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/emit/callback.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
 3	api/lang/jnigen/jni/fn_plan.rs
@@ -143,18 +143,17 @@
 6	api/lang/jnigen/jni/selector.rs
 13	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 51
+# total escapes: types: 47
 
 ## escapes: items
 1	api/core/prebindgen.rs
 2	api/core/registry/scan.rs
 1	api/core/write.rs
 2	api/lang/cbindgen/convert.rs
-1	api/lang/cbindgen/mod.rs
-5	api/lang/cbindgen/trait_impl.rs
+2	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
 2	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/symbols.rs
 2	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 21
+# total escapes: items: 17

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -154,38 +154,5 @@ pub fn pascal_to_snake(s: &str) -> String {
     out
 }
 
-// ── Enum shape: the one definition of "is this enum C-like" ────────────
-
-/// How a captured `enum` can cross a language boundary — the single
-/// classifier both adapters consult instead of each asserting on
-/// `syn::Fields` itself.
-///
-/// The two shapes are not two mechanisms: a [`Unit`](EnumShape::Unit) enum
-/// is the degenerate sum whose every variant group is empty, so a lowering
-/// written for [`Sum`](EnumShape::Sum) collapses to "just a tag" for it.
-/// The distinction exists because the *declarators* differ — `enum_class!`
-/// / `.enum_type()` accept only the degenerate case, and handing them a
-/// payload enum is an error naming the sum declarator rather than a shape
-/// assertion.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum EnumShape {
-    /// Every variant is fieldless: the value is exactly its discriminant.
-    Unit,
-    /// At least one variant carries a payload.
-    Sum,
-}
-
-/// Classify an enum. See [`EnumShape`].
-pub fn enum_shape(e: &syn::ItemEnum) -> EnumShape {
-    if e.variants
-        .iter()
-        .all(|v| matches!(v.fields, syn::Fields::Unit))
-    {
-        EnumShape::Unit
-    } else {
-        EnumShape::Sum
-    }
-}
-
 #[cfg(test)]
 mod tests;

--- a/prebindgen/src/api/core/types_util/tests.rs
+++ b/prebindgen/src/api/core/types_util/tests.rs
@@ -6,29 +6,6 @@ use super::*;
 // ── Enum shape / sum model ─────────────────────────────────────────────
 
 #[test]
-fn enum_shape_classifies_unit_and_payload() {
-    let unit: syn::ItemEnum = syn::parse_quote! { enum E { A, B = 7, C } };
-    assert_eq!(enum_shape(&unit), EnumShape::Unit);
-    // An empty enum has no payload variant, so it is the degenerate unit
-    // case — not a sum.
-    let empty: syn::ItemEnum = syn::parse_quote! { enum E {} };
-    assert_eq!(enum_shape(&empty), EnumShape::Unit);
-
-    // One payload variant is enough, whatever the shape of the others.
-    for src in [
-        quote::quote! { enum E { A(u32), B } },
-        quote::quote! { enum E { A, B { x: u32 } } },
-        // An empty tuple/brace variant still carries fields syntactically
-        // (`Fields::Unnamed`), so it classifies as a sum — the declarator
-        // that accepts it is the sum one.
-        quote::quote! { enum E { A, B() } },
-    ] {
-        let e: syn::ItemEnum = syn::parse_quote!(#src);
-        assert_eq!(enum_shape(&e), EnumShape::Sum, "for `{src}`");
-    }
-}
-
-#[test]
 fn pascal_to_snake_basics() {
     assert_eq!(pascal_to_snake("ZKeyExpr"), "z_key_expr");
     assert_eq!(pascal_to_snake("PeriodicQueries"), "periodic_queries");

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -678,11 +678,22 @@ impl CbindgenBuilder {
     }
 
     pub(super) fn in_name(ty: &syn::Type) -> syn::Ident {
-        format_ident!("__cbg_in_{}", sanitize(&TypeKey::from_type(ty)))
+        Self::in_name_of(&TypeKey::from_type(ty))
     }
 
     pub(super) fn out_name(ty: &syn::Type) -> syn::Ident {
-        format_ident!("__cbg_out_{}", sanitize(&TypeKey::from_type(ty)))
+        Self::out_name_of(&TypeKey::from_type(ty))
+    }
+
+    /// [`Self::in_name`] off the **identity**, for a caller holding a reading
+    /// rather than a node — which is every per-field site.
+    pub(super) fn in_name_of(key: &TypeKey) -> syn::Ident {
+        format_ident!("__cbg_in_{}", sanitize(key))
+    }
+
+    /// [`Self::out_name`] off the identity. See [`Self::in_name_of`].
+    pub(super) fn out_name_of(key: &TypeKey) -> syn::Ident {
+        format_ident!("__cbg_out_{}", sanitize(key))
     }
 
     /// Config of a declared type (across the opaque/data/enum maps), by key.

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -51,7 +51,7 @@ impl CbindgenBuilder {
             registry.output_entry(&reading).is_some()
                 && self
                     .struct_fields(registry, key)
-                    .map(|fields| fields.iter().any(|(_, fty)| is_string(fty)))
+                    .map(|fields| fields.iter().any(|(_, fty)| r_is_string(fty)))
                     .unwrap_or(false)
         })
     }
@@ -82,16 +82,11 @@ impl CbindgenBuilder {
     /// wrapper the model erases cannot change which declaration a payload
     /// matches. See [`Self::payload_field_wire`] for why a union payload asks
     /// this at all where a `repr_c_struct` mirror must not.
-    pub(super) fn declared_opaque_payload_inner(
-        &self,
-        fty: &syn::Type,
-        registry: &impl Conversions<()>,
-    ) -> Option<syn::Type> {
-        if opaque_ptr_payload_inner(fty).is_some() {
+    pub(super) fn declared_opaque_payload_inner(&self, fty: &TypeRef) -> Option<syn::Type> {
+        if r_boxed_inner(fty).is_some() {
             return None;
         }
-        let reading = registry.reading_of(fty)?;
-        let core = reading.optional_inner().unwrap_or(&reading);
+        let core = fty.optional_inner().unwrap_or(fty);
         self.opaque
             .contains_key(&core.stripped_key())
             .then(|| core.stripped_syntax())
@@ -120,31 +115,31 @@ impl CbindgenBuilder {
     /// `bool` parameter now share (#170).
     pub(super) fn payload_field_wire(
         &self,
-        fty: &syn::Type,
+        fty: &TypeRef,
         registry: &Registry<()>,
     ) -> Result<syn::Type, String> {
         // `String` is the one type whose two directions disagree on the wire
         // (`*const c_char` in, `*mut c_char` out), so the union field fixes the
         // OWNING form and the per-arm expressions convert by hand.
-        if is_string(fty) {
+        if r_is_string(fty) {
             return Ok(syn::parse_quote!(*mut ::core::ffi::c_char));
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(&TypeKey::from_type(fty));
+        if self.enums.contains_key(&fty.key()) {
+            let c = self.c_type_ident(&fty.key());
             return Ok(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
         // `bool` is the one scalar with a restricted domain: `2` is a byte a C
         // caller can write into the union and NOT a Rust `bool`, so holding it
         // in the mirror is the same UB an out-of-range discriminant is. Same
         // remedy everywhere C writes a `bool` — see `bool_wire`.
-        if is_bool(fty) {
+        if r_is_bool(fty) {
             return Ok(bool_wire());
         }
         // A `Vec` payload needs TWO C wires (pointer + length) and one union
         // field can carry only one, so its length would be silently dropped.
         // Rejected explicitly, because the converter-destination rule below
         // would otherwise hand back the pointer alone and look like it worked.
-        if is_vec(fty) {
+        if r_is_vec(fty) {
             return Err(
                 "a `Vec` needs TWO C wires (pointer + length) and one union field carries only \
                  one, so its length would be silently dropped — hand the sequence over through \
@@ -181,7 +176,7 @@ impl CbindgenBuilder {
         // (#292). The two spellings now share this C type; their converter bodies
         // differ, which is exactly the split (`kind` decides what C sees, syntax
         // decides how the value is built).
-        if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
+        if let Some(inner) = self.declared_opaque_payload_inner(fty) {
             let c = self.c_type_ident(&TypeKey::from_type(&inner));
             return Ok(syn::parse_quote!(*mut #c));
         }
@@ -197,7 +192,7 @@ impl CbindgenBuilder {
         // legitimately differ (a `String`'s const-ness above), which is why a
         // disagreement is `None` — a rejection naming the payload — rather
         // than a silent pick of one side.
-        let out_entry = registry.reading_of(fty).and_then(|tr| registry.output_entry(&tr)).ok_or_else(|| {
+        let out_entry = registry.output_entry(fty).ok_or_else(|| {
             "no resolved OUTPUT converter — a payload crosses as its converter's destination, so \
              it must be a scalar, a `String`, or a type this binding declares (`enum_type`, \
              `data_struct`, `opaque_ptr`, or a `convert!` conversion)"
@@ -214,10 +209,7 @@ impl CbindgenBuilder {
             );
         }
         let out = out_entry.destination.clone();
-        if let Some(inp) = registry
-            .reading_of(fty)
-            .and_then(|tr| registry.input_entry(&tr))
-        {
+        if let Some(inp) = registry.input_entry(fty) {
             if TypeKey::from_type(&inp.destination) != TypeKey::from_type(&out) {
                 return Err(format!(
                     "its input and output converters disagree on the wire (`{}` in, `{}` out) \
@@ -244,12 +236,20 @@ impl CbindgenBuilder {
     /// [`::core::mem::MaybeUninit`]: one mirror struct serves both directions,
     /// and on the way in its bytes are C's, so the field may not be a Rust enum
     /// until its tag has been validated. Invisible in C either way.
-    pub(super) fn data_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
-        if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(&TypeKey::from_type(fty));
+    pub(super) fn data_field_wire(&self, fty: &TypeRef) -> Option<syn::Type> {
+        if self.tagged_unions.contains_key(&fty.key()) {
+            let c = self.c_type_ident(&fty.key());
             return Some(syn::parse_quote!(::core::mem::MaybeUninit<#c>));
         }
-        c_field_wire(fty)
+        if r_is_string(fty) {
+            return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
+        }
+        // #170 instance 2: the field arrives from C by value, so it may not be
+        // a Rust `bool` until the byte has been normalised.
+        if r_is_bool(fty) {
+            return Some(bool_wire());
+        }
+        r_is_scalar(fty).then(|| spelled(fty))
     }
 
     /// True when a payload wire hands owned memory to C — a `char *` block or
@@ -264,7 +264,7 @@ impl CbindgenBuilder {
     /// zenoh-flat#30 needs.
     pub(super) fn payload_wire_owns(
         &self,
-        fty: &syn::Type,
+        fty: &TypeRef,
         wire: &syn::Type,
         registry: &Registry<()>,
     ) -> bool {
@@ -282,11 +282,11 @@ impl CbindgenBuilder {
     /// dependency so its converter exists by the time the union's own is
     /// emitted; without that it silently degrades to a passthrough and the
     /// generated code does not compile.
-    pub(super) fn payload_needs_converter(&self, fty: &syn::Type) -> bool {
-        if is_string(fty) || is_scalar(fty) || is_vec(fty) {
+    pub(super) fn payload_needs_converter(&self, fty: &TypeRef) -> bool {
+        if r_is_string(fty) || r_is_scalar(fty) || r_is_vec(fty) {
             return false;
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+        if self.enums.contains_key(&fty.key()) {
             return true;
         }
         // `Box<T>` / `Option<Box<T>>` opaque pointers are built inline from the
@@ -296,15 +296,15 @@ impl CbindgenBuilder {
 
     /// The `(name, type)` of every field of a declared `data_struct` whose own
     /// C wire owns memory. Empty when `fty` is not a declared data struct.
-    pub(super) fn owning_data_struct_fields(
+    pub(super) fn owning_data_struct_fields<'r>(
         &self,
-        fty: &syn::Type,
-        registry: &Registry<()>,
-    ) -> Vec<(syn::Ident, syn::Type)> {
-        if !self.data.contains_key(&TypeKey::from_type(fty)) {
+        fty: &TypeRef,
+        registry: &'r Registry<()>,
+    ) -> Vec<(syn::Ident, &'r TypeRef)> {
+        if !self.data.contains_key(&fty.key()) {
             return Vec::new();
         }
-        self.struct_fields(registry, &TypeKey::from_type(fty))
+        self.struct_fields(registry, &fty.key())
             .unwrap_or_default()
             .into_iter()
             .filter(|(_, fty)| self.data_field_owns(fty, registry))
@@ -315,7 +315,7 @@ impl CbindgenBuilder {
     /// is a pointer (`String` → `char *`), or it is a declared
     /// [`CbindgenBuilder::tagged_union`] with an owning arm — which crosses by value,
     /// so the pointer it owns is one level further down.
-    fn data_field_owns(&self, fty: &syn::Type, registry: &Registry<()>) -> bool {
+    fn data_field_owns(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
         if matches!(self.data_field_wire(fty), Some(syn::Type::Ptr(_))) {
             return true;
         }
@@ -330,24 +330,19 @@ impl CbindgenBuilder {
     /// containing struct has to call it, so a union nested inside a payload
     /// cannot be freed through a symbol that was never emitted. `false` for
     /// anything that is not a declared tagged union.
-    pub(super) fn tagged_union_has_drop(&self, fty: &syn::Type, registry: &Registry<()>) -> bool {
-        if !self.tagged_unions.contains_key(&TypeKey::from_type(fty))
-            || registry
-                .reading_of(fty)
-                .and_then(|tr| registry.output_entry(&tr))
-                .is_none()
-        {
+    pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
+        if !self.tagged_unions.contains_key(&fty.key()) || registry.output_entry(fty).is_none() {
             return false;
         }
-        self.enum_alternatives(registry, &TypeKey::from_type(fty))
+        self.enum_alternatives(registry, &fty.key())
             .unwrap_or_default()
             .iter()
             .flat_map(|a| a.fields.iter())
-            .any(|f| match self.payload_field_wire(f.ty.as_syn(), registry) {
+            .any(|f| match self.payload_field_wire(&f.ty, registry) {
                 // A rejected payload is reported from the emission site, which
                 // panics before any of this matters.
                 Err(_) => false,
-                Ok(wire) => self.payload_wire_owns(f.ty.as_syn(), &wire, registry),
+                Ok(wire) => self.payload_wire_owns(&f.ty, &wire, registry),
             })
     }
 
@@ -374,11 +369,11 @@ impl CbindgenBuilder {
     /// Fields (`name`, `type`) of a declared data struct, looked up from the
     /// registry's indexed structs. `None` if the type isn't an indexed named
     /// struct.
-    pub(super) fn struct_fields(
+    pub(super) fn struct_fields<'r>(
         &self,
-        registry: &impl Conversions<()>,
+        registry: &'r impl Conversions<()>,
         key: &TypeKey,
-    ) -> Option<Vec<(syn::Ident, syn::Type)>> {
+    ) -> Option<Vec<(syn::Ident, &'r TypeRef)>> {
         // The element, not its item. A `Struct` holds the field list the
         // `syn::Fields::Named` match used to dig out, each field's name beside
         // the reading of its type — so the name lookup is the key's own ident
@@ -387,7 +382,7 @@ impl CbindgenBuilder {
         let st = registry.flat().struct_type(&key.ident()?)?;
         st.fields
             .iter()
-            .map(|f| Some((f.name.clone()?, f.ty.as_syn().clone())))
+            .map(|f| Some((f.name.clone()?, &f.ty)))
             .collect()
     }
 
@@ -403,24 +398,19 @@ impl CbindgenBuilder {
     /// from C's bytes with no chance to check them. That gap is audited
     /// separately by [`Self::restricted_validity_field`] — this function keeps
     /// answering what the layout is.
-    pub(super) fn mirror_field_wire(&self, fty: &syn::Type) -> Option<syn::Type> {
-        if is_scalar(fty) {
-            return Some(fty.clone());
+    pub(super) fn mirror_field_wire(&self, fty: &TypeRef) -> Option<syn::Type> {
+        if r_is_scalar(fty) {
+            return Some(spelled(fty));
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
-            let c = self.c_type_ident(&TypeKey::from_type(fty));
+        if self.enums.contains_key(&fty.key()) {
+            let c = self.c_type_ident(&fty.key());
             return Some(syn::parse_quote!(#c));
         }
         // Opaque pointer: `Option<Box<T>>` (nullable, null-niche ↔ NULL) or `Box<T>`
         // where `T` is a declared `opaque_ptr` → `*mut t_t`.
-        let boxed = if is_option(fty) {
-            first_type_arg(fty).and_then(|inner| box_inner(&inner))
-        } else {
-            box_inner(fty)
-        };
-        if let Some(inner) = boxed {
-            if self.opaque.contains_key(&TypeKey::from_type(&inner)) {
-                let c = self.c_type_ident(&TypeKey::from_type(&inner));
+        if let Some(inner) = r_boxed_inner(fty) {
+            if self.opaque.contains_key(&inner.key()) {
+                let c = self.c_type_ident(&inner.key());
                 return Some(syn::parse_quote!(*mut #c));
             }
         }
@@ -446,11 +436,11 @@ impl CbindgenBuilder {
     /// value already exists. Wrapping the mirror field in `MaybeUninit` moves
     /// the problem rather than solving it — the transmute's *output* still has
     /// the real field.
-    pub(super) fn restricted_validity_field(&self, fty: &syn::Type) -> Option<&'static str> {
-        if is_bool(fty) {
+    pub(super) fn restricted_validity_field(&self, fty: &TypeRef) -> Option<&'static str> {
+        if r_is_bool(fty) {
             return Some("`bool` — only `0` and `1` are valid");
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+        if self.enums.contains_key(&fty.key()) {
             return Some("a declared `enum_type` — only its declared discriminants are valid");
         }
         None
@@ -462,13 +452,13 @@ impl CbindgenBuilder {
     pub(super) fn restricted_validity_fields(
         &self,
         registry: &Registry<()>,
-        ty: &syn::Type,
+        key: &TypeKey,
     ) -> Vec<(syn::Ident, &'static str)> {
-        self.struct_fields(registry, &TypeKey::from_type(ty))
+        self.struct_fields(registry, key)
             .unwrap_or_default()
             .into_iter()
             .filter_map(|(fname, fty)| {
-                self.restricted_validity_field(&fty)
+                self.restricted_validity_field(fty)
                     .map(|reason| (fname, reason))
             })
             .collect()

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -108,7 +108,7 @@ pub(crate) use crate::api::core::types_util::{
 };
 use crate::api::{
     core::{
-        flat::Origin,
+        flat::{Field, Origin, ScalarKind, TypeKind, TypeRef},
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen},
         registry::{extract_fn_trait_args, Conversions, Direction, Registry, TypeKey},
@@ -487,88 +487,26 @@ fn type_short(key: &TypeKey) -> String {
     key.short_name().unwrap_or_else(|| sanitize(key))
 }
 
-/// The indexed `syn::ItemEnum` for a declared enum type, by tail ident.
-fn enum_item<'r>(registry: &'r impl Conversions<()>, ty: &syn::Type) -> Option<&'r syn::ItemEnum> {
-    let ident = type_path_tail(ty)?;
-    registry.flat().enum_item(&ident)
-}
-
-/// Hard error when a `.tagged_union()`-declared enum is unit-only. The
-/// counterpart of [`unit_enum`]: a fieldless enum is exactly a
-/// discriminant, so it belongs to `.enum_type()` — declaring it here would
-/// emit a `union` with no bodies and a needlessly indirect C surface. Neither
-/// declarator silently accepts the other's shape.
-fn assert_payload_enum(e: &syn::ItemEnum) {
-    use crate::api::core::types_util::{enum_shape, EnumShape};
-    if enum_shape(e) == EnumShape::Unit {
-        panic!(
+/// The declared **payload-carrying** enum under `key`, or a panic naming the
+/// right declarator when it is fieldless.
+///
+/// The mirror image of [`unit_enum`], and the same act: the model split the two
+/// enum shapes into two elements at parse time, so the lookup answers the shape
+/// question. This was `enum_item` + `assert_payload_enum`, the second running
+/// `enum_shape` over a `syn::ItemEnum` to re-derive what the first had thrown
+/// away.
+fn payload_enum<'r>(
+    registry: &'r impl Conversions<()>,
+    key: &TypeKey,
+) -> Option<&'r crate::api::core::flat::Variant> {
+    match registry.flat().declared_type(&key.ident()?)? {
+        crate::api::core::flat::Type::Variant(v) => Some(v),
+        crate::api::core::flat::Type::Enum(e) => panic!(
             "Cbindgen: `{}` has no payload variants: declare it with `.enum_type()`, \
              not `.tagged_union()` — a fieldless enum crosses as a plain C `enum`",
-            e.ident
-        );
-    }
-}
-
-/// If `fty` is an opaque-pointer payload — `Box<T>` or `Option<Box<T>>` with
-/// `T` a path type — return `T`. The shape check only; whether `T` is a
-/// declared `opaque_ptr` is [`CbindgenBuilder::mirror_field_wire`]'s call, and this
-/// is only reached for a field that already passed it.
-fn opaque_ptr_payload_inner(fty: &syn::Type) -> Option<syn::Type> {
-    if is_option(fty) {
-        first_type_arg(fty).and_then(|inner| box_inner(&inner))
-    } else {
-        box_inner(fty)
-    }
-}
-
-/// The `Type` form of a generated C type ident, for the shared
-/// [`variant_ctor`] helper (which takes the enum's path either as a source
-/// type or as a mirror ident).
-fn cname_ty(cname: &syn::Ident) -> syn::Type {
-    syn::parse_quote!(#cname)
-}
-
-/// `Enum::Variant { a: __f0, .. }` / `Enum::Variant(__f0, ..)` / `Enum::Variant`
-/// — the match pattern binding every field of one variant, shaped like the
-/// variant itself. Used for both the source enum and its C mirror, and for
-/// both directions, so the two sides always destructure the same way.
-fn variant_pattern(
-    enum_path: &impl ToTokens,
-    variant: &syn::Ident,
-    fields: &syn::Fields,
-    binds: &[syn::Ident],
-) -> TokenStream {
-    match fields {
-        syn::Fields::Unit => quote!(#enum_path::#variant),
-        syn::Fields::Named(named) => {
-            let pairs = named.named.iter().zip(binds).map(|(f, b)| {
-                let n = f.ident.as_ref().expect("named field");
-                quote!(#n: #b)
-            });
-            quote!(#enum_path::#variant { #(#pairs),* })
-        }
-        syn::Fields::Unnamed(_) => quote!(#enum_path::#variant(#(#binds),*)),
-    }
-}
-
-/// The constructor counterpart of [`variant_pattern`]: rebuild one variant
-/// from already-converted field expressions.
-fn variant_ctor(
-    enum_path: &impl ToTokens,
-    variant: &syn::Ident,
-    fields: &syn::Fields,
-    exprs: &[TokenStream],
-) -> TokenStream {
-    match fields {
-        syn::Fields::Unit => quote!(#enum_path::#variant),
-        syn::Fields::Named(named) => {
-            let pairs = named.named.iter().zip(exprs).map(|(f, e)| {
-                let n = f.ident.as_ref().expect("named field");
-                quote!(#n: #e)
-            });
-            quote!(#enum_path::#variant { #(#pairs),* })
-        }
-        syn::Fields::Unnamed(_) => quote!(#enum_path::#variant(#(#exprs),*)),
+            e.name
+        ),
+        _ => None,
     }
 }
 
@@ -617,21 +555,57 @@ pub fn snake_case(s: &str) -> String {
     crate::api::core::types_util::pascal_to_snake(s)
 }
 
+/// A reading spelled back as a `syn::Type`.
+///
+/// The source's **own tokens**, re-parsed — not [`TypeKind::to_syn`], which
+/// exists to check the lowering rather than to generate with. Every wire this
+/// back-end builds from a field's own type goes through here, so what C sees
+/// is what the source wrote.
+fn spelled(t: &TypeRef) -> syn::Type {
+    let toks = t.spell();
+    syn::parse_quote!(#toks)
+}
+
+/// `String`, off the classification.
+fn r_is_string(t: &TypeRef) -> bool {
+    matches!(t.kind(), TypeKind::String)
+}
+
+/// `bool`, off the classification — the one scalar with a restricted domain.
+fn r_is_bool(t: &TypeRef) -> bool {
+    matches!(t.kind(), TypeKind::Scalar(ScalarKind::Bool))
+}
+
+/// An FFI-safe scalar primitive, off the classification. `ScalarKind` IS the
+/// closed set the name table below was spelling out by hand.
+fn r_is_scalar(t: &TypeRef) -> bool {
+    matches!(t.kind(), TypeKind::Scalar(_))
+}
+
+/// `Vec<T>`, off the classification.
+fn r_is_vec(t: &TypeRef) -> bool {
+    matches!(t.kind(), TypeKind::Vec(_))
+}
+
+/// The opaque-pointer payload shape — `Box<T>` or `Option<Box<T>>` — off the
+/// classification, returning the reading of `T`.
+///
+/// The model peer of [`opaque_ptr_payload_inner`]: same shape question, asked
+/// of `TypeKind` instead of of a path's tail ident.
+fn r_boxed_inner(t: &TypeRef) -> Option<&TypeRef> {
+    let core = t.optional_inner().unwrap_or(t);
+    match core.kind() {
+        TypeKind::Boxed(inner) => Some(inner),
+        _ => None,
+    }
+}
+
 fn is_string(ty: &syn::Type) -> bool {
     type_path_tail(ty).map(|i| i == "String").unwrap_or(false)
 }
 
 fn is_str(ty: &syn::Type) -> bool {
     type_path_tail(ty).map(|i| i == "str").unwrap_or(false)
-}
-
-/// If `ty` is `Box<T>`, return `T` (used to peel an opaque-pointer struct field
-/// such as `Box<String>` / the inner of `Option<Box<String>>`).
-fn box_inner(ty: &syn::Type) -> Option<syn::Type> {
-    if type_path_tail(ty).map(|i| i == "Box").unwrap_or(false) {
-        return first_type_arg(ty);
-    }
-    None
 }
 
 /// If `ty` is `MaybeUninit<T>` (any path form: `MaybeUninit` / `std::mem::…` /
@@ -817,22 +791,4 @@ fn route_result(call: TokenStream, route: &ErrRoute<'_>) -> TokenStream {
             }
         },
     }
-}
-
-/// C-ABI wire type for a struct field. `String` → `*mut c_char`; `bool` →
-/// [`bool_wire`]; the remaining FFI-safe scalars pass through. `None` for
-/// anything else (unsupported this increment).
-fn c_field_wire(ty: &syn::Type) -> Option<syn::Type> {
-    if is_string(ty) {
-        return Some(syn::parse_quote!(*mut ::core::ffi::c_char));
-    }
-    // #170 instance 2: the field arrives from C by value, so it may not be a
-    // Rust `bool` until the byte has been normalised.
-    if is_bool(ty) {
-        return Some(bool_wire());
-    }
-    if is_scalar(ty) {
-        return Some(ty.clone());
-    }
-    None
 }

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -60,21 +60,21 @@ impl CbindgenBuilder {
         let mut subs: Vec<TypeKey> = Vec::new();
         let mut fallible = false;
         for (fname, fty) in &fields {
-            if is_string(fty) {
+            if r_is_string(fty) {
                 inits.push(quote!(#fname: if v.#fname.is_null() {
                     ::std::string::String::new()
                 } else {
                     ::std::ffi::CStr::from_ptr(v.#fname).to_string_lossy().into_owned()
                 }));
-            } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
+            } else if self.tagged_unions.contains_key(&fty.key()) {
                 // A sum field crosses by value as its mirror; its own converter
                 // validates the tag and rebuilds the live arm, which is what
                 // makes this whole decode fallible.
-                let conv = Self::in_name(fty);
-                subs.push(TypeKey::from_type(fty));
+                let conv = Self::in_name_of(&fty.key());
+                subs.push(fty.key());
                 fallible = true;
                 inits.push(quote!(#fname: #conv(v.#fname)?));
-            } else if is_bool(fty) {
+            } else if r_is_bool(fty) {
                 // #170 instance 2: the field's wire is `MaybeUninit<bool>`, so
                 // the byte C wrote is normalised here — a Rust `bool` never
                 // holds it unchecked.
@@ -132,10 +132,9 @@ impl CbindgenBuilder {
         for (fname, fty) in self.struct_fields(registry, &TypeKey::from_type(ty))? {
             // An owned-pointer field is one whose mirror wire is a raw pointer
             // (`Option<Box<T>>` / `Box<T>` → `*mut t_t`); scalars/enums are not.
-            if matches!(self.mirror_field_wire(&fty), Some(syn::Type::Ptr(_))) {
-                if !is_option(&fty) {
-                    return None; // bare `Box<T>`: cannot be nulled (invalid `Box`)
-                }
+            if matches!(self.mirror_field_wire(fty), Some(syn::Type::Ptr(_))) {
+                // Bare `Box<T>`: cannot be nulled (an invalid `Box`).
+                fty.optional_inner()?;
                 idents.push(fname);
             }
         }
@@ -591,7 +590,7 @@ impl CbindgenBuilder {
                         "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
                         fname,
                         type_short(&reading.key()),
-                        fty.to_token_stream()
+                        fty.spell()
                     )
                 });
                 field_defs.push(quote!(pub #fname: #wire));
@@ -655,7 +654,7 @@ impl CbindgenBuilder {
                 // "does it cross in" has no truthful answer here. Over-
                 // reporting is the safe direction, and the acknowledgement
                 // below is the escape for a genuinely write-only mirror.
-                let restricted = self.restricted_validity_fields(registry, &ty);
+                let restricted = self.restricted_validity_fields(registry, &reading.key());
                 if !restricted.is_empty() && !cfg.assume_c_field_validity {
                     let listed: Vec<String> = restricted
                         .iter()
@@ -685,7 +684,7 @@ impl CbindgenBuilder {
                                  opaque pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
                                 fname,
                                 type_short(&reading.key()),
-                                fty.to_token_stream()
+                                fty.spell()
                             )
                         });
                         quote!(pub #fname: #wire)
@@ -875,40 +874,35 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.as_syn().clone();
-            let Some(e) = enum_item(registry, &ty) else {
+            let Some(e) = payload_enum(registry, &reading.key()) else {
                 continue;
             };
-            assert_payload_enum(e);
             let cname = self.c_type_ident(&reading.key());
 
             let mut variant_defs: Vec<TokenStream> = Vec::new();
             // Per-variant drop arm, collected only for variants that own
             // something; the rest fall to a single wildcard arm.
             let mut drop_arms: Vec<TokenStream> = Vec::new();
-            for v in &e.variants {
-                let vident = &v.ident;
-                let wires: Vec<syn::Type> = v
+            for a in &e.alternatives {
+                let vident = &a.name;
+                let wires: Vec<syn::Type> = a
                     .fields
                     .iter()
-                    .map(|f| self.payload_wire_of(&ty, vident, f, registry))
+                    .map(|f| self.payload_wire_of(&reading.key(), vident, f, registry))
                     .collect();
-                match &v.fields {
-                    syn::Fields::Unit => variant_defs.push(quote!(#vident)),
-                    syn::Fields::Named(named) => {
-                        let defs = named.named.iter().zip(&wires).map(|(f, w)| {
-                            let n = f.ident.as_ref().expect("named field");
-                            quote!(#n: #w)
-                        });
-                        variant_defs.push(quote!(#vident { #(#defs),* }));
-                    }
-                    syn::Fields::Unnamed(_) => {
-                        variant_defs.push(quote!(#vident(#(#wires),*)));
-                    }
-                }
+                // `Alternative::spell` writes the delimiters the source wrote,
+                // which is what the three-armed `syn::Fields` match was doing —
+                // and `Field::bind` decides `name: wire` or `wire` per field.
+                let defs: Vec<TokenStream> = a
+                    .fields
+                    .iter()
+                    .zip(&wires)
+                    .map(|(f, w)| f.bind(w))
+                    .collect();
+                variant_defs.push(a.spell(quote!(#vident), &defs));
 
                 // Drop arm: bind every field, free the owning ones.
-                let owning: Vec<(usize, &syn::Field, &syn::Type)> = v
+                let owning: Vec<(usize, &Field, &syn::Type)> = a
                     .fields
                     .iter()
                     .zip(&wires)
@@ -919,10 +913,16 @@ impl CbindgenBuilder {
                 if owning.is_empty() {
                     continue;
                 }
-                let binds: Vec<syn::Ident> = (0..v.fields.len())
+                let binds: Vec<syn::Ident> = (0..a.fields.len())
                     .map(|i| format_ident!("__f{}", i))
                     .collect();
-                let pattern = variant_pattern(&cname, vident, &v.fields, &binds);
+                let parts: Vec<TokenStream> = a
+                    .fields
+                    .iter()
+                    .zip(&binds)
+                    .map(|(f, b)| f.bind(b))
+                    .collect();
+                let pattern = a.spell(quote!(#cname::#vident), &parts);
                 let frees = owning.iter().map(|(i, f, _)| {
                     let b = &binds[*i];
                     self.payload_free_stmt(&f.ty, b, registry)
@@ -941,7 +941,7 @@ impl CbindgenBuilder {
             // The same predicate a CONTAINING struct uses to decide whether to
             // call this drop, so a nested union can never be freed through a
             // symbol that was not emitted.
-            if self.tagged_union_has_drop(&ty, registry) {
+            if self.tagged_union_has_drop(&reading, registry) {
                 debug_assert!(!drop_arms.is_empty(), "has_drop implies an owning arm");
                 let drop_ident = self.destructor_symbol(&reading.key());
                 // The drop is a second C entry point into the same bytes, so it
@@ -951,8 +951,12 @@ impl CbindgenBuilder {
                 // having nowhere to report to, ignores the value (there is no
                 // live arm to release), which keeps `_drop` the always-safe
                 // no-op it is everywhere else.
-                let tag_guard =
-                    self.tag_guard(&cname, e.variants.len(), quote!((*this_)), quote!(return;));
+                let tag_guard = self.tag_guard(
+                    &cname,
+                    e.alternatives.len(),
+                    quote!((*this_)),
+                    quote!(return;),
+                );
                 items.push(syn::parse_quote!(
                     #[no_mangle]
                     #[allow(non_snake_case, unused_variables)]
@@ -978,22 +982,22 @@ impl CbindgenBuilder {
     /// offending variant field and the supported set.
     fn payload_wire_of(
         &self,
-        ty: &syn::Type,
+        key: &TypeKey,
         variant: &syn::Ident,
-        field: &syn::Field,
+        field: &Field,
         registry: &Registry<()>,
     ) -> syn::Type {
         self.payload_field_wire(&field.ty, registry)
             .unwrap_or_else(|reason| {
                 panic!(
                     "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
-                    type_short(&TypeKey::from_type(ty)),
+                    type_short(key),
                     variant,
-                    match &field.ident {
+                    match &field.name {
                         Some(n) => format!(".{n}"),
                         None => String::new(),
                     },
-                    field.ty.to_token_stream(),
+                    field.ty.spell(),
                     reason,
                 )
             })
@@ -1006,11 +1010,11 @@ impl CbindgenBuilder {
     /// destructor.
     fn payload_free_stmt(
         &self,
-        fty: &syn::Type,
+        fty: &TypeRef,
         binding: &syn::Ident,
         registry: &Registry<()>,
     ) -> TokenStream {
-        if is_string(fty) {
+        if r_is_string(fty) {
             return quote!(
                 free(*#binding as *mut ::core::ffi::c_void);
                 *#binding = ::core::ptr::null_mut();
@@ -1025,7 +1029,7 @@ impl CbindgenBuilder {
         let owning = self.owning_data_struct_fields(fty, registry);
         if !owning.is_empty() {
             let frees = owning.iter().map(|(fname, fty)| {
-                if is_string(fty) {
+                if r_is_string(fty) {
                     quote!(
                         free((*#binding).#fname as *mut ::core::ffi::c_void);
                         (*#binding).#fname = ::core::ptr::null_mut();
@@ -1037,7 +1041,7 @@ impl CbindgenBuilder {
                     // — and the owning pointer is reached even though it is two
                     // levels down. Nothing else can reach it: a union arm is not
                     // a top-level struct field the C caller releases by hand.
-                    let drop_ident = self.destructor_symbol(&TypeKey::from_type(fty));
+                    let drop_ident = self.destructor_symbol(&fty.key());
                     quote!(#drop_ident(&mut (*#binding).#fname);)
                 } else {
                     // `owning_data_struct_fields` yields exactly the two shapes
@@ -1048,13 +1052,13 @@ impl CbindgenBuilder {
                         "Cbindgen: data-struct field `{}` of type `{}` is owning but has no \
                          release form (expected a `String` or a declared `tagged_union`)",
                         fname,
-                        fty.to_token_stream(),
+                        fty.spell(),
                     )
                 }
             });
             return quote!(#(#frees)*);
         }
-        let inner = opaque_ptr_payload_inner(fty).unwrap_or_else(|| fty.clone());
+        let inner = spelled(r_boxed_inner(fty).unwrap_or(fty));
         let src_inner = self.src_ty(&inner);
         quote!(
             if !(*#binding).is_null() {
@@ -1090,8 +1094,7 @@ impl CbindgenBuilder {
         if !self.tagged_unions.contains_key(&key) {
             return None;
         }
-        let e = enum_item(r, ty)?;
-        assert_payload_enum(e);
+        let e = payload_enum(r, &key)?;
         let name = Self::in_name(ty);
         let cname = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
@@ -1101,28 +1104,30 @@ impl CbindgenBuilder {
         // returning `None` here is the resolver's DEFERRAL protocol, and it
         // retries at the next fixed point. Without this the payload silently
         // degrades to a passthrough and the generated code does not compile.
-        for v in &e.variants {
-            for f in &v.fields {
-                if self.payload_needs_converter(&f.ty)
-                    && r.reading_of(&f.ty)
-                        .and_then(|tr| r.input_entry(&tr))
-                        .is_none()
-                {
+        for a in &e.alternatives {
+            for f in &a.fields {
+                if self.payload_needs_converter(&f.ty) && r.input_entry(&f.ty).is_none() {
                     return None;
                 }
             }
         }
         let mut subs: Vec<TypeKey> = Vec::new();
         let arms: Vec<TokenStream> = e
-            .variants
+            .alternatives
             .iter()
-            .map(|v| {
-                let vident = &v.ident;
-                let binds: Vec<syn::Ident> = (0..v.fields.len())
+            .map(|a| {
+                let vident = &a.name;
+                let binds: Vec<syn::Ident> = (0..a.fields.len())
                     .map(|i| format_ident!("__f{}", i))
                     .collect();
-                let from = variant_pattern(&cname, vident, &v.fields, &binds);
-                let exprs: Vec<TokenStream> = v
+                let parts: Vec<TokenStream> = a
+                    .fields
+                    .iter()
+                    .zip(&binds)
+                    .map(|(f, b)| f.bind(b))
+                    .collect();
+                let from = a.spell(quote!(#cname::#vident), &parts);
+                let exprs: Vec<TokenStream> = a
                     .fields
                     .iter()
                     .zip(&binds)
@@ -1134,22 +1139,28 @@ impl CbindgenBuilder {
                         // emitted. Without it the payload silently falls back to
                         // a passthrough and the generated code does not compile.
                         if self.payload_needs_converter(&f.ty) {
-                            subs.push(TypeKey::from_type(&f.ty));
+                            subs.push(f.ty.key());
                         }
                         self.payload_in_expr(&f.ty, b, r)
                     })
                     .collect();
-                let to = variant_ctor(&src, vident, &v.fields, &exprs);
+                let inits: Vec<TokenStream> = a
+                    .fields
+                    .iter()
+                    .zip(&exprs)
+                    .map(|(f, e)| f.bind(e))
+                    .collect();
+                let to = a.spell(quote!(#src::#vident), &inits);
                 quote!(#from => #to,)
             })
             .collect();
         let bad_msg = format!(
             "invalid tag {{}} for `{cname}` (expected 0..{})",
-            e.variants.len()
+            e.alternatives.len()
         );
         let tag_guard = self.tag_guard(
             &cname,
-            e.variants.len(),
+            e.alternatives.len(),
             quote!(v),
             quote!(return ::core::result::Result::Err(::std::format!(#bad_msg, __tag));),
         );
@@ -1224,45 +1235,52 @@ impl CbindgenBuilder {
         if !self.tagged_unions.contains_key(&key) {
             return None;
         }
-        let e = enum_item(r, ty)?;
-        assert_payload_enum(e);
+        let e = payload_enum(r, &key)?;
         let name = Self::out_name(ty);
         let cname = self.c_type_ident(&TypeKey::from_type(ty));
         let src = self.src_ty(ty);
         // Deferral, as in `in_tagged_union` — the output counterpart.
-        for v in &e.variants {
-            for f in &v.fields {
-                if self.payload_needs_converter(&f.ty)
-                    && r.reading_of(&f.ty)
-                        .and_then(|tr| r.output_entry(&tr))
-                        .is_none()
-                {
+        for a in &e.alternatives {
+            for f in &a.fields {
+                if self.payload_needs_converter(&f.ty) && r.output_entry(&f.ty).is_none() {
                     return None;
                 }
             }
         }
         let mut subs: Vec<TypeKey> = Vec::new();
         let arms: Vec<TokenStream> = e
-            .variants
+            .alternatives
             .iter()
-            .map(|v| {
-                let vident = &v.ident;
-                let binds: Vec<syn::Ident> = (0..v.fields.len())
+            .map(|a| {
+                let vident = &a.name;
+                let binds: Vec<syn::Ident> = (0..a.fields.len())
                     .map(|i| format_ident!("__f{}", i))
                     .collect();
-                let from = variant_pattern(&src, vident, &v.fields, &binds);
-                let exprs: Vec<TokenStream> = v
+                let parts: Vec<TokenStream> = a
+                    .fields
+                    .iter()
+                    .zip(&binds)
+                    .map(|(f, b)| f.bind(b))
+                    .collect();
+                let from = a.spell(quote!(#src::#vident), &parts);
+                let exprs: Vec<TokenStream> = a
                     .fields
                     .iter()
                     .zip(&binds)
                     .map(|(f, b)| {
                         if self.payload_needs_converter(&f.ty) {
-                            subs.push(TypeKey::from_type(&f.ty));
+                            subs.push(f.ty.key());
                         }
                         self.payload_out_expr(&f.ty, b, r)
                     })
                     .collect();
-                let to = variant_ctor(&cname_ty(&cname), vident, &v.fields, &exprs);
+                let inits: Vec<TokenStream> = a
+                    .fields
+                    .iter()
+                    .zip(&exprs)
+                    .map(|(f, e)| f.bind(e))
+                    .collect();
+                let to = a.spell(quote!(#cname::#vident), &inits);
                 quote!(#from => #to,)
             })
             .collect();
@@ -1290,22 +1308,22 @@ impl CbindgenBuilder {
     /// mirror wire allows.
     fn payload_in_expr(
         &self,
-        fty: &syn::Type,
+        fty: &TypeRef,
         b: &syn::Ident,
         registry: &impl Conversions<()>,
     ) -> TokenStream {
-        if is_string(fty) {
+        if r_is_string(fty) {
             return quote!(if #b.is_null() {
                 ::std::string::String::new()
             } else {
                 ::std::ffi::CStr::from_ptr(#b).to_string_lossy().into_owned()
             });
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
+        if self.enums.contains_key(&fty.key()) {
             // The payload rides as `MaybeUninit<enum mirror>` and goes through
             // the same validating decode a top-level enum parameter does; an
             // out-of-range one propagates out of the union's own converter.
-            let conv = Self::in_name(fty);
+            let conv = Self::in_name_of(&fty.key());
             return quote!(#conv(#b)?);
         }
         // The same opaque-pointer arm the wire took, for a spelling with no
@@ -1313,7 +1331,7 @@ impl CbindgenBuilder {
         // up ownership of, so the pointer is reclaimed the same way — the value
         // is just moved out of the box instead of kept in one. Conversion
         // follows the SYNTAX; the C type followed `kind` + the declaration.
-        if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
+        if let Some(inner) = self.declared_opaque_payload_inner(fty) {
             let src_inner = self.src_ty(&inner);
             let owned = quote!(*::std::boxed::Box::from_raw(#b as *mut #src_inner));
             let null_msg = format!(
@@ -1321,7 +1339,7 @@ impl CbindgenBuilder {
                  union may already have been dropped)",
                 type_short(&TypeKey::from_type(&inner))
             );
-            return if is_option(fty) {
+            return if fty.optional_inner().is_some() {
                 quote!(if #b.is_null() {
                     ::core::option::Option::None
                 } else {
@@ -1338,10 +1356,10 @@ impl CbindgenBuilder {
                 })
             };
         }
-        if let Some(inner) = opaque_ptr_payload_inner(fty) {
-            let src_inner = self.src_ty(&inner);
+        if let Some(inner) = r_boxed_inner(fty) {
+            let src_inner = self.src_ty(&spelled(inner));
             let boxed = quote!(::std::boxed::Box::from_raw(#b as *mut #src_inner));
-            return if is_option(fty) {
+            return if fty.optional_inner().is_some() {
                 quote!(if #b.is_null() {
                     ::core::option::Option::None
                 } else {
@@ -1356,7 +1374,7 @@ impl CbindgenBuilder {
                 let null_msg = format!(
                     "null payload for `{}` (a non-optional `Box` payload cannot be NULL — the \
                      union may already have been dropped)",
-                    type_short(&TypeKey::from_type(&inner))
+                    type_short(&inner.key())
                 );
                 quote!({
                     if #b.is_null() {
@@ -1370,21 +1388,18 @@ impl CbindgenBuilder {
         }
         // A `bool` payload rides as `MaybeUninit<bool>` (see `bool_wire`), so
         // the byte C wrote is normalised rather than materialised.
-        if is_bool(fty) {
+        if r_is_bool(fty) {
             return bool_in_expr(quote!(#b));
         }
         // A scalar is its own wire and needs no call.
-        if is_scalar(fty) {
+        if r_is_scalar(fty) {
             return quote!(#b);
         }
         // Everything else rides its own resolved input converter — the wire
         // came from that converter's destination, so the two cannot disagree.
         // A fallible one propagates with `?`, which the union's own `Result`
         // already provides.
-        match registry
-            .reading_of(fty)
-            .and_then(|tr| registry.input_entry(&tr))
-        {
+        match registry.input_entry(fty) {
             Some(entry) => {
                 let conv = &entry.function.sig.ident;
                 if returns_result(&entry.function.sig.output) {
@@ -1401,22 +1416,22 @@ impl CbindgenBuilder {
     /// `char *` block the union's typed drop later frees.
     fn payload_out_expr(
         &self,
-        fty: &syn::Type,
+        fty: &TypeRef,
         b: &syn::Ident,
         registry: &impl Conversions<()>,
     ) -> TokenStream {
-        if is_string(fty) {
+        if r_is_string(fty) {
             return quote!(__cbg_alloc_cstr(#b));
         }
-        if self.enums.contains_key(&TypeKey::from_type(fty)) {
-            let conv = Self::out_name(fty);
+        if self.enums.contains_key(&fty.key()) {
+            let conv = Self::out_name_of(&fty.key());
             return quote!(::core::mem::MaybeUninit::new(#conv(#b)));
         }
         // The peer of the input arm above: an owned value the C side must later
         // release, so it is boxed HERE rather than having arrived boxed.
-        if let Some(inner) = self.declared_opaque_payload_inner(fty, registry) {
+        if let Some(inner) = self.declared_opaque_payload_inner(fty) {
             let c = self.c_type_ident(&TypeKey::from_type(&inner));
-            return if is_option(fty) {
+            return if fty.optional_inner().is_some() {
                 quote!(match #b {
                     ::core::option::Option::Some(__v) => {
                         ::std::boxed::Box::into_raw(::std::boxed::Box::new(__v)) as *mut #c
@@ -1427,9 +1442,9 @@ impl CbindgenBuilder {
                 quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(#b)) as *mut #c)
             };
         }
-        if let Some(inner) = opaque_ptr_payload_inner(fty) {
-            let c = self.c_type_ident(&TypeKey::from_type(&inner));
-            return if is_option(fty) {
+        if let Some(inner) = r_boxed_inner(fty) {
+            let c = self.c_type_ident(&inner.key());
+            return if fty.optional_inner().is_some() {
                 quote!(match #b {
                     ::core::option::Option::Some(__b) => {
                         ::std::boxed::Box::into_raw(__b) as *mut #c
@@ -1442,20 +1457,17 @@ impl CbindgenBuilder {
         }
         // The counterpart of the normalising read above: Rust always writes a
         // valid `0`/`1`, so this only wraps.
-        if is_bool(fty) {
+        if r_is_bool(fty) {
             return bool_out_expr(quote!(#b));
         }
-        if is_scalar(fty) {
+        if r_is_scalar(fty) {
             return quote!(#b);
         }
         // The output counterpart of the input dispatch above. Acceptance —
         // including the refusal of a FALLIBLE output converter, which a union
         // cannot report through — is decided once in `payload_field_wire`, so
         // this site only emits the call.
-        match registry
-            .reading_of(fty)
-            .and_then(|tr| registry.output_entry(&tr))
-        {
+        match registry.output_entry(fty) {
             Some(entry) => {
                 let conv = entry.function.sig.ident.clone();
                 quote!(#conv(#b))
@@ -1980,13 +1992,13 @@ impl CbindgenBuilder {
             let mut inits: Vec<TokenStream> = Vec::new();
             let mut subs: Vec<TypeKey> = Vec::new();
             for (fname, fty) in &fields {
-                if is_string(fty) {
+                if r_is_string(fty) {
                     inits.push(quote!(#fname: __cbg_alloc_cstr(v.#fname)));
-                } else if self.tagged_unions.contains_key(&TypeKey::from_type(fty)) {
-                    let conv = Self::out_name(fty);
-                    subs.push(TypeKey::from_type(fty));
+                } else if self.tagged_unions.contains_key(&fty.key()) {
+                    let conv = Self::out_name_of(&fty.key());
+                    subs.push(fty.key());
                     inits.push(quote!(#fname: #conv(v.#fname)));
-                } else if is_bool(fty) {
+                } else if r_is_bool(fty) {
                     let wrap = bool_out_expr(quote!(v.#fname));
                     inits.push(quote!(#fname: #wrap));
                 } else {


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). S24 (#337) was the wedge; this is the population it was waiting on.

## What moved

cbindgen decides, per **field**, what C sees. Every one of those decisions took a `&syn::Type` and re-derived from the spelling what the model had already classified:

| | |
|---|---|
| `struct_fields` | returned `Vec<(Ident, syn::Type)>` — a **clone of every field's node** |
| `mirror_field_wire`, `data_field_wire`, `payload_field_wire` | the wire policies |
| `payload_needs_converter`, `payload_wire_owns`, `payload_in_expr`, `payload_out_expr`, `payload_free_stmt` | the per-arm conversion policies |
| `data_field_owns`, `owning_data_struct_fields`, `tagged_union_has_drop` | the ownership audit |
| `restricted_validity_field(s)`, `declared_opaque_payload_inner` | the validity and declaration lookups |

All of them now take `&TypeRef`. `struct_fields` hands back the readings the `Struct` element already holds — no clone, no node. Five tail-ident tests become `TypeKind` matches:

```rust
-fn is_string(ty: &syn::Type) -> bool { type_path_tail(ty).map(|i| i == "String").unwrap_or(false) }
+fn r_is_string(t: &TypeRef) -> bool { matches!(t.kind(), TypeKind::String) }
```

`is_scalar`'s hand-written twelve-name table goes too: `ScalarKind` **is** that set.

## And then the tagged unions

The three walks that S24 could not move — the mirror, the in-converter, the out-converter — follow now that the chain reads:

* `enum_item(registry, &ty)` + `assert_payload_enum(e)` → one `payload_enum(registry, &TypeKey)`. The mirror image of `unit_enum`, and the same act: the model split the two enum shapes into two elements at parse time, so the lookup *is* the shape check. `assert_payload_enum` was running `enum_shape` over a `syn::ItemEnum` to re-derive what the lookup had already thrown away.
* `variant_pattern` / `variant_ctor` → `Alternative::spell` + `Field::bind`. Those two existed to re-match `syn::Fields` for delimiters (`E::B` vs `E::B()` vs `E::B {}`) in four places, in both directions; `flat::spell` already answers it off the alternative's own origin.

## Deleted as callerless

`enum_item`, `variant_pattern`, `variant_ctor`, `cname_ty`, `c_field_wire`, `box_inner`, `opaque_ptr_payload_inner`, and `types_util::{EnumShape, enum_shape}` — the last `syn::Fields`-based enum classifier in the crate, with the test that covered only it.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 83 | 83 |
| escapes: types | 51 | **47** |
| escapes: items | 21 | **17** |

Per file:

```
api/lang/cbindgen/emit.rs        [types]  4 -> 1
api/lang/cbindgen/trait_impl.rs  [types]  5 -> 4
api/lang/cbindgen/mod.rs         [items]  1 -> 0
api/lang/cbindgen/trait_impl.rs  [items]  5 -> 2
```

Classification is flat: what this stage deleted classified through `type_path_tail` and `syn::Fields`, neither of which the census watches — they are the "helper delegation" and "syn enums outside WATCHED" blind spots the ledger header names, and they were only ever reachable *through* the escapes this removes. That is the gating relationship working as designed: closing the door closes the room.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — **every generated artifact byte-identical**, which is the load-bearing check here: `Alternative::spell` had to reproduce `variant_pattern`'s delimiters exactly, and `spelled()` had to reproduce what `fty.clone()` spelled.