### PR TITLE
S27: a lookup key is not a spelling

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -140,10 +140,10 @@
 1	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/render.rs
-6	api/lang/jnigen/jni/selector.rs
-7	api/lang/jnigen/jni/trait_impl.rs
+2	api/lang/jnigen/jni/selector.rs
+5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 41
+# total escapes: types: 35
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -133,7 +133,7 @@ impl Declarations {
             // sub, exactly as the old syntactic slice check did.
             if !*mutable && decoded_vec_satisfies(inner) {
                 if let Some(elem) = inner.sequence_elem() {
-                    let elem_ty = elem.as_syn().clone();
+                    let elem_ty = elem.spell();
                     // The one place `produced` is NOT the crossing's spelling:
                     // there is no owned `[T]` to decode into, so the converter
                     // yields an owned `Vec<T>` and the call site borrows it.
@@ -150,7 +150,7 @@ impl Declarations {
                     if let Some(mut c) =
                         self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry)
                     {
-                        c.subs = vec![TypeKey::from_type(&elem_ty)];
+                        c.subs = vec![elem.key()];
                         return Some(c);
                     }
                     return None;
@@ -193,7 +193,7 @@ impl Declarations {
         //    Read off the model, which calls this shape `TypeKind::Fallible`.
         //    `result_parts` covers a `Result` the adapter composed itself, which
         //    the frontend never read.
-        if let Some((ok, err)) = fallible_parts(syntax, registry) {
+        if let Some((ok, err)) = fallible_parts(ty) {
             if let Some(c) = self.result_peel(syntax, &ok, &err, registry) {
                 return Some(c);
             }
@@ -230,7 +230,7 @@ impl Declarations {
             // directly is a question about the SPELLING.
             if !*mutable && decoded_vec_satisfies(inner) {
                 if let Some(elem) = inner.sequence_elem() {
-                    return self.output_slice(elem.as_syn(), registry);
+                    return self.output_slice(elem, registry);
                 }
             }
             let mutable = ty.is_exclusive_borrow();
@@ -249,28 +249,20 @@ impl Declarations {
     }
 }
 
-/// The `Ok`/`Err` of a `Result`, preferring the frontend's reading.
+/// The `Ok`/`Err` of a `Result`, spelled.
 ///
-/// The model classifies a `Result` as [`TypeKind::Fallible`]; the syntactic
-/// fallback is for a `Result` the adapter composed itself, which no captured
-/// item spells and the frontend therefore never read.
+/// The model classifies a `Result` as [`TypeKind::Fallible`], so a reading
+/// answers this directly — no lookup, and no syntactic fallback.
 ///
-/// **Measured: the fallback never fires in-tree** — zero occurrences across
-/// covertest-kotlin and perftest-kotlin, because #246 indexes a binding-local
-/// fn's types, so even a `sig!((..) -> Result<Summary, String>)` has a reading.
-/// It is kept rather than made a hard error because an out-of-tree consumer may
-/// compose a `Result` the model never sees, and it costs nothing: `result_parts`
-/// already exists and already has six other callers.
-fn fallible_parts(
-    ty: &syn::Type,
-    registry: &impl Conversions<KotlinMeta>,
-) -> Option<(syn::Type, syn::Type)> {
-    if let Some((ok, err)) = registry
-        .flat()
-        .type_ref(ty)
-        .and_then(|t| t.fallible_parts())
-    {
-        return Some((ok.as_syn().clone(), err.as_syn().clone()));
-    }
-    crate::api::core::types_util::result_parts(ty)
+/// The fallback there used to be (`types_util::result_parts` over the node)
+/// existed because the caller held only a **spelling**: a `Result` the adapter
+/// composed itself would have no entry in `flat`, so the reading lookup could
+/// miss. A caller holding a `TypeRef` cannot be in that position — #280 sealed
+/// minting to the model, so every reading reaching here was classified, and
+/// `kind` is what says whether it is a `Result`. The fallback was measured
+/// never to fire in-tree; it is now unreachable by construction.
+fn fallible_parts(ty: &crate::api::core::flat::TypeRef) -> Option<(syn::Type, syn::Type)> {
+    let (ok, err) = ty.fallible_parts()?;
+    let (ok, err) = (ok.spell(), err.spell());
+    Some((syn::parse_quote!(#ok), syn::parse_quote!(#err)))
 }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -2198,7 +2198,11 @@ impl Declarations {
             return None;
         }
         let produced = reading.as_syn();
-        let stripped = reading.stripped_syntax();
+        // The identity under every wrapper. This spelled the stripped type into
+        // a node purely so `reading_of` could key off it and `subs` could key
+        // off it again — `stripped_key` is that key, and the model already
+        // holds it.
+        let stripped = reading.stripped_key();
         // A wrapper over a **borrow** is refused here too, and outbound the
         // reason is its own: a borrow's output route is the clone-into-a-fresh-
         // handle arm, which hands back a wire built from a reference — there is
@@ -2212,7 +2216,7 @@ impl Declarations {
         }
         // It has to be a type this binding already crosses; if it is not, the
         // ordinary "unresolved" diagnostic names it, which is the better error.
-        let inner = registry.reading_of(&stripped)?;
+        let inner = registry.reading(&stripped)?;
         let entry = registry.output_entry(&inner)?;
         let wire = entry.destination.clone();
         // Take the wrappers off what the caller handed us. `None` is `Cow`'s
@@ -2229,7 +2233,7 @@ impl Declarations {
             #inner_call
         });
         Some(ConverterImpl {
-            subs: vec![TypeKey::from_type(&stripped)],
+            subs: vec![stripped],
             pre_stages: vec![],
             function: self.build_output_fn(produced, &wire, &body, None),
             destination: wire,
@@ -2269,9 +2273,10 @@ impl Declarations {
             return None;
         }
         let produced = reading.as_syn();
-        // The spelling under every wrapper — by the model's own definition, the
-        // one whose lowering yields this `kind`.
-        let stripped = reading.stripped_syntax();
+        // The identity under every wrapper — by the model's own definition, the
+        // key of the type whose lowering yields this `kind`. See the outbound
+        // peer for why this is a key rather than a spelling.
+        let stripped = reading.stripped_key();
         // A wrapper over a **borrow** is not bridgeable here, and the reason is
         // the converter's own shape rather than the wrapper's: this produces an
         // owned value, and there is nothing for a `Box<&T>` to borrow *from* —
@@ -2287,7 +2292,7 @@ impl Declarations {
         }
         // It has to be a type this binding already crosses; if it is not, the
         // ordinary "unresolved" diagnostic names it, which is the better error.
-        let inner = registry.reading_of(&stripped)?;
+        let inner = registry.reading(&stripped)?;
         let entry = registry.input_entry(&inner)?;
         let wire = entry.destination.clone();
         // Wrap what the inner converter produced. `None` here is `Cow`'s policy
@@ -2307,7 +2312,7 @@ impl Declarations {
             #built
         });
         Some(ConverterImpl {
-            subs: vec![TypeKey::from_type(&stripped)],
+            subs: vec![stripped],
             pre_stages: vec![],
             function: self.build_input_fn(produced, &wire, &body, None),
             destination: wire,
@@ -2703,12 +2708,14 @@ impl Declarations {
     /// (struct / String / …) — scalar slices are not handled here.
     pub(crate) fn output_slice(
         &self,
-        elem: &syn::Type,
+        elem: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let inner = registry
-            .reading_of(elem)
-            .and_then(|tr| registry.output_entry(&tr))?;
+        let inner = registry.output_entry(elem)?;
+        let elem_key = elem.key();
+        // The element as the source spelled it — the slice type this converter
+        // yields is re-emitted, never re-derived.
+        let elem = elem.spell();
         // A `&[opaque-handle]` callback arg is delivered by the Kotlin-side leaf
         // fold (typed-handle wrap), bypassing this whole-`ArrayList` converter; a
         // handle's `jlong` wire isn't JObject-shaped, so it returns `None` here.
@@ -2746,7 +2753,7 @@ impl Declarations {
         });
         let niches = default_niches_for_wire(&wire);
         Some(ConverterImpl {
-            subs: vec![TypeKey::from_type(elem)],
+            subs: vec![elem_key],
             pre_stages: vec![],
             function: self.build_output_fn(&outer_ty, &wire, &body, None),
             destination: wire,


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

Six escapes, one shape: **a node built or held only so something could key off it.**

## The two transparent bridges

`input_transparent_bridge` and `output_transparent_bridge` each opened with:

```rust
let stripped = reading.stripped_syntax();      // <- escape
let inner = registry.reading_of(&stripped)?;   // key it
...
subs: vec![TypeKey::from_type(&stripped)],     // key it again
```

Spell the stripped type into a `syn::Type`, so that two consumers can turn it straight back into a key. `reading.stripped_key()` **is** that key, and the model already holds it:

```rust
let stripped = reading.stripped_key();
let inner = registry.reading(&stripped)?;
...
subs: vec![stripped],
```

Neither bridge ever *spelled* `stripped`, so nothing else moves. `stripped_syntax` leaves the file.

## selector.rs

| site | was | is |
|---|---|---|
| `output_slice` | took `&syn::Type`, then `reading_of` on it | takes the element's reading; its two uses of the node were a spelling (`&[#elem]`) and a key (`subs`) |
| the `&[T]` input arm | `let elem_ty = elem.as_syn().clone()` | `elem.spell()` for the composed `Vec<#elem_ty>`, `elem.key()` for the sub |
| `fallible_parts` | `(ok.as_syn().clone(), err.as_syn().clone())` after a `flat().type_ref(node)` lookup | takes the reading, spells the two parts |

`output_slice` is the same `reading_of`-on-a-node-the-caller-escaped-from-a-reading pattern S26 removed from `option_input` / `option_output` / `nullable_kind_for*`; it was simply reached through a different arm.

### The fallback that is now unreachable

`fallible_parts` had a documented syntactic fallback:

```rust
crate::api::core::types_util::result_parts(ty)
```

It covered a `Result` **the adapter composed itself**, which `flat` would have no reading for — so the reading lookup could miss. A caller holding a `TypeRef` cannot be in that position: #280 sealed minting to the model, so every reading reaching here was classified, and `kind` is what says whether it is a `Result`. The doc already recorded it as *measured never to fire in-tree*; taking a reading makes it unreachable by construction rather than by measurement. `result_parts` keeps its other callers.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 83 | 83 |
| escapes: types | 41 | **35** |
| escapes: items | 17 | 17 |

```
api/lang/jnigen/jni/selector.rs    6 -> 2
api/lang/jnigen/jni/trait_impl.rs  7 -> 5
```

The four that remain across those two files are one population, and it is `produced`: `let syntax = ty.as_syn()` in both selectors, feeding `input_wrapper_shape` / `output_wrapper_shape`'s `produced: &syn::Type`. That parameter is deliberately a spelling — the `&[T]` input arm composes a `Vec<T>` the adapter has no way to mint a reading for (#280), and the comment there says so. Moving it means `build_from_canonical` / `is_canonical_spelling` / `bridge_layers` take a reading on one side and a composed node on the other; that is its own stage.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical