### PR TITLE
S32: what a Rust arm erases to, and one more node cache

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -114,14 +114,13 @@
 7	api/lang/jnigen/jni/emit/names.rs
 6	api/lang/jnigen/jni/emit/wrapper.rs
 1	api/lang/jnigen/jni/fold.rs
-1	api/lang/jnigen/jni/overloads.rs
 1	api/lang/jnigen/jni/prim.rs
 1	api/lang/jnigen/jni/render.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 70
+# total classification sites: 69
 
 ## escapes: types
 1	api/core/diagnostics.rs
@@ -131,13 +130,11 @@
 2	api/core/registry/scan.rs
 1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/trait_impl.rs
-2	api/lang/jnigen/jni/emit/flat_input.rs
 2	api/lang/jnigen/jni/fn_plan.rs
-3	api/lang/jnigen/jni/overloads.rs
 2	api/lang/jnigen/jni/selector.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 23
+# total escapes: types: 18
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -755,7 +755,9 @@ pub(crate) enum FlatFieldNode {
         /// target. There is no reading here to ask — `FlatFieldNode` is an
         /// emission IR and tokens are what it is for — so the answer travels
         /// from where the reading was (#289).
-        direct_handle: Option<Box<syn::Type>>,
+        /// The handle type a leaf reconstructs by `Box::from_raw` — the
+        /// reading, spelled at the emit site like every other generated type.
+        direct_handle: Option<Box<crate::api::core::flat::TypeRef>>,
         optional_handle: bool,
         rust_ty: Box<crate::api::core::flat::TypeRef>,
         /// The transparent wrappers this field's spelling adds over its
@@ -1473,14 +1475,10 @@ fn build_flat_struct_node(
         // could (#273).
         let field_optional = field.ty.optional_inner().is_some();
         let nested = field.ty.optional_inner().unwrap_or(&field.ty);
-        let nested_ty = nested.as_syn().clone();
         // A data-carrying enum flattens into a tag plus one group per variant.
         // `None` means some payload is not leaf-shaped — fall through and let
         // it cross as one object through its own converter.
-        if matches!(
-            ext.type_kind(registry, &TypeKey::from_type(&nested_ty)),
-            TypeKind::Sum
-        ) {
+        if matches!(ext.type_kind(registry, &nested.key()), TypeKind::Sum) {
             if let Some(node) = build_flat_sum_field(
                 ext,
                 registry,
@@ -1500,7 +1498,7 @@ fn build_flat_struct_node(
         if let TypeKind::DataStruct {
             st: child,
             cfg: Some(cfg),
-        } = ext.type_kind(registry, &TypeKey::from_type(&nested_ty))
+        } = ext.type_kind(registry, &nested.key())
         {
             if cfg.name_spec.is_some() && !cfg.special_decl() && !cfg.jobject_input {
                 let child_optional = field_optional;
@@ -1648,7 +1646,7 @@ fn build_flat_struct_node(
                         field: fident,
                         value_leaf: value_index,
                         present_leaf: None,
-                        direct_handle: Some(Box::new(nested.as_syn().clone())),
+                        direct_handle: Some(Box::new(nested.clone())),
                         optional_handle,
                         rust_ty: Box::new(field.ty.clone()),
                         wrappers: field.ty.erased_wrappers(),
@@ -1940,6 +1938,7 @@ fn render_flat_struct_node(
                         .expect("a field spelling the plan accepted is buildable")
                 };
                 if let Some(target) = direct_handle {
+                    let target_ty = target.spell();
                     if *optional_handle {
                         let gated = wrap(quote! {
                             if #wire == 0 {
@@ -1950,7 +1949,7 @@ fn render_flat_struct_node(
                                     return #on_err;
                                 }
                                 ::core::option::Option::Some(unsafe {
-                                    *::std::boxed::Box::from_raw(#wire as *mut #target)
+                                    *::std::boxed::Box::from_raw(#wire as *mut #target_ty)
                                 })
                             }
                         });

--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -62,7 +62,7 @@ impl Declarations {
             if decl.no_split || decl.variants.len() < 2 {
                 continue;
             }
-            let target = decl.rust_type.as_syn().clone();
+            let target = decl.rust_type.key();
             let sigs: Vec<(String, Vec<ErasedJvmType>)> = decl
                 .variants
                 .iter()
@@ -110,7 +110,7 @@ impl Declarations {
 fn arm_erased_sig(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    target: &syn::Type,
+    target: &TypeKey,
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
     match ctor {
@@ -118,11 +118,20 @@ fn arm_erased_sig(
             Some(f) => f
                 .params
                 .iter()
-                .map(|p| rust_type_erased(ext, registry, p.ty.as_syn()))
+                .map(|p| rust_type_erased(ext, registry, &p.ty))
                 .collect(),
             None => Vec::new(),
         },
-        None => vec![rust_type_erased(ext, registry, target)],
+        // The identity, because the two callers reach it differently: one holds
+        // a plan's reading, the other a `.expand_param(...)` DECLARATION, which
+        // the build script wrote and the model may never have interned. Where
+        // it did, the reading answers as before; where it did not, the erased
+        // form is the identity's own canonical spelling — which is all a
+        // declaration has to be told apart by.
+        None => vec![match registry.reading(target) {
+            Some(reading) => rust_type_erased(ext, registry, &reading),
+            None => ErasedJvmType::raw(target.as_str().to_string()),
+        }],
     }
 }
 
@@ -135,26 +144,27 @@ fn arm_erased_sig(
 fn rust_type_erased(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
-    ty: &syn::Type,
+    ty: &crate::api::core::flat::TypeRef,
 ) -> ErasedJvmType {
-    let peeled = match ty {
-        syn::Type::Reference(r) => &*r.elem,
-        other => other,
+    // The spelling's own outermost borrow, as `TypeKind::Ref` — not
+    // `borrow_target`, which reaches through the erased wrappers (#S31).
+    let peeled = match ty.kind() {
+        crate::api::core::flat::TypeKind::Ref { inner, .. } => inner,
+        _ => ty,
     };
-    let key = TypeKey::from_type(peeled);
+    let key = peeled.key();
     if ext.types.get(&key).is_some_and(|c| c.name_spec.is_some()) {
         if let Some(fqn) = ext.kotlin_fqn(&key) {
             return erase_kt_type(&[], &kt::KtType::cls(fqn));
         }
     }
     if let Some(kt) = registry
-        .reading_of(peeled)
-        .and_then(|tr| registry.input_entry(&tr))
+        .input_entry(peeled)
         .and_then(|e| e.metadata.kotlin_name.clone())
     {
         return erase_kt_type(&[], &kt);
     }
-    ErasedJvmType::raw(peeled.to_token_stream().to_string())
+    ErasedJvmType::raw(peeled.spell().to_string())
 }
 
 /// Whether `plan` is a multi-variant expansion that can be turned into
@@ -435,7 +445,7 @@ pub(crate) fn render_param_overloads(
                 .zip(combo)
                 .flat_map(|(s, &ai)| {
                     let ctor = s.plan.variants[s.arms[ai].0].ctor.as_ref();
-                    arm_erased_sig(ext, registry, s.plan.target.as_syn(), ctor)
+                    arm_erased_sig(ext, registry, &s.plan.target.key(), ctor)
                 })
                 .collect()
         })


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). Two independent populations, both **carrying** a node rather than classifying one.

## `overloads.rs` — JVM erasure

`rust_type_erased` decides what a Rust arm type surfaces as on the JVM, which is how the overload-collision check works. It did four things to a node:

```rust
-let peeled = match ty { syn::Type::Reference(r) => &*r.elem, other => other };
-let key = TypeKey::from_type(peeled);
+let peeled = match ty.kind() { TypeKind::Ref { inner, .. } => inner, _ => ty };
+let key = peeled.key();
 …
-registry.reading_of(peeled).and_then(|tr| registry.input_entry(&tr))
+registry.input_entry(peeled)
 …
-ErasedJvmType::raw(peeled.to_token_stream().to_string())
+ErasedJvmType::raw(peeled.spell().to_string())
```

The peel is `TypeKind::Ref` and **not** `borrow_target` — S31's lesson, applied deliberately: the literal outermost borrow the `syn::Type::Reference` match was, not the target reached through erased wrappers.

### `arm_erased_sig` takes the identity

Its two callers reach the target differently, which is why it takes a `TypeKey` rather than either a node or a reading:

* the split-detection loop holds an `.expand_param(...)` **declaration** — a type the build script wrote, which the model may never have interned;
* the combination loop holds `s.plan.target`, a `TypeRef`.

So the `SelfIdentity` arm resolves the key: where a reading exists it answers exactly as before, and where it does not, the erased form is the identity's own canonical spelling — which is all a declaration has to be told apart by, and is what the token-string fallback was approximating anyway.

## `flat_input.rs` — a node cache with one read

`FlatFieldNode::Value::direct_handle: Option<Box<syn::Type>>` had exactly **one** read in the whole crate:

```rust
*::std::boxed::Box::from_raw(#wire as *mut #target)
```

An interpolation. It carries the reading and spells it at the emit site, like every other generated type. The producing site's `nested_ty` local was a `.as_syn().clone()` whose only two uses were `TypeKey::from_type` of it — `nested.key()`.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 70 | **69** |
| escapes: types | 23 | **18** |
| escapes: items | 15 | 15 |

```
api/lang/jnigen/jni/overloads.rs        [classification]  1 -> 0
api/lang/jnigen/jni/overloads.rs        [types]           3 -> 0
api/lang/jnigen/jni/emit/flat_input.rs  [types]           2 -> 0
```

Both files reach zero. The 18 that remain are concentrated: five in `jnigen/jni/trait_impl.rs` (the two terminals and the two transparent bridges, all four gated on `build_input_fn` / `build_output_fn` / `override_kotlin_name` taking readings), two in `selector.rs` and one in `cbindgen/trait_impl.rs` (the `produced` population), two in `fn_plan.rs`, and seven in `api/core` itself.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical