### PR TITLE
S35: the return target and the declared payload are identities

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -123,13 +123,11 @@
 # total classification sites: 68
 
 ## escapes: types
-1	api/lang/cbindgen/emit.rs
 1	api/lang/cbindgen/trait_impl.rs
-2	api/lang/jnigen/jni/fn_plan.rs
 2	api/lang/jnigen/jni/selector.rs
 1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 7
+# total escapes: types: 4
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -82,14 +82,16 @@ impl CbindgenBuilder {
     /// wrapper the model erases cannot change which declaration a payload
     /// matches. See [`Self::payload_field_wire`] for why a union payload asks
     /// this at all where a `repr_c_struct` mirror must not.
-    pub(super) fn declared_opaque_payload_inner(&self, fty: &TypeRef) -> Option<syn::Type> {
+    pub(super) fn declared_opaque_payload_inner(&self, fty: &TypeRef) -> Option<TypeKey> {
         if r_boxed_inner(fty).is_some() {
             return None;
         }
         let core = fty.optional_inner().unwrap_or(fty);
-        self.opaque
-            .contains_key(&core.stripped_key())
-            .then(|| core.stripped_syntax())
+        let key = core.stripped_key();
+        // The IDENTITY, not the stripped spelling: every caller turned that
+        // spelling straight back into this key (`c_type_ident`, `type_short`)
+        // or into the source path it names (`src_ty_of`).
+        self.opaque.contains_key(&key).then_some(key)
     }
 
     /// Wire type of one **tagged-union payload field**: the
@@ -177,7 +179,7 @@ impl CbindgenBuilder {
         // differ, which is exactly the split (`kind` decides what C sees, syntax
         // decides how the value is built).
         if let Some(inner) = self.declared_opaque_payload_inner(fty) {
-            let c = self.c_type_ident(&TypeKey::from_type(&inner));
+            let c = self.c_type_ident(&inner);
             return Ok(syn::parse_quote!(*mut #c));
         }
         // Otherwise the payload's wire is its **resolved converter

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1331,12 +1331,12 @@ impl CbindgenBuilder {
         // is just moved out of the box instead of kept in one. Conversion
         // follows the SYNTAX; the C type followed `kind` + the declaration.
         if let Some(inner) = self.declared_opaque_payload_inner(fty) {
-            let src_inner = self.src_ty(&inner);
+            let src_inner = self.src_ty_of(&inner);
             let owned = quote!(*::std::boxed::Box::from_raw(#b as *mut #src_inner));
             let null_msg = format!(
                 "null payload for `{}` (a non-optional handle payload cannot be NULL — the \
                  union may already have been dropped)",
-                type_short(&TypeKey::from_type(&inner))
+                type_short(&inner)
             );
             return if fty.optional_inner().is_some() {
                 quote!(if #b.is_null() {
@@ -1429,7 +1429,7 @@ impl CbindgenBuilder {
         // The peer of the input arm above: an owned value the C side must later
         // release, so it is boxed HERE rather than having arrived boxed.
         if let Some(inner) = self.declared_opaque_payload_inner(fty) {
-            let c = self.c_type_ident(&TypeKey::from_type(&inner));
+            let c = self.c_type_ident(&inner);
             return if fty.optional_inner().is_some() {
                 quote!(match #b {
                     ::core::option::Option::Some(__v) => {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -262,8 +262,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let output_entry = match &plan.output {
         FnOutputPlan::Value(v) => Some(
             registry
-                .reading_of(&v.target_ty)
-                .and_then(|tr| registry.output_entry(&tr))
+                .output_entry(&v.target_ty)
                 .expect("output entry validated at plan build"),
         ),
         FnOutputPlan::Unfold(_) => None,

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -181,9 +181,11 @@ pub(crate) struct ValueOutputPlan {
     pub is_convert: bool,
     /// The type whose output converter runs: `convert_out_ty` for a convert,
     /// the `Result` Ok type when an error plan peels, else the declared
-    /// return. Its entry is validated at plan build; the Rust emitter
-    /// re-looks it up (`expect`) to keep the plan lifetime-free.
-    pub target_ty: syn::Type,
+    /// return. A **reading** — all three candidates are one, and the emitter
+    /// asks it for the entry directly. Its entry is validated at plan build;
+    /// the Rust emitter re-looks it up (`expect`) to keep the plan
+    /// lifetime-free.
+    pub target_ty: crate::api::core::flat::TypeRef,
     /// The resolved output entry's `destination` — the extern's wire return
     /// and the sentinel source.
     pub wire_ty: syn::Type,
@@ -705,10 +707,7 @@ fn build_output(
     registry: &Registry<KotlinMeta>,
     f: &crate::api::core::flat::Function,
 ) -> Result<FnOutputPlan, PlanError> {
-    use crate::api::core::{
-        types_util::result_ok_type,
-        unfold::{Delivery, UnfoldShape},
-    };
+    use crate::api::core::unfold::{Delivery, UnfoldShape};
     let ident = &f.name;
     let unfold_plan = registry.unfold_plans().get(ident);
 
@@ -754,29 +753,30 @@ fn build_output(
     let is_convert = unfold_plan.is_some();
     // The element normalizes an elided return and a written `-> ()` to one
     // `Unit` reading, so there is no `ReturnType` match here.
-    let return_ty: syn::Type = f.ret.as_syn().clone();
     let error_plan = registry.error_plans().get(ident);
-    let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
-    let target_ty = match unfold_plan {
-        // The other arm composes a type this adapter built, so the two meet as
-        // spellings: the plan's reading is unwrapped here rather than the whole
-        // local becoming a reading it cannot be.
+    // The `Ok` side off `TypeKind::Fallible`, where `result_ok_type` found the
+    // `Result` in a path first.
+    let ok_ty = error_plan
+        .and_then(|_| f.ret.fallible_parts())
+        .map(|(ok, _)| ok);
+    // All three candidates are readings: a plan's `convert_out_ty`, the `Ok`
+    // side of the return, and the return itself. This met them as spellings
+    // because one of them used to be a node.
+    let target_ty: &crate::api::core::flat::TypeRef = match unfold_plan {
         Some(p) => p
             .convert_out_ty
             .as_ref()
-            .expect("Return delivery carries convert_out_ty")
-            .as_syn()
-            .clone(),
-        None => ok_ty.unwrap_or(return_ty),
+            .expect("Return delivery carries convert_out_ty"),
+        None => ok_ty.unwrap_or(&f.ret),
     };
-    // Two failures, told apart. `target_ty` is composed here (`convert_out_ty`,
-    // or the `Result` peeled to its `Ok`), so unlike the input side there may
-    // genuinely be no reading — and "not registered" wants different advice
+    // Two failures, told apart. Holding a reading is not the same as being in
+    // the type table — `target_ty` is reached through a plan or a peel, so it
+    // may genuinely have no cell — and "not registered" wants different advice
     // from "registered, no converter". Collapsed into one `and_then`, both got
     // the `output_wrapper` message and the first one got it wrong.
-    let Some(target) = registry.reading_of(&target_ty) else {
+    let Some(target) = registry.reading(&target_ty.key()) else {
         return Err(PlanError::UnknownOutputType {
-            ty: TypeKey::from_type(&target_ty),
+            ty: target_ty.key(),
         });
     };
     let Some(entry) = registry.output_entry(&target) else {
@@ -791,7 +791,8 @@ fn build_output(
     // Kotlin error peel rides the entry's `value_rust_type`, so the full
     // `Result<T, E>` type is looked up as written.)
     let ret_decl: syn::ReturnType = if is_convert {
-        syn::parse_quote!(-> #target_ty)
+        let t = target_ty.spell();
+        syn::parse_quote!(-> #t)
     } else {
         let ret = f.ret.spell();
         syn::parse_quote!(-> #ret)
@@ -804,7 +805,7 @@ fn build_output(
 
     Ok(FnOutputPlan::Value(Box::new(ValueOutputPlan {
         is_convert,
-        target_ty,
+        target_ty: target_ty.clone(),
         wire_ty,
         surface,
         is_enum,


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). Two more locals carrying a node to somewhere that wanted a key or a spelling.

## The return conversion target

`fn_plan::build_output` picks the type whose output converter runs, from three candidates, and met them as spellings:

```rust
-let return_ty: syn::Type = f.ret.as_syn().clone();
-let ok_ty = error_plan.and_then(|_| result_ok_type(&return_ty));
-let target_ty = match unfold_plan {
-    // The other arm composes a type this adapter built, so the two meet as
-    // spellings: the plan's reading is unwrapped here rather than the whole
-    // local becoming a reading it cannot be.
-    Some(p) => p.convert_out_ty.as_ref().expect(…).as_syn().clone(),
-    None => ok_ty.unwrap_or(return_ty),
-};
```

The comment was true when it was written and is not now. **All three candidates are readings** — `convert_out_ty` is a `TypeRef`, `f.ret` is a `TypeRef`, and the `Ok` side comes off `TypeKind::Fallible` rather than `result_ok_type` finding the `Result` in a path:

```rust
+let ok_ty = error_plan.and_then(|_| f.ret.fallible_parts()).map(|(ok, _)| ok);
+let target_ty: &TypeRef = match unfold_plan {
+    Some(p) => p.convert_out_ty.as_ref().expect(…),
+    None => ok_ty.unwrap_or(&f.ret),
+};
```

`ValueOutputPlan::target_ty` carries the reading, and its single consumer in `emit/wrapper.rs` stops doing `reading_of(&v.target_ty).and_then(output_entry)` — the round-trip S26 removed from four other helpers, reached here through a plan field instead of an argument.

**The two-error distinction is kept and its reason restated.** Holding a reading is not the same as having a cell: `target_ty` is reached through a plan or a peel, so `registry.reading(&target_ty.key())` can still miss, and "not registered" still wants different advice from "registered, no converter".

## The declared opaque payload

```rust
-self.opaque.contains_key(&core.stripped_key()).then(|| core.stripped_syntax())
+let key = core.stripped_key();
+self.opaque.contains_key(&key).then_some(key)
```

It computed the key, threw it away, returned the stripped **spelling** — and all three callers turned that spelling straight back into the key (`c_type_ident`, `type_short`) or into the source path the key names (`src_ty_of`, from S30).

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 68 | 68 |
| escapes: types | 7 | **4** |
| escapes: items | 15 | 15 |

```
api/lang/jnigen/jni/fn_plan.rs  2 -> 0
api/lang/cbindgen/emit.rs       1 -> 0
```

**Four left**, and they are one design question plus one documented exception:

* `jnigen/jni/selector.rs` (2) and `cbindgen/trait_impl.rs` (1) — the `produced` population. `produced` is *defined* as the tokens a converter yields, and one arm (`&[T]` input) **composes** them: it decodes to an owned `Vec<T>` the call site borrows, and #280 leaves the adapter no way to mint that reading. Handing the other callers a node built from their reading's tokens would drop the count while ungating `bridge_layers` — measuring better while nothing improved. The honest fix is to stop passing a spelling at all: `produced` becomes `Reading(&TypeRef) | Canonical`, where the composing arm says "exactly the canonical form" and `is_canonical_spelling` / `build_from_canonical` / `read_as_canonical` answer structurally. That is the endgame stage.
* `jnigen/jni/trait_impl.rs` (1) — `self.types[key].rust_type`, the declare-phase read #291 documents as answerable only by the declaration, since `reading()` legitimately returns `None` for a type nothing has interned yet.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical