### PR TITLE
S33: api/core reaches zero type escapes

### DIFF
--- a/prebindgen/src/api/core/diagnostics.rs
+++ b/prebindgen/src/api/core/diagnostics.rs
@@ -11,11 +11,7 @@
 
 use std::collections::HashSet;
 
-use crate::api::core::{
-    flat::{type_from_ident, Flat},
-    prebindgen::NamePredicate,
-    registry::TypeKey,
-};
+use crate::api::core::{flat::Flat, prebindgen::NamePredicate, registry::TypeKey};
 
 /// What a binding claimed, so everything else can be reported.
 ///
@@ -113,7 +109,7 @@ pub(crate) fn unclaimed_report(flat: &Flat, claimed: &Claimed) -> Vec<String> {
     for name in sorted(
         struct_enum_idents(flat)
             .filter(|i| {
-                let key = TypeKey::from_type(&type_from_ident(i));
+                let key = TypeKey::from_ident(i);
                 !claimed.types.contains(&key) && !claimed.ignored_types.contains(&key)
             })
             .map(|i| i.to_string())

--- a/prebindgen/src/api/core/expand.rs
+++ b/prebindgen/src/api/core/expand.rs
@@ -193,13 +193,13 @@ pub fn apply<M>(
         // typo guard for both coordinates of `.expand_param(name, decl)`.
         if let Some(declared) = &ed.declared_target {
             let param_ty = param_reading(registry, &ed.func, &ed.param)?;
-            let bare = constructed_value(&param_ty);
-            if TypeKey::from_type(&bare) != *declared {
+            let bare = constructed_value(&param_ty).key();
+            if bare != *declared {
                 return Err(ExpandError::ParamTypeMismatch {
                     func: ed.func.clone(),
                     param: ed.param.clone(),
                     declared: declared.as_str().to_string(),
-                    actual: TypeKey::from_type(&bare).as_str().to_string(),
+                    actual: bare.as_str().to_string(),
                 });
             }
         }
@@ -237,8 +237,7 @@ pub fn apply<M>(
             let receiver_key = method_receivers.get(func);
             let mut receiver_skipped = false;
             for (pname, pty) in params.iter().map(|p| (p.name.clone(), p.ty.clone())) {
-                let bare = constructed_value(&pty);
-                let bare_key = TypeKey::from_type(&bare);
+                let bare_key = constructed_value(&pty).key();
                 if !receiver_skipped && receiver_key == Some(&bare_key) {
                     receiver_skipped = true;
                     continue;
@@ -1084,13 +1083,11 @@ fn ctor_call_result<I: quote::ToTokens>(path: &syn::Path, args: &[I], fallible: 
 /// A type the grammar cannot express answers itself — the identity, not a
 /// fallback classifier. Nothing reaching here can be one: every signature in play
 /// was accepted by the frontend before the scan registered it.
-fn constructed_value(reading: &crate::api::core::flat::TypeRef) -> syn::Type {
+fn constructed_value(
+    reading: &crate::api::core::flat::TypeRef,
+) -> &crate::api::core::flat::TypeRef {
     let after_opt = reading.optional_inner().unwrap_or(reading);
-    after_opt
-        .borrow_target()
-        .unwrap_or(after_opt)
-        .as_syn()
-        .clone()
+    after_opt.borrow_target().unwrap_or(after_opt)
 }
 
 /// [`constructed_value`], plus which of the two layers were there.

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -123,18 +123,13 @@
 # total classification sites: 69
 
 ## escapes: types
-1	api/core/diagnostics.rs
-1	api/core/expand.rs
-1	api/core/registry/key.rs
-2	api/core/registry/order.rs
-2	api/core/registry/scan.rs
 1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/fn_plan.rs
 2	api/lang/jnigen/jni/selector.rs
 5	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 18
+# total escapes: types: 11
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/core/registry/key.rs
+++ b/prebindgen/src/api/core/registry/key.rs
@@ -110,7 +110,7 @@ impl TypeKey {
     /// Build a key for a bare item ident — infallible by construction (an
     /// ident IS a single-segment path type; nothing to parse or normalize).
     pub fn from_ident(ident: &syn::Ident) -> Self {
-        Self::from_type(&crate::api::core::flat::type_from_ident(ident))
+        Self::from_type(&syn::parse_quote!(#ident))
     }
 
     /// The canonical string form.

--- a/prebindgen/src/api/core/registry/order.rs
+++ b/prebindgen/src/api/core/registry/order.rs
@@ -61,13 +61,13 @@ impl<M> Registry<M> {
         }
         let (dir, key) = node.clone();
         // Every node this walk reaches has a cell: the roots are the table's own
-        // keys, and each edge below is filtered by `contains_key`. So the
-        // spelling `plan_edges` needs is the reading the registry already
-        // stored — not one re-derived from the key (#291).
+        // keys, and each edge below is filtered by `contains_key`. So what
+        // `plan_edges` needs is the reading the registry already stored — not
+        // one re-derived from the key (#291).
         let plan_edges = self
             .type_table(dir)
             .get(&key)
-            .map(|cell| self.plan_edges(dir, cell.subject.as_syn()))
+            .map(|cell| self.plan_edges(dir, &cell.subject))
             .unwrap_or_default();
         let mut edges: Vec<Crossing> = self
             .immediate_edges(dir, &key)
@@ -75,11 +75,7 @@ impl<M> Registry<M> {
             // The structural edges arrive as readings, so the key is the
             // model's own answer rather than one re-derived from a spelling.
             .map(|(d, t)| (d, t.key()))
-            .chain(
-                plan_edges
-                    .into_iter()
-                    .map(|(d, t)| (d, TypeKey::from_type(&t))),
-            )
+            .chain(plan_edges)
             .chain(
                 self.declared
                     .edges
@@ -109,18 +105,26 @@ impl<M> Registry<M> {
     /// by the argument's syntax. Without this the order would be structurally
     /// correct and still wrong, which is exactly the kind of gap the old
     /// fixed-point loop papered over by retrying.
-    pub(super) fn plan_edges(&self, dir: Direction, ty: &syn::Type) -> Vec<(Direction, syn::Type)> {
+    /// Crossings, not spellings: every edge here is a table lookup, and the
+    /// model names both ends. `callback_args` is the classification
+    /// `extract_fn_trait_args` re-derived from the parameter's bounds, and a
+    /// leaf's `out_ty` is a reading whose key is its own.
+    pub(super) fn plan_edges(
+        &self,
+        dir: Direction,
+        ty: &crate::api::core::flat::TypeRef,
+    ) -> Vec<Crossing> {
         if dir != Direction::Input {
             return Vec::new();
         }
-        let Some(args) = crate::api::core::flat::extract_fn_trait_args(ty) else {
+        let Some(args) = ty.callback_args() else {
             return Vec::new();
         };
         let mut out = Vec::new();
         for arg in args {
-            if let Some(plan) = self.callback_arg_plans.get(&TypeKey::from_type(&arg)) {
+            if let Some(plan) = self.callback_arg_plans.get(&arg.key()) {
                 for leaf in &plan.leaves {
-                    out.push((Direction::Output, leaf.out_ty.as_syn().clone()));
+                    out.push((Direction::Output, leaf.out_ty.key()));
                 }
             }
         }

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -11,6 +11,18 @@ use quote::ToTokens;
 
 use super::*;
 
+/// The canonical `syn::Type` a **declaration** names, off its identity.
+///
+/// A [`TypeKey`] is `canonical_type` already rendered, so re-parsing it yields
+/// the same type `canonical_type(origin.as_syn())` built — without taking the
+/// node. `declared_ty` is a BUILD-SCRIPT declaration reusing `Origin` for a
+/// placeless location, the over-count the boundary ledger documents, and
+/// `Origin::key` is the answer it names.
+fn canonical_of(declared_ty: &crate::api::core::flat::Origin<syn::Type>) -> syn::Type {
+    syn::parse_str(declared_ty.key().as_str())
+        .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses")
+}
+
 impl<M> Registry<M> {
     pub(super) fn scan_declared_items(&mut self, declared: &Declared) -> Result<(), ScanError> {
         // Source-qualified declared types are a hard error (issue #95). The
@@ -46,7 +58,13 @@ impl<M> Registry<M> {
             if !probed.insert(key) {
                 continue;
             }
-            let ty = crate::api::core::flat::canonical_type(declared_ty.as_syn());
+            // The canonical form off the declaration's own identity: a
+            // `TypeKey` IS `canonical_type` rendered, so re-parsing it is the
+            // same type this spelled the node to build. `declared_ty` is a
+            // BUILD-SCRIPT declaration reusing `Origin` for a placeless
+            // location — the ledger's documented over-count, and `Origin::key`
+            // is the answer it names.
+            let ty = canonical_of(declared_ty);
             // Peel one reference level; the qualified head only appears on
             // path types.
             let inner = match &ty {
@@ -142,7 +160,7 @@ impl<M> Registry<M> {
             // is the form the type used to arrive in, and interning the
             // as-written spelling instead would put a differently-spelled
             // reading in the cell for the same key.
-            let ty = crate::api::core::flat::canonical_type(declared_ty.as_syn());
+            let ty = canonical_of(declared_ty);
             let mut matched = false;
             if let Some(ident) = bare_path_ident(&ty) {
                 if let Some(s) = self.flat.struct_type(&ident).cloned() {


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

The umbrella has claimed **"`api/core` holds zero type escapes as of S8"** since S8. It was not true. Seven were left, across five files — the last places the pipeline itself reached for a node rather than reading one. This stage makes the claim true and the count is the proof.

## `registry/order.rs` (2)

```rust
-pub(super) fn plan_edges(&self, dir: Direction, ty: &syn::Type) -> Vec<(Direction, syn::Type)> {
-    let Some(args) = extract_fn_trait_args(ty) else { return Vec::new() };
-    …
-        if let Some(plan) = self.callback_arg_plans.get(&TypeKey::from_type(&arg)) {
-            out.push((Direction::Output, leaf.out_ty.as_syn().clone()));
+pub(super) fn plan_edges(&self, dir: Direction, ty: &TypeRef) -> Vec<Crossing> {
+    let Some(args) = ty.callback_args() else { return Vec::new() };
+    …
+        if let Some(plan) = self.callback_arg_plans.get(&arg.key()) {
+            out.push((Direction::Output, leaf.out_ty.key()));
```

Every edge in this walk is a table lookup, so it never wanted spellings. `callback_args` **is** the classification `extract_fn_trait_args` re-derived from the parameter's bounds, and the caller's `.map(|(d, t)| (d, TypeKey::from_type(&t)))` disappears with the return type.

## `expand.rs` (1)

`constructed_value` peeled the optional and the borrow off a reading and then *dropped it*, returning a node both callers immediately keyed. It returns the `&TypeRef`, and the two `TypeKey::from_type(&bare)` go with it (one of them was computed twice for an error message).

## `diagnostics.rs` + `registry/key.rs` (2)

```rust
let key = TypeKey::from_type(&type_from_ident(i));   // diagnostics.rs
```

That is `TypeKey::from_ident(i)` — which is the *other* escape, `key.rs:113`, defined by going through the same door. One calls it the long way, the other builds the door's own argument. Both stop:

```rust
-Self::from_type(&crate::api::core::flat::type_from_ident(ident))
+Self::from_type(&syn::parse_quote!(#ident))
```

The `type_from_ident` door now has **no caller in the crate**. It stays defined (it is public API), but nothing in-tree goes through it.

## `registry/scan.rs` (2)

```rust
let ty = crate::api::core::flat::canonical_type(declared_ty.as_syn());
```

`declared_ty` is a build-script **declaration** reusing `Origin` for a placeless location — exactly the over-count the ledger header documents, and it names the answer. A `TypeKey` is `canonical_type` already rendered, so re-parsing it yields the same type the node built:

```rust
fn canonical_of(declared_ty: &Origin<syn::Type>) -> syn::Type {
    syn::parse_str(declared_ty.key().as_str())
        .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses")
}
```

Kept as a private free fn rather than a `TypeKey` method: a public method handing out a `syn::Type` under an uncounted name is precisely what `escape_surface_is_closed` exists to fail on.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 69 | 69 |
| escapes: types | 18 | **11** |
| escapes: items | 15 | 15 |

```
api/core/diagnostics.rs     1 -> 0
api/core/expand.rs          1 -> 0
api/core/registry/key.rs    1 -> 0
api/core/registry/order.rs  2 -> 0
api/core/registry/scan.rs   2 -> 0
```

**`api/core` is now zero.** Every remaining type escape is in an adapter: five in `jnigen/jni/trait_impl.rs`, two in `jnigen/jni/fn_plan.rs`, two in `jnigen/jni/selector.rs`, one in `cbindgen/emit.rs`, one in `cbindgen/trait_impl.rs`.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical