### PR TITLE
S29: the acceptance check the model already made

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -111,7 +111,7 @@
 4	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
-13	api/lang/jnigen/jni/emit/names.rs
+7	api/lang/jnigen/jni/emit/names.rs
 6	api/lang/jnigen/jni/emit/wrapper.rs
 3	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/iface.rs
@@ -122,7 +122,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 79
+# total classification sites: 73
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -149,8 +149,8 @@
 2	api/lang/cbindgen/convert.rs
 2	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
-2	api/lang/jnigen/jni/kotlin_emit.rs
+1	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/symbols.rs
 1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 16
+# total escapes: items: 15

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -100,6 +100,22 @@ impl syn::visit_mut::VisitMut for QualifyEmittedTypes<'_> {
 /// Inverting it makes the failure mode "a legitimate length is refused", which
 /// is loud and trivially worked around by hoisting the value into a named
 /// `const`.
+///
+/// # The whitelist is the model's
+///
+/// It listed eight forms — adding `Binary`, `Unary`, `Paren`, `Group`, `Cast`
+/// and `Call` "const arithmetic over those" — and six of them could never
+/// arrive. [`lower_array_len`](crate::api::core::flat) accepts an integer
+/// literal or a **bare single-segment name of a marked const**, and nothing
+/// else: `[u8; A + 1]`, `[u8; A as usize]` and `[u8; array_len()]` are all
+/// `ArrayLenReason::NotLiteralOrName`, so the type never becomes a
+/// `TypeKind::Array` and never reaches an emitter at all
+/// (`an_extent_is_a_literal_or_a_marked_const_and_nothing_else` pins it).
+///
+/// So the two forms below are the two the language accepts, restated where the
+/// qualifier needs them. Narrowing a whitelist to what upstream already
+/// enforces cannot open a hole — it closes the gap between the two lists, which
+/// is the only way they could have disagreed.
 fn reject_unsupported_array_length(arr: &mut syn::TypeArray) {
     // Rendered before the mutable walk below borrows the length.
     let rendered = quote::ToTokens::to_token_stream(&*arr).to_string();
@@ -108,21 +124,13 @@ fn reject_unsupported_array_length(arr: &mut syn::TypeArray) {
     // feature this crate does not enable, and the walk mutates nothing.
     impl syn::visit_mut::VisitMut for Check {
         fn visit_expr_mut(&mut self, e: &mut syn::Expr) {
+            // The two forms the language accepts — see the note above.
             let ok = matches!(
                 e,
                 // A literal length, `[u8; 4]`.
                 syn::Expr::Lit(_)
-                    // The names this pass exists to qualify: `MAX`,
-                    // `Holder::N`, and the callee of `array_len()`.
+                    // The name this pass exists to qualify: a marked const.
                     | syn::Expr::Path(_)
-                    // Const arithmetic over those: `A + 1`, `-1`, `(A) * 2`,
-                    // `A as usize`, `array_len()`.
-                    | syn::Expr::Binary(_)
-                    | syn::Expr::Unary(_)
-                    | syn::Expr::Paren(_)
-                    | syn::Expr::Group(_)
-                    | syn::Expr::Cast(_)
-                    | syn::Expr::Call(_)
             );
             if !ok && self.0.is_none() {
                 self.0 = Some("an unsupported expression form");
@@ -134,8 +142,8 @@ fn reject_unsupported_array_length(arr: &mut syn::TypeArray) {
     syn::visit_mut::VisitMut::visit_expr_mut(&mut check, &mut arr.len);
     if let Some(what) = check.0 {
         panic!(
-            "fixed-size array `{rendered}`: the length uses {what}. Only a literal, a path, a \
-             call, and const arithmetic over those are supported — anything that can bind a name \
+            "fixed-size array `{rendered}`: the length uses {what}. Only a literal and the name \
+             of a `#[prebindgen]` const are supported — anything that can bind a name \
              (`const {{ … }}`, `match`, `if let`, a closure, a loop) would let a LOCAL be \
              mistaken for a source item, because this generator qualifies the length's paths \
              against their source module. Hoist the value into a named `const` and use that as \

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -52,27 +52,26 @@ pub(crate) fn reject_handle_const(ext: &Declarations, c: &crate::api::core::flat
 /// (`const MAX_LEN` / `constant fn encoding_const_x_str`).
 pub(crate) fn reject_handle_constant_type(
     ext: &Declarations,
-    ty: &syn::Type,
+    ty: &crate::api::core::flat::TypeRef,
     what: &str,
     name: &str,
 ) {
-    let mut ty = ty.clone();
+    // The same three layers, off the classification. The node loop peeled a
+    // `Type::Reference` and then re-read the last path segment's ident twice
+    // (`option_inner_type`, `vec_inner_type`) to decide what it had.
+    let mut ty = ty;
     loop {
-        if let syn::Type::Reference(r) = &ty {
-            ty = (*r.elem).clone();
-            continue;
-        }
-        if let Some(inner) = option_inner_type(&ty) {
-            ty = inner;
-            continue;
-        }
-        if let Some(inner) = vec_inner_type(&ty) {
+        if let Some(inner) = ty
+            .borrow_target()
+            .or_else(|| ty.optional_inner())
+            .or_else(|| ty.sequence_elem())
+        {
             ty = inner;
             continue;
         }
         break;
     }
-    reject_handle_key(ext, &TypeKey::from_type(&ty), what, name);
+    reject_handle_key(ext, &ty.key(), what, name);
 }
 
 /// The refusal itself, once: a declared opaque handle cannot be a shared
@@ -99,23 +98,26 @@ fn reject_handle_key(ext: &Declarations, key: &TypeKey, what: &str, name: &str) 
 /// the `val` initializer's throwing `JniErrorHandler` only fits the
 /// infallible wrapper shape), and its return type must not peel to a
 /// declared opaque handle (same rationale as [`reject_handle_const`]).
-pub(crate) fn validate_constant_fn(ext: &Declarations, f: &syn::ItemFn) {
+pub(crate) fn validate_constant_fn(ext: &Declarations, f: &crate::api::core::flat::Function) {
+    // The ELEMENT: a signature is a parameter list and a return, both already
+    // classified. This walked `sig.inputs` for the arity, matched
+    // `ReturnType::Type` for the return — an elided one the element already
+    // normalizes to `Unit` — and ran `result_ok_type` over a path to re-derive
+    // the fallibility `TypeKind::Fallible` states.
     assert!(
-        f.sig.inputs.is_empty(),
+        f.params.is_empty(),
         "constant fn `{}`: takes {} parameter(s) — a function-backed constant must be nullary \
          (declare it with `.fun(...)` instead if it is a real function)",
-        f.sig.ident,
-        f.sig.inputs.len()
+        f.name,
+        f.params.len()
     );
-    if let syn::ReturnType::Type(_, ty) = &f.sig.output {
-        assert!(
-            result_ok_type(ty).is_none(),
-            "constant fn `{}`: returns a `Result` — a function-backed constant must be \
-             infallible (declare it with `.fun(...)` instead if it can fail)",
-            f.sig.ident
-        );
-        reject_handle_constant_type(ext, ty, "constant fn", &f.sig.ident.to_string());
-    }
+    assert!(
+        f.ret.fallible_parts().is_none(),
+        "constant fn `{}`: returns a `Result` — a function-backed constant must be \
+         infallible (declare it with `.fun(...)` instead if it can fail)",
+        f.name
+    );
+    reject_handle_constant_type(ext, &f.ret, "constant fn", &f.name.to_string());
 }
 
 /// The synthetic nullary getter signature an **expression constant**
@@ -182,7 +184,24 @@ pub(crate) fn validate_constant_expr(ext: &Declarations, kotlin_name: &str, ty: 
         "constant expr `{kotlin_name}`: type is a `Result` — an expression constant must be \
          infallible (declare a real function with `.fun(...)` instead if it can fail)"
     );
-    reject_handle_constant_type(ext, ty, "constant expr", kotlin_name);
+    // The peel, on the SPELLING. Unlike the fn path above there is no reading
+    // to ask: a `const_expr!` type is written by the BUILD SCRIPT and names no
+    // captured item, so the model never classified it (#280) — the ledger's
+    // documented adapter-owned category, and the reason this one node walk
+    // stays where its peer's could go.
+    let mut ty = ty.clone();
+    loop {
+        if let syn::Type::Reference(r) = &ty {
+            ty = (*r.elem).clone();
+            continue;
+        }
+        if let Some(inner) = option_inner_type(&ty).or_else(|| vec_inner_type(&ty)) {
+            ty = inner;
+            continue;
+        }
+        break;
+    }
+    reject_handle_key(ext, &TypeKey::from_type(&ty), "constant expr", kotlin_name);
 }
 
 /// [`emit_jni_function_wrapper`] with the raw callee expression overridable:

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1605,7 +1605,7 @@ impl Declarations {
                         entry.rust_ident,
                     )
                 });
-            validate_constant_fn(self, item_fn.origin.as_syn());
+            validate_constant_fn(self, item_fn);
             if let Some((helper, prop)) = render_constant_fn_val(
                 self,
                 &package,


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

Two adapter-side guards were re-deciding what the language had already refused — each by matching `syn` variants the model never lets through.

## The array-length whitelist was six forms too wide

`reject_unsupported_array_length` guards `QualifyLengthPaths` from rewriting a path that names a local. It whitelisted **eight** `syn::Expr` forms:

```rust
syn::Expr::Lit(_)
    // The names this pass exists to qualify: `MAX`, `Holder::N`,
    // and the callee of `array_len()`.
    | syn::Expr::Path(_)
    // Const arithmetic over those: `A + 1`, `-1`, `(A) * 2`,
    // `A as usize`, `array_len()`.
    | syn::Expr::Binary(_) | syn::Expr::Unary(_) | syn::Expr::Paren(_)
    | syn::Expr::Group(_)  | syn::Expr::Cast(_)  | syn::Expr::Call(_)
```

**Six of those can never arrive.** `flat::lower_array_len` accepts an integer literal, or a bare single-segment name of a marked const, and nothing else — everything else is `ArrayLenReason::NotLiteralOrName`, so the type never becomes a `TypeKind::Array` and never reaches an emitter at all. The acceptance test already says so, naming `array_len()` specifically:

```rust
assert_eq!(extent_reason(quote!([u8; array_len()])), ArrayLenReason::NotLiteralOrName);
```

The associated-const case the doc describes (`[u8; Holder::N]`, "only the LEADING segment is rewritten") is refused upstream too — `NotABareName`.

So the whitelist becomes the model's two forms, and the panic message says what is actually supported. **Narrowing a whitelist to what upstream already enforces cannot open a hole** — it closes the gap between two lists whose only possible relationship was disagreement.

## The constant-fn validation

```rust
-pub(crate) fn validate_constant_fn(ext: &Declarations, f: &syn::ItemFn) {
-    assert!(f.sig.inputs.is_empty(), … f.sig.inputs.len());
-    if let syn::ReturnType::Type(_, ty) = &f.sig.output {
-        assert!(result_ok_type(ty).is_none(), …);
+pub(crate) fn validate_constant_fn(ext: &Declarations, f: &flat::Function) {
+    assert!(f.params.is_empty(), … f.params.len());
+    assert!(f.ret.fallible_parts().is_none(), …);
```

Same shape as S28's `class_members` check: a signature is a parameter list and a return, both already classified. The `ReturnType::Type` match guarded a return the element normalizes (an elided one is `Unit`), and `result_ok_type` re-derived from a path what `TypeKind::Fallible` states. Its caller was passing `item_fn.origin.as_syn()` — that item escape goes with the walk.

## `reject_handle_constant_type`, and the one node walk that stays

It peels `&` / `Option` / `Vec` and rejects a declared handle underneath. That is `borrow_target` / `optional_inner` / `sequence_elem`, so the fn path reads.

Its **other** caller does not, deliberately: `validate_constant_expr` is handed a `ConstExprDecl::ty`, a type the **build script** wrote (`const_expr!`) that names no captured item. #280 seals minting to the model, so there is no reading to ask — this is exactly the "adapter-owned `syn::Type`" category the ledger header documents as an over-count in the safe direction. The loop is inlined at that one call site with the reason stated, rather than kept in a shared helper where it would look like the general case.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 79 | **73** |
| escapes: types | 31 | 31 |
| escapes: items | 16 | **15** |

```
api/lang/jnigen/jni/emit/names.rs   [classification]  13 -> 7
api/lang/jnigen/jni/kotlin_emit.rs  [items]            2 -> 1
```

`names.rs` was the largest single classification population in the crate. Its remaining 7 are a different kind: `annotate_borrow_with_lifetime` / `annotate_jobject_with_lifetime` / `wire_short` splice lifetimes into and shorten **wire** types, which are adapter-composed and never model types — the same floor as `emit/wrapper.rs`'s five `matches!(wire, syn::Type::Ptr(_))`.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical