### PR TITLE
S30: the source path of a declared type is its identity

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -130,9 +130,8 @@
 1	api/core/registry/key.rs
 2	api/core/registry/order.rs
 2	api/core/registry/scan.rs
-2	api/lang/cbindgen/convert.rs
 1	api/lang/cbindgen/emit.rs
-4	api/lang/cbindgen/trait_impl.rs
+1	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
 2	api/lang/jnigen/jni/fn_plan.rs
 3	api/lang/jnigen/jni/iface.rs
@@ -140,7 +139,7 @@
 2	api/lang/jnigen/jni/selector.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 31
+# total escapes: types: 26
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -600,6 +600,21 @@ impl CbindgenBuilder {
         ty.clone()
     }
 
+    /// [`Self::src_ty`] off the **identity** — the type peer of
+    /// [`Self::src_fn`], for the emitters that hold a declared type's key or a
+    /// declaration's own `Origin` rather than a node.
+    ///
+    /// A `TypeKey` is a normalized type, so re-parsing it is the reverse of
+    /// `from_type` and the qualification policy stays in one place: `String`
+    /// still resolves to `::std::string::String` (it can be declared
+    /// `opaque_ptr`), scalars are still left bare, and only a bare
+    /// single-segment path is prefixed.
+    pub(super) fn src_ty_of(&self, key: &TypeKey) -> syn::Type {
+        let spelled: syn::Type = syn::parse_str(key.as_str())
+            .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses");
+        self.src_ty(&spelled)
+    }
+
     /// Path to a source function (e.g. `zenoh_flat::z_keyexpr_try_from`).
     pub(super) fn src_fn(&self, ident: &syn::Ident) -> syn::Path {
         match &self.source_module {

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -190,7 +190,7 @@ impl CbindgenBuilder {
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
     ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty(&decl.rust_type.as_syn().clone());
+        let target = self.src_ty_of(&decl.rust_type.key());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry
@@ -234,7 +234,7 @@ impl CbindgenBuilder {
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
     ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty(&decl.rust_type.as_syn().clone());
+        let target = self.src_ty_of(&decl.rust_type.key());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = &registry

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -122,14 +122,14 @@ impl CbindgenBuilder {
     fn nullable_owned_ptr_fields(
         &self,
         registry: &impl Conversions<()>,
-        ty: &syn::Type,
+        key: &TypeKey,
     ) -> Option<Vec<syn::Ident>> {
-        let cfg = self.value_opaque.get(&TypeKey::from_type(ty))?;
+        let cfg = self.value_opaque.get(key)?;
         if !cfg.generate_mirror {
             return None;
         }
         let mut idents = Vec::new();
-        for (fname, fty) in self.struct_fields(registry, &TypeKey::from_type(ty))? {
+        for (fname, fty) in self.struct_fields(registry, key)? {
             // An owned-pointer field is one whose mirror wire is a raw pointer
             // (`Option<Box<T>>` / `Box<T>` → `*mut t_t`); scalars/enums are not.
             if matches!(self.mirror_field_wire(fty), Some(syn::Type::Ptr(_))) {
@@ -152,13 +152,13 @@ impl CbindgenBuilder {
     fn value_opaque_writeback(
         &self,
         registry: &impl Conversions<()>,
-        ty: &syn::Type,
+        key: &TypeKey,
         slot: &syn::Ident,
     ) -> Option<TokenStream> {
-        let cfg = self.value_opaque.get(&TypeKey::from_type(ty))?;
+        let cfg = self.value_opaque.get(key)?;
         let opaque = &cfg.opaque;
         if cfg.generate_mirror {
-            match self.nullable_owned_ptr_fields(registry, ty) {
+            match self.nullable_owned_ptr_fields(registry, key) {
                 // No owned-pointer fields ⇒ plain data, nothing to clean up.
                 Some(fields) if fields.is_empty() => None,
                 // All owned-pointer fields nullable ⇒ null them in place (drop-safe).
@@ -184,10 +184,10 @@ impl CbindgenBuilder {
     /// has a bare `Box<T>` owned-pointer field (a null `Box` is invalid). Nullable
     /// (`Option<Box<T>>`) mirrors null in place and need no `Gravestone`/`Default`;
     /// non-mirror owned types get their `Gravestone` impl from the consumer.
-    fn mirror_needs_gravestone_impl(&self, registry: &Registry<()>, ty: &syn::Type) -> bool {
-        match self.value_opaque.get(&TypeKey::from_type(ty)) {
+    fn mirror_needs_gravestone_impl(&self, registry: &Registry<()>, key: &TypeKey) -> bool {
+        match self.value_opaque.get(key) {
             Some(cfg) if cfg.generate_mirror => {
-                self.nullable_owned_ptr_fields(registry, ty).is_none()
+                self.nullable_owned_ptr_fields(registry, key).is_none()
             }
             _ => false,
         }
@@ -222,7 +222,8 @@ impl CbindgenBuilder {
         let null_msg = format!("null {short} value passed by value");
         // Owned-ness (whether to clean up the moved-from slot) is inferred from the
         // mirror's fields for a `repr_c_struct`, or the explicit kind for a non-mirror.
-        let writeback = self.value_opaque_writeback(registry, ty, &format_ident!("v"));
+        let writeback =
+            self.value_opaque_writeback(registry, &TypeKey::from_type(ty), &format_ident!("v"));
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
             pub(crate) unsafe fn #name(
@@ -539,7 +540,6 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.as_syn().clone();
             let c_struct = self.c_type_ident(&reading.key());
             // Opaque/incomplete C type: the handle is `#c_struct *`, which IS the
             // `Box::into_raw` pointer to the source value.
@@ -550,7 +550,7 @@ impl CbindgenBuilder {
                     _private: [u8; 0],
                 }
             ));
-            let src = self.src_ty(&ty);
+            let src = self.src_ty_of(&reading.key());
             let drop_ident = self.destructor_symbol(&reading.key());
             items.push(syn::parse_quote!(
                 #[no_mangle]
@@ -578,8 +578,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.as_syn().clone();
-            let Some(fields) = self.struct_fields(registry, &TypeKey::from_type(&ty)) else {
+            let Some(fields) = self.struct_fields(registry, &reading.key()) else {
                 continue;
             };
             let c_struct = self.c_type_ident(&reading.key());
@@ -624,8 +623,7 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let ty = reading.as_syn().clone();
-            let src = self.src_ty(&ty);
+            let src = self.src_ty_of(&reading.key());
             let opaque = &cfg.opaque;
             // `repr_c_struct`: the opaque counterpart is an auto-generated
             // **visible-field** `#[repr(C)]` mirror (so C reads the fields directly),
@@ -635,7 +633,7 @@ impl CbindgenBuilder {
             if cfg.generate_mirror {
                 let mirror_ident = self.c_type_ident(&reading.key());
                 let fields = self
-                    .struct_fields(registry, &TypeKey::from_type(&ty))
+                    .struct_fields(registry, &reading.key())
                     .unwrap_or_else(|| {
                         panic!(
                             "Cbindgen::repr_c_struct: `{}` is not a named struct",
@@ -701,7 +699,7 @@ impl CbindgenBuilder {
                 // nullable owned-pointer fields are nulled in place) gets an
                 // auto-generated `Gravestone` from the source type's `Default`. Nullable
                 // mirrors emit nothing here, so they impose no `Default` requirement.
-                if self.mirror_needs_gravestone_impl(registry, &ty) {
+                if self.mirror_needs_gravestone_impl(registry, &reading.key()) {
                     items.push(syn::parse_quote!(
                         impl ::prebindgen::Gravestone for #mirror_ident {
                             #[inline]
@@ -780,7 +778,8 @@ impl CbindgenBuilder {
                 let take_ident = self.take_symbol(&reading.key());
                 // Same inferred write-back as a consume (field-null for a nullable
                 // mirror, `gravestone()` for a bare-`Box` mirror / non-mirror owned).
-                let writeback = self.value_opaque_writeback(registry, &ty, &format_ident!("src"));
+                let writeback =
+                    self.value_opaque_writeback(registry, &reading.key(), &format_ident!("src"));
                 items.push(syn::parse_quote!(
                     #[no_mangle]
                     #[allow(non_snake_case, unused_variables)]


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

`CbindgenBuilder::src_ty` qualifies a bare source type against `source_module` (`ZKeyExpr` → `zenoh_flat::ZKeyExpr`). It is the type peer of `src_fn`, which has taken an `Ident` all along — but five callers holding a **key** or a **declaration** had to spell a node to call it.

## `src_ty_of`

```rust
pub(super) fn src_ty_of(&self, key: &TypeKey) -> syn::Type {
    let spelled: syn::Type = syn::parse_str(key.as_str())
        .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses");
    self.src_ty(&spelled)
}
```

Re-parsing the key is the reverse of `TypeKey::from_type`, and delegating keeps the qualification policy in one place — `String` still resolves to `::std::string::String` (it can be declared `opaque_ptr`), scalars stay bare, only a bare single-segment path is prefixed. Duplicating those three rules against the key would be a second list to drift.

## The callers

Three declared-type emission loops each opened the same way:

```rust
-let ty = reading.as_syn().clone();
 let c_struct = self.c_type_ident(&reading.key());
-let src = self.src_ty(&ty);
+let src = self.src_ty_of(&reading.key());
```

Both `convert.rs` conversion targets did:

```rust
-let target = self.src_ty(&decl.rust_type.as_syn().clone());
+let target = self.src_ty_of(&decl.rust_type.key());
```

`decl.rust_type` is an adapter declaration reusing `Origin` for a placeless location — the over-count the ledger header names explicitly — and `Origin::key()` has answered it since S2.

## Two S5-style misses, and what they gated

Two of the three loops also re-keyed their own reading:

```rust
-self.struct_fields(registry, &TypeKey::from_type(&ty))
+self.struct_fields(registry, &reading.key())
```

Same miss S24 found in `emit.rs`: the reading was in scope and got round-tripped through a spelling to produce a key it could answer itself.

With those locals gone, the three helpers the loops fed take the key they were deriving anyway — each opened with `self.value_opaque.get(&TypeKey::from_type(ty))`:

* `nullable_owned_ptr_fields`
* `value_opaque_writeback`
* `mirror_needs_gravestone_impl`

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 73 | 73 |
| escapes: types | 31 | **26** |
| escapes: items | 15 | 15 |

```
api/lang/cbindgen/convert.rs     [types]  2 -> 0
api/lang/cbindgen/trait_impl.rs  [types]  4 -> 1
```

`cbindgen/trait_impl.rs`'s last one is `convert_with`'s `built.reading(key)?.as_syn().clone()`, which feeds `select_input_type` / `select_output_type` — cbindgen's selector chain still takes a spelling, and moving it is the cbindgen twin of the jnigen `produced` stage.

Classification is unchanged: `nullable_owned_ptr_fields` keeps its `matches!(self.mirror_field_wire(fty), Some(syn::Type::Ptr(_)))`, which is the wire floor — a wire is what C sees, composed by this adapter, never a model type.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical