### PR TITLE
S34: the JNI terminals and bridges read

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -116,20 +116,20 @@
 1	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/prim.rs
 1	api/lang/jnigen/jni/render.rs
-5	api/lang/jnigen/jni/trait_impl.rs
+4	api/lang/jnigen/jni/trait_impl.rs
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 69
+# total classification sites: 68
 
 ## escapes: types
 1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/fn_plan.rs
 2	api/lang/jnigen/jni/selector.rs
-5	api/lang/jnigen/jni/trait_impl.rs
+1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 11
+# total escapes: types: 7
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1887,13 +1887,13 @@ impl Declarations {
     ///
     pub(crate) fn lookup_input(
         &self,
-        outer: &syn::Type,
+        outer: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // A `convert!`-declared conversion is the only thing that answers here.
         // There was a wildcard-pattern table beside it; nothing ever wrote to
         // the input half, so every lookup through it returned `None`.
-        let key = TypeKey::from_type(outer);
+        let key = outer.key();
         let (ty, exc_ty, body) = self.convert_input_body(&key, registry)?;
         // The closure's middle slot carries the `Result`'s raw Rust error
         // type (or `None` for the framework `__JniErr`); it feeds the
@@ -1905,7 +1905,11 @@ impl Declarations {
         // distinguishes a rust continue-type (compose) from a wire
         // (terminal) without forcing `()` either way. A non-wire `ty` that
         // isn't yet resolved defers.
-        let is_self = TypeKey::from_type(&ty) == TypeKey::from_type(outer);
+        let outer_node: syn::Type = {
+            let spelled = outer.spell();
+            syn::parse_quote!(#spelled)
+        };
+        let is_self = TypeKey::from_type(&ty) == outer.key();
         let inner = if is_self {
             None
         } else {
@@ -1926,7 +1930,7 @@ impl Declarations {
                 Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_input_fn(outer, &ty, &body, exc),
+                    function: self.build_input_fn_of(outer, &ty, &body, exc),
                     destination: ty,
                     niches,
                     metadata: KotlinMeta {
@@ -1948,7 +1952,10 @@ impl Declarations {
                 // yields `outer`, i.e. the same shape an output converter
                 // has — so it's built with `build_output_fn`.
                 let stage = Stage {
-                    function: self.build_output_fn(&ty, outer, &body, exc),
+                    // `outer` sits in the WIRE slot here: the stage yields it
+                    // from `ty`, so it is spelled into the signature rather
+                    // than classified.
+                    function: self.build_output_fn(&ty, &outer_node, &body, exc),
                     metadata: KotlinMeta::default(),
                 };
                 let mut pre_stages = vec![stage];
@@ -1992,10 +1999,10 @@ impl Declarations {
     ///   (`None`) if `ty`'s converter isn't resolved yet.
     pub(crate) fn lookup_output(
         &self,
-        outer: &syn::Type,
+        outer: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let key = TypeKey::from_type(outer);
+        let key = outer.key();
         let (ty, exc_ty, body) = self.convert_output_body(&key, registry)?;
         self.build_output_converter(outer, None, ty, exc_ty, body, registry)
     }
@@ -2009,7 +2016,7 @@ impl Declarations {
     /// engine expressed one fact the frontend states outright.
     pub(crate) fn result_peel(
         &self,
-        outer: &syn::Type,
+        outer: &crate::api::core::flat::TypeRef,
         ok: &syn::Type,
         err: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
@@ -2031,19 +2038,19 @@ impl Declarations {
     /// tested.
     fn build_output_converter(
         &self,
-        outer: &syn::Type,
+        outer: &crate::api::core::flat::TypeRef,
         arg0: Option<&syn::Type>,
         ty: syn::Type,
         exc_ty: Option<syn::Type>,
         body: syn::Expr,
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let key = TypeKey::from_type(outer);
+        let key = outer.key();
         // The middle slot carries the `Result`'s raw Rust error type (or `None`
         // for the framework `__JniErr`).
         let exc = exc_ty.as_ref();
         // Terminal vs composed — see [`Self::lookup_input`] for the rule.
-        let is_self = TypeKey::from_type(&ty) == TypeKey::from_type(outer);
+        let is_self = TypeKey::from_type(&ty) == key;
         let inner = if is_self {
             None
         } else {
@@ -2081,7 +2088,7 @@ impl Declarations {
                 Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_output_fn(outer, &ty, &body, exc),
+                    function: self.build_output_fn_of(outer, &ty, &body, exc),
                     destination: ty,
                     niches,
                     metadata: KotlinMeta {
@@ -2098,7 +2105,7 @@ impl Declarations {
             Some(inner) => {
                 // Composed: `ty` is the continue rust type; chain its converter.
                 let stage = Stage {
-                    function: self.build_output_fn(outer, &ty, &body, exc),
+                    function: self.build_output_fn_of(outer, &ty, &body, exc),
                     metadata: KotlinMeta::default(),
                 };
                 let mut pre_stages = vec![stage];

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -35,8 +35,8 @@ pub(crate) fn sentinel_for_wire(wire: &syn::Type) -> TokenStream {
 // Primitive bodies
 // ──────────────────────────────────────────────────────────────────────
 
-pub(crate) fn primitive_input(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)> {
-    let key = TypeKey::from_type(ty).as_str().to_string();
+pub(crate) fn primitive_input(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
+    let key = key.as_str().to_string();
     // Bodies receive `v: &<wire>`; primitives are Copy so `*v` works.
     Some(match key.as_str() {
         "bool" => (
@@ -107,8 +107,8 @@ pub(crate) fn primitive_input(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)> 
     })
 }
 
-pub(crate) fn primitive_output(ty: &syn::Type) -> Option<(syn::Type, syn::Expr)> {
-    let key = TypeKey::from_type(ty).as_str().to_string();
+pub(crate) fn primitive_output(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
+    let key = key.as_str().to_string();
     // Output wrappers take v by value (move). Primitives are Copy, so
     // `v as wire` works. String/Vec consume v.
     Some(match key.as_str() {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -249,8 +249,8 @@ pub(crate) fn annotate_jobject_with_lifetime(ty: &syn::Type, life: &str) -> syn:
 /// `impl Fn(...)` lambda converters — the legacy
 /// `process_kotlin_<Name>_callback` naming is gone with the fun-interface
 /// subsystem).
-pub(crate) fn input_name(rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
-    let rust_id = sanitize_for_ident(&rust.to_token_stream().to_string());
+pub(crate) fn input_name(rust: &TokenStream, wire: &syn::Type) -> syn::Ident {
+    let rust_id = sanitize_for_ident(&rust.to_string());
     let wire_id = wire_short(wire);
     let h = hash_pair(rust, wire);
     let s = format!("{}_to_{}_{:08x}", wire_id, rust_id, h & 0xffff_ffff);
@@ -258,8 +258,8 @@ pub(crate) fn input_name(rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
 }
 
 /// OUTPUT: rust → wire. Format `<rust_id>_to_<wire_id>_<hash>`.
-pub(crate) fn output_name(rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
-    let rust_id = sanitize_for_ident(&rust.to_token_stream().to_string());
+pub(crate) fn output_name(rust: &TokenStream, wire: &syn::Type) -> syn::Ident {
+    let rust_id = sanitize_for_ident(&rust.to_string());
     let wire_id = wire_short(wire);
     let h = hash_pair(rust, wire);
     let s = format!("{}_to_{}_{:08x}", rust_id, wire_id, h & 0xffff_ffff);
@@ -307,13 +307,13 @@ pub(crate) fn wire_short(wire: &syn::Type) -> String {
     sanitize_for_ident(&wire.to_token_stream().to_string())
 }
 
-pub(crate) fn hash_pair(rust: &syn::Type, wire: &syn::Type) -> u64 {
+pub(crate) fn hash_pair(rust: &TokenStream, wire: &syn::Type) -> u64 {
     use std::{
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
     };
     let mut h = DefaultHasher::new();
-    rust.to_token_stream().to_string().hash(&mut h);
+    rust.to_string().hash(&mut h);
     "::".hash(&mut h);
     wire.to_token_stream().to_string().hash(&mut h);
     h.finish()

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -194,7 +194,7 @@ impl Declarations {
         //    `result_parts` covers a `Result` the adapter composed itself, which
         //    the frontend never read.
         if let Some((ok, err)) = fallible_parts(ty) {
-            if let Some(c) = self.result_peel(syntax, &ok, &err, registry) {
+            if let Some(c) = self.result_peel(ty, &ok, &err, registry) {
                 return Some(c);
             }
         }

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -62,8 +62,52 @@ impl Declarations {
         body: &syn::Expr,
         exc: Option<&syn::Type>,
     ) -> syn::ItemFn {
+        let spelled = rust.to_token_stream();
+        let rust_with_lifetime = annotate_borrow_with_lifetime(rust, "env").to_token_stream();
+        self.build_input_fn_parts(&spelled, &rust_with_lifetime, wire, body, exc)
+    }
+
+    /// [`Self::build_input_fn`] for a caller holding the **reading** of the Rust
+    /// type this converter yields — the terminals and the transparent bridges.
+    ///
+    /// The borrow annotation is the only thing it does differently:
+    /// [`annotate_borrow_with_lifetime`] matched a `syn::Type::Reference` with
+    /// no lifetime, and the model states both facts on
+    /// [`TypeKind::Ref`](crate::api::core::flat::TypeKind::Ref), so this spells
+    /// `&'env [mut] <inner>` off the classification. Everything else the
+    /// signature needs is the spelling, which is the reading's own tokens.
+    pub(crate) fn build_input_fn_of(
+        &self,
+        rust: &crate::api::core::flat::TypeRef,
+        wire: &syn::Type,
+        body: &syn::Expr,
+        exc: Option<&syn::Type>,
+    ) -> syn::ItemFn {
+        let spelled = rust.spell();
+        let rust_with_lifetime = match rust.kind() {
+            crate::api::core::flat::TypeKind::Ref {
+                lifetime: None,
+                mutable,
+                inner,
+            } => {
+                let inner = inner.spell();
+                let m = if *mutable { quote!(mut) } else { quote!() };
+                quote!(&'env #m #inner)
+            }
+            _ => spelled.clone(),
+        };
+        self.build_input_fn_parts(&spelled, &rust_with_lifetime, wire, body, exc)
+    }
+
+    pub(crate) fn build_input_fn_parts(
+        &self,
+        rust: &TokenStream,
+        rust_with_lifetime: &TokenStream,
+        wire: &syn::Type,
+        body: &syn::Expr,
+        exc: Option<&syn::Type>,
+    ) -> syn::ItemFn {
         let name = input_name(rust, wire);
-        let rust_with_lifetime = annotate_borrow_with_lifetime(rust, "env");
         let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "v");
         let err_type = exc.cloned().unwrap_or_else(default_err_type);
         let ret_body = body_for_exc(body, exc);
@@ -94,6 +138,29 @@ impl Declarations {
     pub(crate) fn build_output_fn(
         &self,
         rust: &syn::Type,
+        wire: &syn::Type,
+        body: &syn::Expr,
+        exc: Option<&syn::Type>,
+    ) -> syn::ItemFn {
+        self.build_output_fn_parts(&rust.to_token_stream(), wire, body, exc)
+    }
+
+    /// [`Self::build_output_fn`] off the **reading**. The output signature takes
+    /// the value by move and needs no lifetime splice, so this is the spelling
+    /// and nothing else.
+    pub(crate) fn build_output_fn_of(
+        &self,
+        rust: &crate::api::core::flat::TypeRef,
+        wire: &syn::Type,
+        body: &syn::Expr,
+        exc: Option<&syn::Type>,
+    ) -> syn::ItemFn {
+        self.build_output_fn_parts(&rust.spell(), wire, body, exc)
+    }
+
+    pub(crate) fn build_output_fn_parts(
+        &self,
+        rust: &TokenStream,
         wire: &syn::Type,
         body: &syn::Expr,
         exc: Option<&syn::Type>,
@@ -129,7 +196,8 @@ impl Declarations {
                 <__JniErr as ::core::convert::From<String>>::from(format!("encode_str: {}", e))
             })?
         });
-        let kotlin_name = self.override_kotlin_name(&outer_ty, Some(kt::KtType::string()));
+        let kotlin_name =
+            self.override_kotlin_name(&TypeKey::from_type(&outer_ty), Some(kt::KtType::string()));
         let niches = default_niches_for_wire(&wire);
         ConverterImpl {
             subs: vec![],
@@ -144,19 +212,17 @@ impl Declarations {
     /// `Cow<[u8]>` output converter (any lifetime form) — see the call site
     /// in [`Self::output_terminal`]. `None` when `ty` isn't a
     /// `Cow<…, [u8]>` path.
-    fn cow_bytes_output(&self, ty: &syn::Type) -> Option<ConverterImpl<KotlinMeta>> {
-        let syn::Type::Path(tp) = ty else { return None };
-        let seg = tp.path.segments.last()?;
-        if seg.ident != "Cow" {
-            return None;
-        }
-        let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
+    fn cow_bytes_output(
+        &self,
+        ty: &crate::api::core::flat::TypeRef,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        // `TypeKind::Cow` is the form, and its `inner` is the argument — where
+        // this walked a path's last segment, compared the ident to the NAME
+        // `"Cow"`, and scanned the angle-bracketed arguments for a `[u8]`.
+        let crate::api::core::flat::TypeKind::Cow { inner, .. } = ty.kind() else {
             return None;
         };
-        let inner_is_bytes = ab.args.iter().any(|a| {
-            matches!(a, syn::GenericArgument::Type(t) if TypeKey::from_type(t).as_str() == "[u8]")
-        });
-        if !inner_is_bytes {
+        if inner.key().as_str() != "[u8]" {
             return None;
         }
         // The generated fn's param type must be resolvable without imports —
@@ -171,7 +237,7 @@ impl Declarations {
                 ))
             })?
         });
-        let kotlin_name = self.override_kotlin_name(ty, Some(kt::KtType::byte_array()));
+        let kotlin_name = self.override_kotlin_name(&ty.key(), Some(kt::KtType::byte_array()));
         let niches = default_niches_for_wire(&wire);
         Some(ConverterImpl {
             subs: vec![],
@@ -225,9 +291,13 @@ impl Declarations {
     ///   so `Option<T>` automatically synthesises `0` = `None`,
     ///   matching the legacy "null pointer" ABI for nullable handles.
     ///   A *tagged* (closed-but-present) value is an error, not `None`.
-    pub fn opaque_handle_input(&self, ty: &syn::Type) -> ConverterImpl<KotlinMeta> {
+    pub fn opaque_handle_input(
+        &self,
+        reading: &crate::api::core::flat::TypeRef,
+    ) -> ConverterImpl<KotlinMeta> {
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-        let name = input_name(ty, &wire);
+        let ty = reading.spell();
+        let name = input_name(&ty, &wire);
         let gen_allow = generated_converter_attr();
         let function: syn::ItemFn = syn::parse_quote!(
             #gen_allow
@@ -259,7 +329,7 @@ impl Declarations {
             // an `OwnedObject::from_raw` failure as the framework
             // `JniBindingError`, so the throws fields point at the
             // framework exception.
-            metadata: self.opaque_leaf_meta(TypeKey::from_type(ty)),
+            metadata: self.opaque_leaf_meta(reading.key()),
         }
     }
 
@@ -305,11 +375,10 @@ impl Declarations {
     /// fallback chain had.
     pub(crate) fn override_kotlin_name(
         &self,
-        outer_ty: &syn::Type,
+        key: &TypeKey,
         inherited: Option<kt::KtType>,
     ) -> Option<kt::KtType> {
-        let key = TypeKey::from_type(outer_ty);
-        if let Some(cfg) = self.types.get(&key) {
+        if let Some(cfg) = self.types.get(key) {
             // Opaque-handle entries keep their typed FQN in
             // `name_spec` for FQN-consumers, but the value-context
             // name is `"Long"` (set on the rank-0 handler's metadata).
@@ -329,12 +398,12 @@ impl Declarations {
     /// `impl Into<…>` parameters that can't be expressed via
     /// `input_wrapper_shape`'s fixed signature shape).
     pub fn input_converter_name(&self, rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
-        input_name(rust, wire)
+        input_name(&rust.to_token_stream(), wire)
     }
 
     /// Symmetric to [`Self::input_converter_name`].
     pub fn output_converter_name(&self, rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
-        output_name(rust, wire)
+        output_name(&rust.to_token_stream(), wire)
     }
 
     fn emitted_source_type_names(
@@ -422,13 +491,16 @@ impl Declarations {
 
     /// Output side of [`Self::opaque_handle_input`] — see that method's
     /// docs for the full convention.
-    pub fn opaque_handle_output(&self, ty: &syn::Type) -> ConverterImpl<KotlinMeta> {
+    pub fn opaque_handle_output(
+        &self,
+        reading: &crate::api::core::flat::TypeRef,
+    ) -> ConverterImpl<KotlinMeta> {
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
         let body: syn::Expr =
             syn::parse_quote!(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64);
         ConverterImpl {
             subs: vec![],
-            function: self.build_output_fn(ty, &wire, &body, None),
+            function: self.build_output_fn_of(reading, &wire, &body, None),
             destination: wire,
             pre_stages: vec![],
             niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
@@ -437,7 +509,7 @@ impl Declarations {
             // [`Self::opaque_leaf_meta`]. Framework throws because the
             // wrapper's emitted match-arm still has a `JniBindingError`
             // branch reachable via the chain.
-            metadata: self.opaque_leaf_meta(TypeKey::from_type(ty)),
+            metadata: self.opaque_leaf_meta(reading.key()),
         }
     }
 }
@@ -897,7 +969,10 @@ impl Declarations {
         // `&T` / `&mut T` are Kotlin-side no-ops — inherit the inner
         // type's name, unless the user pinned an explicit override
         // on the outer form itself (rare but legal).
-        let kotlin_name = self.override_kotlin_name(&outer_ty, inner.metadata.kotlin_name.clone());
+        let kotlin_name = self.override_kotlin_name(
+            &TypeKey::from_type(&outer_ty),
+            inner.metadata.kotlin_name.clone(),
+        );
         // The outer form shares T's converter function verbatim, so it
         // inherits T's throws behaviour. A borrowed handle (mut or not) is
         // still opaque (param classification needs to see it), but the holder
@@ -959,7 +1034,7 @@ impl Declarations {
         let inner_wire = inner.destination.clone();
         let inner_conv = inner.function.sig.ident.clone();
         let outer_ty = produced.clone();
-        let name = input_name(&outer_ty, &inner_wire);
+        let name = input_name(&outer_ty.to_token_stream(), &inner_wire);
         let gen_allow = generated_converter_attr();
         let function: syn::ItemFn = syn::parse_quote!(
             #gen_allow
@@ -972,7 +1047,10 @@ impl Declarations {
                 })
             }
         );
-        let kotlin_name = self.override_kotlin_name(&outer_ty, inner.metadata.kotlin_name.clone());
+        let kotlin_name = self.override_kotlin_name(
+            &TypeKey::from_type(&outer_ty),
+            inner.metadata.kotlin_name.clone(),
+        );
         let projection = inner.metadata.projection.clone().map(|h| Projection {
             owned: false,
             // `Option<&Handle>` always rides the inner's `*v == 0` niche
@@ -1048,7 +1126,7 @@ impl Declarations {
         });
         let inner_kotlin = inner.metadata.kotlin_name.clone()?;
         let kotlin_name = self.override_kotlin_name(
-            &outer_ty,
+            &TypeKey::from_type(&outer_ty),
             // `List` is auto-imported in Kotlin (default imports).
             Some(kt::KtType::generic("List", [inner_kotlin])),
         );
@@ -1090,7 +1168,7 @@ impl Declarations {
                 let outer_ty = produced.clone();
                 let canonical: syn::Type = syn::parse_quote!(Option<#t1_ty>);
                 let build = build_from_canonical(produced, &canonical, quote::quote!(__v))?;
-                let name = input_name(&outer_ty, &inner_wire);
+                let name = input_name(&outer_ty.to_token_stream(), &inner_wire);
                 let gen_allow = generated_converter_attr();
                 let function: syn::ItemFn = syn::parse_quote!(
                     #gen_allow
@@ -1117,8 +1195,10 @@ impl Declarations {
                         })
                     }
                 );
-                let kotlin_name =
-                    self.override_kotlin_name(&outer_ty, inner.metadata.kotlin_name.clone());
+                let kotlin_name = self.override_kotlin_name(
+                    &TypeKey::from_type(&outer_ty),
+                    inner.metadata.kotlin_name.clone(),
+                );
                 let projection = inner.metadata.projection.clone().map(|h| Projection {
                     owned: true,
                     // Rides the inner's `*v == 0` niche, so the wire stays
@@ -1157,7 +1237,7 @@ impl Declarations {
             let inherited = registry
                 .input_entry(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
-            let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
+            let kotlin_name = self.override_kotlin_name(&TypeKey::from_type(&outer_ty), inherited);
             // Fold a Nullable layer over the inner projection (if any). The
             // kind mirrors which path `option_input` took: when it consumed
             // an inner niche, the wire stays identical to the inner's
@@ -1958,13 +2038,14 @@ impl Declarations {
         // Classify off `kind`, spell with `spell()`: the arms below that ask what
         // a type IS use `reading`, and everything that has to name it in
         // generated Rust uses this.
-        let ty = reading.as_syn();
+        // Everything below reads the reading: the identity for a lookup, the
+        // spelling for what generated Rust says. Neither needs a node.
         // Structured-config overrides first (opaque handles, then user-
         // registered rank-0 wrappers, then built-ins).
-        let key = TypeKey::from_type(ty);
+        let key = reading.key();
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_opaque() {
-                return Some(self.opaque_handle_input(ty));
+                return Some(self.opaque_handle_input(reading));
             }
         }
         // Fixed-size array of JNI primitives — dual of the output branch.
@@ -1973,12 +2054,12 @@ impl Declarations {
         if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(reading) {
             let body = crate::api::lang::jnigen::jni::prim_array::input_body(reading, &spec);
             let wire = spec.wire.clone();
-            let kotlin_name = self.override_kotlin_name(ty, Some(spec.kotlin.clone()));
+            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(spec.kotlin.clone()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn(ty, &wire, &body, None),
+                function: self.build_input_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -1991,7 +2072,7 @@ impl Declarations {
         // (jint → Rust enum) with the configured Kotlin FQN in metadata.
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
-                if let Some(name) = bare_path_ident(ty) {
+                if let Some(name) = reading.key().ident() {
                     // The ELEMENT, and the match is the check: a declared
                     // `enum_class!` over a data-carrying enum is a `Variant`,
                     // not an `Enum`, so the shape assertion the two bodies used
@@ -2006,7 +2087,7 @@ impl Declarations {
                         return Some(ConverterImpl {
                             subs: vec![],
                             pre_stages: vec![],
-                            function: self.build_input_fn(ty, &wire, &body, None),
+                            function: self.build_input_fn_of(reading, &wire, &body, None),
                             destination: wire,
                             niches,
                             metadata: self.framework_meta(kotlin_name),
@@ -2015,14 +2096,14 @@ impl Declarations {
                 }
             }
         }
-        if let Some(conv) = self.lookup_input(ty, registry) {
+        if let Some(conv) = self.lookup_input(reading, registry) {
             return Some(conv);
         }
         // `str` is unsized, so converters can't return it directly.
         // Still register a rank-0 entry to satisfy resolution for
         // borrowed `&str` parameters: decode `JString` to owned `String`
         // and let call sites borrow as needed.
-        if TypeKey::from_type(ty).as_str() == "str" {
+        if reading.key().as_str() == "str" {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
                 let s = env.get_string(v).map_err(|e| {
@@ -2033,8 +2114,10 @@ impl Declarations {
                 })?;
                 s.into()
             });
+            // The unsized `str` yields an OWNED `String` the call site borrows,
+            // so this converter's Rust type is not the reading's spelling.
             let rust_ty: syn::Type = syn::parse_quote!(String);
-            let kotlin_name = self.override_kotlin_name(ty, Some(kt::KtType::string()));
+            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(kt::KtType::string()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
                 subs: vec![],
@@ -2070,22 +2153,21 @@ impl Declarations {
                 // The canonical value, then the spelling.
                 ::std::string::String::from(s).into()
             });
-            let rust_ty = ty.clone();
-            let kotlin_name = self.override_kotlin_name(ty, Some(kt::KtType::string()));
+            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(kt::KtType::string()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn(&rust_ty, &wire, &body, None),
+                function: self.build_input_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
             });
         }
-        if let Some((wire, body)) = primitive_input(ty) {
+        if let Some((wire, body)) = primitive_input(&reading.key()) {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if TypeKey::from_type(ty).as_str() == "u64" {
+            let metadata = if reading.key().as_str() == "u64" {
                 self.unsigned64_leaf_meta()
             } else {
                 self.framework_meta(kotlin_name)
@@ -2093,13 +2175,13 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn(ty, &wire, &body, None),
+                function: self.build_input_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata,
             });
         }
-        if let Some(name) = bare_path_ident(ty) {
+        if let Some(name) = reading.key().ident() {
             // A `sealed_class` sum reached as a whole `JObject` — a field of a
             // data class, or any position where the parent is already an
             // object. Its own converter, so the parent's generic field branch
@@ -2123,7 +2205,7 @@ impl Declarations {
                     return Some(ConverterImpl {
                         subs: vec![],
                         pre_stages: vec![],
-                        function: self.build_input_fn(ty, &wire, &body, None),
+                        function: self.build_input_fn_of(reading, &wire, &body, None),
                         destination: wire,
                         niches,
                         metadata: self.framework_meta(kotlin_name),
@@ -2145,7 +2227,7 @@ impl Declarations {
                 return Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_input_fn(ty, &wire, &body, None),
+                    function: self.build_input_fn_of(reading, &wire, &body, None),
                     destination: wire,
                     niches,
                     metadata: self.framework_meta(kotlin_name),
@@ -2189,7 +2271,6 @@ impl Declarations {
         if reading.erased_wrappers().is_empty() {
             return None;
         }
-        let produced = reading.as_syn();
         // The identity under every wrapper. This spelled the stripped type into
         // a node purely so `reading_of` could key off it and `subs` could key
         // off it again — `stripped_key` is that key, and the model already
@@ -2227,7 +2308,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![stripped],
             pre_stages: vec![],
-            function: self.build_output_fn(produced, &wire, &body, None),
+            function: self.build_output_fn_of(reading, &wire, &body, None),
             destination: wire,
             niches: entry.niches.clone(),
             // The surface is the inner type's — a wrapper is invisible to the
@@ -2264,7 +2345,6 @@ impl Declarations {
         if reading.erased_wrappers().is_empty() {
             return None;
         }
-        let produced = reading.as_syn();
         // The identity under every wrapper — by the model's own definition, the
         // key of the type whose lowering yields this `kind`. See the outbound
         // peer for why this is a key rather than a spelling.
@@ -2306,7 +2386,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![stripped],
             pre_stages: vec![],
-            function: self.build_input_fn(produced, &wire, &body, None),
+            function: self.build_input_fn_of(reading, &wire, &body, None),
             destination: wire,
             niches: entry.niches.clone(),
             // The surface is the inner type's: a wrapper is invisible to the
@@ -2351,12 +2431,13 @@ impl Declarations {
         registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()` — see `input_terminal`.
-        let ty = reading.as_syn();
+        // Everything below reads the reading: the identity for a lookup, the
+        // spelling for what generated Rust says. Neither needs a node.
         // Structured-config overrides first (opaque handles, then built-ins).
-        let key = TypeKey::from_type(ty);
+        let key = reading.key();
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_opaque() {
-                return Some(self.opaque_handle_output(ty));
+                return Some(self.opaque_handle_output(reading));
             }
         }
         // Fixed-size array of JNI primitives: `[u8; N]` -> `ByteArray`,
@@ -2365,12 +2446,12 @@ impl Declarations {
         if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(reading) {
             let body = crate::api::lang::jnigen::jni::prim_array::output_body(&spec);
             let wire = spec.wire.clone();
-            let kotlin_name = self.override_kotlin_name(ty, Some(spec.kotlin.clone()));
+            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(spec.kotlin.clone()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn(ty, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -2382,7 +2463,7 @@ impl Declarations {
         // declared enum so the discriminant value round-trips identically.
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_enum_class() {
-                if let Some(name) = bare_path_ident(ty) {
+                if let Some(name) = reading.key().ident() {
                     if let Some(e) = flat_unit_enum(registry, &name, "enum_class") {
                         let (wire, body) = enum_output_body(self, e);
                         let niches = default_niches_for_wire(&wire);
@@ -2393,7 +2474,7 @@ impl Declarations {
                         return Some(ConverterImpl {
                             subs: vec![],
                             pre_stages: vec![],
-                            function: self.build_output_fn(ty, &wire, &body, None),
+                            function: self.build_output_fn_of(reading, &wire, &body, None),
                             destination: wire,
                             niches,
                             metadata: self.framework_meta(kotlin_name),
@@ -2402,14 +2483,14 @@ impl Declarations {
                 }
             }
         }
-        if let Some(conv) = self.lookup_output(ty, registry) {
+        if let Some(conv) = self.lookup_output(reading, registry) {
             return Some(conv);
         }
         // `str` is unsized, so it has no by-value output converter — but it is
         // reached as the sub of a `&str` reference accessor leaf. Resolve it to
         // the same `&str → jstring` fn the rank-1 `&str` arm uses (deduped by
         // name) so required-propagation doesn't flag it unresolved.
-        if TypeKey::from_type(ty).as_str() == "str" {
+        if reading.key().as_str() == "str" {
             return Some(self.str_ref_output());
         }
         // An owned string in any representation the model erases — `Box<String>`,
@@ -2431,13 +2512,12 @@ impl Declarations {
                     <__JniErr as ::core::convert::From<String>>::from(format!("encode_str: {}", e))
                 })?
             });
-            let rust_ty = ty.clone();
-            let kotlin_name = self.override_kotlin_name(ty, Some(kt::KtType::string()));
+            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(kt::KtType::string()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn(&rust_ty, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -2448,7 +2528,7 @@ impl Declarations {
         // intermediate owned `Vec` (the zero-copy dual of the `Vec<u8>`
         // output, for accessors like `zenoh::ZBytes::to_bytes()` that borrow
         // when the payload is contiguous). Surfaces as Kotlin `ByteArray`.
-        if let Some(conv) = self.cow_bytes_output(ty) {
+        if let Some(conv) = self.cow_bytes_output(reading) {
             return Some(conv);
         }
         // `()` — identity converter so `fn foo()` and `fn foo() -> ()`
@@ -2464,17 +2544,17 @@ impl Declarations {
             let body: syn::Expr = syn::parse_quote!(v);
             return Some(ConverterImpl {
                 subs: vec![],
-                function: self.build_output_fn(ty, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 pre_stages: vec![],
                 niches: Niches::empty(),
                 metadata: KotlinMeta::default(),
             });
         }
-        if let Some((wire, body)) = primitive_output(ty) {
+        if let Some((wire, body)) = primitive_output(&reading.key()) {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if TypeKey::from_type(ty).as_str() == "u64" {
+            let metadata = if reading.key().as_str() == "u64" {
                 self.unsigned64_leaf_meta()
             } else {
                 self.framework_meta(kotlin_name)
@@ -2482,13 +2562,13 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn(ty, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata,
             });
         }
-        if let Some(name) = bare_path_ident(ty) {
+        if let Some(name) = reading.key().ident() {
             if let Some(s) = registry.flat().struct_type(&name) {
                 let (wire, body) = struct_output_body(self, s, registry)?;
                 let niches = default_niches_for_wire(&wire);
@@ -2500,7 +2580,7 @@ impl Declarations {
                 return Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_output_fn(ty, &wire, &body, None),
+                    function: self.build_output_fn_of(reading, &wire, &body, None),
                     destination: wire,
                     niches,
                     metadata: self.framework_meta(kotlin_name),
@@ -2580,7 +2660,7 @@ impl Declarations {
             let inherited = registry
                 .output_entry(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
-            let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
+            let kotlin_name = self.override_kotlin_name(&TypeKey::from_type(&outer_ty), inherited);
             // Fold a Nullable layer over the inner projection (if any). The
             // kind reflects which path `option_output` took (see
             // [`nullable_kind_for`]): niche-fulfilled keeps the inner wire
@@ -2656,7 +2736,7 @@ impl Declarations {
             });
             let inner_kotlin = inner.metadata.kotlin_name.clone()?;
             let kotlin_name = self.override_kotlin_name(
-                &outer_ty,
+                &TypeKey::from_type(&outer_ty),
                 // `List` is auto-imported in Kotlin (default imports). When
                 // the inner carries a projection, this wire-context name
                 // still drives non-projection consumers; projection-aware
@@ -2737,8 +2817,10 @@ impl Declarations {
             __list_obj
         });
         let inner_kotlin = inner.metadata.kotlin_name.clone()?;
-        let kotlin_name =
-            self.override_kotlin_name(&outer_ty, Some(kt::KtType::generic("List", [inner_kotlin])));
+        let kotlin_name = self.override_kotlin_name(
+            &TypeKey::from_type(&outer_ty),
+            Some(kt::KtType::generic("List", [inner_kotlin])),
+        );
         let projection = inner.metadata.projection.clone().map(|h| Projection {
             strategy: FoldStrategy::Iterable(Box::new(h.strategy)),
             ..h


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). The last big population.

`input_terminal`, `output_terminal`, `input_transparent_bridge` and `output_transparent_bridge` each opened with

```rust
// Classify off `kind`, spell with `spell()`: the arms below that ask what
// a type IS use `reading`, and everything that has to name it in
// generated Rust uses this.
let ty = reading.as_syn();
```

and then handed that node to about twenty sites. The comment was already the plan; every one of those sites wanted an **identity** or a **spelling**.

## The lever: the converter builders

`build_input_fn` / `build_output_fn` do exactly two things with the Rust type — **name** it and **spell** it into the signature. So:

* `input_name` / `output_name` / `hash_pair` take a `TokenStream`. They only ever did `rust.to_token_stream().to_string()`.
* each builder splits into a tokens core plus two front doors: the `&syn::Type` one the ~18 adapter-composed callers keep unchanged, and a `_of` twin taking the reading.

The twin differs in exactly one place:

```rust
-let rust_with_lifetime = annotate_borrow_with_lifetime(rust, "env");
+let rust_with_lifetime = match rust.kind() {
+    TypeKind::Ref { lifetime: None, mutable, inner } => {
+        let inner = inner.spell();
+        let m = if *mutable { quote!(mut) } else { quote!() };
+        quote!(&'env #m #inner)
+    }
+    _ => spelled.clone(),
+};
```

`annotate_borrow_with_lifetime` matched a `syn::Type::Reference` and checked its `lifetime` field; `TypeKind::Ref { lifetime, mutable, inner }` states all three facts, so the reading path spells the annotated form off the classification.

## What that unblocked

| | was | is |
|---|---|---|
| `opaque_handle_input` / `_output` | `&syn::Type` | the reading |
| `lookup_input` / `lookup_output` / `build_output_converter` | `outer: &syn::Type`, then `TypeKey::from_type(outer)` twice | the reading, `outer.key()` |
| `override_kotlin_name` | `&syn::Type`, then `TypeKey::from_type` on line 1 | `&TypeKey` |
| `primitive_input` / `primitive_output` | `&syn::Type`, then `TypeKey::from_type(ty).as_str()` | `&TypeKey` |
| `bare_path_ident(ty)` | a path walk | `key.ident()` |
| `cow_bytes_output` | `Type::Path` → last segment ident `== "Cow"` → `AngleBracketed` args → any arg keys to `[u8]` | `TypeKind::Cow { inner, .. }`, `inner.key() == "[u8]"` |

`result_peel` takes the reading too, which is why `selector.rs`'s `result_peel(syntax, …)` becomes `result_peel(ty, …)`.

## One arm is deliberately not the reading

The `str` **input** terminal's converter yields an **owned `String`** the call site borrows — its Rust type is `String`, not `str`:

```rust
// The unsized `str` yields an OWNED `String` the call site borrows,
// so this converter's Rust type is not the reading's spelling.
let rust_ty: syn::Type = syn::parse_quote!(String);
```

Its owned-string neighbour four lines down *is* the spelling (`Box<String>`, `Cow<'_, str>`, …). A bulk rewrite treated them alike; `regen-check.sh` is what told them apart, before anything else did.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 69 | **68** |
| escapes: types | 11 | **7** |
| escapes: items | 15 | 15 |

```
api/lang/jnigen/jni/trait_impl.rs  [classification]  5 -> 4
api/lang/jnigen/jni/trait_impl.rs  [types]           5 -> 1
```

Seven left, in four files:

* `jnigen/jni/trait_impl.rs` (1) — `self.types[key].rust_type`, a declare-phase read #291 documents as answerable only by the declaration;
* `jnigen/jni/fn_plan.rs` (2), `jnigen/jni/selector.rs` (2), `cbindgen/emit.rs` (1), `cbindgen/trait_impl.rs` (1) — the `produced` population, where the adapter composes a type it cannot mint a reading for.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical