### PR TITLE
S31: the interface leaf reads

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -113,8 +113,7 @@
 4	api/lang/jnigen/jni/emit/flat_input.rs
 7	api/lang/jnigen/jni/emit/names.rs
 6	api/lang/jnigen/jni/emit/wrapper.rs
-3	api/lang/jnigen/jni/fold.rs
-1	api/lang/jnigen/jni/iface.rs
+1	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
 1	api/lang/jnigen/jni/render.rs
@@ -122,7 +121,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 73
+# total classification sites: 70
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -134,12 +133,11 @@
 1	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/emit/flat_input.rs
 2	api/lang/jnigen/jni/fn_plan.rs
-3	api/lang/jnigen/jni/iface.rs
 3	api/lang/jnigen/jni/overloads.rs
 2	api/lang/jnigen/jni/selector.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 26
+# total escapes: types: 23
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/fold.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fold.rs
@@ -31,29 +31,6 @@ pub(crate) fn enum_probe(reading: &TypeRef) -> &TypeRef {
     cur
 }
 
-/// [`enum_probe`] over a bare spelling, for the one caller that does not have a
-/// reading to peel: [`unfold_leaf_kt`](super::render::unfold_leaf_kt), whose
-/// `out_ty` arrives as `syn::Type` through `leaf_iface_param` from
-/// `UnfoldPlan::element` and `LeafDesc::Whole`. Both must become `TypeRef`s
-/// before this can go — an element-walking change, not a helper swap.
-///
-/// It answers about the WRAPPER where the model answers about the type:
-/// `Box<Priority>` probes as `Box<Priority>` here and as `Priority` there.
-/// Prefer [`enum_probe`] wherever a reading is in hand.
-pub(crate) fn enum_probe_type(ty: &syn::Type) -> syn::Type {
-    let stripped = match ty {
-        syn::Type::Reference(r) => (*r.elem).clone(),
-        other => other.clone(),
-    };
-    match crate::api::lang::jnigen::jni::option_inner_type(&stripped) {
-        Some(inner) => match inner {
-            syn::Type::Reference(r) => (*r.elem).clone(),
-            other => other,
-        },
-        None => stripped,
-    }
-}
-
 // The bottom-up layer fold is the shared `crate::api::core::shape::fold_shape`
 // (its `on_optional` receives the layer's `&NullableKind` + the wrapped
 // `&FoldStrategy`, so callers can special-case e.g. a `Niche` layer sitting

--- a/prebindgen/src/api/lang/jnigen/jni/iface.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/iface.rs
@@ -719,7 +719,7 @@ fn plan_leaf_param(
         ext,
         registry,
         name,
-        leaf.out_ty.as_syn(),
+        &leaf.out_ty,
         leaf.nullable || inert_nullable,
         true,
     )
@@ -740,7 +740,7 @@ fn leaf_iface_param(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     name: String,
-    out_ty: &syn::Type,
+    out_ty: &crate::api::core::flat::TypeRef,
     nullable: bool,
     raw_handle: bool,
 ) -> Option<IfaceParam> {
@@ -749,23 +749,22 @@ fn leaf_iface_param(
     // OWNED resolved only `T`'s output entry. Both classify to the same
     // projection/class, so fall back to the peeled form when the borrowed
     // entry was never required.
+    //
+    // `TypeKind::Ref` and NOT `borrow_target`: this peels the spelling's own
+    // outermost borrow, where `borrow_target` reaches the target *through* the
+    // erased wrappers. `Box<&T>` has a borrow target and is deliberately not
+    // servable here (`a_wrapped_borrow_callback_arg_declines`) — peeling it
+    // would resolve a shape the wrapper arms own.
     let mut out_ty = out_ty;
-    let peeled: syn::Type;
-    if registry
-        .reading_of(out_ty)
-        .and_then(|tr| registry.output_entry(&tr))
-        .is_none()
-    {
-        if let syn::Type::Reference(r) = out_ty {
-            peeled = (*r.elem).clone();
-            out_ty = &peeled;
+    if registry.output_entry(out_ty).is_none() {
+        if let crate::api::core::flat::TypeKind::Ref { inner, .. } = out_ty.kind() {
+            out_ty = inner;
         }
     }
     let (builder_kt, _wire_kt, _wrap, is_value_projection) =
         unfold_leaf_kt(ext, registry, out_ty, nullable, "x")?;
     let proj = registry
-        .reading_of(out_ty)
-        .and_then(|tr| registry.output_entry(&tr))
+        .output_entry(out_ty)
         .and_then(|e| e.metadata.projection.as_ref());
     let nullable_kt = |t: kt::KtType| {
         if builder_kt.is_nullable() {
@@ -825,7 +824,7 @@ fn leaf_iface_param(
     // no `asRaw` proxy is generated.
     if let kt::KtType::Named { fqn: bk_fqn, .. } = &builder_kt {
         if !bk_fqn.contains('.') {
-            if let Some(reg_fqn) = ext.kotlin_fqn(&TypeKey::from_type(out_ty)) {
+            if let Some(reg_fqn) = ext.kotlin_fqn(&out_ty.key()) {
                 let reg_short = reg_fqn.rsplit('.').next().unwrap_or(&reg_fqn);
                 if reg_fqn.contains('.') && reg_short == bk_fqn {
                     let raw = kt::KtType::cls(reg_fqn.to_string());
@@ -857,15 +856,10 @@ pub(crate) fn owned_handle_iface_param(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     name: String,
-    out_ty: &syn::Type,
+    out_ty: &crate::api::core::flat::TypeRef,
     nullable: bool,
 ) -> Option<IfaceParam> {
-    let proj = registry
-        .reading_of(out_ty)
-        .and_then(|tr| registry.output_entry(&tr))?
-        .metadata
-        .projection
-        .clone()?;
+    let proj = registry.output_entry(out_ty)?.metadata.projection.clone()?;
     let fqn = ext.kotlin_fqn(&proj.leaf_key)?.to_string();
     let typed = kt::KtType::cls(fqn.clone());
     let (typed, raw) = if nullable {
@@ -1128,7 +1122,7 @@ pub(crate) fn callback_iface_spec(
         Plan(String, crate::api::core::unfold::UnfoldLeaf),
         Whole {
             name: String,
-            ty: syn::Type,
+            ty: crate::api::core::flat::TypeRef,
             nullable: bool,
             owned_handle: bool,
         },
@@ -1247,7 +1241,7 @@ pub(crate) fn callback_iface_spec(
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
                 name: whole_value_name(t, i),
-                ty: t.as_syn().clone(),
+                ty: (*t).clone(),
                 nullable: t.optional_inner().is_some(),
                 owned_handle,
             });
@@ -1398,9 +1392,7 @@ pub(crate) fn whole_folder_iface_spec(
         ext,
         registry,
         "element".to_string(),
-        // `leaf_iface_param` still takes a node, and it is also handed
-        // adapter-composed types — migrating it is its own step.
-        element.as_syn(),
+        element,
         false,
         true,
     )?);

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -2002,13 +2002,12 @@ fn render_body(
 pub(crate) fn unfold_leaf_kt(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
-    out_ty: &syn::Type,
+    out_ty: &crate::api::core::flat::TypeRef,
     nullable: bool,
     pk: &str,
 ) -> Option<(kt::KtType, String, String, bool)> {
     let proj = registry
-        .reading_of(out_ty)
-        .and_then(|tr| registry.output_entry(&tr))
+        .output_entry(out_ty)
         .and_then(|e| e.metadata.projection.clone());
     let is_value_projection = proj
         .as_ref()
@@ -2021,10 +2020,14 @@ pub(crate) fn unfold_leaf_kt(
         .unwrap_or(false);
     // builder_kt: enum → Int; otherwise the normal classified type
     // (handle class / String / ByteArray / Long …).
-    let builder_kt = if ext.is_kotlin_enum(&enum_probe_type(out_ty)) {
+    let builder_kt = if ext.is_kotlin_enum_reading(out_ty) {
         kt::KtType::int()
     } else {
-        let rt: syn::ReturnType = syn::parse_quote!(-> #out_ty);
+        // `classify_return` still takes a signature fragment, so the reading is
+        // spelled here — the source's own tokens, as generated Rust always
+        // spells.
+        let spelled = out_ty.spell();
+        let rt: syn::ReturnType = syn::parse_quote!(-> #spelled);
         classify_return(ext, &rt, registry)?.0?
     };
     let (mut wire_kt, wrap) = if is_value_projection {

--- a/prebindgen/src/api/lang/jnigen/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/mod.rs
@@ -127,9 +127,9 @@ mod spelling_census {
         // vec_build.rs is absent, and off the boundary ledger too: its element
         // peel reads `sequence_elem`/`borrow_target` off the model now.
         //
-        // fold.rs's one call is inside `enum_probe_type`, the spelling twin of
-        // `enum_probe` kept for `unfold_leaf_kt`'s `syn::Type` callers.
-        ("jni/fold.rs", 1),
+        // fold.rs is off the census: `enum_probe_type`, the spelling twin kept
+        // for `unfold_leaf_kt`'s `syn::Type` callers, is deleted — that caller
+        // takes a reading and asks `is_kotlin_enum_reading`.
         // iface.rs is off the census: `subject_short` / `subject_package` peel
         // `&`/`Option`/`Vec` off the KIND now, which is the same grammar the
         // spelling was — see `util::head_type`.


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

`leaf_iface_param` → `unfold_leaf_kt` → `enum_probe_type` is a three-link chain that took a `syn::Type` the whole way. Two of its links opened by looking the reading back up:

```rust
registry.reading_of(out_ty).and_then(|tr| registry.output_entry(&tr))
```

three times across the two — on a node their callers had escaped **from a reading**. All three links take `&TypeRef` now, and `LeafDesc::Whole::ty` carries the reading instead of a clone of its node.

## `enum_probe_type` is deleted

Its own doc said what had to happen first:

> [`enum_probe`] over a bare spelling, for the one caller that does not have a reading to peel: `unfold_leaf_kt`, whose `out_ty` arrives as `syn::Type` through `leaf_iface_param` from `UnfoldPlan::element` and `LeafDesc::Whole`. **Both must become `TypeRef`s before this can go** — an element-walking change, not a helper swap.

Both moved here (`UnfoldPlan::element` already was one; only the `as_syn()` at the call site stood between). `unfold_leaf_kt` asks `is_kotlin_enum_reading` instead — which peels off the model and answers about the **type** where the spelling twin answered about the **wrapper** (`Box<Priority>` probed as `Box<Priority>` there, `Priority` here).

## One peel is deliberately not `borrow_target`

The canonical-spec fallback peels the spelling's own outermost borrow. Written as `borrow_target()` it reached the target **through** the erased wrappers, which made `Box<&T>` resolve here — a shape the wrapper arms own, and one the suite already pins:

```
thread '…a_wrapped_borrow_callback_arg_declines' panicked at …:
a wrapped borrow callback arg must not resolve: …
```

So it matches `TypeKind::Ref` directly, which is the literal form the `syn::Type::Reference` match was. Worth stating explicitly, because the two readings look interchangeable and are not: `borrow_target` is "the target through the accessor", `kind()` is "what the source wrote".

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 73 | **70** |
| escapes: types | 26 | **23** |
| escapes: items | 15 | 15 |

```
api/lang/jnigen/jni/iface.rs  [classification]  1 -> 0
api/lang/jnigen/jni/iface.rs  [types]           3 -> 0
api/lang/jnigen/jni/fold.rs   [classification]  3 -> 1
```

`iface.rs` reaches zero on both counts. `fold.rs`'s remaining site is a wire (`syn::Type::Path(tp) = wire`), the same floor as `wire_access.rs` and `emit/wrapper.rs`.

**Spelling census** (the second measure, over the helpers that read layers off a spelling): `jni/fold.rs` 1 → 0, so that file leaves it as well — the row is removed with the reason, as that census's own protocol requires.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- both censuses regenerated, diffs above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical