### PR TITLE
S26: the JNI wrapper shapes take a reading

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -141,9 +141,9 @@
 3	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/render.rs
 6	api/lang/jnigen/jni/selector.rs
-13	api/lang/jnigen/jni/trait_impl.rs
+7	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 47
+# total escapes: types: 41
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -410,14 +410,17 @@ pub(crate) fn callback_input(
 /// it by the element's folded [`Projection`] being a [`ProjectionKind::Handle`]
 /// and panic with a fix hint, instead of the `Vec<_>` handler silently
 /// `return None`-ing (which surfaces as an opaque "unresolved type" error).
-pub(crate) fn reject_vec_of_handle(inner_projection: &Option<Projection>, elem: &syn::Type) {
+pub(crate) fn reject_vec_of_handle(
+    inner_projection: &Option<Projection>,
+    elem: &crate::api::core::flat::TypeRef,
+) {
     if let Some(p) = inner_projection {
         if p.kind == ProjectionKind::Handle {
             panic!(
                 "JniGen: `Vec<{}>` is unsupported — its elements would be closeable native \
                  handles (jlong) the JVM must free individually. Expose a per-element \
                  accessor instead of returning a `Vec` of handles.",
-                elem.to_token_stream(),
+                elem.spell(),
             );
         }
     }
@@ -426,7 +429,9 @@ pub(crate) fn reject_vec_of_handle(inner_projection: &Option<Projection>, elem: 
 /// Reconstruct the `impl Fn(args...) + Send + Sync + 'static` syn::Type
 /// from a flat slice of arg types. Used by the rank-1/2/3 callback impls
 /// to feed `input_wrapper` the original outer type.
-pub(crate) fn build_fn_type(args: &[syn::Type]) -> syn::Type {
-    let arg_iter = args.iter();
+pub(crate) fn build_fn_type(args: &[crate::api::core::flat::TypeRef]) -> syn::Type {
+    // The args as the source spelled them — the callback's Rust type is
+    // re-emitted, never re-derived.
+    let arg_iter = args.iter().map(|a| a.spell());
     syn::parse_quote!(impl Fn( #(#arg_iter),* ) + Send + Sync + 'static)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -242,12 +242,11 @@ pub(crate) fn composed_inner_output(
 /// If neither path applies (non-primitive wire, no niche), the wrap
 /// fails and the resolver falls through to other rank-1 attempts.
 pub(crate) fn option_input(
-    t1: &syn::Type,
+    t1: &crate::api::core::flat::TypeRef,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry
-        .reading_of(t1)
-        .and_then(|tr| registry.input_entry(&tr))?;
+    let inner_entry = registry.input_entry(t1)?;
+    let t1_spelled = t1.spell();
     let inner_wire = inner_entry.destination.clone();
     let inner_decode = composed_inner_input(inner_entry, quote!(v));
 
@@ -267,7 +266,7 @@ pub(crate) fn option_input(
                 if #pred {
                     None
                 } else {
-                    Some(unsafe { OwnedObject::from_raw(*v as *const #t1).clone() })
+                    Some(unsafe { OwnedObject::from_raw(*v as *const #t1_spelled).clone() })
                 }
             })
         } else {
@@ -310,12 +309,10 @@ pub(crate) fn option_input(
 
 /// Build `Option<T>`'s output converter — symmetric to [`option_input`].
 pub(crate) fn option_output(
-    t1: &syn::Type,
+    t1: &crate::api::core::flat::TypeRef,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry
-        .reading_of(t1)
-        .and_then(|tr| registry.output_entry(&tr))?;
+    let inner_entry = registry.output_entry(t1)?;
     let inner_wire = inner_entry.destination.clone();
     let inner_encode = composed_inner_output(inner_entry, quote!(value));
 
@@ -476,12 +473,11 @@ pub(crate) fn enum_output_body(
 /// they consult — the comparison is identical.
 pub(crate) fn nullable_kind_for(
     outer_wire: &syn::Type,
-    inner_ty: &syn::Type,
+    inner_ty: &crate::api::core::flat::TypeRef,
     registry: &impl Conversions<KotlinMeta>,
 ) -> NullableKind {
     let inner_dest = registry
-        .reading_of(inner_ty)
-        .and_then(|tr| registry.input_entry(&tr))
+        .input_entry(inner_ty)
         .map(|e| e.destination.clone())
         .expect(
             "nullable_kind_for: Option<_> input handler reached here only after option_input \
@@ -496,12 +492,11 @@ pub(crate) fn nullable_kind_for(
 
 pub(crate) fn nullable_kind_for_output(
     outer_wire: &syn::Type,
-    inner_ty: &syn::Type,
+    inner_ty: &crate::api::core::flat::TypeRef,
     registry: &impl Conversions<KotlinMeta>,
 ) -> NullableKind {
     let inner_dest = registry
-        .reading_of(inner_ty)
-        .and_then(|tr| registry.output_entry(&tr))
+        .output_entry(inner_ty)
         .map(|e| e.destination.clone())
         .expect(
             "nullable_kind_for_output: Option<_> output handler reached here only after \

--- a/prebindgen/src/api/lang/jnigen/jni/tests/niches.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/niches.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api::core::registry::Conversions;
 
 /// Single niche, single Option layer — wire stays the inner wire,
 /// remainder is empty. No widening to JObject.
@@ -17,7 +18,8 @@ fn option_carves_single_niche() {
     );
 
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
-    let (wire, _body, niches) = option_input(&inner_ty, &reg).expect("Option<TestType> resolves");
+    let (wire, _body, niches) = option_input(&reg.reading_of(&inner_ty).expect("interned"), &reg)
+        .expect("Option<TestType> resolves");
 
     assert_eq!(
         wire.to_token_stream().to_string(),
@@ -56,7 +58,8 @@ fn option_cascades_through_multi_niche() {
 
     // Layer 1: Option<TestType>.
     let layer1_ty: syn::Type = syn::parse_quote!(TestType);
-    let (w1, _, n1) = option_input(&layer1_ty, &reg).expect("layer 1 resolves");
+    let (w1, _, n1) = option_input(&reg.reading_of(&layer1_ty).expect("interned"), &reg)
+        .expect("layer 1 resolves");
     assert_eq!(w1.to_token_stream().to_string(), "jni :: sys :: jint");
     assert_eq!(n1.len(), 1, "first carve leaves one niche");
 
@@ -72,7 +75,8 @@ fn option_cascades_through_multi_niche() {
 
     // Layer 2: Option<Option<TestType>>.
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
-    let (w2, _, n2) = option_input(&layer2_ty, &reg).expect("layer 2 resolves");
+    let (w2, _, n2) = option_input(&reg.reading_of(&layer2_ty).expect("interned"), &reg)
+        .expect("layer 2 resolves");
     assert_eq!(
         w2.to_token_stream().to_string(),
         "jni :: sys :: jint",
@@ -91,7 +95,8 @@ fn option_cascades_through_multi_niche() {
     // Layer 3: Option<Option<Option<TestType>>>. No niches left,
     // inner wire is jint (a JNI primitive) → boxed-Long fallback.
     let layer3_ty: syn::Type = syn::parse_quote!(Option<Option<TestType>>);
-    let (w3, _, n3) = option_input(&layer3_ty, &reg).expect("layer 3 resolves via box fallback");
+    let (w3, _, n3) = option_input(&reg.reading_of(&layer3_ty).expect("interned"), &reg)
+        .expect("layer 3 resolves via box fallback");
     assert_eq!(
         w3.to_token_stream().to_string(),
         "jni :: objects :: JObject",
@@ -129,7 +134,8 @@ fn option_output_cascades_through_multi_niche() {
     );
 
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
-    let (w1, body1, n1) = option_output(&inner_ty, &reg).expect("Option<TestType> output resolves");
+    let (w1, body1, n1) = option_output(&reg.reading_of(&inner_ty).expect("interned"), &reg)
+        .expect("Option<TestType> output resolves");
     assert_eq!(w1.to_token_stream().to_string(), "jni :: sys :: jint");
     assert_eq!(n1.len(), 1, "one slot left after carving the first");
     // The body must reference the carved value (-1) in the None arm.
@@ -148,8 +154,8 @@ fn option_output_cascades_through_multi_niche() {
     );
 
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
-    let (w2, body2, n2) =
-        option_output(&layer2_ty, &reg).expect("Option<Option<TestType>> output resolves");
+    let (w2, body2, n2) = option_output(&reg.reading_of(&layer2_ty).expect("interned"), &reg)
+        .expect("Option<Option<TestType>> output resolves");
     assert_eq!(w2.to_token_stream().to_string(), "jni :: sys :: jint");
     assert!(n2.is_empty());
     let body2_str = body2.to_token_stream().to_string();
@@ -178,7 +184,8 @@ fn option_over_jobject_uses_default_null_niche() {
     );
 
     let ty: syn::Type = syn::parse_quote!(MyStruct);
-    let (wire, _, rest) = option_input(&ty, &reg).expect("Option<MyStruct> resolves");
+    let (wire, _, rest) = option_input(&reg.reading_of(&ty).expect("interned"), &reg)
+        .expect("Option<MyStruct> resolves");
     assert_eq!(
         wire.to_token_stream().to_string(),
         "jni :: objects :: JObject"
@@ -203,7 +210,7 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
         ),
     );
     let ty: syn::Type = syn::parse_quote!(MyStruct);
-    assert!(option_input(&ty, &reg).is_none());
+    assert!(option_input(&reg.reading_of(&ty).expect("interned"), &reg).is_none());
 }
 
 /// Boxed fallback widens to `JObject` and exposes no further
@@ -223,7 +230,8 @@ fn option_box_fallback_exposes_no_niches() {
         ),
     );
     let ty: syn::Type = syn::parse_quote!(i64);
-    let (wire, _, rest) = option_input(&ty, &reg).expect("Option<i64> via box fallback");
+    let (wire, _, rest) = option_input(&reg.reading_of(&ty).expect("interned"), &reg)
+        .expect("Option<i64> via box fallback");
     assert_eq!(
         wire.to_token_stream().to_string(),
         "jni :: objects :: JObject"

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -259,7 +259,7 @@ impl Declarations {
             // an `OwnedObject::from_raw` failure as the framework
             // `JniBindingError`, so the throws fields point at the
             // framework exception.
-            metadata: self.opaque_leaf_meta(ty),
+            metadata: self.opaque_leaf_meta(TypeKey::from_type(ty)),
         }
     }
 
@@ -267,10 +267,10 @@ impl Declarations {
     /// plus the [`Projection`] that folds outward through wrappers (owned,
     /// [`FoldStrategy::Base`]). The single seam where a Rust type is
     /// first marked a closeable native handle.
-    fn opaque_leaf_meta(&self, ty: &syn::Type) -> KotlinMeta {
+    fn opaque_leaf_meta(&self, key: TypeKey) -> KotlinMeta {
         KotlinMeta {
             projection: Some(Projection {
-                leaf_key: TypeKey::from_type(ty),
+                leaf_key: key,
                 owned: true,
                 strategy: FoldStrategy::Base,
                 kind: ProjectionKind::Handle,
@@ -437,7 +437,7 @@ impl Declarations {
             // [`Self::opaque_leaf_meta`]. Framework throws because the
             // wrapper's emitted match-arm still has a `JniBindingError`
             // branch reachable via the chain.
-            metadata: self.opaque_leaf_meta(ty),
+            metadata: self.opaque_leaf_meta(TypeKey::from_type(ty)),
         }
     }
 }
@@ -871,9 +871,11 @@ impl Declarations {
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions; the
-        // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.as_syn();
+        // `t1`'s spelling, for the parts that ask spelling questions — the
+        // canonical form a produced spelling is compared against, and the
+        // type ascriptions the generated body writes. Everything else takes
+        // the READING itself (#284).
+        let t1_ty = t1.spell();
         let WrapperShape::Borrow { mutable } = shape else {
             return None;
         };
@@ -930,9 +932,11 @@ impl Declarations {
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions; the
-        // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.as_syn();
+        // `t1`'s spelling, for the parts that ask spelling questions — the
+        // canonical form a produced spelling is compared against, and the
+        // type ascriptions the generated body writes. Everything else takes
+        // the READING itself (#284).
+        let t1_ty = t1.spell();
         let WrapperShape::OptionRef { mutable } = shape else {
             return None;
         };
@@ -1001,14 +1005,16 @@ impl Declarations {
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions; the
-        // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.as_syn();
+        // `t1`'s spelling, for the parts that ask spelling questions — the
+        // canonical form a produced spelling is compared against, and the
+        // type ascriptions the generated body writes. Everything else takes
+        // the READING itself (#284).
+        let t1_ty = t1.spell();
         if shape != WrapperShape::Sequence {
             return None;
         }
         let inner = registry.input_entry(t1)?;
-        reject_vec_of_handle(&inner.metadata.projection, t1_ty);
+        reject_vec_of_handle(&inner.metadata.projection, t1);
         let inner_wire = inner.destination.clone();
         if !is_jobject_shaped_wire(&inner_wire) {
             return None;
@@ -1072,9 +1078,11 @@ impl Declarations {
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions; the
-        // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.as_syn();
+        // `t1`'s spelling, for the parts that ask spelling questions — the
+        // canonical form a produced spelling is compared against, and the
+        // type ascriptions the generated body writes. Everything else takes
+        // the READING itself (#284).
+        let t1_ty = t1.spell();
         if shape == WrapperShape::Optional {
             let inner = registry.input_entry(t1)?;
             if inner.metadata.is_direct_handle() {
@@ -1137,7 +1145,7 @@ impl Declarations {
             let outer_ty = produced.clone();
             let canonical: syn::Type = syn::parse_quote!(Option<#t1_ty>);
             let build = build_from_canonical(produced, &canonical, quote::quote!(__v))?;
-            let (wire, inner_body, niches) = option_input(t1_ty, registry)?;
+            let (wire, inner_body, niches) = option_input(t1, registry)?;
             // `option_input` yields the canonical `Option<T>`; the converter
             // yields the spelling.
             let body: syn::Expr = syn::parse_quote!({
@@ -1155,7 +1163,7 @@ impl Declarations {
             // an inner niche, the wire stays identical to the inner's
             // destination and `None` is the niche slot sentinel; the boxed
             // fallback widens the wire to `JObject`.
-            let nullable_kind = nullable_kind_for(&wire, t1_ty, registry);
+            let nullable_kind = nullable_kind_for(&wire, t1, registry);
             let projection = registry
                 .input_entry(t1)
                 .and_then(|e| e.metadata.projection.clone())
@@ -1557,8 +1565,7 @@ impl Declarations {
         args: &[crate::api::core::flat::TypeRef],
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let spellings: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
-        let outer_ty = build_fn_type(&spellings);
+        let outer_ty = build_fn_type(args);
         let (wire, body) = callback_input(self, args, registry)?;
         let niches = default_niches_for_wire(&wire);
         // `impl Fn(...)` crosses the extern tier as the erased lambda object
@@ -2516,9 +2523,11 @@ impl Declarations {
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions; the
-        // READING stays in `t1` for the lookups (#284).
-        let t1_ty = t1.as_syn();
+        // `t1`'s spelling, for the parts that ask spelling questions — the
+        // canonical form a produced spelling is compared against, and the
+        // type ascriptions the generated body writes. Everything else takes
+        // the READING itself (#284).
+        let t1_ty = t1.spell();
         // Borrowed opaque-handle output (`&T` / `&'static T` where `T` is a
         // declared opaque handle). Canonical zenoh-flat's `z_*` accessors
         // return *borrowed* handles for the C tier's zero-copy borrows, but
@@ -2529,14 +2538,9 @@ impl Declarations {
         // arm below (it looks up this `&T` entry as its inner). Matched
         // structurally so the lifetime variant `&'static _` is covered too.
         if let syn::Type::Reference(r) = produced {
-            if r.mutability.is_none()
-                && self
-                    .types
-                    .get(&TypeKey::from_type(t1_ty))
-                    .is_some_and(|c| c.is_opaque())
-            {
+            if r.mutability.is_none() && self.types.get(&t1.key()).is_some_and(|c| c.is_opaque()) {
                 let mut ref_ty = r.clone();
-                *ref_ty.elem = t1_ty.clone();
+                *ref_ty.elem = syn::parse_quote!(#t1_ty);
                 let outer_ty = syn::Type::Reference(ref_ty);
                 let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
                 let body: syn::Expr = syn::parse_quote!(std::boxed::Box::into_raw(
@@ -2548,7 +2552,7 @@ impl Declarations {
                     destination: wire,
                     pre_stages: vec![],
                     niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
-                    metadata: self.opaque_leaf_meta(t1_ty),
+                    metadata: self.opaque_leaf_meta(t1.key()),
                 });
             }
         }
@@ -2558,7 +2562,7 @@ impl Declarations {
         // intermediate owned `String`). The unsized `str` sub resolves via the
         // rank-0 arm to the same fn (see [`Self::str_ref_output`]).
         if let syn::Type::Reference(r) = produced {
-            if r.mutability.is_none() && TypeKey::from_type(t1_ty).as_str() == "str" {
+            if r.mutability.is_none() && t1.key().as_str() == "str" {
                 return Some(self.str_ref_output());
             }
         }
@@ -2571,7 +2575,7 @@ impl Declarations {
             // Bridgeable first: an unsupported representation must not resolve
             // and then emit code the consumer cannot compile.
             let read = read_as_canonical(produced, &canonical)?;
-            let (wire, inner_body, niches) = option_output(t1_ty, registry)?;
+            let (wire, inner_body, niches) = option_output(t1, registry)?;
             let body: syn::Expr = syn::parse_quote!({
                 let v: #canonical = #read;
                 #inner_body
@@ -2585,7 +2589,7 @@ impl Declarations {
             // [`nullable_kind_for`]): niche-fulfilled keeps the inner wire
             // and treats the slot value as `None`; boxed widens to `JObject`
             // and uses JVM null.
-            let nullable_kind = nullable_kind_for_output(&wire, t1_ty, registry);
+            let nullable_kind = nullable_kind_for_output(&wire, t1, registry);
             let projection = registry
                 .output_entry(t1)
                 .and_then(|e| e.metadata.projection.clone())


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). `jnigen/jni/trait_impl.rs` was the densest remaining file at 13 type escapes.

## The line, five times

```rust
// `t1`'s spelling, for the parts that ask spelling questions; the
// READING stays in `t1` for the lookups (#284).
let t1_ty = t1.as_syn();
```

It says what it wants — a *spelling* — and takes a **node** to get one. `TypeRef::spell()` is that spelling, and every downstream use is an interpolation into `quote!` / `parse_quote!`:

```rust
let canonical: syn::Type = syn::parse_quote!(Option<#t1_ty>);
let __v: ::core::option::Option<#t1_ty> = #inner_body;
```

Those are unchanged — a `TokenStream` interpolates exactly as a `syn::Type` does. The handful of uses that were *not* spelling take the reading directly: `TypeKey::from_type(t1_ty)` → `t1.key()`, twice.

The five sites are `input_borrow`, `input_option_ref`, `input_vec`, `input_option`, and `output_wrapper_shape`.

## Why they could not do that before

Because the helpers they feed took nodes. Four of them opened with the same round-trip — `reading_of` on a node the caller had escaped **from a reading** one frame up:

```rust
 pub(crate) fn option_output(
-    t1: &syn::Type,
+    t1: &TypeRef,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry
-        .reading_of(t1)
-        .and_then(|tr| registry.output_entry(&tr))?;
+    let inner_entry = registry.output_entry(t1)?;
```

Same for `option_input`, `nullable_kind_for`, `nullable_kind_for_output`. Alongside them:

* `reject_vec_of_handle` takes the element's reading — it only spells it into a panic message;
* `build_fn_type` takes the callback's arg readings, instead of the `Vec<syn::Type>` its one caller built by cloning every arg's node;
* `opaque_leaf_meta` takes the `TypeKey` it was deriving from the node it was handed.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 83 | 83 |
| escapes: types | 47 | **41** |
| escapes: items | 17 | 17 |

All six from one file: `api/lang/jnigen/jni/trait_impl.rs` **13 → 7**. Classification is unchanged — nothing here classified; these sites were carrying a node to somewhere that then looked up what it already had.

The seven that remain in that file are a different population: `input_terminal` / `output_terminal`'s `let ty = reading.as_syn()` (used across ~15 downstream calls each — `opaque_handle_input`, `build_input_fn`, `override_kotlin_name`), the two `produced` / `stripped` pairs, and the declare-phase `types[key].rust_type` read that #291 documents as answerable only by the declaration.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical