### PR TITLE
S28: an identity is a key, taken off the element

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -117,12 +117,12 @@
 1	api/lang/jnigen/jni/iface.rs
 1	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
-5	api/lang/jnigen/jni/render.rs
+1	api/lang/jnigen/jni/render.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 83
+# total classification sites: 79
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -133,17 +133,14 @@
 2	api/lang/cbindgen/convert.rs
 1	api/lang/cbindgen/emit.rs
 4	api/lang/cbindgen/trait_impl.rs
-1	api/lang/jnigen/jni/emit/callback.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
-3	api/lang/jnigen/jni/fn_plan.rs
+2	api/lang/jnigen/jni/fn_plan.rs
 3	api/lang/jnigen/jni/iface.rs
-1	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/overloads.rs
-1	api/lang/jnigen/jni/render.rs
 2	api/lang/jnigen/jni/selector.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 35
+# total escapes: types: 31
 
 ## escapes: items
 1	api/core/prebindgen.rs
@@ -154,6 +151,6 @@
 2	api/lang/jnigen/jni/builder.rs
 2	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/symbols.rs
-2	api/lang/jnigen/jni/trait_impl.rs
+1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 17
+# total escapes: items: 16

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -311,12 +311,11 @@ pub(crate) fn callback_input(
     // Typed `run` descriptor of the generated callback interface — the SAME
     // memoized spec (`SpecKey::Callback`) the wrapper surface and the
     // interface declaration read, so it cannot drift from the jvalues above.
-    // The memo key is spellings — `SpecKey` needs `Ord`, which a `TypeRef`
-    // cannot give. Keyed off each arg's own `spell()`, which
+    // The memo key holds `TypeKey`s — `SpecKey` needs `Ord`, which a `TypeRef`
+    // cannot give — so it is keyed off each arg's own identity, which
     // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax` pins as
     // the SAME identity the signature-derived key produces.
-    let arg_spellings: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
-    let spec = ext.iface_spec(registry, &SpecKey::callback(&arg_spellings))?;
+    let spec = ext.iface_spec(registry, &SpecKey::callback(args))?;
     let descr_lit = syn::LitStr::new(&spec.descr, Span::call_site());
     // Local-frame capacity: roughly an encoded wire + a wrapped object per
     // delivered leaf, plus call temporaries.

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -612,12 +612,10 @@ fn classify_leaf(
     // erased entry exists but its metadata carries no surface type.
     if let Some(args) = reading.callback_args() {
         // `SpecKey` is a memo key and holds `TypeKey`s, so the args reach it as
-        // spellings either way — but as each arg reading's OWN spelling now,
-        // rather than one re-extracted from the parameter's bounds.
+        // each arg reading's own identity.
         // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax`
-        // pins that the two routes are one memo identity.
-        let arg_tys: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
-        let iface = ext.iface_spec(registry, &SpecKey::callback(&arg_tys));
+        // pins that this is the same identity the signature-derived key gives.
+        let iface = ext.iface_spec(registry, &SpecKey::callback(args));
         return Ok(PlanLeaf {
             reading: reading.clone(),
             kt_name,

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -907,8 +907,12 @@ pub(crate) enum SpecKey {
 
 impl SpecKey {
     /// The impl-Fn identity for a callback's arg types.
-    pub fn callback(args: &[syn::Type]) -> Self {
-        SpecKey::Callback(args.iter().map(TypeKey::from_type).collect())
+    ///
+    /// Off the readings, like its [`whole_folder`](Self::whole_folder) peer:
+    /// the key IS a `Vec<TypeKey>`, and every caller was spelling each arg into
+    /// a throwaway `Vec<syn::Type>` for `TypeKey::from_type` to read back.
+    pub fn callback(args: &[crate::api::core::flat::TypeRef]) -> Self {
+        SpecKey::Callback(args.iter().map(|a| a.key()).collect())
     }
 
     /// The whole-element fold identity for an element type.

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1041,9 +1041,7 @@ impl Declarations {
                 let item_fn = func.origin.as_syn();
                 for p in &func.params {
                     if let Some(cb_args) = p.ty.callback_args() {
-                        let arg_tys: Vec<syn::Type> =
-                            cb_args.iter().map(|a| a.as_syn().clone()).collect();
-                        uses.insert(SpecKey::callback(&arg_tys));
+                        uses.insert(SpecKey::callback(cb_args));
                     }
                 }
                 if let Some(plan) = registry

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -677,27 +677,17 @@ struct Opaque {
 /// Peel `&` / `Option<…>` / `Option<&…>` layers and return the inner type's
 /// [`TypeKey`] — used to match an accessor's receiver parameter against its
 /// owning class key in [`render_wrapper_fn`].
-pub(crate) fn peel_receiver_key(ty: &syn::Type) -> TypeKey {
-    let core = match ty {
-        syn::Type::Reference(r) => &*r.elem,
-        other => other,
-    };
-    if let syn::Type::Path(tp) = core {
-        if let Some(seg) = tp.path.segments.last() {
-            if seg.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = ab.args.first() {
-                        let inner_core = match inner {
-                            syn::Type::Reference(r) => &*r.elem,
-                            other => other,
-                        };
-                        return TypeKey::from_type(inner_core);
-                    }
-                }
-            }
-        }
+///
+/// Off the model. This walked a node four levels deep — a `Type::Reference`,
+/// a `Type::Path`'s last segment compared against the *name* `"Option"`, its
+/// `AngleBracketed` arguments, and a second `Type::Reference` — to reach a
+/// question `borrow_target` / `optional_inner` / `key` answer directly.
+pub(crate) fn peel_receiver_key(ty: &crate::api::core::flat::TypeRef) -> TypeKey {
+    let core = ty.borrow_target().unwrap_or(ty);
+    match core.optional_inner() {
+        Some(inner) => inner.borrow_target().unwrap_or(inner).key(),
+        None => core.key(),
     }
-    TypeKey::from_type(core)
 }
 
 /// Build a single top-level (free-function) wrapper as a [`kt::KtFun`].
@@ -1082,7 +1072,6 @@ fn classify_params(
     let mut params: Vec<Param> = Vec::new();
     for leaf in fplan.leaves() {
         let mut name = leaf.kt_name.clone();
-        let arg_ty = leaf.reading.as_syn();
 
         // Instance-method receiver: the first parameter whose peeled Rust type
         // is the owning class binds to `this` (so `this_ptr`/`this.ptr`/lock or
@@ -1090,7 +1079,7 @@ fn classify_params(
         // from the rendered signature.
         if receiver_idx.is_none() {
             if let Some(rk) = receiver_key {
-                if &peel_receiver_key(arg_ty) == rk {
+                if &peel_receiver_key(&leaf.reading) == rk {
                     receiver_idx = Some(params.len());
                     name = "this".to_string();
                 }
@@ -1221,7 +1210,7 @@ fn classify_params(
                 } else if leaf.reading.optional_inner().is_some() {
                     // by-value `Option<T>` opaque → nullable consume
                     ParamMode::ConsumeNullable
-                } else if matches!(arg_ty, syn::Type::Reference(_)) {
+                } else if leaf.reading.borrow_target().is_some() {
                     ParamMode::Borrow
                 } else {
                     ParamMode::Consume

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -529,7 +529,9 @@ fn iface_spec_memo_shares_one_derivation() {
 
     // The impl-Fn identity: the trampoline (resolve time) and the wrapper
     // surface key on the same canonical arg types.
-    let args: Vec<syn::Type> = vec![syn::parse_quote!(ZThing)];
+    let args = vec![registry
+        .reading_of(&syn::parse_quote!(ZThing))
+        .expect("ZThing is interned")];
     let cb1 = ext
         .iface_spec(registry, &SpecKey::callback(&args))
         .expect("callback spec");
@@ -628,16 +630,17 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
         .expect("z_sub takes a callback");
     let (param, arg_readings) = cb;
 
-    // The two routes to the same identity.
-    let from_reading = SpecKey::callback(
-        &arg_readings
+    // The two routes to the same identity. The syntax route builds the key's
+    // own `Vec<TypeKey>` directly, because `SpecKey::callback` now takes
+    // readings — which is exactly the claim being pinned: the readings and the
+    // signature's own `impl Fn` bounds agree on every arg's identity.
+    let from_reading = SpecKey::callback(arg_readings);
+    let from_syntax = SpecKey::Callback(
+        crate::api::core::registry::extract_fn_trait_args(param.ty.as_syn())
+            .expect("the param is an impl Fn")
             .iter()
-            .map(|a| a.as_syn().clone())
-            .collect::<Vec<_>>(),
-    );
-    let from_syntax = SpecKey::callback(
-        &crate::api::core::registry::extract_fn_trait_args(param.ty.as_syn())
-            .expect("the param is an impl Fn"),
+            .map(crate::api::core::registry::TypeKey::from_type)
+            .collect(),
     );
 
     assert_eq!(

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1612,30 +1612,23 @@ impl Prebindgen for Declarations {
         for (key, members) in &self.class_members {
             for m in members {
                 // A binding-absent fn already hard-errored in the scan.
-                let Some(item_fn) = binding
-                    .flat()
-                    .function(&m.rust_ident)
-                    .map(|func| func.origin.as_syn())
-                else {
+                //
+                // The ELEMENT, not its item: a signature is a parameter list
+                // and a return, both already classified, so neither check
+                // below walks `syn::FnArg` / `syn::ReturnType` to re-derive
+                // what the model states.
+                let Some(func) = binding.flat().function(&m.rust_ident) else {
                     continue;
                 };
                 match m.kind {
                     MemberKind::Method => {
-                        let has_receiver = item_fn.sig.inputs.iter().any(|input| {
-                            matches!(input, syn::FnArg::Typed(pt)
-                                if &peel_receiver_key(&pt.ty) == key)
-                        });
+                        let has_receiver =
+                            func.params.iter().any(|p| &peel_receiver_key(&p.ty) == key);
                         if !has_receiver {
-                            let took: Vec<String> = item_fn
-                                .sig
-                                .inputs
+                            let took: Vec<String> = func
+                                .params
                                 .iter()
-                                .filter_map(|i| match i {
-                                    syn::FnArg::Typed(pt) => {
-                                        Some(pt.ty.to_token_stream().to_string())
-                                    }
-                                    _ => None,
-                                })
+                                .map(|p| p.ty.spell().to_string())
                                 .collect();
                             return Err(format!(
                                 "class `{}` method `{}`: no parameter of type `{}` — an \
@@ -1653,14 +1646,13 @@ impl Prebindgen for Declarations {
                         }
                     }
                     MemberKind::Constructor => {
-                        let ret = match &item_fn.sig.output {
-                            syn::ReturnType::Type(_, ty) => (**ty).clone(),
-                            syn::ReturnType::Default => syn::parse_quote!(()),
-                        };
                         // Allowed factory shapes: `Self` and `Result<Self, E>`.
-                        let core = crate::api::core::types_util::result_ok_type(&ret)
-                            .unwrap_or_else(|| ret.clone());
-                        if &peel_receiver_key(&core) != key {
+                        // The element normalizes an elided return to `Unit`, so
+                        // there is no `ReturnType::Default` arm to write, and
+                        // `fallible_parts` is `result_ok_type` asked of the
+                        // classification instead of of a path.
+                        let core = func.ret.fallible_parts().map_or(&func.ret, |(ok, _)| ok);
+                        if &peel_receiver_key(core) != key {
                             return Err(format!(
                                 "class `{}` constructor `{}`: must return `{}` or \
                                  `Result<{}, E>` — it returns `{}`",
@@ -1668,7 +1660,7 @@ impl Prebindgen for Declarations {
                                 m.rust_ident,
                                 key.as_str(),
                                 key.as_str(),
-                                ret.to_token_stream()
+                                func.ret.spell()
                             ));
                         }
                     }


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

Three identity derivations, each spelling a node to reach a key it had already been handed.

## `SpecKey::callback`

```rust
-pub fn callback(args: &[syn::Type]) -> Self {
-    SpecKey::Callback(args.iter().map(TypeKey::from_type).collect())
+pub fn callback(args: &[TypeRef]) -> Self {
+    SpecKey::Callback(args.iter().map(|a| a.key()).collect())
 }
```

The key **is** a `Vec<TypeKey>`, and its `whole_folder` peer three lines below already took a reading. So all three callers were doing this:

```rust
let arg_tys: Vec<syn::Type> = args.iter().map(|a| a.as_syn().clone()).collect();
… SpecKey::callback(&arg_tys)
```

— cloning every arg's node into a throwaway vector, for the constructor to read the key straight back out. Gone from `fn_plan.rs`, `emit/callback.rs` and `kotlin_emit.rs`.

## `peel_receiver_key`

```rust
-pub(crate) fn peel_receiver_key(ty: &syn::Type) -> TypeKey {
-    let core = match ty { syn::Type::Reference(r) => &*r.elem, other => other };
-    if let syn::Type::Path(tp) = core {
-        if let Some(seg) = tp.path.segments.last() {
-            if seg.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(ab) = &seg.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = ab.args.first() {
-                        let inner_core = match inner { syn::Type::Reference(r) => &*r.elem, other => other };
-                        return TypeKey::from_type(inner_core);
-    …
-    TypeKey::from_type(core)
-}
+pub(crate) fn peel_receiver_key(ty: &TypeRef) -> TypeKey {
+    let core = ty.borrow_target().unwrap_or(ty);
+    match core.optional_inner() {
+        Some(inner) => inner.borrow_target().unwrap_or(inner).key(),
+        None => core.key(),
+    }
+}
```

Four levels of node walking — including an `Option` recognised by its **name** on a path's last segment, the ident-classification blind spot the ledger header lists — to ask what three model readings answer. Those levels were four watched classification sites: `render.rs` goes **5 → 1**.

Its caller in `render.rs` had `leaf.reading` in hand the whole time; the same `let arg_ty = leaf.reading.as_syn()` also fed one `matches!(arg_ty, syn::Type::Reference(_))`, now `leaf.reading.borrow_target().is_some()`.

## And then the class-member validation

`peel_receiver_key`'s other two callers were inside a `class_members` check that fetched `func.origin.as_syn()` and walked the `syn::Signature`. A signature is a parameter list and a return, both already classified:

| | was | is |
|---|---|---|
| method receiver | `sig.inputs.iter().any(matches!(FnArg::Typed(pt) if …))` | `func.params.iter().any(…)` |
| the "took:" message | `filter_map` over `FnArg` + `to_token_stream()` | `func.params.iter().map(\|p\| p.ty.spell())` |
| constructor return | `match sig.output { Type(_, ty) => …, Default => parse_quote!(()) }` then `result_ok_type` | `func.ret.fallible_parts().map_or(&func.ret, \|(ok, _)\| ok)` |

The `ReturnType::Default → ()` normalization is one the element already performs (`Function::ret` is `TypeKind::Unit` for an elided return, by its own doc). With `sig` unread, the item escape goes too.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 83 | **79** |
| escapes: types | 35 | **31** |
| escapes: items | 17 | **16** |

```
api/lang/jnigen/jni/render.rs        [classification]  5 -> 1
api/lang/jnigen/jni/emit/callback.rs [types]  1 -> 0
api/lang/jnigen/jni/kotlin_emit.rs   [types]  1 -> 0
api/lang/jnigen/jni/render.rs        [types]  1 -> 0
api/lang/jnigen/jni/fn_plan.rs       [types]  3 -> 2
api/lang/jnigen/jni/trait_impl.rs    [items]  2 -> 1
```

First classification move since S19 — and it lands where the ledger predicted it would, once the escape feeding the classifier was closed.

## The identity test

`a_callback_identity_is_the_same_from_the_reading_or_the_syntax` pins that the reading route and the `impl Fn`-bounds route produce one memo key. It now builds the syntax side as `SpecKey::Callback(…)` directly, since `SpecKey::callback` takes readings — which is the claim itself, stated more directly than before.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical